### PR TITLE
[CodeStyle][Xdoctest][191,192,197,201,203] Fix example code(paddle.optimizer.lr.{ExponentialDecay,InverseTimeDecay,NaturalExpDecay,PolynomialDecay,StepDecay})

### DIFF
--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -579,7 +579,10 @@ class NaturalExpDecay(LRScheduler):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             feed={
+            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
+            ...                 'y': np.random.randn(3, 4, 5).astype('float32'),
+            ...             },
             ...             fetch_list=[loss],
             ...         )
             ...         scheduler.step()  # If you update learning rate each step
@@ -673,7 +676,10 @@ class InverseTimeDecay(LRScheduler):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             feed={
+            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
+            ...                 'y': np.random.randn(3, 4, 5).astype('float32'),
+            ...             },
             ...             fetch_list=[loss],
             ...         )
             ...         scheduler.step()  # If you update learning rate each step
@@ -780,7 +786,10 @@ class PolynomialDecay(LRScheduler):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             feed={
+            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
+            ...                 'y': np.random.randn(3, 4, 5).astype('float32'),
+            ...             },
             ...             fetch_list=[loss],
             ...         )
             ...         scheduler.step()  # If you update learning rate each step
@@ -1056,7 +1065,10 @@ class ExponentialDecay(LRScheduler):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             feed={
+            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
+            ...                 'y': np.random.randn(3, 4, 5).astype('float32'),
+            ...             },
             ...             fetch_list=[loss],
             ...         )
             ...         scheduler.step()  # If you update learning rate each step
@@ -1280,7 +1292,10 @@ class StepDecay(LRScheduler):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             feed={
+            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
+            ...                 'y': np.random.randn(3, 4, 5).astype('float32'),
+            ...             },
             ...             fetch_list=[loss],
             ...         )
             ...         scheduler.step()  # If you update learning rate each step

--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -553,7 +553,7 @@ class NaturalExpDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()    # If you update learning rate each step
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -573,19 +573,16 @@ class NaturalExpDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.NaturalExpDecay(learning_rate=0.5, gamma=0.1, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
-            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={
-            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
-            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
-            ...             },
-            ...             fetch_list=[loss])
-            ...         scheduler.step()    # If you update learning rate each step
+            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             fetch_list=[loss],
+            ...         )
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
 
@@ -650,7 +647,7 @@ class InverseTimeDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()    # If you update learning rate each step
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -670,21 +667,17 @@ class InverseTimeDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.InverseTimeDecay(learning_rate=0.5, gamma=0.1, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
-            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={
-            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
-            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
-            ...             },
-            ...             fetch_list=[loss])
-            ...         scheduler.step()    # If you update learning rate each step
+            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             fetch_list=[loss],
+            ...         )
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
-            ...
     """
 
     gamma: float
@@ -761,7 +754,7 @@ class PolynomialDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()    # If you update learning rate each step
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -781,19 +774,16 @@ class PolynomialDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.PolynomialDecay(learning_rate=0.5, decay_steps=20, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
-            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={
-            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
-            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
-            ...             },
-            ...             fetch_list=[loss])
-            ...         scheduler.step()    # If you update learning rate each step
+            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             fetch_list=[loss],
+            ...         )
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
 
@@ -1040,7 +1030,7 @@ class ExponentialDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()    # If you update learning rate each step
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -1060,19 +1050,16 @@ class ExponentialDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.ExponentialDecay(learning_rate=0.5, gamma=0.9, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
-            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={
-            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
-            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
-            ...             },
-            ...             fetch_list=loss.name)
-            ...         scheduler.step()    # If you update learning rate each step
+            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             fetch_list=[loss],
+            ...         )
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
 
@@ -1267,7 +1254,7 @@ class StepDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()    # If you update learning rate each step
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -1287,19 +1274,16 @@ class StepDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.StepDecay(learning_rate=0.5, step_size=5, gamma=0.8, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
-            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={
-            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
-            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
-            ...             },
-            ...             fetch_list=[loss])
-            ...         scheduler.step()    # If you update learning rate each step
+            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             fetch_list=[loss],
+            ...         )
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
 

--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -367,7 +367,7 @@ class NoamDecay(LRScheduler):
             ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
             ...                 'y': np.random.randn(3, 4, 5).astype('float32')
             ...             },
-            ...             fetch_list=loss.name)
+            ...             fetch_list=[loss])
             ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
             ...
@@ -553,7 +553,7 @@ class NaturalExpDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()    # If you update learning rate each step
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -573,19 +573,16 @@ class NaturalExpDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.NaturalExpDecay(learning_rate=0.5, gamma=0.1, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
-            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={
-            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
-            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
-            ...             },
-            ...             fetch_list=[loss])
-            ...         scheduler.step()    # If you update learning rate each step
+            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             fetch_list=[loss],
+            ...         )
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
 
@@ -650,7 +647,7 @@ class InverseTimeDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()    # If you update learning rate each step
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -670,21 +667,17 @@ class InverseTimeDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.InverseTimeDecay(learning_rate=0.5, gamma=0.1, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
-            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={
-            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
-            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
-            ...             },
-            ...             fetch_list=[loss])
-            ...         scheduler.step()    # If you update learning rate each step
+            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             fetch_list=[loss],
+            ...         )
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
-            ...
     """
 
     gamma: float
