### PR TITLE
[API Compatibility No.3、38] add parameter out and alias for bitwise_and -part

### DIFF
--- a/paddle/fluid/pybind/eager_math_op_patch.cc
+++ b/paddle/fluid/pybind/eager_math_op_patch.cc
@@ -2340,6 +2340,77 @@ static PyObject* tensor__eq__method(TensorObject* self,
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }
 
+static PyObject* tensor__and__method(TensorObject* self,
+                                     PyObject* args,
+                                     PyObject* kwargs) {
+  phi::RecordEvent pythonc_record_event(
+      "__and__ pybind_patch_func", phi::TracerEventType::UserDefined, 1);
+
+  EAGER_TRY
+  VLOG(6) << "Running Eager tensor__and__method";
+
+  SetPythonStack();
+
+  // Set Device ID
+  auto place = egr::Controller::Instance().GetExpectedPlace();
+  SetDevice(place);
+
+  paddle::Tensor ret;
+  paddle::Tensor self_tensor = self->tensor;
+  PyObject* other_obj = PyTuple_GET_ITEM(args, 0);
+
+  // 1. scalar exists cases (int/bool)
+  if (PyCheckInteger(other_obj) || PyBool_Check(other_obj)) {
+    int64_t other_value = CastPyArg2Long(other_obj, "__and__", 0);
+    paddle::Tensor other_tensor;
+    {
+      eager_gil_scoped_release guard;
+      other_tensor = full_ad_func(self_tensor.shape(),
+                                  phi::Scalar(other_value),
+                                  self_tensor.dtype(),
+                                  self_tensor.place());
+    }
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(&mesh, self_tensor, other_tensor)) {
+      ConvertAllInputsToDistTensor(mesh, self_tensor, other_tensor);
+    }
+    {
+      eager_gil_scoped_release guard;
+      ret = bitwise_and_ad_func(self_tensor, other_tensor);
+    }
+    return ToPyObject(ret);
+  }
+
+  // 2. create or get tensor for other_obj
+  paddle::Tensor other_tensor;
+  if (PyCheckTensor(other_obj)) {
+    auto& self_tensor_ref_addr = self->tensor;
+    auto& other_tensor_ref_addr = CastPyArg2Tensor(other_obj, 0);
+    const phi::distributed::ProcessMesh* mesh = nullptr;
+    if (InputsContainDistTensor(
+            &mesh, self_tensor_ref_addr, other_tensor_ref_addr)) {
+      ConvertAllInputsToDistTensor(
+          mesh, self_tensor_ref_addr, other_tensor_ref_addr);
+    }
+    self_tensor = self_tensor_ref_addr;
+    other_tensor = other_tensor_ref_addr;
+  } else {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "Unsupported operand type(s) for &: 'Tensor' and '%s'",
+        other_obj->ob_type->tp_name));
+  }
+
+  // 3. calculation
+  VLOG(6) << "Calling bitwise_and_ad_func in tensor__and__method";
+  {
+    eager_gil_scoped_release guard;
+    ret = bitwise_and_ad_func(self_tensor, other_tensor);
+  }
+
+  return ToPyObject(ret);
+  EAGER_CATCH_AND_THROW_RETURN_NULL
+}
+
 PyMethodDef math_op_patch_methods[] = {  // NOLINT
     {"__add__",
      (PyCFunction)(void (*)())tensor__add__method,
@@ -2435,6 +2506,14 @@ PyMethodDef math_op_patch_methods[] = {  // NOLINT
      nullptr},
     {"__ne__",
      (PyCFunction)(void (*)())tensor__ne__method,
+     METH_VARARGS | METH_KEYWORDS,
+     nullptr},
+    {"__and__",
+     (PyCFunction)(void (*)())tensor__and__method,
+     METH_VARARGS | METH_KEYWORDS,
+     nullptr},
+    {"__rand__",
+     (PyCFunction)(void (*)())tensor__and__method,
      METH_VARARGS | METH_KEYWORDS,
      nullptr},
     {nullptr, nullptr, 0, nullptr}};

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -319,3 +319,8 @@
   args_alias:
     x : [batch1]
     y : [batch2]
+
+- op : bitwise_and
+  name : [paddle.bitwise_and, paddle.Tensor.bitwise_and]
+  args_alias:
+    use_default_mapping : True

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -3441,11 +3441,6 @@ add_doc_and_signature(
             >>> print(res)
             Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
             [0, 2, 1])
-            >>> # using alias 'input' and 'other'
-            >>> res = paddle.bitwise_and(input=x, other=y)
-            >>> print(res)
-            Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
-            [0, 2, 1])
     """,
     """
 def bitwise_and(

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -3294,7 +3294,6 @@ def asin(
 """,
 )
 
-
 add_doc_and_signature(
     "allclose",
     r"""
@@ -3407,6 +3406,51 @@ def baddbmm(
     beta: float = 1.0,
     alpha: float = 1.0,
     out_dtype: paddle.dtype | None = None,
+    name: str | None = None,
+    *,
+    out: Tensor | None = None,
+) -> Tensor
+""",
+)
+
+add_doc_and_signature(
+    "bitwise_and",
+    r"""
+    Apply ``bitwise_and`` on Tensor ``x`` and ``y`` .
+    .. math::
+        Out = X \& Y
+    Note:
+        ``paddle.bitwise_and`` supports broadcasting. If you want know more about broadcasting, please refer to `Introduction to Tensor`_ .
+        .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
+    Args:
+        x (Tensor): Input Tensor of ``bitwise_and`` . It is a N-D Tensor of bool, uint8, int8, int16, int32, int64.
+            Alias: ``input``.
+        y (Tensor): Input Tensor of ``bitwise_and`` . It is a N-D Tensor of bool, uint8, int8, int16, int32, int64.
+            Alias: ``other``.
+        out (Tensor|None, optional): Result of ``bitwise_and`` . It is a N-D Tensor with the same data type of input Tensor. Default: None.
+        name (str|None, optional): The default value is None.  Normally there is no need for
+            user to set this property.  For more information, please refer to :ref:`api_guide_Name`.
+    Returns:
+        Tensor: Result of ``bitwise_and`` . It is a N-D Tensor with the same data type of input Tensor.
+    Examples:
+        .. code-block:: python
+            >>> import paddle
+            >>> x = paddle.to_tensor([-5, -1, 1])
+            >>> y = paddle.to_tensor([4,  2, -3])
+            >>> res = paddle.bitwise_and(x, y)
+            >>> print(res)
+            Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [0, 2, 1])
+            >>> # using alias 'input' and 'other'
+            >>> res = paddle.bitwise_and(input=x, other=y)
+            >>> print(res)
+            Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [0, 2, 1])
+    """,
+    """
+def bitwise_and(
+    x: Tensor,
+    y: Tensor,
     name: str | None = None,
     *,
     out: Tensor | None = None,

--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -666,6 +666,8 @@ def monkey_patch_math_tensor():
         '__rpow__',
         '__eq__',
         '__ne__',
+        '__and__',
+        '__rand__',
     ]
 
     global _already_patch_eager_tensor

