### PR TITLE
[API Compatibility No.67] Add torch-style arg and alias for `frac` -part

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5984,13 +5984,17 @@ def heaviside(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def frac(x: Tensor, name: str | None = None) -> Tensor:
+@param_one_alias(["x", "input"])
+def frac(
+    x: Tensor, name: str | None = None, *, out: Tensor | None = None
+) -> Tensor:
     """
     This API is used to return the fractional portion of each element in input.
 
     Args:
         x (Tensor): The input tensor, which data type should be int32, int64, float32, float64.
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+        out (Tensor, optional): The output tensor. Default: None.
 
     Returns:
         Tensor: The output Tensor of frac.
@@ -6025,7 +6029,7 @@ def frac(x: Tensor, name: str | None = None) -> Tensor:
         )
     if in_dynamic_or_pir_mode():
         y = _C_ops.trunc(x)
-        return _C_ops.subtract(x, y)
+        return _C_ops.subtract(x, y, out=out)
     else:
         inputs = {"X": x}
         attrs = {}

--- a/test/legacy_test/test_frac_api.py
+++ b/test/legacy_test/test_frac_api.py
@@ -121,5 +121,41 @@ class TestFracAPI_ZeroSize(unittest.TestCase):
         np.testing.assert_allclose(x.grad.shape, x.shape)
 
 
+class TestFracAPI_Compatibility(unittest.TestCase):
+    def setUp(self):
+        self.shape = [5, 6]
+        self.dtype = "float32"
+        np.random.seed(2025)
+        self.x_np = np.random.rand(*self.shape).astype(self.dtype)
+        self.place = get_device_place()
+
+    def test_frac_input_arg(self):
+        paddle.disable_static(self.place)
+        x = paddle.to_tensor(self.x_np)
+        out_ref = ref_frac(self.x_np)
+        out = paddle.frac(input=x)
+        np.testing.assert_allclose(out.numpy(), out_ref, rtol=1e-05)
+        paddle.enable_static()
+
+    def test_frac_output_arg(self):
+        paddle.disable_static(self.place)
+        x = paddle.to_tensor(self.x_np)
+        out_ref = ref_frac(self.x_np)
+        out = paddle.empty([])
+        paddle.frac(x, out=out)
+        np.testing.assert_allclose(out.numpy(), out_ref, rtol=1e-05)
+        paddle.enable_static()
+
+    def test_frac_tensor_output_arg(self):
+        paddle.disable_static(self.place)
+        x = paddle.to_tensor(self.x_np)
+        out_ref = ref_frac(self.x_np)
+        out1 = paddle.empty([])
+        out2 = paddle.frac(x, out=out1)
+        np.testing.assert_allclose(out1.numpy(), out_ref, rtol=1e-05)
+        np.testing.assert_allclose(out2.numpy(), out_ref, rtol=1e-05)
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
> API & Unittest & EN Doc
- Use decorator to add arg alias `input`
- Add arg `out`
- Update `paddle.frac` EN documentation
- Add unittests of compatibility for `paddle.frac`


ℹ️`paddle.frac` has no corresponding kernel, so I used decorator.

**Used AI Studio**
