### PR TITLE
fix redundant DataType [fluid_ops]

### DIFF
--- a/paddle/phi/core/device_context.cc
+++ b/paddle/phi/core/device_context.cc
@@ -26,7 +26,6 @@
 #include "paddle/phi/core/string_tensor.h"
 
 namespace phi {
-using DataType = phi::DataType;
 
 struct DeviceContext::Impl {
   Impl() = default;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
当前命名空间为phi，using DataType 定义不需要