### PR TITLE
[API Compatibility] diable attn flag export on CPU

### DIFF
--- a/paddle/phi/core/flags.cc
+++ b/paddle/phi/core/flags.cc
@@ -31,26 +31,18 @@
 PHI_DEFINE_EXPORTED_int64(conv_workspace_size_limit,
                           phi::backends::gpu::kDefaultConvWorkspaceSizeLimitMB,
                           "cuDNN convolution workspace limit in MB unit.");
-#endif
 
 #ifdef PADDLE_WITH_MEMORY_EFFICIENT_ATTENTION
-static const bool kMemEffAttnDefault = true;
-#else
-static const bool kMemEffAttnDefault = false;
-#endif
-
 PHI_DEFINE_EXPORTED_bool(
     mem_efficient_attn_available,
-    kMemEffAttnDefault,
+    true,
     "Weather memory efficient attention is available on the current device.");
-
-#ifdef PADDLE_WITH_FLASHATTN
-static const bool kFlashAttnDefault = true;
-#else
-static const bool kFlashAttnDefault = false;
 #endif
 
+#ifdef PADDLE_WITH_FLASHATTN
 PHI_DEFINE_EXPORTED_bool(
     flash_attn_available,
-    kFlashAttnDefault,
+    true,
     "Weather flash attention is available on the current device.");
+#endif
+#endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
mem_efficient_attn_available flash_attn_available 这两个 Flag 在 CPU 包中不启用，以避免在 Custom Device 中对这两个 Flag 重复编译