### PR TITLE
[SOT] Mark `coverage` and `colorama` as no need convert module

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/skip_files.py
+++ b/python/paddle/jit/sot/opcode_translator/skip_files.py
@@ -122,10 +122,7 @@ _extend_skip_modules_if_exists("colorama")
 
 
 def _strip_init_py(s):
-    try:
-        return re.sub(r"__init__.py$", "", s)
-    except TypeError as e:
-        raise TypeError(f"Expected a string, but got {type(s)}, {s}") from e
+    return re.sub(r"__init__.py$", "", s)
 
 
 def _module_dir(m: types.ModuleType):

--- a/python/paddle/jit/sot/opcode_translator/skip_files.py
+++ b/python/paddle/jit/sot/opcode_translator/skip_files.py
@@ -129,10 +129,17 @@ def _strip_init_py(s):
 
 
 def _module_dir(m: types.ModuleType):
-    return _strip_init_py(m.__file__)
+    module_file = getattr(m, "__file__", None)
+    if module_file is None:
+        return None
+    return _strip_init_py(module_file)
 
 
-skip_file_names = {_module_dir(m) for m in NEED_SKIP_THIRD_PARTY_MODULES}
+skip_file_names = {
+    path
+    for path in [_module_dir(m) for m in NEED_SKIP_THIRD_PARTY_MODULES]
+    if path is not None
+}
 
 
 sot_path = os.path.dirname(__file__).rpartition(os.sep)[0] + os.sep

--- a/python/paddle/jit/sot/opcode_translator/skip_files.py
+++ b/python/paddle/jit/sot/opcode_translator/skip_files.py
@@ -107,6 +107,20 @@ if sys.version_info < (3, 12):
     NEED_SKIP_THIRD_PARTY_MODULES.add(distutils)
 
 
+def _extend_skip_modules_if_exists(module_name: str):
+    """Extend skip modules set if the module exists."""
+    try:
+        module = importlib.import_module(module_name)
+        NEED_SKIP_THIRD_PARTY_MODULES.add(module)
+    except ImportError:
+        pass
+
+
+# Some modules may not be installed in the environment, so we try to import them.
+_extend_skip_modules_if_exists("coverage")
+_extend_skip_modules_if_exists("colorama")
+
+
 def _strip_init_py(s):
     return re.sub(r"__init__.py$", "", s)
 

--- a/python/paddle/jit/sot/opcode_translator/skip_files.py
+++ b/python/paddle/jit/sot/opcode_translator/skip_files.py
@@ -122,7 +122,10 @@ _extend_skip_modules_if_exists("colorama")
 
 
 def _strip_init_py(s):
-    return re.sub(r"__init__.py$", "", s)
+    try:
+        return re.sub(r"__init__.py$", "", s)
+    except TypeError as e:
+        raise TypeError(f"Expected a string, but got {type(s)}, {s}") from e
 
 
 def _module_dir(m: types.ModuleType):

--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -1,5 +1,5 @@
 PyGithub
-coverage==5.5
+coverage==7.10.7
 mock
 gymnasium>=1.0.0a1
 hypothesis<6.145.0

--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -1,5 +1,5 @@
 PyGithub
-coverage==7.10.7
+coverage==5.5
 mock
 gymnasium>=1.0.0a1
 hypothesis<6.145.0


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

- `coverage` 库在升级到 7.12 时会导致 `Coverage` 流水线里 `coverage` 包自身的插桩逻辑走到 eval frame
- `colorama` 库则是当初 SOT 迁移到 Paddle repo 时调试发现 Windows 下 `colorama` 逻辑会进到 eval frame

这两者都应该禁掉，因为这些库里不可能有组网逻辑

<!-- PCard-66972 -->