### PR TITLE
[Bug fixes] Solve EP communication conflict between xDeepEP and Paddle

### DIFF
--- a/paddle/phi/backends/xpu/xpu_context.cc
+++ b/paddle/phi/backends/xpu/xpu_context.cc
@@ -486,6 +486,12 @@ void XPUContext::SetBkclContext(xpu::BKCLContext_t context) {
 void XPUContext::CreateStream(int i) {
   CheckValidStreamId(i);
   impls_[i]->CreateStream();
+  // Update stream pool and handle after creating the stream
+  if (i == 0 && current_stream_idx == 0 && stream_pool.size() > 0) {
+    stream_pool[current_stream_idx] = impls_[i]->context_->get_stream();
+    current_stream_handle.set_stream(impls_[i]->context_->get_stream());
+    idle_stream_flags[current_stream_idx] = false;
+  }
 }
 
 void XPUContext::RecordEvent(XPUEvent event, int s) const {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Bug原因：
xDeepEP通过phi::get_current_stream_handle()这个接口获取计算流，由于https://github.com/PaddlePaddle/Paddle/commit/15301e07f37bc2f660b9052d6868a3c95a483063 新创建了一个计算流，导致接口会直接返回未初始化stream_pool等相关变量的current_stream_handle，所以FD EP推理会卡住。
<img width="437" height="187" alt="image" src="https://github.com/user-attachments/assets/57c926f1-ca29-44db-8c48-ad9a0a50dd26" />

修改方案：
在CreateStream的时候补充current_stream_handle和相关变量的更新。更新逻辑参考get_current_stream_handle()


