### PR TITLE
 fix cuda_helper.h include

### DIFF
--- a/paddle/phi/backends/gpu/cuda/cuda_helper.h
+++ b/paddle/phi/backends/gpu/cuda/cuda_helper.h
@@ -16,10 +16,7 @@
 
 #ifdef PADDLE_WITH_CUDA
 #include <cuda_runtime.h>  // NOLINT
-
-#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/common/data_type.h"
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/enforce.h"
 
 namespace phi {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
fix cuda_helper.h include
data_type.h已包含float16.h和bfloat16.h，不用再包含float16.h和bfloat16.h