### PR TITLE
[Compat] Use cached values when import module out of scope

### DIFF
--- a/python/paddle/compat/proxy.py
+++ b/python/paddle/compat/proxy.py
@@ -444,7 +444,6 @@ def enable_torch_proxy(
             >>> assert torch.sin is paddle.sin
     """
     _register_compat_override()
-    # _clear_torch_modules()
     _swap_torch_modules_to_cache()
     _modify_scope_of_torch_proxy(scope, silent=silent)
     sys.meta_path.insert(0, TORCH_PROXY_FINDER)

--- a/python/paddle/compat/proxy.py
+++ b/python/paddle/compat/proxy.py
@@ -223,12 +223,16 @@ class TorchProxyMetaFinder:
             return None
 
         if _is_called_by_torch_proxy_blocked_module():
+            if fullname in TORCH_MODULES_CACHE:
+                return self._find_spec_for_cached_torch_module(fullname)
             return None
 
         if (
             not self._globally_enabled
             and not _is_called_by_torch_proxy_local_enabled_module()
         ):
+            if fullname in TORCH_MODULES_CACHE:
+                return self._find_spec_for_cached_torch_module(fullname)
             return None
 
         return self._find_spec_for_torch_module(fullname)
@@ -248,7 +252,7 @@ class TorchProxyMetaFinder:
             if original_loader is None:
                 return None
 
-            class TorchBlockedModuleLoader(importlib.abc.Loader):
+            class SpecificModuleLoader(importlib.abc.Loader):
                 def create_module(self, spec):
                     mod = original_loader.create_module(spec)
                     if mod is None:
@@ -272,7 +276,7 @@ class TorchProxyMetaFinder:
                     # Mark module as torch proxy disabled/local enabled
                     module.__dict__[patched_dunder_attr] = True
 
-        spec.loader = TorchBlockedModuleLoader()
+        spec.loader = SpecificModuleLoader()
         return spec
 
     def _find_spec_for_torch_proxy_local_enabled_module(self, fullname: str):
@@ -287,6 +291,21 @@ class TorchProxyMetaFinder:
             fullname,
             enable_proxy_when_exec_module=False,
             patched_dunder_attr=MAGIC_DISABLED_MODULE_ATTR,
+        )
+
+    def _find_spec_for_cached_torch_module(self, fullname: str):
+        # Return cached module before enable proxy
+        class CachedTorchModuleLoader(importlib.abc.Loader):
+            def create_module(self, spec):
+                return TORCH_MODULES_CACHE[fullname]
+
+            def exec_module(self, module):
+                pass
+
+        return importlib.util.spec_from_loader(
+            fullname,
+            CachedTorchModuleLoader(),
+            origin=getattr(TORCH_MODULES_CACHE[fullname], "__file__", None),
         )
 
     def _find_spec_for_torch_module(self, fullname: str):
@@ -350,12 +369,27 @@ class TorchProxyMetaFinder:
 
 
 TORCH_PROXY_FINDER = TorchProxyMetaFinder()
+TORCH_MODULES_CACHE: dict[str, types.ModuleType] = {}
 
 
 def _clear_torch_modules():
     for name in list(sys.modules):
         if _is_torch_module(name):
             del sys.modules[name]
+
+
+def _swap_torch_modules_to_cache():
+    for name in list(sys.modules):
+        if _is_torch_module(name):
+            TORCH_MODULES_CACHE[name] = sys.modules[name]
+            del sys.modules[name]
+
+
+def _swap_torch_modules_from_cache():
+    for name in list(TORCH_MODULES_CACHE):
+        assert _is_torch_module(name), f"`{name}` is not a PyTorch module"
+        sys.modules[name] = TORCH_MODULES_CACHE[name]
+        del TORCH_MODULES_CACHE[name]
 
 
 def _modify_scope_of_torch_proxy(
@@ -410,7 +444,8 @@ def enable_torch_proxy(
             >>> assert torch.sin is paddle.sin
     """
     _register_compat_override()
-    _clear_torch_modules()
+    # _clear_torch_modules()
+    _swap_torch_modules_to_cache()
     _modify_scope_of_torch_proxy(scope, silent=silent)
     sys.meta_path.insert(0, TORCH_PROXY_FINDER)
 
@@ -436,6 +471,7 @@ def disable_torch_proxy() -> None:
     if TORCH_PROXY_FINDER in sys.meta_path:
         sys.meta_path.remove(TORCH_PROXY_FINDER)
         _clear_torch_modules()
+        _swap_torch_modules_from_cache()
         return
     warnings.warn("torch proxy is not installed.")
 

--- a/python/paddle/jit/sot/opcode_translator/skip_files.py
+++ b/python/paddle/jit/sot/opcode_translator/skip_files.py
@@ -106,13 +106,6 @@ if sys.version_info < (3, 12):
 
     NEED_SKIP_THIRD_PARTY_MODULES.add(distutils)
 
-try:
-    import coverage
-except ImportError:
-    ...
-else:
-    NEED_SKIP_THIRD_PARTY_MODULES.add(coverage)
-
 
 def _strip_init_py(s):
     return re.sub(r"__init__.py$", "", s)

--- a/python/paddle/jit/sot/opcode_translator/skip_files.py
+++ b/python/paddle/jit/sot/opcode_translator/skip_files.py
@@ -106,6 +106,13 @@ if sys.version_info < (3, 12):
 
     NEED_SKIP_THIRD_PARTY_MODULES.add(distutils)
 
+try:
+    import coverage
+except ImportError:
+    ...
+else:
+    NEED_SKIP_THIRD_PARTY_MODULES.add(coverage)
+
 
 def _strip_init_py(s):
     return re.sub(r"__init__.py$", "", s)

--- a/test/compat/test_torch_proxy.py
+++ b/test/compat/test_torch_proxy.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import unittest
+from unittest.mock import MagicMock
 
 import numpy as np
 
@@ -119,26 +121,24 @@ class TestTorchProxyLocalEnabledModule(unittest.TestCase):
         import torch_proxy_local_enabled_module
 
         torch_proxy_local_enabled_module.use_torch_compat_api()
-        paddle.compat.proxy.TORCH_PROXY_FINDER._scope = None
+        paddle.compat.proxy.TORCH_PROXY_FINDER._globally_enabled = False
+        paddle.compat.proxy.TORCH_PROXY_FINDER._local_enabled_scope = set()
         paddle.compat.disable_torch_proxy()
 
 
-class TestTorchProxyLocalEnabledModule(unittest.TestCase):
-    def test_local_enabled_module(self):
-        with self.assertRaises(ModuleNotFoundError):
-            import torch_proxy_local_enabled_module
+class TestTorchProxyUseMockedModule(unittest.TestCase):
+    def test_use_mocked_module(self):
+        # Define mocked torch before use torch proxy
+        mocked_torch = MagicMock()
+        sys.modules["torch"] = mocked_torch
+        with paddle.compat.use_torch_proxy_guard(scope=set()):
+            import torch
 
-        paddle.compat.enable_torch_proxy(
-            scope={"torch_proxy_local_enabled_module"}
-        )
-        with self.assertRaises(ModuleNotFoundError):
-            import torch  # noqa: F401
+            # torch proxy should not affect mocked torch,
+            # because the `import torch` not under the enabled scope
+            self.assertIs(torch, mocked_torch)
 
-        import torch_proxy_local_enabled_module
-
-        torch_proxy_local_enabled_module.use_torch_compat_api()
-        paddle.compat.proxy.TORCH_PROXY_FINDER._scope = None
-        paddle.compat.disable_torch_proxy()
+        self.assertIs(torch, mocked_torch)
 
 
 class TestOverrideTorchModule(unittest.TestCase):

--- a/test/compat/test_torch_proxy.py
+++ b/test/compat/test_torch_proxy.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import numpy as np
+
 import paddle
 from paddle.compat.proxy import create_fake_class, create_fake_function
 
@@ -24,83 +26,83 @@ def use_torch_inside_inner_function():
     return torch.sin(torch.tensor([0.0, 1.0, 2.0])).numpy()
 
 
-# class TestTorchProxy(unittest.TestCase):
-#     def test_enable_torch_proxy(self):
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch
+class TestTorchProxy(unittest.TestCase):
+    def test_enable_torch_proxy(self):
+        with self.assertRaises(ModuleNotFoundError):
+            import torch
 
-#         paddle.compat.enable_torch_proxy()
-#         import torch
+        paddle.compat.enable_torch_proxy()
+        import torch
 
-#         self.assertIs(torch.sin, paddle.sin)
+        self.assertIs(torch.sin, paddle.sin)
 
-#         import torch.nn
+        import torch.nn
 
-#         self.assertIs(torch.nn.Conv2d, paddle.nn.Conv2d)
+        self.assertIs(torch.nn.Conv2d, paddle.nn.Conv2d)
 
-#         import torch.nn.functional
+        import torch.nn.functional
 
-#         self.assertIs(torch.nn.functional.sigmoid, paddle.nn.functional.sigmoid)
+        self.assertIs(torch.nn.functional.sigmoid, paddle.nn.functional.sigmoid)
 
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch.nonexistent_module
+        with self.assertRaises(ModuleNotFoundError):
+            import torch.nonexistent_module
 
-#         paddle.compat.disable_torch_proxy()
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch.nn
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch.nn.functional
+        paddle.compat.disable_torch_proxy()
+        with self.assertRaises(ModuleNotFoundError):
+            import torch
+        with self.assertRaises(ModuleNotFoundError):
+            import torch.nn
+        with self.assertRaises(ModuleNotFoundError):
+            import torch.nn.functional
 
-#     def test_use_torch_proxy_guard(self):
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch
-#         with paddle.compat.use_torch_proxy_guard():
-#             import torch
+    def test_use_torch_proxy_guard(self):
+        with self.assertRaises(ModuleNotFoundError):
+            import torch
+        with paddle.compat.use_torch_proxy_guard():
+            import torch
 
-#             self.assertIs(torch.sin, paddle.sin)
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch
+            self.assertIs(torch.sin, paddle.sin)
+        with self.assertRaises(ModuleNotFoundError):
+            import torch
 
-#         with paddle.compat.use_torch_proxy_guard():
-#             import torch
+        with paddle.compat.use_torch_proxy_guard():
+            import torch
 
-#             self.assertIs(torch.cos, paddle.cos)
-#             with paddle.compat.use_torch_proxy_guard(enable=False):
-#                 with self.assertRaises(ModuleNotFoundError):
-#                     import torch
-#                 with paddle.compat.use_torch_proxy_guard(enable=True):
-#                     import torch
+            self.assertIs(torch.cos, paddle.cos)
+            with paddle.compat.use_torch_proxy_guard(enable=False):
+                with self.assertRaises(ModuleNotFoundError):
+                    import torch
+                with paddle.compat.use_torch_proxy_guard(enable=True):
+                    import torch
 
-#         with self.assertRaises(ModuleNotFoundError):
-#             import torch
+        with self.assertRaises(ModuleNotFoundError):
+            import torch
 
-#     @paddle.compat.use_torch_proxy_guard()
-#     def test_use_torch_inside_inner_function(self):
-#         result = use_torch_inside_inner_function()
+    @paddle.compat.use_torch_proxy_guard()
+    def test_use_torch_inside_inner_function(self):
+        result = use_torch_inside_inner_function()
 
-#         np.testing.assert_allclose(
-#             result, np.sin([0.0, 1.0, 2.0]), atol=1e-6, rtol=1e-6
-#         )
+        np.testing.assert_allclose(
+            result, np.sin([0.0, 1.0, 2.0]), atol=1e-6, rtol=1e-6
+        )
 
 
-# class TestTorchProxyBlockedModule(unittest.TestCase):
-#     def test_blocked_module(self):
-#         with paddle.compat.use_torch_proxy_guard():
-#             with self.assertRaises(ModuleNotFoundError):
-#                 import torch._dynamo.allow_in_graph
+class TestTorchProxyBlockedModule(unittest.TestCase):
+    def test_blocked_module(self):
+        with paddle.compat.use_torch_proxy_guard():
+            with self.assertRaises(ModuleNotFoundError):
+                import torch._dynamo.allow_in_graph  # noqa: F401
 
-#             with self.assertRaises(AttributeError):
-#                 import torch_proxy_blocked_module
+            with self.assertRaises(AttributeError):
+                import torch_proxy_blocked_module
 
-#             paddle.compat.extend_torch_proxy_blocked_modules(
-#                 {"torch_proxy_blocked_module"}
-#             )
-#             import torch_proxy_blocked_module
+            paddle.compat.extend_torch_proxy_blocked_modules(
+                {"torch_proxy_blocked_module"}
+            )
+            import torch_proxy_blocked_module
 
-#             # Use torch specific function out of execute module stage
-#             torch_proxy_blocked_module.use_torch_specific_fn()
+            # Use torch specific function out of execute module stage
+            torch_proxy_blocked_module.use_torch_specific_fn()
 
 
 class TestTorchProxyLocalEnabledModule(unittest.TestCase):
@@ -112,11 +114,13 @@ class TestTorchProxyLocalEnabledModule(unittest.TestCase):
             scope={"torch_proxy_local_enabled_module"}
         )
         with self.assertRaises(ModuleNotFoundError):