--- a/python/paddle/base/layers/math_op_patch.py
+++ b/python/paddle/base/layers/math_op_patch.py
@@ -969,6 +969,8 @@ def monkey_patch_variable():
         ('values', values),
         ('indices', indices),
         ('to_dense', to_dense),
+        ('__and__', _binary_creator_('__and__', 'bitwise_and', False, None)),
+        ('__rand__', _binary_creator_('__rand__', 'bitwise_and', False, None)),
     ]
 
     global _already_patch_variable

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -1666,6 +1666,16 @@ def monkey_patch_value():
         ('__bool__', _bool_),
         ('__complex__', _complex_),
         ('itemsize', itemsize),
+        (
+            '__and__',
+            _binary_creator_('__and__', paddle.tensor.bitwise_and, False, None),
+        ),
+        (
+            '__rand__',
+            _binary_creator_(
+                '__rand__', paddle.tensor.bitwise_and, False, None
+            ),
+        ),
     ]
     dtype_conversion_methods = _create_dtype_conversion_methods()
     value_methods.extend(dtype_conversion_methods)

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -956,8 +956,6 @@ tensor_method_func = [
 
 # this list used in math_op_patch.py for magic_method bind
 magic_method_func = [
-    ('__and__', 'bitwise_and'),
-    ('__rand__', '__rand__'),
     ('__or__', 'bitwise_or'),
     ('__ror__', '__ror__'),
     ('__xor__', 'bitwise_xor'),

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -949,6 +949,7 @@ def _bitwise_op(
         return out
 
 
+@param_two_alias(["x", "input"], ["y", "other"])
 def bitwise_and(
     x: Tensor, y: Tensor, out: Tensor | None = None, name: str | None = None
 ) -> Tensor:
@@ -1002,6 +1003,7 @@ def __rand__(x: Tensor, y: int | bool):
         )
 
 
+@param_two_alias(["x", "input"], ["y", "other"])
 @inplace_apis_in_dygraph_only
 def bitwise_and_(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     r"""

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -986,8 +986,11 @@ def bitwise_and(
             Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
             [0, 2, 1])
     """
-    if in_dynamic_or_pir_mode() and out is None:
-        return _C_ops.bitwise_and(x, y)
+    if in_dynamic_or_pir_mode():
+        if out is None:
+            return _C_ops.bitwise_and(x, y)
+        else:
+            return _C_ops.bitwise_and(x, y, out)
     return _bitwise_op(
         op_name="bitwise_and", x=x, y=y, name=name, out=out, binary_op=True
     )

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -22,6 +22,7 @@ import paddle
 from paddle import _C_ops
 from paddle._C_ops import (  # noqa: F401
     allclose,
+    bitwise_and,
     greater_than,
     isclose,
     logical_and,
@@ -947,53 +948,6 @@ def _bitwise_op(
             )
 
         return out
-
-
-@param_two_alias(["x", "input"], ["y", "other"])
-def bitwise_and(
-    x: Tensor, y: Tensor, out: Tensor | None = None, name: str | None = None
-) -> Tensor:
-    r"""
-
-    Apply ``bitwise_and`` on Tensor ``X`` and ``Y`` .
-
-    .. math::
-        Out = X \& Y
-
-    Note:
-        ``paddle.bitwise_and`` supports broadcasting. If you want know more about broadcasting, please refer to please refer to `Introduction to Tensor`_ .
-
-        .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
-
-    Args:
-        x (Tensor): Input Tensor of ``bitwise_and`` . It is a N-D Tensor of bool, uint8, int8, int16, int32, int64.
-        y (Tensor): Input Tensor of ``bitwise_and`` . It is a N-D Tensor of bool, uint8, int8, int16, int32, int64.
-        out (Tensor|None, optional): Result of ``bitwise_and`` . It is a N-D Tensor with the same data type of input Tensor. Default: None.
-        name (str|None, optional): The default value is None.  Normally there is no need for
-            user to set this property.  For more information, please refer to :ref:`api_guide_Name`.
-
-    Returns:
-        Tensor: Result of ``bitwise_and`` . It is a N-D Tensor with the same data type of input Tensor.
-
-    Examples:
-        .. code-block:: python
-
-            >>> import paddle
-            >>> x = paddle.to_tensor([-5, -1, 1])
-            >>> y = paddle.to_tensor([4,  2, -3])
-            >>> res = paddle.bitwise_and(x, y)
-            >>> print(res)
-            Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
-            [0, 2, 1])
-    """
-    if in_dynamic_or_pir_mode():
-        if out is None:
-            return _C_ops.bitwise_and(x, y)
-        else:
-            return _C_ops.bitwise_and(x, y, out)
-    return _bitwise_op(
-        op_name="bitwise_and", x=x, y=y, name=name, out=out, binary_op=True
-    )
 
 
 def __rand__(x: Tensor, y: int | bool):

--- a/test/legacy_test/test_bitwise_op.py
+++ b/test/legacy_test/test_bitwise_op.py
@@ -132,6 +132,117 @@ class TestBitwiseAndBool(TestBitwiseAnd):
         self.outputs = {'Out': out}
 
 
+class TestBitwiseAndAlias(unittest.TestCase):
+    """Test parameter aliases for bitwise_and API"""
+
+    def test_bitwise_and_alias_input(self):
+        """Test using 'input' alias for parameter 'x'"""
+        paddle.disable_static()
+        x_data = np.array([1, 2, 3], dtype=np.int32)
+        y_data = np.array([4, 2, 1], dtype=np.int32)
+        x = paddle.to_tensor(x_data)
+        y = paddle.to_tensor(y_data)
+
+        # Use 'input' alias for 'x'
+        result = paddle.bitwise_and(input=x, y=y)
+        expected = np.bitwise_and(x_data, y_data)
+        np.testing.assert_array_equal(result.numpy(), expected)
+        paddle.enable_static()
+
+    def test_bitwise_and_alias_other(self):
+        """Test using 'other' alias for parameter 'y'"""
+        paddle.disable_static()
+        x_data = np.array([1, 2, 3], dtype=np.int32)
+        y_data = np.array([4, 2, 1], dtype=np.int32)
+        x = paddle.to_tensor(x_data)
+        y = paddle.to_tensor(y_data)
+
+        # Use 'other' alias for 'y'
+        result = paddle.bitwise_and(x=x, other=y)
+        expected = np.bitwise_and(x_data, y_data)
+        np.testing.assert_array_equal(result.numpy(), expected)
+        paddle.enable_static()
+
+    def test_bitwise_and_alias_both(self):
+        """Test using both 'input' and 'other' aliases"""
+        paddle.disable_static()
+        x_data = np.array([5, 6, 7], dtype=np.int32)
+        y_data = np.array([3, 2, 1], dtype=np.int32)
+        x = paddle.to_tensor(x_data)
+        y = paddle.to_tensor(y_data)
+
+        # Use both aliases
+        result = paddle.bitwise_and(input=x, other=y)
+        expected = np.bitwise_and(x_data, y_data)
+        np.testing.assert_array_equal(result.numpy(), expected)
+        paddle.enable_static()
+
+    def test_bitwise_and_with_out_parameter(self):
+        """Test bitwise_and with out parameter"""
+        paddle.disable_static()
+        x_data = np.array([1, 2, 3], dtype=np.int32)
+        y_data = np.array([4, 2, 1], dtype=np.int32)
+        x = paddle.to_tensor(x_data)
+        y = paddle.to_tensor(y_data)
+        out = paddle.empty([3], dtype='int32')
+
+        # Test with out parameter
+        result = paddle.bitwise_and(x, y, out=out)
+        expected = np.bitwise_and(x_data, y_data)
+        np.testing.assert_array_equal(result.numpy(), expected)
+        np.testing.assert_array_equal(out.numpy(), expected)
+        paddle.enable_static()
+
+
+class TestBitwiseAndInplaceAlias(unittest.TestCase):
+    """Test parameter aliases for bitwise_and_ inplace API"""
+
+    def test_bitwise_and_inplace_alias_input(self):
+        """Test using 'input' alias for parameter 'x' in inplace version"""
+        paddle.disable_static()
+        x_data = np.array([1, 2, 3], dtype=np.int32)
+        y_data = np.array([4, 2, 1], dtype=np.int32)
+        x = paddle.to_tensor(x_data)
+        y = paddle.to_tensor(y_data)
+
+        # Use 'input' alias for 'x'
+        result = paddle.bitwise_and_(input=x, y=y)
+        expected = np.bitwise_and(x_data, y_data)
+        np.testing.assert_array_equal(result.numpy(), expected)
+        np.testing.assert_array_equal(x.numpy(), expected)
+        paddle.enable_static()
+
+    def test_bitwise_and_inplace_alias_other(self):
+        """Test using 'other' alias for parameter 'y' in inplace version"""
+        paddle.disable_static()
+        x_data = np.array([1, 2, 3], dtype=np.int32)
+        y_data = np.array([4, 2, 1], dtype=np.int32)
+        x = paddle.to_tensor(x_data)
+        y = paddle.to_tensor(y_data)
+
+        # Use 'other' alias for 'y'
+        result = paddle.bitwise_and_(x=x, other=y)
+        expected = np.bitwise_and(x_data, y_data)
+        np.testing.assert_array_equal(result.numpy(), expected)
+        np.testing.assert_array_equal(x.numpy(), expected)
+        paddle.enable_static()
+
+    def test_bitwise_and_inplace_alias_both(self):
+        """Test using both 'input' and 'other' aliases in inplace version"""
+        paddle.disable_static()
+        x_data = np.array([5, 6, 7], dtype=np.int32)
+        y_data = np.array([3, 2, 1], dtype=np.int32)
+        x = paddle.to_tensor(x_data)
+        y = paddle.to_tensor(y_data)
+
+        # Use both aliases
+        result = paddle.bitwise_and_(input=x, other=y)
+        expected = np.bitwise_and(x_data, y_data)
+        np.testing.assert_array_equal(result.numpy(), expected)
+        np.testing.assert_array_equal(x.numpy(), expected)
+        paddle.enable_static()
+
+
 @unittest.skipIf(
     not (core.is_compiled_with_cuda() or is_custom_device()),
     "core is not compiled with CUDA",

--- a/test/legacy_test/test_bitwise_op.py
+++ b/test/legacy_test/test_bitwise_op.py
@@ -27,7 +27,7 @@ paddle.enable_static()
 class TestBitwiseAnd(OpTest):
     def setUp(self):
         self.op_type = "bitwise_and"
-        self.python_api = paddle.tensor.logic.bitwise_and
+        self.python_api = paddle.bitwise_and
         self.init_dtype()
         self.init_shape()
         self.init_bound()
@@ -120,7 +120,7 @@ class TestBitwiseAndInt64(TestBitwiseAnd):
 class TestBitwiseAndBool(TestBitwiseAnd):
     def setUp(self):
         self.op_type = "bitwise_and"
-        self.python_api = paddle.tensor.logic.bitwise_and
+        self.python_api = paddle.bitwise_and
 
         self.init_shape()
 
@@ -194,6 +194,77 @@ class TestBitwiseAndAlias(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestBitwiseAndMagicMethod(unittest.TestCase):
+    """Test magic method x & y for bitwise_and"""
+
+    def test_bitwise_and_magic_method(self):
+        """Test using & operator for bitwise_and"""
+        paddle.disable_static()
+        x_data = np.array([1, 2, 3], dtype=np.int32)
+        y_data = np.array([4, 2, 1], dtype=np.int32)
+        x = paddle.to_tensor(x_data)
+        y = paddle.to_tensor(y_data)
+
+        # Use & magic method
+        result = x & y
+        expected = np.bitwise_and(x_data, y_data)
+        np.testing.assert_array_equal(result.numpy(), expected)
+        paddle.enable_static()
+
+    def test_bitwise_and_magic_method_different_dtypes(self):
+        """Test & operator with different data types"""
+        paddle.disable_static()
+
+        # Test with uint8
+        x_uint8 = paddle.to_tensor(np.array([15, 255, 128], dtype=np.uint8))
+        y_uint8 = paddle.to_tensor(np.array([240, 15, 64], dtype=np.uint8))
+        result_uint8 = x_uint8 & y_uint8
+        expected_uint8 = np.bitwise_and(x_uint8.numpy(), y_uint8.numpy())
+        np.testing.assert_array_equal(result_uint8.numpy(), expected_uint8)
+
+        # Test with int8
+        x_int8 = paddle.to_tensor(np.array([15, -128, 127], dtype=np.int8))
+        y_int8 = paddle.to_tensor(np.array([7, 64, -1], dtype=np.int8))
+        result_int8 = x_int8 & y_int8
+        expected_int8 = np.bitwise_and(x_int8.numpy(), y_int8.numpy())
+        np.testing.assert_array_equal(result_int8.numpy(), expected_int8)
+
+        # Test with bool
+        x_bool = paddle.to_tensor(np.array([True, False, True], dtype=bool))
+        y_bool = paddle.to_tensor(np.array([True, True, False], dtype=bool))
+        result_bool = x_bool & y_bool
+        expected_bool = np.bitwise_and(x_bool.numpy(), y_bool.numpy())
+        np.testing.assert_array_equal(result_bool.numpy(), expected_bool)
+
+        paddle.enable_static()
+
+    def test_bitwise_and_magic_method_broadcast(self):
+        """Test & operator with broadcasting"""
+        paddle.disable_static()
+        x_data = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32)
+        y_data = np.array([7, 6, 5], dtype=np.int32)
+        x = paddle.to_tensor(x_data)
+        y = paddle.to_tensor(y_data)
+
+        result = x & y
+        expected = np.bitwise_and(x_data, y_data)
+        np.testing.assert_array_equal(result.numpy(), expected)
+        paddle.enable_static()
+
+    def test_bitwise_and_magic_method_zero_dim(self):
+        """Test & operator with zero-dimensional tensors"""
+        paddle.disable_static()
+        x_data = np.array(5, dtype=np.int32)
+        y_data = np.array(3, dtype=np.int32)
+        x = paddle.to_tensor(x_data)
+        y = paddle.to_tensor(y_data)
+
+        result = x & y
+        expected = np.bitwise_and(x_data, y_data)
+        np.testing.assert_array_equal(result.numpy(), expected)
+        paddle.enable_static()
+
+
 class TestBitwiseAndInplaceAlias(unittest.TestCase):
     """Test parameter aliases for bitwise_and_ inplace API"""
 
@@ -252,8 +323,8 @@ class TestElementwiseBitwiseAndOp_Stride(OpTest):
 
     def setUp(self):
         self.op_type = "bitwise_and"
-        self.python_api = paddle.tensor.logic.bitwise_and
-        self.public_python_api = paddle.tensor.logic.bitwise_and
+        self.python_api = paddle.bitwise_and
+        self.public_python_api = paddle.bitwise_and
         self.transpose_api = paddle.transpose
         self.as_stride_api = paddle.as_strided
         self.init_dtype()
@@ -404,7 +475,7 @@ class TestElementwiseBitwiseAndOp_Stride_ZeroSize1(
 class TestBitwiseOr(OpTest):
     def setUp(self):
         self.op_type = "bitwise_or"
-        self.python_api = paddle.tensor.logic.bitwise_or
+        self.python_api = paddle.bitwise_or
         self.init_dtype()
         self.init_shape()
         self.init_bound()
@@ -497,7 +568,7 @@ class TestBitwiseOrInt64(TestBitwiseOr):
 class TestBitwiseOrBool(TestBitwiseOr):
     def setUp(self):
         self.op_type = "bitwise_or"
-        self.python_api = paddle.tensor.logic.bitwise_or
+        self.python_api = paddle.bitwise_or
 
         self.init_shape()
 
@@ -518,8 +589,8 @@ class TestElementwiseBitwiseOrOp_Stride(OpTest):
 
     def setUp(self):
         self.op_type = "bitwise_or"
-        self.python_api = paddle.tensor.logic.bitwise_or
-        self.public_python_api = paddle.tensor.logic.bitwise_or
+        self.python_api = paddle.bitwise_or
+        self.public_python_api = paddle.bitwise_or
         self.transpose_api = paddle.transpose
         self.as_stride_api = paddle.as_strided
         self.init_dtype()
@@ -670,7 +741,7 @@ class TestElementwiseBitwiseOrOp_Stride_ZeroSize1(
 class TestBitwiseXor(OpTest):
     def setUp(self):
         self.op_type = "bitwise_xor"
-        self.python_api = paddle.tensor.logic.bitwise_xor
+        self.python_api = paddle.bitwise_xor
 
         self.init_dtype()
         self.init_shape()
@@ -764,7 +835,7 @@ class TestBitwiseXorInt64(TestBitwiseXor):
 class TestBitwiseXorBool(TestBitwiseXor):
     def setUp(self):
         self.op_type = "bitwise_xor"
-        self.python_api = paddle.tensor.logic.bitwise_xor
+        self.python_api = paddle.bitwise_xor
 
         self.init_shape()
 
@@ -785,8 +856,8 @@ class TestElementwiseBitwiseXorOp_Stride(OpTest):
 
     def setUp(self):
         self.op_type = "bitwise_xor"
-        self.python_api = paddle.tensor.logic.bitwise_xor
-        self.public_python_api = paddle.tensor.logic.bitwise_xor
+        self.python_api = paddle.bitwise_xor
+        self.public_python_api = paddle.bitwise_xor
         self.transpose_api = paddle.transpose
         self.as_stride_api = paddle.as_strided
         self.init_dtype()
@@ -937,7 +1008,7 @@ class TestElementwiseBitwiseXorOp_Stride_ZeroSize1(
 class TestBitwiseNot(OpTest):
     def setUp(self):
         self.op_type = "bitwise_not"
-        self.python_api = paddle.tensor.logic.bitwise_not
+        self.python_api = paddle.bitwise_not
 
         self.init_dtype()
         self.init_shape()
@@ -1016,7 +1087,7 @@ class TestBitwiseNotInt64(TestBitwiseNot):
 class TestBitwiseNotBool(TestBitwiseNot):
     def setUp(self):
         self.op_type = "bitwise_not"
-        self.python_api = paddle.tensor.logic.bitwise_not
+        self.python_api = paddle.bitwise_not
         self.init_shape()
 
         x = np.random.choice([True, False], self.x_shape)

--- a/test/legacy_test/test_zero_dim_binary_api.py
+++ b/test/legacy_test/test_zero_dim_binary_api.py
@@ -167,7 +167,9 @@ class TestBinaryAPI(unittest.TestCase):
             # 1) x is 0D, y is 0D
             x_np = np.random.randint(-10, 10, [])
             y_np = np.random.randint(-10, 10, [])
-            out_np = eval(f'np.{api.__name__}(x_np, y_np)')
+            # Handle C++ binding functions with leading underscore in __name__
+            api_name = api.__name__.lstrip('_')
+            out_np = eval(f'np.{api_name}(x_np, y_np)')
 
             x = paddle.to_tensor(x_np)
             y = paddle.to_tensor(y_np)
@@ -179,7 +181,7 @@ class TestBinaryAPI(unittest.TestCase):
             # 2) x is ND, y is 0D
             x_np = np.random.randint(-10, 10, [3, 5])
             y_np = np.random.randint(-10, 10, [])
-            out_np = eval(f'np.{api.__name__}(x_np, y_np)')
+            out_np = eval(f'np.{api_name}(x_np, y_np)')
 
             x = paddle.to_tensor(x_np)
             y = paddle.to_tensor(y_np)
@@ -191,7 +193,7 @@ class TestBinaryAPI(unittest.TestCase):
             # 3) x is 0D , y is ND
             x_np = np.random.randint(-10, 10, [])
             y_np = np.random.randint(-10, 10, [3, 5])
-            out_np = eval(f'np.{api.__name__}(x_np, y_np)')
+            out_np = eval(f'np.{api_name}(x_np, y_np)')
 
             x = paddle.to_tensor(x_np)
             y = paddle.to_tensor(y_np)

--- a/test/xpu/test_zero_dim_tensor_xpu.py
+++ b/test/xpu/test_zero_dim_tensor_xpu.py
@@ -345,7 +345,9 @@ class TestBinaryAPI(unittest.TestCase):
             # 1) x is 0D, y is 0D
             x_np = np.random.randint(-10, 10, [])
             y_np = np.random.randint(-10, 10, [])
-            out_np = eval(f'np.{api.__name__}(x_np, y_np)')
+            # Handle C++ binding functions with leading underscore in __name__
+            api_name = api.__name__.lstrip('_')
+            out_np = eval(f'np.{api_name}(x_np, y_np)')
 
             x = paddle.to_tensor(x_np)
             y = paddle.to_tensor(y_np)
@@ -357,7 +359,7 @@ class TestBinaryAPI(unittest.TestCase):
             # 2) x is ND, y is 0D
             x_np = np.random.randint(-10, 10, [3, 5])
             y_np = np.random.randint(-10, 10, [])
-            out_np = eval(f'np.{api.__name__}(x_np, y_np)')
+            out_np = eval(f'np.{api_name}(x_np, y_np)')
 
             x = paddle.to_tensor(x_np)
             y = paddle.to_tensor(y_np)
@@ -369,7 +371,7 @@ class TestBinaryAPI(unittest.TestCase):
             # 3) x is 0D , y is ND
             x_np = np.random.randint(-10, 10, [])
             y_np = np.random.randint(-10, 10, [3, 5])
-            out_np = eval(f'np.{api.__name__}(x_np, y_np)')
+            out_np = eval(f'np.{api_name}(x_np, y_np)')
 
             x = paddle.to_tensor(x_np)
             y = paddle.to_tensor(y_np)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
New features


### Description
- 为 `paddle.bitwise_and` 和 `paddle.bitwise_and` 添加参数别名
- 为新增参数别名添加单测
