### PR TITLE
[API compatibility] Add para alias for LayerList and LayerDict

### DIFF
--- a/python/paddle/nn/layer/container.py
+++ b/python/paddle/nn/layer/container.py
@@ -262,6 +262,7 @@ class LayerDict(Layer):
         """
         return self._sub_layers.values()
 
+    @param_one_alias(["sublayers", "modules"])
     def update(
         self,
         sublayers: (
@@ -609,6 +610,7 @@ class LayerList(Layer):
         keys = [key for key in keys if not key.isdigit()]
         return keys
 
+    @param_one_alias(["sublayer", "module"])
     def append(self, sublayer: Layer) -> Self:
         """
         Appends a sublayer to the end of the list.
@@ -630,6 +632,7 @@ class LayerList(Layer):
         self.add_sublayer(str(len(self)), sublayer)
         return self
 
+    @param_one_alias(["sublayer", "module"])
     def insert(self, index: int, sublayer: Layer) -> None:
         """
         Insert a sublayer before a given index in the list.
@@ -665,6 +668,7 @@ class LayerList(Layer):
             self._sub_layers[str(i)] = self._sub_layers[str(i - 1)]
         self._sub_layers[str(index)] = sublayer
 
+    @param_one_alias(["sublayers", "modules"])
     def extend(self, sublayers: Iterable[Layer]) -> Self:
         """
         Appends sublayers to the end of the list.

--- a/test/legacy_test/test_base_module.py
+++ b/test/legacy_test/test_base_module.py
@@ -1059,7 +1059,7 @@ class TestModuleListOperations(unittest.TestCase):
 
     def test_insert(self):
         new_module = nn.Sigmoid()
-        self.module_list1.insert(1, new_module)
+        self.module_list1.insert(1, module=new_module)
 
         self.assertEqual(len(self.module_list1), 3)
         self.assertIs(self.module_list1[0], self.modules1[0])
@@ -1080,7 +1080,7 @@ class TestModuleListOperations(unittest.TestCase):
     def test_append(self):
         new_module = nn.Softmax()
         original_len = len(self.module_list1)
-        result = self.module_list1.append(new_module)
+        result = self.module_list1.append(module=new_module)
 
         self.assertEqual(len(self.module_list1), original_len + 1)
         self.assertIs(self.module_list1[-1], new_module)
@@ -1111,7 +1111,7 @@ class TestModuleListOperations(unittest.TestCase):
     def test_extend(self):
         additional_modules = [nn.Dropout(0.3), nn.Sigmoid()]
         original_len = len(self.module_list1)
-        result = self.module_list1.extend(additional_modules)
+        result = self.module_list1.extend(modules=additional_modules)
 
         self.assertEqual(
             len(self.module_list1), original_len + len(additional_modules)
@@ -1356,7 +1356,7 @@ class TestModuleDictOperations(unittest.TestCase):
 
     def test_update_with_dict(self):
         new_modules = {'bn': nn.BatchNorm2D(16), 'pool': nn.MaxPool2D(2)}
-        self.module_dict.update(new_modules)
+        self.module_dict.update(modules=new_modules)
 
         self.assertEqual(len(self.module_dict), 4)
         self.assertIn('conv', self.module_dict)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Add para alias for LayerList and LayerDict

pcard-67164