### PR TITLE
[CodeStyle] Bump `ast-grep` to v0.40.0 and disable color

### DIFF
--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -42,14 +42,14 @@ jobs:
         if: steps.check-bypass.outputs.can-skip != 'true'
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-          cache: 'pip'
+          python-version: "3.12"
+          cache: "pip"
 
       - name: Install dependencies
         if: steps.check-bypass.outputs.can-skip != 'true'
         run: |
           pip install pre-commit==2.17.0 cpplint==1.6.0  clang-format==13.0.0
-          pip install ast-grep-cli==0.39.9 # This version should be consistent with the one in .pre-commit-config.yaml
+          pip install ast-grep-cli==0.40.0 # This version should be consistent with the one in .pre-commit-config.yaml
 
       - name: Run ast-grep unit tests
         if: steps.check-bypass.outputs.can-skip != 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
     rev: v0.39.9
     hooks:
       - id: ast-grep
+        args: [--color=never]
   - repo: local
     hooks:
       - id: copyright_checker

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,10 +38,9 @@ repos:
             test/dygraph_to_static/test_error.py
           )$
   - repo: https://github.com/PFCCLab/ast-grep-pre-commit-mirror
-    rev: v0.39.9
+    rev: v0.40.0.1
     hooks:
       - id: ast-grep
-        args: [--color=never]
   - repo: local
     hooks:
       - id: copyright_checker


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

- 更新 ast-grep 到 v0.40.0，hook revision 1
- 添加 `--color=never` 显示错位问题，见 ast-grep/ast-grep#2114

<!-- PCard-66972 -->