### PR TITLE
[API Compatiblity] Fix normalize and Support `paddle.uniform_`, `paddle.unfold`

### DIFF
--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -56,9 +56,8 @@ def normalize(
     p: float = 2,
     axis: int = 1,
     epsilon: float = 1e-12,
-    name: str | None = None,
-    *,
     out: Tensor | None = None,
+    name: str | None = None,
 ) -> Tensor:
     r"""
     Normalize ``x`` along dimension ``axis`` using :math:`L_p` norm. This layer computes

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -7967,6 +7967,7 @@ def view_as(x: Tensor, other: Tensor, name: str | None = None) -> Tensor:
 
 
 @dygraph_only
+@param_one_alias(["axis", "dimension"])
 def unfold(
     x: Tensor, axis: int, size: int, step: int, name: str | None = None
 ) -> Tensor:
@@ -7978,7 +7979,7 @@ def unfold(
 
     Args:
         x (Tensor): An N-D Tensor. The data type is ``float32``, ``float64``, ``int32``, ``int64`` or ``bool``
-        axis (int): The axis along which the input is unfolded.
+        axis (int): The axis along which the input is unfolded. Alias: ``dimension``.
         size (int): The size of each slice that is unfolded.
         step (int): The step between each slice.
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -31,6 +31,7 @@ from paddle.framework import (
 )
 from paddle.utils.decorator_utils import (
     param_one_alias,
+    param_two_alias,
     size_args_decorator,
 )
 
@@ -1504,7 +1505,7 @@ def normal_(
 def uniform(
     shape: ShapeLike,
     dtype: DTypeLike | None = None,
-    min: float = -1.0,
+    min: float = 0,
     max: float = 1.0,
     seed: int = 0,
     name: str | None = None,
@@ -1535,7 +1536,7 @@ def uniform(
             Default is None, use global default dtype (see ``get_default_dtype``
             for details).
         min(float|int, optional): The lower bound on the range of random values
-            to generate, ``min`` is included in the range. Default is -1.0.
+            to generate, ``min`` is included in the range. Default is 0.
         max(float|int, optional): The upper bound on the range of random values
             to generate, ``max`` is excluded in the range. Default is 1.0.
         seed(int, optional): Random seed used for generating samples. If seed is 0,
@@ -1681,10 +1682,11 @@ def uniform(
         return out
 
 
+@param_two_alias(["min", "from"], ["max", "to"])
 @dygraph_only
 def uniform_(
     x: Tensor,
-    min: float = -1.0,
+    min: float = 0,
     max: float = 1.0,
     seed: int = 0,
     name: str | None = None,
@@ -1697,9 +1699,11 @@ def uniform_(
     Args:
         x(Tensor): The input tensor to be filled with random values.
         min(float|int, optional): The lower bound on the range of random values
-            to generate, ``min`` is included in the range. Default is -1.0.
+            to generate, ``min`` is included in the range. Default is 0.
+            Alias: ``from``.
         max(float|int, optional): The upper bound on the range of random values
             to generate, ``max`` is excluded in the range. Default is 1.0.
+            Alias: ``to``.
         seed(int, optional): Random seed used for generating samples. If seed is 0,
             it will use the seed of the global default generator (which can be set by paddle.seed).
             Note that if seed is not 0, this operator will always generate the same random numbers every
@@ -1707,9 +1711,11 @@ def uniform_(
         name(str|None, optional): The default value is None. Normally there is no
             need for user to set this property. For more information, please
             refer to :ref:`api_guide_Name`.
+
     Returns:
         Tensor, The input tensor x filled with random values sampled from a uniform
         distribution in the range [``min``, ``max``).
+
     Examples:
         .. code-block:: python
 

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -935,8 +935,6 @@ def index_add_decorator() -> Callable[
                     kwargs["index"] = args[2]
                 if len(args) > 3:
                     kwargs["value"] = args[3]
-                if len(args) > 4:
-                    kwargs["alpha"] = args[4]
                 args = ()
 
             return func(*args, **kwargs)

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -928,8 +928,16 @@ def index_add_decorator() -> Callable[
             if "source" in kwargs:
                 kwargs["value"] = kwargs.pop("source")
 
-            if len(args) >= 3 and isinstance(args[1], int):
-                args = (args[0], args[2], args[1], *args[3:])
+            if len(args) >= 2 and isinstance(args[1], int):
+                kwargs["x"] = args[0]
+                kwargs["axis"] = args[1]
+                if len(args) > 2:
+                    kwargs["index"] = args[2]
+                if len(args) > 3:
+                    kwargs["value"] = args[3]
+                if len(args) > 4:
+                    kwargs["alpha"] = args[4]
+                args = ()
 
             return func(*args, **kwargs)
 

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -935,7 +935,8 @@ def index_add_decorator() -> Callable[
                     kwargs["index"] = args[2]
                 if len(args) > 3:
                     kwargs["value"] = args[3]
-                args = args[4:]
+                if len(args) > 4:
+                    kwargs["alpha"] = args[4]
 
             return func(*args, **kwargs)
 

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -928,15 +928,8 @@ def index_add_decorator() -> Callable[
             if "source" in kwargs:
                 kwargs["value"] = kwargs.pop("source")
 
-            if len(args) >= 2 and isinstance(args[1], int):
-                kwargs["x"] = args[0]
-                kwargs["axis"] = args[1]
-                if len(args) > 2:
-                    kwargs["index"] = args[2]
-                if len(args) > 3:
-                    kwargs["value"] = args[3]
-                if len(args) > 4:
-                    kwargs["alpha"] = args[4]
+            if len(args) >= 3 and isinstance(args[1], int):
+                args = (args[0], args[2], args[1], *args[3:])
 
             return func(*args, **kwargs)
 

--- a/test/legacy_test/test_index_add_op.py
+++ b/test/legacy_test/test_index_add_op.py
@@ -624,10 +624,11 @@ class TestIndexAddAPI_Compatibility(unittest.TestCase):
         paddle_dygraph_out.append(out7)
         # 8. Test 'alpha' parameter
         alpha = 2.0
-        out8 = paddle.index_add(
+        out8 = paddle.index_add(x, self.axis, index, value, alpha=alpha)
+        out9 = paddle.index_add(
             input=x, dim=self.axis, index=index, source=value, alpha=alpha
         )
-        out9 = paddle.index_add_(
+        out10 = paddle.index_add_(
             input=x, dim=self.axis, index=index, source=value, alpha=alpha
         )
         ref_out_alpha = self.get_ref_out(alpha=alpha)
@@ -636,6 +637,7 @@ class TestIndexAddAPI_Compatibility(unittest.TestCase):
             np.testing.assert_allclose(ref_out, out.numpy(), rtol=1e-05)
         np.testing.assert_allclose(ref_out_alpha, out8.numpy(), rtol=1e-05)
         np.testing.assert_allclose(ref_out_alpha, out9.numpy(), rtol=1e-05)
+        np.testing.assert_allclose(ref_out_alpha, out10.numpy(), rtol=1e-05)
         paddle.enable_static()
 
     def test_static_Compatibility(self):

--- a/test/legacy_test/test_tensor_unfold.py
+++ b/test/legacy_test/test_tensor_unfold.py
@@ -131,5 +131,34 @@ class TestTensorUnfold_ZeroSize(TestTensorUnfold):
                 self.assertEqual((b.grad.numpy() == 1).all().item(), True)
 
 
+class TestUnfoldAPI_Compatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2025)
+        self.shape = [10, 10]
+        self.dtype = "float32"
+        self.init_data()
+
+    def init_data(self):
+        self.axis = 1
+        self.size = 3
+        self.step = 2
+
+    def test_dygraph_compatibility(self):
+        x = paddle.randn(self.shape, dtype=self.dtype)
+        # Position args
+        out1 = paddle.unfold(x, self.axis, self.size, self.step)
+        # Key words args
+        out2 = paddle.unfold(x, axis=self.axis, size=self.size, step=self.step)
+        np.testing.assert_array_equal(out1.numpy(), out2.numpy())
+        # Key words args for Alias
+        out3 = paddle.unfold(
+            x, dimension=self.axis, size=self.size, step=self.step
+        )
+        np.testing.assert_array_equal(out1.numpy(), out3.numpy())
+        # Tensor method
+        out4 = x.unfold(dimension=self.axis, size=self.size, step=self.step)
+        np.testing.assert_array_equal(out1.numpy(), out4.numpy())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_uniform_random_inplace_op.py
+++ b/test/legacy_test/test_uniform_random_inplace_op.py
@@ -255,5 +255,39 @@ class TestUniformRandomInplaceGrad(unittest.TestCase):
         self.run_()
 
 
+class TestUniformInplaceAPI_Compatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2025)
+        self.shape = [10, 10]
+        self.dtype = "float32"
+        self.init_data()
+
+    def init_data(self):
+        self.min_v = 0.0
+        self.max_v = 1.0
+        self.seed = 123
+
+    def _check_range(self, tensor, min_val, max_val):
+        np_res = tensor.numpy()
+        self.assertTrue(np.all(np_res >= min_val))
+        self.assertTrue(np.all(np_res <= max_val))
+        self.assertNotEqual(np.std(np_res), 0)
+
+    def test_dygraph_Compatibility(self):
+        # Position args
+        x1 = paddle.zeros(self.shape, dtype=self.dtype)
+        out1 = x1.uniform_(self.min_v, self.max_v, self.seed)
+        self._check_range(out1, self.min_v, self.max_v)
+        # Key words args
+        x2 = paddle.zeros(self.shape, dtype=self.dtype)
+        out2 = x2.uniform_(min=self.min_v, max=self.max_v, seed=self.seed)
+        self._check_range(out2, self.min_v, self.max_v)
+        # Key words args for Alias
+        x3 = paddle.zeros(self.shape, dtype=self.dtype)
+        kwargs_alias = {"from": self.min_v, "to": self.max_v, "seed": self.seed}
+        out3 = x3.uniform_(**kwargs_alias)
+        self._check_range(out3, self.min_v, self.max_v)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_uniform_random_inplace_op.py
+++ b/test/legacy_test/test_uniform_random_inplace_op.py
@@ -287,6 +287,10 @@ class TestUniformInplaceAPI_Compatibility(unittest.TestCase):
         kwargs_alias = {"from": self.min_v, "to": self.max_v, "seed": self.seed}
         out3 = x3.uniform_(**kwargs_alias)
         self._check_range(out3, self.min_v, self.max_v)
+        # Default parameters
+        x4 = paddle.zeros(self.shape, dtype=self.dtype)
+        out4 = x4.uniform_()
+        self._check_range(out4, 0, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->
修复了paddle.index_add的bug
修复了normalize的bug，torch的normalize中out不是关键字参数，需要支持位置参数传入方式
新增了paddle.uniform的别名支持，修改了默认最小值
新增了paddle.unfold，paddle.Tensor.unfold的别名支持
<img width="1411" height="289" alt="987fb023-0d75-4f43-b0b6-cb3db1f2b6b0" src="https://github.com/user-attachments/assets/cc56de85-f63b-489a-b0f1-2c451e80e173" />

