### PR TITLE
[CodeStyle][Xdoctest][8,12,15,16,18-20,22-26,29-40,42,43,45-48,50,51,60-65,75,80,82,83,85-87,89-94,99-141,143,145,147-167,169-187,207-220,257,258,260-275,277-313,315-325][API Compatibility] Update shape output format in documentation examples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ target-version = "py39"
 # Prevent change to double quotes by some users use ruff format
 quote-style = "preserve"
 docstring-code-format = true
+docstring-code-line-length = 120
 
 [tool.ruff.lint]
 select = [

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -710,7 +710,7 @@ add_doc_and_signature(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -719,35 +719,35 @@ add_doc_and_signature(
             >>> y = paddle.rand([10])
             >>> z = paddle.matmul(x, y)
             >>> print(z.shape)
-            []
+            paddle.Size([])
 
             >>> # matrix * vector
             >>> x = paddle.rand([10, 5])
             >>> y = paddle.rand([5])
             >>> z = paddle.matmul(x, y)
             >>> print(z.shape)
-            [10]
+            paddle.Size([10])
 
             >>> # batched matrix * broadcasted vector
             >>> x = paddle.rand([10, 5, 2])
             >>> y = paddle.rand([2])
             >>> z = paddle.matmul(x, y)
             >>> print(z.shape)
-            [10, 5]
+            paddle.Size([10, 5])
 
             >>> # batched matrix * batched matrix
             >>> x = paddle.rand([10, 5, 2])
             >>> y = paddle.rand([10, 2, 5])
             >>> z = paddle.matmul(x, y)
             >>> print(z.shape)
-            [10, 5, 5]
+            paddle.Size([10, 5, 5])
 
             >>> # batched matrix * broadcasted matrix
             >>> x = paddle.rand([10, 1, 5, 2])
             >>> y = paddle.rand([1, 3, 2, 5])
             >>> z = paddle.matmul(x, y)
             >>> print(z.shape)
-            [10, 3, 5, 5]
+            paddle.Size([10, 3, 5, 5])
 
     """,
     """    def matmul(

--- a/python/paddle/autograd/autograd.py
+++ b/python/paddle/autograd/autograd.py
@@ -545,16 +545,8 @@ def jacobian(
 
             >>> import paddle
 
-            >>> x1 = paddle.randn(
-            ...     [
-            ...         3,
-            ...     ]
-            ... )
-            >>> x2 = paddle.randn(
-            ...     [
-            ...         3,
-            ...     ]
-            ... )
+            >>> x1 = paddle.randn([3])
+            >>> x2 = paddle.randn([3])
             >>> x1.stop_gradient = False
             >>> x2.stop_gradient = False
 
@@ -653,16 +645,8 @@ def hessian(
 
             >>> import paddle
 
-            >>> x1 = paddle.randn(
-            ...     [
-            ...         3,
-            ...     ]
-            ... )
-            >>> x2 = paddle.randn(
-            ...     [
-            ...         4,
-            ...     ]
-            ... )
+            >>> x1 = paddle.randn([3])
+            >>> x2 = paddle.randn([4])
             >>> x1.stop_gradient = False
             >>> x2.stop_gradient = False
 

--- a/python/paddle/autograd/autograd.py
+++ b/python/paddle/autograd/autograd.py
@@ -541,25 +541,33 @@ def jacobian(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
-            >>> x1 = paddle.randn([3, ])
-            >>> x2 = paddle.randn([3, ])
+            >>> x1 = paddle.randn(
+            ...     [
+            ...         3,
+            ...     ]
+            ... )
+            >>> x2 = paddle.randn(
+            ...     [
+            ...         3,
+            ...     ]
+            ... )
             >>> x1.stop_gradient = False
             >>> x2.stop_gradient = False
 
             >>> y = x1 + x2
 
             >>> J = paddle.autograd.jacobian(y, (x1, x2))
-            >>> J_y_x1 = J[0][:] # evaluate result of dy/dx1
-            >>> J_y_x2 = J[1][:] # evaluate result of dy/dx2
+            >>> J_y_x1 = J[0][:]  # evaluate result of dy/dx1
+            >>> J_y_x2 = J[1][:]  # evaluate result of dy/dx2
 
             >>> print(J_y_x1.shape)
-            [3, 3]
+            paddle.Size([3, 3])
             >>> print(J_y_x2.shape)
-            [3, 3]
+            paddle.Size([3, 3])
     """
 
     if batch_axis is not None and batch_axis != 0:
@@ -641,31 +649,39 @@ def hessian(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
-            >>> x1 = paddle.randn([3, ])
-            >>> x2 = paddle.randn([4, ])
+            >>> x1 = paddle.randn(
+            ...     [
+            ...         3,
+            ...     ]
+            ... )
+            >>> x2 = paddle.randn(
+            ...     [
+            ...         4,
+            ...     ]
+            ... )
             >>> x1.stop_gradient = False
             >>> x2.stop_gradient = False
 
             >>> y = x1.sum() + x2.sum()
 
             >>> H = paddle.autograd.hessian(y, (x1, x2))
-            >>> H_y_x1_x1 = H[0][0][:] # evaluate result of ddy/dx1x1
-            >>> H_y_x1_x2 = H[0][1][:] # evaluate result of ddy/dx1x2
-            >>> H_y_x2_x1 = H[1][0][:] # evaluate result of ddy/dx2x1
-            >>> H_y_x2_x2 = H[1][1][:] # evaluate result of ddy/dx2x2
+            >>> H_y_x1_x1 = H[0][0][:]  # evaluate result of ddy/dx1x1
+            >>> H_y_x1_x2 = H[0][1][:]  # evaluate result of ddy/dx1x2
+            >>> H_y_x2_x1 = H[1][0][:]  # evaluate result of ddy/dx2x1
+            >>> H_y_x2_x2 = H[1][1][:]  # evaluate result of ddy/dx2x2
 
             >>> print(H_y_x1_x1.shape)
-            [3, 3]
+            paddle.Size([3, 3])
             >>> print(H_y_x1_x2.shape)
-            [3, 4]
+            paddle.Size([3, 4])
             >>> print(H_y_x2_x1.shape)
-            [4, 3]
+            paddle.Size([4, 3])
             >>> print(H_y_x2_x2.shape)
-            [4, 4]
+            paddle.Size([4, 4])
     """
 
     if batch_axis is None:

--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -329,13 +329,13 @@ def monkey_patch_math_tensor():
             Tensor: A new Tensor with its last two dimensions swapped.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> x = paddle.randn([2, 3, 4])
                 >>> x_transposed = x.mT
                 >>> x_transposed.shape
-                [2, 4, 3]
+                paddle.Size([2, 4, 3])
         """
         if len(var.shape) < 2:
             raise ValueError(
@@ -422,13 +422,13 @@ def monkey_patch_math_tensor():
             Tensor: A new uninitialized Tensor with the specified shape.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> x = paddle.ones([2, 2])
                 >>> y = x.new_empty(3, 3)  # type: ignore
                 >>> y.shape
-                [3, 3]
+                paddle.Size([3, 3])
         """
 
         if dtype is None:

--- a/python/paddle/base/lod_tensor.py
+++ b/python/paddle/base/lod_tensor.py
@@ -152,14 +152,19 @@ def create_random_int_lodtensor(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle.base as base
 
-            >>> t = base.create_random_int_lodtensor(recursive_seq_lens=[[2, 3]],
-            ...         base_shape=[30], place=base.CPUPlace(), low=0, high=10)
+            >>> t = base.create_random_int_lodtensor(
+            ...     recursive_seq_lens=[[2, 3]],
+            ...     base_shape=[30],
+            ...     place=base.CPUPlace(),
+            ...     low=0,
+            ...     high=10,
+            ... )
             >>> print(t.shape())
-            [5, 30]
+            paddle.Size([5, 30])
     """
     assert isinstance(base_shape, list), "base_shape should be a list"
     # append the total number of basic elements to the front of its shape

--- a/python/paddle/compat/__init__.py
+++ b/python/paddle/compat/__init__.py
@@ -827,9 +827,7 @@ def split(
             >>> # x is a Tensor of shape [3, 8, 5]
             >>> x = paddle.rand([3, 8, 5])
 
-            >>> out0, out1, out2 = paddle.compat.split(
-            ...     x, split_size_or_sections=3, dim=1
-            ... )
+            >>> out0, out1, out2 = paddle.compat.split(x, split_size_or_sections=3, dim=1)
             >>> print(out0.shape)
             paddle.Size([3, 3, 5])
             >>> print(out1.shape)
@@ -837,9 +835,7 @@ def split(
             >>> print(out2.shape)
             paddle.Size([3, 2, 5])
 
-            >>> out0, out1, out2 = paddle.compat.split(
-            ...     x, split_size_or_sections=[1, 2, 5], dim=1
-            ... )
+            >>> out0, out1, out2 = paddle.compat.split(x, split_size_or_sections=[1, 2, 5], dim=1)
             >>> print(out0.shape)
             paddle.Size([3, 1, 5])
             >>> print(out1.shape)
@@ -848,9 +844,7 @@ def split(
             paddle.Size([3, 5, 5])
 
             >>> # dim is negative, the real dim is (rank(x) + dim)=1
-            >>> out0, out1, out2 = paddle.compat.split(
-            ...     x, split_size_or_sections=3, dim=-2
-            ... )
+            >>> out0, out1, out2 = paddle.compat.split(x, split_size_or_sections=3, dim=-2)
             >>> print(out0.shape)
             paddle.Size([3, 3, 5])
             >>> print(out1.shape)

--- a/python/paddle/compat/__init__.py
+++ b/python/paddle/compat/__init__.py
@@ -820,37 +820,43 @@ def split(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> # x is a Tensor of shape [3, 8, 5]
             >>> x = paddle.rand([3, 8, 5])
 
-            >>> out0, out1, out2 = paddle.compat.split(x, split_size_or_sections=3, dim=1)
+            >>> out0, out1, out2 = paddle.compat.split(
+            ...     x, split_size_or_sections=3, dim=1
+            ... )
             >>> print(out0.shape)
-            [3, 3, 5]
+            paddle.Size([3, 3, 5])
             >>> print(out1.shape)
-            [3, 3, 5]
+            paddle.Size([3, 3, 5])
             >>> print(out2.shape)
-            [3, 2, 5]
+            paddle.Size([3, 2, 5])
 
-            >>> out0, out1, out2 = paddle.compat.split(x, split_size_or_sections=[1, 2, 5], dim=1)
+            >>> out0, out1, out2 = paddle.compat.split(
+            ...     x, split_size_or_sections=[1, 2, 5], dim=1
+            ... )
             >>> print(out0.shape)
-            [3, 1, 5]
+            paddle.Size([3, 1, 5])
             >>> print(out1.shape)
-            [3, 2, 5]
+            paddle.Size([3, 2, 5])
             >>> print(out2.shape)
-            [3, 5, 5]
+            paddle.Size([3, 5, 5])
 
             >>> # dim is negative, the real dim is (rank(x) + dim)=1
-            >>> out0, out1, out2 = paddle.compat.split(x, split_size_or_sections=3, dim=-2)
+            >>> out0, out1, out2 = paddle.compat.split(
+            ...     x, split_size_or_sections=3, dim=-2
+            ... )
             >>> print(out0.shape)
-            [3, 3, 5]
+            paddle.Size([3, 3, 5])
             >>> print(out1.shape)
-            [3, 3, 5]
+            paddle.Size([3, 3, 5])
             >>> print(out2.shape)
-            [3, 2, 5]
+            paddle.Size([3, 2, 5])
     """
 
     def GetSplitSize(split_size, shape_on_dim):

--- a/python/paddle/compat/nn/__init__.py
+++ b/python/paddle/compat/nn/__init__.py
@@ -111,9 +111,7 @@ class AvgPool1D(nn.Layer):
             >>> import paddle
             >>> import paddle.compat.nn as nn
 
-            >>> data = paddle.uniform(
-            ...     [1, 3, 32], dtype="float32", min=-1, max=1
-            ... )
+            >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
             >>> AvgPool1D = nn.AvgPool1D(kernel_size=2, stride=2, padding=0)
             >>> pool_out = AvgPool1D(data)
             >>> print(pool_out.shape)
@@ -228,9 +226,7 @@ class AvgPool2D(nn.Layer):
             >>> import paddle.compat.nn as nn
 
             >>> # max pool2d
-            >>> input = paddle.uniform(
-            ...     [1, 3, 32, 32], dtype="float32", min=-1, max=1
-            ... )
+            >>> input = paddle.uniform([1, 3, 32, 32], dtype="float32", min=-1, max=1)
             >>> AvgPool2D = nn.AvgPool2D(kernel_size=2, stride=2, padding=0)
             >>> output = AvgPool2D(input)
             >>> print(output.shape)
@@ -338,9 +334,7 @@ class AvgPool3D(nn.Layer):
             >>> import paddle.compat.nn as nn
 
             >>> # avg pool3d
-            >>> input = paddle.uniform(
-            ...     [1, 2, 3, 32, 32], dtype="float32", min=-1, max=1
-            ... )
+            >>> input = paddle.uniform([1, 2, 3, 32, 32], dtype="float32", min=-1, max=1)
             >>> AvgPool3D = nn.AvgPool3D(kernel_size=2, stride=2, padding=0)
             >>> output = AvgPool3D(input)
             >>> print(output.shape)

--- a/python/paddle/compat/nn/__init__.py
+++ b/python/paddle/compat/nn/__init__.py
@@ -106,16 +106,18 @@ class AvgPool1D(nn.Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.compat.nn as nn
 
-            >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
+            >>> data = paddle.uniform(
+            ...     [1, 3, 32], dtype="float32", min=-1, max=1
+            ... )
             >>> AvgPool1D = nn.AvgPool1D(kernel_size=2, stride=2, padding=0)
             >>> pool_out = AvgPool1D(data)
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
 
     """
 
@@ -220,17 +222,19 @@ class AvgPool2D(nn.Layer):
         A callable object of AvgPool2D.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.compat.nn as nn
 
             >>> # max pool2d
-            >>> input = paddle.uniform([1, 3, 32, 32], dtype="float32", min=-1, max=1)
+            >>> input = paddle.uniform(
+            ...     [1, 3, 32, 32], dtype="float32", min=-1, max=1
+            ... )
             >>> AvgPool2D = nn.AvgPool2D(kernel_size=2, stride=2, padding=0)
             >>> output = AvgPool2D(input)
             >>> print(output.shape)
-            [1, 3, 16, 16]
+            paddle.Size([1, 3, 16, 16])
 
     """
 
@@ -328,17 +332,19 @@ class AvgPool3D(nn.Layer):
           The data type is same as input x.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.compat.nn as nn
 
             >>> # avg pool3d
-            >>> input = paddle.uniform([1, 2, 3, 32, 32], dtype="float32", min=-1, max=1)
+            >>> input = paddle.uniform(
+            ...     [1, 2, 3, 32, 32], dtype="float32", min=-1, max=1
+            ... )
             >>> AvgPool3D = nn.AvgPool3D(kernel_size=2, stride=2, padding=0)
             >>> output = AvgPool3D(input)
             >>> print(output.shape)
-            [1, 2, 1, 16, 16]
+            paddle.Size([1, 2, 1, 16, 16])
 
     """
 
@@ -425,14 +431,14 @@ class Unfold(nn.Unfold):
             For default, it will be [1, 1].
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> x = paddle.randn((100, 3, 224, 224))
             >>> unfold = paddle.compat.nn.Unfold(kernel_size=[3, 3])
             >>> result = unfold(x)
             >>> print(result.shape)
-            [100, 27, 49284]
+            paddle.Size([100, 27, 49284])
     """
 
     kernel_sizes: Size2

--- a/python/paddle/distributed/auto_parallel/intermediate/context_parallel.py
+++ b/python/paddle/distributed/auto_parallel/intermediate/context_parallel.py
@@ -50,11 +50,7 @@ class PrepareContextParallel(PlanBase):
             ...         super().__init__()
             ...
             ...     def forward(self, q, k, v):
-            ...         return (
-            ...             paddle.nn.functional.scaled_dot_product_attention(
-            ...                 q, k, v
-            ...             )
-            ...         )
+            ...         return paddle.nn.functional.scaled_dot_product_attention(q, k, v)
             >>>
             >>> class AttentionLayer(paddle.nn.Layer):
             ...     def __init__(self):
@@ -249,9 +245,7 @@ class ContextParallel(PlanBase):
         ...         super().__init__()
         ...
         ...     def forward(self, q, k, v):
-        ...         return paddle.nn.functional.scaled_dot_product_attention(
-        ...             q, k, v
-        ...         )
+        ...         return paddle.nn.functional.scaled_dot_product_attention(q, k, v)
         >>>
         >>> class AttentionLayer(paddle.nn.Layer):
         ...     def __init__(self):

--- a/python/paddle/distributed/auto_parallel/static/cost/op_runtime_cost.py
+++ b/python/paddle/distributed/auto_parallel/static/cost/op_runtime_cost.py
@@ -269,9 +269,7 @@ def measure_program_real_op_cost(
     >>> from paddle.distributed.auto_parallel.static.utils import (
     ...     measure_program_real_op_cost,
     ... )
-    >>> place: str = (
-    ...     paddle.device.get_device()
-    ... )  # here we assume place = "cuda:x"
+    >>> place: str = paddle.device.get_device()  # here we assume place = "cuda:x"
     >>> place = paddle.CUDAPlace(int(place.split(':')[1]))
     >>> # here "program" is an inner object that has already been built before
     >>> measure_program_real_op_cost(program, verbose_level=1)

--- a/python/paddle/distributed/fleet/utils/hybrid_parallel_inference.py
+++ b/python/paddle/distributed/fleet/utils/hybrid_parallel_inference.py
@@ -50,15 +50,9 @@ class HybridParallelInferenceHelper:
             >>> # while op pattern
             >>> with paddle.base.device_guard(f'{device}:all'):
             ...     # init global cond
-            ...     max_len = paddle.full(
-            ...         shape=[1], dtype="int64", fill_value=10
-            ...     )
-            ...     step_idx = paddle.full(
-            ...         shape=[1], dtype="int64", fill_value=0
-            ...     )
-            ...     cond_int = paddle.full(
-            ...         shape=[1], dtype="int64", fill_value=0, name="cond_int"
-            ...     )
+            ...     max_len = paddle.full(shape=[1], dtype="int64", fill_value=10)
+            ...     step_idx = paddle.full(shape=[1], dtype="int64", fill_value=0)
+            ...     cond_int = paddle.full(shape=[1], dtype="int64", fill_value=0, name="cond_int")
             ...     cond = layers.cast(step_idx < max_len, dtype="bool")
             ...     while_op = layers.While(cond, is_test=True)
 
@@ -68,15 +62,11 @@ class HybridParallelInferenceHelper:
             >>> with while_op.block():
             ...     with paddle.base.device_guard(f'{device}:all'):
             ...         # read data from global lod_tensor_array
-            ...         element_in_arr = paddle.tensor.array_read(
-            ...             array=arr, i=step_idx
-            ...         )
+            ...         element_in_arr = paddle.tensor.array_read(array=arr, i=step_idx)
             ...         # write placeholder data to global lod_tensor_array,
             ...         # it need for send_v2 of lod_tensor_array
             ...         paddle.increment(x=step_idx, value=1.0)
-            ...         paddle.tensor.array_write(
-            ...             element_in_arr, i=step_idx, array=arr
-            ...         )
+            ...         paddle.tensor.array_write(element_in_arr, i=step_idx, array=arr)
             ...     with paddle.base.device_guard(f'{device}:0'):
             ...         pass  # some code
             ...     with paddle.base.device_guard(f'{device}:1'):
@@ -85,13 +75,9 @@ class HybridParallelInferenceHelper:
             ...         # generate some data in while block and write to global lod_tensor_array
             ...         # that they are read in next while step.
             ...         # we will using send_v2 to send global lod_tensor_array to other pipeline and sync
-            ...         paddle.tensor.array_write(
-            ...             other_var, i=step_idx, array=arr
-            ...         )
+            ...         paddle.tensor.array_write(other_var, i=step_idx, array=arr)
             ...         # update cond and assign to cond_int, we will sync cond_int
-            ...         layers.assign(
-            ...             layers.cast(cond, dtype="int32"), cond_int
-            ...         )
+            ...         layers.assign(layers.cast(cond, dtype="int32"), cond_int)
             ...     with paddle.base.device_guard(f'{model._device}:all'):
             ...         # the code below must at end of while block and exists in device:all
             ...         layers.assign(layers.cast(cond_int, dtype='bool'), cond)

--- a/python/paddle/distribution/bernoulli.py
+++ b/python/paddle/distribution/bernoulli.py
@@ -238,11 +238,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
 
                 >>> # `rsample` has to be followed by a `sigmoid`
                 >>> rv = Bernoulli(0.3)
-                >>> rsample = rv.rsample(
-                ...     [
-                ...         3,
-                ...     ]
-                ... )
+                >>> rsample = rv.rsample([3])
                 >>> rsample_sigmoid = paddle.nn.functional.sigmoid(rsample)
                 >>> print(rsample)
                 Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -255,9 +251,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
                 >>> print(
                 ...     paddle.nn.functional.sigmoid(
                 ...         rv.rsample(
-                ...             [
-                ...                 1000,
-                ...             ],
+                ...             [1000],
                 ...             temperature=1.0,
                 ...         )
                 ...     ).sum()
@@ -270,9 +264,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
                 >>> print(
                 ...     paddle.nn.functional.sigmoid(
                 ...         rv.rsample(
-                ...             [
-                ...                 1000,
-                ...             ],
+                ...             [1000],
                 ...             temperature=0.1,
                 ...         )
                 ...     ).sum()

--- a/python/paddle/distribution/bernoulli.py
+++ b/python/paddle/distribution/bernoulli.py
@@ -157,26 +157,26 @@ class Bernoulli(exponential_family.ExponentialFamily):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Bernoulli
 
                 >>> rv = Bernoulli(paddle.full([1], 0.3))
                 >>> print(rv.sample([100]).shape)
-                [100, 1]
+                paddle.Size([100, 1])
 
                 >>> rv = Bernoulli(paddle.to_tensor(0.3))
                 >>> print(rv.sample([100]).shape)
-                [100]
+                paddle.Size([100])
 
                 >>> rv = Bernoulli(paddle.to_tensor([0.3, 0.5]))
                 >>> print(rv.sample([100]).shape)
-                [100, 2]
+                paddle.Size([100, 2])
 
                 >>> rv = Bernoulli(paddle.to_tensor([0.3, 0.5]))
                 >>> print(rv.sample([100, 2]).shape)
-                [100, 2, 2]
+                paddle.Size([100, 2, 2])
         """
         name = self.name + '_sample'
         if not in_dynamic_mode():
@@ -214,7 +214,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> paddle.seed(1)
@@ -222,23 +222,27 @@ class Bernoulli(exponential_family.ExponentialFamily):
 
                 >>> rv = Bernoulli(paddle.full([1], 0.3))
                 >>> print(rv.sample([100]).shape)
-                [100, 1]
+                paddle.Size([100, 1])
 
                 >>> rv = Bernoulli(0.3)
                 >>> print(rv.rsample([100]).shape)
-                [100]
+                paddle.Size([100])
 
                 >>> rv = Bernoulli(paddle.to_tensor([0.3, 0.5]))
                 >>> print(rv.rsample([100]).shape)
-                [100, 2]
+                paddle.Size([100, 2])
 
                 >>> rv = Bernoulli(paddle.to_tensor([0.3, 0.5]))
                 >>> print(rv.rsample([100, 2]).shape)
-                [100, 2, 2]
+                paddle.Size([100, 2, 2])
 
                 >>> # `rsample` has to be followed by a `sigmoid`
                 >>> rv = Bernoulli(0.3)
-                >>> rsample = rv.rsample([3, ])
+                >>> rsample = rv.rsample(
+                ...     [
+                ...         3,
+                ...     ]
+                ... )
                 >>> rsample_sigmoid = paddle.nn.functional.sigmoid(rsample)
                 >>> print(rsample)
                 Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -248,13 +252,31 @@ class Bernoulli(exponential_family.ExponentialFamily):
                 [0.18829606, 0.49690047, 0.20954758])
 
                 >>> # The smaller the `temperature`, the distribution of `rsample` closer to `sample`, with `probs` of 0.3.
-                >>> print(paddle.nn.functional.sigmoid(rv.rsample([1000, ], temperature=1.0)).sum())
+                >>> print(
+                ...     paddle.nn.functional.sigmoid(
+                ...         rv.rsample(
+                ...             [
+                ...                 1000,
+                ...             ],
+                ...             temperature=1.0,
+                ...         )
+                ...     ).sum()
+                ... )
                 >>> # doctest: +SKIP('output will be different')
                 Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
                 365.63122559)
                 >>> # doctest: -SKIP
 
-                >>> print(paddle.nn.functional.sigmoid(rv.rsample([1000, ], temperature=0.1)).sum())
+                >>> print(
+                ...     paddle.nn.functional.sigmoid(
+                ...         rv.rsample(
+                ...             [
+                ...                 1000,
+                ...             ],
+                ...             temperature=0.1,
+                ...         )
+                ...     ).sum()
+                ... )
                 Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
                 320.15057373)
         """

--- a/python/paddle/distribution/cauchy.py
+++ b/python/paddle/distribution/cauchy.py
@@ -138,7 +138,7 @@ class Cauchy(distribution.Distribution):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Cauchy
@@ -146,26 +146,34 @@ class Cauchy(distribution.Distribution):
                 >>> # init Cauchy with float
                 >>> rv = Cauchy(loc=0.1, scale=1.2)
                 >>> print(rv.sample([10]).shape)
-                [10]
+                paddle.Size([10])
 
                 >>> # init Cauchy with 0-Dim tensor
-                >>> rv = Cauchy(loc=paddle.full((), 0.1), scale=paddle.full((), 1.2))
+                >>> rv = Cauchy(
+                ...     loc=paddle.full((), 0.1), scale=paddle.full((), 1.2)
+                ... )
                 >>> print(rv.sample([10]).shape)
-                [10]
+                paddle.Size([10])
 
                 >>> # init Cauchy with N-Dim tensor
-                >>> rv = Cauchy(loc=paddle.to_tensor(0.1), scale=paddle.to_tensor([1.0, 2.0]))
+                >>> rv = Cauchy(
+                ...     loc=paddle.to_tensor(0.1),
+                ...     scale=paddle.to_tensor([1.0, 2.0]),
+                ... )
                 >>> print(rv.sample([10]).shape)
-                [10, 2]
+                paddle.Size([10, 2])
 
                 >>> # sample 2-Dim data
                 >>> rv = Cauchy(loc=0.1, scale=1.2)
                 >>> print(rv.sample([10, 2]).shape)
-                [10, 2]
+                paddle.Size([10, 2])
 
-                >>> rv = Cauchy(loc=paddle.to_tensor(0.1), scale=paddle.to_tensor([1.0, 2.0]))
+                >>> rv = Cauchy(
+                ...     loc=paddle.to_tensor(0.1),
+                ...     scale=paddle.to_tensor([1.0, 2.0]),
+                ... )
                 >>> print(rv.sample([10, 2]).shape)
-                [10, 2, 2]
+                paddle.Size([10, 2, 2])
         """
         name = name if name is not None else (self.name + '_sample')
         with paddle.no_grad():
@@ -185,7 +193,7 @@ class Cauchy(distribution.Distribution):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Cauchy
@@ -193,26 +201,34 @@ class Cauchy(distribution.Distribution):
                 >>> # init Cauchy with float
                 >>> rv = Cauchy(loc=0.1, scale=1.2)
                 >>> print(rv.rsample([10]).shape)
-                [10]
+                paddle.Size([10])
 
                 >>> # init Cauchy with 0-Dim tensor
-                >>> rv = Cauchy(loc=paddle.full((), 0.1), scale=paddle.full((), 1.2))
+                >>> rv = Cauchy(
+                ...     loc=paddle.full((), 0.1), scale=paddle.full((), 1.2)
+                ... )
                 >>> print(rv.rsample([10]).shape)
-                [10]
+                paddle.Size([10])
 
                 >>> # init Cauchy with N-Dim tensor
-                >>> rv = Cauchy(loc=paddle.to_tensor(0.1), scale=paddle.to_tensor([1.0, 2.0]))
+                >>> rv = Cauchy(
+                ...     loc=paddle.to_tensor(0.1),
+                ...     scale=paddle.to_tensor([1.0, 2.0]),
+                ... )
                 >>> print(rv.rsample([10]).shape)
-                [10, 2]
+                paddle.Size([10, 2])
 
                 >>> # sample 2-Dim data
                 >>> rv = Cauchy(loc=0.1, scale=1.2)
                 >>> print(rv.rsample([10, 2]).shape)
-                [10, 2]
+                paddle.Size([10, 2])
 
-                >>> rv = Cauchy(loc=paddle.to_tensor(0.1), scale=paddle.to_tensor([1.0, 2.0]))
+                >>> rv = Cauchy(
+                ...     loc=paddle.to_tensor(0.1),
+                ...     scale=paddle.to_tensor([1.0, 2.0]),
+                ... )
                 >>> print(rv.rsample([10, 2]).shape)
-                [10, 2, 2]
+                paddle.Size([10, 2, 2])
         """
         name = name if name is not None else (self.name + '_rsample')
 

--- a/python/paddle/distribution/cauchy.py
+++ b/python/paddle/distribution/cauchy.py
@@ -149,9 +149,7 @@ class Cauchy(distribution.Distribution):
                 paddle.Size([10])
 
                 >>> # init Cauchy with 0-Dim tensor
-                >>> rv = Cauchy(
-                ...     loc=paddle.full((), 0.1), scale=paddle.full((), 1.2)
-                ... )
+                >>> rv = Cauchy(loc=paddle.full((), 0.1), scale=paddle.full((), 1.2))
                 >>> print(rv.sample([10]).shape)
                 paddle.Size([10])
 
@@ -204,9 +202,7 @@ class Cauchy(distribution.Distribution):
                 paddle.Size([10])
 
                 >>> # init Cauchy with 0-Dim tensor
-                >>> rv = Cauchy(
-                ...     loc=paddle.full((), 0.1), scale=paddle.full((), 1.2)
-                ... )
+                >>> rv = Cauchy(loc=paddle.full((), 0.1), scale=paddle.full((), 1.2))
                 >>> print(rv.rsample([10]).shape)
                 paddle.Size([10])
 

--- a/python/paddle/distribution/chi2.py
+++ b/python/paddle/distribution/chi2.py
@@ -37,13 +37,13 @@ class Chi2(Gamma):
         df (float or Tensor): The degree of freedom of the distribution, which should be non-negative. If the input data type is Tensor, it indicates the batch creation of distributions with multiple different parameters, and the `batch_shape` (refer to the :ref:`api_paddle_distribution_Distribution` base class) is the parameter.
 
     Example:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> m = paddle.distribution.Chi2(paddle.to_tensor([1.0]))
             >>> sample = m.sample()
             >>> sample.shape
-            [1]
+            paddle.Size([1])
 
     """
 

--- a/python/paddle/distribution/lkj_cholesky.py
+++ b/python/paddle/distribution/lkj_cholesky.py
@@ -137,7 +137,7 @@ class LKJCholesky(distribution.Distribution):
         sample_method (str, optional): The sampling method to use, either "onion" or "cvine". Default is "onion".
 
     Example:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -145,7 +145,7 @@ class LKJCholesky(distribution.Distribution):
             >>> lkj = paddle.distribution.LKJCholesky(dim=dim)
             >>> sample = lkj.sample()
             >>> sample.shape
-            [3, 3]
+            paddle.Size([3, 3])
     """
 
     concentration: Tensor

--- a/python/paddle/incubate/nn/functional/block_multihead_attention.py
+++ b/python/paddle/incubate/nn/functional/block_multihead_attention.py
@@ -125,24 +125,18 @@ def block_multihead_attention(
             >>> paddle.device.set_device('gpu')
 
             >>> def get_padding_offset(bsz, max_seq_len, seq_lens_this_time):
-            ...     cum_offsets_now = paddle.cumsum(
-            ...         max_seq_len - seq_lens_this_time
-            ...     )
+            ...     cum_offsets_now = paddle.cumsum(max_seq_len - seq_lens_this_time)
             ...     cum_offsets = paddle.zeros(shape=(bsz + 1), dtype="int32")
             ...     cum_offsets[1:] = cum_offsets_now
             ...     token_num = paddle.sum(seq_lens_this_time)
-            ...     padding_offsets = paddle.zeros(
-            ...         shape=(token_num), dtype="int32"
-            ...     )
+            ...     padding_offsets = paddle.zeros(shape=(token_num), dtype="int32")
             ...     cu_seqlens_q = paddle.zeros(shape=(bsz + 1), dtype="int32")
             ...     cu_seqlens_k = paddle.zeros(shape=(bsz + 1), dtype="int32")
             ...     for i in range(bsz):
             ...         seq_len_now = seq_lens_this_time[i]
             ...         cum_offset = cum_offsets[i]
             ...         for j in range(seq_len_now):
-            ...             padding_offsets[
-            ...                 i * max_seq_len - cum_offset + j
-            ...             ] = cum_offset
+            ...             padding_offsets[i * max_seq_len - cum_offset + j] = cum_offset
             ...         cum_seq_len = (i + 1) * max_seq_len - cum_offsets[i + 1]
             ...         cu_seqlens_q[i + 1] = cum_seq_len
             ...         cu_seqlens_k[i + 1] = cum_seq_len
@@ -159,16 +153,12 @@ def block_multihead_attention(
             ...         shape=[token_num, num_head * head_size],
             ...         dtype=inputs.dtype,
             ...     )
-            ...     inputs = inputs.transpose([0, 2, 1, 3]).reshape(
-            ...         [bsz, seq_len, -1]
-            ...     )
+            ...     inputs = inputs.transpose([0, 2, 1, 3]).reshape([bsz, seq_len, -1])
             ...     for i in range(bsz):
             ...         seq_len_now = seq_lens[i]
             ...         start_idx = cu_seq_lens[i]
             ...         end_idx = cu_seq_lens[i + 1]
-            ...         output[start_idx:end_idx, :] = inputs[
-            ...             i, :seq_len_now, :
-            ...         ]
+            ...         output[start_idx:end_idx, :] = inputs[i, :seq_len_now, :]
             ...     return output
 
             >>> def create_attn_mask(
@@ -190,14 +180,7 @@ def block_multihead_attention(
             ...     mask[:, :, :, :pre_cache_length] = 1
             ...     for i in range(batch_size):
             ...         seq_len = seq_lens[i]
-            ...         mask[i, 0, :seq_len, :seq_len] = (
-            ...             paddle.tril(
-            ...                 paddle.ones(
-            ...                     shape=(seq_len, seq_len), dtype=mask_type
-            ...                 )
-            ...             )
-            ...             - 1
-            ...         ) * 1e4
+            ...         mask[i, 0, :seq_len, :seq_len] = (paddle.tril(paddle.ones(shape=(seq_len, seq_len), dtype=mask_type)) - 1) * 1e4
             ...     return mask
 
             >>> def naive_attention_impl(
@@ -223,9 +206,7 @@ def block_multihead_attention(
             ...         key = paddle.concat([pre_cache_k, key], axis=2)
             ...     if cache_k is not None:
             ...         key = paddle.concat([cache_k, key], axis=2)
-            ...     value = value.reshape(
-            ...         [batch, kv_head, 1, seq_len, head_dim]
-            ...     )
+            ...     value = value.reshape([batch, kv_head, 1, seq_len, head_dim])
             ...     value = paddle.tile(value, [1, 1, heads // kv_head, 1, 1])
             ...     value = value.reshape([batch, heads, seq_len, head_dim])
             ...     if pre_cache_v is not None:
@@ -247,9 +228,7 @@ def block_multihead_attention(
             >>> head_size = 64
             >>> hid_dim = num_head * head_size
             >>> block_size = 64
-            >>> block_num_per_seq = (
-            ...     seq_len + max_dec_len + block_size - 1
-            ... ) // block_size
+            >>> block_num_per_seq = (seq_len + max_dec_len + block_size - 1) // block_size
             >>> max_block_num = block_num_per_seq * batch_size
             >>> free_list = list(range(max_block_num - 1, -1, -1))
             >>> token_num = seq_len * batch_size
@@ -292,18 +271,12 @@ def block_multihead_attention(
             >>> cache_shape = (max_block_num, num_head, block_size, head_size)
             >>> cache_k = paddle.zeros(cache_shape, dtype=dtype)
             >>> cache_v = paddle.zeros(cache_shape, dtype=dtype)
-            >>> block_tables = paddle.zeros(
-            ...     shape=(batch_size, block_num_per_seq), dtype="int32"
-            ... )
+            >>> block_tables = paddle.zeros(shape=(batch_size, block_num_per_seq), dtype="int32")
             >>> for i in range(batch_size):
-            ...     need_block_num = (
-            ...         seq_len + max_dec_len + block_size - 1
-            ...     ) // block_size
+            ...     need_block_num = (seq_len + max_dec_len + block_size - 1) // block_size
             ...     for j in range(need_block_num):
             ...         block_tables[i, j] = free_list.pop()
-            >>> padding_offset, cum_offset, cu_seqlens_q, cu_seqlens_k = (
-            ...     get_padding_offset(batch_size, seq_len, seq_lens_this_time)
-            ... )
+            >>> padding_offset, cum_offset, cu_seqlens_q, cu_seqlens_k = get_padding_offset(batch_size, seq_len, seq_lens_this_time)
             >>> out = block_multihead_attention(
             ...     qkv,
             ...     cache_k,
@@ -344,12 +317,8 @@ def block_multihead_attention(
             ...     * batch_size,
             ... )
 
-            >>> out_ref = naive_attention_impl(
-            ...     q, k, v, None, None, None, None, attention_mask, scale
-            ... )
-            >>> out_ref = remove_padding(
-            ...     seq_lens_this_time, cu_seqlens_q, out_ref, token_num
-            ... )
+            >>> out_ref = naive_attention_impl(q, k, v, None, None, None, None, attention_mask, scale)
+            >>> out_ref = remove_padding(seq_lens_this_time, cu_seqlens_q, out_ref, token_num)
             >>> # equals to: out_ref = out
 
             >>> print(out.shape)  # [token_num, hid_dim]

--- a/python/paddle/incubate/nn/functional/block_multihead_attention.py
+++ b/python/paddle/incubate/nn/functional/block_multihead_attention.py
@@ -169,12 +169,7 @@ def block_multihead_attention(
             ... ):
             ...     max_seq_len = max(seq_lens)
             ...     mask = paddle.zeros(
-            ...         [
-            ...             batch_size,
-            ...             1,
-            ...             max_seq_len,
-            ...             max_seq_len + pre_cache_length,
-            ...         ],
+            ...         [batch_size, 1, max_seq_len, max_seq_len + pre_cache_length],
             ...         dtype=mask_type,
             ...     )
             ...     mask[:, :, :, :pre_cache_length] = 1
@@ -243,10 +238,7 @@ def block_multihead_attention(
             ...     "int32",
             ... )
             >>> seq_lens_decoder = paddle.to_tensor(
-            ...     [
-            ...         0,
-            ...     ]
-            ...     * batch_size,
+            ...     [0] * batch_size,
             ...     "int32",
             ... )
             >>> seq_lens_this_time = seq_lens_encoder

--- a/python/paddle/incubate/nn/functional/block_multihead_attention.py
+++ b/python/paddle/incubate/nn/functional/block_multihead_attention.py
@@ -113,42 +113,62 @@ def block_multihead_attention(
         block_multihead_attention layers, qkv_out is inplace with input `qkv`, cache_k_out and cache_v_out are inplace with input `cache_k` and `cache_v`.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('Need compile flash attention')
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import numpy as np
             >>> import paddle
-            >>> from paddle.incubate.nn.functional import block_multihead_attention
+            >>> from paddle.incubate.nn.functional import (
+            ...     block_multihead_attention,
+            ... )
             >>> paddle.device.set_device('gpu')
 
             >>> def get_padding_offset(bsz, max_seq_len, seq_lens_this_time):
-            ...     cum_offsets_now = paddle.cumsum(max_seq_len - seq_lens_this_time)
+            ...     cum_offsets_now = paddle.cumsum(
+            ...         max_seq_len - seq_lens_this_time
+            ...     )
             ...     cum_offsets = paddle.zeros(shape=(bsz + 1), dtype="int32")
             ...     cum_offsets[1:] = cum_offsets_now
             ...     token_num = paddle.sum(seq_lens_this_time)
-            ...     padding_offsets = paddle.zeros(shape=(token_num), dtype="int32")
+            ...     padding_offsets = paddle.zeros(
+            ...         shape=(token_num), dtype="int32"
+            ...     )
             ...     cu_seqlens_q = paddle.zeros(shape=(bsz + 1), dtype="int32")
             ...     cu_seqlens_k = paddle.zeros(shape=(bsz + 1), dtype="int32")
             ...     for i in range(bsz):
             ...         seq_len_now = seq_lens_this_time[i]
             ...         cum_offset = cum_offsets[i]
             ...         for j in range(seq_len_now):
-            ...             padding_offsets[i * max_seq_len - cum_offset + j] = cum_offset
+            ...             padding_offsets[
+            ...                 i * max_seq_len - cum_offset + j
+            ...             ] = cum_offset
             ...         cum_seq_len = (i + 1) * max_seq_len - cum_offsets[i + 1]
             ...         cu_seqlens_q[i + 1] = cum_seq_len
             ...         cu_seqlens_k[i + 1] = cum_seq_len
-            ...     return padding_offsets, cum_offsets[:-1], cu_seqlens_q, cu_seqlens_k
+            ...     return (
+            ...         padding_offsets,
+            ...         cum_offsets[:-1],
+            ...         cu_seqlens_q,
+            ...         cu_seqlens_k,
+            ...     )
 
             >>> def remove_padding(seq_lens, cu_seq_lens, inputs, token_num):
             ...     bsz, num_head, seq_len, head_size = inputs.shape
-            ...     output = paddle.zeros(shape=[token_num, num_head * head_size], dtype=inputs.dtype)
-            ...     inputs = inputs.transpose([0, 2, 1, 3]).reshape([bsz, seq_len, -1])
+            ...     output = paddle.zeros(
+            ...         shape=[token_num, num_head * head_size],
+            ...         dtype=inputs.dtype,
+            ...     )
+            ...     inputs = inputs.transpose([0, 2, 1, 3]).reshape(
+            ...         [bsz, seq_len, -1]
+            ...     )
             ...     for i in range(bsz):
             ...         seq_len_now = seq_lens[i]
             ...         start_idx = cu_seq_lens[i]
             ...         end_idx = cu_seq_lens[i + 1]
-            ...         output[start_idx:end_idx, :] = inputs[i, :seq_len_now, :]
+            ...         output[start_idx:end_idx, :] = inputs[
+            ...             i, :seq_len_now, :
+            ...         ]
             ...     return output
 
             >>> def create_attn_mask(
@@ -159,19 +179,38 @@ def block_multihead_attention(
             ... ):
             ...     max_seq_len = max(seq_lens)
             ...     mask = paddle.zeros(
-            ...         [batch_size, 1, max_seq_len, max_seq_len + pre_cache_length],
+            ...         [
+            ...             batch_size,
+            ...             1,
+            ...             max_seq_len,
+            ...             max_seq_len + pre_cache_length,
+            ...         ],
             ...         dtype=mask_type,
             ...     )
             ...     mask[:, :, :, :pre_cache_length] = 1
             ...     for i in range(batch_size):
             ...         seq_len = seq_lens[i]
             ...         mask[i, 0, :seq_len, :seq_len] = (
-            ...             paddle.tril(paddle.ones(shape=(seq_len, seq_len), dtype=mask_type))
+            ...             paddle.tril(
+            ...                 paddle.ones(
+            ...                     shape=(seq_len, seq_len), dtype=mask_type
+            ...                 )
+            ...             )
             ...             - 1
             ...         ) * 1e4
             ...     return mask
 
-            >>> def naive_attention_impl(query, key, value, cache_k, cache_v, pre_cache_k, pre_cache_v, mask, scale=1.0):
+            >>> def naive_attention_impl(
+            ...     query,
+            ...     key,
+            ...     value,
+            ...     cache_k,
+            ...     cache_v,
+            ...     pre_cache_k,
+            ...     pre_cache_v,
+            ...     mask,
+            ...     scale=1.0,
+            ... ):
             ...     batch = query.shape[0]
             ...     heads = query.shape[1]
             ...     seq_len = query.shape[2]
@@ -184,7 +223,9 @@ def block_multihead_attention(
             ...         key = paddle.concat([pre_cache_k, key], axis=2)
             ...     if cache_k is not None:
             ...         key = paddle.concat([cache_k, key], axis=2)
-            ...     value = value.reshape([batch, kv_head, 1, seq_len, head_dim])
+            ...     value = value.reshape(
+            ...         [batch, kv_head, 1, seq_len, head_dim]
+            ...     )
             ...     value = paddle.tile(value, [1, 1, heads // kv_head, 1, 1])
             ...     value = value.reshape([batch, heads, seq_len, head_dim])
             ...     if pre_cache_v is not None:
@@ -206,7 +247,9 @@ def block_multihead_attention(
             >>> head_size = 64
             >>> hid_dim = num_head * head_size
             >>> block_size = 64
-            >>> block_num_per_seq = (seq_len + max_dec_len + block_size - 1) // block_size
+            >>> block_num_per_seq = (
+            ...     seq_len + max_dec_len + block_size - 1
+            ... ) // block_size
             >>> max_block_num = block_num_per_seq * batch_size
             >>> free_list = list(range(max_block_num - 1, -1, -1))
             >>> token_num = seq_len * batch_size
@@ -237,20 +280,31 @@ def block_multihead_attention(
             >>> q = paddle.randn(shape=qkv_shape, dtype=dtype)
             >>> k = paddle.randn(shape=qkv_shape, dtype=dtype)
             >>> v = paddle.randn(shape=qkv_shape, dtype=dtype)
-            >>> qkv = paddle.stack([q.transpose([0, 2, 1, 3]).reshape([token_num, hid_dim]),
-            ...                     k.transpose([0, 2, 1, 3]).reshape([token_num, hid_dim]),
-            ...                     v.transpose([0, 2, 1, 3]).reshape([token_num, hid_dim])], axis=1).reshape([token_num, -1])
+            >>> qkv = paddle.stack(
+            ...     [
+            ...         q.transpose([0, 2, 1, 3]).reshape([token_num, hid_dim]),
+            ...         k.transpose([0, 2, 1, 3]).reshape([token_num, hid_dim]),
+            ...         v.transpose([0, 2, 1, 3]).reshape([token_num, hid_dim]),
+            ...     ],
+            ...     axis=1,
+            ... ).reshape([token_num, -1])
             >>> scale = 1.0 / np.sqrt(head_size)
             >>> cache_shape = (max_block_num, num_head, block_size, head_size)
             >>> cache_k = paddle.zeros(cache_shape, dtype=dtype)
             >>> cache_v = paddle.zeros(cache_shape, dtype=dtype)
-            >>> block_tables = paddle.zeros(shape=(batch_size, block_num_per_seq), dtype="int32")
+            >>> block_tables = paddle.zeros(
+            ...     shape=(batch_size, block_num_per_seq), dtype="int32"
+            ... )
             >>> for i in range(batch_size):
-            ...     need_block_num = (seq_len + max_dec_len + block_size - 1) // block_size
+            ...     need_block_num = (
+            ...         seq_len + max_dec_len + block_size - 1
+            ...     ) // block_size
             ...     for j in range(need_block_num):
             ...         block_tables[i, j] = free_list.pop()
-            >>> padding_offset, cum_offset, cu_seqlens_q, cu_seqlens_k = get_padding_offset(batch_size, seq_len, seq_lens_this_time)
-            >>> out  = block_multihead_attention(
+            >>> padding_offset, cum_offset, cu_seqlens_q, cu_seqlens_k = (
+            ...     get_padding_offset(batch_size, seq_len, seq_lens_this_time)
+            ... )
+            >>> out = block_multihead_attention(
             ...     qkv,
             ...     cache_k,
             ...     cache_v,
@@ -262,23 +316,23 @@ def block_multihead_attention(
             ...     cu_seqlens_q,
             ...     cu_seqlens_k,
             ...     block_tables,
-            ...     None, # pre_key_cache
-            ...     None, # pre_value_cache
-            ...     None, # cache_k_quant_scales
-            ...     None, # cache_v_quant_scales
-            ...     None, # cache_k_dequant_scales
-            ...     None, # cache_v_dequant_scales
-            ...     None, # qkv_out_scale
-            ...     None, # qkv_bias
-            ...     None, # out_shift
-            ...     None, # out_smooth
-            ...     None, # max_enc_len_this_time
-            ...     None, # max_dec_len_this_time
-            ...     None, # rotary_embs
-            ...     None, # attn_mask
-            ...     None, # tgt_mask
+            ...     None,  # pre_key_cache
+            ...     None,  # pre_value_cache
+            ...     None,  # cache_k_quant_scales
+            ...     None,  # cache_v_quant_scales
+            ...     None,  # cache_k_dequant_scales
+            ...     None,  # cache_v_dequant_scales
+            ...     None,  # qkv_out_scale
+            ...     None,  # qkv_bias
+            ...     None,  # out_shift
+            ...     None,  # out_smooth
+            ...     None,  # max_enc_len_this_time
+            ...     None,  # max_dec_len_this_time
+            ...     None,  # rotary_embs
+            ...     None,  # attn_mask
+            ...     None,  # tgt_mask
             ...     seq_len,
-            ...     block_size
+            ...     block_size,
             ... )[0]
 
             >>> attention_mask = create_attn_mask(
@@ -290,12 +344,16 @@ def block_multihead_attention(
             ...     * batch_size,
             ... )
 
-            >>> out_ref = naive_attention_impl(q, k, v, None, None, None, None, attention_mask, scale)
-            >>> out_ref = remove_padding(seq_lens_this_time, cu_seqlens_q, out_ref, token_num)
+            >>> out_ref = naive_attention_impl(
+            ...     q, k, v, None, None, None, None, attention_mask, scale
+            ... )
+            >>> out_ref = remove_padding(
+            ...     seq_lens_this_time, cu_seqlens_q, out_ref, token_num
+            ... )
             >>> # equals to: out_ref = out
 
-            >>> print(out.shape) # [token_num, hid_dim]
-            [128, 512]
+            >>> print(out.shape)  # [token_num, hid_dim]
+            paddle.Size([128, 512])
     """
 
     if in_dynamic_or_pir_mode():

--- a/python/paddle/incubate/nn/functional/fp8.py
+++ b/python/paddle/incubate/nn/functional/fp8.py
@@ -51,9 +51,9 @@ def fused_stack_transpose_quant(
             - scale (Tensor): A float32 tensor representing the quantization scale.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
-            >>> # doctest: +REQUIRES(env:GPU)
+            >>> # doctest: +SKIP('BF16 requires SM80 or higher env')
             >>> import paddle
             >>> import paddle.incubate.nn.functional as F
             >>> paddle.set_device('gpu')
@@ -67,11 +67,13 @@ def fused_stack_transpose_quant(
             ...     x = paddle.clip(x, min=-50, max=50)
             ...     x_vec.append(x)
 
-            >>> out, scale = F.fused_stack_transpose_quant(x_vec, transpose=True)
+            >>> out, scale = F.fused_stack_transpose_quant(
+            ...     x_vec, transpose=True
+            ... )
             >>> print(out.shape)
-            [128, 2048]
+            paddle.Size([128, 2048])
             >>> print(scale.shape)
-            [1, 16]
+            paddle.Size([1, 16])
     """
     if in_dynamic_or_pir_mode():
         if transpose:
@@ -147,9 +149,9 @@ def fused_swiglu_weighted_bwd(
               This avoids storing forward activations, trading computation for memory.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
-            >>> # doctest: +REQUIRES(env:GPU)
+            >>> # doctest: +SKIP('BF16 requires SM80 or higher env')
             >>> import paddle
             >>> import paddle.incubate.nn.functional as F
             >>> paddle.set_device('gpu')
@@ -157,17 +159,26 @@ def fused_swiglu_weighted_bwd(
             >>> batch_size, seq_len = 32, 128
             >>> intermediate_size = 2048
 
-            >>> o1 = paddle.randn([batch_size, seq_len, intermediate_size * 2], dtype='bfloat16')
-            >>> do2_s = paddle.randn([batch_size, seq_len, intermediate_size], dtype='bfloat16')
-            >>> expert_probs = paddle.rand([batch_size, seq_len, 1], dtype='float32')
+            >>> o1 = paddle.randn(
+            ...     [batch_size, seq_len, intermediate_size * 2],
+            ...     dtype='bfloat16',
+            ... )
+            >>> do2_s = paddle.randn(
+            ...     [batch_size, seq_len, intermediate_size], dtype='bfloat16'
+            ... )
+            >>> expert_probs = paddle.rand(
+            ...     [batch_size, seq_len, 1], dtype='float32'
+            ... )
 
-            >>> do1, probs_grad, o2_s = F.fused_swiglu_weighted_bwd(o1, do2_s, expert_probs)
+            >>> do1, probs_grad, o2_s = F.fused_swiglu_weighted_bwd(
+            ...     o1, do2_s, expert_probs
+            ... )
             >>> print(do1.shape)
-            [32, 128, 4096]
+            paddle.Size([32, 128, 4096])
             >>> print(probs_grad.shape)
-            [32, 128, 1]
+            paddle.Size([32, 128, 1])
             >>> print(o2_s.shape)
-            [32, 128, 2048]
+            paddle.Size([32, 128, 2048])
     """
     if in_dynamic_or_pir_mode():
         return _C_ops.fused_swiglu_weighted_bwd(o1, do2_s, unzipped_probs)
@@ -207,9 +218,9 @@ def fused_transpose_split_quant(
               and dtype float32. These are the reciprocal of quantization scales.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
-            >>> # doctest: +REQUIRES(env:GPU)
+            >>> # doctest: +SKIP('BF16 requires SM80 or higher env')
             >>> import paddle
             >>> import paddle.incubate.nn.functional as F
             >>> paddle.set_device('gpu')
@@ -217,11 +228,13 @@ def fused_transpose_split_quant(
             >>> x = paddle.randn([384, 512], dtype='bfloat16')
             >>> x = paddle.clip(x, min=-50, max=50)
             >>> tokens_per_expert = [128, 128, 128]
-            >>> outs, scales = F.fused_transpose_split_quant(x,None, tokens_per_expert, pow_2_scales=True)
+            >>> outs, scales = F.fused_transpose_split_quant(
+            ...     x, None, tokens_per_expert, pow_2_scales=True
+            ... )
             >>> print(outs[0].shape)
-            [512, 128]
+            paddle.Size([512, 128])
             >>> print(scales[0].shape)
-            [1, 512]
+            paddle.Size([1, 512])
     """
     tokens_per_expert = [int(t) for t in tokens_per_expert]
 
@@ -286,22 +299,24 @@ def fused_weighted_swiglu_act_quant(
               block in the output tensor. To dequantize: original_value = quantized_value / scale.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
-            >>> # doctest: +REQUIRES(env:GPU)
+            >>> # doctest: +SKIP('BF16 requires SM80 or higher env')
             >>> import paddle
             >>> import paddle.incubate.nn.functional as F
             >>> paddle.set_device('gpu')
 
             >>> batch_size, seq_len, expert_dim = 32, 128, 2048
-            >>> x = paddle.randn([batch_size, seq_len, expert_dim], dtype='bfloat16')
+            >>> x = paddle.randn(
+            ...     [batch_size, seq_len, expert_dim], dtype='bfloat16'
+            ... )
             >>> quantized_out, scales = F.fused_weighted_swiglu_act_quant(x)
             >>> print(x.shape)
-            [32, 128, 2048]
+            paddle.Size([32, 128, 2048])
             >>> print(quantized_out.shape)
-            [4096, 1024]
+            paddle.Size([4096, 1024])
             >>> print(scales.shape)
-            [4096, 8]
+            paddle.Size([4096, 8])
     """
     if in_dynamic_or_pir_mode():
         return _C_ops.fused_weighted_swiglu_act_quant(

--- a/python/paddle/incubate/nn/functional/fp8.py
+++ b/python/paddle/incubate/nn/functional/fp8.py
@@ -67,9 +67,7 @@ def fused_stack_transpose_quant(
             ...     x = paddle.clip(x, min=-50, max=50)
             ...     x_vec.append(x)
 
-            >>> out, scale = F.fused_stack_transpose_quant(
-            ...     x_vec, transpose=True
-            ... )
+            >>> out, scale = F.fused_stack_transpose_quant(x_vec, transpose=True)
             >>> print(out.shape)
             paddle.Size([128, 2048])
             >>> print(scale.shape)
@@ -163,16 +161,10 @@ def fused_swiglu_weighted_bwd(
             ...     [batch_size, seq_len, intermediate_size * 2],
             ...     dtype='bfloat16',
             ... )
-            >>> do2_s = paddle.randn(
-            ...     [batch_size, seq_len, intermediate_size], dtype='bfloat16'
-            ... )
-            >>> expert_probs = paddle.rand(
-            ...     [batch_size, seq_len, 1], dtype='float32'
-            ... )
+            >>> do2_s = paddle.randn([batch_size, seq_len, intermediate_size], dtype='bfloat16')
+            >>> expert_probs = paddle.rand([batch_size, seq_len, 1], dtype='float32')
 
-            >>> do1, probs_grad, o2_s = F.fused_swiglu_weighted_bwd(
-            ...     o1, do2_s, expert_probs
-            ... )
+            >>> do1, probs_grad, o2_s = F.fused_swiglu_weighted_bwd(o1, do2_s, expert_probs)
             >>> print(do1.shape)
             paddle.Size([32, 128, 4096])
             >>> print(probs_grad.shape)
@@ -228,9 +220,7 @@ def fused_transpose_split_quant(
             >>> x = paddle.randn([384, 512], dtype='bfloat16')
             >>> x = paddle.clip(x, min=-50, max=50)
             >>> tokens_per_expert = [128, 128, 128]
-            >>> outs, scales = F.fused_transpose_split_quant(
-            ...     x, None, tokens_per_expert, pow_2_scales=True
-            ... )
+            >>> outs, scales = F.fused_transpose_split_quant(x, None, tokens_per_expert, pow_2_scales=True)
             >>> print(outs[0].shape)
             paddle.Size([512, 128])
             >>> print(scales[0].shape)
@@ -307,9 +297,7 @@ def fused_weighted_swiglu_act_quant(
             >>> paddle.set_device('gpu')
 
             >>> batch_size, seq_len, expert_dim = 32, 128, 2048
-            >>> x = paddle.randn(
-            ...     [batch_size, seq_len, expert_dim], dtype='bfloat16'
-            ... )
+            >>> x = paddle.randn([batch_size, seq_len, expert_dim], dtype='bfloat16')
             >>> quantized_out, scales = F.fused_weighted_swiglu_act_quant(x)
             >>> print(x.shape)
             paddle.Size([32, 128, 2048])

--- a/python/paddle/incubate/nn/functional/fused_bias_act.py
+++ b/python/paddle/incubate/nn/functional/fused_bias_act.py
@@ -57,7 +57,7 @@ def fused_bias_act(
         Tensor: the output Tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
@@ -68,7 +68,7 @@ def fused_bias_act(
             >>> bias = paddle.randn([5])
             >>> out = fused_bias_act(x, bias)
             >>> print(out.shape)
-            [3, 5]
+            paddle.Size([3, 5])
     """
     if in_dynamic_or_pir_mode():
         return _C_ops.fused_bias_act(

--- a/python/paddle/incubate/nn/functional/fused_gate_attention.py
+++ b/python/paddle/incubate/nn/functional/fused_gate_attention.py
@@ -118,24 +118,18 @@ def fused_gate_attention(
             >>> qkv_weight = paddle.rand(shape=[3, 8, 4, 4], dtype="float32")
 
             >>> # nonbatched_bias: [batch_size, 1, num_heads, res_len, m_size]
-            >>> nonbatched_bias = paddle.rand(
-            ...     shape=[2, 1, 8, 2, 2], dtype="float32"
-            ... )
+            >>> nonbatched_bias = paddle.rand(shape=[2, 1, 8, 2, 2], dtype="float32")
 
             >>> # attn_mask: [batch_size, msa_len, 1, 1, m_size]
             >>> attn_mask = paddle.rand(shape=[2, 4, 1, 1, 2], dtype="float32")
 
             >>> # gate_linear_weight: [q_dim, num_heads, head_dim]
-            >>> gate_linear_weight = paddle.rand(
-            ...     shape=[4, 8, 4], dtype="float32"
-            ... )
+            >>> gate_linear_weight = paddle.rand(shape=[4, 8, 4], dtype="float32")
             >>> # gate_bias: [num_heads, head_dim]
             >>> gate_linear_bias = paddle.rand(shape=[8, 4], dtype="float32")
 
             >>> # out_linear_weight: [num_heads, head_dim, q_dim]
-            >>> out_linear_weight = paddle.rand(
-            ...     shape=[8, 4, 4], dtype="float32"
-            ... )
+            >>> out_linear_weight = paddle.rand(shape=[8, 4, 4], dtype="float32")
             >>> # out_linear_bias: [q_dim]
             >>> out_linear_bias = paddle.rand(shape=[4], dtype="float32")
 

--- a/python/paddle/incubate/nn/functional/fused_gate_attention.py
+++ b/python/paddle/incubate/nn/functional/fused_gate_attention.py
@@ -97,7 +97,7 @@ def fused_gate_attention(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
@@ -118,18 +118,24 @@ def fused_gate_attention(
             >>> qkv_weight = paddle.rand(shape=[3, 8, 4, 4], dtype="float32")
 
             >>> # nonbatched_bias: [batch_size, 1, num_heads, res_len, m_size]
-            >>> nonbatched_bias = paddle.rand(shape=[2, 1, 8, 2, 2], dtype="float32")
+            >>> nonbatched_bias = paddle.rand(
+            ...     shape=[2, 1, 8, 2, 2], dtype="float32"
+            ... )
 
             >>> # attn_mask: [batch_size, msa_len, 1, 1, m_size]
             >>> attn_mask = paddle.rand(shape=[2, 4, 1, 1, 2], dtype="float32")
 
             >>> # gate_linear_weight: [q_dim, num_heads, head_dim]
-            >>> gate_linear_weight = paddle.rand(shape=[4, 8, 4], dtype="float32")
+            >>> gate_linear_weight = paddle.rand(
+            ...     shape=[4, 8, 4], dtype="float32"
+            ... )
             >>> # gate_bias: [num_heads, head_dim]
             >>> gate_linear_bias = paddle.rand(shape=[8, 4], dtype="float32")
 
             >>> # out_linear_weight: [num_heads, head_dim, q_dim]
-            >>> out_linear_weight = paddle.rand(shape=[8, 4, 4], dtype="float32")
+            >>> out_linear_weight = paddle.rand(
+            ...     shape=[8, 4, 4], dtype="float32"
+            ... )
             >>> # out_linear_bias: [q_dim]
             >>> out_linear_bias = paddle.rand(shape=[4], dtype="float32")
 
@@ -144,9 +150,10 @@ def fused_gate_attention(
             ...     nonbatched_bias=nonbatched_bias,
             ...     attn_mask=attn_mask,
             ...     has_gating=True,
-            ...     merge_qkv=True)
+            ...     merge_qkv=True,
+            ... )
             >>> print(output.shape)
-            [2, 4, 2, 4]
+            paddle.Size([2, 4, 2, 4])
 
     """
     if in_dynamic_mode():

--- a/python/paddle/incubate/nn/functional/fused_matmul_bias.py
+++ b/python/paddle/incubate/nn/functional/fused_matmul_bias.py
@@ -55,7 +55,7 @@ def fused_matmul_bias(
         Tensor: the output Tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('fused_gemm_epilogue is only supported when CUDA version >= 11.6')
             >>> # doctest: +REQUIRES(env:GPU)
@@ -68,7 +68,7 @@ def fused_matmul_bias(
             >>> bias = paddle.randn([5])
             >>> out = fused_matmul_bias(x, y, bias)
             >>> print(out.shape)
-            [3, 5]
+            paddle.Size([3, 5])
     """
     if bias is None:
         return matmul(x, y, transpose_x, transpose_y, name)
@@ -112,7 +112,7 @@ def fused_linear(
         Tensor: the output Tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('fused_gemm_epilogue is only supported when CUDA version >= 11.6')
             >>> # doctest: +REQUIRES(env:GPU)
@@ -125,7 +125,7 @@ def fused_linear(
             >>> bias = paddle.randn([5])
             >>> out = fused_linear(x, weight, bias)
             >>> print(out.shape)
-            [3, 5]
+            paddle.Size([3, 5])
     """
     return fused_matmul_bias(x, weight, bias, False, transpose_weight, name)
 
@@ -155,12 +155,14 @@ def fused_linear_activation(
         Tensor: the output Tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('fused_gemm_epilogue is only supported when CUDA version >= 11.6')
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
-            >>> from paddle.incubate.nn.functional import fused_linear_activation
+            >>> from paddle.incubate.nn.functional import (
+            ...     fused_linear_activation,
+            ... )
 
             >>> paddle.set_device('gpu')
             >>> x = paddle.randn([3, 4])
@@ -168,7 +170,7 @@ def fused_linear_activation(
             >>> bias = paddle.randn([5])
             >>> out = fused_linear_activation(x, weight, bias)
             >>> print(out.shape)
-            [3, 5]
+            paddle.Size([3, 5])
     """
     if activation is None:
         activation = "none"

--- a/python/paddle/incubate/nn/functional/fused_transformer.py
+++ b/python/paddle/incubate/nn/functional/fused_transformer.py
@@ -123,7 +123,7 @@ def fused_feedforward(
         Tensor: The output Tensor, the data type and shape is same as `x`.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
@@ -135,7 +135,7 @@ def fused_feedforward(
             >>> linear2_weight = paddle.randn(shape=(8, 8), dtype="float32")
             >>> out = F.fused_feedforward(x, linear1_weight, linear2_weight)
             >>> print(out.shape)
-            [1, 8, 8]
+            paddle.Size([1, 8, 8])
     """
     _verify_dropout_rate(dropout1_rate)
     _verify_dropout_rate(dropout2_rate)
@@ -380,7 +380,7 @@ def fused_bias_dropout_residual_layer_norm(
         Tensor, The output Tensor, the data type and shape is same as `x`.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
@@ -395,9 +395,10 @@ def fused_bias_dropout_residual_layer_norm(
             >>> bias = paddle.rand(shape=[128], dtype="float32")
             >>> # output: [batch_size, seq_len, embed_dim]
             >>> output = F.fused_bias_dropout_residual_layer_norm(
-            ...     x, residual, bias)
+            ...     x, residual, bias
+            ... )
             >>> print(output.shape)
-            [2, 4, 128]
+            paddle.Size([2, 4, 128])
 
     """
     seed = None
@@ -1204,7 +1205,7 @@ def fused_multi_transformer(
         Transformer layers, cache_kvs is inplace with input `cache_kvs`.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('Depends on Flash Attention 2.')
             >>> import re
@@ -1232,11 +1233,11 @@ def fused_multi_transformer(
             >>> ffn_ln_bias = paddle.rand(shape=(128,), dtype="float32")
 
             >>> # ffn1_weight: [embed_dim, 4*embed_dim], ffn1_bias: [4*embed_dim]
-            >>> ffn1_weight = paddle.rand(shape=(128, 4*128), dtype="float16")
-            >>> ffn1_bias = paddle.rand(shape=(4*128,), dtype="float16")
+            >>> ffn1_weight = paddle.rand(shape=(128, 4 * 128), dtype="float16")
+            >>> ffn1_bias = paddle.rand(shape=(4 * 128,), dtype="float16")
 
             >>> # ffn2_weight: [4*embed_dim, embed_dim], ffn2_bias: [embed_dim]
-            >>> ffn2_weight = paddle.rand(shape=(4*128, 128), dtype="float16")
+            >>> ffn2_weight = paddle.rand(shape=(4 * 128, 128), dtype="float16")
             >>> ffn2_bias = paddle.rand(shape=(128,), dtype="float16")
 
             >>> # self attention mask: [batch_size, 1, seq_len, seq_len]
@@ -1244,12 +1245,23 @@ def fused_multi_transformer(
 
             >>> # output: [batch_size, seq_len, embed_dim]
             >>> output = F.fused_multi_transformer(
-            ...     x, [ln_scale], [ln_bias], [qkv_weight], [qkv_bias],
-            ...     [linear_weight], [linear_bias], [ffn_ln_scale], [ffn_ln_bias],
-            ...     [ffn1_weight], [ffn1_bias], [ffn2_weight], [ffn2_bias],
-            ...     attn_mask=attn_mask)
+            ...     x,
+            ...     [ln_scale],
+            ...     [ln_bias],
+            ...     [qkv_weight],
+            ...     [qkv_bias],
+            ...     [linear_weight],
+            ...     [linear_bias],
+            ...     [ffn_ln_scale],
+            ...     [ffn_ln_bias],
+            ...     [ffn1_weight],
+            ...     [ffn1_bias],
+            ...     [ffn2_weight],
+            ...     [ffn2_bias],
+            ...     attn_mask=attn_mask,
+            ... )
             >>> print(output.shape)
-            [2, 4, 128]
+            paddle.Size([2, 4, 128])
     """
     if mode not in ('downscale_in_infer', 'upscale_in_train'):
         raise ValueError(

--- a/python/paddle/incubate/nn/functional/fused_transformer.py
+++ b/python/paddle/incubate/nn/functional/fused_transformer.py
@@ -394,9 +394,7 @@ def fused_bias_dropout_residual_layer_norm(
             >>> # linear bias: [embed_dim]
             >>> bias = paddle.rand(shape=[128], dtype="float32")
             >>> # output: [batch_size, seq_len, embed_dim]
-            >>> output = F.fused_bias_dropout_residual_layer_norm(
-            ...     x, residual, bias
-            ... )
+            >>> output = F.fused_bias_dropout_residual_layer_norm(x, residual, bias)
             >>> print(output.shape)
             paddle.Size([2, 4, 128])
 

--- a/python/paddle/incubate/nn/functional/variable_length_memory_efficient_attention.py
+++ b/python/paddle/incubate/nn/functional/variable_length_memory_efficient_attention.py
@@ -59,12 +59,14 @@ def variable_length_memory_efficient_attention(
         Tensor, the output Tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import math
             >>> import paddle
-            >>> from paddle.incubate.nn.functional import variable_length_memory_efficient_attention
+            >>> from paddle.incubate.nn.functional import (
+            ...     variable_length_memory_efficient_attention,
+            ... )
             >>> paddle.device.set_device('gpu')
 
             >>> batch = 1
@@ -74,10 +76,22 @@ def variable_length_memory_efficient_attention(
 
             >>> dtype = paddle.float16
 
-            >>> query = paddle.randn([batch, num_head, seq_len, head_size], dtype=dtype)
-            >>> key = paddle.randn([batch, num_head, seq_len, head_size], dtype=dtype)
-            >>> value = paddle.randn([batch, num_head, seq_len, head_size], dtype=dtype)
-            >>> seq_lens = paddle.to_tensor([seq_len, ] * batch, dtype='int32')
+            >>> query = paddle.randn(
+            ...     [batch, num_head, seq_len, head_size], dtype=dtype
+            ... )
+            >>> key = paddle.randn(
+            ...     [batch, num_head, seq_len, head_size], dtype=dtype
+            ... )
+            >>> value = paddle.randn(
+            ...     [batch, num_head, seq_len, head_size], dtype=dtype
+            ... )
+            >>> seq_lens = paddle.to_tensor(
+            ...     [
+            ...         seq_len,
+            ...     ]
+            ...     * batch,
+            ...     dtype='int32',
+            ... )
             >>> mask = paddle.randn([batch, 1, seq_len, seq_len], dtype=dtype)
 
             >>> scale = float(1.0 / math.sqrt(head_size))
@@ -94,8 +108,8 @@ def variable_length_memory_efficient_attention(
             >>> out = naive_attention_impl(query, key, value, mask, scale)
             >>> # equals to: out = variable_length_memory_efficient_attention(query, key, value, seq_lens, seq_lens, mask, scale, pre_cache_length)
 
-            >>> out.shape # [batch, num_head, seq_len, head_size]
-            [1, 8, 256, 32]
+            >>> out.shape  # [batch, num_head, seq_len, head_size]
+            paddle.Size([1, 8, 256, 32])
     """
     if scale is None:
         head_size = query.shape[3]

--- a/python/paddle/incubate/nn/functional/variable_length_memory_efficient_attention.py
+++ b/python/paddle/incubate/nn/functional/variable_length_memory_efficient_attention.py
@@ -80,10 +80,7 @@ def variable_length_memory_efficient_attention(
             >>> key = paddle.randn([batch, num_head, seq_len, head_size], dtype=dtype)
             >>> value = paddle.randn([batch, num_head, seq_len, head_size], dtype=dtype)
             >>> seq_lens = paddle.to_tensor(
-            ...     [
-            ...         seq_len,
-            ...     ]
-            ...     * batch,
+            ...     [seq_len] * batch,
             ...     dtype='int32',
             ... )
             >>> mask = paddle.randn([batch, 1, seq_len, seq_len], dtype=dtype)

--- a/python/paddle/incubate/nn/functional/variable_length_memory_efficient_attention.py
+++ b/python/paddle/incubate/nn/functional/variable_length_memory_efficient_attention.py
@@ -76,15 +76,9 @@ def variable_length_memory_efficient_attention(
 
             >>> dtype = paddle.float16
 
-            >>> query = paddle.randn(
-            ...     [batch, num_head, seq_len, head_size], dtype=dtype
-            ... )
-            >>> key = paddle.randn(
-            ...     [batch, num_head, seq_len, head_size], dtype=dtype
-            ... )
-            >>> value = paddle.randn(
-            ...     [batch, num_head, seq_len, head_size], dtype=dtype
-            ... )
+            >>> query = paddle.randn([batch, num_head, seq_len, head_size], dtype=dtype)
+            >>> key = paddle.randn([batch, num_head, seq_len, head_size], dtype=dtype)
+            >>> value = paddle.randn([batch, num_head, seq_len, head_size], dtype=dtype)
             >>> seq_lens = paddle.to_tensor(
             ...     [
             ...         seq_len,

--- a/python/paddle/incubate/nn/layer/fused_linear.py
+++ b/python/paddle/incubate/nn/layer/fused_linear.py
@@ -61,7 +61,7 @@ class FusedLinear(Layer):
         - output: Multi-dimensional tensor with shape :math:`[batch\_size, *, out\_features]` .
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
@@ -72,7 +72,7 @@ class FusedLinear(Layer):
             >>> linear = FusedLinear(4, 5)
             >>> y = linear(x)
             >>> print(y.shape)
-            [3, 5]
+            paddle.Size([3, 5])
     """
 
     weight: Tensor

--- a/python/paddle/incubate/nn/layer/fused_transformer.py
+++ b/python/paddle/incubate/nn/layer/fused_transformer.py
@@ -124,9 +124,7 @@ class FusedBiasDropoutResidualLayerNorm(Layer):
             >>> x = paddle.rand((2, 4, 128))
             >>> # residual: [batch_size, seq_len, embed_dim]
             >>> residual = paddle.rand((2, 4, 128))
-            >>> fused_bias_dropout_residual_ln = (
-            ...     paddle.incubate.nn.FusedBiasDropoutResidualLayerNorm(128)
-            ... )
+            >>> fused_bias_dropout_residual_ln = paddle.incubate.nn.FusedBiasDropoutResidualLayerNorm(128)
             >>> output = fused_bias_dropout_residual_ln(x, residual)
             >>> print(output.shape)
             paddle.Size([2, 4, 128])
@@ -287,9 +285,7 @@ class FusedMultiHeadAttention(Layer):
             >>> query = paddle.rand((2, 4, 128))
             >>> # self attention mask: [batch_size, num_heads, query_len, query_len]
             >>> attn_mask = paddle.rand((2, 2, 4, 4))
-            >>> multi_head_attn = paddle.incubate.nn.FusedMultiHeadAttention(
-            ...     128, 2
-            ... )
+            >>> multi_head_attn = paddle.incubate.nn.FusedMultiHeadAttention(128, 2)
             >>> output = multi_head_attn(query, None, None, attn_mask=attn_mask)
             >>> print(output.shape)
             paddle.Size([2, 4, 128])
@@ -1235,9 +1231,7 @@ class FusedMultiTransformer(Layer):
             >>> enc_input = paddle.rand((2, 4, 128))
             >>> # self attention mask: [batch_size, 1, src_len, src_len]
             >>> attn_mask = paddle.rand((2, 1, 4, 4))
-            >>> encoder_layers = FusedMultiTransformer(
-            ...     128, 2, 512, num_layers=1
-            ... )
+            >>> encoder_layers = FusedMultiTransformer(128, 2, 512, num_layers=1)
             >>> enc_output = encoder_layers(enc_input, attn_mask)
             >>> print(enc_output.shape)
             paddle.Size([2, 4, 128])

--- a/python/paddle/incubate/nn/layer/fused_transformer.py
+++ b/python/paddle/incubate/nn/layer/fused_transformer.py
@@ -115,7 +115,7 @@ class FusedBiasDropoutResidualLayerNorm(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
@@ -124,10 +124,12 @@ class FusedBiasDropoutResidualLayerNorm(Layer):
             >>> x = paddle.rand((2, 4, 128))
             >>> # residual: [batch_size, seq_len, embed_dim]
             >>> residual = paddle.rand((2, 4, 128))
-            >>> fused_bias_dropout_residual_ln = paddle.incubate.nn.FusedBiasDropoutResidualLayerNorm(128)
+            >>> fused_bias_dropout_residual_ln = (
+            ...     paddle.incubate.nn.FusedBiasDropoutResidualLayerNorm(128)
+            ... )
             >>> output = fused_bias_dropout_residual_ln(x, residual)
             >>> print(output.shape)
-            [2, 4, 128]
+            paddle.Size([2, 4, 128])
     """
 
     embed_dim: int
@@ -276,7 +278,7 @@ class FusedMultiHeadAttention(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
@@ -285,10 +287,12 @@ class FusedMultiHeadAttention(Layer):
             >>> query = paddle.rand((2, 4, 128))
             >>> # self attention mask: [batch_size, num_heads, query_len, query_len]
             >>> attn_mask = paddle.rand((2, 2, 4, 4))
-            >>> multi_head_attn = paddle.incubate.nn.FusedMultiHeadAttention(128, 2)
+            >>> multi_head_attn = paddle.incubate.nn.FusedMultiHeadAttention(
+            ...     128, 2
+            ... )
             >>> output = multi_head_attn(query, None, None, attn_mask=attn_mask)
             >>> print(output.shape)
-            [2, 4, 128]
+            paddle.Size([2, 4, 128])
     """
 
     normalize_before: bool
@@ -1017,7 +1021,7 @@ class FusedTransformer(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.nn import Transformer
@@ -1033,13 +1037,15 @@ class FusedTransformer(Layer):
             >>> # memory_mask: [batch_size, n_head, tgt_len, src_len]
             >>> cross_attn_mask = paddle.rand((2, 2, 6, 4))
             >>> transformer = Transformer(128, 2, 4, 4, 512)
-            >>> output = transformer(enc_input,
-            ...                      dec_input,
-            ...                      enc_self_attn_mask,
-            ...                      dec_self_attn_mask,
-            ...                      cross_attn_mask)
+            >>> output = transformer(
+            ...     enc_input,
+            ...     dec_input,
+            ...     enc_self_attn_mask,
+            ...     dec_self_attn_mask,
+            ...     cross_attn_mask,
+            ... )
             >>> print(output.shape)
-            [2, 6, 128]
+            paddle.Size([2, 6, 128])
     """
 
     def __init__(
@@ -1217,7 +1223,7 @@ class FusedMultiTransformer(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('Need compile flash attention')
             >>> # doctest: +REQUIRES(env:GPU)
@@ -1229,10 +1235,12 @@ class FusedMultiTransformer(Layer):
             >>> enc_input = paddle.rand((2, 4, 128))
             >>> # self attention mask: [batch_size, 1, src_len, src_len]
             >>> attn_mask = paddle.rand((2, 1, 4, 4))
-            >>> encoder_layers = FusedMultiTransformer(128, 2, 512, num_layers=1)
+            >>> encoder_layers = FusedMultiTransformer(
+            ...     128, 2, 512, num_layers=1
+            ... )
             >>> enc_output = encoder_layers(enc_input, attn_mask)
             >>> print(enc_output.shape)
-            [2, 4, 128]
+            paddle.Size([2, 4, 128])
     """
 
     normalize_before: bool

--- a/python/paddle/incubate/operators/softmax_mask_fuse.py
+++ b/python/paddle/incubate/operators/softmax_mask_fuse.py
@@ -52,7 +52,7 @@ def softmax_mask_fuse(
         4-D Tensor. A location into which the result is stored. It's dimension is 4D. Has same shape with x.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
@@ -61,9 +61,9 @@ def softmax_mask_fuse(
             >>> x = paddle.rand([2, 8, 8, 32])
             >>> mask = paddle.rand([2, 1, 8, 32])
 
-            >>> rst = incubate.softmax_mask_fuse(x, mask) # type: ignore[operator]
+            >>> rst = incubate.softmax_mask_fuse(x, mask)  # type: ignore[operator]
             >>> rst.shape
-            [2, 8, 8, 32]
+            paddle.Size([2, 8, 8, 32])
     """
     if in_dynamic_or_pir_mode():
         if isinstance(mask, (paddle.Tensor)) and mask.size == 0:

--- a/python/paddle/incubate/optimizer/gradient_merge.py
+++ b/python/paddle/incubate/optimizer/gradient_merge.py
@@ -56,19 +56,13 @@ class GradientMergeOptimizer:
 
             >>> def gen_data(batch_size):
             ...     return {
-            ...         "x": np.random.random(size=(batch_size, 32)).astype(
-            ...             'float32'
-            ...         ),
-            ...         "y": np.random.random(size=(batch_size, 1)).astype(
-            ...             'int64'
-            ...         ),
+            ...         "x": np.random.random(size=(batch_size, 32)).astype('float32'),
+            ...         "y": np.random.random(size=(batch_size, 1)).astype('int64'),
             ...     }
 
             >>> def mlp(input_x, input_y, hid_dim=128, label_dim=2):
             ...     fc_1 = paddle.static.nn.fc(x=input_x, size=hid_dim)
-            ...     prediction = paddle.static.nn.fc(
-            ...         x=[fc_1], size=label_dim, activation='softmax'
-            ...     )
+            ...     prediction = paddle.static.nn.fc(x=[fc_1], size=label_dim, activation='softmax')
             ...     cost = paddle.nn.functional.cross_entropy(
             ...         input=prediction,
             ...         label=input_y,
@@ -78,17 +72,11 @@ class GradientMergeOptimizer:
             ...     sum_cost = paddle.mean(cost)
             ...     return sum_cost, fc_1, prediction
 
-            >>> input_x = paddle.static.data(
-            ...     name="x", shape=[-1, 32], dtype='float32'
-            ... )
-            >>> input_y = paddle.static.data(
-            ...     name="y", shape=[-1, 1], dtype='int64'
-            ... )
+            >>> input_x = paddle.static.data(name="x", shape=[-1, 32], dtype='float32')
+            >>> input_y = paddle.static.data(name="y", shape=[-1, 1], dtype='int64')
             >>> cost, fc_1, pred = mlp(input_x, input_y)
             >>> sgd = paddle.optimizer.Adam(learning_rate=0.01)
-            >>> sgd = paddle.incubate.optimizer.GradientMergeOptimizer(
-            ...     sgd, k_steps=4, avg=True
-            ... )
+            >>> sgd = paddle.incubate.optimizer.GradientMergeOptimizer(sgd, k_steps=4, avg=True)
             >>> sgd.minimize(cost)
 
             >>> place = paddle.CPUPlace()

--- a/python/paddle/incubate/tensor/manipulation.py
+++ b/python/paddle/incubate/tensor/manipulation.py
@@ -50,9 +50,7 @@ def _npu_identity(x, format=-1):
             >>> paddle.device.set_device('npu')
 
             >>> x = paddle.ones(shape=[6])
-            >>> y = paddle.incubate._npu_identity(
-            ...     x, 3
-            ... )  # ACL_FORMAT_NC1HWC0 = 3
+            >>> y = paddle.incubate._npu_identity(x, 3)  # ACL_FORMAT_NC1HWC0 = 3
             >>> print(y.shape)
             paddle.Size([1, 1, 1, 1, 16])
     """

--- a/python/paddle/incubate/tensor/manipulation.py
+++ b/python/paddle/incubate/tensor/manipulation.py
@@ -43,16 +43,18 @@ def _npu_identity(x, format=-1):
         Tensor: A Tensor with acl storage format on Ascend NPU.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:NPU)
             >>> import paddle
             >>> paddle.device.set_device('npu')
 
             >>> x = paddle.ones(shape=[6])
-            >>> y = paddle.incubate._npu_identity(x, 3) # ACL_FORMAT_NC1HWC0 = 3
+            >>> y = paddle.incubate._npu_identity(
+            ...     x, 3
+            ... )  # ACL_FORMAT_NC1HWC0 = 3
             >>> print(y.shape)
-            [1, 1, 1, 1, 16]
+            paddle.Size([1, 1, 1, 1, 16])
     """
     if in_dynamic_or_pir_mode():
         return _C_ops.npu_identity(x, format)

--- a/python/paddle/incubate/xpu/resnet_block.py
+++ b/python/paddle/incubate/xpu/resnet_block.py
@@ -398,7 +398,7 @@ class ResNetBasicBlock(Layer):
 
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env: XPU)
             >>> import paddle
@@ -427,7 +427,7 @@ class ResNetBasicBlock(Layer):
             >>> out = resnet_basic_block.forward(x)
 
             >>> print(out.shape)
-            [2, 8, 16, 16]
+            paddle.Size([2, 8, 16, 16])
 
     """
 

--- a/python/paddle/jit/sot/translate.py
+++ b/python/paddle/jit/sot/translate.py
@@ -69,9 +69,7 @@ def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:
         >>> symbolic_translate_out
         Tensor(shape=[], dtype=int64, place=Place(cpu), stop_gradient=True,
         2)
-        >>> np.testing.assert_allclose(
-        ...     dygraph_out.numpy(), symbolic_translate_out.numpy()
-        ... )
+        >>> np.testing.assert_allclose(dygraph_out.numpy(), symbolic_translate_out.numpy())
         >>> # For the false branch, the output is 0.
         >>> cond = paddle.to_tensor(False)
         >>> dygraph_out = foo(cond, x)
@@ -82,9 +80,7 @@ def symbolic_translate(fn: Callable[P, R], **kwargs) -> Callable[P, R]:
         >>> symbolic_translate_out
         Tensor(shape=[], dtype=int64, place=Place(cpu), stop_gradient=True,
         0)
-        >>> np.testing.assert_allclose(
-        ...     dygraph_out.numpy(), symbolic_translate_out.numpy()
-        ... )
+        >>> np.testing.assert_allclose(dygraph_out.numpy(), symbolic_translate_out.numpy())
 
     """
 

--- a/python/paddle/nn/decode.py
+++ b/python/paddle/nn/decode.py
@@ -1337,7 +1337,7 @@ def dynamic_decode(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.nn import BeamSearchDecoder, dynamic_decode
@@ -1356,7 +1356,7 @@ def dynamic_decode(
             ...                          inits=decoder_cell.get_initial_states(encoder_output),
             ...                          max_step_num=10)
             >>> print(outputs[0].shape)
-            [4, 11, 4]
+            paddle.Size([4, 11, 4])
     """
     if in_dynamic_mode():
         return _dynamic_decode_imperative(

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -461,9 +461,7 @@ def interpolate(*args: Any, **kwargs: Any) -> Tensor:
             >>> import paddle
             >>> import paddle.nn.functional as F
 
-            >>> input_data = paddle.randn(shape=(2, 3, 6, 10)).astype(
-            ...     paddle.float32
-            ... )
+            >>> input_data = paddle.randn(shape=(2, 3, 6, 10)).astype(paddle.float32)
             >>> output_1 = F.interpolate(x=input_data, size=[12, 12])
             >>> print(output_1.shape)
             paddle.Size([2, 3, 12, 12])
@@ -472,9 +470,7 @@ def interpolate(*args: Any, **kwargs: Any) -> Tensor:
             >>> print(output_2.shape)
             paddle.Size([2, 3, 12, 10])
             >>> # bilinear interp
-            >>> output_3 = F.interpolate(
-            ...     x=input_data, scale_factor=[2, 1], mode="bilinear"
-            ... )
+            >>> output_3 = F.interpolate(x=input_data, scale_factor=[2, 1], mode="bilinear")
             >>> print(output_2.shape)
             paddle.Size([2, 3, 12, 10])
     """
@@ -1164,9 +1160,7 @@ def upsample(
             >>> import paddle
             >>> import paddle.nn as nn
 
-            >>> input_data = paddle.randn(shape=(2, 3, 6, 10)).astype(
-            ...     paddle.float32
-            ... )
+            >>> input_data = paddle.randn(shape=(2, 3, 6, 10)).astype(paddle.float32)
             >>> upsample_out = paddle.nn.Upsample(size=[12, 12])
             >>> output = upsample_out(x=input_data)
             >>> print(output.shape)

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -456,23 +456,27 @@ def interpolate(*args: Any, **kwargs: Any) -> Tensor:
 
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
 
-            >>> input_data = paddle.randn(shape=(2,3,6,10)).astype(paddle.float32)
-            >>> output_1 = F.interpolate(x=input_data, size=[12,12])
+            >>> input_data = paddle.randn(shape=(2, 3, 6, 10)).astype(
+            ...     paddle.float32
+            ... )
+            >>> output_1 = F.interpolate(x=input_data, size=[12, 12])
             >>> print(output_1.shape)
-            [2, 3, 12, 12]
+            paddle.Size([2, 3, 12, 12])
             >>> # given scale
-            >>> output_2 = F.interpolate(x=input_data, scale_factor=[2,1])
+            >>> output_2 = F.interpolate(x=input_data, scale_factor=[2, 1])
             >>> print(output_2.shape)
-            [2, 3, 12, 10]
+            paddle.Size([2, 3, 12, 10])
             >>> # bilinear interp
-            >>> output_3 = F.interpolate(x=input_data, scale_factor=[2,1], mode="bilinear")
+            >>> output_3 = F.interpolate(
+            ...     x=input_data, scale_factor=[2, 1], mode="bilinear"
+            ... )
             >>> print(output_2.shape)
-            [2, 3, 12, 10]
+            paddle.Size([2, 3, 12, 10])
     """
     len_args = len(args)
 
@@ -1155,16 +1159,18 @@ def upsample(
         A 3-D, 4-D or 5-D Tensor, with the same data format of the input :attr:`x`.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
-            >>> input_data = paddle.randn(shape=(2,3,6,10)).astype(paddle.float32)
-            >>> upsample_out = paddle.nn.Upsample(size=[12,12])
+            >>> input_data = paddle.randn(shape=(2, 3, 6, 10)).astype(
+            ...     paddle.float32
+            ... )
+            >>> upsample_out = paddle.nn.Upsample(size=[12, 12])
             >>> output = upsample_out(x=input_data)
             >>> print(output.shape)
-            [2, 3, 12, 12]
+            paddle.Size([2, 3, 12, 12])
 
     """
 
@@ -1197,7 +1203,7 @@ def bilinear(
         Tensor: A 2-D Tensor of shape [batch_size, out_features].
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
@@ -1208,7 +1214,7 @@ def bilinear(
             >>> b = paddle.randn((1, 1000)).astype(paddle.float32)
             >>> result = F.bilinear(x1, x2, w, b)
             >>> print(result.shape)
-            [5, 1000]
+            paddle.Size([5, 1000])
     """
 
     if in_dynamic_or_pir_mode():
@@ -2928,7 +2934,7 @@ def fold(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
@@ -2938,7 +2944,7 @@ def fold(
             >>> x = paddle.randn([2,3*2*2,12])
             >>> y = F.fold(x, output_sizes=[4, 5], kernel_sizes=2)
             >>> print(y.shape)
-            [2, 3, 4, 5]
+            paddle.Size([2, 3, 4, 5])
 
     """
 

--- a/python/paddle/nn/functional/conv.py
+++ b/python/paddle/nn/functional/conv.py
@@ -662,7 +662,7 @@ def conv2d(
         A Tensor representing the conv2d result, whose data type is the same with input.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
@@ -673,7 +673,7 @@ def conv2d(
             >>> y_var = F.conv2d(x_var, w_var)
 
             >>> print(y_var.shape)
-            [2, 6, 6, 6]
+            paddle.Size([2, 6, 6, 6])
     """
     # entry checks
     if data_format not in ["NCHW", "NHWC"]:
@@ -1189,7 +1189,7 @@ def conv2d_transpose(
         transposed convolution result.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
@@ -1200,7 +1200,7 @@ def conv2d_transpose(
             >>> y_var = F.conv2d_transpose(x_var, w_var)
 
             >>> print(y_var.shape)
-            [2, 6, 10, 10]
+            paddle.Size([2, 6, 10, 10])
     """
 
     if data_format not in ['NCHW', 'NHWC']:
@@ -1474,7 +1474,7 @@ def conv3d(
         convolution and non-linearity activation result.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
@@ -1485,7 +1485,7 @@ def conv3d(
             >>> y_var = F.conv3d(x_var, w_var)
 
             >>> print(y_var.shape)
-            [2, 6, 6, 6, 6]
+            paddle.Size([2, 6, 6, 6, 6])
     """
     # entry check
     if data_format not in ["NCDHW", "NDHWC"]:
@@ -1677,7 +1677,7 @@ def conv3d_transpose(
         variable storing transposed convolution and non-linearity activation result.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
@@ -1688,7 +1688,7 @@ def conv3d_transpose(
             >>> y_var = F.conv3d_transpose(x_var, w_var)
 
             >>> print(y_var.shape)
-            [2, 6, 10, 10, 10]
+            paddle.Size([2, 6, 10, 10, 10])
     """
     # entry checks
     if data_format not in ["NCDHW", "NDHWC"]:

--- a/python/paddle/nn/functional/input.py
+++ b/python/paddle/nn/functional/input.py
@@ -99,9 +99,7 @@ def one_hot(
             >>> label = paddle.to_tensor([1, 1, 3, 0], dtype='int64')
             >>> print(label.shape)
             paddle.Size([4])
-            >>> one_hot_label = paddle.nn.functional.one_hot(
-            ...     label, num_classes=4
-            ... )
+            >>> one_hot_label = paddle.nn.functional.one_hot(label, num_classes=4)
             >>> print(one_hot_label.shape)
             paddle.Size([4, 4])
             >>> print(one_hot_label)
@@ -252,9 +250,7 @@ def embedding(
             >>> import paddle.nn as nn
 
             >>> x0 = paddle.arange(3, 6).reshape((3, 1)).astype(paddle.int64)
-            >>> w0 = paddle.full(shape=(10, 3), fill_value=2).astype(
-            ...     paddle.float32
-            ... )
+            >>> w0 = paddle.full(shape=(10, 3), fill_value=2).astype(paddle.float32)
 
             >>> x = paddle.to_tensor(x0, stop_gradient=False)
             >>> print(x.numpy())
@@ -279,9 +275,7 @@ def embedding(
             >>> print(w.shape)
             paddle.Size([10, 3])
 
-            >>> emb = nn.functional.embedding(
-            ...     x=x, weight=w, sparse=True, name="embedding"
-            ... )
+            >>> emb = nn.functional.embedding(x=x, weight=w, sparse=True, name="embedding")
             >>> print(emb.numpy())
             [[[2. 2. 2.]]
              [[2. 2. 2.]]

--- a/python/paddle/nn/functional/input.py
+++ b/python/paddle/nn/functional/input.py
@@ -92,16 +92,18 @@ def one_hot(
         Tensor, The one-hot representations of `x`. A Tensor with type float32.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> # Correspond to the first example above, where label.shape is 4 and one_hot_label.shape is [4, 4].
             >>> label = paddle.to_tensor([1, 1, 3, 0], dtype='int64')
             >>> print(label.shape)
-            [4]
-            >>> one_hot_label = paddle.nn.functional.one_hot(label, num_classes=4)
+            paddle.Size([4])
+            >>> one_hot_label = paddle.nn.functional.one_hot(
+            ...     label, num_classes=4
+            ... )
             >>> print(one_hot_label.shape)
-            [4, 4]
+            paddle.Size([4, 4])
             >>> print(one_hot_label)
             Tensor(shape=[4, 4], dtype=float32, place=Place(cpu), stop_gradient=True,
                    [[0., 1., 0., 0.],
@@ -244,13 +246,15 @@ def embedding(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> x0 = paddle.arange(3, 6).reshape((3, 1)).astype(paddle.int64)
-            >>> w0 = paddle.full(shape=(10, 3), fill_value=2).astype(paddle.float32)
+            >>> w0 = paddle.full(shape=(10, 3), fill_value=2).astype(
+            ...     paddle.float32
+            ... )
 
             >>> x = paddle.to_tensor(x0, stop_gradient=False)
             >>> print(x.numpy())
@@ -258,7 +262,7 @@ def embedding(
              [4]
              [5]]
             >>> print(x.shape)
-            [3, 1]
+            paddle.Size([3, 1])
 
             >>> w = paddle.to_tensor(w0, stop_gradient=False)
             >>> print(w.numpy())
@@ -273,16 +277,17 @@ def embedding(
              [2. 2. 2.]
              [2. 2. 2.]]
             >>> print(w.shape)
-            [10, 3]
+            paddle.Size([10, 3])
 
             >>> emb = nn.functional.embedding(
-            ...         x=x, weight=w, sparse=True, name="embedding")
+            ...     x=x, weight=w, sparse=True, name="embedding"
+            ... )
             >>> print(emb.numpy())
             [[[2. 2. 2.]]
              [[2. 2. 2.]]
              [[2. 2. 2.]]]
             >>> print(emb.shape)
-            [3, 1, 3]
+            paddle.Size([3, 1, 3])
 
     """
     padding_idx = (

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1739,9 +1739,7 @@ def kl_div(
             >>> # input(x) should be a distribution in the log space
             >>> x = F.log_softmax(paddle.randn(shape), axis=1).astype('float32')
 
-            >>> target = paddle.uniform(shape, min=-10, max=10).astype(
-            ...     'float32'
-            ... )
+            >>> target = paddle.uniform(shape, min=-10, max=10).astype('float32')
 
             >>> # 'batchmean' reduction, loss shape will be [], who is 0-D Tensor
             >>> pred_loss = F.kl_div(x, target, reduction='batchmean')
@@ -1767,9 +1765,7 @@ def kl_div(
             >>> target = paddle.uniform(shape, min=0, max=10).astype('float32')
             >>> log_target = paddle.log(target)
             >>> pred_loss_1 = F.kl_div(x, target, reduction='none')
-            >>> pred_loss_2 = F.kl_div(
-            ...     x, log_target, reduction='none', log_target=True
-            ... )
+            >>> pred_loss_2 = F.kl_div(x, log_target, reduction='none', log_target=True)
             >>> print(paddle.allclose(pred_loss_1, pred_loss_2))
             Tensor(shape=[], dtype=bool, place=Place(cpu), stop_gradient=True,
             True)

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1728,7 +1728,7 @@ def kl_div(
         Tensor: The KL divergence loss. The data type is same as input tensor
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
@@ -1739,33 +1739,37 @@ def kl_div(
             >>> # input(x) should be a distribution in the log space
             >>> x = F.log_softmax(paddle.randn(shape), axis=1).astype('float32')
 
-            >>> target = paddle.uniform(shape, min=-10, max=10).astype('float32')
+            >>> target = paddle.uniform(shape, min=-10, max=10).astype(
+            ...     'float32'
+            ... )
 
             >>> # 'batchmean' reduction, loss shape will be [], who is 0-D Tensor
             >>> pred_loss = F.kl_div(x, target, reduction='batchmean')
             >>> print(pred_loss.shape)
-            []
+            paddle.Size([])
 
             >>> # 'mean' reduction, loss shape will be [], who is 0-D Tensor
             >>> pred_loss = F.kl_div(x, target, reduction='mean')
             >>> print(pred_loss.shape)
-            []
+            paddle.Size([])
 
             >>> # 'sum' reduction, loss shape will be [], who is 0-D Tensor
             >>> pred_loss = F.kl_div(x, target, reduction='sum')
             >>> print(pred_loss.shape)
-            []
+            paddle.Size([])
 
             >>> # 'none' reduction, loss shape is same with input shape
             >>> pred_loss = F.kl_div(x, target, reduction='none')
             >>> print(pred_loss.shape)
-            [5, 20]
+            paddle.Size([5, 20])
 
             >>> # if label is in the log space, set log_target = True
             >>> target = paddle.uniform(shape, min=0, max=10).astype('float32')
             >>> log_target = paddle.log(target)
             >>> pred_loss_1 = F.kl_div(x, target, reduction='none')
-            >>> pred_loss_2 = F.kl_div(x, log_target, reduction='none', log_target=True)
+            >>> pred_loss_2 = F.kl_div(
+            ...     x, log_target, reduction='none', log_target=True
+            ... )
             >>> print(paddle.allclose(pred_loss_1, pred_loss_2))
             Tensor(shape=[], dtype=bool, place=Place(cpu), stop_gradient=True,
             True)

--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -608,14 +608,14 @@ def local_response_norm(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> x = paddle.rand(shape=(3, 3, 112, 112), dtype="float32")
             >>> y = paddle.nn.functional.local_response_norm(x, size=5)
             >>> print(y.shape)
-            [3, 3, 112, 112]
+            paddle.Size([3, 3, 112, 112])
 
     """
     if not in_dynamic_mode():

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -502,9 +502,7 @@ def avg_pool3d(
 
             >>> x = paddle.uniform([1, 3, 32, 32, 32], paddle.float32)
             >>> # avg pool3d
-            >>> out = paddle.nn.functional.avg_pool3d(
-            ...     x, kernel_size=2, stride=2, padding=0
-            ... )
+            >>> out = paddle.nn.functional.avg_pool3d(x, kernel_size=2, stride=2, padding=0)
             >>> print(out.shape)
             paddle.Size([1, 3, 16, 16, 16])
     """
@@ -619,14 +617,10 @@ def max_pool1d(
             >>> import paddle.nn.functional as F
 
             >>> data = paddle.uniform([1, 3, 32], paddle.float32)
-            >>> pool_out = F.max_pool1d(
-            ...     data, kernel_size=2, stride=2, padding=0
-            ... )
+            >>> pool_out = F.max_pool1d(data, kernel_size=2, stride=2, padding=0)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 16])
-            >>> pool_out, indices = F.max_pool1d(
-            ...     data, kernel_size=2, stride=2, padding=0, return_mask=True
-            ... )
+            >>> pool_out, indices = F.max_pool1d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 16])
             >>> print(indices.shape)
@@ -812,16 +806,12 @@ def max_unpool1d(
             >>> import paddle.nn.functional as F
 
             >>> data = paddle.rand(shape=[1, 3, 16])
-            >>> pool_out, indices = F.max_pool1d(
-            ...     data, kernel_size=2, stride=2, padding=0, return_mask=True
-            ... )
+            >>> pool_out, indices = F.max_pool1d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 8])
             >>> print(indices.shape)
             paddle.Size([1, 3, 8])
-            >>> unpool_out = F.max_unpool1d(
-            ...     pool_out, indices, kernel_size=2, padding=0
-            ... )
+            >>> unpool_out = F.max_unpool1d(pool_out, indices, kernel_size=2, padding=0)
             >>> print(unpool_out.shape)
             paddle.Size([1, 3, 16])
 
@@ -956,9 +946,7 @@ def max_unpool2d(
                 paddle.Size([1, 1, 3, 3])
                 >>> print(indices.shape)
                 paddle.Size([1, 1, 3, 3])
-                >>> unpool_out = F.max_unpool2d(
-                ...     pool_out, indices, kernel_size=2, padding=0
-                ... )
+                >>> unpool_out = F.max_unpool2d(pool_out, indices, kernel_size=2, padding=0)
                 >>> print(unpool_out.shape)
                 paddle.Size([1, 1, 6, 6])
 
@@ -1093,16 +1081,12 @@ def max_unpool3d(
             >>> import paddle.nn.functional as F
 
             >>> data = paddle.rand(shape=[1, 1, 4, 4, 6])
-            >>> pool_out, indices = F.max_pool3d(
-            ...     data, kernel_size=2, stride=2, padding=0, return_mask=True
-            ... )
+            >>> pool_out, indices = F.max_pool3d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
             >>> print(pool_out.shape)
             paddle.Size([1, 1, 2, 2, 3])
             >>> print(indices.shape)
             paddle.Size([1, 1, 2, 2, 3])
-            >>> unpool_out = F.max_unpool3d(
-            ...     pool_out, indices, kernel_size=2, padding=0
-            ... )
+            >>> unpool_out = F.max_unpool3d(pool_out, indices, kernel_size=2, padding=0)
             >>> print(unpool_out.shape)
             paddle.Size([1, 1, 4, 4, 6])
 
@@ -1215,9 +1199,7 @@ def max_pool2d(
             >>> print(out.shape)
             paddle.Size([1, 3, 16, 16])
             >>> # for return_mask=True
-            >>> out, max_indices = F.max_pool2d(
-            ...     x, kernel_size=2, stride=2, padding=0, return_mask=True
-            ... )
+            >>> out, max_indices = F.max_pool2d(x, kernel_size=2, stride=2, padding=0, return_mask=True)
             >>> print(out.shape)
             paddle.Size([1, 3, 16, 16])
             >>> print(max_indices.shape)
@@ -1380,9 +1362,7 @@ def max_pool3d(
 
             >>> # for return_mask=True
             >>> x = paddle.uniform([1, 3, 32, 32, 32])
-            >>> output, max_indices = paddle.nn.functional.max_pool3d(
-            ...     x, kernel_size=2, stride=2, padding=0, return_mask=True
-            ... )
+            >>> output, max_indices = paddle.nn.functional.max_pool3d(x, kernel_size=2, stride=2, padding=0, return_mask=True)
             >>> print(output.shape)
             paddle.Size([1, 3, 16, 16, 16])
             >>> print(max_indices.shape)
@@ -1870,9 +1850,7 @@ def adaptive_max_pool1d(
             >>> pool_out = F.adaptive_max_pool1d(data, output_size=16)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 16])
-            >>> pool_out, indices = F.adaptive_max_pool1d(
-            ...     data, output_size=16, return_mask=True
-            ... )
+            >>> pool_out, indices = F.adaptive_max_pool1d(data, output_size=16, return_mask=True)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 16])
             >>> print(indices.shape)
@@ -1968,9 +1946,7 @@ def adaptive_max_pool2d(
             >>> import paddle
 
             >>> input_data = paddle.randn(shape=(2, 3, 32, 32))
-            >>> out = paddle.nn.functional.adaptive_max_pool2d(
-            ...     x=input_data, output_size=[3, 3]
-            ... )
+            >>> out = paddle.nn.functional.adaptive_max_pool2d(x=input_data, output_size=[3, 3])
             >>> print(out.shape)
             paddle.Size([2, 3, 3, 3])
     """
@@ -2064,9 +2040,7 @@ def adaptive_max_pool3d(
             >>> import paddle
 
             >>> input_data = paddle.randn(shape=(2, 3, 8, 32, 32))
-            >>> out = paddle.nn.functional.adaptive_max_pool3d(
-            ...     x=input_data, output_size=[3, 3, 3]
-            ... )
+            >>> out = paddle.nn.functional.adaptive_max_pool3d(x=input_data, output_size=[3, 3, 3])
             >>> print(out.shape)
             paddle.Size([2, 3, 3, 3, 3])
     """
@@ -2189,22 +2163,16 @@ def fractional_max_pool2d(
             >>> x = paddle.rand([2, 3, 32, 32])
 
             >>> # disjont: without `kernel_size`
-            >>> pool_out = paddle.nn.functional.fractional_max_pool2d(
-            ...     x, output_size=3
-            ... )
+            >>> pool_out = paddle.nn.functional.fractional_max_pool2d(x, output_size=3)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 3, 3])
 
             >>> # overlapping: with `kernel_size`
-            >>> pool_out = paddle.nn.functional.fractional_max_pool2d(
-            ...     x, kernel_size=2, output_size=3
-            ... )
+            >>> pool_out = paddle.nn.functional.fractional_max_pool2d(x, kernel_size=2, output_size=3)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 3, 3])
 
-            >>> pool_out, indices = paddle.nn.functional.fractional_max_pool2d(
-            ...     x, output_size=[2, 3], return_mask=True
-            ... )
+            >>> pool_out, indices = paddle.nn.functional.fractional_max_pool2d(x, output_size=[2, 3], return_mask=True)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 2, 3])
             >>> print(indices.shape)
@@ -2350,22 +2318,16 @@ def fractional_max_pool3d(
             >>> x = paddle.rand([2, 3, 8, 32, 32])
 
             >>> # disjont: without `kernel_size`
-            >>> pool_out = paddle.nn.functional.fractional_max_pool3d(
-            ...     x, output_size=3
-            ... )
+            >>> pool_out = paddle.nn.functional.fractional_max_pool3d(x, output_size=3)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 3, 3, 3])
 
             >>> # overlapping: with `kernel_size`
-            >>> pool_out = paddle.nn.functional.fractional_max_pool3d(
-            ...     x, kernel_size=2, output_size=3
-            ... )
+            >>> pool_out = paddle.nn.functional.fractional_max_pool3d(x, kernel_size=2, output_size=3)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 3, 3, 3])
 
-            >>> pool_out, indices = paddle.nn.functional.fractional_max_pool3d(
-            ...     x, output_size=[2, 3, 3], return_mask=True
-            ... )
+            >>> pool_out, indices = paddle.nn.functional.fractional_max_pool3d(x, output_size=[2, 3, 3], return_mask=True)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 2, 3, 3])
             >>> print(indices.shape)
@@ -2499,9 +2461,7 @@ def lp_pool1d(
             >>> import paddle.nn as nn
 
             >>> data = paddle.uniform([1, 3, 32], paddle.float32)
-            >>> LPPool1D = nn.LPPool1D(
-            ...     norm_type=3, kernel_size=2, stride=2, padding=0
-            ... )
+            >>> LPPool1D = nn.LPPool1D(norm_type=3, kernel_size=2, stride=2, padding=0)
             >>> pool_out = LPPool1D(data)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 16])
@@ -2637,9 +2597,7 @@ def lp_pool2d(
 
             >>> # lp pool2d
             >>> x = paddle.uniform([1, 3, 32, 32], paddle.float32)
-            >>> out = F.lp_pool2d(
-            ...     x, norm_type=2, kernel_size=2, stride=2, padding=0
-            ... )
+            >>> out = F.lp_pool2d(x, norm_type=2, kernel_size=2, stride=2, padding=0)
             >>> print(out.shape)
             paddle.Size([1, 3, 16, 16])
     """

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -237,7 +237,7 @@ def avg_pool1d(
         Tensor: The output tensor of pooling result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
@@ -246,7 +246,7 @@ def avg_pool1d(
             >>> AvgPool1D = nn.AvgPool1D(kernel_size=2, stride=2, padding=0)
             >>> pool_out = AvgPool1D(data)
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
     """
     """NCL to NCHW"""
     data_format = "NCHW"
@@ -368,18 +368,16 @@ def avg_pool2d(
         Tensor: The output tensor of pooling result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
 
             >>> # avg pool2d
             >>> x = paddle.uniform([1, 3, 32, 32], paddle.float32)
-            >>> out = F.avg_pool2d(x,
-            ...                    kernel_size=2,
-            ...                    stride=2, padding=0)
+            >>> out = F.avg_pool2d(x, kernel_size=2, stride=2, padding=0)
             >>> print(out.shape)
-            [1, 3, 16, 16]
+            paddle.Size([1, 3, 16, 16])
     """
     kernel_size = convert_to_list(kernel_size, 2, 'pool_size')
     if stride is None:
@@ -498,18 +496,17 @@ def avg_pool3d(
         Tensor: The output tensor of pooling result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> x = paddle.uniform([1, 3, 32, 32, 32], paddle.float32)
             >>> # avg pool3d
-            >>> out = paddle.nn.functional.avg_pool3d(x,
-            ...                                       kernel_size = 2,
-            ...                                       stride = 2,
-            ...                                       padding=0)
+            >>> out = paddle.nn.functional.avg_pool3d(
+            ...     x, kernel_size=2, stride=2, padding=0
+            ... )
             >>> print(out.shape)
-            [1, 3, 16, 16, 16]
+            paddle.Size([1, 3, 16, 16, 16])
     """
     kernel_size = convert_to_list(kernel_size, 3, 'pool_size')
     if stride is None:
@@ -616,20 +613,24 @@ def max_pool1d(
         Tensor: The output tensor of pooling result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
 
             >>> data = paddle.uniform([1, 3, 32], paddle.float32)
-            >>> pool_out = F.max_pool1d(data, kernel_size=2, stride=2, padding=0)
+            >>> pool_out = F.max_pool1d(
+            ...     data, kernel_size=2, stride=2, padding=0
+            ... )
             >>> print(pool_out.shape)
-            [1, 3, 16]
-            >>> pool_out, indices = F.max_pool1d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
+            paddle.Size([1, 3, 16])
+            >>> pool_out, indices = F.max_pool1d(
+            ...     data, kernel_size=2, stride=2, padding=0, return_mask=True
+            ... )
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
             >>> print(indices.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
     """
     """NCL to NCHW"""
     data_format = "NCHW"
@@ -805,20 +806,24 @@ def max_unpool1d(
         Tensor: The output tensor of unpooling result.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
 
             >>> data = paddle.rand(shape=[1, 3, 16])
-            >>> pool_out, indices = F.max_pool1d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
+            >>> pool_out, indices = F.max_pool1d(
+            ...     data, kernel_size=2, stride=2, padding=0, return_mask=True
+            ... )
             >>> print(pool_out.shape)
-            [1, 3, 8]
+            paddle.Size([1, 3, 8])
             >>> print(indices.shape)
-            [1, 3, 8]
-            >>> unpool_out = F.max_unpool1d(pool_out, indices, kernel_size=2, padding=0)
+            paddle.Size([1, 3, 8])
+            >>> unpool_out = F.max_unpool1d(
+            ...     pool_out, indices, kernel_size=2, padding=0
+            ... )
             >>> print(unpool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
 
     """
     """NCL to NCHW"""
@@ -934,25 +939,39 @@ def max_unpool2d(
 
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.nn.functional as F
 
                 >>> data = paddle.rand(shape=[1, 1, 6, 6])
-                >>> pool_out, indices = F.max_pool2d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
+                >>> pool_out, indices = F.max_pool2d(
+                ...     data,
+                ...     kernel_size=2,
+                ...     stride=2,
+                ...     padding=0,
+                ...     return_mask=True,
+                ... )
                 >>> print(pool_out.shape)
-                [1, 1, 3, 3]
+                paddle.Size([1, 1, 3, 3])
                 >>> print(indices.shape)
-                [1, 1, 3, 3]
-                >>> unpool_out = F.max_unpool2d(pool_out, indices, kernel_size=2, padding=0)
+                paddle.Size([1, 1, 3, 3])
+                >>> unpool_out = F.max_unpool2d(
+                ...     pool_out, indices, kernel_size=2, padding=0
+                ... )
                 >>> print(unpool_out.shape)
-                [1, 1, 6, 6]
+                paddle.Size([1, 1, 6, 6])
 
                 >>> # specify a different output size than input size
-                >>> unpool_out = F.max_unpool2d(pool_out, indices, kernel_size=2, padding=0, output_size=[7, 7])
+                >>> unpool_out = F.max_unpool2d(
+                ...     pool_out,
+                ...     indices,
+                ...     kernel_size=2,
+                ...     padding=0,
+                ...     output_size=[7, 7],
+                ... )
                 >>> print(unpool_out.shape)
-                [1, 1, 7, 7]
+                paddle.Size([1, 1, 7, 7])
 
     """
     if x.ndim != 4:
@@ -1068,20 +1087,24 @@ def max_unpool3d(
         Tensor: The output tensor of unpooling result.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
 
             >>> data = paddle.rand(shape=[1, 1, 4, 4, 6])
-            >>> pool_out, indices = F.max_pool3d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
+            >>> pool_out, indices = F.max_pool3d(
+            ...     data, kernel_size=2, stride=2, padding=0, return_mask=True
+            ... )
             >>> print(pool_out.shape)
-            [1, 1, 2, 2, 3]
+            paddle.Size([1, 1, 2, 2, 3])
             >>> print(indices.shape)
-            [1, 1, 2, 2, 3]
-            >>> unpool_out = F.max_unpool3d(pool_out, indices, kernel_size=2, padding=0)
+            paddle.Size([1, 1, 2, 2, 3])
+            >>> unpool_out = F.max_unpool3d(
+            ...     pool_out, indices, kernel_size=2, padding=0
+            ... )
             >>> print(unpool_out.shape)
-            [1, 1, 4, 4, 6]
+            paddle.Size([1, 1, 4, 4, 6])
 
     """
     if x.ndim != 5:
@@ -1181,7 +1204,7 @@ def max_pool2d(
         Tensor: The output tensor of pooling result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
@@ -1190,13 +1213,15 @@ def max_pool2d(
             >>> x = paddle.uniform([1, 3, 32, 32], paddle.float32)
             >>> out = F.max_pool2d(x, kernel_size=2, stride=2, padding=0)
             >>> print(out.shape)
-            [1, 3, 16, 16]
+            paddle.Size([1, 3, 16, 16])
             >>> # for return_mask=True
-            >>> out, max_indices = F.max_pool2d(x, kernel_size=2, stride=2, padding=0, return_mask=True)
+            >>> out, max_indices = F.max_pool2d(
+            ...     x, kernel_size=2, stride=2, padding=0, return_mask=True
+            ... )
             >>> print(out.shape)
-            [1, 3, 16, 16]
+            paddle.Size([1, 3, 16, 16])
             >>> print(max_indices.shape)
-            [1, 3, 16, 16]
+            paddle.Size([1, 3, 16, 16])
     """
 
     kernel_size = convert_to_list(kernel_size, 2, 'pool_size')
@@ -1342,32 +1367,26 @@ def max_pool3d(
         Tensor: The output tensor of pooling result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
 
             >>> # max pool3d
             >>> x = paddle.uniform([1, 3, 32, 32, 32])
-            >>> output = F.max_pool3d(x,
-            ...                       kernel_size=2,
-            ...                       stride=2,
-            ...                       padding=0)
+            >>> output = F.max_pool3d(x, kernel_size=2, stride=2, padding=0)
             >>> print(output.shape)
-            [1, 3, 16, 16, 16]
+            paddle.Size([1, 3, 16, 16, 16])
 
             >>> # for return_mask=True
             >>> x = paddle.uniform([1, 3, 32, 32, 32])
-            >>> output, max_indices = paddle.nn.functional.max_pool3d(x,
-            ...                                                       kernel_size=2,
-            ...                                                       stride=2,
-            ...                                                       padding=0,
-            ...                                                       return_mask=True)
-            ...
+            >>> output, max_indices = paddle.nn.functional.max_pool3d(
+            ...     x, kernel_size=2, stride=2, padding=0, return_mask=True
+            ... )
             >>> print(output.shape)
-            [1, 3, 16, 16, 16]
+            paddle.Size([1, 3, 16, 16, 16])
             >>> print(max_indices.shape)
-            [1, 3, 16, 16, 16]
+            paddle.Size([1, 3, 16, 16, 16])
     """
 
     kernel_size = convert_to_list(kernel_size, 3, 'pool_size')
@@ -1460,7 +1479,7 @@ def adaptive_avg_pool1d(
         Tensor: The result of 1D adaptive average pooling. Its data type is same as input.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # average adaptive pool1d
             >>> # suppose input data in shape of [N, C, L], `output_size` is m or [m],
@@ -1480,7 +1499,7 @@ def adaptive_avg_pool1d(
             >>> data = paddle.uniform([1, 3, 32])
             >>> pool_out = F.adaptive_avg_pool1d(data, output_size=16)
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
     """
     pool_type = 'avg'
     _check_input(x, 3)
@@ -1568,7 +1587,7 @@ def adaptive_avg_pool2d(
         Tensor, The output tensor of avg adaptive pool2d result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # adaptive avg pool2d
             >>> # suppose input data in shape of [N, C, H, W], `output_size` is [m, n],
@@ -1592,7 +1611,7 @@ def adaptive_avg_pool2d(
             >>> out = paddle.nn.functional.adaptive_avg_pool2d(x = x,
             ...                                                output_size=[3, 3])
             >>> print(out.shape)
-            [2, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3])
 
     """
     if data_format not in ["NCHW", "NHWC"]:
@@ -1708,7 +1727,7 @@ def adaptive_avg_pool3d(
         Tensor, The output tensor of avg adaptive pool3d result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # adaptive avg pool3d
             >>> # suppose input data in shape of [N, C, D, H, W], `output_size` is [l, m, n],
@@ -1734,7 +1753,7 @@ def adaptive_avg_pool3d(
             >>> out = paddle.nn.functional.adaptive_avg_pool3d(x = input_data,
             ...                                                output_size=[3, 3, 3])
             >>> print(out.shape)
-            [2, 3, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3, 3])
 
     """
     if data_format not in ["NCDHW", "NDHWC"]:
@@ -1830,7 +1849,7 @@ def adaptive_max_pool1d(
                       as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # max adaptive pool1d
             >>> # suppose input data in shape of [N, C, L], `output_size` is m or [m],
@@ -1850,12 +1869,14 @@ def adaptive_max_pool1d(
             >>> data = paddle.uniform([1, 3, 32], paddle.float32)
             >>> pool_out = F.adaptive_max_pool1d(data, output_size=16)
             >>> print(pool_out.shape)
-            [1, 3, 16]
-            >>> pool_out, indices = F.adaptive_max_pool1d(data, output_size=16, return_mask=True)
+            paddle.Size([1, 3, 16])
+            >>> pool_out, indices = F.adaptive_max_pool1d(
+            ...     data, output_size=16, return_mask=True
+            ... )
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
             >>> print(indices.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
     """
     _check_input(x, 3)
 
@@ -1927,7 +1948,7 @@ def adaptive_max_pool2d(
         Tensor: The output tensor of adaptive max pool2d result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # max adaptive pool2d
             >>> # suppose input data in the shape of [N, C, H, W], `output_size` is [m, n]
@@ -1947,10 +1968,11 @@ def adaptive_max_pool2d(
             >>> import paddle
 
             >>> input_data = paddle.randn(shape=(2, 3, 32, 32))
-            >>> out = paddle.nn.functional.adaptive_max_pool2d(x = input_data,
-            ...                                                output_size=[3, 3])
+            >>> out = paddle.nn.functional.adaptive_max_pool2d(
+            ...     x=input_data, output_size=[3, 3]
+            ... )
             >>> print(out.shape)
-            [2, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3])
     """
     _check_input(x, 4)
 
@@ -2019,7 +2041,7 @@ def adaptive_max_pool3d(
         Tensor: The output tensor of adaptive max pool3d result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # adaptive max pool3d
             >>> # suppose input data in the shape of [N, C, D, H, W], `output_size` is [l, m, n]
@@ -2042,10 +2064,11 @@ def adaptive_max_pool3d(
             >>> import paddle
 
             >>> input_data = paddle.randn(shape=(2, 3, 8, 32, 32))
-            >>> out = paddle.nn.functional.adaptive_max_pool3d(x = input_data,
-            ...                                                output_size=[3, 3, 3])
+            >>> out = paddle.nn.functional.adaptive_max_pool3d(
+            ...     x=input_data, output_size=[3, 3, 3]
+            ... )
             >>> print(out.shape)
-            [2, 3, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3, 3])
     """
     _check_input(x, 5)
 
@@ -2153,7 +2176,7 @@ def fractional_max_pool2d(
         Tensor: The output tensor of fractional max pool2d result which is a 4-D tensor.. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # fractional max pool2d
             >>> # suppose input data in shape of [N, C, H, W], `output_size` is [m, n],
@@ -2166,20 +2189,26 @@ def fractional_max_pool2d(
             >>> x = paddle.rand([2, 3, 32, 32])
 
             >>> # disjont: without `kernel_size`
-            >>> pool_out = paddle.nn.functional.fractional_max_pool2d(x, output_size=3)
+            >>> pool_out = paddle.nn.functional.fractional_max_pool2d(
+            ...     x, output_size=3
+            ... )
             >>> print(pool_out.shape)
-            [2, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3])
 
             >>> # overlapping: with `kernel_size`
-            >>> pool_out = paddle.nn.functional.fractional_max_pool2d(x, kernel_size=2, output_size=3)
+            >>> pool_out = paddle.nn.functional.fractional_max_pool2d(
+            ...     x, kernel_size=2, output_size=3
+            ... )
             >>> print(pool_out.shape)
-            [2, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3])
 
-            >>> pool_out, indices = paddle.nn.functional.fractional_max_pool2d(x, output_size=[2, 3], return_mask=True)
+            >>> pool_out, indices = paddle.nn.functional.fractional_max_pool2d(
+            ...     x, output_size=[2, 3], return_mask=True
+            ... )
             >>> print(pool_out.shape)
-            [2, 3, 2, 3]
+            paddle.Size([2, 3, 2, 3])
             >>> print(indices.shape)
-            [2, 3, 2, 3]
+            paddle.Size([2, 3, 2, 3])
     """
     _check_input(x, 4)
 
@@ -2308,7 +2337,7 @@ def fractional_max_pool3d(
         Tensor: The output tensor of fractional max pool3d result which is a 5-D tensor.. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # fractional max pool3d
             >>> # suppose input data in shape of [N, C, D, H, W], `output_size` is [l, m, n],
@@ -2321,20 +2350,26 @@ def fractional_max_pool3d(
             >>> x = paddle.rand([2, 3, 8, 32, 32])
 
             >>> # disjont: without `kernel_size`
-            >>> pool_out = paddle.nn.functional.fractional_max_pool3d(x, output_size=3)
+            >>> pool_out = paddle.nn.functional.fractional_max_pool3d(
+            ...     x, output_size=3
+            ... )
             >>> print(pool_out.shape)
-            [2, 3, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3, 3])
 
             >>> # overlapping: with `kernel_size`
-            >>> pool_out = paddle.nn.functional.fractional_max_pool3d(x, kernel_size=2, output_size=3)
+            >>> pool_out = paddle.nn.functional.fractional_max_pool3d(
+            ...     x, kernel_size=2, output_size=3
+            ... )
             >>> print(pool_out.shape)
-            [2, 3, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3, 3])
 
-            >>> pool_out, indices = paddle.nn.functional.fractional_max_pool3d(x, output_size=[2, 3, 3], return_mask=True)
+            >>> pool_out, indices = paddle.nn.functional.fractional_max_pool3d(
+            ...     x, output_size=[2, 3, 3], return_mask=True
+            ... )
             >>> print(pool_out.shape)
-            [2, 3, 2, 3, 3]
+            paddle.Size([2, 3, 2, 3, 3])
             >>> print(indices.shape)
-            [2, 3, 2, 3, 3]
+            paddle.Size([2, 3, 2, 3, 3])
     """
     _check_input(x, 5)
 
@@ -2458,16 +2493,18 @@ def lp_pool1d(
         Tensor: The output tensor of pooling result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> data = paddle.uniform([1, 3, 32], paddle.float32)
-            >>> LPPool1D = nn.LPPool1D(norm_type=3, kernel_size=2, stride=2, padding=0)
+            >>> LPPool1D = nn.LPPool1D(
+            ...     norm_type=3, kernel_size=2, stride=2, padding=0
+            ... )
             >>> pool_out = LPPool1D(data)
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
     """
     # NCL to NCHW
     ori_data_format = data_format
@@ -2593,19 +2630,18 @@ def lp_pool2d(
         Tensor: The output tensor of pooling result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
 
             >>> # lp pool2d
             >>> x = paddle.uniform([1, 3, 32, 32], paddle.float32)
-            >>> out = F.lp_pool2d(x,
-            ...                   norm_type=2,
-            ...                   kernel_size=2,
-            ...                   stride=2, padding=0)
+            >>> out = F.lp_pool2d(
+            ...     x, norm_type=2, kernel_size=2, stride=2, padding=0
+            ... )
             >>> print(out.shape)
-            [1, 3, 16, 16]
+            paddle.Size([1, 3, 16, 16])
     """
 
     _check_input(x, 4)

--- a/python/paddle/nn/functional/sparse_attention.py
+++ b/python/paddle/nn/functional/sparse_attention.py
@@ -89,7 +89,7 @@ def sparse_attention(
         The dtype can be float32 or float64.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('This API is only used in CUDA11.3 and above.')
             >>> import paddle
@@ -97,30 +97,53 @@ def sparse_attention(
             >>> paddle.disable_static()
 
             >>> # `query`, `key` and `value` all have shape [1, 1, 4, 2]
-            >>> query = paddle.to_tensor([[[[0, 1, ], [2, 3],
-            ...                             [0, 1], [2, 3]]]], dtype="float32")
-            >>> key = paddle.to_tensor([[[[0, 1], [2, 3],
-            ...                           [0, 1], [2, 3]]]], dtype="float32")
-            >>> value = paddle.to_tensor([[[[0, 1], [2, 3],
-            ...                             [0, 1], [2, 3]]]], dtype="float32")
-            ...
+            >>> query = paddle.to_tensor(
+            ...     [
+            ...         [
+            ...             [
+            ...                 [
+            ...                     0,
+            ...                     1,
+            ...                 ],
+            ...                 [2, 3],
+            ...                 [0, 1],
+            ...                 [2, 3],
+            ...             ]
+            ...         ]
+            ...     ],
+            ...     dtype="float32",
+            ... )
+            >>> key = paddle.to_tensor(
+            ...     [[[[0, 1], [2, 3], [0, 1], [2, 3]]]], dtype="float32"
+            ... )
+            >>> value = paddle.to_tensor(
+            ...     [[[[0, 1], [2, 3], [0, 1], [2, 3]]]], dtype="float32"
+            ... )
             >>> offset = paddle.to_tensor([[[0, 2, 4, 6, 8]]], dtype="int32")
-            >>> columns = paddle.to_tensor([[[0, 1, 0, 1, 2, 3, 2, 3]]], dtype="int32")
-            ...
+            >>> columns = paddle.to_tensor(
+            ...     [[[0, 1, 0, 1, 2, 3, 2, 3]]], dtype="int32"
+            ... )
             >>> print(offset.shape)
-            [1, 1, 5]
+            paddle.Size([1, 1, 5])
             >>> print(columns.shape)
-            [1, 1, 8]
+            paddle.Size([1, 1, 8])
             ...
-            >>> key_padding_mask = paddle.to_tensor([[1, 1, 1, 0]], dtype="float32")
-            >>> attention_mask = paddle.to_tensor([[1, 0, 1, 1],
-            ...                                    [1, 1, 1, 1],
-            ...                                    [1, 1, 1, 1],
-            ...                                    [1, 1, 1, 1]], dtype="float32")
-            >>> output_mask = paddle.nn.functional.sparse_attention(query, key,
-            ...                                                     value, offset, columns,
-            ...                                                     key_padding_mask=key_padding_mask,
-            ...                                                     attn_mask=attention_mask)
+            >>> key_padding_mask = paddle.to_tensor(
+            ...     [[1, 1, 1, 0]], dtype="float32"
+            ... )
+            >>> attention_mask = paddle.to_tensor(
+            ...     [[1, 0, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]],
+            ...     dtype="float32",
+            ... )
+            >>> output_mask = paddle.nn.functional.sparse_attention(
+            ...     query,
+            ...     key,
+            ...     value,
+            ...     offset,
+            ...     columns,
+            ...     key_padding_mask=key_padding_mask,
+            ...     attn_mask=attention_mask,
+            ... )
             >>> print(output_mask)
             Tensor(shape=[1, 1, 4, 2], dtype=float32, place=Place(cpu), stop_gradient=False,
             [[[[0.        , 1.        ],
@@ -128,8 +151,9 @@ def sparse_attention(
                [0.        , 1.        ],
                [0.        , 1.        ]]]])
 
-            >>> output = paddle.nn.functional.sparse_attention(query, key,
-            ...                                             value, offset, columns)
+            >>> output = paddle.nn.functional.sparse_attention(
+            ...     query, key, value, offset, columns
+            ... )
             >>> print(output)
             Tensor(shape=[1, 1, 4, 2], dtype=float32, place=Place(cpu), stop_gradient=False,
             [[[[1.60885942, 2.60885954],

--- a/python/paddle/nn/functional/sparse_attention.py
+++ b/python/paddle/nn/functional/sparse_attention.py
@@ -112,7 +112,12 @@ def sparse_attention(
             ...
             >>> key_padding_mask = paddle.to_tensor([[1, 1, 1, 0]], dtype="float32")
             >>> attention_mask = paddle.to_tensor(
-            ...     [[1, 0, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]],
+            ...     [
+            ...         [1, 0, 1, 1],
+            ...         [1, 1, 1, 1],
+            ...         [1, 1, 1, 1],
+            ...         [1, 1, 1, 1],
+            ...     ],
             ...     dtype="float32",
             ... )
             >>> output_mask = paddle.nn.functional.sparse_attention(

--- a/python/paddle/nn/functional/sparse_attention.py
+++ b/python/paddle/nn/functional/sparse_attention.py
@@ -113,24 +113,16 @@ def sparse_attention(
             ...     ],
             ...     dtype="float32",
             ... )
-            >>> key = paddle.to_tensor(
-            ...     [[[[0, 1], [2, 3], [0, 1], [2, 3]]]], dtype="float32"
-            ... )
-            >>> value = paddle.to_tensor(
-            ...     [[[[0, 1], [2, 3], [0, 1], [2, 3]]]], dtype="float32"
-            ... )
+            >>> key = paddle.to_tensor([[[[0, 1], [2, 3], [0, 1], [2, 3]]]], dtype="float32")
+            >>> value = paddle.to_tensor([[[[0, 1], [2, 3], [0, 1], [2, 3]]]], dtype="float32")
             >>> offset = paddle.to_tensor([[[0, 2, 4, 6, 8]]], dtype="int32")
-            >>> columns = paddle.to_tensor(
-            ...     [[[0, 1, 0, 1, 2, 3, 2, 3]]], dtype="int32"
-            ... )
+            >>> columns = paddle.to_tensor([[[0, 1, 0, 1, 2, 3, 2, 3]]], dtype="int32")
             >>> print(offset.shape)
             paddle.Size([1, 1, 5])
             >>> print(columns.shape)
             paddle.Size([1, 1, 8])
             ...
-            >>> key_padding_mask = paddle.to_tensor(
-            ...     [[1, 1, 1, 0]], dtype="float32"
-            ... )
+            >>> key_padding_mask = paddle.to_tensor([[1, 1, 1, 0]], dtype="float32")
             >>> attention_mask = paddle.to_tensor(
             ...     [[1, 0, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]],
             ...     dtype="float32",
@@ -151,9 +143,7 @@ def sparse_attention(
                [0.        , 1.        ],
                [0.        , 1.        ]]]])
 
-            >>> output = paddle.nn.functional.sparse_attention(
-            ...     query, key, value, offset, columns
-            ... )
+            >>> output = paddle.nn.functional.sparse_attention(query, key, value, offset, columns)
             >>> print(output)
             Tensor(shape=[1, 1, 4, 2], dtype=float32, place=Place(cpu), stop_gradient=False,
             [[[[1.60885942, 2.60885954],

--- a/python/paddle/nn/functional/sparse_attention.py
+++ b/python/paddle/nn/functional/sparse_attention.py
@@ -98,19 +98,7 @@ def sparse_attention(
 
             >>> # `query`, `key` and `value` all have shape [1, 1, 4, 2]
             >>> query = paddle.to_tensor(
-            ...     [
-            ...         [
-            ...             [
-            ...                 [
-            ...                     0,
-            ...                     1,
-            ...                 ],
-            ...                 [2, 3],
-            ...                 [0, 1],
-            ...                 [2, 3],
-            ...             ]
-            ...         ]
-            ...     ],
+            ...     [[[[0, 1], [2, 3], [0, 1], [2, 3]]]],
             ...     dtype="float32",
             ... )
             >>> key = paddle.to_tensor([[[[0, 1], [2, 3], [0, 1], [2, 3]]]], dtype="float32")

--- a/python/paddle/nn/functional/vision.py
+++ b/python/paddle/nn/functional/vision.py
@@ -166,15 +166,15 @@ def pixel_shuffle(
         Out(tensor): Reshaped tensor according to the new dimension.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
 
-            >>> x = paddle.randn(shape=[2,9,4,4])
+            >>> x = paddle.randn(shape=[2, 9, 4, 4])
             >>> out_var = F.pixel_shuffle(x, 3)
             >>> print(out_var.shape)
-            [2, 1, 12, 12]
+            paddle.Size([2, 1, 12, 12])
     """
     if not isinstance(upscale_factor, int):
         raise TypeError("upscale factor must be int type")
@@ -224,14 +224,14 @@ def pixel_unshuffle(
         Out (Tensor): Reshaped tensor according to the new dimension.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
             >>> x = paddle.randn([2, 1, 12, 12])
             >>> out = F.pixel_unshuffle(x, 3)
             >>> print(out.shape)
-            [2, 9, 4, 4]
+            paddle.Size([2, 9, 4, 4])
     """
     if len(x.shape) != 4:
         raise ValueError(

--- a/python/paddle/nn/initializer/dirac.py
+++ b/python/paddle/nn/initializer/dirac.py
@@ -58,9 +58,7 @@ class Dirac(Initializer):
             >>> import paddle
 
             >>> # 1. For kernel_size is uneven number:
-            >>> attr = paddle.ParamAttr(
-            ...     initializer=paddle.nn.initializer.Dirac()
-            ... )
+            >>> attr = paddle.ParamAttr(initializer=paddle.nn.initializer.Dirac())
             >>> conv = paddle.nn.Conv1D(3, 2, 3, weight_attr=attr)
             >>> print(conv.weight)
             Parameter containing:
@@ -79,9 +77,7 @@ class Dirac(Initializer):
             >>> # It means output is almost the same with input, 2 channels are reserved
 
             >>> # 2. For kernel_size is even number:
-            >>> attr = paddle.ParamAttr(
-            ...     initializer=paddle.nn.initializer.Dirac()
-            ... )
+            >>> attr = paddle.ParamAttr(initializer=paddle.nn.initializer.Dirac())
             >>> conv = paddle.nn.Conv1D(3, 2, 4, weight_attr=attr)
             >>> print(conv.weight)
             Parameter containing:

--- a/python/paddle/nn/initializer/dirac.py
+++ b/python/paddle/nn/initializer/dirac.py
@@ -53,12 +53,14 @@ class Dirac(Initializer):
         Dirac initializer instance objects.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> # 1. For kernel_size is uneven number:
-            >>> attr = paddle.ParamAttr(initializer=paddle.nn.initializer.Dirac())
+            >>> attr = paddle.ParamAttr(
+            ...     initializer=paddle.nn.initializer.Dirac()
+            ... )
             >>> conv = paddle.nn.Conv1D(3, 2, 3, weight_attr=attr)
             >>> print(conv.weight)
             Parameter containing:
@@ -73,11 +75,13 @@ class Dirac(Initializer):
             >>> output = conv(input)
             >>> output == input[:, 0:2, 1:9]
             >>> print(output.shape)
-            [8, 2, 8]
+            paddle.Size([8, 2, 8])
             >>> # It means output is almost the same with input, 2 channels are reserved
 
             >>> # 2. For kernel_size is even number:
-            >>> attr = paddle.ParamAttr(initializer=paddle.nn.initializer.Dirac())
+            >>> attr = paddle.ParamAttr(
+            ...     initializer=paddle.nn.initializer.Dirac()
+            ... )
             >>> conv = paddle.nn.Conv1D(3, 2, 4, weight_attr=attr)
             >>> print(conv.weight)
             Parameter containing:

--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -429,7 +429,7 @@ class Upsample(Layer):
         A callable object of Upsample.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -438,7 +438,7 @@ class Upsample(Layer):
 
             >>> output = upsample_out(x=input)
             >>> print(output.shape)
-            [2, 3, 12, 12]
+            paddle.Size([2, 3, 12, 12])
 
     """
 
@@ -549,17 +549,17 @@ class UpsamplingNearest2D(Layer):
 
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> input_data = paddle.rand(shape=(2, 3, 6, 10)).astype("float32")
-            >>> upsample_out  = paddle.nn.UpsamplingNearest2D(size=[12, 12])
+            >>> upsample_out = paddle.nn.UpsamplingNearest2D(size=[12, 12])
             >>> input = paddle.to_tensor(input_data)
             >>> output = upsample_out(x=input)
             >>> print(output.shape)
-            [2, 3, 12, 12]
+            paddle.Size([2, 3, 12, 12])
     """
 
     size: ShapeLike | None
@@ -646,17 +646,17 @@ class UpsamplingBilinear2D(Layer):
         A 4-D Tensor of the shape (num_batches, channels, out_h, out_w) or (num_batches, out_h, out_w, channels),
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> input_data = paddle.rand(shape=(2, 3, 6, 10)).astype("float32")
-            >>> upsample_out  = paddle.nn.UpsamplingBilinear2D(size=[12, 12])
+            >>> upsample_out = paddle.nn.UpsamplingBilinear2D(size=[12, 12])
             >>> input = paddle.to_tensor(input_data)
             >>> output = upsample_out(x=input)
             >>> print(output.shape)
-            [2, 3, 12, 12]
+            paddle.Size([2, 3, 12, 12])
     """
 
     size: ShapeLike | None
@@ -743,19 +743,19 @@ class Bilinear(Layer):
        Tensor: A 2-D Tensor of shape [batch_size, out_features].
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> layer1 = paddle.rand((5, 5)).astype('float32')
             >>> layer2 = paddle.rand((5, 4)).astype('float32')
-            >>> bilinear = paddle.nn.Bilinear(in1_features=5,
-            ...                               in2_features=4,
-            ...                               out_features=1000)
+            >>> bilinear = paddle.nn.Bilinear(
+            ...     in1_features=5, in2_features=4, out_features=1000
+            ... )
 
-            >>> result = bilinear(layer1,layer2)
+            >>> result = bilinear(layer1, layer2)
             >>> print(result.shape)
-            [5, 1000]
+            paddle.Size([5, 1000])
 
     """
 
@@ -2537,7 +2537,7 @@ class Unfold(Layer):
 
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
@@ -2546,7 +2546,7 @@ class Unfold(Layer):
             >>> unfold = nn.Unfold(kernel_sizes=[3, 3])
             >>> result = unfold(x)
             >>> print(result.shape)
-            [100, 27, 49284]
+            paddle.Size([100, 27, 49284])
 
     """
 
@@ -2639,7 +2639,7 @@ class Fold(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
@@ -2648,7 +2648,7 @@ class Fold(Layer):
             >>> fold = nn.Fold(output_sizes=[4, 5], kernel_sizes=2)
             >>> y = fold(x)
             >>> print(y.shape)
-            [2, 3, 4, 5]
+            paddle.Size([2, 3, 4, 5])
    """
 
     output_sizes: Size2
@@ -2756,7 +2756,7 @@ class Flatten(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -2764,7 +2764,7 @@ class Flatten(Layer):
             >>> flatten = paddle.nn.Flatten(start_axis=1, stop_axis=2)
             >>> y = flatten(inp)
             >>> print(y.shape)
-            [5, 6, 4]
+            paddle.Size([5, 6, 4])
 
     """
 
@@ -2802,7 +2802,7 @@ class Unflatten(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -2812,7 +2812,7 @@ class Unflatten(Layer):
             >>> unflatten = paddle.nn.Unflatten(axis, shape)
             >>> res = unflatten(x)
             >>> print(res.shape)
-            [4, 2, 3, 8]
+            paddle.Size([4, 2, 3, 8])
 
     """
 

--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -749,9 +749,7 @@ class Bilinear(Layer):
 
             >>> layer1 = paddle.rand((5, 5)).astype('float32')
             >>> layer2 = paddle.rand((5, 4)).astype('float32')
-            >>> bilinear = paddle.nn.Bilinear(
-            ...     in1_features=5, in2_features=4, out_features=1000
-            ... )
+            >>> bilinear = paddle.nn.Bilinear(in1_features=5, in2_features=4, out_features=1000)
 
             >>> result = bilinear(layer1, layer2)
             >>> print(result.shape)

--- a/python/paddle/nn/layer/container.py
+++ b/python/paddle/nn/layer/container.py
@@ -344,12 +344,7 @@ class ParameterDict(Layer):
             ...         super().__init__()
             ...         # create ParameterDict with iterable Parameters
             ...         self.params = paddle.nn.ParameterDict(
-            ...             {
-            ...                 f"t{i}": paddle.create_parameter(
-            ...                     shape=[2, 2], dtype='float32'
-            ...                 )
-            ...                 for i in range(num_stacked_param)
-            ...             }
+            ...             {f"t{i}": paddle.create_parameter(shape=[2, 2], dtype='float32') for i in range(num_stacked_param)}
             ...         )
             ...
             ...     def forward(self, x):
@@ -365,16 +360,12 @@ class ParameterDict(Layer):
             >>> print(res.shape)
             paddle.Size([5, 2])
 
-            >>> replaced_param = paddle.create_parameter(
-            ...     shape=[2, 3], dtype='float32'
-            ... )
+            >>> replaced_param = paddle.create_parameter(shape=[2, 3], dtype='float32')
             >>> model.params['t3'] = replaced_param  # replace t3 param
             >>> res = model(x)
             >>> print(res.shape)
             paddle.Size([5, 3])
-            >>> model.params['t4'] = paddle.create_parameter(
-            ...     shape=[3, 4], dtype='float32'
-            ... )  # append param
+            >>> model.params['t4'] = paddle.create_parameter(shape=[3, 4], dtype='float32')  # append param
             >>> print(len(model.params))
             5
             >>> res = model(x)
@@ -455,12 +446,7 @@ class ParameterList(Layer):
             ...         super().__init__()
             ...         # create ParameterList with iterable Parameters
             ...         self.params = paddle.nn.ParameterList(
-            ...             [
-            ...                 paddle.create_parameter(
-            ...                     shape=[2, 2], dtype='float32'
-            ...                 )
-            ...                 for _ in range(num_stacked_param)
-            ...             ]
+            ...             [paddle.create_parameter(shape=[2, 2], dtype='float32') for _ in range(num_stacked_param)]
             ...         )
             ...
             ...     def forward(self, x):
@@ -475,16 +461,12 @@ class ParameterList(Layer):
             >>> res = model(x)
             >>> print(res.shape)
             paddle.Size([5, 2])
-            >>> replaced_param = paddle.create_parameter(
-            ...     shape=[2, 3], dtype='float32'
-            ... )
+            >>> replaced_param = paddle.create_parameter(shape=[2, 3], dtype='float32')
             >>> model.params[num_stacked_param - 1] = replaced_param
             >>> res = model(x)
             >>> print(res.shape)
             paddle.Size([5, 3])
-            >>> model.params.append(
-            ...     paddle.create_parameter(shape=[3, 4], dtype='float32')
-            ... )  # append param
+            >>> model.params.append(paddle.create_parameter(shape=[3, 4], dtype='float32'))  # append param
             >>> print(len(model.params))
             5
             >>> res = model(x)

--- a/python/paddle/nn/layer/container.py
+++ b/python/paddle/nn/layer/container.py
@@ -335,7 +335,7 @@ class ParameterDict(Layer):
         parameters (iterable, optional): a mapping (dictionary) of (string : Any) or an iterable of key-value pairs of type (string, Any)
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -344,13 +344,18 @@ class ParameterDict(Layer):
             ...         super().__init__()
             ...         # create ParameterDict with iterable Parameters
             ...         self.params = paddle.nn.ParameterDict(
-            ...             {f"t{i}": paddle.create_parameter(shape=[2, 2], dtype='float32') for i in range(num_stacked_param)})
+            ...             {
+            ...                 f"t{i}": paddle.create_parameter(
+            ...                     shape=[2, 2], dtype='float32'
+            ...                 )
+            ...                 for i in range(num_stacked_param)
+            ...             }
+            ...         )
             ...
             ...     def forward(self, x):
             ...         for i, key in enumerate(self.params):
             ...             x = paddle.matmul(x, self.params[key])
             ...         return x
-            ...
             >>> x = paddle.uniform(shape=[5, 2], dtype='float32')
             >>> num_stacked_param = 4
             >>> model = MyLayer(num_stacked_param)
@@ -358,19 +363,23 @@ class ParameterDict(Layer):
             4
             >>> res = model(x)
             >>> print(res.shape)
-            [5, 2]
+            paddle.Size([5, 2])
 
-            >>> replaced_param = paddle.create_parameter(shape=[2, 3], dtype='float32')
+            >>> replaced_param = paddle.create_parameter(
+            ...     shape=[2, 3], dtype='float32'
+            ... )
             >>> model.params['t3'] = replaced_param  # replace t3 param
             >>> res = model(x)
             >>> print(res.shape)
-            [5, 3]
-            >>> model.params['t4'] = paddle.create_parameter(shape=[3, 4], dtype='float32')  # append param
+            paddle.Size([5, 3])
+            >>> model.params['t4'] = paddle.create_parameter(
+            ...     shape=[3, 4], dtype='float32'
+            ... )  # append param
             >>> print(len(model.params))
             5
             >>> res = model(x)
             >>> print(res.shape)
-            [5, 4]
+            paddle.Size([5, 4])
     """
 
     def __init__(
@@ -437,7 +446,7 @@ class ParameterList(Layer):
         parameters (iterable, optional): Iterable Parameters to be added.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -446,22 +455,18 @@ class ParameterList(Layer):
             ...         super().__init__()
             ...         # create ParameterList with iterable Parameters
             ...         self.params = paddle.nn.ParameterList(
-            ...             [paddle.create_parameter(
-            ...                 shape=[2, 2], dtype='float32')] * num_stacked_param)
+            ...             [
+            ...                 paddle.create_parameter(
+            ...                     shape=[2, 2], dtype='float32'
+            ...                 )
+            ...                 for _ in range(num_stacked_param)
+            ...             ]
+            ...         )
             ...
             ...     def forward(self, x):
             ...         for i, p in enumerate(self.params):
-            ...             tmp = self._helper.create_variable_for_type_inference('float32')
-            ...             self._helper.append_op(
-            ...                 type="mul",
-            ...                 inputs={"X": x,
-            ...                         "Y": p},
-            ...                 outputs={"Out": tmp},
-            ...                 attrs={"x_num_col_dims": 1,
-            ...                         "y_num_col_dims": 1})
-            ...             x = tmp
+            ...             x = paddle.matmul(x, p)
             ...         return x
-            ...
             >>> x = paddle.uniform(shape=[5, 2], dtype='float32')
             >>> num_stacked_param = 4
             >>> model = MyLayer(num_stacked_param)
@@ -469,19 +474,22 @@ class ParameterList(Layer):
             4
             >>> res = model(x)
             >>> print(res.shape)
-            [5, 2]
-
-            >>> replaced_param = paddle.create_parameter(shape=[2, 3], dtype='float32')
-            >>> model.params[num_stacked_param - 1] = replaced_param  # replace last param
+            paddle.Size([5, 2])
+            >>> replaced_param = paddle.create_parameter(
+            ...     shape=[2, 3], dtype='float32'
+            ... )
+            >>> model.params[num_stacked_param - 1] = replaced_param
             >>> res = model(x)
             >>> print(res.shape)
-            [5, 3]
-            >>> model.params.append(paddle.create_parameter(shape=[3, 4], dtype='float32'))  # append param
+            paddle.Size([5, 3])
+            >>> model.params.append(
+            ...     paddle.create_parameter(shape=[3, 4], dtype='float32')
+            ... )  # append param
             >>> print(len(model.params))
             5
             >>> res = model(x)
             >>> print(res.shape)
-            [5, 4]
+            paddle.Size([5, 4])
     """
 
     def __init__(self, parameters: Iterable[Tensor] | None = None) -> None:

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -544,7 +544,7 @@ class Conv1DTranspose(_ConvNd):
         - output(Tensor): 3-D tensor with same shape as input x.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.nn import Conv1DTranspose
@@ -553,13 +553,13 @@ class Conv1DTranspose(_ConvNd):
             >>> x = paddle.to_tensor([[[4, 0, 9, 7],
             ... [8, 0, 9, 2]]], dtype="float32")
             >>> print(x.shape)
-            [1, 2, 4]
+            paddle.Size([1, 2, 4])
 
             >>> # shape: (2, 1, 2)
             >>> w = paddle.to_tensor([[[7, 0]],
             ... [[4, 2]]], dtype="float32")
             >>> print(w.shape)
-            [2, 1, 2]
+            paddle.Size([2, 1, 2])
 
             >>> conv = Conv1DTranspose(2, 1, 2)
             >>> conv.weight.set_value(w)
@@ -713,19 +713,21 @@ class Conv2D(_ConvNd):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> paddle.disable_static()
 
-            >>> x_var = paddle.uniform((2, 4, 8, 8), dtype='float32', min=-1., max=1.)
+            >>> x_var = paddle.uniform(
+            ...     (2, 4, 8, 8), dtype='float32', min=-1.0, max=1.0
+            ... )
 
             >>> conv = nn.Conv2D(4, 6, (3, 3))
             >>> y_var = conv(x_var)
             >>> print(y_var.shape)
-            [2, 6, 6, 6]
+            paddle.Size([2, 6, 6, 6])
     """
 
     def __init__(
@@ -924,19 +926,21 @@ class Conv2DTranspose(_ConvNd):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> paddle.disable_static()
 
-            >>> x_var = paddle.uniform((2, 4, 8, 8), dtype='float32', min=-1., max=1.)
+            >>> x_var = paddle.uniform(
+            ...     (2, 4, 8, 8), dtype='float32', min=-1.0, max=1.0
+            ... )
 
             >>> conv = nn.Conv2DTranspose(4, 6, (3, 3))
             >>> y_var = conv(x_var)
             >>> print(y_var.shape)
-            [2, 6, 10, 10]
+            paddle.Size([2, 6, 10, 10])
     """
 
     def __init__(
@@ -1085,19 +1089,21 @@ class Conv3D(_ConvNd):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> paddle.disable_static()
 
-            >>> x_var = paddle.uniform((2, 4, 8, 8, 8), dtype='float32', min=-1., max=1.)
+            >>> x_var = paddle.uniform(
+            ...     (2, 4, 8, 8, 8), dtype='float32', min=-1.0, max=1.0
+            ... )
 
             >>> conv = nn.Conv3D(4, 6, (3, 3, 3))
             >>> y_var = conv(x_var)
             >>> print(y_var.shape)
-            [2, 6, 6, 6, 6]
+            paddle.Size([2, 6, 6, 6, 6])
     """
 
     def __init__(
@@ -1274,19 +1280,21 @@ class Conv3DTranspose(_ConvNd):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> paddle.disable_static()
 
-            >>> x_var = paddle.uniform((2, 4, 8, 8, 8), dtype='float32', min=-1., max=1.)
+            >>> x_var = paddle.uniform(
+            ...     (2, 4, 8, 8, 8), dtype='float32', min=-1.0, max=1.0
+            ... )
 
             >>> conv = nn.Conv3DTranspose(4, 6, (3, 3, 3))
             >>> y_var = conv(x_var)
             >>> print(y_var.shape)
-            [2, 6, 10, 10, 10]
+            paddle.Size([2, 6, 10, 10, 10])
     """
 
     def __init__(

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -720,9 +720,7 @@ class Conv2D(_ConvNd):
 
             >>> paddle.disable_static()
 
-            >>> x_var = paddle.uniform(
-            ...     (2, 4, 8, 8), dtype='float32', min=-1.0, max=1.0
-            ... )
+            >>> x_var = paddle.uniform((2, 4, 8, 8), dtype='float32', min=-1.0, max=1.0)
 
             >>> conv = nn.Conv2D(4, 6, (3, 3))
             >>> y_var = conv(x_var)
@@ -933,9 +931,7 @@ class Conv2DTranspose(_ConvNd):
 
             >>> paddle.disable_static()
 
-            >>> x_var = paddle.uniform(
-            ...     (2, 4, 8, 8), dtype='float32', min=-1.0, max=1.0
-            ... )
+            >>> x_var = paddle.uniform((2, 4, 8, 8), dtype='float32', min=-1.0, max=1.0)
 
             >>> conv = nn.Conv2DTranspose(4, 6, (3, 3))
             >>> y_var = conv(x_var)
@@ -1096,9 +1092,7 @@ class Conv3D(_ConvNd):
 
             >>> paddle.disable_static()
 
-            >>> x_var = paddle.uniform(
-            ...     (2, 4, 8, 8, 8), dtype='float32', min=-1.0, max=1.0
-            ... )
+            >>> x_var = paddle.uniform((2, 4, 8, 8, 8), dtype='float32', min=-1.0, max=1.0)
 
             >>> conv = nn.Conv3D(4, 6, (3, 3, 3))
             >>> y_var = conv(x_var)
@@ -1287,9 +1281,7 @@ class Conv3DTranspose(_ConvNd):
 
             >>> paddle.disable_static()
 
-            >>> x_var = paddle.uniform(
-            ...     (2, 4, 8, 8, 8), dtype='float32', min=-1.0, max=1.0
-            ... )
+            >>> x_var = paddle.uniform((2, 4, 8, 8, 8), dtype='float32', min=-1.0, max=1.0)
 
             >>> conv = nn.Conv3DTranspose(4, 6, (3, 3, 3))
             >>> y_var = conv(x_var)

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -1150,9 +1150,7 @@ class KLDivLoss(Layer):
 
             >>> shape = (5, 20)
             >>> x = paddle.uniform(shape, min=-10, max=10).astype('float32')
-            >>> target = paddle.uniform(shape, min=-10, max=10).astype(
-            ...     'float32'
-            ... )
+            >>> target = paddle.uniform(shape, min=-10, max=10).astype('float32')
 
             >>> # 'batchmean' reduction, loss shape will be []
             >>> kldiv_criterion = nn.KLDivLoss(reduction='batchmean')
@@ -1182,9 +1180,7 @@ class KLDivLoss(Layer):
             >>> target = paddle.uniform(shape, min=0, max=10).astype('float32')
             >>> log_target = paddle.log(target)
             >>> kldiv_criterion_1 = nn.KLDivLoss(reduction='none')
-            >>> kldiv_criterion_2 = nn.KLDivLoss(
-            ...     reduction='none', log_target=True
-            ... )
+            >>> kldiv_criterion_2 = nn.KLDivLoss(reduction='none', log_target=True)
             >>> pred_loss_1 = kldiv_criterion_1(x, target)
             >>> pred_loss_2 = kldiv_criterion_2(x, log_target)
             >>> print(paddle.allclose(pred_loss_1, pred_loss_2))

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -1143,44 +1143,48 @@ class KLDivLoss(Layer):
         output (Tensor): tensor with shape: [] by default.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> shape = (5, 20)
             >>> x = paddle.uniform(shape, min=-10, max=10).astype('float32')
-            >>> target = paddle.uniform(shape, min=-10, max=10).astype('float32')
+            >>> target = paddle.uniform(shape, min=-10, max=10).astype(
+            ...     'float32'
+            ... )
 
             >>> # 'batchmean' reduction, loss shape will be []
             >>> kldiv_criterion = nn.KLDivLoss(reduction='batchmean')
             >>> pred_loss = kldiv_criterion(x, target)
             >>> print(pred_loss.shape)
-            []
+            paddle.Size([])
 
             >>> # 'mean' reduction, loss shape will be []
             >>> kldiv_criterion = nn.KLDivLoss(reduction='mean')
             >>> pred_loss = kldiv_criterion(x, target)
             >>> print(pred_loss.shape)
-            []
+            paddle.Size([])
 
             >>> # 'sum' reduction, loss shape will be []
             >>> kldiv_criterion = nn.KLDivLoss(reduction='sum')
             >>> pred_loss = kldiv_criterion(x, target)
             >>> print(pred_loss.shape)
-            []
+            paddle.Size([])
 
             >>> # 'none' reduction, loss shape is same with X shape
             >>> kldiv_criterion = nn.KLDivLoss(reduction='none')
             >>> pred_loss = kldiv_criterion(x, target)
             >>> print(pred_loss.shape)
-            [5, 20]
+            paddle.Size([5, 20])
 
             >>> # if label is in the log space, set log_target = True
             >>> target = paddle.uniform(shape, min=0, max=10).astype('float32')
             >>> log_target = paddle.log(target)
             >>> kldiv_criterion_1 = nn.KLDivLoss(reduction='none')
-            >>> kldiv_criterion_2 = nn.KLDivLoss(reduction='none', log_target=True)
+            >>> kldiv_criterion_2 = nn.KLDivLoss(
+            ...     reduction='none', log_target=True
+            ... )
             >>> pred_loss_1 = kldiv_criterion_1(x, target)
             >>> pred_loss_2 = kldiv_criterion_2(x, log_target)
             >>> print(paddle.allclose(pred_loss_1, pred_loss_2))

--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -1961,9 +1961,7 @@ class SpectralNorm(Layer):
 
             >>> import paddle
             >>> x = paddle.rand((2, 8, 32, 32))
-            >>> spectral_norm = paddle.nn.SpectralNorm(
-            ...     x.shape, dim=1, power_iters=2
-            ... )
+            >>> spectral_norm = paddle.nn.SpectralNorm(x.shape, dim=1, power_iters=2)
             >>> spectral_norm_out = spectral_norm(x)
             >>> print(spectral_norm_out.shape)
             paddle.Size([2, 8, 32, 32])

--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -1855,7 +1855,7 @@ class LocalResponseNorm(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -1863,7 +1863,7 @@ class LocalResponseNorm(Layer):
             >>> m = paddle.nn.LocalResponseNorm(size=5)
             >>> y = m(x)
             >>> print(y.shape)
-            [3, 3, 112, 112]
+            paddle.Size([3, 3, 112, 112])
     """
 
     size: int
@@ -1957,14 +1957,16 @@ class SpectralNorm(Layer):
         None
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
-            >>> x = paddle.rand((2,8,32,32))
-            >>> spectral_norm = paddle.nn.SpectralNorm(x.shape, dim=1, power_iters=2)
+            >>> x = paddle.rand((2, 8, 32, 32))
+            >>> spectral_norm = paddle.nn.SpectralNorm(
+            ...     x.shape, dim=1, power_iters=2
+            ... )
             >>> spectral_norm_out = spectral_norm(x)
             >>> print(spectral_norm_out.shape)
-            [2, 8, 32, 32]
+            paddle.Size([2, 8, 32, 32])
 
     """
 

--- a/python/paddle/nn/layer/pooling.py
+++ b/python/paddle/nn/layer/pooling.py
@@ -91,16 +91,18 @@ class AvgPool1D(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
-            >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
+            >>> data = paddle.uniform(
+            ...     [1, 3, 32], dtype="float32", min=-1, max=1
+            ... )
             >>> AvgPool1D = nn.AvgPool1D(kernel_size=2, stride=2, padding=0)
             >>> pool_out = AvgPool1D(data)
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
 
     """
 
@@ -204,17 +206,19 @@ class AvgPool2D(Layer):
         A callable object of AvgPool2D.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> # max pool2d
-            >>> input = paddle.uniform([1, 3, 32, 32], dtype="float32", min=-1, max=1)
+            >>> input = paddle.uniform(
+            ...     [1, 3, 32, 32], dtype="float32", min=-1, max=1
+            ... )
             >>> AvgPool2D = nn.AvgPool2D(kernel_size=2, stride=2, padding=0)
             >>> output = AvgPool2D(input)
             >>> print(output.shape)
-            [1, 3, 16, 16]
+            paddle.Size([1, 3, 16, 16])
 
     """
 
@@ -314,17 +318,19 @@ class AvgPool3D(Layer):
           The data type is same as input x.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> # avg pool3d
-            >>> input = paddle.uniform([1, 2, 3, 32, 32], dtype="float32", min=-1, max=1)
+            >>> input = paddle.uniform(
+            ...     [1, 2, 3, 32, 32], dtype="float32", min=-1, max=1
+            ... )
             >>> AvgPool3D = nn.AvgPool3D(kernel_size=2, stride=2, padding=0)
             >>> output = AvgPool3D(input)
             >>> print(output.shape)
-            [1, 2, 1, 16, 16]
+            paddle.Size([1, 2, 1, 16, 16])
 
     """
 
@@ -424,16 +430,20 @@ class LPPool1D(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
-            >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
-            >>> LPPool1D = nn.LPPool1D(norm_type=2, kernel_size=2, stride=2, padding=0)
+            >>> data = paddle.uniform(
+            ...     [1, 3, 32], dtype="float32", min=-1, max=1
+            ... )
+            >>> LPPool1D = nn.LPPool1D(
+            ...     norm_type=2, kernel_size=2, stride=2, padding=0
+            ... )
             >>> pool_out = LPPool1D(data)
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
 
     """
 
@@ -540,17 +550,21 @@ class LPPool2D(Layer):
         A callable object of LPPool2D.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> # lp pool2d
-            >>> input = paddle.uniform([1, 3, 32, 32], dtype="float32", min=-1, max=1)
-            >>> LPPool2D = nn.LPPool2D(norm_type=2, kernel_size=2, stride=2, padding=0)
+            >>> input = paddle.uniform(
+            ...     [1, 3, 32, 32], dtype="float32", min=-1, max=1
+            ... )
+            >>> LPPool2D = nn.LPPool2D(
+            ...     norm_type=2, kernel_size=2, stride=2, padding=0
+            ... )
             >>> output = LPPool2D(input)
             >>> print(output.shape)
-            [1, 3, 16, 16]
+            paddle.Size([1, 3, 16, 16])
 
     """
 
@@ -645,23 +659,27 @@ class MaxPool1D(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
-            >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
+            >>> data = paddle.uniform(
+            ...     [1, 3, 32], dtype="float32", min=-1, max=1
+            ... )
             >>> MaxPool1D = nn.MaxPool1D(kernel_size=2, stride=2, padding=0)
             >>> pool_out = MaxPool1D(data)
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
 
-            >>> MaxPool1D = nn.MaxPool1D(kernel_size=2, stride=2, padding=0, return_mask=True)
+            >>> MaxPool1D = nn.MaxPool1D(
+            ...     kernel_size=2, stride=2, padding=0, return_mask=True
+            ... )
             >>> pool_out, indices = MaxPool1D(data)
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
             >>> print(indices.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
 
     """
 
@@ -761,25 +779,29 @@ class MaxPool2D(Layer):
           The data type is same as input x.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> # max pool2d
-            >>> input = paddle.uniform([1, 3, 32, 32], dtype="float32", min=-1, max=1)
+            >>> input = paddle.uniform(
+            ...     [1, 3, 32, 32], dtype="float32", min=-1, max=1
+            ... )
             >>> MaxPool2D = nn.MaxPool2D(kernel_size=2, stride=2, padding=0)
             >>> output = MaxPool2D(input)
             >>> print(output.shape)
-            [1, 3, 16, 16]
+            paddle.Size([1, 3, 16, 16])
 
             >>> # for return_mask=True
-            >>> MaxPool2D = nn.MaxPool2D(kernel_size=2, stride=2, padding=0, return_mask=True)
+            >>> MaxPool2D = nn.MaxPool2D(
+            ...     kernel_size=2, stride=2, padding=0, return_mask=True
+            ... )
             >>> output, max_indices = MaxPool2D(input)
             >>> print(output.shape)
-            [1, 3, 16, 16]
+            paddle.Size([1, 3, 16, 16])
             >>> print(max_indices.shape)
-            [1, 3, 16, 16]
+            paddle.Size([1, 3, 16, 16])
     """
 
     kernel_size: Size2
@@ -869,25 +891,29 @@ class MaxPool3D(Layer):
           The data type is same as input x.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
 
             >>> # max pool3d
-            >>> input = paddle.uniform([1, 2, 3, 32, 32], dtype="float32", min=-1, max=1)
+            >>> input = paddle.uniform(
+            ...     [1, 2, 3, 32, 32], dtype="float32", min=-1, max=1
+            ... )
             >>> MaxPool3D = nn.MaxPool3D(kernel_size=2, stride=2, padding=0)
             >>> output = MaxPool3D(input)
             >>> print(output.shape)
-            [1, 2, 1, 16, 16]
+            paddle.Size([1, 2, 1, 16, 16])
 
             >>> # for return_mask=True
-            >>> MaxPool3D = nn.MaxPool3D(kernel_size=2, stride=2, padding=0, return_mask=True)
+            >>> MaxPool3D = nn.MaxPool3D(
+            ...     kernel_size=2, stride=2, padding=0, return_mask=True
+            ... )
             >>> output, max_indices = MaxPool3D(input)
             >>> print(output.shape)
-            [1, 2, 1, 16, 16]
+            paddle.Size([1, 2, 1, 16, 16])
             >>> print(max_indices.shape)
-            [1, 2, 1, 16, 16]
+            paddle.Size([1, 2, 1, 16, 16])
     """
 
     kernel_size: Size3
@@ -962,7 +988,7 @@ class AdaptiveAvgPool1D(Layer):
         A callable object for computing 1D adaptive average pooling.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # average adaptive pool1d
             >>> # suppose input data in shape of [N, C, L], `output_size` is m or [m],
@@ -979,11 +1005,13 @@ class AdaptiveAvgPool1D(Layer):
             >>> import paddle
             >>> import paddle.nn as nn
 
-            >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
+            >>> data = paddle.uniform(
+            ...     [1, 3, 32], dtype="float32", min=-1, max=1
+            ... )
             >>> AdaptiveAvgPool1D = nn.AdaptiveAvgPool1D(output_size=16)
             >>> pool_out = AdaptiveAvgPool1D(data)
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
     """
 
     output_size: int
@@ -1042,7 +1070,7 @@ class AdaptiveAvgPool2D(Layer):
         A callable object of AdaptiveAvgPool2D.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # adaptive avg pool2d
             >>> # suppose input data in shape of [N, C, H, W], `output_size` is [m, n],
@@ -1064,9 +1092,9 @@ class AdaptiveAvgPool2D(Layer):
             >>> x = paddle.rand([2, 3, 32, 32])
 
             >>> adaptive_avg_pool = paddle.nn.AdaptiveAvgPool2D(output_size=3)
-            >>> pool_out = adaptive_avg_pool(x = x)
+            >>> pool_out = adaptive_avg_pool(x=x)
             >>> print(pool_out.shape)
-            [2, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3])
     """
 
     def __init__(
@@ -1146,7 +1174,7 @@ class AdaptiveAvgPool3D(Layer):
         A callable object of AdaptiveAvgPool3D.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # adaptive avg pool3d
             >>> # suppose input data in shape of [N, C, D, H, W], `output_size` is [l, m, n],
@@ -1171,9 +1199,9 @@ class AdaptiveAvgPool3D(Layer):
             >>> x = paddle.rand([2, 3, 8, 32, 32])
 
             >>> adaptive_avg_pool = paddle.nn.AdaptiveAvgPool3D(output_size=3)
-            >>> pool_out = adaptive_avg_pool(x = x)
+            >>> pool_out = adaptive_avg_pool(x=x)
             >>> print(pool_out.shape)
-            [2, 3, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3, 3])
     """
 
     def __init__(
@@ -1243,7 +1271,7 @@ class AdaptiveMaxPool1D(Layer):
           The data type is same as input x.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # max adaptive pool1d
             >>> # suppose input data in shape of [N, C, L], `output_size` is m or [m],
@@ -1260,19 +1288,23 @@ class AdaptiveMaxPool1D(Layer):
             >>> import paddle
             >>> import paddle.nn as nn
 
-            >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
+            >>> data = paddle.uniform(
+            ...     [1, 3, 32], dtype="float32", min=-1, max=1
+            ... )
             >>> AdaptiveMaxPool1D = nn.AdaptiveMaxPool1D(output_size=16)
             >>> pool_out = AdaptiveMaxPool1D(data)
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
 
             >>> # for return_mask = true
-            >>> AdaptiveMaxPool1D = nn.AdaptiveMaxPool1D(output_size=16, return_mask=True)
+            >>> AdaptiveMaxPool1D = nn.AdaptiveMaxPool1D(
+            ...     output_size=16, return_mask=True
+            ... )
             >>> pool_out, indices = AdaptiveMaxPool1D(data)
             >>> print(pool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
             >>> print(indices.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
 
     """
 
@@ -1346,7 +1378,7 @@ class AdaptiveMaxPool2D(Layer):
     Returns:
         A callable object of AdaptiveMaxPool2D.
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # adaptive max pool2d
             >>> # suppose input data in shape of [N, C, H, W], `output_size` is [m, n],
@@ -1367,12 +1399,14 @@ class AdaptiveMaxPool2D(Layer):
 
             >>> x = paddle.rand([2, 3, 32, 32])
 
-            >>> adaptive_max_pool = paddle.nn.AdaptiveMaxPool2D(output_size=3, return_mask=True)
-            >>> pool_out, indices = adaptive_max_pool(x = x)
+            >>> adaptive_max_pool = paddle.nn.AdaptiveMaxPool2D(
+            ...     output_size=3, return_mask=True
+            ... )
+            >>> pool_out, indices = adaptive_max_pool(x=x)
             >>> print(pool_out.shape)
-            [2, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3])
             >>> print(indices.shape)
-            [2, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3])
     """
 
     @param_one_alias(["return_mask", "return_indices"])
@@ -1451,7 +1485,7 @@ class AdaptiveMaxPool3D(Layer):
     Returns:
         A callable object of AdaptiveMaxPool3D.
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # adaptive max pool3d
             >>> # suppose input data in shape of [N, C, D, H, W], `output_size` is [l, m, n],
@@ -1477,13 +1511,15 @@ class AdaptiveMaxPool3D(Layer):
             >>> pool = paddle.nn.AdaptiveMaxPool3D(output_size=4)
             >>> out = pool(x)
             >>> print(out.shape)
-            [2, 3, 4, 4, 4]
-            >>> pool = paddle.nn.AdaptiveMaxPool3D(output_size=3, return_mask=True)
+            paddle.Size([2, 3, 4, 4, 4])
+            >>> pool = paddle.nn.AdaptiveMaxPool3D(
+            ...     output_size=3, return_mask=True
+            ... )
             >>> out, indices = pool(x)
             >>> print(out.shape)
-            [2, 3, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3, 3])
             >>> print(indices.shape)
-            [2, 3, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3, 3])
 
     """
 
@@ -1559,21 +1595,23 @@ class MaxUnPool1D(Layer):
         A callable object of MaxUnPool1D.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
 
             >>> data = paddle.rand(shape=[1, 3, 16])
-            >>> pool_out, indices = F.max_pool1d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
+            >>> pool_out, indices = F.max_pool1d(
+            ...     data, kernel_size=2, stride=2, padding=0, return_mask=True
+            ... )
             >>> print(pool_out.shape)
-            [1, 3, 8]
+            paddle.Size([1, 3, 8])
             >>> print(indices.shape)
-            [1, 3, 8]
+            paddle.Size([1, 3, 8])
             >>> Unpool1D = paddle.nn.MaxUnPool1D(kernel_size=2, padding=0)
             >>> unpool_out = Unpool1D(pool_out, indices)
             >>> print(unpool_out.shape)
-            [1, 3, 16]
+            paddle.Size([1, 3, 16])
 
     """
 
@@ -1676,21 +1714,23 @@ class MaxUnPool2D(Layer):
 
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
 
             >>> data = paddle.rand(shape=[1, 1, 6, 6])
-            >>> pool_out, indices = F.max_pool2d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
+            >>> pool_out, indices = F.max_pool2d(
+            ...     data, kernel_size=2, stride=2, padding=0, return_mask=True
+            ... )
             >>> print(pool_out.shape)
-            [1, 1, 3, 3]
+            paddle.Size([1, 1, 3, 3])
             >>> print(indices.shape)
-            [1, 1, 3, 3]
+            paddle.Size([1, 1, 3, 3])
             >>> Unpool2D = paddle.nn.MaxUnPool2D(kernel_size=2, padding=0)
             >>> unpool_out = Unpool2D(pool_out, indices)
             >>> print(unpool_out.shape)
-            [1, 1, 6, 6]
+            paddle.Size([1, 1, 6, 6])
 
     """
 
@@ -1794,21 +1834,23 @@ class MaxUnPool3D(Layer):
         A callable object of MaxUnPool3D.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn.functional as F
 
             >>> data = paddle.rand(shape=[1, 1, 4, 4, 6])
-            >>> pool_out, indices = F.max_pool3d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
+            >>> pool_out, indices = F.max_pool3d(
+            ...     data, kernel_size=2, stride=2, padding=0, return_mask=True
+            ... )
             >>> print(pool_out.shape)
-            [1, 1, 2, 2, 3]
+            paddle.Size([1, 1, 2, 2, 3])
             >>> print(indices.shape)
-            [1, 1, 2, 2, 3]
+            paddle.Size([1, 1, 2, 2, 3])
             >>> Unpool3D = paddle.nn.MaxUnPool3D(kernel_size=2, padding=0)
             >>> unpool_out = Unpool3D(pool_out, indices)
             >>> print(unpool_out.shape)
-            [1, 1, 4, 4, 6]
+            paddle.Size([1, 1, 4, 4, 6])
 
     """
 
@@ -1920,7 +1962,7 @@ class FractionalMaxPool2D(Layer):
         A callable object of FractionalMaxPool2D.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # fractional max pool2d
             >>> # suppose input data in shape of [N, C, H, W], `output_size` is [m, n],
@@ -1933,23 +1975,29 @@ class FractionalMaxPool2D(Layer):
             >>> x = paddle.rand([2, 3, 32, 32])
 
             >>> # disjoint: without `kernel_size`
-            >>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(output_size=3)
+            >>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(
+            ...     output_size=3
+            ... )
             >>> pool_out = fractional_max_pool(x=x)
             >>> print(pool_out.shape)
-            [2, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3])
 
             >>> # overlapping: with `kernel_size`
-            >>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(kernel_size=2, output_size=3)
+            >>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(
+            ...     kernel_size=2, output_size=3
+            ... )
             >>> pool_out = fractional_max_pool(x=x)
             >>> print(pool_out.shape)
-            [2, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3])
 
-            >>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(output_size=[2, 3], return_mask=True)
+            >>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(
+            ...     output_size=[2, 3], return_mask=True
+            ... )
             >>> pool_out, indices = fractional_max_pool(x=x)
             >>> print(pool_out.shape)
-            [2, 3, 2, 3]
+            paddle.Size([2, 3, 2, 3])
             >>> print(indices.shape)
-            [2, 3, 2, 3]
+            paddle.Size([2, 3, 2, 3])
     """
 
     def __init__(
@@ -2036,7 +2084,7 @@ class FractionalMaxPool3D(Layer):
         A callable object of FractionalMaxPool3D.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # fractional max pool3d
             >>> # suppose input data in shape of [N, C, D, H, W], `output_size` is [l, m, n],
@@ -2049,23 +2097,29 @@ class FractionalMaxPool3D(Layer):
             >>> x = paddle.rand([2, 3, 8, 32, 32])
 
             >>> # disjoint: without `kernel_size`
-            >>> fractional_max_pool = paddle.nn.FractionalMaxPool3D(output_size=3)
+            >>> fractional_max_pool = paddle.nn.FractionalMaxPool3D(
+            ...     output_size=3
+            ... )
             >>> pool_out = fractional_max_pool(x=x)
             >>> print(pool_out.shape)
-            [2, 3, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3, 3])
 
             >>> # overlapping: with `kernel_size`
-            >>> fractional_max_pool = paddle.nn.FractionalMaxPool3D(kernel_size=2, output_size=3)
+            >>> fractional_max_pool = paddle.nn.FractionalMaxPool3D(
+            ...     kernel_size=2, output_size=3
+            ... )
             >>> pool_out = fractional_max_pool(x=x)
             >>> print(pool_out.shape)
-            [2, 3, 3, 3, 3]
+            paddle.Size([2, 3, 3, 3, 3])
 
-            >>> fractional_max_pool = paddle.nn.FractionalMaxPool3D(output_size=[2, 3, 3], return_mask=True)
+            >>> fractional_max_pool = paddle.nn.FractionalMaxPool3D(
+            ...     output_size=[2, 3, 3], return_mask=True
+            ... )
             >>> pool_out, indices = fractional_max_pool(x=x)
             >>> print(pool_out.shape)
-            [2, 3, 2, 3, 3]
+            paddle.Size([2, 3, 2, 3, 3])
             >>> print(indices.shape)
-            [2, 3, 2, 3, 3]
+            paddle.Size([2, 3, 2, 3, 3])
     """
 
     def __init__(

--- a/python/paddle/nn/layer/pooling.py
+++ b/python/paddle/nn/layer/pooling.py
@@ -96,9 +96,7 @@ class AvgPool1D(Layer):
             >>> import paddle
             >>> import paddle.nn as nn
 
-            >>> data = paddle.uniform(
-            ...     [1, 3, 32], dtype="float32", min=-1, max=1
-            ... )
+            >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
             >>> AvgPool1D = nn.AvgPool1D(kernel_size=2, stride=2, padding=0)
             >>> pool_out = AvgPool1D(data)
             >>> print(pool_out.shape)
@@ -212,9 +210,7 @@ class AvgPool2D(Layer):
             >>> import paddle.nn as nn
 
             >>> # max pool2d
-            >>> input = paddle.uniform(
-            ...     [1, 3, 32, 32], dtype="float32", min=-1, max=1
-            ... )
+            >>> input = paddle.uniform([1, 3, 32, 32], dtype="float32", min=-1, max=1)
             >>> AvgPool2D = nn.AvgPool2D(kernel_size=2, stride=2, padding=0)
             >>> output = AvgPool2D(input)
             >>> print(output.shape)
@@ -324,9 +320,7 @@ class AvgPool3D(Layer):
             >>> import paddle.nn as nn
 
             >>> # avg pool3d
-            >>> input = paddle.uniform(
-            ...     [1, 2, 3, 32, 32], dtype="float32", min=-1, max=1
-            ... )
+            >>> input = paddle.uniform([1, 2, 3, 32, 32], dtype="float32", min=-1, max=1)
             >>> AvgPool3D = nn.AvgPool3D(kernel_size=2, stride=2, padding=0)
             >>> output = AvgPool3D(input)
             >>> print(output.shape)
@@ -435,12 +429,8 @@ class LPPool1D(Layer):
             >>> import paddle
             >>> import paddle.nn as nn
 
-            >>> data = paddle.uniform(
-            ...     [1, 3, 32], dtype="float32", min=-1, max=1
-            ... )
-            >>> LPPool1D = nn.LPPool1D(
-            ...     norm_type=2, kernel_size=2, stride=2, padding=0
-            ... )
+            >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
+            >>> LPPool1D = nn.LPPool1D(norm_type=2, kernel_size=2, stride=2, padding=0)
             >>> pool_out = LPPool1D(data)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 16])
@@ -556,12 +546,8 @@ class LPPool2D(Layer):
             >>> import paddle.nn as nn
 
             >>> # lp pool2d
-            >>> input = paddle.uniform(
-            ...     [1, 3, 32, 32], dtype="float32", min=-1, max=1
-            ... )
-            >>> LPPool2D = nn.LPPool2D(
-            ...     norm_type=2, kernel_size=2, stride=2, padding=0
-            ... )
+            >>> input = paddle.uniform([1, 3, 32, 32], dtype="float32", min=-1, max=1)
+            >>> LPPool2D = nn.LPPool2D(norm_type=2, kernel_size=2, stride=2, padding=0)
             >>> output = LPPool2D(input)
             >>> print(output.shape)
             paddle.Size([1, 3, 16, 16])
@@ -664,17 +650,13 @@ class MaxPool1D(Layer):
             >>> import paddle
             >>> import paddle.nn as nn
 
-            >>> data = paddle.uniform(
-            ...     [1, 3, 32], dtype="float32", min=-1, max=1
-            ... )
+            >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
             >>> MaxPool1D = nn.MaxPool1D(kernel_size=2, stride=2, padding=0)
             >>> pool_out = MaxPool1D(data)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 16])
 
-            >>> MaxPool1D = nn.MaxPool1D(
-            ...     kernel_size=2, stride=2, padding=0, return_mask=True
-            ... )
+            >>> MaxPool1D = nn.MaxPool1D(kernel_size=2, stride=2, padding=0, return_mask=True)
             >>> pool_out, indices = MaxPool1D(data)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 16])
@@ -785,18 +767,14 @@ class MaxPool2D(Layer):
             >>> import paddle.nn as nn
 
             >>> # max pool2d
-            >>> input = paddle.uniform(
-            ...     [1, 3, 32, 32], dtype="float32", min=-1, max=1
-            ... )
+            >>> input = paddle.uniform([1, 3, 32, 32], dtype="float32", min=-1, max=1)
             >>> MaxPool2D = nn.MaxPool2D(kernel_size=2, stride=2, padding=0)
             >>> output = MaxPool2D(input)
             >>> print(output.shape)
             paddle.Size([1, 3, 16, 16])
 
             >>> # for return_mask=True
-            >>> MaxPool2D = nn.MaxPool2D(
-            ...     kernel_size=2, stride=2, padding=0, return_mask=True
-            ... )
+            >>> MaxPool2D = nn.MaxPool2D(kernel_size=2, stride=2, padding=0, return_mask=True)
             >>> output, max_indices = MaxPool2D(input)
             >>> print(output.shape)
             paddle.Size([1, 3, 16, 16])
@@ -897,18 +875,14 @@ class MaxPool3D(Layer):
             >>> import paddle.nn as nn
 
             >>> # max pool3d
-            >>> input = paddle.uniform(
-            ...     [1, 2, 3, 32, 32], dtype="float32", min=-1, max=1
-            ... )
+            >>> input = paddle.uniform([1, 2, 3, 32, 32], dtype="float32", min=-1, max=1)
             >>> MaxPool3D = nn.MaxPool3D(kernel_size=2, stride=2, padding=0)
             >>> output = MaxPool3D(input)
             >>> print(output.shape)
             paddle.Size([1, 2, 1, 16, 16])
 
             >>> # for return_mask=True
-            >>> MaxPool3D = nn.MaxPool3D(
-            ...     kernel_size=2, stride=2, padding=0, return_mask=True
-            ... )
+            >>> MaxPool3D = nn.MaxPool3D(kernel_size=2, stride=2, padding=0, return_mask=True)
             >>> output, max_indices = MaxPool3D(input)
             >>> print(output.shape)
             paddle.Size([1, 2, 1, 16, 16])
@@ -1005,9 +979,7 @@ class AdaptiveAvgPool1D(Layer):
             >>> import paddle
             >>> import paddle.nn as nn
 
-            >>> data = paddle.uniform(
-            ...     [1, 3, 32], dtype="float32", min=-1, max=1
-            ... )
+            >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
             >>> AdaptiveAvgPool1D = nn.AdaptiveAvgPool1D(output_size=16)
             >>> pool_out = AdaptiveAvgPool1D(data)
             >>> print(pool_out.shape)
@@ -1288,18 +1260,14 @@ class AdaptiveMaxPool1D(Layer):
             >>> import paddle
             >>> import paddle.nn as nn
 
-            >>> data = paddle.uniform(
-            ...     [1, 3, 32], dtype="float32", min=-1, max=1
-            ... )
+            >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
             >>> AdaptiveMaxPool1D = nn.AdaptiveMaxPool1D(output_size=16)
             >>> pool_out = AdaptiveMaxPool1D(data)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 16])
 
             >>> # for return_mask = true
-            >>> AdaptiveMaxPool1D = nn.AdaptiveMaxPool1D(
-            ...     output_size=16, return_mask=True
-            ... )
+            >>> AdaptiveMaxPool1D = nn.AdaptiveMaxPool1D(output_size=16, return_mask=True)
             >>> pool_out, indices = AdaptiveMaxPool1D(data)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 16])
@@ -1399,9 +1367,7 @@ class AdaptiveMaxPool2D(Layer):
 
             >>> x = paddle.rand([2, 3, 32, 32])
 
-            >>> adaptive_max_pool = paddle.nn.AdaptiveMaxPool2D(
-            ...     output_size=3, return_mask=True
-            ... )
+            >>> adaptive_max_pool = paddle.nn.AdaptiveMaxPool2D(output_size=3, return_mask=True)
             >>> pool_out, indices = adaptive_max_pool(x=x)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 3, 3])
@@ -1512,9 +1478,7 @@ class AdaptiveMaxPool3D(Layer):
             >>> out = pool(x)
             >>> print(out.shape)
             paddle.Size([2, 3, 4, 4, 4])
-            >>> pool = paddle.nn.AdaptiveMaxPool3D(
-            ...     output_size=3, return_mask=True
-            ... )
+            >>> pool = paddle.nn.AdaptiveMaxPool3D(output_size=3, return_mask=True)
             >>> out, indices = pool(x)
             >>> print(out.shape)
             paddle.Size([2, 3, 3, 3, 3])
@@ -1601,9 +1565,7 @@ class MaxUnPool1D(Layer):
             >>> import paddle.nn.functional as F
 
             >>> data = paddle.rand(shape=[1, 3, 16])
-            >>> pool_out, indices = F.max_pool1d(
-            ...     data, kernel_size=2, stride=2, padding=0, return_mask=True
-            ... )
+            >>> pool_out, indices = F.max_pool1d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 8])
             >>> print(indices.shape)
@@ -1720,9 +1682,7 @@ class MaxUnPool2D(Layer):
             >>> import paddle.nn.functional as F
 
             >>> data = paddle.rand(shape=[1, 1, 6, 6])
-            >>> pool_out, indices = F.max_pool2d(
-            ...     data, kernel_size=2, stride=2, padding=0, return_mask=True
-            ... )
+            >>> pool_out, indices = F.max_pool2d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
             >>> print(pool_out.shape)
             paddle.Size([1, 1, 3, 3])
             >>> print(indices.shape)
@@ -1840,9 +1800,7 @@ class MaxUnPool3D(Layer):
             >>> import paddle.nn.functional as F
 
             >>> data = paddle.rand(shape=[1, 1, 4, 4, 6])
-            >>> pool_out, indices = F.max_pool3d(
-            ...     data, kernel_size=2, stride=2, padding=0, return_mask=True
-            ... )
+            >>> pool_out, indices = F.max_pool3d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
             >>> print(pool_out.shape)
             paddle.Size([1, 1, 2, 2, 3])
             >>> print(indices.shape)
@@ -1975,24 +1933,18 @@ class FractionalMaxPool2D(Layer):
             >>> x = paddle.rand([2, 3, 32, 32])
 
             >>> # disjoint: without `kernel_size`
-            >>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(
-            ...     output_size=3
-            ... )
+            >>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(output_size=3)
             >>> pool_out = fractional_max_pool(x=x)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 3, 3])
 
             >>> # overlapping: with `kernel_size`
-            >>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(
-            ...     kernel_size=2, output_size=3
-            ... )
+            >>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(kernel_size=2, output_size=3)
             >>> pool_out = fractional_max_pool(x=x)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 3, 3])
 
-            >>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(
-            ...     output_size=[2, 3], return_mask=True
-            ... )
+            >>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(output_size=[2, 3], return_mask=True)
             >>> pool_out, indices = fractional_max_pool(x=x)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 2, 3])
@@ -2097,24 +2049,18 @@ class FractionalMaxPool3D(Layer):
             >>> x = paddle.rand([2, 3, 8, 32, 32])
 
             >>> # disjoint: without `kernel_size`
-            >>> fractional_max_pool = paddle.nn.FractionalMaxPool3D(
-            ...     output_size=3
-            ... )
+            >>> fractional_max_pool = paddle.nn.FractionalMaxPool3D(output_size=3)
             >>> pool_out = fractional_max_pool(x=x)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 3, 3, 3])
 
             >>> # overlapping: with `kernel_size`
-            >>> fractional_max_pool = paddle.nn.FractionalMaxPool3D(
-            ...     kernel_size=2, output_size=3
-            ... )
+            >>> fractional_max_pool = paddle.nn.FractionalMaxPool3D(kernel_size=2, output_size=3)
             >>> pool_out = fractional_max_pool(x=x)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 3, 3, 3])
 
-            >>> fractional_max_pool = paddle.nn.FractionalMaxPool3D(
-            ...     output_size=[2, 3, 3], return_mask=True
-            ... )
+            >>> fractional_max_pool = paddle.nn.FractionalMaxPool3D(output_size=[2, 3, 3], return_mask=True)
             >>> pool_out, indices = fractional_max_pool(x=x)
             >>> print(pool_out.shape)
             paddle.Size([2, 3, 2, 3, 3])

--- a/python/paddle/nn/layer/rnn.py
+++ b/python/paddle/nn/layer/rnn.py
@@ -109,7 +109,7 @@ def rnn(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -120,9 +120,9 @@ def rnn(
             >>> rnn = paddle.nn.RNN(cell)
             >>> outputs, final_states = rnn(inputs, prev_h)
             >>> print(outputs.shape)
-            [4, 23, 32]
+            paddle.Size([4, 23, 32])
             >>> print(final_states.shape)
-            [4, 32]
+            paddle.Size([4, 32])
 
     """
 
@@ -433,7 +433,7 @@ def birnn(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -443,9 +443,9 @@ def birnn(
             >>> inputs = paddle.rand((2, 23, 16))
             >>> outputs, final_states = rnn(inputs)
             >>> print(outputs.shape)
-            [2, 23, 64]
+            paddle.Size([2, 23, 64])
             >>> print(final_states[0][0].shape)
-            [2, 32]
+            paddle.Size([2, 32])
 
     """
 
@@ -791,7 +791,7 @@ class SimpleRNNCell(RNNCellBase):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -801,7 +801,7 @@ class SimpleRNNCell(RNNCellBase):
             >>> cell = paddle.nn.SimpleRNNCell(16, 32)
             >>> y, h = cell(x, prev_h)
             >>> print(y.shape)
-            [4, 32]
+            paddle.Size([4, 32])
 
     """
 
@@ -990,7 +990,7 @@ class LSTMCell(RNNCellBase):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -1002,11 +1002,11 @@ class LSTMCell(RNNCellBase):
             >>> y, (h, c) = cell(x, (prev_h, prev_c))
 
             >>> print(y.shape)
-            [4, 32]
+            paddle.Size([4, 32])
             >>> print(h.shape)
-            [4, 32]
+            paddle.Size([4, 32])
             >>> print(c.shape)
-            [4, 32]
+            paddle.Size([4, 32])
 
     """
 
@@ -1202,7 +1202,7 @@ class GRUCell(RNNCellBase):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -1213,9 +1213,9 @@ class GRUCell(RNNCellBase):
             >>> y, h = cell(x, prev_h)
 
             >>> print(y.shape)
-            [4, 32]
+            paddle.Size([4, 32])
             >>> print(h.shape)
-            [4, 32]
+            paddle.Size([4, 32])
 
 
     """
@@ -1368,7 +1368,7 @@ class RNN(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -1380,9 +1380,9 @@ class RNN(Layer):
             >>> outputs, final_states = rnn(inputs, prev_h)
 
             >>> print(outputs.shape)
-            [4, 23, 32]
+            paddle.Size([4, 23, 32])
             >>> print(final_states.shape)
-            [4, 32]
+            paddle.Size([4, 32])
 
     """
 
@@ -1450,7 +1450,7 @@ class BiRNN(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -1462,8 +1462,12 @@ class BiRNN(Layer):
             >>> outputs, final_states = rnn(inputs)
 
             >>> print(outputs.shape)
-            [2, 23, 64]
-            >>> print(final_states[0][0].shape,len(final_states),len(final_states[0]))
+            paddle.Size([2, 23, 64])
+            >>> print(
+            ...     final_states[0][0].shape,
+            ...     len(final_states),
+            ...     len(final_states[0]),
+            ... )
             [2, 32] 2 2
 
     """
@@ -1926,7 +1930,7 @@ class SimpleRNN(RNNBase):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -1937,9 +1941,9 @@ class SimpleRNN(RNNBase):
             >>> y, h = rnn(x, prev_h)
 
             >>> print(y.shape)
-            [4, 23, 32]
+            paddle.Size([4, 23, 32])
             >>> print(h.shape)
-            [2, 4, 32]
+            paddle.Size([2, 4, 32])
 
 
     """
@@ -2067,7 +2071,7 @@ class LSTM(RNNBase):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -2079,11 +2083,11 @@ class LSTM(RNNBase):
             >>> y, (h, c) = rnn(x, (prev_h, prev_c))
 
             >>> print(y.shape)
-            [4, 23, 32]
+            paddle.Size([4, 23, 32])
             >>> print(h.shape)
-            [2, 4, 32]
+            paddle.Size([2, 4, 32])
             >>> print(c.shape)
-            [2, 4, 32]
+            paddle.Size([2, 4, 32])
 
 
     """
@@ -2191,7 +2195,7 @@ class GRU(RNNBase):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -2202,9 +2206,9 @@ class GRU(RNNBase):
             >>> y, h = rnn(x, prev_h)
 
             >>> print(y.shape)
-            [4, 23, 32]
+            paddle.Size([4, 23, 32])
             >>> print(h.shape)
-            [2, 4, 32]
+            paddle.Size([2, 4, 32])
 
 
     """

--- a/python/paddle/nn/layer/rnn.py
+++ b/python/paddle/nn/layer/rnn.py
@@ -1468,7 +1468,7 @@ class BiRNN(Layer):
             ...     len(final_states),
             ...     len(final_states[0]),
             ... )
-            [2, 32] 2 2
+            paddle.Size([2, 32]) 2 2
 
     """
 

--- a/python/paddle/nn/layer/transformer.py
+++ b/python/paddle/nn/layer/transformer.py
@@ -989,9 +989,7 @@ class TransformerDecoderLayer(Layer):
             >>> # cross attention mask: [batch_size, n_head, tgt_len, src_len]
             >>> cross_attn_mask = paddle.rand((2, 2, 4, 6))
             >>> decoder_layer = TransformerDecoderLayer(128, 2, 512)
-            >>> output = decoder_layer(
-            ...     dec_input, enc_output, self_attn_mask, cross_attn_mask
-            ... )
+            >>> output = decoder_layer(dec_input, enc_output, self_attn_mask, cross_attn_mask)
             >>> print(output.shape)
             paddle.Size([2, 4, 128])
     """
@@ -1242,9 +1240,7 @@ class TransformerDecoder(Layer):
             >>> cross_attn_mask = paddle.rand((2, 2, 4, 6))
             >>> decoder_layer = TransformerDecoderLayer(128, 2, 512)
             >>> decoder = TransformerDecoder(decoder_layer, 2)
-            >>> output = decoder(
-            ...     dec_input, enc_output, self_attn_mask, cross_attn_mask
-            ... )
+            >>> output = decoder(dec_input, enc_output, self_attn_mask, cross_attn_mask)
             >>> print(output.shape)
             paddle.Size([2, 4, 128])
     """

--- a/python/paddle/nn/layer/transformer.py
+++ b/python/paddle/nn/layer/transformer.py
@@ -159,7 +159,7 @@ class MultiHeadAttention(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -170,7 +170,7 @@ class MultiHeadAttention(Layer):
             >>> multi_head_attn = paddle.nn.MultiHeadAttention(128, 2)
             >>> output = multi_head_attn(query, None, None, attn_mask=attn_mask)
             >>> print(output.shape)
-            [2, 4, 128]
+            paddle.Size([2, 4, 128])
     """
 
     Cache = collections.namedtuple("Cache", ["k", "v"])
@@ -795,10 +795,13 @@ class TransformerEncoder(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
-            >>> from paddle.nn import TransformerEncoderLayer, TransformerEncoder
+            >>> from paddle.nn import (
+            ...     TransformerEncoderLayer,
+            ...     TransformerEncoder,
+            ... )
 
             >>> # encoder input: [batch_size, src_len, d_model]
             >>> enc_input = paddle.rand((2, 4, 128))
@@ -808,7 +811,7 @@ class TransformerEncoder(Layer):
             >>> encoder = TransformerEncoder(encoder_layer, 2)
             >>> enc_output = encoder(enc_input, attn_mask)
             >>> print(enc_output.shape)
-            [2, 4, 128]
+            paddle.Size([2, 4, 128])
     """
 
     num_layers: int
@@ -1221,10 +1224,13 @@ class TransformerDecoder(Layer):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
-            >>> from paddle.nn import TransformerDecoderLayer, TransformerDecoder
+            >>> from paddle.nn import (
+            ...     TransformerDecoderLayer,
+            ...     TransformerDecoder,
+            ... )
 
             >>> # decoder input: [batch_size, tgt_len, d_model]
             >>> dec_input = paddle.rand((2, 4, 128))
@@ -1236,12 +1242,11 @@ class TransformerDecoder(Layer):
             >>> cross_attn_mask = paddle.rand((2, 2, 4, 6))
             >>> decoder_layer = TransformerDecoderLayer(128, 2, 512)
             >>> decoder = TransformerDecoder(decoder_layer, 2)
-            >>> output = decoder(dec_input,
-            ...                  enc_output,
-            ...                  self_attn_mask,
-            ...                  cross_attn_mask)
+            >>> output = decoder(
+            ...     dec_input, enc_output, self_attn_mask, cross_attn_mask
+            ... )
             >>> print(output.shape)
-            [2, 4, 128]
+            paddle.Size([2, 4, 128])
     """
 
     num_layers: int

--- a/python/paddle/nn/layer/vision.py
+++ b/python/paddle/nn/layer/vision.py
@@ -50,7 +50,7 @@ class PixelShuffle(Layer):
 
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
@@ -59,7 +59,7 @@ class PixelShuffle(Layer):
             >>> pixel_shuffle = nn.PixelShuffle(3)
             >>> out = pixel_shuffle(x)
             >>> print(out.shape)
-            [2, 1, 12, 12]
+            paddle.Size([2, 1, 12, 12])
 
     """
 
@@ -118,7 +118,7 @@ class PixelUnshuffle(Layer):
         - **out**: 4-D tensor with shape of :math:`[N, r^2C, H/r, W/r]` or :math:`[N, H/r, W/r, r^2C]`, where :math:`r` is :attr:`downscale_factor`.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
@@ -127,7 +127,7 @@ class PixelUnshuffle(Layer):
             >>> pixel_unshuffle = nn.PixelUnshuffle(3)
             >>> out = pixel_unshuffle(x)
             >>> print(out.shape)
-            [2, 9, 4, 4]
+            paddle.Size([2, 9, 4, 4])
 
     """
 

--- a/python/paddle/nn/quant/quant_layers.py
+++ b/python/paddle/nn/quant/quant_layers.py
@@ -650,21 +650,25 @@ class QuantizedConv2DTranspose(Layer):
     The only difference is that its inputs are all fake quantized.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
-            >>> from paddle.nn.quant.quant_layers import QuantizedConv2DTranspose
+            >>> from paddle.nn.quant.quant_layers import (
+            ...     QuantizedConv2DTranspose,
+            ... )
 
-            >>> x_var = paddle.uniform((2, 4, 8, 8), dtype='float32', min=-1., max=1.)
+            >>> x_var = paddle.uniform(
+            ...     (2, 4, 8, 8), dtype='float32', min=-1.0, max=1.0
+            ... )
             >>> conv = nn.Conv2DTranspose(4, 6, (3, 3))
             >>> conv_quantized = QuantizedConv2DTranspose(conv)
             >>> y_quantized = conv_quantized(x_var)
             >>> y_var = conv(x_var)
             >>> print(y_var.shape)
-            [2, 6, 10, 10]
+            paddle.Size([2, 6, 10, 10])
             >>> print(y_quantized.shape)
-            [2, 6, 10, 10]
+            paddle.Size([2, 6, 10, 10])
 
     """
 

--- a/python/paddle/nn/quant/quant_layers.py
+++ b/python/paddle/nn/quant/quant_layers.py
@@ -658,9 +658,7 @@ class QuantizedConv2DTranspose(Layer):
             ...     QuantizedConv2DTranspose,
             ... )
 
-            >>> x_var = paddle.uniform(
-            ...     (2, 4, 8, 8), dtype='float32', min=-1.0, max=1.0
-            ... )
+            >>> x_var = paddle.uniform((2, 4, 8, 8), dtype='float32', min=-1.0, max=1.0)
             >>> conv = nn.Conv2DTranspose(4, 6, (3, 3))
             >>> conv_quantized = QuantizedConv2DTranspose(conv)
             >>> y_quantized = conv_quantized(x_var)

--- a/python/paddle/nn/quant/quantized_linear.py
+++ b/python/paddle/nn/quant/quantized_linear.py
@@ -79,7 +79,7 @@ def weight_quantize(
         out (Tensor): The Tensor which is the quantitative results, the data type is int8, the shape is transposition of x.
         scale (Tensor): The scale Tensor which is the scale of pre-channel, the data type is float32.
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('No testing required')
             >>> import paddle
@@ -89,9 +89,9 @@ def weight_quantize(
             >>> x = paddle.rand(shape=[64, 32], dtype=paddle.float16)
             >>> out, scale = weight_quantize(x, algo='weight_only_int8')
             >>> print(out.shape)
-            [32, 64]
+            paddle.Size([32, 64])
             >>> print(scale.shape)
-            [32]
+            paddle.Size([32])
     """
     if arch is None:
         arch = _get_arch_info()
@@ -211,20 +211,28 @@ def weight_only_linear(
         Tensor: the output Tensor, the data type is the same as that of x.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('No testing required')
             >>> import paddle
             >>> from paddle.nn.quant import weight_only_linear
 
             >>> x = paddle.cast(paddle.randn([1, 2, 64]), dtype='float16')
-            >>> weight = paddle.cast(paddle.randint(0, 127, [32, 64]), dtype='int8')
+            >>> weight = paddle.cast(
+            ...     paddle.randint(0, 127, [32, 64]), dtype='int8'
+            ... )
             >>> scale = paddle.randn([32], dtype='float32')
             >>> bias = paddle.cast(paddle.randn([32]), dtype='float16')
             >>> if paddle.device.cuda.get_device_capability()[0] >= 8:
-            ...    out = weight_only_linear(x, weight, bias=bias, weight_scale=scale, weight_dtype='int8')
-            ...    print(out.shape)
-            [1, 2, 32]
+            ...     out = weight_only_linear(
+            ...         x,
+            ...         weight,
+            ...         bias=bias,
+            ...         weight_scale=scale,
+            ...         weight_dtype='int8',
+            ...     )
+            ...     print(out.shape)
+            paddle.Size([1, 2, 32])
     """
     if arch is None:
         arch = _get_arch_info()
@@ -304,20 +312,24 @@ def llm_int8_linear(
         Tensor: the output Tensor, the data type is the same as that of x.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('No testing required')
             >>> import paddle
             >>> from paddle.nn.quant import llm_int8_linear
 
             >>> x = paddle.cast(paddle.randn([1, 2, 64]), dtype='float16')
-            >>> weight = paddle.cast(paddle.randint(0, 127, [32, 64]), dtype='int8')
+            >>> weight = paddle.cast(
+            ...     paddle.randint(0, 127, [32, 64]), dtype='int8'
+            ... )
             >>> scale = paddle.randn([32], dtype='float32')
             >>> bias = paddle.cast(paddle.randn([32]), dtype='float16')
             >>> if paddle.device.cuda.get_device_capability()[0] >= 8:
-            ...    out = llm_int8_linear(x, weight, bias=bias, weight_scale=scale, threshold=6.0)
-            ...    print(out.shape)
-            [1, 2, 32]
+            ...     out = llm_int8_linear(
+            ...         x, weight, bias=bias, weight_scale=scale, threshold=6.0
+            ...     )
+            ...     print(out.shape)
+            paddle.Size([1, 2, 32])
     """
     if in_dynamic_or_pir_mode():
         out = _C_ops.llm_int8_linear(x, weight, bias, weight_scale, threshold)

--- a/python/paddle/nn/quant/quantized_linear.py
+++ b/python/paddle/nn/quant/quantized_linear.py
@@ -218,9 +218,7 @@ def weight_only_linear(
             >>> from paddle.nn.quant import weight_only_linear
 
             >>> x = paddle.cast(paddle.randn([1, 2, 64]), dtype='float16')
-            >>> weight = paddle.cast(
-            ...     paddle.randint(0, 127, [32, 64]), dtype='int8'
-            ... )
+            >>> weight = paddle.cast(paddle.randint(0, 127, [32, 64]), dtype='int8')
             >>> scale = paddle.randn([32], dtype='float32')
             >>> bias = paddle.cast(paddle.randn([32]), dtype='float16')
             >>> if paddle.device.cuda.get_device_capability()[0] >= 8:
@@ -319,15 +317,11 @@ def llm_int8_linear(
             >>> from paddle.nn.quant import llm_int8_linear
 
             >>> x = paddle.cast(paddle.randn([1, 2, 64]), dtype='float16')
-            >>> weight = paddle.cast(
-            ...     paddle.randint(0, 127, [32, 64]), dtype='int8'
-            ... )
+            >>> weight = paddle.cast(paddle.randint(0, 127, [32, 64]), dtype='int8')
             >>> scale = paddle.randn([32], dtype='float32')
             >>> bias = paddle.cast(paddle.randn([32]), dtype='float16')
             >>> if paddle.device.cuda.get_device_capability()[0] >= 8:
-            ...     out = llm_int8_linear(
-            ...         x, weight, bias=bias, weight_scale=scale, threshold=6.0
-            ...     )
+            ...     out = llm_int8_linear(x, weight, bias=bias, weight_scale=scale, threshold=6.0)
             ...     print(out.shape)
             paddle.Size([1, 2, 32])
     """

--- a/python/paddle/nn/utils/transform_parameters.py
+++ b/python/paddle/nn/utils/transform_parameters.py
@@ -100,7 +100,7 @@ def parameters_to_vector(
 
 
     Examples:
-       .. code-block:: python
+       .. code-block:: pycon
 
             >>> import paddle
             >>> paddle.seed(2023)
@@ -108,7 +108,7 @@ def parameters_to_vector(
 
             >>> t = paddle.nn.utils.parameters_to_vector(linear.parameters())
             >>> print(t.shape)
-            [165]
+            paddle.Size([165])
 
     """
     dtype = parameters[0].dtype

--- a/python/paddle/nn/utils/weight_norm_hook.py
+++ b/python/paddle/nn/utils/weight_norm_hook.py
@@ -205,7 +205,7 @@ def weight_norm(layer: Layer, name: str = 'weight', dim: int = 0) -> Layer:
         Origin layer with weight norm hook.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
           >>> from paddle.nn import Conv2D
           >>> from paddle.nn.utils import weight_norm
@@ -213,9 +213,9 @@ def weight_norm(layer: Layer, name: str = 'weight', dim: int = 0) -> Layer:
           >>> conv = Conv2D(3, 5, 3)
           >>> wn = weight_norm(conv)
           >>> print(conv.weight_g.shape)
-          [5]
+          paddle.Size([5])
           >>> print(conv.weight_v.shape)
-          [5, 3, 3, 3]
+          paddle.Size([5, 3, 3, 3])
     """
     WeightNorm.apply(layer, name, dim)
     return layer

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -611,9 +611,7 @@ def monkey_patch_value():
                 >>> startup_prog = paddle.static.Program()
                 >>> main_prog = paddle.static.Program()
                 >>> with paddle.static.program_guard(startup_prog, main_prog):
-                ...     x = paddle.assign(
-                ...         np.random.rand(2, 3, 4).astype("float32")
-                ...     )
+                ...     x = paddle.assign(np.random.rand(2, 3, 4).astype("float32"))
                 ...     (output_x,) = exe.run(main_program, fetch_list=[x.size])
                 ...     print(f"value's size is: {output_x}")
                 value's size is: 24

--- a/python/paddle/quantization/config.py
+++ b/python/paddle/quantization/config.py
@@ -236,9 +236,7 @@ class QuantConfig:
                 >>> model = Model()
                 >>> quanter = FakeQuanterWithAbsMaxObserver(moving_rate=0.9)
                 >>> q_config = QuantConfig(activation=None, weight=None)
-                >>> q_config.add_type_config(
-                ...     [Linear], activation=quanter, weight=quanter
-                ... )
+                >>> q_config.add_type_config([Linear], activation=quanter, weight=quanter)
                 >>> # doctest: +SKIP('random memory address')
                 >>> print(q_config)
                 Global config:
@@ -287,9 +285,7 @@ class QuantConfig:
                 ...     def forward(self, x):
                 ...         pass
                 ...         # add some code for quantization simulation
-                >>> q_config.add_qat_layer_mapping(
-                ...     Conv2D, CustomizedQuantedConv2D
-                ... )
+                >>> q_config.add_qat_layer_mapping(Conv2D, CustomizedQuantedConv2D)
         """
         assert isinstance(source, type) and issubclass(
             source, paddle.nn.Layer

--- a/python/paddle/signal.py
+++ b/python/paddle/signal.py
@@ -69,7 +69,7 @@ def frame(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle import signal
@@ -108,18 +108,18 @@ def frame(
             >>> x1 = paddle.arange(16).reshape([8, 2])
             >>> y1 = signal.frame(x1, frame_length=4, hop_length=2, axis=0)
             >>> print(y1.shape)
-            [3, 4, 2]
+            paddle.Size([3, 4, 2])
 
             >>> # > 2D
             >>> x0 = paddle.arange(32).reshape([2, 2, 8])
             >>> y0 = signal.frame(x0, frame_length=4, hop_length=2, axis=-1)
             >>> print(y0.shape)
-            [2, 2, 4, 3]
+            paddle.Size([2, 2, 4, 3])
 
             >>> x1 = paddle.arange(32).reshape([8, 2, 2])
             >>> y1 = signal.frame(x1, frame_length=4, hop_length=2, axis=0)
             >>> print(y1.shape)
-            [3, 4, 2, 2]
+            paddle.Size([3, 4, 2, 2])
     """
     if axis not in [0, -1]:
         raise ValueError(f'Unexpected axis: {axis}. It should be 0 or -1.')
@@ -190,7 +190,7 @@ def overlap_add(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.signal import overlap_add
@@ -231,12 +231,12 @@ def overlap_add(
             >>> x0 = paddle.arange(32).reshape([2, 1, 8, 2])
             >>> y0 = overlap_add(x0, hop_length=2, axis=-1)
             >>> print(y0.shape)
-            [2, 1, 10]
+            paddle.Size([2, 1, 10])
 
             >>> x1 = paddle.arange(32).reshape([2, 8, 1, 2])
             >>> y1 = overlap_add(x1, hop_length=2, axis=0)
             >>> print(y1.shape)
-            [10, 1, 2]
+            paddle.Size([10, 1, 2])
     """
     if axis not in [0, -1]:
         raise ValueError(f'Unexpected axis: {axis}. It should be 0 or -1.')
@@ -327,7 +327,7 @@ def stft(
         (`onesided` is `False`)
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.signal import stft
@@ -336,23 +336,23 @@ def stft(
             >>> x = paddle.randn([8, 48000], dtype=paddle.float64)
             >>> y1 = stft(x, n_fft=512)
             >>> print(y1.shape)
-            [8, 257, 376]
+            paddle.Size([8, 257, 376])
 
             >>> y2 = stft(x, n_fft=512, onesided=False)
             >>> print(y2.shape)
-            [8, 512, 376]
+            paddle.Size([8, 512, 376])
 
             >>> # complex input
             >>> x = paddle.randn([8, 48000], dtype=paddle.float64) + \
             ...         paddle.randn([8, 48000], dtype=paddle.float64)*1j
             >>> print(x.shape)
-            [8, 48000]
+            paddle.Size([8, 48000])
             >>> print(x.dtype)
             paddle.complex128
 
             >>> y1 = stft(x, n_fft=512, center=False, onesided=False)
             >>> print(y1.shape)
-            [8, 512, 372]
+            paddle.Size([8, 512, 372])
 
     """
 
@@ -517,7 +517,7 @@ def istft(
         `[..., seq_length]`
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import numpy as np
             >>> import paddle
@@ -529,12 +529,12 @@ def istft(
             >>> x = paddle.randn([8, 48000], dtype=paddle.float64)
             >>> y = stft(x, n_fft=512)
             >>> print(y.shape)
-            [8, 257, 376]
+            paddle.Size([8, 257, 376])
 
             >>> # ISTFT
             >>> x_ = istft(y, n_fft=512)
             >>> print(x_.shape)
-            [8, 48000]
+            paddle.Size([8, 48000])
 
             >>> np.allclose(x, x_)
             True

--- a/python/paddle/sparse/nn/functional/conv.py
+++ b/python/paddle/sparse/nn/functional/conv.py
@@ -448,9 +448,7 @@ def conv3d(
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
-            ...     indices, values, dense_shape, stop_gradient=True
-            ... )
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
             >>> weight = paddle.randn((1, 3, 3, 1, 1), dtype='float32')
             >>> y = paddle.sparse.nn.functional.conv3d(sparse_x, weight)
             >>> print(y.shape)
@@ -567,9 +565,7 @@ def subm_conv3d(
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
-            ...     indices, values, dense_shape, stop_gradient=True
-            ... )
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
             >>> weight = paddle.randn((1, 3, 3, 1, 1), dtype='float32')
             >>> y = paddle.sparse.nn.functional.subm_conv3d(sparse_x, weight)
             >>> print(y.shape)
@@ -686,9 +682,7 @@ def subm_conv3d_igemm(
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
-            ...     indices, values, dense_shape, stop_gradient=True
-            ... )
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
             >>> weight = paddle.randn((1, 3, 3, 1, 1), dtype='float32')
             >>> y = paddle.sparse.nn.functional.subm_conv3d(sparse_x, weight)
             >>> print(y.shape)
@@ -792,9 +786,7 @@ def conv2d(
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
-            ...     indices, values, dense_shape, stop_gradient=True
-            ... )
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
             >>> weight = paddle.randn((3, 3, 1, 1), dtype='float32')
             >>> y = paddle.sparse.nn.functional.conv2d(sparse_x, weight)
             >>> print(y.shape)
@@ -903,9 +895,7 @@ def subm_conv2d(
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
-            ...     indices, values, dense_shape, stop_gradient=True
-            ... )
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
             >>> weight = paddle.randn((3, 3, 1, 1), dtype='float32')
             >>> y = paddle.sparse.nn.functional.subm_conv2d(sparse_x, weight)
             >>> print(y.shape)
@@ -1014,9 +1004,7 @@ def subm_conv2d_igemm(
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
-            ...     indices, values, dense_shape, stop_gradient=True
-            ... )
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
             >>> weight = paddle.randn((3, 3, 1, 1), dtype='float32')
             >>> y = paddle.sparse.nn.functional.subm_conv2d(sparse_x, weight)
             >>> print(y.shape)

--- a/python/paddle/sparse/nn/functional/conv.py
+++ b/python/paddle/sparse/nn/functional/conv.py
@@ -434,20 +434,27 @@ def conv3d(
         A SparseCooTensor representing the conv3d, whose data type is the same with input.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
-            >>> indices = [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 2], [1, 3, 2, 3]]
+            >>> indices = [
+            ...     [0, 0, 0, 0],
+            ...     [0, 0, 0, 0],
+            ...     [0, 0, 1, 2],
+            ...     [1, 3, 2, 3],
+            ... ]
             >>> values = [[1], [2], [3], [4]]
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
+            ...     indices, values, dense_shape, stop_gradient=True
+            ... )
             >>> weight = paddle.randn((1, 3, 3, 1, 1), dtype='float32')
             >>> y = paddle.sparse.nn.functional.conv3d(sparse_x, weight)
             >>> print(y.shape)
-            [1, 1, 1, 2, 1]
+            paddle.Size([1, 1, 1, 2, 1])
     """
     return _conv3d(
         x,
@@ -546,20 +553,27 @@ def subm_conv3d(
         the same with input.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
-            >>> indices = [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 2], [1, 3, 2, 3]]
+            >>> indices = [
+            ...     [0, 0, 0, 0],
+            ...     [0, 0, 0, 0],
+            ...     [0, 0, 1, 2],
+            ...     [1, 3, 2, 3],
+            ... ]
             >>> values = [[1], [2], [3], [4]]
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
+            ...     indices, values, dense_shape, stop_gradient=True
+            ... )
             >>> weight = paddle.randn((1, 3, 3, 1, 1), dtype='float32')
             >>> y = paddle.sparse.nn.functional.subm_conv3d(sparse_x, weight)
             >>> print(y.shape)
-            [1, 1, 3, 4, 1]
+            paddle.Size([1, 1, 3, 4, 1])
     """
     return _conv3d(
         x,
@@ -658,20 +672,27 @@ def subm_conv3d_igemm(
         the same with input.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
-            >>> indices = [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 2], [1, 3, 2, 3]]
+            >>> indices = [
+            ...     [0, 0, 0, 0],
+            ...     [0, 0, 0, 0],
+            ...     [0, 0, 1, 2],
+            ...     [1, 3, 2, 3],
+            ... ]
             >>> values = [[1], [2], [3], [4]]
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
+            ...     indices, values, dense_shape, stop_gradient=True
+            ... )
             >>> weight = paddle.randn((1, 3, 3, 1, 1), dtype='float32')
             >>> y = paddle.sparse.nn.functional.subm_conv3d(sparse_x, weight)
             >>> print(y.shape)
-            [1, 1, 3, 4, 1]
+            paddle.Size([1, 1, 3, 4, 1])
     """
     return _conv3d_igemm(
         x,
@@ -762,7 +783,7 @@ def conv2d(
         A SparseCooTensor representing the conv2d, whose data type is the same with input.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -771,11 +792,13 @@ def conv2d(
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
+            ...     indices, values, dense_shape, stop_gradient=True
+            ... )
             >>> weight = paddle.randn((3, 3, 1, 1), dtype='float32')
             >>> y = paddle.sparse.nn.functional.conv2d(sparse_x, weight)
             >>> print(y.shape)
-            [1, 1, 2, 1]
+            paddle.Size([1, 1, 2, 1])
     """
     return _conv2d(
         x,
@@ -871,7 +894,7 @@ def subm_conv2d(
         A SparseCooTensor representing the conv2d, whose data type is the same with input.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -880,11 +903,13 @@ def subm_conv2d(
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
+            ...     indices, values, dense_shape, stop_gradient=True
+            ... )
             >>> weight = paddle.randn((3, 3, 1, 1), dtype='float32')
             >>> y = paddle.sparse.nn.functional.subm_conv2d(sparse_x, weight)
             >>> print(y.shape)
-            [1, 3, 4, 1]
+            paddle.Size([1, 3, 4, 1])
     """
     return _conv2d(
         x,
@@ -980,7 +1005,7 @@ def subm_conv2d_igemm(
         A SparseCooTensor representing the conv2d, whose data type is the same with input.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -989,11 +1014,13 @@ def subm_conv2d_igemm(
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
+            ...     indices, values, dense_shape, stop_gradient=True
+            ... )
             >>> weight = paddle.randn((3, 3, 1, 1), dtype='float32')
             >>> y = paddle.sparse.nn.functional.subm_conv2d(sparse_x, weight)
             >>> print(y.shape)
-            [1, 3, 4, 1]
+            paddle.Size([1, 3, 4, 1])
     """
     return _conv2d_igemm(
         x,

--- a/python/paddle/sparse/nn/functional/pooling.py
+++ b/python/paddle/sparse/nn/functional/pooling.py
@@ -84,9 +84,7 @@ def max_pool3d(
             >>> kernel_sizes = [3, 3, 3]
             >>> paddings = [0, 0, 0]
             >>> strides = [1, 1, 1]
-            >>> out = paddle.sparse.nn.functional.max_pool3d(
-            ...     sparse_x, kernel_sizes, stride=strides, padding=paddings
-            ... )
+            >>> out = paddle.sparse.nn.functional.max_pool3d(sparse_x, kernel_sizes, stride=strides, padding=paddings)
             >>> print(out.shape)
             paddle.Size([1, 2, 2, 2, 3])
     """

--- a/python/paddle/sparse/nn/functional/pooling.py
+++ b/python/paddle/sparse/nn/functional/pooling.py
@@ -75,7 +75,7 @@ def max_pool3d(
         Tensor: The output tensor of pooling result. The data type is same as input tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -84,9 +84,11 @@ def max_pool3d(
             >>> kernel_sizes = [3, 3, 3]
             >>> paddings = [0, 0, 0]
             >>> strides = [1, 1, 1]
-            >>> out = paddle.sparse.nn.functional.max_pool3d(sparse_x, kernel_sizes, stride=strides, padding=paddings)
+            >>> out = paddle.sparse.nn.functional.max_pool3d(
+            ...     sparse_x, kernel_sizes, stride=strides, padding=paddings
+            ... )
             >>> print(out.shape)
-            [1, 2, 2, 2, 3]
+            paddle.Size([1, 2, 2, 2, 3])
     """
 
     assert in_dynamic_or_pir_mode(), (

--- a/python/paddle/sparse/nn/layer/conv.py
+++ b/python/paddle/sparse/nn/layer/conv.py
@@ -407,9 +407,7 @@ class Conv3D(_Conv3D):
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
-            ...     indices, values, dense_shape, stop_gradient=True
-            ... )
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
             >>> conv = paddle.sparse.nn.Conv3D(1, 1, (1, 3, 3))
             >>> y = conv(sparse_x)
             >>> print(y.shape)
@@ -544,9 +542,7 @@ class Conv2D(_Conv2D):
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
-            ...     indices, values, dense_shape, stop_gradient=True
-            ... )
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
             >>> conv = paddle.sparse.nn.Conv2D(1, 1, (3, 3))
             >>> y = conv(sparse_x)
             >>> print(y.shape)
@@ -690,9 +686,7 @@ class SubmConv3D(_Conv3D):
             >>> dense_shape = [1, 1, 3, 4, 1]
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
-            ...     indices, values, dense_shape, stop_gradient=True
-            ... )
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
             >>> subm_conv = paddle.sparse.nn.SubmConv3D(1, 1, (1, 3, 3))
             >>> y = subm_conv(sparse_x)
             >>> print(y.shape)
@@ -834,9 +828,7 @@ class SubmConv2D(_Conv2D):
             >>> dense_shape = [1, 3, 4, 1]
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
-            ...     indices, values, dense_shape, stop_gradient=True
-            ... )
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
             >>> subm_conv = paddle.sparse.nn.SubmConv2D(1, 1, (3, 3))
             >>> y = subm_conv(sparse_x)
             >>> print(y.shape)

--- a/python/paddle/sparse/nn/layer/conv.py
+++ b/python/paddle/sparse/nn/layer/conv.py
@@ -393,20 +393,27 @@ class Conv3D(_Conv3D):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
-            >>> indices = [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 2], [1, 3, 2, 3]]
+            >>> indices = [
+            ...     [0, 0, 0, 0],
+            ...     [0, 0, 0, 0],
+            ...     [0, 0, 1, 2],
+            ...     [1, 3, 2, 3],
+            ... ]
             >>> values = [[1], [2], [3], [4]]
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
+            ...     indices, values, dense_shape, stop_gradient=True
+            ... )
             >>> conv = paddle.sparse.nn.Conv3D(1, 1, (1, 3, 3))
             >>> y = conv(sparse_x)
             >>> print(y.shape)
-            [1, 1, 1, 2, 1]
+            paddle.Size([1, 1, 1, 2, 1])
     """
 
     def __init__(
@@ -528,7 +535,7 @@ class Conv2D(_Conv2D):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -537,11 +544,13 @@ class Conv2D(_Conv2D):
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
             >>> dense_shape = [1, 3, 4, 1]
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
+            ...     indices, values, dense_shape, stop_gradient=True
+            ... )
             >>> conv = paddle.sparse.nn.Conv2D(1, 1, (3, 3))
             >>> y = conv(sparse_x)
             >>> print(y.shape)
-            [1, 1, 2, 1]
+            paddle.Size([1, 1, 2, 1])
     """
 
     def __init__(
@@ -667,20 +676,27 @@ class SubmConv3D(_Conv3D):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
-            >>> indices = [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 2], [1, 3, 2, 3]]
+            >>> indices = [
+            ...     [0, 0, 0, 0],
+            ...     [0, 0, 0, 0],
+            ...     [0, 0, 1, 2],
+            ...     [1, 3, 2, 3],
+            ... ]
             >>> values = [[1], [2], [3], [4]]
             >>> dense_shape = [1, 1, 3, 4, 1]
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
+            ...     indices, values, dense_shape, stop_gradient=True
+            ... )
             >>> subm_conv = paddle.sparse.nn.SubmConv3D(1, 1, (1, 3, 3))
             >>> y = subm_conv(sparse_x)
             >>> print(y.shape)
-            [1, 1, 3, 4, 1]
+            paddle.Size([1, 1, 3, 4, 1])
     """
 
     def __init__(
@@ -809,7 +825,7 @@ class SubmConv2D(_Conv2D):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -818,11 +834,13 @@ class SubmConv2D(_Conv2D):
             >>> dense_shape = [1, 3, 4, 1]
             >>> indices = paddle.to_tensor(indices, dtype='int32')
             >>> values = paddle.to_tensor(values, dtype='float32')
-            >>> sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, dense_shape, stop_gradient=True)
+            >>> sparse_x = paddle.sparse.sparse_coo_tensor(
+            ...     indices, values, dense_shape, stop_gradient=True
+            ... )
             >>> subm_conv = paddle.sparse.nn.SubmConv2D(1, 1, (3, 3))
             >>> y = subm_conv(sparse_x)
             >>> print(y.shape)
-            [1, 3, 4, 1]
+            paddle.Size([1, 3, 4, 1])
     """
 
     def __init__(

--- a/python/paddle/sparse/nn/layer/norm.py
+++ b/python/paddle/sparse/nn/layer/norm.py
@@ -92,7 +92,7 @@ class BatchNorm(paddle.nn.BatchNorm1D):
 
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> paddle.seed(123)
@@ -103,7 +103,7 @@ class BatchNorm(paddle.nn.BatchNorm1D):
             >>> batch_norm = paddle.sparse.nn.BatchNorm(channels)
             >>> batch_norm_out = batch_norm(sparse_x)
             >>> print(batch_norm_out.shape)
-            [1, 6, 6, 6, 3]
+            paddle.Size([1, 6, 6, 6, 3])
     """
 
     def __init__(

--- a/python/paddle/sparse/nn/layer/pooling.py
+++ b/python/paddle/sparse/nn/layer/pooling.py
@@ -72,17 +72,18 @@ class MaxPool3D(Layer):
           The data type is same as input x.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> dense_x = paddle.randn((2, 3, 6, 6, 3))
             >>> sparse_x = dense_x.to_sparse_coo(4)
             >>> max_pool3d = paddle.sparse.nn.MaxPool3D(
-            ...     kernel_size=3, data_format='NDHWC')
+            ...     kernel_size=3, data_format='NDHWC'
+            ... )
             >>> out = max_pool3d(sparse_x)
             >>> print(out.shape)
-            [2, 1, 2, 2, 3]
+            paddle.Size([2, 1, 2, 2, 3])
     """
 
     kernel_size: Size3

--- a/python/paddle/sparse/nn/layer/pooling.py
+++ b/python/paddle/sparse/nn/layer/pooling.py
@@ -78,9 +78,7 @@ class MaxPool3D(Layer):
 
             >>> dense_x = paddle.randn((2, 3, 6, 6, 3))
             >>> sparse_x = dense_x.to_sparse_coo(4)
-            >>> max_pool3d = paddle.sparse.nn.MaxPool3D(
-            ...     kernel_size=3, data_format='NDHWC'
-            ... )
+            >>> max_pool3d = paddle.sparse.nn.MaxPool3D(kernel_size=3, data_format='NDHWC')
             >>> out = max_pool3d(sparse_x)
             >>> print(out.shape)
             paddle.Size([2, 1, 2, 2, 3])

--- a/python/paddle/sparse/unary.py
+++ b/python/paddle/sparse/unary.py
@@ -932,9 +932,7 @@ def reshape(x: Tensor, shape: ShapeLike, name: str | None = None) -> Tensor:
             >>> new_shape = [1, 0, 2, -1, 3]
             >>> format = "coo"
 
-            >>> dense_x = paddle.randint(-100, 100, x_shape) * paddle.randint(
-            ...     0, 2, x_shape
-            ... )
+            >>> dense_x = paddle.randint(-100, 100, x_shape) * paddle.randint(0, 2, x_shape)
 
             >>> if format == "coo":
             ...     sp_x = dense_x.to_sparse_coo(len(x_shape))

--- a/python/paddle/sparse/unary.py
+++ b/python/paddle/sparse/unary.py
@@ -924,7 +924,7 @@ def reshape(x: Tensor, shape: ShapeLike, name: str | None = None) -> Tensor:
         Tensor: A reshaped Tensor with the same data type as ``x``.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -932,7 +932,9 @@ def reshape(x: Tensor, shape: ShapeLike, name: str | None = None) -> Tensor:
             >>> new_shape = [1, 0, 2, -1, 3]
             >>> format = "coo"
 
-            >>> dense_x = paddle.randint(-100, 100, x_shape) * paddle.randint(0, 2, x_shape)
+            >>> dense_x = paddle.randint(-100, 100, x_shape) * paddle.randint(
+            ...     0, 2, x_shape
+            ... )
 
             >>> if format == "coo":
             ...     sp_x = dense_x.to_sparse_coo(len(x_shape))
@@ -941,7 +943,7 @@ def reshape(x: Tensor, shape: ShapeLike, name: str | None = None) -> Tensor:
             >>> sp_out = paddle.sparse.reshape(sp_x, new_shape)
 
             >>> print(sp_out.shape)
-            [1, 2, 2, 3, 3]
+            paddle.Size([1, 2, 2, 3, 3])
 
     """
     if in_dynamic_or_pir_mode():

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2629,7 +2629,7 @@ def meshgrid(*args, **kwargs):
          Tensor: k tensors. The shape of each tensor is (N1, N2, ..., Nk)
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -2639,9 +2639,9 @@ def meshgrid(*args, **kwargs):
             >>> grid_x, grid_y = paddle.meshgrid(x, y)
 
             >>> print(grid_x.shape)
-            [100, 200]
+            paddle.Size([100, 200])
             >>> print(grid_y.shape)
-            [100, 200]
+            paddle.Size([100, 200])
 
     """
     name = kwargs.get("name", None)

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -128,14 +128,14 @@ def transpose(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> x = paddle.randn([2, 3, 4])
             >>> x_transposed = paddle.transpose(x, perm=[1, 0, 2])
             >>> print(x_transposed.shape)
-            [3, 2, 4]
+            paddle.Size([3, 2, 4])
 
     """
     if in_dynamic_or_pir_mode():
@@ -217,18 +217,18 @@ def permute(input: Tensor, dims: Sequence[int]) -> Tensor:
         Tensor: A tensor with permuted dimensions.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> x = paddle.randn([2, 3, 4])
             >>> y = paddle.permute(x, (1, 0, 2))
             >>> print(y.shape)
-            [3, 2, 4]
+            paddle.Size([3, 2, 4])
 
             >>> y = x.permute([1, 0, 2])
             >>> print(y.shape)
-            [3, 2, 4]
+            paddle.Size([3, 2, 4])
     """
     return transpose(x=input, perm=dims)
 
@@ -251,13 +251,13 @@ def matrix_transpose(
         Tensor: A new tensor with the same shape as `x`, except that the last two dimensions are transposed.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> x = paddle.ones(shape=[2, 3, 5])
             >>> x_transposed = paddle.matrix_transpose(x)
             >>> print(x_transposed.shape)
-            [2, 5, 3]
+            paddle.Size([2, 5, 3])
     """
     return x.mT
 
@@ -1919,7 +1919,7 @@ def t(input: Tensor, name: str | None = None) -> Tensor:
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example
 
             >>> import paddle
@@ -1938,13 +1938,12 @@ def t(input: Tensor, name: str | None = None) -> Tensor:
             Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
             [0.79000002, 0.83999997, 0.31999999])
             >>> print(paddle.t(x).shape)
-            [3]
+            paddle.Size([3])
 
             >>> # Example 3 (2-D tensor)
-            >>> x = paddle.to_tensor([[0.79, 0.84, 0.32],
-            ...                       [0.64, 0.14, 0.57]])
+            >>> x = paddle.to_tensor([[0.79, 0.84, 0.32], [0.64, 0.14, 0.57]])
             >>> print(x.shape)
-            [2, 3]
+            paddle.Size([2, 3])
             >>> out3 = paddle.t(x)
             >>> print(out3)
             Tensor(shape=[3, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -1952,7 +1951,7 @@ def t(input: Tensor, name: str | None = None) -> Tensor:
              [0.83999997, 0.14000000],
              [0.31999999, 0.56999999]])
             >>> print(paddle.t(x).shape)
-            [3, 2]
+            paddle.Size([3, 2])
 
     """
     if len(input.shape) > 2:
@@ -3770,7 +3769,7 @@ def multi_dot(x: list[Tensor], name: str | None = None) -> Tensor:
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -3779,7 +3778,7 @@ def multi_dot(x: list[Tensor], name: str | None = None) -> Tensor:
             >>> B = paddle.rand([4, 5])
             >>> out = paddle.linalg.multi_dot([A, B])
             >>> print(out.shape)
-            [3, 5]
+            paddle.Size([3, 5])
 
             >>> # A * B * C
             >>> A = paddle.rand([10, 5])
@@ -3787,7 +3786,7 @@ def multi_dot(x: list[Tensor], name: str | None = None) -> Tensor:
             >>> C = paddle.rand([8, 7])
             >>> out = paddle.linalg.multi_dot([A, B, C])
             >>> print(out.shape)
-            [10, 7]
+            paddle.Size([10, 7])
 
     """
     if in_dynamic_or_pir_mode():

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -815,11 +815,7 @@ def shard_index(
     following formula:
     ::
 
-        v = (
-            v - shard_id * shard_size
-            if shard_id * shard_size <= v < (shard_id + 1) * shard_size
-            else ignore_value
-        )
+        v = v - shard_id * shard_size if shard_id * shard_size <= v < (shard_id + 1) * shard_size else ignore_value
 
     That is, the value `v` is set to the new offset within the range represented by the shard `shard_id`
     if it in the range. Otherwise, we reset it to be `ignore_value`.
@@ -2041,12 +2037,7 @@ def flatten(
 
             >>> image_shape = (2, 3, 4, 4)
 
-            >>> x = paddle.arange(
-            ...     end=image_shape[0]
-            ...     * image_shape[1]
-            ...     * image_shape[2]
-            ...     * image_shape[3]
-            ... )
+            >>> x = paddle.arange(end=image_shape[0] * image_shape[1] * image_shape[2] * image_shape[3])
             >>> img = paddle.reshape(x, image_shape)
 
             >>> out = paddle.flatten(img, start_axis=1, stop_axis=2)
@@ -2157,12 +2148,7 @@ def ravel(input: Tensor) -> Tensor:
 
             >>> image_shape = (2, 3, 4, 4)
 
-            >>> x = paddle.arange(
-            ...     end=image_shape[0]
-            ...     * image_shape[1]
-            ...     * image_shape[2]
-            ...     * image_shape[3]
-            ... )
+            >>> x = paddle.arange(end=image_shape[0] * image_shape[1] * image_shape[2] * image_shape[3])
             >>> img = paddle.reshape(x, image_shape)
 
             >>> out = paddle.ravel(img)
@@ -2802,9 +2788,7 @@ def split(
             >>> print(out2.shape)
             paddle.Size([3, 3, 5])
 
-            >>> out0, out1, out2 = paddle.split(
-            ...     x, num_or_sections=[2, 3, 4], axis=1
-            ... )
+            >>> out0, out1, out2 = paddle.split(x, num_or_sections=[2, 3, 4], axis=1)
             >>> print(out0.shape)
             paddle.Size([3, 2, 5])
             >>> print(out1.shape)
@@ -2812,9 +2796,7 @@ def split(
             >>> print(out2.shape)
             paddle.Size([3, 4, 5])
 
-            >>> out0, out1, out2 = paddle.split(
-            ...     x, num_or_sections=[2, 3, -1], axis=1
-            ... )
+            >>> out0, out1, out2 = paddle.split(x, num_or_sections=[2, 3, -1], axis=1)
             >>> print(out0.shape)
             paddle.Size([3, 2, 5])
             >>> print(out1.shape)
@@ -3108,9 +3090,7 @@ def tensor_split(
             >>> # split along axis with indices
             >>> # x is a Tensor of shape [7, 8]
             >>> x = paddle.rand([7, 8])
-            >>> out0, out1, out2 = paddle.tensor_split(
-            ...     x, num_or_indices=[2, 3], axis=1
-            ... )
+            >>> out0, out1, out2 = paddle.tensor_split(x, num_or_indices=[2, 3], axis=1)
             >>> print(out0.shape)
             paddle.Size([7, 2])
             >>> print(out1.shape)
@@ -4650,9 +4630,7 @@ def scatter(*args: Any, **kwargs: Any) -> Tensor:
         >>> index = paddle.to_tensor([2, 1, 0, 1], dtype='int64')
         >>> # shape of updates should be the same as x
         >>> # shape of updates with dim > 1 should be the same as input
-        >>> updates = paddle.to_tensor(
-        ...     [[1, 1], [2, 2], [3, 3], [4, 4]], dtype='float32'
-        ... )
+        >>> updates = paddle.to_tensor([[1, 1], [2, 2], [3, 3], [4, 4]], dtype='float32')
         >>> overwrite = False
         >>> # calculation:
         >>> if not overwrite:
@@ -4798,9 +4776,7 @@ def scatter_nd_add(
 
             >>> x = paddle.rand(shape=[3, 5, 9, 10], dtype='float32')
             >>> updates = paddle.rand(shape=[3, 9, 10], dtype='float32')
-            >>> index = paddle.to_tensor(
-            ...     [[1, 1], [0, 1], [1, 3]], dtype='int64'
-            ... )
+            >>> index = paddle.to_tensor([[1, 1], [0, 1], [1, 3]], dtype='int64')
 
             >>> output = paddle.scatter_nd_add(x, index, updates)
             >>> print(output.shape)
@@ -6874,9 +6850,7 @@ def moveaxis(
             paddle.Size([4, 3, 2])
 
             >>> x = paddle.ones([2, 3])
-            >>> outshape = paddle.moveaxis(
-            ...     x, 0, 1
-            ... ).shape  # equivalent to paddle.t(x)
+            >>> outshape = paddle.moveaxis(x, 0, 1).shape  # equivalent to paddle.t(x)
             >>> print(outshape)
             paddle.Size([3, 2])
     """

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -675,14 +675,14 @@ def transpose(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> x = paddle.randn([2, 3, 4])
             >>> x_transposed = paddle.transpose(x, perm=[1, 0, 2])
             >>> print(x_transposed.shape)
-            [3, 2, 4]
+            paddle.Size([3, 2, 4])
 
     """
     if in_dynamic_or_pir_mode():
@@ -2151,18 +2151,23 @@ def ravel(input: Tensor) -> Tensor:
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
-            >>> image_shape=(2, 3, 4, 4)
+            >>> image_shape = (2, 3, 4, 4)
 
-            >>> x = paddle.arange(end=image_shape[0] * image_shape[1] * image_shape[2] * image_shape[3])
+            >>> x = paddle.arange(
+            ...     end=image_shape[0]
+            ...     * image_shape[1]
+            ...     * image_shape[2]
+            ...     * image_shape[3]
+            ... )
             >>> img = paddle.reshape(x, image_shape)
 
             >>> out = paddle.ravel(img)
             >>> print(out.shape)
-            [96]
+            paddle.Size([96])
     """
     return flatten(input)
 
@@ -2319,7 +2324,7 @@ def stack(
         Tensor, The stacked tensor with same data type as input.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -2329,7 +2334,7 @@ def stack(
 
             >>> out = paddle.stack([x1, x2, x3], axis=0)
             >>> print(out.shape)
-            [3, 1, 2]
+            paddle.Size([3, 1, 2])
             >>> print(out)
             Tensor(shape=[3, 1, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
             [[[1., 2.]],
@@ -2338,7 +2343,7 @@ def stack(
 
             >>> out = paddle.stack([x1, x2, x3], axis=-2)
             >>> print(out.shape)
-            [1, 3, 2]
+            paddle.Size([1, 3, 2])
             >>> print(out)
             Tensor(shape=[1, 3, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
             [[[1., 2.],
@@ -2351,7 +2356,7 @@ def stack(
 
             >>> out = paddle.stack([x1, x2], axis=0)
             >>> print(out.shape)
-            [2, 0, 1, 2]
+            paddle.Size([2, 0, 1, 2])
             >>> print(out)
             Tensor(shape=[2, 0, 1, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
             [[],
@@ -2359,7 +2364,7 @@ def stack(
 
             >>> out = paddle.stack([x1, x2], axis=1)
             >>> print(out.shape)
-            [0, 2, 1, 2]
+            paddle.Size([0, 2, 1, 2])
             >>> print(out)
             Tensor(shape=[0, 2, 1, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
             [])
@@ -2782,7 +2787,7 @@ def split(
         list(Tensor), The list of segmented Tensors.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -2791,36 +2796,40 @@ def split(
 
             >>> out0, out1, out2 = paddle.split(x, num_or_sections=3, axis=1)
             >>> print(out0.shape)
-            [3, 3, 5]
+            paddle.Size([3, 3, 5])
             >>> print(out1.shape)
-            [3, 3, 5]
+            paddle.Size([3, 3, 5])
             >>> print(out2.shape)
-            [3, 3, 5]
+            paddle.Size([3, 3, 5])
 
-            >>> out0, out1, out2 = paddle.split(x, num_or_sections=[2, 3, 4], axis=1)
+            >>> out0, out1, out2 = paddle.split(
+            ...     x, num_or_sections=[2, 3, 4], axis=1
+            ... )
             >>> print(out0.shape)
-            [3, 2, 5]
+            paddle.Size([3, 2, 5])
             >>> print(out1.shape)
-            [3, 3, 5]
+            paddle.Size([3, 3, 5])
             >>> print(out2.shape)
-            [3, 4, 5]
+            paddle.Size([3, 4, 5])
 
-            >>> out0, out1, out2 = paddle.split(x, num_or_sections=[2, 3, -1], axis=1)
+            >>> out0, out1, out2 = paddle.split(
+            ...     x, num_or_sections=[2, 3, -1], axis=1
+            ... )
             >>> print(out0.shape)
-            [3, 2, 5]
+            paddle.Size([3, 2, 5])
             >>> print(out1.shape)
-            [3, 3, 5]
+            paddle.Size([3, 3, 5])
             >>> print(out2.shape)
-            [3, 4, 5]
+            paddle.Size([3, 4, 5])
 
             >>> # axis is negative, the real axis is (rank(x) + axis)=1
             >>> out0, out1, out2 = paddle.split(x, num_or_sections=3, axis=-2)
             >>> print(out0.shape)
-            [3, 3, 5]
+            paddle.Size([3, 3, 5])
             >>> print(out1.shape)
-            [3, 3, 5]
+            paddle.Size([3, 3, 5])
             >>> print(out2.shape)
-            [3, 3, 5]
+            paddle.Size([3, 3, 5])
     """
 
     input = x
@@ -3022,7 +3031,7 @@ def tensor_split(
         list[Tensor], The list of segmented Tensors.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
             :name: tensor-split-example-1
 
             >>> import paddle
@@ -3032,14 +3041,14 @@ def tensor_split(
             >>> x = paddle.rand([8])
             >>> out0, out1 = paddle.tensor_split(x, num_or_indices=2)
             >>> print(out0.shape)
-            [4]
+            paddle.Size([4])
             >>> print(out1.shape)
-            [4]
+            paddle.Size([4])
 
 
         .. image:: https://githubraw.cdn.bcebos.com/PaddlePaddle/docs/develop/docs/images/api_legend/tensor_split/tensor_split-2.png
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: tensor-split-example-2
 
             >>> import paddle
@@ -3049,15 +3058,15 @@ def tensor_split(
             >>> x = paddle.rand([8])
             >>> out0, out1, out2 = paddle.tensor_split(x, num_or_indices=3)
             >>> print(out0.shape)
-            [3]
+            paddle.Size([3])
             >>> print(out1.shape)
-            [3]
+            paddle.Size([3])
             >>> print(out2.shape)
-            [2]
+            paddle.Size([2])
 
         .. image:: https://githubraw.cdn.bcebos.com/PaddlePaddle/docs/develop/docs/images/api_legend/tensor_split/tensor_split-3_en.png
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: tensor-split-example-3
 
             >>> import paddle
@@ -3067,15 +3076,15 @@ def tensor_split(
             >>> x = paddle.rand([8])
             >>> out0, out1, out2 = paddle.tensor_split(x, num_or_indices=[2, 3])
             >>> print(out0.shape)
-            [2]
+            paddle.Size([2])
             >>> print(out1.shape)
-            [1]
+            paddle.Size([1])
             >>> print(out2.shape)
-            [5]
+            paddle.Size([5])
 
         .. image:: https://githubraw.cdn.bcebos.com/PaddlePaddle/docs/develop/docs/images/api_legend/tensor_split/tensor_split-4.png
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: tensor-split-example-4
 
             >>> import paddle
@@ -3085,13 +3094,13 @@ def tensor_split(
             >>> x = paddle.rand([7, 8])
             >>> out0, out1 = paddle.tensor_split(x, num_or_indices=2, axis=1)
             >>> print(out0.shape)
-            [7, 4]
+            paddle.Size([7, 4])
             >>> print(out1.shape)
-            [7, 4]
+            paddle.Size([7, 4])
 
         .. image:: https://githubraw.cdn.bcebos.com/PaddlePaddle/docs/develop/docs/images/api_legend/tensor_split/tensor_split-5.png
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: tensor-split-example-5
 
             >>> import paddle
@@ -3099,13 +3108,15 @@ def tensor_split(
             >>> # split along axis with indices
             >>> # x is a Tensor of shape [7, 8]
             >>> x = paddle.rand([7, 8])
-            >>> out0, out1, out2 = paddle.tensor_split(x, num_or_indices=[2, 3], axis=1)
+            >>> out0, out1, out2 = paddle.tensor_split(
+            ...     x, num_or_indices=[2, 3], axis=1
+            ... )
             >>> print(out0.shape)
-            [7, 2]
+            paddle.Size([7, 2])
             >>> print(out1.shape)
-            [7, 1]
+            paddle.Size([7, 1])
             >>> print(out2.shape)
-            [7, 5]
+            paddle.Size([7, 5])
 
         .. image:: https://githubraw.cdn.bcebos.com/PaddlePaddle/docs/develop/docs/images/api_legend/tensor_split/tensor_split-6.png
 
@@ -3184,7 +3195,7 @@ def hsplit(
         list[Tensor], The list of segmented Tensors.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -3192,25 +3203,25 @@ def hsplit(
             >>> x = paddle.rand([8])
             >>> out0, out1 = paddle.hsplit(x, num_or_indices=2)
             >>> print(out0.shape)
-            [4]
+            paddle.Size([4])
             >>> print(out1.shape)
-            [4]
+            paddle.Size([4])
 
             >>> # x is a Tensor of shape [7, 8]
             >>> x = paddle.rand([7, 8])
             >>> out0, out1 = paddle.hsplit(x, num_or_indices=2)
             >>> print(out0.shape)
-            [7, 4]
+            paddle.Size([7, 4])
             >>> print(out1.shape)
-            [7, 4]
+            paddle.Size([7, 4])
 
             >>> out0, out1, out2 = paddle.hsplit(x, num_or_indices=[1, 4])
             >>> print(out0.shape)
-            [7, 1]
+            paddle.Size([7, 1])
             >>> print(out1.shape)
-            [7, 3]
+            paddle.Size([7, 3])
             >>> print(out2.shape)
-            [7, 4]
+            paddle.Size([7, 4])
 
     """
     if x.ndim < 1:
@@ -3248,7 +3259,7 @@ def dsplit(
         list[Tensor], The list of segmented Tensors.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -3256,17 +3267,17 @@ def dsplit(
             >>> x = paddle.rand([7, 6, 8])
             >>> out0, out1 = paddle.dsplit(x, num_or_indices=2)
             >>> print(out0.shape)
-            [7, 6, 4]
+            paddle.Size([7, 6, 4])
             >>> print(out1.shape)
-            [7, 6, 4]
+            paddle.Size([7, 6, 4])
 
             >>> out0, out1, out2 = paddle.dsplit(x, num_or_indices=[1, 4])
             >>> print(out0.shape)
-            [7, 6, 1]
+            paddle.Size([7, 6, 1])
             >>> print(out1.shape)
-            [7, 6, 3]
+            paddle.Size([7, 6, 3])
             >>> print(out2.shape)
-            [7, 6, 4]
+            paddle.Size([7, 6, 4])
 
     """
     if x.ndim < 3:
@@ -3306,7 +3317,7 @@ def vsplit(
         list[Tensor], The list of segmented Tensors.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -3314,17 +3325,17 @@ def vsplit(
             >>> x = paddle.rand([8, 6, 7])
             >>> out0, out1 = paddle.vsplit(x, num_or_indices=2)
             >>> print(out0.shape)
-            [4, 6, 7]
+            paddle.Size([4, 6, 7])
             >>> print(out1.shape)
-            [4, 6, 7]
+            paddle.Size([4, 6, 7])
 
             >>> out0, out1, out2 = paddle.vsplit(x, num_or_indices=[1, 4])
             >>> print(out0.shape)
-            [1, 6, 7]
+            paddle.Size([1, 6, 7])
             >>> print(out1.shape)
-            [3, 6, 7]
+            paddle.Size([3, 6, 7])
             >>> print(out2.shape)
-            [4, 6, 7]
+            paddle.Size([4, 6, 7])
 
     """
     if x.ndim < 2:
@@ -3401,7 +3412,7 @@ def squeeze(
         Tensor, Squeezed Tensor with the same data type as input Tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -3409,12 +3420,12 @@ def squeeze(
             >>> output = paddle.squeeze(x, axis=1)
 
             >>> print(x.shape)
-            [5, 1, 10]
+            paddle.Size([5, 1, 10])
             >>> print(output.shape)
-            [5, 10]
+            paddle.Size([5, 10])
 
             >>> # output shares data with x in dygraph mode
-            >>> x[0, 0, 0] = 10.
+            >>> x[0, 0, 0] = 10.0
             >>> print(output[0, 0])
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             10.)
@@ -3997,29 +4008,29 @@ def unsqueeze(
         Tensor, Unsqueezed Tensor with the same data type as input Tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> x = paddle.rand([5, 10])
             >>> print(x.shape)
-            [5, 10]
+            paddle.Size([5, 10])
 
             >>> out1 = paddle.unsqueeze(x, axis=0)
             >>> print(out1.shape)
-            [1, 5, 10]
+            paddle.Size([1, 5, 10])
 
             >>> out2 = paddle.unsqueeze(x, axis=[0, 2])
             >>> print(out2.shape)
-            [1, 5, 1, 10]
+            paddle.Size([1, 5, 1, 10])
 
             >>> axis = paddle.to_tensor([0, 1, 2])
             >>> out3 = paddle.unsqueeze(x, axis=axis)
             >>> print(out3.shape)
-            [1, 1, 1, 5, 10]
+            paddle.Size([1, 1, 1, 5, 10])
 
             >>> # out1, out2, out3 share data with x in dygraph mode
-            >>> x[0, 0] = 10.
+            >>> x[0, 0] = 10.0
             >>> print(out1[0, 0, 0])
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             10.)
@@ -4630,30 +4641,32 @@ def scatter(*args: Any, **kwargs: Any) -> Tensor:
     .. image:: https://githubraw.cdn.bcebos.com/PaddlePaddle/docs/develop/docs/images/api_legend/scatter.png
         :alt: Legend - scatter behavior display
 
-    .. code-block:: python
+    .. code-block:: pycon
         :name: scatter-example-1
 
         >>> import paddle
-        >>> #input:
+        >>> # input:
         >>> x = paddle.to_tensor([[1, 1], [2, 2], [3, 3]], dtype='float32')
         >>> index = paddle.to_tensor([2, 1, 0, 1], dtype='int64')
         >>> # shape of updates should be the same as x
         >>> # shape of updates with dim > 1 should be the same as input
-        >>> updates = paddle.to_tensor([[1, 1], [2, 2], [3, 3], [4, 4]], dtype='float32')
+        >>> updates = paddle.to_tensor(
+        ...     [[1, 1], [2, 2], [3, 3], [4, 4]], dtype='float32'
+        ... )
         >>> overwrite = False
         >>> # calculation:
         >>> if not overwrite:
         ...     for i in range(len(index)):
         ...         x[index[i]] = paddle.zeros([2])
         >>> for i in range(len(index)):
-        ...     if (overwrite):
+        ...     if overwrite:
         ...         x[index[i]] = updates[i]
         ...     else:
         ...         x[index[i]] += updates[i]
         >>> # output:
         >>> out = paddle.to_tensor([[3, 3], [6, 6], [1, 1]])
         >>> print(out.shape)
-        [3, 2]
+        paddle.Size([3, 2])
 
     **NOTICE**: The order in which updates are applied is nondeterministic,
     so the output will be nondeterministic if index contains duplicates.
@@ -4779,19 +4792,19 @@ def scatter_nd_add(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> x = paddle.rand(shape=[3, 5, 9, 10], dtype='float32')
             >>> updates = paddle.rand(shape=[3, 9, 10], dtype='float32')
-            >>> index = paddle.to_tensor([[1, 1],
-            ...                           [0, 1],
-            ...                           [1, 3]], dtype='int64')
+            >>> index = paddle.to_tensor(
+            ...     [[1, 1], [0, 1], [1, 3]], dtype='int64'
+            ... )
 
             >>> output = paddle.scatter_nd_add(x, index, updates)
             >>> print(output.shape)
-            [3, 5, 9, 10]
+            paddle.Size([3, 5, 9, 10])
     """
     if x.dtype != updates.dtype:
         raise TypeError(
@@ -5375,7 +5388,7 @@ def reshape(x: Tensor, shape: ShapeLike, name: str | None = None) -> Tensor:
         Tensor, A reshaped Tensor with the same data type as ``x``.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -5384,18 +5397,18 @@ def reshape(x: Tensor, shape: ShapeLike, name: str | None = None) -> Tensor:
 
             >>> out = paddle.reshape(x, [-1, 0, 3, 2])
             >>> print(out.shape)
-            [2, 4, 3, 2]
+            paddle.Size([2, 4, 3, 2])
 
             >>> out = paddle.reshape(x, shape=[positive_four, 12])
             >>> print(out.shape)
-            [4, 12]
+            paddle.Size([4, 12])
 
             >>> shape_tensor = paddle.to_tensor([8, 6], dtype=paddle.int32)
             >>> out = paddle.reshape(x, shape=shape_tensor)
             >>> print(out.shape)
-            [8, 6]
+            paddle.Size([8, 6])
             >>> # out shares data with x in dygraph mode
-            >>> x[0, 0, 0] = 10.
+            >>> x[0, 0, 0] = 10.0
             >>> print(out[0, 0])
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             10.)
@@ -6851,19 +6864,21 @@ def moveaxis(
         Tensor, A new tensor whose axis have been moved.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> x = paddle.ones([3, 2, 4])
             >>> outshape = paddle.moveaxis(x, [0, 1], [1, 2]).shape
             >>> print(outshape)
-            [4, 3, 2]
+            paddle.Size([4, 3, 2])
 
             >>> x = paddle.ones([2, 3])
-            >>> outshape = paddle.moveaxis(x, 0, 1).shape # equivalent to paddle.t(x)
+            >>> outshape = paddle.moveaxis(
+            ...     x, 0, 1
+            ... ).shape  # equivalent to paddle.t(x)
             >>> print(outshape)
-            [3, 2]
+            paddle.Size([3, 2])
     """
     src = [source] if isinstance(source, int) else source
     dst = [destination] if isinstance(destination, int) else destination
@@ -7829,7 +7844,7 @@ def as_strided(
         Tensor, A as_strided Tensor with the same data type as ``x``.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
@@ -7838,7 +7853,7 @@ def as_strided(
 
             >>> out = paddle.as_strided(x, [8, 6], [6, 1])
             >>> print(out.shape)
-            [8, 6]
+            paddle.Size([8, 6])
             >>> # the stride is [6, 1].
     """
     return _C_ops.as_strided(x, shape, stride, offset)
@@ -7876,7 +7891,7 @@ def view(
         Tensor, A viewed Tensor with the same data as ``x``.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
@@ -7885,7 +7900,7 @@ def view(
 
             >>> out = paddle.view(x, [8, 6])
             >>> print(out.shape)
-            [8, 6]
+            paddle.Size([8, 6])
 
             >>> import paddle
             >>> paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
@@ -7894,7 +7909,7 @@ def view(
 
             >>> out = paddle.view(x, "uint8")
             >>> print(out.shape)
-            [2, 4, 24]
+            paddle.Size([2, 4, 24])
 
             >>> import paddle
             >>> paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
@@ -7903,7 +7918,7 @@ def view(
 
             >>> out = paddle.view(x, [8, -1])
             >>> print(out.shape)
-            [8, 6]
+            paddle.Size([8, 6])
 
             >>> import paddle
             >>> paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
@@ -7912,7 +7927,7 @@ def view(
 
             >>> out = paddle.view(x, paddle.uint8)
             >>> print(out.shape)
-            [2, 4, 24]
+            paddle.Size([2, 4, 24])
 
     """
     if isinstance(shape_or_dtype, (list, tuple)):
@@ -7951,7 +7966,7 @@ def view_as(x: Tensor, other: Tensor, name: str | None = None) -> Tensor:
         Tensor, A viewed Tensor with the same shape as ``other``.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
@@ -7961,7 +7976,7 @@ def view_as(x: Tensor, other: Tensor, name: str | None = None) -> Tensor:
 
             >>> out = paddle.view_as(x, y)
             >>> print(out.shape)
-            [8, 6]
+            paddle.Size([8, 6])
     """
     return _C_ops.view_shape(x, other.shape)
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -3514,7 +3514,7 @@ def trace(
         Tensor: the output data type is the same as input data type.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -3523,13 +3523,13 @@ def trace(
             >>> case3 = paddle.randn([3, 10, 5, 10])
             >>> data1 = paddle.trace(case1)
             >>> data1.shape
-            []
+            paddle.Size([])
             >>> data2 = paddle.trace(case2, offset=1, axis1=1, axis2=2)
             >>> data2.shape
-            [3]
+            paddle.Size([3])
             >>> data3 = paddle.trace(case3, offset=-3, axis1=1, axis2=-1)
             >>> data3.shape
-            [3, 5]
+            paddle.Size([3, 5])
     """
 
     def __check_input(x, offset, axis1, axis2):

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5884,11 +5884,7 @@ def angle(x: Tensor, name: str | None = None) -> Tensor:
 
             >>> import paddle
 
-            >>> x = (
-            ...     paddle.to_tensor([-2, -1, 0, 1])
-            ...     .unsqueeze(-1)
-            ...     .astype('float32')
-            ... )
+            >>> x = paddle.to_tensor([-2, -1, 0, 1]).unsqueeze(-1).astype('float32')
             >>> y = paddle.to_tensor([-2, -1, 0, 1]).astype('float32')
             >>> z = x + 1j * y
             >>> z

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -595,17 +595,13 @@ def uniform_random_batch_size_like(
             >>> from paddle.tensor import random
             >>> paddle.enable_static()
             >>> # example 1:
-            >>> input = paddle.static.data(
-            ...     name="input", shape=[1, 3], dtype='float32'
-            ... )
+            >>> input = paddle.static.data(name="input", shape=[1, 3], dtype='float32')
             >>> out_1 = random.uniform_random_batch_size_like(input, [2, 4])
             >>> print(out_1.shape)
             paddle.Size([1, 4])
 
             >>> # example 2:
-            >>> out_2 = random.uniform_random_batch_size_like(
-            ...     input, [2, 4], input_dim_idx=1, output_dim_idx=1
-            ... )
+            >>> out_2 = random.uniform_random_batch_size_like(input, [2, 4], input_dim_idx=1, output_dim_idx=1)
             >>> print(out_2.shape)
             paddle.Size([2, 3])
     """

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -588,22 +588,26 @@ def uniform_random_batch_size_like(
     Returns:
         Tensor, A Tensor of the specified shape filled with uniform_random values. The shape of the Tensor is determined by the shape parameter and the specified dimension of the input Tensor.
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.base as base
             >>> from paddle.tensor import random
             >>> paddle.enable_static()
             >>> # example 1:
-            >>> input = paddle.static.data(name="input", shape=[1, 3], dtype='float32')
+            >>> input = paddle.static.data(
+            ...     name="input", shape=[1, 3], dtype='float32'
+            ... )
             >>> out_1 = random.uniform_random_batch_size_like(input, [2, 4])
             >>> print(out_1.shape)
-            [1, 4]
+            paddle.Size([1, 4])
 
             >>> # example 2:
-            >>> out_2 = random.uniform_random_batch_size_like(input, [2, 4], input_dim_idx=1, output_dim_idx=1)
+            >>> out_2 = random.uniform_random_batch_size_like(
+            ...     input, [2, 4], input_dim_idx=1, output_dim_idx=1
+            ... )
             >>> print(out_2.shape)
-            [2, 3]
+            paddle.Size([2, 3])
     """
     if in_dynamic_or_pir_mode():
         dtype = convert_np_dtype_to_dtype_(dtype)

--- a/python/paddle/tensorrt/export.py
+++ b/python/paddle/tensorrt/export.py
@@ -154,9 +154,7 @@ class Input:
                 >>> )
                 >>> input.input_data_type = 'int64'
                 >>> input.input_range = (1, 10)
-                >>> input_min_data, input_optim_data, input_max_data = (
-                ...     input_config.generate_input_data()
-                ... )
+                >>> input_min_data, input_optim_data, input_max_data = input_config.generate_input_data()
         """
         if self.warmup_data is not None:
             raise RuntimeError(

--- a/python/paddle/vision/models/alexnet.py
+++ b/python/paddle/vision/models/alexnet.py
@@ -96,7 +96,7 @@ class AlexNet(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of AlexNet model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import AlexNet
@@ -105,7 +105,7 @@ class AlexNet(nn.Layer):
             >>> x = paddle.rand([1, 3, 224, 224])
             >>> out = alexnet(x)
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
 
     num_classes: int
@@ -221,7 +221,7 @@ def alexnet(
         :ref:`api_paddle_nn_Layer`. An instance of AlexNet model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import alexnet
@@ -236,6 +236,6 @@ def alexnet(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _alexnet('alexnet', pretrained, **kwargs)

--- a/python/paddle/vision/models/densenet.py
+++ b/python/paddle/vision/models/densenet.py
@@ -255,7 +255,7 @@ class DenseNet(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of DenseNet model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import DenseNet
@@ -267,7 +267,7 @@ class DenseNet(nn.Layer):
             >>> out = densenet(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
 
     num_classes: int
@@ -412,7 +412,7 @@ def densenet121(
         :ref:`api_paddle_nn_Layer`. An instance of DenseNet 121-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import densenet121
@@ -427,7 +427,7 @@ def densenet121(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _densenet('densenet121', 121, pretrained, **kwargs)
 
@@ -447,7 +447,7 @@ def densenet161(
         :ref:`api_paddle_nn_Layer`. An instance of DenseNet 161-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import densenet161
@@ -462,7 +462,7 @@ def densenet161(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _densenet('densenet161', 161, pretrained, **kwargs)
 
@@ -482,7 +482,7 @@ def densenet169(
         :ref:`api_paddle_nn_Layer`. An instance of DenseNet 169-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import densenet169
@@ -497,7 +497,7 @@ def densenet169(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _densenet('densenet169', 169, pretrained, **kwargs)
 
@@ -517,7 +517,7 @@ def densenet201(
         :ref:`api_paddle_nn_Layer`. An instance of DenseNet 201-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import densenet201
@@ -531,7 +531,7 @@ def densenet201(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _densenet('densenet201', 201, pretrained, **kwargs)
 
@@ -551,7 +551,7 @@ def densenet264(
         :ref:`api_paddle_nn_Layer`. An instance of DenseNet 264-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import densenet264
@@ -566,6 +566,6 @@ def densenet264(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _densenet('densenet264', 264, pretrained, **kwargs)

--- a/python/paddle/vision/models/inceptionv3.py
+++ b/python/paddle/vision/models/inceptionv3.py
@@ -517,7 +517,7 @@ class InceptionV3(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of Inception v3 model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import InceptionV3
@@ -528,7 +528,7 @@ class InceptionV3(nn.Layer):
             >>> out = inception_v3(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
 
     num_classes: int
@@ -622,7 +622,7 @@ def inception_v3(
         :ref:`api_paddle_nn_Layer`. An instance of Inception v3 model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import inception_v3
@@ -637,7 +637,7 @@ def inception_v3(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     model = InceptionV3(**kwargs)
     arch = "inception_v3"

--- a/python/paddle/vision/models/lenet.py
+++ b/python/paddle/vision/models/lenet.py
@@ -39,7 +39,7 @@ class LeNet(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of LeNet model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import LeNet
@@ -50,7 +50,7 @@ class LeNet(nn.Layer):
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 10]
+            paddle.Size([1, 10])
     """
 
     num_classes: int

--- a/python/paddle/vision/models/mobilenetv1.py
+++ b/python/paddle/vision/models/mobilenetv1.py
@@ -96,7 +96,7 @@ class MobileNetV1(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of MobileNetV1 model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import MobileNetV1
@@ -107,7 +107,7 @@ class MobileNetV1(nn.Layer):
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
 
     scale: float
@@ -308,7 +308,7 @@ def mobilenet_v1(
         :ref:`api_paddle_nn_Layer`. An instance of MobileNetV1 model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import mobilenet_v1
@@ -326,7 +326,7 @@ def mobilenet_v1(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     model = _mobilenet(
         'mobilenetv1_' + str(scale), pretrained, scale=scale, **kwargs

--- a/python/paddle/vision/models/mobilenetv2.py
+++ b/python/paddle/vision/models/mobilenetv2.py
@@ -111,7 +111,7 @@ class MobileNetV2(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of MobileNetV2 model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import MobileNetV2
@@ -122,7 +122,7 @@ class MobileNetV2(nn.Layer):
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
 
     num_classes: int
@@ -249,7 +249,7 @@ def mobilenet_v2(
         :ref:`api_paddle_nn_Layer`. An instance of MobileNetV2 model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import mobilenet_v2
@@ -267,7 +267,7 @@ def mobilenet_v2(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     model = _mobilenet(
         'mobilenetv2_' + str(scale), pretrained, scale=scale, **kwargs

--- a/python/paddle/vision/models/mobilenetv3.py
+++ b/python/paddle/vision/models/mobilenetv3.py
@@ -312,7 +312,7 @@ class MobileNetV3Small(MobileNetV3):
         :ref:`api_paddle_nn_Layer`. An instance of MobileNetV3 Small architecture model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import MobileNetV3Small
@@ -324,7 +324,7 @@ class MobileNetV3Small(MobileNetV3):
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
 
     def __init__(
@@ -370,7 +370,7 @@ class MobileNetV3Large(MobileNetV3):
         :ref:`api_paddle_nn_Layer`. An instance of MobileNetV3 Large architecture model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import MobileNetV3Large
@@ -382,7 +382,7 @@ class MobileNetV3Large(MobileNetV3):
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
 
     def __init__(
@@ -477,7 +477,7 @@ def mobilenet_v3_small(
         :ref:`api_paddle_nn_Layer`. An instance of MobileNetV3 Small architecture model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import mobilenet_v3_small
@@ -495,7 +495,7 @@ def mobilenet_v3_small(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     model = _mobilenet_v3(
         "mobilenet_v3_small", scale=scale, pretrained=pretrained, **kwargs
@@ -520,7 +520,7 @@ def mobilenet_v3_large(
         :ref:`api_paddle_nn_Layer`. An instance of MobileNetV3 Large architecture model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import mobilenet_v3_large
@@ -538,7 +538,7 @@ def mobilenet_v3_large(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     model = _mobilenet_v3(
         "mobilenet_v3_large", scale=scale, pretrained=pretrained, **kwargs

--- a/python/paddle/vision/models/resnet.py
+++ b/python/paddle/vision/models/resnet.py
@@ -261,9 +261,7 @@ class ResNet(nn.Layer):
             >>> wide_resnet50_2 = ResNet(BottleneckBlock, 50, width=64 * 2)
 
             >>> # build ResNeXt model
-            >>> resnext50_32x4d = ResNet(
-            ...     BottleneckBlock, 50, width=4, groups=32
-            ... )
+            >>> resnext50_32x4d = ResNet(BottleneckBlock, 50, width=4, groups=32)
 
             >>> x = paddle.rand([1, 3, 224, 224])
             >>> out = resnet18(x)

--- a/python/paddle/vision/models/resnet.py
+++ b/python/paddle/vision/models/resnet.py
@@ -242,11 +242,14 @@ class ResNet(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of ResNet model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import ResNet
-            >>> from paddle.vision.models.resnet import BottleneckBlock, BasicBlock
+            >>> from paddle.vision.models.resnet import (
+            ...     BottleneckBlock,
+            ...     BasicBlock,
+            ... )
 
             >>> # build ResNet with 18 layers
             >>> resnet18 = ResNet(BasicBlock, 18)
@@ -255,16 +258,18 @@ class ResNet(nn.Layer):
             >>> resnet50 = ResNet(BottleneckBlock, 50)
 
             >>> # build Wide ResNet model
-            >>> wide_resnet50_2 = ResNet(BottleneckBlock, 50, width=64*2)
+            >>> wide_resnet50_2 = ResNet(BottleneckBlock, 50, width=64 * 2)
 
             >>> # build ResNeXt model
-            >>> resnext50_32x4d = ResNet(BottleneckBlock, 50, width=4, groups=32)
+            >>> resnext50_32x4d = ResNet(
+            ...     BottleneckBlock, 50, width=4, groups=32
+            ... )
 
             >>> x = paddle.rand([1, 3, 224, 224])
             >>> out = resnet18(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
 
     groups: int
@@ -430,7 +435,7 @@ def resnet18(pretrained=False, **kwargs: Unpack[_ResNetOptions]) -> ResNet:
         :ref:`api_paddle_nn_Layer`. An instance of ResNet 18-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import resnet18
@@ -445,7 +450,7 @@ def resnet18(pretrained=False, **kwargs: Unpack[_ResNetOptions]) -> ResNet:
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _resnet('resnet18', BasicBlock, 18, pretrained, **kwargs)
 
@@ -465,7 +470,7 @@ def resnet34(
         :ref:`api_paddle_nn_Layer`. An instance of ResNet 34-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import resnet34
@@ -480,7 +485,7 @@ def resnet34(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _resnet('resnet34', BasicBlock, 34, pretrained, **kwargs)
 
@@ -500,7 +505,7 @@ def resnet50(
         :ref:`api_paddle_nn_Layer`. An instance of ResNet 50-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import resnet50
@@ -515,7 +520,7 @@ def resnet50(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _resnet('resnet50', BottleneckBlock, 50, pretrained, **kwargs)
 
@@ -535,7 +540,7 @@ def resnet101(
         :ref:`api_paddle_nn_Layer`. An instance of ResNet 101-layer.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import resnet101
@@ -550,7 +555,7 @@ def resnet101(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _resnet('resnet101', BottleneckBlock, 101, pretrained, **kwargs)
 
@@ -570,7 +575,7 @@ def resnet152(
         :ref:`api_paddle_nn_Layer`. An instance of ResNet 152-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import resnet152
@@ -585,7 +590,7 @@ def resnet152(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _resnet('resnet152', BottleneckBlock, 152, pretrained, **kwargs)
 
@@ -605,7 +610,7 @@ def resnext50_32x4d(
         :ref:`api_paddle_nn_Layer`. An instance of ResNeXt-50 32x4d model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import resnext50_32x4d
@@ -620,7 +625,7 @@ def resnext50_32x4d(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     kwargs['groups'] = 32
     kwargs['width'] = 4
@@ -642,7 +647,7 @@ def resnext50_64x4d(
         :ref:`api_paddle_nn_Layer`. An instance of ResNeXt-50 64x4d model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import resnext50_64x4d
@@ -657,7 +662,7 @@ def resnext50_64x4d(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     kwargs['groups'] = 64
     kwargs['width'] = 4
@@ -679,7 +684,7 @@ def resnext101_32x4d(
         :ref:`api_paddle_nn_Layer`. An instance of ResNeXt-101 32x4d model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import resnext101_32x4d
@@ -694,7 +699,7 @@ def resnext101_32x4d(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     kwargs['groups'] = 32
     kwargs['width'] = 4
@@ -718,7 +723,7 @@ def resnext101_64x4d(
         :ref:`api_paddle_nn_Layer`. An instance of ResNeXt-101 64x4d model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import resnext101_64x4d
@@ -733,7 +738,7 @@ def resnext101_64x4d(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     kwargs['groups'] = 64
     kwargs['width'] = 4
@@ -757,7 +762,7 @@ def resnext152_32x4d(
         :ref:`api_paddle_nn_Layer`. An instance of ResNeXt-152 32x4d model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import resnext152_32x4d
@@ -772,7 +777,7 @@ def resnext152_32x4d(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     kwargs['groups'] = 32
     kwargs['width'] = 4
@@ -796,7 +801,7 @@ def resnext152_64x4d(
         :ref:`api_paddle_nn_Layer`. An instance of ResNeXt-152 64x4d model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import resnext152_64x4d
@@ -811,7 +816,7 @@ def resnext152_64x4d(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     kwargs['groups'] = 64
     kwargs['width'] = 4
@@ -835,7 +840,7 @@ def wide_resnet50_2(
         :ref:`api_paddle_nn_Layer`. An instance of Wide ResNet-50-2 model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import wide_resnet50_2
@@ -850,7 +855,7 @@ def wide_resnet50_2(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     kwargs['width'] = 64 * 2
     return _resnet('wide_resnet50_2', BottleneckBlock, 50, pretrained, **kwargs)
@@ -871,7 +876,7 @@ def wide_resnet101_2(
         :ref:`api_paddle_nn_Layer`. An instance of Wide ResNet-101-2 model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import wide_resnet101_2
@@ -886,7 +891,7 @@ def wide_resnet101_2(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     kwargs['width'] = 64 * 2
     return _resnet(

--- a/python/paddle/vision/models/shufflenetv2.py
+++ b/python/paddle/vision/models/shufflenetv2.py
@@ -249,7 +249,7 @@ class ShuffleNetV2(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of ShuffleNetV2 model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import ShuffleNetV2
@@ -258,7 +258,7 @@ class ShuffleNetV2(nn.Layer):
             >>> x = paddle.rand([1, 3, 224, 224])
             >>> out = shufflenet_v2_swish(x)
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
 
     scale: float
@@ -400,7 +400,7 @@ def shufflenet_v2_x0_25(
         :ref:`api_paddle_nn_Layer`. An instance of ShuffleNetV2 with 0.25x output channels.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import shufflenet_v2_x0_25
@@ -415,7 +415,7 @@ def shufflenet_v2_x0_25(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _shufflenet_v2(
         "shufflenet_v2_x0_25", scale=0.25, pretrained=pretrained, **kwargs
@@ -437,7 +437,7 @@ def shufflenet_v2_x0_33(
         :ref:`api_paddle_nn_Layer`. An instance of ShuffleNetV2 with 0.33x output channels.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import shufflenet_v2_x0_33
@@ -452,7 +452,7 @@ def shufflenet_v2_x0_33(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _shufflenet_v2(
         "shufflenet_v2_x0_33", scale=0.33, pretrained=pretrained, **kwargs
@@ -474,7 +474,7 @@ def shufflenet_v2_x0_5(
         :ref:`api_paddle_nn_Layer`. An instance of ShuffleNetV2 with 0.5x output channels.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import shufflenet_v2_x0_5
@@ -489,7 +489,7 @@ def shufflenet_v2_x0_5(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _shufflenet_v2(
         "shufflenet_v2_x0_5", scale=0.5, pretrained=pretrained, **kwargs
@@ -511,7 +511,7 @@ def shufflenet_v2_x1_0(
         :ref:`api_paddle_nn_Layer`. An instance of ShuffleNetV2 with 1.0x output channels.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import shufflenet_v2_x1_0
@@ -526,7 +526,7 @@ def shufflenet_v2_x1_0(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _shufflenet_v2(
         "shufflenet_v2_x1_0", scale=1.0, pretrained=pretrained, **kwargs
@@ -548,7 +548,7 @@ def shufflenet_v2_x1_5(
         :ref:`api_paddle_nn_Layer`. An instance of ShuffleNetV2 with 1.5x output channels.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import shufflenet_v2_x1_5
@@ -563,7 +563,7 @@ def shufflenet_v2_x1_5(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _shufflenet_v2(
         "shufflenet_v2_x1_5", scale=1.5, pretrained=pretrained, **kwargs
@@ -585,7 +585,7 @@ def shufflenet_v2_x2_0(
         :ref:`api_paddle_nn_Layer`. An instance of ShuffleNetV2 with 2.0x output channels.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import shufflenet_v2_x2_0
@@ -600,7 +600,7 @@ def shufflenet_v2_x2_0(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _shufflenet_v2(
         "shufflenet_v2_x2_0", scale=2.0, pretrained=pretrained, **kwargs
@@ -622,7 +622,7 @@ def shufflenet_v2_swish(
         :ref:`api_paddle_nn_Layer`. An instance of ShuffleNetV2 with swish activation function.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import shufflenet_v2_swish
@@ -637,7 +637,7 @@ def shufflenet_v2_swish(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _shufflenet_v2(
         "shufflenet_v2_swish",

--- a/python/paddle/vision/models/squeezenet.py
+++ b/python/paddle/vision/models/squeezenet.py
@@ -112,7 +112,7 @@ class SqueezeNet(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of SqueezeNet model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import SqueezeNet
@@ -127,7 +127,7 @@ class SqueezeNet(nn.Layer):
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
 
     version: str
@@ -264,7 +264,7 @@ def squeezenet1_0(
         :ref:`api_paddle_nn_Layer`. An instance of SqueezeNet v1.0 model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import squeezenet1_0
@@ -279,7 +279,7 @@ def squeezenet1_0(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _squeezenet('squeezenet1_0', '1.0', pretrained, **kwargs)
 
@@ -300,7 +300,7 @@ def squeezenet1_1(
         :ref:`api_paddle_nn_Layer`. An instance of SqueezeNet v1.1 model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import squeezenet1_1
@@ -315,6 +315,6 @@ def squeezenet1_1(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     return _squeezenet('squeezenet1_1', '1.1', pretrained, **kwargs)

--- a/python/paddle/vision/models/vgg.py
+++ b/python/paddle/vision/models/vgg.py
@@ -63,13 +63,27 @@ class VGG(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of VGG model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import VGG
             >>> from paddle.vision.models.vgg import make_layers
 
-            >>> vgg11_cfg = [64, 'M', 128, 'M', 256, 256, 'M', 512, 512, 'M', 512, 512, 'M']
+            >>> vgg11_cfg = [
+            ...     64,
+            ...     'M',
+            ...     128,
+            ...     'M',
+            ...     256,
+            ...     256,
+            ...     'M',
+            ...     512,
+            ...     512,
+            ...     'M',
+            ...     512,
+            ...     512,
+            ...     'M',
+            ... ]
 
             >>> features = make_layers(vgg11_cfg)  # type: ignore
 
@@ -79,7 +93,7 @@ class VGG(nn.Layer):
             >>> out = vgg11(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
 
     num_classes: int
@@ -211,7 +225,7 @@ def vgg11(
         :ref:`api_paddle_nn_Layer`. An instance of VGG 11-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import vgg11
@@ -226,7 +240,7 @@ def vgg11(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     model_name = 'vgg11'
     if batch_norm:
@@ -252,7 +266,7 @@ def vgg13(
         :ref:`api_paddle_nn_Layer`. An instance of VGG 13-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import vgg13
@@ -267,7 +281,7 @@ def vgg13(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     model_name = 'vgg13'
     if batch_norm:
@@ -293,7 +307,7 @@ def vgg16(
         :ref:`api_paddle_nn_Layer`. An instance of VGG 16-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import vgg16
@@ -308,7 +322,7 @@ def vgg16(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     model_name = 'vgg16'
     if batch_norm:
@@ -334,7 +348,7 @@ def vgg19(
         :ref:`api_paddle_nn_Layer`. An instance of VGG 19-layer model.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.models import vgg19
@@ -349,7 +363,7 @@ def vgg19(
             >>> out = model(x)
 
             >>> print(out.shape)
-            [1, 1000]
+            paddle.Size([1, 1000])
     """
     model_name = 'vgg19'
     if batch_norm:

--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -1373,9 +1373,7 @@ def read_file(filename: str, name: str | None = None) -> Tensor:
             >>> import cv2
             >>> import paddle
             >>> paddle.seed(2023)
-            >>> fake_img = (paddle.rand((400, 300, 3)).numpy() * 255).astype(
-            ...     'uint8'
-            ... )
+            >>> fake_img = (paddle.rand((400, 300, 3)).numpy() * 255).astype('uint8')
             >>> cv2.imwrite('fake.jpg', fake_img)
             >>> img_bytes = paddle.vision.ops.read_file('fake.jpg')
             >>> print(img_bytes.shape)
@@ -1428,9 +1426,7 @@ def decode_jpeg(
             >>> import paddle
             >>> paddle.device.set_device('gpu')
 
-            >>> fake_img = (np.random.random((400, 300, 3)) * 255).astype(
-            ...     'uint8'
-            ... )
+            >>> fake_img = (np.random.random((400, 300, 3)) * 255).astype('uint8')
             >>> cv2.imwrite('fake.jpg', fake_img)
             >>> img_bytes = paddle.vision.ops.read_file('fake.jpg')
             >>> img = paddle.vision.ops.decode_jpeg(img_bytes)
@@ -1496,9 +1492,7 @@ def psroi_pool(
             ...     dtype='float32',
             ... )
             >>> boxes_num = paddle.to_tensor([1, 2], dtype='int32')
-            >>> pool_out = paddle.vision.ops.psroi_pool(
-            ...     x, boxes, boxes_num, 7, 1.0
-            ... )
+            >>> pool_out = paddle.vision.ops.psroi_pool(x, boxes, boxes_num, 7, 1.0)
             >>> print(pool_out.shape)
             paddle.Size([3, 10, 7, 7])
     """
@@ -1632,9 +1626,7 @@ def roi_pool(
             >>> boxes[:, 2] += boxes[:, 0] + 3
             >>> boxes[:, 3] += boxes[:, 1] + 4
             >>> boxes_num = paddle.to_tensor([3]).astype('int32')
-            >>> pool_out = roi_pool(
-            ...     data, boxes, boxes_num=boxes_num, output_size=3
-            ... )
+            >>> pool_out = roi_pool(data, boxes, boxes_num=boxes_num, output_size=3)
             >>> print(pool_out.shape)
             paddle.Size([3, 256, 3, 3])
     """

--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -854,7 +854,7 @@ def deform_conv2d(
             A Tensor with type float32, float64.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> #deformable conv v2:
 
@@ -870,7 +870,7 @@ def deform_conv2d(
             >>> mask = paddle.rand((8, kh * kw, 26, 26))
             >>> out = paddle.vision.ops.deform_conv2d(input, offset, weight, mask=mask)
             >>> print(out.shape)
-            [8, 16, 26, 26]
+            paddle.Size([8, 16, 26, 26])
 
             >>> #deformable conv v1:
 
@@ -884,7 +884,7 @@ def deform_conv2d(
             >>> offset = paddle.rand((8, 2 * kh * kw, 26, 26))
             >>> out = paddle.vision.ops.deform_conv2d(input, offset, weight)
             >>> print(out.shape)
-            [8, 16, 26, 26]
+            paddle.Size([8, 16, 26, 26])
     """
     stride = convert_to_list(stride, 2, 'stride')
     padding = convert_to_list(padding, 2, 'padding')
@@ -1073,7 +1073,7 @@ class DeformConv2D(Layer):
             W_{out}&= \frac{(W_{in} + 2 * paddings[1] - (dilations[1] * (kernel\_size[1] - 1) + 1))}{strides[1]} + 1
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> #deformable conv v2:
             >>> import paddle
@@ -1091,7 +1091,7 @@ class DeformConv2D(Layer):
             ...     kernel_size=[kh, kw])
             >>> out = deform_conv(input, offset, mask)
             >>> print(out.shape)
-            [8, 16, 26, 26]
+            paddle.Size([8, 16, 26, 26])
 
             >>> #deformable conv v1:
             >>> import paddle
@@ -1108,7 +1108,7 @@ class DeformConv2D(Layer):
             ...     kernel_size=[kh, kw])
             >>> out = deform_conv(input, offset)
             >>> print(out.shape)
-            [8, 16, 26, 26]
+            paddle.Size([8, 16, 26, 26])
     """
 
     weight: Tensor
@@ -1368,16 +1368,18 @@ def read_file(filename: str, name: str | None = None) -> Tensor:
         A uint8 tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import cv2
             >>> import paddle
             >>> paddle.seed(2023)
-            >>> fake_img = (paddle.rand((400, 300, 3)).numpy() * 255).astype('uint8')
+            >>> fake_img = (paddle.rand((400, 300, 3)).numpy() * 255).astype(
+            ...     'uint8'
+            ... )
             >>> cv2.imwrite('fake.jpg', fake_img)
             >>> img_bytes = paddle.vision.ops.read_file('fake.jpg')
             >>> print(img_bytes.shape)
-            [142773]
+            paddle.Size([142773])
     """
 
     attr_dtype = convert_np_dtype_to_dtype_('uint8')
@@ -1418,7 +1420,7 @@ def decode_jpeg(
         Tensor: A decoded image tensor with shape (image_channels, image_height, image_width)
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import cv2
@@ -1426,13 +1428,14 @@ def decode_jpeg(
             >>> import paddle
             >>> paddle.device.set_device('gpu')
 
-            >>> fake_img = (np.random.random(
-            ...             (400, 300, 3)) * 255).astype('uint8')
+            >>> fake_img = (np.random.random((400, 300, 3)) * 255).astype(
+            ...     'uint8'
+            ... )
             >>> cv2.imwrite('fake.jpg', fake_img)
             >>> img_bytes = paddle.vision.ops.read_file('fake.jpg')
             >>> img = paddle.vision.ops.decode_jpeg(img_bytes)
             >>> print(img.shape)
-            [3, 400, 300]
+            paddle.Size([3, 400, 300])
     """
     if in_dynamic_or_pir_mode():
         return _C_ops.decode_jpeg(x, mode, _current_expected_place())
@@ -1484,15 +1487,20 @@ def psroi_pool(
         The output_channels equal to C / (pooled_h * pooled_w), where C is the channels of input.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> x = paddle.uniform([2, 490, 28, 28], dtype='float32')
-            >>> boxes = paddle.to_tensor([[1, 5, 8, 10], [4, 2, 6, 7], [12, 12, 19, 21]], dtype='float32')
+            >>> boxes = paddle.to_tensor(
+            ...     [[1, 5, 8, 10], [4, 2, 6, 7], [12, 12, 19, 21]],
+            ...     dtype='float32',
+            ... )
             >>> boxes_num = paddle.to_tensor([1, 2], dtype='int32')
-            >>> pool_out = paddle.vision.ops.psroi_pool(x, boxes, boxes_num, 7, 1.0)
+            >>> pool_out = paddle.vision.ops.psroi_pool(
+            ...     x, boxes, boxes_num, 7, 1.0
+            ... )
             >>> print(pool_out.shape)
-            [3, 10, 7, 7]
+            paddle.Size([3, 10, 7, 7])
     """
 
     check_type(output_size, 'output_size', (int, tuple, list), 'psroi_pool')
@@ -1553,17 +1561,20 @@ class PSRoIPool(Layer):
         None.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> psroi_module = paddle.vision.ops.PSRoIPool(7, 1.0)
             >>> x = paddle.uniform([2, 490, 28, 28], dtype='float32')
-            >>> boxes = paddle.to_tensor([[1, 5, 8, 10], [4, 2, 6, 7], [12, 12, 19, 21]], dtype='float32')
+            >>> boxes = paddle.to_tensor(
+            ...     [[1, 5, 8, 10], [4, 2, 6, 7], [12, 12, 19, 21]],
+            ...     dtype='float32',
+            ... )
             >>> boxes_num = paddle.to_tensor([1, 2], dtype='int32')
             >>> pool_out = psroi_module(x, boxes, boxes_num)
             >>> print(pool_out.shape)
-            [3, 10, 7, 7]
+            paddle.Size([3, 10, 7, 7])
     """
 
     output_size: Size2
@@ -1611,7 +1622,7 @@ def roi_pool(
         pool_out (Tensor): the pooled feature, 4D-Tensor with the shape of [num_boxes, C, output_size[0], output_size[1]].
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.ops import roi_pool
@@ -1621,9 +1632,11 @@ def roi_pool(
             >>> boxes[:, 2] += boxes[:, 0] + 3
             >>> boxes[:, 3] += boxes[:, 1] + 4
             >>> boxes_num = paddle.to_tensor([3]).astype('int32')
-            >>> pool_out = roi_pool(data, boxes, boxes_num=boxes_num, output_size=3)
+            >>> pool_out = roi_pool(
+            ...     data, boxes, boxes_num=boxes_num, output_size=3
+            ... )
             >>> print(pool_out.shape)
-            [3, 256, 3, 3]
+            paddle.Size([3, 256, 3, 3])
     """
 
     check_type(output_size, 'output_size', (int, tuple), 'roi_pool')
@@ -1678,7 +1691,7 @@ class RoIPool(Layer):
         pool_out (Tensor): the pooled feature, 4D-Tensor with the shape of [num_boxes, C, output_size[0], output_size[1]].
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.ops import RoIPool
@@ -1691,7 +1704,7 @@ class RoIPool(Layer):
             >>> roi_pool = RoIPool(output_size=(4, 3))
             >>> pool_out = roi_pool(data, boxes, boxes_num)
             >>> print(pool_out.shape)
-            [3, 256, 4, 3]
+            paddle.Size([3, 256, 4, 3])
     """
 
     def __init__(self, output_size: Size2, spatial_scale: float = 1.0) -> None:
@@ -1771,7 +1784,7 @@ def roi_align(
             channels, pooled_h, pooled_w). The data type is float32 or float64.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.ops import roi_align
@@ -1783,7 +1796,7 @@ def roi_align(
             >>> boxes_num = paddle.to_tensor([3]).astype('int32')
             >>> align_out = roi_align(data, boxes, boxes_num, output_size=3)
             >>> print(align_out.shape)
-            [3, 256, 3, 3]
+            paddle.Size([3, 256, 3, 3])
     """
 
     check_type(output_size, 'output_size', (int, tuple), 'roi_align')
@@ -1851,7 +1864,7 @@ class RoIAlign(Layer):
             shape (num_boxes, channels, pooled_h, pooled_w).
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.ops import RoIAlign
@@ -1864,7 +1877,7 @@ class RoIAlign(Layer):
             >>> roi_align = RoIAlign(output_size=(4, 3))
             >>> align_out = roi_align(data, boxes, boxes_num)
             >>> print(align_out.shape)
-            [3, 256, 4, 3]
+            paddle.Size([3, 256, 4, 3])
     """
 
     def __init__(self, output_size: Size2, spatial_scale: float = 1.0) -> None:

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -919,9 +919,7 @@ def perspective(
             >>> fake_img = paddle.randn((3, 256, 300)).astype(paddle.float32)
             >>> startpoints = [[0, 0], [33, 0], [33, 25], [0, 25]]
             >>> endpoints = [[3, 2], [32, 3], [30, 24], [2, 25]]
-            >>> perspectived_img = F.perspective(
-            ...     fake_img, startpoints, endpoints
-            ... )
+            >>> perspectived_img = F.perspective(fake_img, startpoints, endpoints)
             >>> print(perspectived_img.shape)
             paddle.Size([3, 256, 300])
 

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -99,16 +99,16 @@ def to_tensor(
         Tensor: Converted image. Data type is same as input img.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import numpy as np
             >>> from PIL import Image
             >>> from paddle.vision.transforms import functional as F
-            >>> fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+            >>> fake_img = (np.random.rand(256, 300, 3) * 255.0).astype('uint8')
             >>> fake_img = Image.fromarray(fake_img)
             >>> tensor = F.to_tensor(fake_img)
             >>> print(tensor.shape)
-            [3, 256, 300]
+            paddle.Size([3, 256, 300])
 
     """
     if not (
@@ -660,14 +660,20 @@ def affine(
         PIL.Image|np.array|paddle.Tensor: Affine Transformed image.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.transforms import functional as F
             >>> fake_img = paddle.randn((3, 256, 300)).astype(paddle.float32)
-            >>> affined_img = F.affine(fake_img, 45, translate=[0.2, 0.2], scale=0.5, shear=[-10, 10])
+            >>> affined_img = F.affine(
+            ...     fake_img,
+            ...     45,
+            ...     translate=[0.2, 0.2],
+            ...     scale=0.5,
+            ...     shear=[-10, 10],
+            ... )
             >>> print(affined_img.shape)
-            [3, 256, 300]
+            paddle.Size([3, 256, 300])
     """
 
     if not (
@@ -906,16 +912,18 @@ def perspective(
         PIL.Image|np.array|paddle.Tensor: transformed Image.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.transforms import functional as F
             >>> fake_img = paddle.randn((3, 256, 300)).astype(paddle.float32)
             >>> startpoints = [[0, 0], [33, 0], [33, 25], [0, 25]]
             >>> endpoints = [[3, 2], [32, 3], [30, 24], [2, 25]]
-            >>> perspectived_img = F.perspective(fake_img, startpoints, endpoints)
+            >>> perspectived_img = F.perspective(
+            ...     fake_img, startpoints, endpoints
+            ... )
             >>> print(perspectived_img.shape)
-            [3, 256, 300]
+            paddle.Size([3, 256, 300])
 
     """
     if not (

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -377,19 +377,21 @@ class ToTensor(BaseTransform[_InputT, "Tensor"]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> from PIL import Image
             >>> import paddle
             >>> import paddle.vision.transforms as T
             >>> import paddle.vision.transforms.functional as F
 
-            >>> img_arr = ((paddle.rand((4, 5, 3)) * 255.).astype('uint8')).numpy()
+            >>> img_arr = (
+            ...     (paddle.rand((4, 5, 3)) * 255.0).astype('uint8')
+            ... ).numpy()
             >>> fake_img = Image.fromarray(img_arr)
             >>> transform = T.ToTensor()
             >>> tensor = transform(fake_img)
             >>> print(tensor.shape)
-            [3, 4, 5]
+            paddle.Size([3, 4, 5])
             >>> print(tensor.dtype)
             paddle.float32
     """
@@ -1347,20 +1349,22 @@ class RandomCrop(BaseTransform[_InputT, _RetT]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example1
 
             >>> import paddle
             >>> from paddle.vision.transforms import RandomCrop
             >>> transform = RandomCrop(224)
 
-            >>> fake_img = paddle.randint(0, 255, shape=(3, 324,300), dtype = 'int32')
+            >>> fake_img = paddle.randint(
+            ...     0, 255, shape=(3, 324, 300), dtype='int32'
+            ... )
             >>> print(fake_img.shape)
-            [3, 324, 300]
+            paddle.Size([3, 324, 300])
 
             >>> crop_img = transform(fake_img)
             >>> print(crop_img.shape)
-            [3, 224, 224]
+            paddle.Size([3, 224, 224])
     """
 
     size: Size2
@@ -1597,16 +1601,21 @@ class RandomAffine(BaseTransform[_InputT, _RetT]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.transforms import RandomAffine
 
-            >>> transform = RandomAffine([-90, 90], translate=[0.2, 0.2], scale=[0.5, 0.5], shear=[-10, 10])
+            >>> transform = RandomAffine(
+            ...     [-90, 90],
+            ...     translate=[0.2, 0.2],
+            ...     scale=[0.5, 0.5],
+            ...     shear=[-10, 10],
+            ... )
             >>> fake_img = paddle.randn((3, 256, 300)).astype(paddle.float32)
             >>> fake_img = transform(fake_img)
             >>> print(fake_img.shape)
-            [3, 256, 300]
+            paddle.Size([3, 256, 300])
     """
 
     degrees: float | list[float] | tuple[float, float]
@@ -1875,7 +1884,7 @@ class RandomPerspective(BaseTransform[_InputT, _RetT]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.vision.transforms import RandomPerspective
@@ -1884,7 +1893,7 @@ class RandomPerspective(BaseTransform[_InputT, _RetT]):
             >>> fake_img = paddle.randn((3, 200, 150)).astype(paddle.float32)
             >>> fake_img = transform(fake_img)
             >>> print(fake_img.shape)
-            [3, 200, 150]
+            paddle.Size([3, 200, 150])
     """
 
     prob: float

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -384,9 +384,7 @@ class ToTensor(BaseTransform[_InputT, "Tensor"]):
             >>> import paddle.vision.transforms as T
             >>> import paddle.vision.transforms.functional as F
 
-            >>> img_arr = (
-            ...     (paddle.rand((4, 5, 3)) * 255.0).astype('uint8')
-            ... ).numpy()
+            >>> img_arr = ((paddle.rand((4, 5, 3)) * 255.0).astype('uint8')).numpy()
             >>> fake_img = Image.fromarray(img_arr)
             >>> transform = T.ToTensor()
             >>> tensor = transform(fake_img)
@@ -1356,9 +1354,7 @@ class RandomCrop(BaseTransform[_InputT, _RetT]):
             >>> from paddle.vision.transforms import RandomCrop
             >>> transform = RandomCrop(224)
 
-            >>> fake_img = paddle.randint(
-            ...     0, 255, shape=(3, 324, 300), dtype='int32'
-            ... )
+            >>> fake_img = paddle.randint(0, 255, shape=(3, 324, 300), dtype='int32')
             >>> print(fake_img.shape)
             paddle.Size([3, 324, 300])
 

--- a/test/legacy_test/nets.py
+++ b/test/legacy_test/nets.py
@@ -110,9 +110,7 @@ def simple_img_conv_pool(
             >>> import paddle
 
             >>> paddle.enable_static()
-            >>> img = paddle.static.data(
-            ...     name='img', shape=[100, 1, 28, 28], dtype='float32'
-            ... )
+            >>> img = paddle.static.data(name='img', shape=[100, 1, 28, 28], dtype='float32')
             >>> conv_pool = base.nets.simple_img_conv_pool(
             ...     input=img,
             ...     filter_size=5,
@@ -218,9 +216,7 @@ def img_conv_group(
 
             paddle.enable_static()
 
-            img = paddle.static.data(
-                name='img', shape=[None, 1, 28, 28], dtype='float32'
-            )
+            img = paddle.static.data(name='img', shape=[None, 1, 28, 28], dtype='float32')
             conv_pool = base.nets.img_conv_group(
                 input=img,
                 conv_padding=1,
@@ -337,12 +333,8 @@ def sequence_conv_pool(
             input_dim = 100  # len(word_dict)
             emb_dim = 128
             hid_dim = 512
-            data = paddle.static.data(
-                name="words", shape=[None, 1], dtype="int64"
-            )
-            emb = paddle.static.nn.embedding(
-                input=data, size=[input_dim, emb_dim], is_sparse=True
-            )
+            data = paddle.static.data(name="words", shape=[None, 1], dtype="int64")
+            emb = paddle.static.nn.embedding(input=data, size=[input_dim, emb_dim], is_sparse=True)
             seq_conv = base.nets.sequence_conv_pool(
                 input=emb,
                 num_filters=hid_dim,
@@ -404,9 +396,7 @@ def glu(input, dim=-1):
 
             paddle.enable_static()
 
-            data = paddle.static.data(
-                name="words", shape=[-1, 6, 3, 9], dtype="float32"
-            )
+            data = paddle.static.data(name="words", shape=[-1, 6, 3, 9], dtype="float32")
             # shape of output: [-1, 3, 3, 9]
             output = base.nets.glu(input=data, dim=1)
     """


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Docs

### Description
<!-- Describe what you’ve done -->
https://github.com/PaddlePaddle/Paddle/pull/76361 后，Paddle 的 shape 类型从 List 变成 paddle.Size。

本 PR 扫描了 Python 目录下含有 .shape 语句的 sample 代码，并将输出的 List 修改为 Paddle.Size