### PR TITLE
[Compat] Allow user pass `str` or `Iterable` as scope

### DIFF
--- a/test/compat/test_torch_proxy.py
+++ b/test/compat/test_torch_proxy.py
@@ -113,7 +113,7 @@ class TestTorchProxyLocalEnabledModule(unittest.TestCase):
             import torch_proxy_local_enabled_module
 
         paddle.compat.enable_torch_proxy(
-            scope={"torch_proxy_local_enabled_module"}
+            scope="torch_proxy_local_enabled_module"
         )
         with self.assertRaises(ModuleNotFoundError):
             import torch  # noqa: F401


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

易用性增强，允许用户通过 `paddle.compat.enable_torch_proxy(scope=["module"])`、`paddle.compat.enable_torch_proxy(scope="module")` 这两种方式来传参，避免强制传入 `set` 带来的麻烦

<!-- PCard-66972 -->