### PR TITLE
fix helpers.cpp path 

### DIFF
--- a/paddle/phi/kernels/gpudnn/conv_cudnn_frontend.h
+++ b/paddle/phi/kernels/gpudnn/conv_cudnn_frontend.h
@@ -60,7 +60,7 @@ class CudnnFrontendConvHelper {
   static std::vector<int64_t> GenerateStrides(
       const std::vector<int64_t>& dim, cudnnTensorFormat_t filter_format) {
     // ref:
-    // https://github.com/NVIDIA/cudnn-frontend/blob/main/samples/helpers.cpp
+    // https://github.com/NVIDIA/cudnn-frontend/blob/main/samples/legacy_samples/helpers.cpp
     // For INT8x4 and INT8x32 we still compute standard strides here to input
     // into the cuDNN functions. We will manually scale by resizeFactor in the
     // cpu ref.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
文件路径修改为 https://github.com/NVIDIA/cudnn-frontend/blob/main/samples/legacy_samples/helpers.cpp，https://github.com/NVIDIA/cudnn-frontend/blob/main/samples/helpers.cpp已找不到
<img width="1558" height="359" alt="image" src="https://github.com/user-attachments/assets/ceefba0d-a83e-4558-98f3-d0e4baa82c20" />
