### PR TITLE
[Infra] Add `setuptools` as dependency in python3.12+

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,3 +6,4 @@ opt_einsum==3.3.0
 networkx
 typing_extensions
 safetensors>=0.6.0
+setuptools; python_version>="3.12"

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1637,7 +1637,7 @@ def check_build_dependency():
 Please run 'pip install -r python/requirements.txt' to make sure you have all the dependencies installed.
 '''.strip()
 
-    with open(TOP_DIR + '/python/requirements.txt') as f:
+    with open('${PADDLE_SOURCE_DIR}' + '/python/requirements.txt') as f:
         build_dependencies = (
             f.read().splitlines()
         )  # Specify the dependencies to install
@@ -1654,22 +1654,33 @@ Please run 'pip install -r python/requirements.txt' to make sure you have all th
 
         # Build environment dict
         env_markers = {
-            'python_version': f"{sys.version_info.major}.{sys.version_info.minor}",
-            'python_full_version': f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
-            'platform_system': platform.system(),
-            'platform_machine': platform.machine(),
-            'sys_platform': sys.platform,
+            'python_version': (sys.version_info.major, sys.version_info.minor),
+            'python_full_version': (
+                sys.version_info.major,
+                sys.version_info.minor,
+                sys.version_info.micro,
+            ),
+            'platform_system': f'"{platform.system()}"',
+            'platform_machine': f'"{platform.machine()}"',
+            'sys_platform': f'"{sys.platform}"',
         }
 
-        # Simple marker evaluation - handle common cases
-        # This is a simplified version that handles the most common patterns
+        # Marker evaluation
         try:
-            # Replace marker variables with their values
             eval_str = marker_str
+            # Replace marker variables with their values
             for key, value in env_markers.items():
-                eval_str = eval_str.replace(key, f'"{value}"')
+                eval_str = eval_str.replace(key, str(value))
 
-            # Evaluate the expression
+            def version_to_tuple(match):
+                version_str = match.group(1)
+                parts = version_str.split('.')
+                return '(' + ', '.join(parts) + ')'
+
+            eval_str = re.sub(
+                r'["\'](\d+(?:\.\d+)*)["\']', version_to_tuple, eval_str
+            )
+
             return eval(eval_str)
         except Exception as e:
             raise RuntimeError(f"Failed to evaluate marker '{marker_str}': {e}")

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1637,7 +1637,7 @@ def check_build_dependency():
 Please run 'pip install -r python/requirements.txt' to make sure you have all the dependencies installed.
 '''.strip()
 
-    with open('${PADDLE_SOURCE_DIR}' + '/python/requirements.txt') as f:
+    with open(TOP_DIR + '/python/requirements.txt') as f:
         build_dependencies = (
             f.read().splitlines()
         )  # Specify the dependencies to install
@@ -1645,10 +1645,60 @@ Please run 'pip install -r python/requirements.txt' to make sure you have all th
     python_dependencies_module = []
     installed_packages = []
 
+    def eval_marker(marker_str):
+        """Simple evaluation of PEP 508 environment markers."""
+        if not marker_str:
+            return True
+
+        marker_str = marker_str.strip()
+
+        # Build environment dict
+        env_markers = {
+            'python_version': f"{sys.version_info.major}.{sys.version_info.minor}",
+            'python_full_version': f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            'platform_system': platform.system(),
+            'platform_machine': platform.machine(),
+            'sys_platform': sys.platform,
+        }
+
+        # Simple marker evaluation - handle common cases
+        # This is a simplified version that handles the most common patterns
+        try:
+            # Replace marker variables with their values
+            eval_str = marker_str
+            for key, value in env_markers.items():
+                eval_str = eval_str.replace(key, f'"{value}"')
+
+            # Evaluate the expression
+            return eval(eval_str)
+        except Exception as e:
+            raise RuntimeError(f"Failed to evaluate marker '{marker_str}': {e}")
+
     for dependency in build_dependencies:
-        python_dependencies_module.append(
-            re.sub("_|-", '', re.sub(r"==.*|>=.*|<=.*", '', dependency))
-        )
+        dependency = dependency.strip()
+        if not dependency or dependency.startswith('#'):
+            continue
+
+        # Split dependency spec and environment marker
+        if ';' in dependency:
+            dependency_spec, marker = dependency.split(';', 1)
+            dependency_spec = dependency_spec.strip()
+            marker = marker.strip()
+
+            # Evaluate marker - skip if not applicable to current environment
+            if not eval_marker(marker):
+                continue
+        else:
+            dependency_spec = dependency
+
+        # Remove version specifiers from dependency spec
+        dependency_name = re.sub(
+            r"==.*|>=.*|<=.*|~=.*|!=.*", '', dependency_spec
+        ).strip()
+
+        # Normalize package name (remove _ and -)
+        python_dependencies_module.append(re.sub("_|-", '', dependency_name))
+
     reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
 
     for r in reqs.split():

