### PR TITLE
fix arch range in WeightQuantizeInferMeta [fluid_ops]

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -6485,11 +6485,9 @@ void WeightQuantizeInferMeta(const MetaTensor& x,
                              MetaTensor* scale) {
 #ifdef PADDLE_WITH_CUDA
   PADDLE_ENFORCE_EQ(
-      ((arch == 70) || (arch == 75) || (arch == 80) || (arch == 86) ||
-       (arch == 89) || (arch == 90)),
+      arch >= 70,
       true,
-      common::errors::InvalidArgument(
-          "Currently, arch only support 70, 75, 80, 86, 89, 90."));
+      common::errors::InvalidArgument("Currently, arch only support >= 70."));
 #endif
 
   auto x_dims = x.dims();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
WeightQuantizeInferMeta 中 arch 判断范围修改为 arch >= 70
paddle/phi/backends/gpu/gpu_resources.cc 中已有列表判断，优化代码
<img width="807" height="405" alt="image" src="https://github.com/user-attachments/assets/6ddc29a4-2a73-4f46-b0a6-eabb791337f8" />

