### PR TITLE
fix DeviceContext in kernels/cpu [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/cpu/one_hot_kernel.cc
+++ b/paddle/phi/kernels/cpu/one_hot_kernel.cc
@@ -20,17 +20,17 @@
 
 namespace phi {
 
-template <typename DeviceContext, typename InT>
+template <typename Context, typename InT>
 struct OneHotV2OpFunctor {
   const DenseTensor* in_;
   DenseTensor* out_;
   int depth_;
-  const DeviceContext& dev_ctx_;
+  const Context& dev_ctx_;
 
   OneHotV2OpFunctor(const DenseTensor* in,
                     DenseTensor* out,
                     int depth,
-                    const DeviceContext& dev_ctx)
+                    const Context& dev_ctx)
       : in_(in), out_(out), depth_(depth), dev_ctx_(dev_ctx) {}
 
   template <typename OutT>

--- a/paddle/phi/kernels/cpu/reduce.h
+++ b/paddle/phi/kernels/cpu/reduce.h
@@ -22,8 +22,8 @@
 
 namespace phi {
 
-template <typename DeviceContext, typename T, typename Functor>
-void Reduce(const DeviceContext& dev_ctx,
+template <typename Context, typename T, typename Functor>
+void Reduce(const Context& dev_ctx,
             const DenseTensor& x,
             bool reduce_all,
             const std::vector<int64_t>& dims,
@@ -49,25 +49,25 @@ void Reduce(const DeviceContext& dev_ctx,
     // do reduce sum
     PD_VISIT_ALL_CPU_TYPES(
         x.dtype(), "ReduceKernelImpl", ([&] {
-          phi::funcs::ReduceKernelImpl<DeviceContext, T, data_t, Functor>(
+          phi::funcs::ReduceKernelImpl<Context, T, data_t, Functor>(
               dev_ctx, x, out, dims, keep_dim, reduce_all);
         }));
 
   } else {
     // cast x tensor to out_dtype
-    auto tmp_tensor = phi::Cast<T, DeviceContext>(dev_ctx, x, out_dtype);
+    auto tmp_tensor = phi::Cast<T, Context>(dev_ctx, x, out_dtype);
 
     // do reduce sum
     PD_VISIT_ALL_CPU_TYPES(
         out_dtype, "ReduceKernelImpl", ([&] {
-          phi::funcs::ReduceKernelImpl<DeviceContext, T, data_t, Functor>(
+          phi::funcs::ReduceKernelImpl<Context, T, data_t, Functor>(
               dev_ctx, tmp_tensor, out, dims, keep_dim, reduce_all);
         }));
   }
 }
 
-template <typename DeviceContext, typename T, typename Functor>
-void BoolReduceKernel(const DeviceContext& dev_ctx,
+template <typename Context, typename T, typename Functor>
+void BoolReduceKernel(const Context& dev_ctx,
                       const phi::DenseTensor& input,
                       const std::vector<int64_t>& dims,
                       bool keep_dim,
@@ -89,12 +89,11 @@ void BoolReduceKernel(const DeviceContext& dev_ctx,
   reduce_all = (reduce_all || full_dim);
   DenseTensor tmp_tensor;
   if (input.dtype() != phi::DataType::BOOL) {
-    tmp_tensor =
-        phi::Cast<T, DeviceContext>(dev_ctx, input, phi::DataType::BOOL);
+    tmp_tensor = phi::Cast<T, Context>(dev_ctx, input, phi::DataType::BOOL);
   } else {
     tmp_tensor = input;
   }
-  funcs::ReduceKernelImpl<DeviceContext, bool, bool, Functor>(
+  funcs::ReduceKernelImpl<Context, bool, bool, Functor>(
       dev_ctx, tmp_tensor, output, dims, keep_dim, reduce_all);
 }
 

--- a/paddle/phi/kernels/cpu/weight_quantize_kernel.cc
+++ b/paddle/phi/kernels/cpu/weight_quantize_kernel.cc
@@ -22,12 +22,12 @@ limitations under the License. */
 
 namespace phi {
 
-template <typename DeviceContext,
+template <typename Context,
           typename T,
           typename D,
           int bits,
           typename ScaleT = T>
-void quant_compute(const DeviceContext& dev_ctx,
+void quant_compute(const Context& dev_ctx,
                    const DenseTensor& x,
                    DenseTensor* out,
                    DenseTensor* scale,
@@ -107,20 +107,20 @@ void quant_compute(const DeviceContext& dev_ctx,
   }
   if (algo == "llm.int8") {
     std::vector<int> axis = {1, 0};
-    funcs::Transpose<DeviceContext, int8_t, 2> trans;
+    funcs::Transpose<Context, int8_t, 2> trans;
     trans(dev_ctx, x_int, out, axis);
   } else {
 #ifdef PADDLE_WITH_HIP
     if (bits == 8) {
       std::vector<int> axis = {1, 0};
-      funcs::Transpose<DeviceContext, int8_t, 2> trans;
+      funcs::Transpose<Context, int8_t, 2> trans;
       trans(dev_ctx, x_int, out, axis);
     } else {
       for (int i = 0; i < out->numel(); ++i) {
         x_int_tmp_data[i] = x_int_data[i];
       }
       std::vector<int> axis = {1, 0};
-      funcs::Transpose<DeviceContext, int8_t, 2> trans;
+      funcs::Transpose<Context, int8_t, 2> trans;
       trans(dev_ctx, x_int_tmp, out, axis);
     }
 #else


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
修改 DeviceContext 为 Context
kernels template定义中为Context，同时 paddle/phi/core/device_context.h 中已有 DeviceContext 定义
<img width="817" height="399" alt="image" src="https://github.com/user-attachments/assets/8ab928d4-59a1-489a-bfbf-ce9aacf4af89" />