@@ -761,7 +754,7 @@ class PolynomialDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()    # If you update learning rate each step
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -781,19 +774,16 @@ class PolynomialDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.PolynomialDecay(learning_rate=0.5, decay_steps=20, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
-            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={
-            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
-            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
-            ...             },
-            ...             fetch_list=[loss])
-            ...         scheduler.step()    # If you update learning rate each step
+            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             fetch_list=[loss],
+            ...         )
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
 
@@ -1040,7 +1030,7 @@ class ExponentialDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()    # If you update learning rate each step
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -1060,19 +1050,16 @@ class ExponentialDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.ExponentialDecay(learning_rate=0.5, gamma=0.9, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
-            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={
-            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
-            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
-            ...             },
-            ...             fetch_list=loss.name)
-            ...         scheduler.step()    # If you update learning rate each step
+            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             fetch_list=loss.name,
+            ...         )
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
 
@@ -1267,7 +1254,7 @@ class StepDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()    # If you update learning rate each step
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -1287,19 +1274,16 @@ class StepDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.StepDecay(learning_rate=0.5, step_size=5, gamma=0.8, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
-            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={
-            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
-            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
-            ...             },
-            ...             fetch_list=[loss])
-            ...         scheduler.step()    # If you update learning rate each step
+            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
+            ...             fetch_list=[loss],
+            ...         )
+            ...         scheduler.step()  # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
 

--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -536,7 +536,7 @@ class NaturalExpDecay(LRScheduler):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example1
 
             >>> # Example1: train on default dynamic graph mode
@@ -552,11 +552,11 @@ class NaturalExpDecay(LRScheduler):
             ...         loss = paddle.mean(out)
             ...         loss.backward()
             ...         sgd.step()
-            ...         sgd.clear_gradients()
+            ...         sgd.clear_grad()
             ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example2
 
             >>> # Example2: train on static graph mode
@@ -584,7 +584,7 @@ class NaturalExpDecay(LRScheduler):
             ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
             ...                 'y': np.random.randn(3, 4, 5).astype('float32')
             ...             },
-            ...             fetch_list=loss.name)
+            ...             fetch_list=[loss])
             ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
@@ -631,7 +631,7 @@ class InverseTimeDecay(LRScheduler):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example1
 
             >>> # Example1: train on default dynamic graph mode
@@ -649,11 +649,11 @@ class InverseTimeDecay(LRScheduler):
             ...         loss = paddle.mean(out)
             ...         loss.backward()
             ...         sgd.step()
-            ...         sgd.clear_gradients()
+            ...         sgd.clear_grad()
             ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example2
 
             >>> # Example2: train on static graph mode
@@ -681,7 +681,7 @@ class InverseTimeDecay(LRScheduler):
             ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
             ...                 'y': np.random.randn(3, 4, 5).astype('float32')
             ...             },
-            ...             fetch_list=loss.name)
+            ...             fetch_list=[loss])
             ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
             ...
@@ -742,7 +742,7 @@ class PolynomialDecay(LRScheduler):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example1
 
             >>> # Example1: train on default dynamic graph mode
@@ -760,11 +760,11 @@ class PolynomialDecay(LRScheduler):
             ...         loss = paddle.mean(out)
             ...         loss.backward()
             ...         sgd.step()
-            ...         sgd.clear_gradients()
+            ...         sgd.clear_grad()
             ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example2
 
             >>> # Example2: train on static graph mode
@@ -792,7 +792,7 @@ class PolynomialDecay(LRScheduler):
             ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
             ...                 'y': np.random.randn(3, 4, 5).astype('float32')
             ...             },
-            ...             fetch_list=loss.name)
+            ...             fetch_list=[loss])
             ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
@@ -1021,7 +1021,7 @@ class ExponentialDecay(LRScheduler):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example1
 
             >>> # Example1: train on default dynamic graph mode
@@ -1039,11 +1039,11 @@ class ExponentialDecay(LRScheduler):
             ...         loss = paddle.mean(out)
             ...         loss.backward()
             ...         sgd.step()
-            ...         sgd.clear_gradients()
+            ...         sgd.clear_grad()
             ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example2
 
             >>> # Example2: train on static graph mode
