### PR TITLE
[Compat] Dont clean `TORCH_MODULES_CACHE` when swap out

### DIFF
--- a/python/paddle/compat/proxy.py
+++ b/python/paddle/compat/proxy.py
@@ -393,7 +393,6 @@ def _swap_torch_modules_from_cache():
     for name in list(TORCH_MODULES_CACHE):
         assert _is_torch_module(name), f"`{name}` is not a PyTorch module"
         sys.modules[name] = TORCH_MODULES_CACHE[name]
-        del TORCH_MODULES_CACHE[name]
 
 
 def _modify_scope_of_torch_proxy(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

`TORCH_MODULES_CACHE` 不清理，避免深层次嵌套场景 `TORCH_MODULES_CACHE` 内容丢失问题

本质上是 `TORCH_MODULES_CACHE` 只有一层，无法满足深层次嵌套场景的需求，后续会考虑整体重构下，目前不清理 `TORCH_MODULES_CACHE` 问题也不大

<!-- PCard-66972 -->