### PR TITLE
Fix log level reset

### DIFF
--- a/python/paddle/distributed/utils/log_utils.py
+++ b/python/paddle/distributed/utils/log_utils.py
@@ -29,6 +29,5 @@ def get_logger(log_level, name="root"):
         )
         log_handler.setFormatter(log_format)
         logger.addHandler(log_handler)
-    else:
-        logger.setLevel(log_level)
+
     return logger


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

Fix global logger override in paddle.distributed.utils.log_utils.get_logger.
The helper always calls `setLevel` on the root logger, clobbering application logging even when handlers already exist.
Now it only configures when the logger has no handlers, preserving user-defined logging setups.