-            pass
+            import torch  # noqa: F401
 
         import torch_proxy_local_enabled_module
 
         torch_proxy_local_enabled_module.use_torch_compat_api()
+        paddle.compat.proxy.TORCH_PROXY_FINDER._scope = None
+        paddle.compat.disable_torch_proxy()
 
 
 class TestTorchProxyLocalEnabledModule(unittest.TestCase):

--- a/test/compat/test_torch_proxy.py
+++ b/test/compat/test_torch_proxy.py
@@ -14,8 +14,6 @@
 
 import unittest
 
-import numpy as np
-
 import paddle
 from paddle.compat.proxy import create_fake_class, create_fake_function
 
@@ -26,83 +24,99 @@ def use_torch_inside_inner_function():
     return torch.sin(torch.tensor([0.0, 1.0, 2.0])).numpy()
 
 
-class TestTorchProxy(unittest.TestCase):
-    def test_enable_torch_proxy(self):
+# class TestTorchProxy(unittest.TestCase):
+#     def test_enable_torch_proxy(self):
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch
+
+#         paddle.compat.enable_torch_proxy()
+#         import torch
+
+#         self.assertIs(torch.sin, paddle.sin)
+
+#         import torch.nn
+
+#         self.assertIs(torch.nn.Conv2d, paddle.nn.Conv2d)
+
+#         import torch.nn.functional
+
+#         self.assertIs(torch.nn.functional.sigmoid, paddle.nn.functional.sigmoid)
+
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch.nonexistent_module
+
+#         paddle.compat.disable_torch_proxy()
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch.nn
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch.nn.functional
+
+#     def test_use_torch_proxy_guard(self):
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch
+#         with paddle.compat.use_torch_proxy_guard():
+#             import torch
+
+#             self.assertIs(torch.sin, paddle.sin)
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch
+
+#         with paddle.compat.use_torch_proxy_guard():
+#             import torch
+
+#             self.assertIs(torch.cos, paddle.cos)
+#             with paddle.compat.use_torch_proxy_guard(enable=False):
+#                 with self.assertRaises(ModuleNotFoundError):
+#                     import torch
+#                 with paddle.compat.use_torch_proxy_guard(enable=True):
+#                     import torch
+
+#         with self.assertRaises(ModuleNotFoundError):
+#             import torch
+
+#     @paddle.compat.use_torch_proxy_guard()
+#     def test_use_torch_inside_inner_function(self):
+#         result = use_torch_inside_inner_function()
+
+#         np.testing.assert_allclose(
+#             result, np.sin([0.0, 1.0, 2.0]), atol=1e-6, rtol=1e-6
+#         )
+
+
+# class TestTorchProxyBlockedModule(unittest.TestCase):
+#     def test_blocked_module(self):
+#         with paddle.compat.use_torch_proxy_guard():
+#             with self.assertRaises(ModuleNotFoundError):
+#                 import torch._dynamo.allow_in_graph
+
+#             with self.assertRaises(AttributeError):
+#                 import torch_proxy_blocked_module
+
+#             paddle.compat.extend_torch_proxy_blocked_modules(
+#                 {"torch_proxy_blocked_module"}
+#             )
+#             import torch_proxy_blocked_module
+
+#             # Use torch specific function out of execute module stage
+#             torch_proxy_blocked_module.use_torch_specific_fn()
+
+
+class TestTorchProxyLocalEnabledModule(unittest.TestCase):
+    def test_local_enabled_module(self):
         with self.assertRaises(ModuleNotFoundError):
