### PR TITLE
[Infra] Fix normalized package name in `setup.py`

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1656,6 +1656,9 @@ Please run 'pip install -r python/requirements.txt' to make sure you have all th
     python_dependencies_module = []
     installed_packages = []
 
+    def normalize_package_name(package_name: str) -> str:
+        return package_name.replace("_", "-").lower()
+
     def eval_marker(marker_str):
         """Simple evaluation of PEP 508 environment markers."""
         if not marker_str:
@@ -1718,14 +1721,15 @@ Please run 'pip install -r python/requirements.txt' to make sure you have all th
             r"==.*|>=.*|<=.*|~=.*|!=.*", '', dependency_spec
         ).strip()
 
-        # Normalize package name (remove _ and -)
-        python_dependencies_module.append(re.sub("_|-", '', dependency_name))
+        python_dependencies_module.append(
+            normalize_package_name(dependency_name)
+        )
 
     reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
 
     for r in reqs.split():
         installed_packages.append(
-            re.sub("_|-", '', r.decode().split('==')[0]).lower()
+            normalize_package_name(r.decode().split('==')[0])
         )
 
     for dependency in python_dependencies_module:

--- a/setup.py
+++ b/setup.py
@@ -2577,6 +2577,9 @@ Please run 'pip install -r python/requirements.txt' to make sure you have all th
     python_dependencies_module = []
     installed_packages = []
 
+    def normalize_package_name(package_name: str) -> str:
+        return package_name.replace("_", "-").lower()
+
     def eval_marker(marker_str):
         """Simple evaluation of PEP 508 environment markers."""
         if not marker_str:
@@ -2639,14 +2642,15 @@ Please run 'pip install -r python/requirements.txt' to make sure you have all th
             r"==.*|>=.*|<=.*|~=.*|!=.*", '', dependency_spec
         ).strip()
 
-        # Normalize package name (remove _ and -)
-        python_dependencies_module.append(re.sub("_|-", '', dependency_name))
+        python_dependencies_module.append(
+            normalize_package_name(dependency_name)
+        )
 
     reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
 
     for r in reqs.split():
         installed_packages.append(
-            re.sub("_|-", '', r.decode().split('==')[0]).lower()
+            normalize_package_name(r.decode().split('==')[0])
         )
 
     for dependency in python_dependencies_module:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复 build dependency 检查时候，报错 name 缺失 `-`/`_` 的问题，normalize name 时候不应该直接删掉

```
Traceback (most recent call last):
  File "/ssd2/xuxiaojian/Paddle/build/python/setup.py", line 1782, in <module>
    check_build_dependency()
  File "/ssd2/xuxiaojian/Paddle/build/python/setup.py", line 1737, in check_build_dependency
    raise RuntimeError(missing_modules.format(dependency=dependency))
RuntimeError: Missing build dependency: cudapython
Please run 'pip install -r python/requirements.txt' to make sure you have all the dependencies installed.
ninja: build stopped: subcommand failed.
```

修复前展示 `cudapython`，修复后正确展示 `cuda-python`

<!-- PCard-66972 -->