### PR TITLE
 fix kNHWC in kernels/onednn 

### DIFF
--- a/paddle/phi/kernels/onednn/conv_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/conv_grad_kernel.cc
@@ -243,7 +243,7 @@ KernelKey ConvGradGetKernelTypeForVar(const GetKernelTypeForVarContext* ctx) {
     auto dl = common::StringToDataLayout(data_format);
     // Some models may have intentionally set "AnyLayout" for pool
     // op. Treat this as NCHW (default data_format value)
-    if (dl != phi::DataLayout::kAnyLayout) {
+    if (dl != phi::DataLayout::ANY) {
       return phi::KernelKey(tensor.place(), dl, expected_kernel_type.dtype());
     }
   }

--- a/paddle/phi/kernels/onednn/conv_kernel.cc
+++ b/paddle/phi/kernels/onednn/conv_kernel.cc
@@ -133,7 +133,7 @@ KernelKey ConvGetKernelTypeForVar(const GetKernelTypeForVarContext* ctx) {
     auto dl = common::StringToDataLayout(data_format);
     // Some models may have intentionally set "AnyLayout" for conv
     // op. Treat this as NCHW (default data_format value)
-    if (dl != phi::DataLayout::kAnyLayout) {
+    if (dl != phi::DataLayout::ANY) {
       return phi::KernelKey(tensor.place(), dl, expected_kernel_type.dtype());
     }
   }

--- a/paddle/phi/kernels/onednn/conv_transpose_kernel.cc
+++ b/paddle/phi/kernels/onednn/conv_transpose_kernel.cc
@@ -615,7 +615,7 @@ KernelKey ConvTransposeGetKernelTypeForVar(
     auto dl = common::StringToDataLayout(data_format);
     // Some models may have intentionally set "AnyLayout" for pool
     // op. Treat this as NCHW (default data_format value)
-    if (dl != phi::DataLayout::kAnyLayout) {
+    if (dl != phi::DataLayout::ANY) {
       return phi::KernelKey(tensor.place(), dl, expected_kernel_type.dtype());
     }
   }

--- a/paddle/phi/kernels/onednn/elementwise_kernel.cc
+++ b/paddle/phi/kernels/onednn/elementwise_kernel.cc
@@ -39,9 +39,9 @@ KernelKey ElementwiseGetKernelTypeForVar(
     if ((expected_kernel_type.layout() == phi::DataLayout::ONEDNN) &&
         (tensor.layout() != phi::DataLayout::ONEDNN) &&
         phi::OneDNNContext::tls().get_cur_paddle_data_layout() ==
-            phi::DataLayout::kNHWC) {
+            phi::DataLayout::NHWC) {
       return phi::KernelKey(
-          tensor.place(), phi::DataLayout::kNHWC, expected_kernel_type.dtype());
+          tensor.place(), phi::DataLayout::NHWC, expected_kernel_type.dtype());
     }
     return phi::KernelKey(
         tensor.place(), tensor.layout(), expected_kernel_type.dtype());

--- a/paddle/phi/kernels/onednn/interpolate_kernel.cc
+++ b/paddle/phi/kernels/onednn/interpolate_kernel.cc
@@ -36,7 +36,7 @@ KernelKey InterpolateGetKernelTypeForVar(
     auto dl = common::StringToDataLayout(data_layout);
     // Some models may have intentionally set "AnyLayout" for pool
     // op. Treat this as NCHW (default data_format value)
-    if (dl != DataLayout::kAnyLayout) {
+    if (dl != DataLayout::ANY) {
       return KernelKey(tensor.place(), dl, expected_kernel_type.dtype());
     }
   }

--- a/paddle/phi/kernels/onednn/matmul_kernel.cc
+++ b/paddle/phi/kernels/onednn/matmul_kernel.cc
@@ -40,9 +40,9 @@ KernelKey MatmulGetkernelTypeForVar(const GetKernelTypeForVarContext *ctx) {
     if ((expected_kernel_type.layout() == phi::DataLayout::ONEDNN) &&
         (tensor.layout() != phi::DataLayout::ONEDNN) &&
         phi::OneDNNContext::tls().get_cur_paddle_data_layout() ==
-            phi::DataLayout::kNHWC) {
+            phi::DataLayout::NHWC) {
       return phi::KernelKey(
-          tensor.place(), phi::DataLayout::kNHWC, expected_kernel_type.dtype());
+          tensor.place(), phi::DataLayout::NHWC, expected_kernel_type.dtype());
     }
 #endif
     return phi::KernelKey(

--- a/paddle/phi/kernels/onednn/pool_kernel.cc
+++ b/paddle/phi/kernels/onednn/pool_kernel.cc
@@ -99,7 +99,7 @@ phi::KernelKey PoolOpGetKernelTypeForVar(
     auto dl = common::StringToDataLayout(data_format);
     // Some models may have intentionally set "AnyLayout" for pool
     // op. Treat this as NCHW (default data_format value)
-    if (dl != phi::DataLayout::kAnyLayout) {
+    if (dl != phi::DataLayout::ANY) {
       return phi::KernelKey(tensor.place(), dl, expected_kernel_type.dtype());
     }
   }

--- a/paddle/phi/kernels/onednn/shape_kernel.cc
+++ b/paddle/phi/kernels/onednn/shape_kernel.cc
@@ -28,7 +28,7 @@ void ShapeKernel(const Context& dev_ctx,
   // Output of shape op is often fed as x to fill_constant ops
   // and we need to rotate a shape otherwise Tensors of wrong shape may be
   // allocated
-  if (OneDNNContext::tls().get_cur_paddle_data_layout() == DataLayout::kNHWC &&
+  if (OneDNNContext::tls().get_cur_paddle_data_layout() == DataLayout::NHWC &&
       x_dims.size() >= 3) {
     auto rdims = common::vectorize<int>(x_dims);
     std::rotate(rdims.begin() + 1, rdims.begin() + 2, rdims.end());

--- a/paddle/phi/kernels/onednn/transpose_kernel.cc
+++ b/paddle/phi/kernels/onednn/transpose_kernel.cc
@@ -31,7 +31,7 @@ void TransposeKernel(const Context& dev_ctx,
   auto x_dims = x.dims();
   if ((x_dims.size() >= 3) &&
       (phi::OneDNNContext::tls().get_cur_paddle_data_layout() ==
-       phi::DataLayout::kNHWC)) {
+       phi::DataLayout::NHWC)) {
     int axis_size = static_cast<int>(axis.size());
     std::vector<int> formatted_axis = axis;
     std::vector<int> count(axis_size, 0);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
fix kNHWC in kernels/onednn

paddle/common/layout.h 中 kNHWC 为 NHWC
paddle/common/layout.h 中 kAnyLayout 为 ANY, k前缀为fluid用法
<img width="783" height="155" alt="image" src="https://github.com/user-attachments/assets/dd6848cd-cb84-4979-a56f-3f2e8f899c84" />