-            import torch
+            import torch_proxy_local_enabled_module
 
-        paddle.compat.enable_torch_proxy()
-        import torch
-
-        self.assertIs(torch.sin, paddle.sin)
-
-        import torch.nn
-
-        self.assertIs(torch.nn.Conv2d, paddle.nn.Conv2d)
-
-        import torch.nn.functional
-
-        self.assertIs(torch.nn.functional.sigmoid, paddle.nn.functional.sigmoid)
-
-        with self.assertRaises(ModuleNotFoundError):
-            import torch.nonexistent_module
-
-        paddle.compat.disable_torch_proxy()
-        with self.assertRaises(ModuleNotFoundError):
-            import torch
-        with self.assertRaises(ModuleNotFoundError):
-            import torch.nn
-        with self.assertRaises(ModuleNotFoundError):
-            import torch.nn.functional
-
-    def test_use_torch_proxy_guard(self):
-        with self.assertRaises(ModuleNotFoundError):
-            import torch
-        with paddle.compat.use_torch_proxy_guard():
-            import torch
-
-            self.assertIs(torch.sin, paddle.sin)
-        with self.assertRaises(ModuleNotFoundError):
-            import torch
-
-        with paddle.compat.use_torch_proxy_guard():
-            import torch
-
-            self.assertIs(torch.cos, paddle.cos)
-            with paddle.compat.use_torch_proxy_guard(enable=False):
-                with self.assertRaises(ModuleNotFoundError):
-                    import torch
-                with paddle.compat.use_torch_proxy_guard(enable=True):
-                    import torch
-
-        with self.assertRaises(ModuleNotFoundError):
-            import torch
-
-    @paddle.compat.use_torch_proxy_guard()
-    def test_use_torch_inside_inner_function(self):
-        result = use_torch_inside_inner_function()
-
-        np.testing.assert_allclose(
-            result, np.sin([0.0, 1.0, 2.0]), atol=1e-6, rtol=1e-6
+        paddle.compat.enable_torch_proxy(
+            scope={"torch_proxy_local_enabled_module"}
         )
+        with self.assertRaises(ModuleNotFoundError):
+            pass
 
+        import torch_proxy_local_enabled_module
 
-class TestTorchProxyBlockedModule(unittest.TestCase):
-    def test_blocked_module(self):
-        with paddle.compat.use_torch_proxy_guard():
-            with self.assertRaises(ModuleNotFoundError):
-                import torch._dynamo.allow_in_graph  # noqa: F401
-
-            with self.assertRaises(AttributeError):
-                import torch_proxy_blocked_module
-
-            paddle.compat.extend_torch_proxy_blocked_modules(
-                {"torch_proxy_blocked_module"}
-            )
-            import torch_proxy_blocked_module
-
-            # Use torch specific function out of execute module stage
-            torch_proxy_blocked_module.use_torch_specific_fn()
+        torch_proxy_local_enabled_module.use_torch_compat_api()
 
 
 class TestTorchProxyLocalEnabledModule(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

当进入 proxy 之前 `sys.modules` 里 `torch`（或子模块）有值时，如果我们在 proxy 里遇到了以下情况时，应该直接从之前 `sys.modules` 里的 `torch` 取

- 当遇到 proxy 局部开启，但是当前并非被开启的局部时
- 当遇到当前模块是被 block 的模块时

这样可以有效避免原来 `sys.modules` 里的 `torch` 被清理掉，重新加载时出现

```pycon
>>> import torch
>>> for n in list(sys.modules):
...     if n.startswith('torch'):
...         del sys.modules[n]
... 
>>> import torch
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/miniforge3/envs/torch-py310/lib/python3.10/site-packages/torch/__init__.py", line 1848, in <module>
    from torch._tensor import Tensor  # usort: skip
  File "/root/miniforge3/envs/torch-py310/lib/python3.10/site-packages/torch/_tensor.py", line 22, in <module>
    from torch.overrides import (
  File "/root/miniforge3/envs/torch-py310/lib/python3.10/site-packages/torch/overrides.py", line 1765, in <module>
    has_torch_function = _add_docstr(
RuntimeError: function '_has_torch_function' already has a docstring
```

也能避免前面 mock 的 torch 进入 proxy 就直接被清理掉的问题

我们现在的流程是

- 进入 proxy 时
   - 将 `sys.modules` 中的 `torch` 模块 swap 到 `TORCH_MODULES_CACHE`
- 退出 proxy 时
   - 清理 `sys.modules` 全部 proxy 的 torch
   - 将 `TORCH_MODULES_CACHE` swap 回 `sys.modules`

<!-- PCard-66972 -->