### PR TITLE
clean redundant code `using DataLayout` 

### DIFF
--- a/paddle/phi/kernels/funcs/im2col.h
+++ b/paddle/phi/kernels/funcs/im2col.h
@@ -24,8 +24,6 @@ limitations under the License. */
 namespace phi {
 namespace funcs {
 
-using DataLayout = phi::DataLayout;
-
 /* The storage format of the coldata in the Im2ColFunctor and Col2ImFunctor. */
 enum class ColFormat { kCFO = 0, kOCF = 1 };
 

--- a/paddle/phi/kernels/funcs/vol2col.h
+++ b/paddle/phi/kernels/funcs/vol2col.h
@@ -22,8 +22,6 @@ limitations under the License. */
 namespace phi {
 namespace funcs {
 
-using DataLayout = phi::DataLayout;
-
 /*
  * \brief Converts the feature data of four dimensions(CDHW) into a colData of
  *        seven dimensions in the Vol2ColFunctor calculation,

--- a/paddle/phi/kernels/gpu/depthwise_conv.h
+++ b/paddle/phi/kernels/gpu/depthwise_conv.h
@@ -125,7 +125,6 @@ namespace phi::math {
  * \brief Compute the depthwise convolution which include
  * forward process and backpropagation process
  */
-using DataLayout = phi::DataLayout;
 template <typename DeviceContext,
           typename T,
           bool fuse_relu_before_conv = false>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
命名空间为phi，可以不用 `using DataLayout = phi::DataLayout`