--- a/setup.py
+++ b/setup.py
@@ -2576,22 +2576,33 @@ Please run 'pip install -r python/requirements.txt' to make sure you have all th
 
         # Build environment dict
         env_markers = {
-            'python_version': f"{sys.version_info.major}.{sys.version_info.minor}",
-            'python_full_version': f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
-            'platform_system': platform.system(),
-            'platform_machine': platform.machine(),
-            'sys_platform': sys.platform,
+            'python_version': (sys.version_info.major, sys.version_info.minor),
+            'python_full_version': (
+                sys.version_info.major,
+                sys.version_info.minor,
+                sys.version_info.micro,
+            ),
+            'platform_system': f'"{platform.system()}"',
+            'platform_machine': f'"{platform.machine()}"',
+            'sys_platform': f'"{sys.platform}"',
         }
 
-        # Simple marker evaluation - handle common cases
-        # This is a simplified version that handles the most common patterns
+        # Marker evaluation
         try:
-            # Replace marker variables with their values
             eval_str = marker_str
+            # Replace marker variables with their values
             for key, value in env_markers.items():
-                eval_str = eval_str.replace(key, f'"{value}"')
+                eval_str = eval_str.replace(key, str(value))
 
-            # Evaluate the expression
+            def version_to_tuple(match):
+                version_str = match.group(1)
+                parts = version_str.split('.')
+                return '(' + ', '.join(parts) + ')'
+
+            eval_str = re.sub(
+                r'["\'](\d+(?:\.\d+)*)["\']', version_to_tuple, eval_str
+            )
+
             return eval(eval_str)
         except Exception as e:
             raise RuntimeError(f"Failed to evaluate marker '{marker_str}': {e}")

--- a/setup.py
+++ b/setup.py
@@ -2567,10 +2567,60 @@ Please run 'pip install -r python/requirements.txt' to make sure you have all th
     python_dependencies_module = []
     installed_packages = []
 
+    def eval_marker(marker_str):
+        """Simple evaluation of PEP 508 environment markers."""
+        if not marker_str:
+            return True
+
+        marker_str = marker_str.strip()
+
+        # Build environment dict
+        env_markers = {
+            'python_version': f"{sys.version_info.major}.{sys.version_info.minor}",
+            'python_full_version': f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            'platform_system': platform.system(),
+            'platform_machine': platform.machine(),
+            'sys_platform': sys.platform,
+        }
+
+        # Simple marker evaluation - handle common cases
+        # This is a simplified version that handles the most common patterns
+        try:
+            # Replace marker variables with their values
+            eval_str = marker_str
+            for key, value in env_markers.items():
+                eval_str = eval_str.replace(key, f'"{value}"')
+
+            # Evaluate the expression
+            return eval(eval_str)
+        except Exception as e:
+            raise RuntimeError(f"Failed to evaluate marker '{marker_str}': {e}")
+
     for dependency in build_dependencies:
-        python_dependencies_module.append(
-            re.sub("_|-", '', re.sub(r"==.*|>=.*|<=.*", '', dependency))
-        )
+        dependency = dependency.strip()
+        if not dependency or dependency.startswith('#'):
+            continue
+
+        # Split dependency spec and environment marker
+        if ';' in dependency:
+            dependency_spec, marker = dependency.split(';', 1)
+            dependency_spec = dependency_spec.strip()
+            marker = marker.strip()
+
+            # Evaluate marker - skip if not applicable to current environment
+            if not eval_marker(marker):
+                continue
+        else:
+            dependency_spec = dependency
+
+        # Remove version specifiers from dependency spec
+        dependency_name = re.sub(
+            r"==.*|>=.*|<=.*|~=.*|!=.*", '', dependency_spec
+        ).strip()
+
+        # Normalize package name (remove _ and -)
+        python_dependencies_module.append(re.sub("_|-", '', dependency_name))
+
     reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
 
     for r in reqs.split():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

在 Python 3.12+ 将 setuptools 作为依赖，paddle cpp extension 依赖 setuptools，但在 Python 3.12+ 不再在环境中默认安装 setuptools [^1]

> [gh-95299](https://github.com/python/cpython/issues/95299): Do not pre-install setuptools in virtual environments created with [venv](https://docs.python.org/3/library/venv.html#module-venv). This means that distutils, setuptools, pkg_resources, and easy_install will no longer available by default; to access these run pip install setuptools in the [activated](https://docs.python.org/3/library/venv.html#venv-explanation) virtual environment.

fixes #73449, fixes #71650, closes #71651

<!-- PCard-66972 -->

[^1]: https://docs.python.org/3/whatsnew/3.12.html