@@ -1248,7 +1248,7 @@ class StepDecay(LRScheduler):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example1
 
             >>> # Example1: train on default dynamic graph mode
@@ -1266,11 +1266,11 @@ class StepDecay(LRScheduler):
             ...         loss = paddle.mean(out)
             ...         loss.backward()
             ...         sgd.step()
-            ...         sgd.clear_gradients()
+            ...         sgd.clear_grad()
             ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example2
 
             >>> # Example2: train on static graph mode
@@ -1298,7 +1298,7 @@ class StepDecay(LRScheduler):
             ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
             ...                 'y': np.random.randn(3, 4, 5).astype('float32')
             ...             },
-            ...             fetch_list=loss.name)
+            ...             fetch_list=[loss])
             ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """

--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -367,7 +367,7 @@ class NoamDecay(LRScheduler):
             ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
             ...                 'y': np.random.randn(3, 4, 5).astype('float32')
             ...             },
-            ...             fetch_list=[loss])
+            ...             fetch_list=loss.name)
             ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
             ...
@@ -553,7 +553,7 @@ class NaturalExpDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()  # If you update learning rate each step
+            ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -573,16 +573,19 @@ class NaturalExpDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.NaturalExpDecay(learning_rate=0.5, gamma=0.1, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
+            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
-            ...             fetch_list=[loss],
-            ...         )
-            ...         scheduler.step()  # If you update learning rate each step
+            ...             feed={
+            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
+            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
+            ...             },
+            ...             fetch_list=[loss])
+            ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
 
@@ -647,7 +650,7 @@ class InverseTimeDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()  # If you update learning rate each step
+            ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -667,17 +670,21 @@ class InverseTimeDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.InverseTimeDecay(learning_rate=0.5, gamma=0.1, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
+            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
-            ...             fetch_list=[loss],
-            ...         )
-            ...         scheduler.step()  # If you update learning rate each step
+            ...             feed={
+            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
+            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
+            ...             },
+            ...             fetch_list=[loss])
+            ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
+            ...
     """
 
     gamma: float
@@ -754,7 +761,7 @@ class PolynomialDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()  # If you update learning rate each step
+            ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -774,16 +781,19 @@ class PolynomialDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.PolynomialDecay(learning_rate=0.5, decay_steps=20, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
+            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
-            ...             fetch_list=[loss],
-            ...         )
-            ...         scheduler.step()  # If you update learning rate each step
+            ...             feed={
+            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
+            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
+            ...             },
+            ...             fetch_list=[loss])
+            ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
 
@@ -1030,7 +1040,7 @@ class ExponentialDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()  # If you update learning rate each step
+            ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -1050,16 +1060,19 @@ class ExponentialDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.ExponentialDecay(learning_rate=0.5, gamma=0.9, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
+            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
-            ...             fetch_list=loss.name,
-            ...         )
-            ...         scheduler.step()  # If you update learning rate each step
+            ...             feed={
+            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
+            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
+            ...             },
+            ...             fetch_list=loss.name)
+            ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
 
@@ -1254,7 +1267,7 @@ class StepDecay(LRScheduler):
             ...         loss.backward()
             ...         sgd.step()
             ...         sgd.clear_grad()
-            ...         scheduler.step()  # If you update learning rate each step
+            ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
 
         .. code-block:: pycon
@@ -1274,16 +1287,19 @@ class StepDecay(LRScheduler):
             ...     scheduler = paddle.optimizer.lr.StepDecay(learning_rate=0.5, step_size=5, gamma=0.8, verbose=True)
             ...     sgd = paddle.optimizer.SGD(learning_rate=scheduler)
             ...     sgd.minimize(loss)
+            ...
             >>> exe = paddle.static.Executor()
             >>> exe.run(start_prog)
             >>> for epoch in range(20):
             ...     for batch_id in range(5):
             ...         out = exe.run(
             ...             main_prog,
-            ...             feed={'x': np.random.randn(3, 4, 5).astype('float32'), 'y': np.random.randn(3, 4, 5).astype('float32')},
-            ...             fetch_list=[loss],
-            ...         )
-            ...         scheduler.step()  # If you update learning rate each step
+            ...             feed={
+            ...                 'x': np.random.randn(3, 4, 5).astype('float32'),
+            ...                 'y': np.random.randn(3, 4, 5).astype('float32')
+            ...             },
+            ...             fetch_list=[loss])
+            ...         scheduler.step()    # If you update learning rate each step
             ...     # scheduler.step()        # If you update learning rate each epoch
     """
 


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

Fix xdoctest example errors in several lr schedulers.

### Describe
This PR fixes incorrect example codes in:
- ExponentialDecay
- InverseTimeDecay
- NaturalExpDecay
- PolynomialDecay
- StepDecay
to make xdoctest pass