### PR TITLE
Allow cuda 11.8 using fused_rms_norm_ext

### DIFF
--- a/paddle/phi/kernels/CMakeLists.txt
+++ b/paddle/phi/kernels/CMakeLists.txt
@@ -91,7 +91,7 @@ if(((WITH_GPU) AND (CUDA_VERSION VERSION_LESS 12.0))
     "fusion/gpu/fused_weighted_swiglu_act_quant_kernel.cu")
 endif()
 
-if(((WITH_GPU) AND (CUDA_VERSION VERSION_LESS 12.0))
+if(((WITH_GPU) AND (CUDA_VERSION VERSION_LESS 11.8))
    OR APPLE
    OR WITH_ROCM)
   list(REMOVE_ITEM kernel_cu "legacy/gpu/layer_norm_cuda_kernel.cu")

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -571,9 +571,17 @@ if(NOT WITH_GPU
    OR APPLE
    OR WITH_ROCM
    OR (${CUDA_ARCH_NAME} STREQUAL "Volta") # Affects the accuracy of op tests
-   OR ((WITH_GPU) AND (CUDA_VERSION VERSION_LESS 12.0))
+   OR ((WITH_GPU) AND (CUDA_VERSION VERSION_LESS 11.8))
 )# Restrict the use of older versions of CUB
   list(REMOVE_ITEM TEST_OPS test_incubate_fused_rmsnorm_ext)
+endif()
+
+if(NOT WITH_GPU
+   OR APPLE
+   OR WITH_ROCM
+   OR (${CUDA_ARCH_NAME} STREQUAL "Volta") # Affects the accuracy of op tests
+   OR ((WITH_GPU) AND (CUDA_VERSION VERSION_LESS 12.0))
+)# Restrict the use of older versions of CUB
   list(REMOVE_ITEM TEST_OPS test_incubate_fast_ln)
 endif()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
Allow cuda 11.8 using fused_rms_norm_ext

pcard-91067
