### PR TITLE
 fix device_event.h [fluid_ops]

### DIFF
--- a/paddle/phi/core/platform/device_event.h
+++ b/paddle/phi/core/platform/device_event.h
@@ -18,9 +18,7 @@
 /*
  * NOTE: Now we generate this file manually and will consider
  *  automatically generate it later. Just as 'paddle/fluid/pybind/pybind.h'
- *  for USE_OP from op_library macros, and
- * `paddle/fluid/inference/paddle_inference_pass.h`
- *  for USE_PASS from pass_library.
+ *  for USE_OP from op_library macros.
  */
 
 using ::paddle::platform::kCPU;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
fix device_event.h
paddle/fluid/inference/paddle_inference_pass.h 文件不存在