### PR TITLE
Bypass fused_ln instatiation in architectures below sm_70

### DIFF
--- a/paddle/phi/kernels/legacy/gpu/ln_bwd_semi_cuda_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/ln_bwd_semi_cuda_kernel.cu
@@ -115,7 +115,7 @@ void launch_(LaunchParams<BwdParams> &launch_params,  // NOLINT
 // Create backward launch function and register. Macro signature:
 //  HIDDEN_SIZE, WTYPE, ITYPE, OTYPE, CTYPE, CTAS_PER_ROW, WARPS_M, WARPS_N,
 //  BYTES_PER_LDG, BYTES_PER_LDG_FINAL
-
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700)
 REGISTER_BWD_LAUNCHER(768, fp32, fp32, fp32, fp32, 1, 4, 1, 16, 4);
 REGISTER_BWD_LAUNCHER(768, fp16, fp16, fp16, fp32, 1, 4, 1, 16, 4);
 REGISTER_BWD_LAUNCHER(768, fp16, fp32, fp16, fp32, 1, 4, 1, 16, 4);
@@ -271,3 +271,4 @@ REGISTER_BWD_LAUNCHER(65536, fp16, fp16, fp16, fp32, 8, 1, 8, 16, 4);
 REGISTER_BWD_LAUNCHER(65536, fp16, fp32, fp16, fp32, 8, 1, 8, 16, 4);
 REGISTER_BWD_LAUNCHER(65536, bf16, bf16, bf16, fp32, 8, 1, 8, 16, 4);
 REGISTER_BWD_LAUNCHER(65536, bf16, fp32, bf16, fp32, 8, 1, 8, 16, 4);
+#endif  // (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700)

--- a/paddle/phi/kernels/legacy/gpu/ln_fwd_cuda_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/ln_fwd_cuda_kernel.cu
@@ -100,7 +100,7 @@ void launch_(LaunchParams<FwdParams> &launch_params,  // NOLINT
 // Create forward launch function and register. Macro signature:
 //  HIDDEN_SIZE, WTYPE, ITYPE, OTYPE, CTYPE, CTAS_PER_ROW, WARPS_M, WARPS_N,
 //  BYTES_PER_LDG
-
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700)
 REGISTER_FWD_LAUNCHER(768, fp32, fp32, fp32, fp32, 1, 4, 1, 16);
 REGISTER_FWD_LAUNCHER(768, fp16, fp16, fp16, fp32, 1, 4, 1, 16);
 REGISTER_FWD_LAUNCHER(768, fp16, fp32, fp16, fp32, 1, 4, 1, 16);
@@ -256,3 +256,4 @@ REGISTER_FWD_LAUNCHER(65536, fp16, fp16, fp16, fp32, 8, 1, 4, 16);
 REGISTER_FWD_LAUNCHER(65536, fp16, fp32, fp16, fp32, 8, 1, 4, 16);
 REGISTER_FWD_LAUNCHER(65536, bf16, bf16, bf16, fp32, 8, 1, 4, 16);
 REGISTER_FWD_LAUNCHER(65536, bf16, fp32, bf16, fp32, 8, 1, 4, 16);
+#endif  // (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
Bypass fused_ln instatiation in architectures below sm_70

pcard-91067
