### PR TITLE
fix GPUDNNDataLayout in funcs/softmax.cu [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/funcs/softmax.cu
+++ b/paddle/phi/kernels/funcs/softmax.cu
@@ -23,7 +23,6 @@ namespace phi {
 namespace funcs {
 
 using ScopedTensorDescriptor = phi::backends::gpu::ScopedTensorDescriptor;
-using GpuDataLayout = phi::backends::gpu::DataLayout;
 template <typename T>
 using CudnnDataType = phi::backends::gpu::CudnnDataType<T>;
 
@@ -36,9 +35,9 @@ void SoftmaxCUDNNFunctor<T, DeviceContext>::operator()(
   ScopedTensorDescriptor xDesc;
   ScopedTensorDescriptor yDesc;
   std::vector<int> cudnn_tensor_dims = common::vectorize<int>(X->dims());
-  GpuDataLayout layout = GpuDataLayout::kNCHW;
+  DataLayout layout = DataLayout::NCHW;
   if (cudnn_tensor_dims.size() == 5) {
-    layout = GpuDataLayout::kNCDHW;
+    layout = DataLayout::NCDHW;
   }
   // NOTE(*) : cudnn softmax only support >= 4D phi::DenseTensor,
   // fill 1 at unused dims
@@ -89,9 +88,9 @@ void SoftmaxGradCUDNNFunctor<T, DeviceContext>::operator()(
   ScopedTensorDescriptor dyDesc;
   ScopedTensorDescriptor dxDesc;
   std::vector<int> cudnn_tensor_dims = common::vectorize<int>(Y->dims());
-  GpuDataLayout layout = GpuDataLayout::kNCHW;
+  DataLayout layout = DataLayout::NCHW;
   if (cudnn_tensor_dims.size() == 5) {
-    layout = GpuDataLayout::kNCDHW;
+    layout = DataLayout::NCDHW;
   }
   // NOTE(*) : cudnn softmax only support >= 4D phi::DenseTensor,
   // fill 1 at unused dims

--- a/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
@@ -769,7 +769,7 @@ static void SoftmaxWithCrossEntropySoftLabel(const GPUContext& dev_ctx,
   } else {
     ScopedTensorDescriptor desc;
     std::vector<int> tensor_dims = {N, dim, D, 1};
-    DataLayout layout = DataLayout::kNCHW;
+    DataLayout layout = DataLayout::NCHW;
 #ifdef PADDLE_WITH_HIP
     miopenTensorDescriptor_t descp = desc.descriptor<T>(layout, tensor_dims);
     auto handle = dev_ctx.cudnn_handle();
@@ -1195,7 +1195,7 @@ static void SoftmaxWithCrossEntropyHardLabel(const GPUContext& dev_ctx,
     auto* softmax_data = softmax->data<T>();
     ScopedTensorDescriptor desc;
     std::vector<int> tensor_dims = {N, dim, D, 1};
-    DataLayout layout = DataLayout::kNCHW;
+    DataLayout layout = DataLayout::NCHW;
 
 #ifdef PADDLE_WITH_HIP
     miopenTensorDescriptor_t descp = desc.descriptor<T>(layout, tensor_dims);

--- a/paddle/phi/kernels/gpu/cudnn_lstm_cache.h
+++ b/paddle/phi/kernels/gpu/cudnn_lstm_cache.h
@@ -184,8 +184,7 @@ class ScopedRNNBase {
         common::errors::InvalidArgument(
             "The cudnn lstm and setting weight size should be same."));
     // ------------------- cudnn weight descriptors ---------------------
-    phi::backends::gpu::DataLayout layout =
-        phi::backends::gpu::DataLayout::kNCHW;
+    DataLayout layout = DataLayout::NCHW;
     int dim_tmp = weights_size_ / sizeof(T);
     std::vector<int> dim_w = {dim_tmp, 1, 1};
     weight_desc_.descriptor<T>(layout, dim_w);

--- a/paddle/phi/kernels/gpu/miopen_lstm_cache.h
+++ b/paddle/phi/kernels/gpu/miopen_lstm_cache.h
@@ -117,8 +117,7 @@ class ScopedRNNBase {
         common::errors::InvalidArgument(
             "The miopen lstm and setting weight size should be same."));
     // ------------------- miopen weight descriptors ---------------------
-    phi::backends::gpu::DataLayout layout =
-        phi::backends::gpu::DataLayout::kNCHW;
+    DataLayout layout = DataLayout::NCHW;
     int dim_tmp = weights_size_ / sizeof(T);
     std::vector<int> dim_w = {dim_tmp, 1, 1};
     weight_desc_.descriptor<T>(layout, dim_w);

--- a/paddle/phi/kernels/gpu/rnn_functor.h
+++ b/paddle/phi/kernels/gpu/rnn_functor.h
@@ -238,7 +238,7 @@ class RNNDescriptors {
         common::errors::InvalidArgument(
             "The cudnn rnn and setting weight size should be same."));
     // ------------------- cudnn weight descriptors ---------------------
-    auto layout = phi::backends::gpu::DataLayout::kNCHW;
+    auto layout = DataLayout::NCHW;
     int dim_tmp = weights_size_ / sizeof(T);
     std::vector<int> dim_w = {dim_tmp, 1, 1};
     weight_desc_.descriptor<T>(layout, dim_w);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
paddle/phi/kernels/funcs/softmax.cu 修改 phi::backends::gpu::DataLayout 为 phi::DataLayout 
GPUDNNDataLayout 为 phi 命名空间下的 DataLayout
 phi::backends::gpu::DataLayout 注释为不使用
<img width="835" height="168" alt="image" src="https://github.com/user-attachments/assets/4c7149bb-5315-457e-a2ff-5c85b6ebde44" />

DataLayout::kNHWC 修改为 DataLayout::NHWC