### PR TITLE
[Compat] Allow user to specify which module need enable torch proxy

### DIFF
--- a/python/paddle/compat/proxy.py
+++ b/python/paddle/compat/proxy.py
@@ -107,6 +107,9 @@ TORCH_PROXY_BLOCKED_MODULES = {
     "transformers",
 }
 
+MAGIC_DISABLED_MODULE_ATTR: str = "__disable_torch_proxy__"
+MAGIC_ENABLED_MODULE_ATTR: str = "__enable_torch_proxy__"
+
 
 def _extend_torch_proxy_overrides(
     overrides: dict[str, OverriddenAttribute],
@@ -152,6 +155,13 @@ def _is_torch_module(name: str) -> bool:
     return _is_specific_module_or_its_submodule(name, "torch")
 
 
+def _is_torch_proxy_local_enabled_module(name: str, scope: set[str]) -> bool:
+    for enabled_module in scope:
+        if _is_specific_module_or_its_submodule(name, enabled_module):
+            return True
+    return False
+
+
 def _is_torch_proxy_blocked_module(name: str) -> bool:
     for blocked_module in TORCH_PROXY_BLOCKED_MODULES:
         if _is_specific_module_or_its_submodule(name, blocked_module):
@@ -159,12 +169,24 @@ def _is_torch_proxy_blocked_module(name: str) -> bool:
     return False
 
 
-def _is_called_by_torch_proxy_blocked_module():
+def _is_called_by_module_with_specific_dunder_attr(dunder_attr: str) -> bool:
     stack = inspect.stack()
     for frame_info in stack[1:]:
-        if frame_info.frame.f_globals.get("__disable_torch_proxy__"):
+        if frame_info.frame.f_globals.get(dunder_attr):
             return True
     return False
+
+
+def _is_called_by_torch_proxy_blocked_module():
+    return _is_called_by_module_with_specific_dunder_attr(
+        MAGIC_DISABLED_MODULE_ATTR
+    )
+
+
+def _is_called_by_torch_proxy_local_enabled_module():
+    return _is_called_by_module_with_specific_dunder_attr(
+        MAGIC_ENABLED_MODULE_ATTR
+    )
 
 
 class TorchProxyMetaFinder:
@@ -176,9 +198,19 @@ class TorchProxyMetaFinder:
     Inspired by the setuptools _distutils_hack.
     """
 
+    def __init__(self, scope: set[str] | None = None):
+        self._scope = scope
+
     def find_spec(self, fullname, path, target=None):
         if _is_torch_proxy_blocked_module(fullname):
             return self._find_spec_for_torch_proxy_blocked_module(fullname)
+
+        if self._scope is not None and _is_torch_proxy_local_enabled_module(
+            fullname, self._scope
+        ):
+            return self._find_spec_for_torch_proxy_local_enabled_module(
+                fullname
+            )
 
         if not _is_torch_module(fullname):
             return None
@@ -186,11 +218,22 @@ class TorchProxyMetaFinder:
         if _is_called_by_torch_proxy_blocked_module():
             return None
 
+        if (
+            self._scope is not None
+            and not _is_called_by_torch_proxy_local_enabled_module()
+        ):
+            return None
+
         return self._find_spec_for_torch_module(fullname)
 
-    def _find_spec_for_torch_proxy_blocked_module(self, fullname: str):
+    def _find_spec_for_specific_module(
+        self,
+        fullname: str,
+        enable_proxy_when_exec_module: bool,
+        patched_dunder_attr: str,
+    ):
         # Return a special loader that imports the blocked module without torch proxy
-        with use_torch_proxy_guard(False):
+        with use_torch_proxy_guard(enable=False):
             spec = importlib.util.find_spec(fullname)
             if spec is None:
                 return None
@@ -215,13 +258,29 @@ class TorchProxyMetaFinder:
 
                 def exec_module(self, module):
                     # Import the real module with torch proxy disabled
-                    with use_torch_proxy_guard(False):
+                    with use_torch_proxy_guard(
+                        enable=enable_proxy_when_exec_module, silent=True
+                    ):
                         original_loader.exec_module(module)
-                    # Mark module as torch proxy disabled
-                    module.__dict__["__disable_torch_proxy__"] = True
+                    # Mark module as torch proxy disabled/local enabled
+                    module.__dict__[patched_dunder_attr] = True
 
         spec.loader = TorchBlockedModuleLoader()
         return spec
+
+    def _find_spec_for_torch_proxy_local_enabled_module(self, fullname: str):
+        return self._find_spec_for_specific_module(
+            fullname,
+            enable_proxy_when_exec_module=True,
+            patched_dunder_attr=MAGIC_ENABLED_MODULE_ATTR,
+        )
+
+    def _find_spec_for_torch_proxy_blocked_module(self, fullname: str):
+        return self._find_spec_for_specific_module(
+            fullname,
+            enable_proxy_when_exec_module=False,
+            patched_dunder_attr=MAGIC_DISABLED_MODULE_ATTR,
+        )
 
     def _find_spec_for_torch_module(self, fullname: str):
         # Map the requested torch fullname to the corresponding paddle fullname.
@@ -292,7 +351,44 @@ def _clear_torch_modules():
             del sys.modules[name]
 
 
-def enable_torch_proxy() -> None:
+def _modify_scope_of_torch_proxy(
+    scope: set[str] | None,
+    *,
+    silent: bool = False,
+) -> None:
+    def _warn_or_not(msg: str):
+        if silent:
+            return
+        warnings.warn(msg)
+
+    if TORCH_PROXY_FINDER not in sys.meta_path:
+        TORCH_PROXY_FINDER._scope = scope
+        return
+
+    if TORCH_PROXY_FINDER._scope is None:
+        if scope is not None:
+            _warn_or_not(
+                "PyTorch already enabled globally, scope modification ignored."
+            )
+        return
+    if scope is None:
+        _warn_or_not(
+            "Enabling PyTorch proxy globally, previous scope will be ignored."
+        )
+        TORCH_PROXY_FINDER._scope = scope
+        return
+    if scope != TORCH_PROXY_FINDER._scope:
+        _warn_or_not(
+            f"Extending PyTorch proxy scope, previous scope: {TORCH_PROXY_FINDER._scope}, new scope: {scope}."
+        )
+    TORCH_PROXY_FINDER._scope |= scope
+
+
+def enable_torch_proxy(
+    *,
+    scope: set[str] | None = None,
+    silent: bool = False,
+) -> None:
     """
     Enable the PyTorch proxy by adding the TorchProxyMetaFinder to sys.meta_path.
     This allows importing 'torch' modules that are actually proxies to PaddlePaddle.
@@ -307,6 +403,7 @@ def enable_torch_proxy() -> None:
     """
     _register_compat_override()
     _clear_torch_modules()
+    _modify_scope_of_torch_proxy(scope, silent=silent)
     sys.meta_path.insert(0, TORCH_PROXY_FINDER)
 
 
@@ -336,7 +433,12 @@ def disable_torch_proxy() -> None:
 
 
 @contextmanager
-def use_torch_proxy_guard(enable: bool = True):
+def use_torch_proxy_guard(
+    *,
+    enable: bool = True,
+    scope: set[str] | None = None,
+    silent: bool = False,
+):
     """
     Context manager to temporarily enable or disable the PyTorch proxy.
 
@@ -369,21 +471,23 @@ def use_torch_proxy_guard(enable: bool = True):
             ...     assert torch.sin is paddle.sin
     """
     already_has_torch_proxy = TORCH_PROXY_FINDER in sys.meta_path
-    if enable == already_has_torch_proxy:
+    original_scope = TORCH_PROXY_FINDER._scope
+    if enable == already_has_torch_proxy and scope == original_scope:
         yield
         return
     if enable:
-        enable_torch_proxy()
+        enable_torch_proxy(scope=scope, silent=silent)
         try:
             yield
         finally:
+            TORCH_PROXY_FINDER._scope = original_scope
             disable_torch_proxy()
     else:
         disable_torch_proxy()
         try:
             yield
         finally:
-            enable_torch_proxy()
+            enable_torch_proxy(scope=original_scope, silent=True)
 
 
 def extend_torch_proxy_blocked_modules(modules: Iterable[str]):

--- a/python/paddle/compat/proxy.py
+++ b/python/paddle/compat/proxy.py
@@ -198,15 +198,22 @@ class TorchProxyMetaFinder:
     Inspired by the setuptools _distutils_hack.
     """
 
+    _local_enabled_scope: set[str]
+    _globally_enabled: bool
+
     def __init__(self, scope: set[str] | None = None):
-        self._scope = scope
+        self._set_scope(scope)
+
+    def _set_scope(self, scope: set[str] | None):
+        self._local_enabled_scope = scope or set()
+        self._globally_enabled = scope is None
 
     def find_spec(self, fullname, path, target=None):
         if _is_torch_proxy_blocked_module(fullname):
             return self._find_spec_for_torch_proxy_blocked_module(fullname)
 
-        if self._scope is not None and _is_torch_proxy_local_enabled_module(
-            fullname, self._scope
+        if _is_torch_proxy_local_enabled_module(
+            fullname, self._local_enabled_scope
         ):
             return self._find_spec_for_torch_proxy_local_enabled_module(
                 fullname
@@ -219,7 +226,7 @@ class TorchProxyMetaFinder:
             return None
 
         if (
-            self._scope is not None
+            not self._globally_enabled
             and not _is_called_by_torch_proxy_local_enabled_module()
         ):
             return None
@@ -362,26 +369,27 @@ def _modify_scope_of_torch_proxy(
         warnings.warn(msg)
 
     if TORCH_PROXY_FINDER not in sys.meta_path:
-        TORCH_PROXY_FINDER._scope = scope
+        TORCH_PROXY_FINDER._set_scope(scope)
         return
 
-    if TORCH_PROXY_FINDER._scope is None:
+    if TORCH_PROXY_FINDER._globally_enabled:
         if scope is not None:
             _warn_or_not(
                 "PyTorch already enabled globally, scope modification ignored."
             )
+        TORCH_PROXY_FINDER._set_scope(scope)
         return
     if scope is None:
         _warn_or_not(
             "Enabling PyTorch proxy globally, previous scope will be ignored."
         )
-        TORCH_PROXY_FINDER._scope = scope
+        TORCH_PROXY_FINDER._globally_enabled = True
         return
-    if scope != TORCH_PROXY_FINDER._scope:
+    if scope != TORCH_PROXY_FINDER._local_enabled_scope:
         _warn_or_not(
-            f"Extending PyTorch proxy scope, previous scope: {TORCH_PROXY_FINDER._scope}, new scope: {scope}."
+            f"Extending PyTorch proxy scope, previous scope: {TORCH_PROXY_FINDER._local_enabled_scope}, new scope: {scope}."
         )
-    TORCH_PROXY_FINDER._scope |= scope
+    TORCH_PROXY_FINDER._local_enabled_scope |= scope
 
 
 def enable_torch_proxy(
@@ -471,8 +479,12 @@ def use_torch_proxy_guard(
             ...     assert torch.sin is paddle.sin
     """
     already_has_torch_proxy = TORCH_PROXY_FINDER in sys.meta_path
-    original_scope = TORCH_PROXY_FINDER._scope
-    if enable == already_has_torch_proxy and scope == original_scope:
+    original_local_enabled_scope = TORCH_PROXY_FINDER._local_enabled_scope
+    original_globally_enabled = TORCH_PROXY_FINDER._globally_enabled
+    if enable == already_has_torch_proxy and (
+        (original_globally_enabled and scope is None)
+        or (original_local_enabled_scope == (scope or set()))
+    ):
         yield
         return
     if enable:
@@ -480,14 +492,21 @@ def use_torch_proxy_guard(
         try:
             yield
         finally:
-            TORCH_PROXY_FINDER._scope = original_scope
+            TORCH_PROXY_FINDER._local_enabled_scope = (
+                original_local_enabled_scope
+            )
+            TORCH_PROXY_FINDER._globally_enabled = original_globally_enabled
             disable_torch_proxy()
     else:
         disable_torch_proxy()
         try:
             yield
         finally:
-            enable_torch_proxy(scope=original_scope, silent=True)
+            enable_torch_proxy(scope=None, silent=True)
+            TORCH_PROXY_FINDER._local_enabled_scope = (
+                original_local_enabled_scope
+            )
+            TORCH_PROXY_FINDER._globally_enabled = original_globally_enabled
 
 
 def extend_torch_proxy_blocked_modules(modules: Iterable[str]):

--- a/test/compat/test_torch_proxy.py
+++ b/test/compat/test_torch_proxy.py
@@ -14,8 +14,6 @@
 
 import unittest
 
-import numpy as np
-
 import paddle
 from paddle.compat.proxy import create_fake_class, create_fake_function
 
@@ -26,83 +24,99 @@ def use_torch_inside_inner_function():
     return torch.sin(torch.tensor([0.0, 1.0, 2.0])).numpy()
 
 
-class TestTorchProxy(unittest.TestCase):
-    def test_enable_torch_proxy(self):
+# class TestTorchProxy(unittest.TestCase):
+#     def test_enable_torch_proxy(self):
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch
+
+#         paddle.compat.enable_torch_proxy()
+#         import torch
+
+#         self.assertIs(torch.sin, paddle.sin)
+
+#         import torch.nn
+
+#         self.assertIs(torch.nn.Conv2d, paddle.nn.Conv2d)
+
+#         import torch.nn.functional
+
+#         self.assertIs(torch.nn.functional.sigmoid, paddle.nn.functional.sigmoid)
+
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch.nonexistent_module
+
+#         paddle.compat.disable_torch_proxy()
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch.nn
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch.nn.functional
+
+#     def test_use_torch_proxy_guard(self):
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch
+#         with paddle.compat.use_torch_proxy_guard():
+#             import torch
+
+#             self.assertIs(torch.sin, paddle.sin)
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch
+
+#         with paddle.compat.use_torch_proxy_guard():
+#             import torch
+
+#             self.assertIs(torch.cos, paddle.cos)
+#             with paddle.compat.use_torch_proxy_guard(enable=False):
+#                 with self.assertRaises(ModuleNotFoundError):
+#                     import torch
+#                 with paddle.compat.use_torch_proxy_guard(enable=True):
+#                     import torch
+
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch
+
+#     @paddle.compat.use_torch_proxy_guard()
+#     def test_use_torch_inside_inner_function(self):
+#         result = use_torch_inside_inner_function()
+
+#         np.testing.assert_allclose(
+#             result, np.sin([0.0, 1.0, 2.0]), atol=1e-6, rtol=1e-6
+#         )
+
+
+# class TestTorchProxyBlockedModule(unittest.TestCase):
+#     def test_blocked_module(self):
+#         with paddle.compat.use_torch_proxy_guard():
+#             with self.assertRaises(ModuleNotFoundError):
+#                 import torch._dynamo.allow_in_graph
+
+#             with self.assertRaises(AttributeError):
+#                 import torch_proxy_blocked_module
+
+#             paddle.compat.extend_torch_proxy_blocked_modules(
+#                 {"torch_proxy_blocked_module"}
+#             )
+#             import torch_proxy_blocked_module
+
+#             # Use torch specific function out of execute module stage
+#             torch_proxy_blocked_module.use_torch_specific_fn()
+
+
+class TestTorchProxyLocalEnabledModule(unittest.TestCase):
+    def test_local_enabled_module(self):
         with self.assertRaises(ModuleNotFoundError):
-            import torch
+            import torch_proxy_local_enabled_module
 
-        paddle.compat.enable_torch_proxy()
-        import torch
-
-        self.assertIs(torch.sin, paddle.sin)
-
-        import torch.nn
-
-        self.assertIs(torch.nn.Conv2d, paddle.nn.Conv2d)
-
-        import torch.nn.functional
-
-        self.assertIs(torch.nn.functional.sigmoid, paddle.nn.functional.sigmoid)
-
-        with self.assertRaises(ModuleNotFoundError):
-            import torch.nonexistent_module
-
-        paddle.compat.disable_torch_proxy()
-        with self.assertRaises(ModuleNotFoundError):
-            import torch
-        with self.assertRaises(ModuleNotFoundError):
-            import torch.nn
-        with self.assertRaises(ModuleNotFoundError):
-            import torch.nn.functional
-
-    def test_use_torch_proxy_guard(self):
-        with self.assertRaises(ModuleNotFoundError):
-            import torch
-        with paddle.compat.use_torch_proxy_guard():
-            import torch
-
-            self.assertIs(torch.sin, paddle.sin)
-        with self.assertRaises(ModuleNotFoundError):
-            import torch
-
-        with paddle.compat.use_torch_proxy_guard():
-            import torch
-
-            self.assertIs(torch.cos, paddle.cos)
-            with paddle.compat.use_torch_proxy_guard(enable=False):
-                with self.assertRaises(ModuleNotFoundError):
-                    import torch
-                with paddle.compat.use_torch_proxy_guard(enable=True):
-                    import torch
-
-        with self.assertRaises(ModuleNotFoundError):
-            import torch
-
-    @paddle.compat.use_torch_proxy_guard()
-    def test_use_torch_inside_inner_function(self):
-        result = use_torch_inside_inner_function()
-
-        np.testing.assert_allclose(
-            result, np.sin([0.0, 1.0, 2.0]), atol=1e-6, rtol=1e-6
+        paddle.compat.enable_torch_proxy(
+            scope={"torch_proxy_local_enabled_module"}
         )
+        with self.assertRaises(ModuleNotFoundError):
+            pass
 
+        import torch_proxy_local_enabled_module
 
-class TestTorchProxyBlockedModule(unittest.TestCase):
-    def test_blocked_module(self):
-        with paddle.compat.use_torch_proxy_guard():
-            with self.assertRaises(ModuleNotFoundError):
-                import torch._dynamo.allow_in_graph  # noqa: F401
-
-            with self.assertRaises(AttributeError):
-                import torch_proxy_blocked_module
-
-            paddle.compat.extend_torch_proxy_blocked_modules(
-                {"torch_proxy_blocked_module"}
-            )
-            import torch_proxy_blocked_module
-
-            # Use torch specific function out of execute module stage
-            torch_proxy_blocked_module.use_torch_specific_fn()
+        torch_proxy_local_enabled_module.use_torch_compat_api()
 
 
 class TestOverrideTorchModule(unittest.TestCase):

--- a/test/compat/test_torch_proxy.py
+++ b/test/compat/test_torch_proxy.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import numpy as np
+
 import paddle
 from paddle.compat.proxy import create_fake_class, create_fake_function
 
@@ -24,83 +26,83 @@ def use_torch_inside_inner_function():
     return torch.sin(torch.tensor([0.0, 1.0, 2.0])).numpy()
 
 
-# class TestTorchProxy(unittest.TestCase):
-#     def test_enable_torch_proxy(self):
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch
+class TestTorchProxy(unittest.TestCase):
+    def test_enable_torch_proxy(self):
+        with self.assertRaises(ModuleNotFoundError):
+            import torch
 
-#         paddle.compat.enable_torch_proxy()
-#         import torch
+        paddle.compat.enable_torch_proxy()
+        import torch
 
-#         self.assertIs(torch.sin, paddle.sin)
+        self.assertIs(torch.sin, paddle.sin)
 
-#         import torch.nn
+        import torch.nn
 
-#         self.assertIs(torch.nn.Conv2d, paddle.nn.Conv2d)
+        self.assertIs(torch.nn.Conv2d, paddle.nn.Conv2d)
 
-#         import torch.nn.functional
+        import torch.nn.functional
 
-#         self.assertIs(torch.nn.functional.sigmoid, paddle.nn.functional.sigmoid)
+        self.assertIs(torch.nn.functional.sigmoid, paddle.nn.functional.sigmoid)
 
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch.nonexistent_module
+        with self.assertRaises(ModuleNotFoundError):
+            import torch.nonexistent_module
 
-#         paddle.compat.disable_torch_proxy()
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch.nn
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch.nn.functional
+        paddle.compat.disable_torch_proxy()
+        with self.assertRaises(ModuleNotFoundError):
+            import torch
+        with self.assertRaises(ModuleNotFoundError):
+            import torch.nn
+        with self.assertRaises(ModuleNotFoundError):
+            import torch.nn.functional
 
-#     def test_use_torch_proxy_guard(self):
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch
-#         with paddle.compat.use_torch_proxy_guard():
-#             import torch
+    def test_use_torch_proxy_guard(self):
+        with self.assertRaises(ModuleNotFoundError):
+            import torch
+        with paddle.compat.use_torch_proxy_guard():
+            import torch
 
-#             self.assertIs(torch.sin, paddle.sin)
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch
+            self.assertIs(torch.sin, paddle.sin)
+        with self.assertRaises(ModuleNotFoundError):
+            import torch
 
-#         with paddle.compat.use_torch_proxy_guard():
-#             import torch
+        with paddle.compat.use_torch_proxy_guard():
+            import torch
 
-#             self.assertIs(torch.cos, paddle.cos)
-#             with paddle.compat.use_torch_proxy_guard(enable=False):
-#                 with self.assertRaises(ModuleNotFoundError):
-#                     import torch
-#                 with paddle.compat.use_torch_proxy_guard(enable=True):
-#                     import torch
+            self.assertIs(torch.cos, paddle.cos)
+            with paddle.compat.use_torch_proxy_guard(enable=False):
+                with self.assertRaises(ModuleNotFoundError):
+                    import torch
+                with paddle.compat.use_torch_proxy_guard(enable=True):
+                    import torch
 
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch
+        with self.assertRaises(ModuleNotFoundError):
+            import torch
 
-#     @paddle.compat.use_torch_proxy_guard()
-#     def test_use_torch_inside_inner_function(self):
-#         result = use_torch_inside_inner_function()
+    @paddle.compat.use_torch_proxy_guard()
+    def test_use_torch_inside_inner_function(self):
+        result = use_torch_inside_inner_function()
 
-#         np.testing.assert_allclose(
-#             result, np.sin([0.0, 1.0, 2.0]), atol=1e-6, rtol=1e-6
-#         )
+        np.testing.assert_allclose(
+            result, np.sin([0.0, 1.0, 2.0]), atol=1e-6, rtol=1e-6
+        )
 
 
-# class TestTorchProxyBlockedModule(unittest.TestCase):
-#     def test_blocked_module(self):
-#         with paddle.compat.use_torch_proxy_guard():
-#             with self.assertRaises(ModuleNotFoundError):
-#                 import torch._dynamo.allow_in_graph
+class TestTorchProxyBlockedModule(unittest.TestCase):
+    def test_blocked_module(self):
+        with paddle.compat.use_torch_proxy_guard():
+            with self.assertRaises(ModuleNotFoundError):
+                import torch._dynamo.allow_in_graph  # noqa: F401
 
-#             with self.assertRaises(AttributeError):
-#                 import torch_proxy_blocked_module
+            with self.assertRaises(AttributeError):
+                import torch_proxy_blocked_module
 
-#             paddle.compat.extend_torch_proxy_blocked_modules(
-#                 {"torch_proxy_blocked_module"}
-#             )
-#             import torch_proxy_blocked_module
+            paddle.compat.extend_torch_proxy_blocked_modules(
+                {"torch_proxy_blocked_module"}
+            )
+            import torch_proxy_blocked_module
 
-#             # Use torch specific function out of execute module stage
-#             torch_proxy_blocked_module.use_torch_specific_fn()
+            # Use torch specific function out of execute module stage
+            torch_proxy_blocked_module.use_torch_specific_fn()
 
 
 class TestTorchProxyLocalEnabledModule(unittest.TestCase):
@@ -112,11 +114,13 @@ class TestTorchProxyLocalEnabledModule(unittest.TestCase):
             scope={"torch_proxy_local_enabled_module"}
         )
         with self.assertRaises(ModuleNotFoundError):
-            pass
+            import torch  # noqa: F401
 
         import torch_proxy_local_enabled_module
 
         torch_proxy_local_enabled_module.use_torch_compat_api()
+        paddle.compat.proxy.TORCH_PROXY_FINDER._scope = None
+        paddle.compat.disable_torch_proxy()
 
 
 class TestOverrideTorchModule(unittest.TestCase):

--- a/test/compat/torch_proxy_local_enabled_module.py
+++ b/test/compat/torch_proxy_local_enabled_module.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def use_torch_compat_api():
+    import torch
+
+    torch.randn([2, 3])
+
+
+use_torch_compat_api()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

`paddle.compat.enable_torch_proxy` 允许局部启用，添加参数 `scope`，仅仅在该模块下才会开启 proxy，技术路线同 #76482

示例：

```python
import paddle

paddle.compat.enable_torch_proxy(scope={"triton"})
```

> [!NOTE]
>
> 目前逻辑可能不是最优的，应该还有不少边界 case，后续找时间优化下

<!-- PCard-66972 -->