### PR TITLE
fix DataLayout in pool_kernel.cu [fluid_ops]

### DIFF
--- a/paddle/phi/backends/gpu/cuda/cudnn_helper.h
+++ b/paddle/phi/backends/gpu/cuda/cudnn_helper.h
@@ -209,6 +209,22 @@ inline cudnnTensorFormat_t GetCudnnTensorFormat(
   return CUDNN_TENSOR_NCHW;
 }
 
+inline cudnnTensorFormat_t GetCudnnTensorFormat(const phi::DataLayout& order) {
+  switch (order) {
+    case phi::DataLayout::NHWC:
+      return CUDNN_TENSOR_NHWC;
+    case phi::DataLayout::NCHW:
+      return CUDNN_TENSOR_NCHW;
+    case phi::DataLayout::NCDHW:
+      return CUDNN_TENSOR_NCHW;  // NOTE: cudnn treat NdTensor as the same
+    case phi::DataLayout::NDHWC:
+      return CUDNN_TENSOR_NHWC;
+    default:
+      PADDLE_THROW(common::errors::Unimplemented(
+          "CUDNN has no equivalent dataLayout for input order."));
+  }
+  return CUDNN_TENSOR_NCHW;
+}
 class ScopedTensorDescriptor {
  public:
   ScopedTensorDescriptor() {
@@ -267,6 +283,14 @@ class ScopedTensorDescriptor {
 
   template <typename T>
   inline cudnnTensorDescriptor_t descriptor(const DataLayout& order,
+                                            const std::vector<int>& dims,
+                                            const int groups = 1) {
+    return descriptor(
+        GetCudnnTensorFormat(order), CudnnDataType<T>::type, dims, groups);
+  }
+
+  template <typename T>
+  inline cudnnTensorDescriptor_t descriptor(const phi::DataLayout& order,
                                             const std::vector<int>& dims,
                                             const int groups = 1) {
     return descriptor(
@@ -456,6 +480,14 @@ class ScopedFilterDescriptor {
 
   template <typename T>
   inline cudnnFilterDescriptor_t descriptor(const DataLayout& order,
+                                            const std::vector<int>& kernel,
+                                            const int groups = 1) {
+    return descriptor(
+        GetCudnnTensorFormat(order), CudnnDataType<T>::type, kernel, groups);
+  }
+
+  template <typename T>
+  inline cudnnFilterDescriptor_t descriptor(const phi::DataLayout& order,
                                             const std::vector<int>& kernel,
                                             const int groups = 1) {
     return descriptor(

--- a/paddle/phi/backends/gpu/rocm/miopen_helper.h
+++ b/paddle/phi/backends/gpu/rocm/miopen_helper.h
@@ -199,6 +199,22 @@ inline miopenTensorFormat_t GetCudnnTensorFormat(const DataLayout& order) {
   return MIOPEN_TENSOR_NCHW;
 }
 
+inline miopenTensorFormat_t GetCudnnTensorFormat(const phi::DataLayout& order) {
+  switch (order) {
+    case phi::DataLayout::NHWC:
+      return MIOPEN_TENSOR_NHWC;
+    case phi::DataLayout::NCHW:
+      return MIOPEN_TENSOR_NCHW;
+    case phi::DataLayout::NCDHW:
+      return MIOPEN_TENSOR_NCHW;
+    case phi::DataLayout::NDHWC:
+      return MIOPEN_TENSOR_NHWC;
+    default:
+      PADDLE_THROW(common::errors::Unimplemented(
+          "MIOPEN has no equivalent dataLayout for input order."));
+  }
+  return MIOPEN_TENSOR_NCHW;
+}
 class ScopedTensorDescriptor {
  public:
   ScopedTensorDescriptor() {
@@ -252,6 +268,14 @@ class ScopedTensorDescriptor {
 
   template <typename T>
   inline miopenTensorDescriptor_t descriptor(const DataLayout& order,
+                                             const std::vector<int>& dims,
+                                             const int groups = 1) {
+    return descriptor(
+        GetCudnnTensorFormat(order), CudnnDataType<T>::type, dims, groups);
+  }
+
+  template <typename T>
+  inline miopenTensorDescriptor_t descriptor(const phi::DataLayout& order,
                                              const std::vector<int>& dims,
                                              const int groups = 1) {
     return descriptor(
@@ -405,6 +429,14 @@ class ScopedFilterDescriptor {
 
   template <typename T>
   inline miopenTensorDescriptor_t descriptor(const DataLayout& order,
+                                             const std::vector<int>& kernel,
+                                             const int groups = 1) {
+    return descriptor(
+        GetCudnnTensorFormat(order), CudnnDataType<T>::type, kernel, groups);
+  }
+
+  template <typename T>
+  inline miopenTensorDescriptor_t descriptor(const phi::DataLayout& order,
                                              const std::vector<int>& kernel,
                                              const int groups = 1) {
     return descriptor(

--- a/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
@@ -746,7 +746,7 @@ static void SoftmaxWithCrossEntropySoftLabel(const GPUContext& dev_ctx,
     int kWarpSize = (kDimCeil < 32) ? kDimCeil : 32;
     int batches_per_warp = (kDimCeil <= 128) ? 2 : 1;
 
-    // use 128 threads per block to maximimize gpu utilization
+    // use 128 threads per block to maximize gpu utilization
     constexpr int threads_per_block = 128;
     int warps_per_block = (threads_per_block / kWarpSize);
     int batches_per_block = warps_per_block * batches_per_warp;

--- a/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
@@ -769,7 +769,7 @@ static void SoftmaxWithCrossEntropySoftLabel(const GPUContext& dev_ctx,
   } else {
     ScopedTensorDescriptor desc;
     std::vector<int> tensor_dims = {N, dim, D, 1};
-    GPUDNNDataLayout layout = GPUDNNDataLayout::kNCHW;
+    DataLayout layout = DataLayout::kNCHW;
 #ifdef PADDLE_WITH_HIP
     miopenTensorDescriptor_t descp = desc.descriptor<T>(layout, tensor_dims);
     auto handle = dev_ctx.cudnn_handle();
@@ -1195,7 +1195,7 @@ static void SoftmaxWithCrossEntropyHardLabel(const GPUContext& dev_ctx,
     auto* softmax_data = softmax->data<T>();
     ScopedTensorDescriptor desc;
     std::vector<int> tensor_dims = {N, dim, D, 1};
-    GPUDNNDataLayout layout = GPUDNNDataLayout::kNCHW;
+    DataLayout layout = DataLayout::kNCHW;
 
 #ifdef PADDLE_WITH_HIP
     miopenTensorDescriptor_t descp = desc.descriptor<T>(layout, tensor_dims);

--- a/paddle/phi/kernels/gpudnn/conv_gpudnn_base.h
+++ b/paddle/phi/kernels/gpudnn/conv_gpudnn_base.h
@@ -31,7 +31,7 @@ limitations under the License. */
 
 namespace phi {
 
-using GPUDNNDataLayout = phi::backends::gpu::DataLayout;
+using GPUDNNDataLayout = phi::DataLayout;
 
 template <typename T>
 using ScalingParamType =

--- a/paddle/phi/kernels/gpudnn/conv_gpudnn_base.h
+++ b/paddle/phi/kernels/gpudnn/conv_gpudnn_base.h
@@ -171,8 +171,8 @@ static inline void GetNCDHW(const phi::DDim& dims,
                             int* H,
                             int* W) {
   *N = dims[0];
-  *C = layout == DataLayout::kNCHW ? dims[1] : dims[dims.size() - 1];
-  int i = layout == DataLayout::kNCHW ? 0 : 1;
+  *C = layout == DataLayout::NCHW ? dims[1] : dims[dims.size() - 1];
+  int i = layout == DataLayout::NCHW ? 0 : 1;
   if (dims.size() == 5) {
     *D = dims[2 - i];
     *H = dims[3 - i];

--- a/paddle/phi/kernels/gpudnn/conv_gpudnn_base.h
+++ b/paddle/phi/kernels/gpudnn/conv_gpudnn_base.h
@@ -31,8 +31,6 @@ limitations under the License. */
 
 namespace phi {
 
-using GPUDNNDataLayout = phi::DataLayout;
-
 template <typename T>
 using ScalingParamType =
     typename phi::backends::gpu::CudnnDataType<T>::ScalingParamType;
@@ -121,7 +119,7 @@ struct ConvArgsBase {
   int group;
 
   // data format
-  GPUDNNDataLayout data_layout;
+  DataLayout data_layout;
 
   ConvArgsBase(const HandleT& h,
                const phi::DenseTensor* x,
@@ -132,7 +130,7 @@ struct ConvArgsBase {
                const std::vector<int> d,
                DataT dtype,
                int g,
-               GPUDNNDataLayout layout)
+               DataLayout layout)
       : handle(h),
         x(x),
         w(w),
@@ -166,15 +164,15 @@ struct ConvArgsBase {
 };
 
 static inline void GetNCDHW(const phi::DDim& dims,
-                            const GPUDNNDataLayout& layout,
+                            const DataLayout& layout,
                             int* N,
                             int* C,
                             int* D,
                             int* H,
                             int* W) {
   *N = dims[0];
-  *C = layout == GPUDNNDataLayout::kNCHW ? dims[1] : dims[dims.size() - 1];
-  int i = layout == GPUDNNDataLayout::kNCHW ? 0 : 1;
+  *C = layout == DataLayout::kNCHW ? dims[1] : dims[dims.size() - 1];
+  int i = layout == DataLayout::kNCHW ? 0 : 1;
   if (dims.size() == 5) {
     *D = dims[2 - i];
     *H = dims[3 - i];

--- a/paddle/phi/kernels/gpudnn/conv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_grad_kernel.cu
@@ -41,7 +41,6 @@
 #endif
 
 namespace phi {
-using GPUDNNDataLayout = phi::DataLayout;
 template <typename T, typename Context>
 void ConvCudnnGradKernelImplV7(
     const DenseTensor* transformed_input,
@@ -53,8 +52,8 @@ void ConvCudnnGradKernelImplV7(
     const std::vector<int>& strides,
     const std::vector<int>& padding_common,
     const std::vector<int>& dilations,
-    GPUDNNDataLayout compute_format,
-    GPUDNNDataLayout layout,
+    DataLayout compute_format,
+    DataLayout layout,
     bool use_addto,
     bool exhaustive_search,
     bool deterministic,
@@ -97,16 +96,16 @@ void ConvCudnnGradKernelImplV7(
 
   int i_n, i_c, i_d, i_h, i_w;
   int o_n, o_c, o_d, o_h, o_w;
-  if (compute_format == GPUDNNDataLayout::kNHWC) {
+  if (compute_format == DataLayout::kNHWC) {
     GetNCDHW(transformed_input->dims(),
-             GPUDNNDataLayout::kNHWC,
+             DataLayout::kNHWC,
              &i_n,
              &i_c,
              &i_d,
              &i_h,
              &i_w);
     GetNCDHW(transformed_output_grad_channel->dims(),
-             GPUDNNDataLayout::kNHWC,
+             DataLayout::kNHWC,
              &o_n,
              &o_c,
              &o_d,
@@ -114,14 +113,14 @@ void ConvCudnnGradKernelImplV7(
              &o_w);
   } else {
     GetNCDHW(transformed_input->dims(),
-             GPUDNNDataLayout::kNCHW,
+             DataLayout::kNCHW,
              &i_n,
              &i_c,
              &i_d,
              &i_h,
              &i_w);
     GetNCDHW(transformed_output_grad_channel->dims(),
-             GPUDNNDataLayout::kNCHW,
+             DataLayout::kNCHW,
              &o_n,
              &o_c,
              &o_d,
@@ -348,7 +347,7 @@ void ConvCudnnGradKernelImplV8(
     const std::vector<int>& strides,
     const std::vector<int>& padding_common,
     const std::vector<int>& dilations,
-    GPUDNNDataLayout layout,
+    DataLayout layout,
     bool use_addto,
     bool exhaustive_search,
     bool deterministic,
@@ -466,7 +465,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
 
 #ifdef PADDLE_WITH_HIP
   // HIP MIOPEN ONLY SUPPORT NCHW format
-  auto compute_format = GPUDNNDataLayout::kNCHW;
+  auto compute_format = DataLayout::kNCHW;
 #else
 #if CUDNN_VERSION_MIN(8, 1, 0)
   const bool compute_in_nhwc =
@@ -476,13 +475,12 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
   const bool compute_in_nhwc =
       dtype == CUDNN_DATA_HALF && IsVoltaOrLater(dev_ctx);
 #endif
-  auto compute_format = compute_in_nhwc && channel_last
-                            ? GPUDNNDataLayout::kNHWC
-                            : GPUDNNDataLayout::kNCHW;
+  auto compute_format =
+      compute_in_nhwc && channel_last ? DataLayout::kNHWC : DataLayout::kNCHW;
 #endif
   VLOG(3) << "Compute ConvGradOp with cuDNN:"
           << " data_format=" << data_format << " compute_format="
-          << (compute_format == GPUDNNDataLayout::kNHWC ? "NHWC" : "NCHW");
+          << (compute_format == DataLayout::kNHWC ? "NHWC" : "NCHW");
 
   // transform Tensor
   DenseTensor transformed_input_channel(input.type());
@@ -491,7 +489,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
   DenseTensor transformed_filter_channel(filter.type());
   DenseTensor transformed_filter_grad_channel(filter.type());
 
-  if (channel_last && compute_format == GPUDNNDataLayout::kNCHW) {
+  if (channel_last && compute_format == DataLayout::kNCHW) {
     VLOG(3) << "Transform input, output_grad, input_grad and tensor from "
                "NHWC to NCHW.";
     ResizeToChannelFirst<Context, T>(
@@ -522,7 +520,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
     }
   }
 
-  if (compute_format == GPUDNNDataLayout::kNHWC) {
+  if (compute_format == DataLayout::kNHWC) {
     VLOG(3) << "Transform filter and filter_grad tensor from NCHW to NHWC.";
     ResizeToChannelLast<Context, T>(
         dev_ctx, &filter, &transformed_filter_channel);
@@ -545,7 +543,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
   auto filter_dims = transformed_filter_channel.dims();
   DDim in_data_dims;
   DDim filter_data_dims;
-  if (compute_format == GPUDNNDataLayout::kNCHW) {
+  if (compute_format == DataLayout::kNCHW) {
     in_data_dims = slice_ddim(in_dims, 2, in_dims.size());
     filter_data_dims = slice_ddim(filter_dims, 2, filter_dims.size());
   } else {
@@ -570,7 +568,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
     std::vector<int> padding_diff(data_dim);
     std::vector<int> new_input_shape_vec(data_dim + 2);
     new_input_shape_vec[0] = transformed_input_channel.dims()[0];
-    if (compute_format == GPUDNNDataLayout::kNCHW) {
+    if (compute_format == DataLayout::kNCHW) {
       new_input_shape_vec[1] = transformed_input_channel.dims()[1];
     } else {
       new_input_shape_vec[data_dim + 1] =
@@ -580,14 +578,14 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
     for (size_t i = 0; i < data_dim; ++i) {
       padding_diff[i] = std::abs(paddings[2 * i] - paddings[2 * i + 1]);
       padding_common[i] = std::min(paddings[2 * i], paddings[2 * i + 1]);
-      if (compute_format == GPUDNNDataLayout::kNCHW) {
+      if (compute_format == DataLayout::kNCHW) {
         new_input_shape_vec[i + 2] =
             transformed_input_channel.dims()[i + 2] + padding_diff[i];
       } else {
         new_input_shape_vec[i + 1] =
             transformed_input_channel.dims()[i + 1] + padding_diff[i];
       }
-      if (compute_format == GPUDNNDataLayout::kNCHW) {
+      if (compute_format == DataLayout::kNCHW) {
         input_pad[2 * i + 4] = paddings[2 * i] - padding_common[i];
         input_pad[2 * i + 4 + 1] = paddings[2 * i + 1] - padding_common[i];
       } else {
@@ -641,13 +639,11 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
       }
     }
   }
-  GPUDNNDataLayout layout = compute_format == GPUDNNDataLayout::kNHWC
-                                ? GPUDNNDataLayout::kNHWC
-                                : GPUDNNDataLayout::kNCHW;
+  DataLayout layout = compute_format == DataLayout::kNHWC ? DataLayout::kNHWC
+                                                          : DataLayout::kNCHW;
   if (transformed_input.dims().size() == 5) {
-    layout = compute_format == GPUDNNDataLayout::kNHWC
-                 ? GPUDNNDataLayout::kNDHWC
-                 : GPUDNNDataLayout::kNCDHW;
+    layout = compute_format == DataLayout::kNHWC ? DataLayout::kNDHWC
+                                                 : DataLayout::kNCDHW;
   }
   CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_input);
   CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_filter_channel);
@@ -735,14 +731,14 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
       }
     }
 
-    if (channel_last && compute_format == GPUDNNDataLayout::kNCHW) {
+    if (channel_last && compute_format == DataLayout::kNCHW) {
       TransToChannelLast<Context, T>(
           dev_ctx, &transformed_input_grad_channel, input_grad);
     }
   }
 
   if (filter_grad) {
-    if (compute_format == GPUDNNDataLayout::kNHWC) {
+    if (compute_format == DataLayout::kNHWC) {
       TransToChannelFirst<Context, T>(
           dev_ctx, &transformed_filter_grad_channel, filter_grad);
     }
@@ -1004,8 +1000,7 @@ void ConvCudnnGradGradKernel(
   auto dtype = phi::backends::gpu::CudnnDataType<T>::type;
 
   auto handle = dev_ctx.cudnn_handle();
-  auto layout =
-      phi::backends::gpu::GetCudnnTensorFormat(GPUDNNDataLayout::kNCHW);
+  auto layout = phi::backends::gpu::GetCudnnTensorFormat(DataLayout::kNCHW);
 
   ConvArgs args1{handle,
                  &transformed_ddX,
@@ -1016,7 +1011,7 @@ void ConvCudnnGradGradKernel(
                  dilations,
                  dtype,
                  groups,
-                 GPUDNNDataLayout::kNCHW};
+                 DataLayout::kNCHW};
   ConvArgs args2{handle,
                  &transformed_X,
                  ddW,
@@ -1026,7 +1021,7 @@ void ConvCudnnGradGradKernel(
                  dilations,
                  dtype,
                  groups,
-                 GPUDNNDataLayout::kNCHW};
+                 DataLayout::kNCHW};
   ConvArgs args3{handle,
                  &transformed_ddX,
                  dW,
@@ -1036,7 +1031,7 @@ void ConvCudnnGradGradKernel(
                  dilations,
                  dtype,
                  groups,
-                 GPUDNNDataLayout::kNCHW};
+                 DataLayout::kNCHW};
   ConvArgs args4{handle,
                  &transformed_dX,
                  ddW,
@@ -1046,7 +1041,7 @@ void ConvCudnnGradGradKernel(
                  dilations,
                  dtype,
                  groups,
-                 GPUDNNDataLayout::kNCHW};
+                 DataLayout::kNCHW};
 
 #ifdef PADDLE_WITH_HIP
   SearchResult<miopenConvFwdAlgorithm_t> fwd_result1;

--- a/paddle/phi/kernels/gpudnn/conv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_grad_kernel.cu
@@ -96,16 +96,16 @@ void ConvCudnnGradKernelImplV7(
 
   int i_n, i_c, i_d, i_h, i_w;
   int o_n, o_c, o_d, o_h, o_w;
-  if (compute_format == DataLayout::kNHWC) {
+  if (compute_format == DataLayout::NHWC) {
     GetNCDHW(transformed_input->dims(),
-             DataLayout::kNHWC,
+             DataLayout::NHWC,
              &i_n,
              &i_c,
              &i_d,
              &i_h,
              &i_w);
     GetNCDHW(transformed_output_grad_channel->dims(),
-             DataLayout::kNHWC,
+             DataLayout::NHWC,
              &o_n,
              &o_c,
              &o_d,
@@ -113,14 +113,14 @@ void ConvCudnnGradKernelImplV7(
              &o_w);
   } else {
     GetNCDHW(transformed_input->dims(),
-             DataLayout::kNCHW,
+             DataLayout::NCHW,
              &i_n,
              &i_c,
              &i_d,
              &i_h,
              &i_w);
     GetNCDHW(transformed_output_grad_channel->dims(),
-             DataLayout::kNCHW,
+             DataLayout::NCHW,
              &o_n,
              &o_c,
              &o_d,
@@ -465,7 +465,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
 
 #ifdef PADDLE_WITH_HIP
   // HIP MIOPEN ONLY SUPPORT NCHW format
-  auto compute_format = DataLayout::kNCHW;
+  auto compute_format = DataLayout::NCHW;
 #else
 #if CUDNN_VERSION_MIN(8, 1, 0)
   const bool compute_in_nhwc =
@@ -476,11 +476,11 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
       dtype == CUDNN_DATA_HALF && IsVoltaOrLater(dev_ctx);
 #endif
   auto compute_format =
-      compute_in_nhwc && channel_last ? DataLayout::kNHWC : DataLayout::kNCHW;
+      compute_in_nhwc && channel_last ? DataLayout::NHWC : DataLayout::NCHW;
 #endif
   VLOG(3) << "Compute ConvGradOp with cuDNN:"
           << " data_format=" << data_format << " compute_format="
-          << (compute_format == DataLayout::kNHWC ? "NHWC" : "NCHW");
+          << (compute_format == DataLayout::NHWC ? "NHWC" : "NCHW");
 
   // transform Tensor
   DenseTensor transformed_input_channel(input.type());
@@ -489,7 +489,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
   DenseTensor transformed_filter_channel(filter.type());
   DenseTensor transformed_filter_grad_channel(filter.type());
 
-  if (channel_last && compute_format == DataLayout::kNCHW) {
+  if (channel_last && compute_format == DataLayout::NCHW) {
     VLOG(3) << "Transform input, output_grad, input_grad and tensor from "
                "NHWC to NCHW.";
     ResizeToChannelFirst<Context, T>(
@@ -520,7 +520,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
     }
   }
 
-  if (compute_format == DataLayout::kNHWC) {
+  if (compute_format == DataLayout::NHWC) {
     VLOG(3) << "Transform filter and filter_grad tensor from NCHW to NHWC.";
     ResizeToChannelLast<Context, T>(
         dev_ctx, &filter, &transformed_filter_channel);
@@ -543,7 +543,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
   auto filter_dims = transformed_filter_channel.dims();
   DDim in_data_dims;
   DDim filter_data_dims;
-  if (compute_format == DataLayout::kNCHW) {
+  if (compute_format == DataLayout::NCHW) {
     in_data_dims = slice_ddim(in_dims, 2, in_dims.size());
     filter_data_dims = slice_ddim(filter_dims, 2, filter_dims.size());
   } else {
@@ -568,7 +568,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
     std::vector<int> padding_diff(data_dim);
     std::vector<int> new_input_shape_vec(data_dim + 2);
     new_input_shape_vec[0] = transformed_input_channel.dims()[0];
-    if (compute_format == DataLayout::kNCHW) {
+    if (compute_format == DataLayout::NCHW) {
       new_input_shape_vec[1] = transformed_input_channel.dims()[1];
     } else {
       new_input_shape_vec[data_dim + 1] =
@@ -578,14 +578,14 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
     for (size_t i = 0; i < data_dim; ++i) {
       padding_diff[i] = std::abs(paddings[2 * i] - paddings[2 * i + 1]);
       padding_common[i] = std::min(paddings[2 * i], paddings[2 * i + 1]);
-      if (compute_format == DataLayout::kNCHW) {
+      if (compute_format == DataLayout::NCHW) {
         new_input_shape_vec[i + 2] =
             transformed_input_channel.dims()[i + 2] + padding_diff[i];
       } else {
         new_input_shape_vec[i + 1] =
             transformed_input_channel.dims()[i + 1] + padding_diff[i];
       }
-      if (compute_format == DataLayout::kNCHW) {
+      if (compute_format == DataLayout::NCHW) {
         input_pad[2 * i + 4] = paddings[2 * i] - padding_common[i];
         input_pad[2 * i + 4 + 1] = paddings[2 * i + 1] - padding_common[i];
       } else {
@@ -639,11 +639,11 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
       }
     }
   }
-  DataLayout layout = compute_format == DataLayout::kNHWC ? DataLayout::kNHWC
-                                                          : DataLayout::kNCHW;
+  DataLayout layout =
+      compute_format == DataLayout::NHWC ? DataLayout::NHWC : DataLayout::NCHW;
   if (transformed_input.dims().size() == 5) {
-    layout = compute_format == DataLayout::kNHWC ? DataLayout::kNDHWC
-                                                 : DataLayout::kNCDHW;
+    layout = compute_format == DataLayout::NHWC ? DataLayout::NDHWC
+                                                : DataLayout::NCDHW;
   }
   CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_input);
   CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_filter_channel);
@@ -731,14 +731,14 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
       }
     }
 
-    if (channel_last && compute_format == DataLayout::kNCHW) {
+    if (channel_last && compute_format == DataLayout::NCHW) {
       TransToChannelLast<Context, T>(
           dev_ctx, &transformed_input_grad_channel, input_grad);
     }
   }
 
   if (filter_grad) {
-    if (compute_format == DataLayout::kNHWC) {
+    if (compute_format == DataLayout::NHWC) {
       TransToChannelFirst<Context, T>(
           dev_ctx, &transformed_filter_grad_channel, filter_grad);
     }
@@ -1000,7 +1000,7 @@ void ConvCudnnGradGradKernel(
   auto dtype = phi::backends::gpu::CudnnDataType<T>::type;
 
   auto handle = dev_ctx.cudnn_handle();
-  auto layout = phi::backends::gpu::GetCudnnTensorFormat(DataLayout::kNCHW);
+  auto layout = phi::backends::gpu::GetCudnnTensorFormat(DataLayout::NCHW);
 
   ConvArgs args1{handle,
                  &transformed_ddX,
@@ -1011,7 +1011,7 @@ void ConvCudnnGradGradKernel(
                  dilations,
                  dtype,
                  groups,
-                 DataLayout::kNCHW};
+                 DataLayout::NCHW};
   ConvArgs args2{handle,
                  &transformed_X,
                  ddW,
@@ -1021,7 +1021,7 @@ void ConvCudnnGradGradKernel(
                  dilations,
                  dtype,
                  groups,
-                 DataLayout::kNCHW};
+                 DataLayout::NCHW};
   ConvArgs args3{handle,
                  &transformed_ddX,
                  dW,
@@ -1031,7 +1031,7 @@ void ConvCudnnGradGradKernel(
                  dilations,
                  dtype,
                  groups,
-                 DataLayout::kNCHW};
+                 DataLayout::NCHW};
   ConvArgs args4{handle,
                  &transformed_dX,
                  ddW,
@@ -1041,7 +1041,7 @@ void ConvCudnnGradGradKernel(
                  dilations,
                  dtype,
                  groups,
-                 DataLayout::kNCHW};
+                 DataLayout::NCHW};
 
 #ifdef PADDLE_WITH_HIP
   SearchResult<miopenConvFwdAlgorithm_t> fwd_result1;
@@ -1167,11 +1167,11 @@ void ConvCudnnGradGradKernel(
 
   int i_n, i_c, i_d, i_h, i_w;
   GetNCDHW(
-      transformed_X.dims(), DataLayout::kNCHW, &i_n, &i_c, &i_d, &i_h, &i_w);
+      transformed_X.dims(), DataLayout::NCHW, &i_n, &i_c, &i_d, &i_h, &i_w);
 
   int o_n, o_c, o_d, o_h, o_w;
   GetNCDHW(transformed_dO_channel.dims(),
-           DataLayout::kNCHW,
+           DataLayout::NCHW,
            &o_n,
            &o_c,
            &o_d,

--- a/paddle/phi/kernels/gpudnn/conv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_grad_kernel.cu
@@ -41,7 +41,7 @@
 #endif
 
 namespace phi {
-
+using GPUDNNDataLayout = phi::DataLayout;
 template <typename T, typename Context>
 void ConvCudnnGradKernelImplV7(
     const DenseTensor* transformed_input,
@@ -53,8 +53,8 @@ void ConvCudnnGradKernelImplV7(
     const std::vector<int>& strides,
     const std::vector<int>& padding_common,
     const std::vector<int>& dilations,
-    phi::backends::gpu::DataLayout compute_format,
-    phi::backends::gpu::DataLayout layout,
+    GPUDNNDataLayout compute_format,
+    GPUDNNDataLayout layout,
     bool use_addto,
     bool exhaustive_search,
     bool deterministic,
@@ -97,16 +97,16 @@ void ConvCudnnGradKernelImplV7(
 
   int i_n, i_c, i_d, i_h, i_w;
   int o_n, o_c, o_d, o_h, o_w;
-  if (compute_format == phi::backends::gpu::DataLayout::kNHWC) {
+  if (compute_format == GPUDNNDataLayout::kNHWC) {
     GetNCDHW(transformed_input->dims(),
-             phi::backends::gpu::DataLayout::kNHWC,
+             GPUDNNDataLayout::kNHWC,
              &i_n,
              &i_c,
              &i_d,
              &i_h,
              &i_w);
     GetNCDHW(transformed_output_grad_channel->dims(),
-             phi::backends::gpu::DataLayout::kNHWC,
+             GPUDNNDataLayout::kNHWC,
              &o_n,
              &o_c,
              &o_d,
@@ -114,14 +114,14 @@ void ConvCudnnGradKernelImplV7(
              &o_w);
   } else {
     GetNCDHW(transformed_input->dims(),
-             phi::backends::gpu::DataLayout::kNCHW,
+             GPUDNNDataLayout::kNCHW,
              &i_n,
              &i_c,
              &i_d,
              &i_h,
              &i_w);
     GetNCDHW(transformed_output_grad_channel->dims(),
-             phi::backends::gpu::DataLayout::kNCHW,
+             GPUDNNDataLayout::kNCHW,
              &o_n,
              &o_c,
              &o_d,
@@ -348,7 +348,7 @@ void ConvCudnnGradKernelImplV8(
     const std::vector<int>& strides,
     const std::vector<int>& padding_common,
     const std::vector<int>& dilations,
-    phi::backends::gpu::DataLayout layout,
+    GPUDNNDataLayout layout,
     bool use_addto,
     bool exhaustive_search,
     bool deterministic,
@@ -466,7 +466,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
 
 #ifdef PADDLE_WITH_HIP
   // HIP MIOPEN ONLY SUPPORT NCHW format
-  auto compute_format = phi::backends::gpu::DataLayout::kNCHW;
+  auto compute_format = GPUDNNDataLayout::kNCHW;
 #else
 #if CUDNN_VERSION_MIN(8, 1, 0)
   const bool compute_in_nhwc =
@@ -477,13 +477,12 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
       dtype == CUDNN_DATA_HALF && IsVoltaOrLater(dev_ctx);
 #endif
   auto compute_format = compute_in_nhwc && channel_last
-                            ? phi::backends::gpu::DataLayout::kNHWC
-                            : phi::backends::gpu::DataLayout::kNCHW;
+                            ? GPUDNNDataLayout::kNHWC
+                            : GPUDNNDataLayout::kNCHW;
 #endif
   VLOG(3) << "Compute ConvGradOp with cuDNN:"
           << " data_format=" << data_format << " compute_format="
-          << (compute_format == phi::backends::gpu::DataLayout::kNHWC ? "NHWC"
-                                                                      : "NCHW");
+          << (compute_format == GPUDNNDataLayout::kNHWC ? "NHWC" : "NCHW");
 
   // transform Tensor
   DenseTensor transformed_input_channel(input.type());
@@ -492,7 +491,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
   DenseTensor transformed_filter_channel(filter.type());
   DenseTensor transformed_filter_grad_channel(filter.type());
 
-  if (channel_last && compute_format == phi::backends::gpu::DataLayout::kNCHW) {
+  if (channel_last && compute_format == GPUDNNDataLayout::kNCHW) {
     VLOG(3) << "Transform input, output_grad, input_grad and tensor from "
                "NHWC to NCHW.";
     ResizeToChannelFirst<Context, T>(
@@ -523,7 +522,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
     }
   }
 
-  if (compute_format == phi::backends::gpu::DataLayout::kNHWC) {
+  if (compute_format == GPUDNNDataLayout::kNHWC) {
     VLOG(3) << "Transform filter and filter_grad tensor from NCHW to NHWC.";
     ResizeToChannelLast<Context, T>(
         dev_ctx, &filter, &transformed_filter_channel);
@@ -546,7 +545,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
   auto filter_dims = transformed_filter_channel.dims();
   DDim in_data_dims;
   DDim filter_data_dims;
-  if (compute_format == phi::backends::gpu::DataLayout::kNCHW) {
+  if (compute_format == GPUDNNDataLayout::kNCHW) {
     in_data_dims = slice_ddim(in_dims, 2, in_dims.size());
     filter_data_dims = slice_ddim(filter_dims, 2, filter_dims.size());
   } else {
@@ -571,7 +570,7 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
     std::vector<int> padding_diff(data_dim);
     std::vector<int> new_input_shape_vec(data_dim + 2);
     new_input_shape_vec[0] = transformed_input_channel.dims()[0];
-    if (compute_format == phi::backends::gpu::DataLayout::kNCHW) {
+    if (compute_format == GPUDNNDataLayout::kNCHW) {
       new_input_shape_vec[1] = transformed_input_channel.dims()[1];
     } else {
       new_input_shape_vec[data_dim + 1] =
@@ -581,14 +580,14 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
     for (size_t i = 0; i < data_dim; ++i) {
       padding_diff[i] = std::abs(paddings[2 * i] - paddings[2 * i + 1]);
       padding_common[i] = std::min(paddings[2 * i], paddings[2 * i + 1]);
-      if (compute_format == phi::backends::gpu::DataLayout::kNCHW) {
+      if (compute_format == GPUDNNDataLayout::kNCHW) {
         new_input_shape_vec[i + 2] =
             transformed_input_channel.dims()[i + 2] + padding_diff[i];
       } else {
         new_input_shape_vec[i + 1] =
             transformed_input_channel.dims()[i + 1] + padding_diff[i];
       }
-      if (compute_format == phi::backends::gpu::DataLayout::kNCHW) {
+      if (compute_format == GPUDNNDataLayout::kNCHW) {
         input_pad[2 * i + 4] = paddings[2 * i] - padding_common[i];
         input_pad[2 * i + 4 + 1] = paddings[2 * i + 1] - padding_common[i];
       } else {
@@ -642,14 +641,13 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
       }
     }
   }
-  phi::backends::gpu::DataLayout layout =
-      compute_format == phi::backends::gpu::DataLayout::kNHWC
-          ? phi::backends::gpu::DataLayout::kNHWC
-          : phi::backends::gpu::DataLayout::kNCHW;
+  GPUDNNDataLayout layout = compute_format == GPUDNNDataLayout::kNHWC
+                                ? GPUDNNDataLayout::kNHWC
+                                : GPUDNNDataLayout::kNCHW;
   if (transformed_input.dims().size() == 5) {
-    layout = compute_format == phi::backends::gpu::DataLayout::kNHWC
-                 ? phi::backends::gpu::DataLayout::kNDHWC
-                 : phi::backends::gpu::DataLayout::kNCDHW;
+    layout = compute_format == GPUDNNDataLayout::kNHWC
+                 ? GPUDNNDataLayout::kNDHWC
+                 : GPUDNNDataLayout::kNCDHW;
   }
   CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_input);
   CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_filter_channel);
@@ -737,15 +735,14 @@ void ConvCudnnGradKernel(const Context& dev_ctx,
       }
     }
 
-    if (channel_last &&
-        compute_format == phi::backends::gpu::DataLayout::kNCHW) {
+    if (channel_last && compute_format == GPUDNNDataLayout::kNCHW) {
       TransToChannelLast<Context, T>(
           dev_ctx, &transformed_input_grad_channel, input_grad);
     }
   }
 
   if (filter_grad) {
-    if (compute_format == phi::backends::gpu::DataLayout::kNHWC) {
+    if (compute_format == GPUDNNDataLayout::kNHWC) {
       TransToChannelFirst<Context, T>(
           dev_ctx, &transformed_filter_grad_channel, filter_grad);
     }
@@ -1007,8 +1004,8 @@ void ConvCudnnGradGradKernel(
   auto dtype = phi::backends::gpu::CudnnDataType<T>::type;
 
   auto handle = dev_ctx.cudnn_handle();
-  auto layout = phi::backends::gpu::GetCudnnTensorFormat(
-      phi::backends::gpu::DataLayout::kNCHW);
+  auto layout =
+      phi::backends::gpu::GetCudnnTensorFormat(GPUDNNDataLayout::kNCHW);
 
   ConvArgs args1{handle,
                  &transformed_ddX,
@@ -1019,7 +1016,7 @@ void ConvCudnnGradGradKernel(
                  dilations,
                  dtype,
                  groups,
-                 phi::backends::gpu::DataLayout::kNCHW};
+                 GPUDNNDataLayout::kNCHW};
   ConvArgs args2{handle,
                  &transformed_X,
                  ddW,
@@ -1029,7 +1026,7 @@ void ConvCudnnGradGradKernel(
                  dilations,
                  dtype,
                  groups,
-                 phi::backends::gpu::DataLayout::kNCHW};
+                 GPUDNNDataLayout::kNCHW};
   ConvArgs args3{handle,
                  &transformed_ddX,
                  dW,
@@ -1039,7 +1036,7 @@ void ConvCudnnGradGradKernel(
                  dilations,
                  dtype,
                  groups,
-                 phi::backends::gpu::DataLayout::kNCHW};
+                 GPUDNNDataLayout::kNCHW};
   ConvArgs args4{handle,
                  &transformed_dX,
                  ddW,
@@ -1049,7 +1046,7 @@ void ConvCudnnGradGradKernel(
                  dilations,
                  dtype,
                  groups,
-                 phi::backends::gpu::DataLayout::kNCHW};
+                 GPUDNNDataLayout::kNCHW};
 
 #ifdef PADDLE_WITH_HIP
   SearchResult<miopenConvFwdAlgorithm_t> fwd_result1;

--- a/paddle/phi/kernels/gpudnn/conv_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_kernel.cu
@@ -109,16 +109,16 @@ void ConvCudnnKernelImplV7(const DenseTensor* transformed_input,
   int i_n, i_c, i_d, i_h, i_w;
   int o_n, o_c, o_d, o_h, o_w;
 
-  if (compute_format == DataLayout::kNHWC) {
+  if (compute_format == DataLayout::NHWC) {
     GetNCDHW(transformed_input->dims(),
-             DataLayout::kNHWC,
+             DataLayout::NHWC,
              &i_n,
              &i_c,
              &i_d,
              &i_h,
              &i_w);
     GetNCDHW(transformed_output->dims(),
-             DataLayout::kNHWC,
+             DataLayout::NHWC,
              &o_n,
              &o_c,
              &o_d,
@@ -126,14 +126,14 @@ void ConvCudnnKernelImplV7(const DenseTensor* transformed_input,
              &o_w);
   } else {
     GetNCDHW(transformed_input->dims(),
-             DataLayout::kNCHW,
+             DataLayout::NCHW,
              &i_n,
              &i_c,
              &i_d,
              &i_h,
              &i_w);
     GetNCDHW(transformed_output->dims(),
-             DataLayout::kNCHW,
+             DataLayout::NCHW,
              &o_n,
              &o_c,
              &o_d,
@@ -340,7 +340,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
 
 #ifdef PADDLE_WITH_HIP
   // HIP MIOPEN ONLY SUPPORT NCHW format
-  auto compute_format = DataLayout::kNCHW;
+  auto compute_format = DataLayout::NCHW;
 #else
 #if CUDNN_VERSION_MIN(8, 1, 0)
   // Tensor Core introduced from Volta GPUs supports more faster conv op
@@ -357,18 +357,18 @@ void ConvCudnnKernel(const Context& dev_ctx,
   // We will only do data format conversion from NHWC to NCHW.
   // cudnn will convert NCHW to NHWC automatically on Tensor Core.
   auto compute_format =
-      compute_in_nhwc && channel_last ? DataLayout::kNHWC : DataLayout::kNCHW;
+      compute_in_nhwc && channel_last ? DataLayout::NHWC : DataLayout::NCHW;
 #endif
   VLOG(3) << "Compute ConvOp with cuDNN:"
           << " data_format=" << data_format << " compute_format="
-          << (compute_format == DataLayout::kNHWC ? "NHWC" : "NCHW");
+          << (compute_format == DataLayout::NHWC ? "NHWC" : "NCHW");
 
   // ------------ transformed tensor -----------
   DenseTensor transformed_input_channel(input.type());
   DenseTensor transformed_output(output->type());
   DenseTensor transformed_filter_channel(filter.type());
 
-  if (channel_last && compute_format == DataLayout::kNCHW) {
+  if (channel_last && compute_format == DataLayout::NCHW) {
     VLOG(3) << "Transform input tensor from NHWC to NCHW.";
     ResizeToChannelFirst<Context, T>(
         dev_ctx, &input, &transformed_input_channel);
@@ -381,8 +381,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
     transformed_input_channel.ShareDataWith(input);
     transformed_output.ShareDataWith(*output);
   }
-  if (compute_format == DataLayout::kNHWC &&
-      !FLAGS_manually_trans_conv_filter) {
+  if (compute_format == DataLayout::NHWC && !FLAGS_manually_trans_conv_filter) {
     VLOG(3) << "Transform filter tensor from NCHW to NHWC.";
     ResizeToChannelLast<Context, T>(
         dev_ctx, &filter, &transformed_filter_channel);
@@ -398,7 +397,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
   DDim in_data_dims;
   DDim filter_data_dims;
 
-  if (compute_format == DataLayout::kNCHW) {
+  if (compute_format == DataLayout::NCHW) {
     in_data_dims = slice_ddim(in_dims, 2, in_dims.size());
     filter_data_dims = slice_ddim(filter_dims, 2, filter_dims.size());
   } else {
@@ -420,7 +419,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
     std::vector<int> new_input_shape_vec(data_dim + 2);
     new_input_shape_vec[0] = transformed_input_channel.dims()[0];
 
-    if (compute_format == DataLayout::kNCHW) {
+    if (compute_format == DataLayout::NCHW) {
       new_input_shape_vec[1] = transformed_input_channel.dims()[1];
     } else {
       new_input_shape_vec[data_dim + 1] =
@@ -431,14 +430,14 @@ void ConvCudnnKernel(const Context& dev_ctx,
     for (size_t i = 0; i < data_dim; ++i) {
       padding_diff[i] = std::abs(paddings[2 * i] - paddings[2 * i + 1]);
       padding_common[i] = std::min(paddings[2 * i], paddings[2 * i + 1]);
-      if (compute_format == DataLayout::kNCHW) {
+      if (compute_format == DataLayout::NCHW) {
         new_input_shape_vec[i + 2] =
             transformed_input_channel.dims()[i + 2] + padding_diff[i];
       } else {
         new_input_shape_vec[i + 1] =
             transformed_input_channel.dims()[i + 1] + padding_diff[i];
       }
-      if (compute_format == DataLayout::kNCHW) {
+      if (compute_format == DataLayout::NCHW) {
         input_pad[2 * i + 4] = paddings[2 * i] - padding_common[i];
         input_pad[2 * i + 4 + 1] = paddings[2 * i + 1] - padding_common[i];
       } else {
@@ -485,11 +484,11 @@ void ConvCudnnKernel(const Context& dev_ctx,
     }
   }
 
-  DataLayout layout = compute_format == DataLayout::kNHWC ? DataLayout::kNHWC
-                                                          : DataLayout::kNCHW;
+  DataLayout layout =
+      compute_format == DataLayout::NHWC ? DataLayout::NHWC : DataLayout::NCHW;
   if (transformed_input.dims().size() == 5) {
-    layout = compute_format == DataLayout::kNHWC ? DataLayout::kNDHWC
-                                                 : DataLayout::kNCDHW;
+    layout = compute_format == DataLayout::NHWC ? DataLayout::NDHWC
+                                                : DataLayout::NCDHW;
   }
 
   CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_input);
@@ -536,7 +535,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
                            &transformed_output);
 #endif
 
-  if (channel_last && compute_format == DataLayout::kNCHW) {
+  if (channel_last && compute_format == DataLayout::NCHW) {
     TransToChannelLast<Context, T>(dev_ctx, &transformed_output, output);
   }
 }

--- a/paddle/phi/kernels/gpudnn/conv_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_kernel.cu
@@ -47,7 +47,6 @@
 COMMON_DECLARE_bool(manually_trans_conv_filter);
 
 namespace phi {
-using GPUDNNDataLayout = phi::DataLayout;
 template <typename T, typename Context>
 void ConvCudnnKernelImplV7(const DenseTensor* transformed_input,
                            const DenseTensor* transformed_filter_channel,
@@ -55,8 +54,8 @@ void ConvCudnnKernelImplV7(const DenseTensor* transformed_input,
                            const std::vector<int>& strides,
                            const std::vector<int>& padding_common,
                            const std::vector<int>& dilations,
-                           GPUDNNDataLayout compute_format,
-                           GPUDNNDataLayout layout,
+                           DataLayout compute_format,
+                           DataLayout layout,
                            bool exhaustive_search,
                            bool deterministic,
                            int groups,
@@ -110,16 +109,16 @@ void ConvCudnnKernelImplV7(const DenseTensor* transformed_input,
   int i_n, i_c, i_d, i_h, i_w;
   int o_n, o_c, o_d, o_h, o_w;
 
-  if (compute_format == GPUDNNDataLayout::kNHWC) {
+  if (compute_format == DataLayout::kNHWC) {
     GetNCDHW(transformed_input->dims(),
-             GPUDNNDataLayout::kNHWC,
+             DataLayout::kNHWC,
              &i_n,
              &i_c,
              &i_d,
              &i_h,
              &i_w);
     GetNCDHW(transformed_output->dims(),
-             GPUDNNDataLayout::kNHWC,
+             DataLayout::kNHWC,
              &o_n,
              &o_c,
              &o_d,
@@ -127,14 +126,14 @@ void ConvCudnnKernelImplV7(const DenseTensor* transformed_input,
              &o_w);
   } else {
     GetNCDHW(transformed_input->dims(),
-             GPUDNNDataLayout::kNCHW,
+             DataLayout::kNCHW,
              &i_n,
              &i_c,
              &i_d,
              &i_h,
              &i_w);
     GetNCDHW(transformed_output->dims(),
-             GPUDNNDataLayout::kNCHW,
+             DataLayout::kNCHW,
              &o_n,
              &o_c,
              &o_d,
@@ -223,7 +222,7 @@ void ConvCudnnKernelImplV8(const DenseTensor* input_tensor,
                            const std::vector<int>& strides,
                            const std::vector<int>& padding_common,
                            const std::vector<int>& dilations,
-                           GPUDNNDataLayout layout,
+                           DataLayout layout,
                            bool exhaustive_search,
                            bool deterministic,
                            int groups,
@@ -341,7 +340,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
 
 #ifdef PADDLE_WITH_HIP
   // HIP MIOPEN ONLY SUPPORT NCHW format
-  auto compute_format = GPUDNNDataLayout::kNCHW;
+  auto compute_format = DataLayout::kNCHW;
 #else
 #if CUDNN_VERSION_MIN(8, 1, 0)
   // Tensor Core introduced from Volta GPUs supports more faster conv op
@@ -357,20 +356,19 @@ void ConvCudnnKernel(const Context& dev_ctx,
 #endif
   // We will only do data format conversion from NHWC to NCHW.
   // cudnn will convert NCHW to NHWC automatically on Tensor Core.
-  auto compute_format = compute_in_nhwc && channel_last
-                            ? GPUDNNDataLayout::kNHWC
-                            : GPUDNNDataLayout::kNCHW;
+  auto compute_format =
+      compute_in_nhwc && channel_last ? DataLayout::kNHWC : DataLayout::kNCHW;
 #endif
   VLOG(3) << "Compute ConvOp with cuDNN:"
           << " data_format=" << data_format << " compute_format="
-          << (compute_format == GPUDNNDataLayout::kNHWC ? "NHWC" : "NCHW");
+          << (compute_format == DataLayout::kNHWC ? "NHWC" : "NCHW");
 
   // ------------ transformed tensor -----------
   DenseTensor transformed_input_channel(input.type());
   DenseTensor transformed_output(output->type());
   DenseTensor transformed_filter_channel(filter.type());
 
-  if (channel_last && compute_format == GPUDNNDataLayout::kNCHW) {
+  if (channel_last && compute_format == DataLayout::kNCHW) {
     VLOG(3) << "Transform input tensor from NHWC to NCHW.";
     ResizeToChannelFirst<Context, T>(
         dev_ctx, &input, &transformed_input_channel);
@@ -383,7 +381,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
     transformed_input_channel.ShareDataWith(input);
     transformed_output.ShareDataWith(*output);
   }
-  if (compute_format == GPUDNNDataLayout::kNHWC &&
+  if (compute_format == DataLayout::kNHWC &&
       !FLAGS_manually_trans_conv_filter) {
     VLOG(3) << "Transform filter tensor from NCHW to NHWC.";
     ResizeToChannelLast<Context, T>(
@@ -400,7 +398,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
   DDim in_data_dims;
   DDim filter_data_dims;
 
-  if (compute_format == GPUDNNDataLayout::kNCHW) {
+  if (compute_format == DataLayout::kNCHW) {
     in_data_dims = slice_ddim(in_dims, 2, in_dims.size());
     filter_data_dims = slice_ddim(filter_dims, 2, filter_dims.size());
   } else {
@@ -422,7 +420,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
     std::vector<int> new_input_shape_vec(data_dim + 2);
     new_input_shape_vec[0] = transformed_input_channel.dims()[0];
 
-    if (compute_format == GPUDNNDataLayout::kNCHW) {
+    if (compute_format == DataLayout::kNCHW) {
       new_input_shape_vec[1] = transformed_input_channel.dims()[1];
     } else {
       new_input_shape_vec[data_dim + 1] =
@@ -433,14 +431,14 @@ void ConvCudnnKernel(const Context& dev_ctx,
     for (size_t i = 0; i < data_dim; ++i) {
       padding_diff[i] = std::abs(paddings[2 * i] - paddings[2 * i + 1]);
       padding_common[i] = std::min(paddings[2 * i], paddings[2 * i + 1]);
-      if (compute_format == GPUDNNDataLayout::kNCHW) {
+      if (compute_format == DataLayout::kNCHW) {
         new_input_shape_vec[i + 2] =
             transformed_input_channel.dims()[i + 2] + padding_diff[i];
       } else {
         new_input_shape_vec[i + 1] =
             transformed_input_channel.dims()[i + 1] + padding_diff[i];
       }
-      if (compute_format == GPUDNNDataLayout::kNCHW) {
+      if (compute_format == DataLayout::kNCHW) {
         input_pad[2 * i + 4] = paddings[2 * i] - padding_common[i];
         input_pad[2 * i + 4 + 1] = paddings[2 * i + 1] - padding_common[i];
       } else {
@@ -487,13 +485,11 @@ void ConvCudnnKernel(const Context& dev_ctx,
     }
   }
 
-  GPUDNNDataLayout layout = compute_format == GPUDNNDataLayout::kNHWC
-                                ? GPUDNNDataLayout::kNHWC
-                                : GPUDNNDataLayout::kNCHW;
+  DataLayout layout = compute_format == DataLayout::kNHWC ? DataLayout::kNHWC
+                                                          : DataLayout::kNCHW;
   if (transformed_input.dims().size() == 5) {
-    layout = compute_format == GPUDNNDataLayout::kNHWC
-                 ? GPUDNNDataLayout::kNDHWC
-                 : GPUDNNDataLayout::kNCDHW;
+    layout = compute_format == DataLayout::kNHWC ? DataLayout::kNDHWC
+                                                 : DataLayout::kNCDHW;
   }
 
   CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_input);
@@ -540,7 +536,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
                            &transformed_output);
 #endif
 
-  if (channel_last && compute_format == GPUDNNDataLayout::kNCHW) {
+  if (channel_last && compute_format == DataLayout::kNCHW) {
     TransToChannelLast<Context, T>(dev_ctx, &transformed_output, output);
   }
 }

--- a/paddle/phi/kernels/gpudnn/conv_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_kernel.cu
@@ -47,7 +47,7 @@
 COMMON_DECLARE_bool(manually_trans_conv_filter);
 
 namespace phi {
-
+using GPUDNNDataLayout = phi::DataLayout;
 template <typename T, typename Context>
 void ConvCudnnKernelImplV7(const DenseTensor* transformed_input,
                            const DenseTensor* transformed_filter_channel,
@@ -55,8 +55,8 @@ void ConvCudnnKernelImplV7(const DenseTensor* transformed_input,
                            const std::vector<int>& strides,
                            const std::vector<int>& padding_common,
                            const std::vector<int>& dilations,
-                           phi::backends::gpu::DataLayout compute_format,
-                           phi::backends::gpu::DataLayout layout,
+                           GPUDNNDataLayout compute_format,
+                           GPUDNNDataLayout layout,
                            bool exhaustive_search,
                            bool deterministic,
                            int groups,
@@ -110,16 +110,16 @@ void ConvCudnnKernelImplV7(const DenseTensor* transformed_input,
   int i_n, i_c, i_d, i_h, i_w;
   int o_n, o_c, o_d, o_h, o_w;
 
-  if (compute_format == phi::backends::gpu::DataLayout::kNHWC) {
+  if (compute_format == GPUDNNDataLayout::kNHWC) {
     GetNCDHW(transformed_input->dims(),
-             phi::backends::gpu::DataLayout::kNHWC,
+             GPUDNNDataLayout::kNHWC,
              &i_n,
              &i_c,
              &i_d,
              &i_h,
              &i_w);
     GetNCDHW(transformed_output->dims(),
-             phi::backends::gpu::DataLayout::kNHWC,
+             GPUDNNDataLayout::kNHWC,
              &o_n,
              &o_c,
              &o_d,
@@ -127,14 +127,14 @@ void ConvCudnnKernelImplV7(const DenseTensor* transformed_input,
              &o_w);
   } else {
     GetNCDHW(transformed_input->dims(),
-             phi::backends::gpu::DataLayout::kNCHW,
+             GPUDNNDataLayout::kNCHW,
              &i_n,
              &i_c,
              &i_d,
              &i_h,
              &i_w);
     GetNCDHW(transformed_output->dims(),
-             phi::backends::gpu::DataLayout::kNCHW,
+             GPUDNNDataLayout::kNCHW,
              &o_n,
              &o_c,
              &o_d,
@@ -223,7 +223,7 @@ void ConvCudnnKernelImplV8(const DenseTensor* input_tensor,
                            const std::vector<int>& strides,
                            const std::vector<int>& padding_common,
                            const std::vector<int>& dilations,
-                           phi::backends::gpu::DataLayout layout,
+                           GPUDNNDataLayout layout,
                            bool exhaustive_search,
                            bool deterministic,
                            int groups,
@@ -341,7 +341,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
 
 #ifdef PADDLE_WITH_HIP
   // HIP MIOPEN ONLY SUPPORT NCHW format
-  auto compute_format = phi::backends::gpu::DataLayout::kNCHW;
+  auto compute_format = GPUDNNDataLayout::kNCHW;
 #else
 #if CUDNN_VERSION_MIN(8, 1, 0)
   // Tensor Core introduced from Volta GPUs supports more faster conv op
@@ -358,20 +358,19 @@ void ConvCudnnKernel(const Context& dev_ctx,
   // We will only do data format conversion from NHWC to NCHW.
   // cudnn will convert NCHW to NHWC automatically on Tensor Core.
   auto compute_format = compute_in_nhwc && channel_last
-                            ? phi::backends::gpu::DataLayout::kNHWC
-                            : phi::backends::gpu::DataLayout::kNCHW;
+                            ? GPUDNNDataLayout::kNHWC
+                            : GPUDNNDataLayout::kNCHW;
 #endif
   VLOG(3) << "Compute ConvOp with cuDNN:"
           << " data_format=" << data_format << " compute_format="
-          << (compute_format == phi::backends::gpu::DataLayout::kNHWC ? "NHWC"
-                                                                      : "NCHW");
+          << (compute_format == GPUDNNDataLayout::kNHWC ? "NHWC" : "NCHW");
 
   // ------------ transformed tensor -----------
   DenseTensor transformed_input_channel(input.type());
   DenseTensor transformed_output(output->type());
   DenseTensor transformed_filter_channel(filter.type());
 
-  if (channel_last && compute_format == phi::backends::gpu::DataLayout::kNCHW) {
+  if (channel_last && compute_format == GPUDNNDataLayout::kNCHW) {
     VLOG(3) << "Transform input tensor from NHWC to NCHW.";
     ResizeToChannelFirst<Context, T>(
         dev_ctx, &input, &transformed_input_channel);
@@ -384,7 +383,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
     transformed_input_channel.ShareDataWith(input);
     transformed_output.ShareDataWith(*output);
   }
-  if (compute_format == phi::backends::gpu::DataLayout::kNHWC &&
+  if (compute_format == GPUDNNDataLayout::kNHWC &&
       !FLAGS_manually_trans_conv_filter) {
     VLOG(3) << "Transform filter tensor from NCHW to NHWC.";
     ResizeToChannelLast<Context, T>(
@@ -401,7 +400,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
   DDim in_data_dims;
   DDim filter_data_dims;
 
-  if (compute_format == phi::backends::gpu::DataLayout::kNCHW) {
+  if (compute_format == GPUDNNDataLayout::kNCHW) {
     in_data_dims = slice_ddim(in_dims, 2, in_dims.size());
     filter_data_dims = slice_ddim(filter_dims, 2, filter_dims.size());
   } else {
@@ -423,7 +422,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
     std::vector<int> new_input_shape_vec(data_dim + 2);
     new_input_shape_vec[0] = transformed_input_channel.dims()[0];
 
-    if (compute_format == phi::backends::gpu::DataLayout::kNCHW) {
+    if (compute_format == GPUDNNDataLayout::kNCHW) {
       new_input_shape_vec[1] = transformed_input_channel.dims()[1];
     } else {
       new_input_shape_vec[data_dim + 1] =
@@ -434,14 +433,14 @@ void ConvCudnnKernel(const Context& dev_ctx,
     for (size_t i = 0; i < data_dim; ++i) {
       padding_diff[i] = std::abs(paddings[2 * i] - paddings[2 * i + 1]);
       padding_common[i] = std::min(paddings[2 * i], paddings[2 * i + 1]);
-      if (compute_format == phi::backends::gpu::DataLayout::kNCHW) {
+      if (compute_format == GPUDNNDataLayout::kNCHW) {
         new_input_shape_vec[i + 2] =
             transformed_input_channel.dims()[i + 2] + padding_diff[i];
       } else {
         new_input_shape_vec[i + 1] =
             transformed_input_channel.dims()[i + 1] + padding_diff[i];
       }
-      if (compute_format == phi::backends::gpu::DataLayout::kNCHW) {
+      if (compute_format == GPUDNNDataLayout::kNCHW) {
         input_pad[2 * i + 4] = paddings[2 * i] - padding_common[i];
         input_pad[2 * i + 4 + 1] = paddings[2 * i + 1] - padding_common[i];
       } else {
@@ -488,14 +487,13 @@ void ConvCudnnKernel(const Context& dev_ctx,
     }
   }
 
-  phi::backends::gpu::DataLayout layout =
-      compute_format == phi::backends::gpu::DataLayout::kNHWC
-          ? phi::backends::gpu::DataLayout::kNHWC
-          : phi::backends::gpu::DataLayout::kNCHW;
+  GPUDNNDataLayout layout = compute_format == GPUDNNDataLayout::kNHWC
+                                ? GPUDNNDataLayout::kNHWC
+                                : GPUDNNDataLayout::kNCHW;
   if (transformed_input.dims().size() == 5) {
-    layout = compute_format == phi::backends::gpu::DataLayout::kNHWC
-                 ? phi::backends::gpu::DataLayout::kNDHWC
-                 : phi::backends::gpu::DataLayout::kNCDHW;
+    layout = compute_format == GPUDNNDataLayout::kNHWC
+                 ? GPUDNNDataLayout::kNDHWC
+                 : GPUDNNDataLayout::kNCDHW;
   }
 
   CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(transformed_input);
@@ -542,7 +540,7 @@ void ConvCudnnKernel(const Context& dev_ctx,
                            &transformed_output);
 #endif
 
-  if (channel_last && compute_format == phi::backends::gpu::DataLayout::kNCHW) {
+  if (channel_last && compute_format == GPUDNNDataLayout::kNCHW) {
     TransToChannelLast<Context, T>(dev_ctx, &transformed_output, output);
   }
 }

--- a/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
@@ -39,7 +39,7 @@ limitations under the License. */
 
 namespace phi {
 
-using GPUDNNDataLayout = phi::backends::gpu::DataLayout;
+using GPUDNNDataLayout = phi::DataLayout;
 
 template <typename T, typename Context>
 void ConvTransposeGradRawGPUDNNKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
@@ -77,14 +77,14 @@ void ConvTransposeGradRawGPUDNNKernel(const Context& dev_ctx,
   std::vector<int> dilations_ =
       dilations;  // cudnn v5 does not support dilations
   const DataLayout data_layout =
-      (data_format != "NHWC" ? DataLayout::kNCHW : DataLayout::kNHWC);
+      (data_format != "NHWC" ? DataLayout::NCHW : DataLayout::NHWC);
 
   // if channel_last, transpose to channel_first
   DenseTensor x_transpose;
   DenseTensor dout_transpose;
   std::vector<int> x_vec = common::vectorize<int>(x.dims());
   std::vector<int> out_vec = common::vectorize<int>(dout.dims());
-  if (data_layout == DataLayout::kNHWC) {
+  if (data_layout == DataLayout::NHWC) {
     if (strides.size() == 2U) {
       std::vector<int> axis = {0, 3, 1, 2};
       for (size_t i = 0; i < axis.size(); ++i) {
@@ -183,9 +183,9 @@ void ConvTransposeGradRawGPUDNNKernel(const Context& dev_ctx,
   DataLayout layout;
 
   if (strides.size() == 2U) {
-    layout = DataLayout::kNCHW;
+    layout = DataLayout::NCHW;
   } else {
-    layout = DataLayout::kNCDHW;
+    layout = DataLayout::NCDHW;
   }
 
   int iwo_groups = groups;
@@ -332,7 +332,7 @@ void ConvTransposeGradRawGPUDNNKernel(const Context& dev_ctx,
                                              false);
 #endif  // PADDLE_WITH_HIP
 
-    if (data_layout == DataLayout::kNHWC) {
+    if (data_layout == DataLayout::NHWC) {
       DenseTensor dx_transpose;
       DenseTensor dx_nchw;
       dx_nchw.ShareDataWith(*dx);
@@ -653,7 +653,7 @@ void Conv2dTransposeDoubleGradGPUDNNKernel(
   auto dtype = phi::backends::gpu::CudnnDataType<T>::type;
 
   auto handle = dev_ctx.cudnn_handle();
-  auto layout = phi::backends::gpu::GetCudnnTensorFormat(DataLayout::kNCHW);
+  auto layout = phi::backends::gpu::GetCudnnTensorFormat(DataLayout::NCHW);
 
   ConvArgs args1{handle,
                  &transformed_ddout_channel,
@@ -664,7 +664,7 @@ void Conv2dTransposeDoubleGradGPUDNNKernel(
                  dilations_,
                  dtype,
                  groups,
-                 DataLayout::kNCHW};
+                 DataLayout::NCHW};
   ConvArgs args2{handle,
                  &transformed_ddout_channel,
                  &ddfilter,
@@ -674,7 +674,7 @@ void Conv2dTransposeDoubleGradGPUDNNKernel(
                  dilations_,
                  dtype,
                  groups,
-                 DataLayout::kNCHW};
+                 DataLayout::NCHW};
 
   ConvArgs args3{handle,
                  &transformed_dout,
@@ -685,7 +685,7 @@ void Conv2dTransposeDoubleGradGPUDNNKernel(
                  dilations_,
                  dtype,
                  groups,
-                 DataLayout::kNCHW};
+                 DataLayout::NCHW};
   ConvArgs args4{handle,
                  &transformed_dout,
                  &ddfilter,
@@ -695,7 +695,7 @@ void Conv2dTransposeDoubleGradGPUDNNKernel(
                  dilations_,
                  dtype,
                  groups,
-                 DataLayout::kNCHW};
+                 DataLayout::NCHW};
 #ifdef PADDLE_WITH_HIP
   SearchResult<miopenConvBwdDataAlgorithm_t> bwd_result1;
   SearchResult<miopenConvBwdDataAlgorithm_t> bwd_result2;
@@ -815,11 +815,11 @@ void Conv2dTransposeDoubleGradGPUDNNKernel(
 
   int i_n, i_c, i_d, i_h, i_w;
   GetNCDHW(
-      transformed_x.dims(), DataLayout::kNCHW, &i_n, &i_c, &i_d, &i_h, &i_w);
+      transformed_x.dims(), DataLayout::NCHW, &i_n, &i_c, &i_d, &i_h, &i_w);
 
   int o_n, o_c, o_d, o_h, o_w;
   GetNCDHW(
-      transformed_dout.dims(), DataLayout::kNCHW, &o_n, &o_c, &o_d, &o_h, &o_w);
+      transformed_dout.dims(), DataLayout::NCHW, &o_n, &o_c, &o_d, &o_h, &o_w);
 
   int group_offset_in =
       transformed_x.numel() / transformed_x.dims()[0] / groups;

--- a/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
@@ -39,8 +39,6 @@ limitations under the License. */
 
 namespace phi {
 
-using GPUDNNDataLayout = phi::DataLayout;
-
 template <typename T, typename Context>
 void ConvTransposeGradRawGPUDNNKernel(const Context& dev_ctx,
                                       const DenseTensor& x,
@@ -78,16 +76,15 @@ void ConvTransposeGradRawGPUDNNKernel(const Context& dev_ctx,
   std::vector<int> paddings_ = paddings;
   std::vector<int> dilations_ =
       dilations;  // cudnn v5 does not support dilations
-  const GPUDNNDataLayout data_layout =
-      (data_format != "NHWC" ? GPUDNNDataLayout::kNCHW
-                             : GPUDNNDataLayout::kNHWC);
+  const DataLayout data_layout =
+      (data_format != "NHWC" ? DataLayout::kNCHW : DataLayout::kNHWC);
 
   // if channel_last, transpose to channel_first
   DenseTensor x_transpose;
   DenseTensor dout_transpose;
   std::vector<int> x_vec = common::vectorize<int>(x.dims());
   std::vector<int> out_vec = common::vectorize<int>(dout.dims());
-  if (data_layout == GPUDNNDataLayout::kNHWC) {
+  if (data_layout == DataLayout::kNHWC) {
     if (strides.size() == 2U) {
       std::vector<int> axis = {0, 3, 1, 2};
       for (size_t i = 0; i < axis.size(); ++i) {
@@ -183,12 +180,12 @@ void ConvTransposeGradRawGPUDNNKernel(const Context& dev_ctx,
   CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(x_transpose);
 #endif
 
-  GPUDNNDataLayout layout;
+  DataLayout layout;
 
   if (strides.size() == 2U) {
-    layout = GPUDNNDataLayout::kNCHW;
+    layout = DataLayout::kNCHW;
   } else {
-    layout = GPUDNNDataLayout::kNCDHW;
+    layout = DataLayout::kNCDHW;
   }
 
   int iwo_groups = groups;
@@ -335,7 +332,7 @@ void ConvTransposeGradRawGPUDNNKernel(const Context& dev_ctx,
                                              false);
 #endif  // PADDLE_WITH_HIP
 
-    if (data_layout == GPUDNNDataLayout::kNHWC) {
+    if (data_layout == DataLayout::kNHWC) {
       DenseTensor dx_transpose;
       DenseTensor dx_nchw;
       dx_nchw.ShareDataWith(*dx);
@@ -656,8 +653,7 @@ void Conv2dTransposeDoubleGradGPUDNNKernel(
   auto dtype = phi::backends::gpu::CudnnDataType<T>::type;
 
   auto handle = dev_ctx.cudnn_handle();
-  auto layout =
-      phi::backends::gpu::GetCudnnTensorFormat(GPUDNNDataLayout::kNCHW);
+  auto layout = phi::backends::gpu::GetCudnnTensorFormat(DataLayout::kNCHW);
 
   ConvArgs args1{handle,
                  &transformed_ddout_channel,
@@ -668,7 +664,7 @@ void Conv2dTransposeDoubleGradGPUDNNKernel(
                  dilations_,
                  dtype,
                  groups,
-                 GPUDNNDataLayout::kNCHW};
+                 DataLayout::kNCHW};
   ConvArgs args2{handle,
                  &transformed_ddout_channel,
                  &ddfilter,
@@ -678,7 +674,7 @@ void Conv2dTransposeDoubleGradGPUDNNKernel(
                  dilations_,
                  dtype,
                  groups,
-                 GPUDNNDataLayout::kNCHW};
+                 DataLayout::kNCHW};
 
   ConvArgs args3{handle,
                  &transformed_dout,
@@ -689,7 +685,7 @@ void Conv2dTransposeDoubleGradGPUDNNKernel(
                  dilations_,
                  dtype,
                  groups,
-                 GPUDNNDataLayout::kNCHW};
+                 DataLayout::kNCHW};
   ConvArgs args4{handle,
                  &transformed_dout,
                  &ddfilter,
@@ -699,7 +695,7 @@ void Conv2dTransposeDoubleGradGPUDNNKernel(
                  dilations_,
                  dtype,
                  groups,
-                 GPUDNNDataLayout::kNCHW};
+                 DataLayout::kNCHW};
 #ifdef PADDLE_WITH_HIP
   SearchResult<miopenConvBwdDataAlgorithm_t> bwd_result1;
   SearchResult<miopenConvBwdDataAlgorithm_t> bwd_result2;
@@ -818,22 +814,12 @@ void Conv2dTransposeDoubleGradGPUDNNKernel(
   }
 
   int i_n, i_c, i_d, i_h, i_w;
-  GetNCDHW(transformed_x.dims(),
-           GPUDNNDataLayout::kNCHW,
-           &i_n,
-           &i_c,
-           &i_d,
-           &i_h,
-           &i_w);
+  GetNCDHW(
+      transformed_x.dims(), DataLayout::kNCHW, &i_n, &i_c, &i_d, &i_h, &i_w);
 
   int o_n, o_c, o_d, o_h, o_w;
-  GetNCDHW(transformed_dout.dims(),
-           GPUDNNDataLayout::kNCHW,
-           &o_n,
-           &o_c,
-           &o_d,
-           &o_h,
-           &o_w);
+  GetNCDHW(
+      transformed_dout.dims(), DataLayout::kNCHW, &o_n, &o_c, &o_d, &o_h, &o_w);
 
   int group_offset_in =
       transformed_x.numel() / transformed_x.dims()[0] / groups;

--- a/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
@@ -45,7 +45,7 @@ limitations under the License. */
 
 namespace phi {
 
-using GPUDNNDataLayout = phi::backends::gpu::DataLayout;
+using GPUDNNDataLayout = phi::DataLayout;
 
 template <typename T, typename Context>
 void ConvTransposeCudnnKernelImplV7(const DenseTensor* transformed_x,

--- a/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
@@ -45,8 +45,6 @@ limitations under the License. */
 
 namespace phi {
 
-using GPUDNNDataLayout = phi::DataLayout;
-
 template <typename T, typename Context>
 void ConvTransposeCudnnKernelImplV7(const DenseTensor* transformed_x,
                                     const DenseTensor* filter,
@@ -54,8 +52,8 @@ void ConvTransposeCudnnKernelImplV7(const DenseTensor* transformed_x,
                                     const std::vector<int>& strides,
                                     const std::vector<int>& padding_common,
                                     const std::vector<int>& dilations_,
-                                    GPUDNNDataLayout data_layout,
-                                    GPUDNNDataLayout layout,
+                                    DataLayout data_layout,
+                                    DataLayout layout,
                                     bool exhaustive_search,
                                     bool deterministic,
                                     int groups,
@@ -165,8 +163,8 @@ void ConvTransposeCudnnKernelImplV8(const DenseTensor* transformed_x,
                                     const std::vector<int>& strides,
                                     const std::vector<int>& padding_common,
                                     const std::vector<int>& dilations_,
-                                    GPUDNNDataLayout data_layout,
-                                    GPUDNNDataLayout layout,
+                                    DataLayout data_layout,
+                                    DataLayout layout,
                                     bool exhaustive_search,
                                     bool deterministic,
                                     int groups,
@@ -269,14 +267,13 @@ void ConvTransposeRawGPUDNNKernel(const Context& dev_ctx,
 
   std::vector<int> paddings_ = paddings;
   std::vector<int> dilations_ = dilations;
-  const GPUDNNDataLayout data_layout =
-      (data_format != "NHWC" ? GPUDNNDataLayout::kNCHW
-                             : GPUDNNDataLayout::kNHWC);
+  const DataLayout data_layout =
+      (data_format != "NHWC" ? DataLayout::kNCHW : DataLayout::kNHWC);
   std::vector<int64_t> x_vec = common::vectorize<int64_t>(x.dims());
   std::vector<int64_t> out_vec = common::vectorize<int64_t>(out->dims());
   // if channel_last, transpose to channel_first
   DenseTensor x_transpose;
-  if (data_layout == GPUDNNDataLayout::kNHWC) {
+  if (data_layout == DataLayout::kNHWC) {
     if (strides.size() == 2U) {
       std::vector<int> axis = {0, 3, 1, 2};
       for (size_t i = 0; i < axis.size(); ++i) {
@@ -385,11 +382,11 @@ void ConvTransposeRawGPUDNNKernel(const Context& dev_ctx,
     transformed_out.Resize(common::make_ddim(transformed_out_vec));
   }
 
-  GPUDNNDataLayout layout;
+  DataLayout layout;
   if (strides.size() == 2U) {
-    layout = GPUDNNDataLayout::kNCHW;
+    layout = DataLayout::kNCHW;
   } else {
-    layout = GPUDNNDataLayout::kNCDHW;
+    layout = DataLayout::kNCDHW;
   }
 
 #ifdef PADDLE_WITH_CUDNN_FRONTEND
@@ -442,7 +439,7 @@ void ConvTransposeRawGPUDNNKernel(const Context& dev_ctx,
         dev_ctx, &transformed_out, out, starts, ends, axes);
   }
 
-  if (data_layout == GPUDNNDataLayout::kNHWC) {
+  if (data_layout == DataLayout::kNHWC) {
     DenseTensor out_transpose;
     DenseTensor out_nchw;
     out_nchw.ShareDataWith(*out);

--- a/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
@@ -268,12 +268,12 @@ void ConvTransposeRawGPUDNNKernel(const Context& dev_ctx,
   std::vector<int> paddings_ = paddings;
   std::vector<int> dilations_ = dilations;
   const DataLayout data_layout =
-      (data_format != "NHWC" ? DataLayout::kNCHW : DataLayout::kNHWC);
+      (data_format != "NHWC" ? DataLayout::NCHW : DataLayout::NHWC);
   std::vector<int64_t> x_vec = common::vectorize<int64_t>(x.dims());
   std::vector<int64_t> out_vec = common::vectorize<int64_t>(out->dims());
   // if channel_last, transpose to channel_first
   DenseTensor x_transpose;
-  if (data_layout == DataLayout::kNHWC) {
+  if (data_layout == DataLayout::NHWC) {
     if (strides.size() == 2U) {
       std::vector<int> axis = {0, 3, 1, 2};
       for (size_t i = 0; i < axis.size(); ++i) {
@@ -384,9 +384,9 @@ void ConvTransposeRawGPUDNNKernel(const Context& dev_ctx,
 
   DataLayout layout;
   if (strides.size() == 2U) {
-    layout = DataLayout::kNCHW;
+    layout = DataLayout::NCHW;
   } else {
-    layout = DataLayout::kNCDHW;
+    layout = DataLayout::NCDHW;
   }
 
 #ifdef PADDLE_WITH_CUDNN_FRONTEND
@@ -439,7 +439,7 @@ void ConvTransposeRawGPUDNNKernel(const Context& dev_ctx,
         dev_ctx, &transformed_out, out, starts, ends, axes);
   }
 
-  if (data_layout == DataLayout::kNHWC) {
+  if (data_layout == DataLayout::NHWC) {
     DenseTensor out_transpose;
     DenseTensor out_nchw;
     out_nchw.ShareDataWith(*out);

--- a/paddle/phi/kernels/gpudnn/pool_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/pool_gpudnn.h
@@ -20,7 +20,6 @@ limitations under the License. */
 
 namespace phi {
 
-using GPUDNNDataLayout = phi::backends::gpu::DataLayout;
 using PoolingMode = phi::backends::gpu::PoolingMode;
 using ScopedPoolingDescriptor = phi::backends::gpu::ScopedPoolingDescriptor;
 using ScopedTensorDescriptor = phi::backends::gpu::ScopedTensorDescriptor;
@@ -52,15 +51,15 @@ class CudnnIndexType<int8_t> {
 #endif
 };
 
-inline GPUDNNDataLayout GetLayoutFromStr(std::string data_format) {
+inline DataLayout GetLayoutFromStr(std::string data_format) {
   if (data_format == "NHWC") {
-    return GPUDNNDataLayout::kNHWC;
+    return DataLayout::kNHWC;
   } else if (data_format == "NCHW") {
-    return GPUDNNDataLayout::kNCHW;
+    return DataLayout::kNCHW;
   } else if (data_format == "NCDHW") {
-    return GPUDNNDataLayout::kNCDHW;
+    return DataLayout::kNCDHW;
   } else {
-    return GPUDNNDataLayout::kNCDHW;
+    return DataLayout::kNCDHW;
   }
 }
 

--- a/paddle/phi/kernels/gpudnn/pool_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/pool_gpudnn.h
@@ -53,13 +53,13 @@ class CudnnIndexType<int8_t> {
 
 inline DataLayout GetLayoutFromStr(std::string data_format) {
   if (data_format == "NHWC") {
-    return DataLayout::kNHWC;
+    return DataLayout::NHWC;
   } else if (data_format == "NCHW") {
-    return DataLayout::kNCHW;
+    return DataLayout::NCHW;
   } else if (data_format == "NCDHW") {
-    return DataLayout::kNCDHW;
+    return DataLayout::NCDHW;
   } else {
-    return DataLayout::kNCDHW;
+    return DataLayout::NCDHW;
   }
 }
 

--- a/paddle/phi/kernels/gpudnn/pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/pool_grad_kernel.cu
@@ -123,11 +123,11 @@ void PoolGradRawGPUDNNKernel(const Context& dev_ctx,
 
   dev_ctx.template Alloc<T>(input_grad);
   DenseTensor transformed_input_grad(input_grad->type());
-  GPUDNNDataLayout layout;
+  DataLayout layout;
   const std::string str_NCHW = "NCHW", str_NHWC = "NHWC";
   const std::string str_NCDHW = "NCDHW", str_NDHWC = "NDHWC";
   if (data_format == str_NDHWC) {
-    layout = GPUDNNDataLayout::kNCDHW;
+    layout = DataLayout::kNCDHW;
     std::vector<int> axis{0, 4, 1, 2, 3};
 
     // input
@@ -170,7 +170,7 @@ void PoolGradRawGPUDNNKernel(const Context& dev_ctx,
 #ifdef PADDLE_WITH_HIP
     // MIOPEN not support NHWC data layout
   } else if (data_format == str_NHWC) {
-    layout = GPUDNNDataLayout::kNCHW;
+    layout = DataLayout::kNCHW;
 
     std::vector<int> axis{0, 3, 1, 2};
 

--- a/paddle/phi/kernels/gpudnn/pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/pool_grad_kernel.cu
@@ -127,7 +127,7 @@ void PoolGradRawGPUDNNKernel(const Context& dev_ctx,
   const std::string str_NCHW = "NCHW", str_NHWC = "NHWC";
   const std::string str_NCDHW = "NCDHW", str_NDHWC = "NDHWC";
   if (data_format == str_NDHWC) {
-    layout = DataLayout::kNCDHW;
+    layout = DataLayout::NCDHW;
     std::vector<int> axis{0, 4, 1, 2, 3};
 
     // input
@@ -170,7 +170,7 @@ void PoolGradRawGPUDNNKernel(const Context& dev_ctx,
 #ifdef PADDLE_WITH_HIP
     // MIOPEN not support NHWC data layout
   } else if (data_format == str_NHWC) {
-    layout = DataLayout::kNCHW;
+    layout = DataLayout::NCHW;
 
     std::vector<int> axis{0, 3, 1, 2};
 

--- a/paddle/phi/kernels/gpudnn/pool_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/pool_kernel.cu
@@ -107,10 +107,10 @@ void PoolRawGPUDNNKernel(const Context& dev_ctx,
 
   DenseTensor transformed_input(input->type());
   DenseTensor transformed_output(output->type());
-  GPUDNNDataLayout layout;
+  DataLayout layout;
 
   if (data_format == str_NDHWC) {
-    layout = GPUDNNDataLayout::kNCDHW;
+    layout = DataLayout::kNCDHW;
     std::vector<int> axis{0, 4, 1, 2, 3};
 
     // input
@@ -139,7 +139,7 @@ void PoolRawGPUDNNKernel(const Context& dev_ctx,
 #ifdef PADDLE_WITH_HIP
     // MIOPEN not support NHWC data layout
   } else if (data_format == str_NHWC) {
-    layout = GPUDNNDataLayout::kNCHW;
+    layout = DataLayout::kNCHW;
 
     std::vector<int> axis{0, 3, 1, 2};
 

--- a/paddle/phi/kernels/gpudnn/pool_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/pool_kernel.cu
@@ -110,7 +110,7 @@ void PoolRawGPUDNNKernel(const Context& dev_ctx,
   DataLayout layout;
 
   if (data_format == str_NDHWC) {
-    layout = DataLayout::kNCDHW;
+    layout = DataLayout::NCDHW;
     std::vector<int> axis{0, 4, 1, 2, 3};
 
     // input
@@ -139,7 +139,7 @@ void PoolRawGPUDNNKernel(const Context& dev_ctx,
 #ifdef PADDLE_WITH_HIP
     // MIOPEN not support NHWC data layout
   } else if (data_format == str_NHWC) {
-    layout = DataLayout::kNCHW;
+    layout = DataLayout::NCHW;
 
     std::vector<int> axis{0, 3, 1, 2};
 

--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -1074,7 +1074,7 @@ void SoftmaxForwardCudnnKernel(const GPUContext& dev_ctx,
                                const std::vector<int>& tensor_dims,
                                T* out_data) {
   auto handle = dev_ctx.cudnn_handle();
-  DataLayout layout = DataLayout::kNCHW;
+  DataLayout layout = DataLayout::NCHW;
 
   ScopedTensorDescriptor scoped_desc;
 #ifdef PADDLE_WITH_HIP
@@ -1146,7 +1146,7 @@ void SoftmaxBackwardCudnnKernel(const GPUContext& dev_ctx,
                                 const std::vector<int>& tensor_dims,
                                 T* dx_data) {
   auto handle = dev_ctx.cudnn_handle();
-  DataLayout layout = DataLayout::kNCHW;
+  DataLayout layout = DataLayout::NCHW;
 
   ScopedTensorDescriptor scoped_desc;
 #ifdef PADDLE_WITH_HIP

--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -35,7 +35,6 @@ COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
 namespace phi {
 
 using ScopedTensorDescriptor = phi::backends::gpu::ScopedTensorDescriptor;
-using GPUDNNDataLayout = phi::backends::gpu::DataLayout;
 
 // Vectorization trait 4 * sizeof(T)
 template <typename T>
@@ -1075,7 +1074,7 @@ void SoftmaxForwardCudnnKernel(const GPUContext& dev_ctx,
                                const std::vector<int>& tensor_dims,
                                T* out_data) {
   auto handle = dev_ctx.cudnn_handle();
-  GPUDNNDataLayout layout = GPUDNNDataLayout::kNCHW;
+  DataLayout layout = DataLayout::kNCHW;
 
   ScopedTensorDescriptor scoped_desc;
 #ifdef PADDLE_WITH_HIP
@@ -1147,7 +1146,7 @@ void SoftmaxBackwardCudnnKernel(const GPUContext& dev_ctx,
                                 const std::vector<int>& tensor_dims,
                                 T* dx_data) {
   auto handle = dev_ctx.cudnn_handle();
-  GPUDNNDataLayout layout = GPUDNNDataLayout::kNCHW;
+  DataLayout layout = DataLayout::kNCHW;
 
   ScopedTensorDescriptor scoped_desc;
 #ifdef PADDLE_WITH_HIP

--- a/paddle/phi/kernels/impl/conv_cudnn_impl.h
+++ b/paddle/phi/kernels/impl/conv_cudnn_impl.h
@@ -57,6 +57,7 @@ static inline bool IsVoltaOrLater(const phi::GPUContext& dev_ctx) {
 //   return CUDNN_TENSOR_NCHW;
 // }
 
+/*
 static inline void GetNCDHW(const DDim& dims,
                             const phi::DataLayout& layout,
                             int* N,
@@ -77,6 +78,7 @@ static inline void GetNCDHW(const DDim& dims,
     *W = dims[3 - i];
   }
 }
+*/
 
 }  // namespace phi
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
paddle/phi/kernels/gpudnn/ 中 GPUDNNDataLayout 修改为 phi命名空间下DataLayout
paddle/phi/backends/gpu/cuda/cudnn_helper.h 中DataLayout注释为不使用
<img width="835" height="168" alt="image" src="https://github.com/user-attachments/assets/4c7149bb-5315-457e-a2ff-5c85b6ebde44" />
