### PR TITLE
[CINN] Fix incorrect block reduce result on DCU

### DIFF
--- a/paddle/cinn/runtime/hip/cinn_hip_runtime_source.h
+++ b/paddle/cinn/runtime/hip/cinn_hip_runtime_source.h
@@ -553,7 +553,10 @@ EXPAND_REDUCE_FP16_MACRO(CINN_WARP_SHUFFLE_INTERNAL_IMPL)
   }                                                               \
   __syncthreads();                                                \
   if (threadIdx.x < (blockDim.x + WARP_SIZE - 1) / WARP_SIZE) {   \
-    shm[0] = cinn_warp_shuffle_internal(shm[threadIdx.x]);        \
+    tmp_val = cinn_warp_shuffle_internal(shm[threadIdx.x]);       \
+    if (threadIdx.x == 0) {                                       \
+      shm[0] = tmp_val;                                           \
+    }                                                             \
   }                                                               \
   __syncthreads();                                                \
   return shm[0];


### PR DESCRIPTION
### PR Category
CINN

### PR Types
Bug fixes

### Description
修复 DCU 后端在 CINN 融合 Reduce 类算子时，当 warp 数介于 8～16 时出现的 block reduce 结果错误问题。

原因：当 8 < num_warps < 16 时，block reduce 的第二阶段 warp shuffle 中，参与计算的线程获得的 shuffle 结果不一致，但这些线程都会将值写 `shm[0]`，导致 block reduce 输出错误

### 复现代码

``` python
import paddle
from paddle import nn
from paddle.static import InputSpec
import numpy as np

class TestNet(nn.Layer):
    def forward(self, x):
        s = paddle.sum(x)
        return x / s

if __name__ == '__main__': 
    net = TestNet()
    fused_net = paddle.jit.to_static(
        TestNet(),
        input_spec=[InputSpec(shape=[1,768],dtype='float32')],
        full_graph=True,
    )
    
    input_x = paddle.randn([1, 768], dtype='float32')
    
    cinn_out = fused_net(input_x)
    dy_out = net(input_x)
    np.testing.assert_allclose(dy_out.numpy(), cinn_out.numpy(), rtol=1e-5, atol=1e-5) 
```

### 复现输出
``` python
AssertionError: 
Not equal to tolerance rtol=1e-05, atol=1e-05

Mismatched elements: 767 / 768 (99.9%)
Max absolute difference: 0.02012142
Max relative difference: 0.24228704
 x: array([[ 2.367853e-02, -3.123360e-02, -1.397309e-02, -6.867881e-03,
         3.108260e-02, -1.051988e-02,  2.015113e-02, -8.533381e-03,
         2.751643e-02,  9.062208e-03,  3.911981e-02, -3.989761e-02,...
 y: array([[ 3.124999e-02, -4.122088e-02, -1.844114e-02, -9.063961e-03,
         4.102160e-02, -1.388373e-02,  2.659467e-02, -1.126202e-02,
         3.631511e-02,  1.195995e-02,  5.162879e-02, -5.265531e-02,...
```
