### PR TITLE
[XPU] Fix `FLAGS_enable_api_kernel_fallback` does not take effect in XPU

### DIFF
--- a/paddle/phi/core/kernel_factory.cc
+++ b/paddle/phi/core/kernel_factory.cc
@@ -355,7 +355,7 @@ KernelResult KernelFactory::SelectKernelOrThrowError(
       !phi::backends::xpu::is_xpu_support_op(TransToFluidOpName(kernel_name),
                                              kernel_key.dtype()) &&
       !phi::backends::xpu::is_xpu_support_op(kernel_name, kernel_key.dtype());
-  if ((FLAGS_enable_api_kernel_fallback && kernel_iter == iter->second.end()) ||
+  if (FLAGS_enable_api_kernel_fallback && kernel_iter == iter->second.end() &&
       is_xpu_unsupported
 #elif defined(PADDLE_WITH_CUSTOM_DEVICE)
   if (kernel_iter == iter->second.end() &&

--- a/test/xpu/test_fallback_flag.py
+++ b/test/xpu/test_fallback_flag.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+
+class TestFLAGSEnableApiKernelFallback(unittest.TestCase):
+    def test_FLAGS_enable_api_kernel_fallback(self):
+        FLAGS_enable_api_kernel_fallback_prev: bool = paddle.get_flags(
+            ["FLAGS_enable_api_kernel_fallback"]
+        )["FLAGS_enable_api_kernel_fallback"]
+        paddle.set_flags({"FLAGS_enable_api_kernel_fallback": False})
+        x = paddle.to_tensor(1.0, dtype="float64")
+        with self.assertRaisesRegex(RuntimeError, "not registered"):
+            z = paddle.sqrt(x)
+        paddle.set_flags(
+            {
+                'FLAGS_enable_api_kernel_fallback': FLAGS_enable_api_kernel_fallback_prev
+            }
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
Pcard-75624

修复`FLAGS_enable_api_kernel_fallback`变量在XPU设备上不起效的问题，具体表现为：设置为false或0后，仍然会fallback到CPU上，核心原因在于原先的分支逻辑错误地使用了 `||`，这会导致一旦出现kernel不支持，一定会进入fallback分支。

<!-- Describe what you’ve done -->
This pull request improves the handling and testing of the `FLAGS_enable_api_kernel_fallback` flag for XPU kernel selection in PaddlePaddle. The main changes include a bug fix to the flag logic in the kernel factory and the addition of a new unit test to verify the flag's behavior.

**Kernel fallback flag logic:**

* Fixed the condition in `KernelFactory::SelectKernelOrThrowError` to ensure that kernel fallback is only attempted when `FLAGS_enable_api_kernel_fallback` is enabled and the kernel is unsupported on XPU. This prevents unintended fallback behavior.

**Testing:**

* Added a new test file `test/xpu/test_fallback_flag.py` that verifies disabling `FLAGS_enable_api_kernel_fallback` raises a runtime error when running an unsupported operation, and restores the flag to its previous state after the test.
