### PR TITLE
 rename DataLayout GpuDataLayout in softmax.cu [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/funcs/softmax.cu
+++ b/paddle/phi/kernels/funcs/softmax.cu
@@ -23,7 +23,7 @@ namespace phi {
 namespace funcs {
 
 using ScopedTensorDescriptor = phi::backends::gpu::ScopedTensorDescriptor;
-using DataLayout = phi::backends::gpu::DataLayout;
+using GpuDataLayout = phi::backends::gpu::DataLayout;
 template <typename T>
 using CudnnDataType = phi::backends::gpu::CudnnDataType<T>;
 
@@ -36,9 +36,9 @@ void SoftmaxCUDNNFunctor<T, DeviceContext>::operator()(
   ScopedTensorDescriptor xDesc;
   ScopedTensorDescriptor yDesc;
   std::vector<int> cudnn_tensor_dims = common::vectorize<int>(X->dims());
-  DataLayout layout = DataLayout::kNCHW;
+  GpuDataLayout layout = GpuDataLayout::kNCHW;
   if (cudnn_tensor_dims.size() == 5) {
-    layout = DataLayout::kNCDHW;
+    layout = GpuDataLayout::kNCDHW;
   }
   // NOTE(*) : cudnn softmax only support >= 4D phi::DenseTensor,
   // fill 1 at unused dims
@@ -89,9 +89,9 @@ void SoftmaxGradCUDNNFunctor<T, DeviceContext>::operator()(
   ScopedTensorDescriptor dyDesc;
   ScopedTensorDescriptor dxDesc;
   std::vector<int> cudnn_tensor_dims = common::vectorize<int>(Y->dims());
-  DataLayout layout = DataLayout::kNCHW;
+  GpuDataLayout layout = GpuDataLayout::kNCHW;
   if (cudnn_tensor_dims.size() == 5) {
-    layout = DataLayout::kNCDHW;
+    layout = GpuDataLayout::kNCDHW;
   }
   // NOTE(*) : cudnn softmax only support >= 4D phi::DenseTensor,
   // fill 1 at unused dims


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
paddle/common/layout.h 中已有 DataLayout 定义，避免冲突修改 DataLayout 为 GpuDataLayout 

