### PR TITLE
[API Compatibility] Add pir support for SDPA and set enable_gqa default to True for better compatibility

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention_kernel.cu
@@ -17,6 +17,7 @@
 #include "paddle/common/errors.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/autogen/memory_efficient_attention.h"
 #include "paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/gemm_kernel_utils.h"
 #include "paddle/phi/kernels/fusion/cutlass/memory_efficient_attention_utils.h"
@@ -47,6 +48,35 @@ void MemoryEfficientAttentionForwardKernel(
     DenseTensor* output,
     DenseTensor* logsumexp,
     DenseTensor* seed_and_offset) {
+  phi::Dim<1> seed_dims;
+  seed_dims[0] = 2;
+  seed_and_offset->Resize(seed_dims);
+  dev_ctx.template HostAlloc<int64_t>(seed_and_offset);
+  int64_t* seed_and_offset_ptr =
+      phi::SafeGetTensorPtr<int64_t>(seed_and_offset);
+  auto gen = dev_ctx.GetGenerator();
+  uint64_t inc = query.dims()[0] * query.dims()[2] * 32;
+  auto seed_offset_pair = gen->IncrementOffset(inc);
+  auto seed = (seed_offset_pair.first);
+  auto offset = (seed_offset_pair.second);
+  seed_and_offset_ptr[0] = (int64_t)seed;
+  seed_and_offset_ptr[1] = (int64_t)offset;
+  VLOG(3) << "seed and offset: " << seed << " " << offset << " "
+          << seed_and_offset_ptr;
+
+  if (query.numel() == 0 || key.numel() == 0 || value.numel() == 0) {
+    if (output) {
+      Full<T, Context>(
+          dev_ctx, phi::IntArray(common::vectorize(output->dims())), 0, output);
+    }
+    if (logsumexp) {
+      Full<T, Context>(dev_ctx,
+                       phi::IntArray(common::vectorize(logsumexp->dims())),
+                       0,
+                       logsumexp);
+    }
+    return;
+  }
   int compute_capacity = dev_ctx.GetComputeCapability();
   const auto max_shmem =
       getMaximumSharedMemoryPerBlockKb(compute_capacity) * 1024;
@@ -217,23 +247,6 @@ void MemoryEfficientAttentionForwardKernel(
     VLOG(3) << "bias_strideB " << p.bias_strideB;
     VLOG(3) << "bias_strideH " << p.bias_strideH;
     VLOG(3) << "bias_strideM " << p.bias_strideM;
-
-    phi::Dim<1> seed_dims;
-    seed_dims[0] = 2;
-    seed_and_offset->Resize(seed_dims);
-    dev_ctx.template HostAlloc<int64_t>(seed_and_offset);
-    int64_t* seed_and_offset_ptr =
-        phi::SafeGetTensorPtr<int64_t>(seed_and_offset);
-
-    auto gen = dev_ctx.GetGenerator();
-    uint64_t inc = query.dims()[0] * query.dims()[2] * 32;
-    auto seed_offset_pair = gen->IncrementOffset(inc);
-    auto seed = (seed_offset_pair.first);
-    auto offset = (seed_offset_pair.second);
-    seed_and_offset_ptr[0] = (int64_t)seed;
-    seed_and_offset_ptr[1] = (int64_t)offset;
-    VLOG(3) << "seed and offset: " << seed << " " << offset << " "
-            << seed_and_offset_ptr;
 
     p.use_dropout = use_dropout;
     if (use_dropout) {

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -569,7 +569,7 @@ def is_bf16_supported(including_emulation: bool = True) -> bool:
 
     """
     # including_emulation is not used here, but kept for compatibility with the original implementation
-    if core.is_bfloat16_supported(paddle.framework._current_expected_place()):
+    if core.is_bfloat16_supported(paddle.framework._current_expected_place_()):
         return True
 
     # If CUDA is not available, than it does not support bf16 either

--- a/python/paddle/incubate/nn/memory_efficient_attention.py
+++ b/python/paddle/incubate/nn/memory_efficient_attention.py
@@ -35,6 +35,7 @@ from .attn_bias import (
 SUPPORTED_ATTN_BIAS_TYPES = {
     type(None),
     paddle.Tensor,
+    paddle.pir.Value,
     LowerTriangularMask,
     LowerTriangularMaskWithTensorBias,
     BlockDiagonalMask,
@@ -59,7 +60,7 @@ def _get_seqlen_info(attn_bias):
 
 
 def _get_tensor_bias(attn_bias):
-    if isinstance(attn_bias, paddle.Tensor):
+    if isinstance(attn_bias, (paddle.Tensor, paddle.pir.Value)):
         return attn_bias
     elif isinstance(attn_bias, LowerTriangularMaskWithTensorBias):
         return attn_bias._bias

--- a/python/paddle/nn/functional/flash_attention.py
+++ b/python/paddle/nn/functional/flash_attention.py
@@ -133,13 +133,13 @@ def _math_attention(
     query = paddle.transpose(query, [0, 2, 1, 3])
     key = paddle.transpose(key, [0, 2, 1, 3])
     value = paddle.transpose(value, [0, 2, 1, 3])
-    scale = scale or head_dim**-0.5
+    # head_dim may be 0 in zero size case
+    scale = scale or (head_dim**-0.5 if head_dim != 0 else 1.0)
     product = paddle.matmul(x=query * scale, y=key, transpose_y=True)
 
-    if mask is not None:
-        product = product + mask
-
     if not causal:
+        if mask is not None:
+            product = product + mask
         weights = F.softmax(product)
     else:
         # special for XPU device

--- a/python/paddle/nn/functional/flash_attention.py
+++ b/python/paddle/nn/functional/flash_attention.py
@@ -148,6 +148,8 @@ def _math_attention(
             "xpu" in place
             or product.shape[-1] < 32
             or product.shape[-1] > 16384
+            or place == paddle.CPUPlace()
+            or product.shape[-1] != product.shape[-2]
         ):
             # softmax_mask_fuse_upper_triangle is not supported on XPU, use plain implementation
             mask = get_triangle_upper_mask(product)

--- a/python/paddle/nn/functional/sdpa.py
+++ b/python/paddle/nn/functional/sdpa.py
@@ -423,7 +423,7 @@ def scaled_dot_product_attention(
     training: bool = True,
     backend: str | None = None,
     scale: float | None = None,
-    enable_gqa: bool = False,
+    enable_gqa: bool = True,
     name: str | None = None,
 ) -> Tensor:
     r"""
@@ -480,7 +480,7 @@ def scaled_dot_product_attention(
                         Currently only support "p2p" for distribution usage.
         scale(float, optional): The scaling factor used in the calculation of attention weights.
                         If None, scale = 1 / sqrt(head_dim).
-        enable_gqa(bool, optional): Whether enable GQA(Generic Query Attention) mode.
+        enable_gqa(bool, optional): Whether enable GQA(Generic Query Attention) mode. Default is True.
         name(str|None, optional): The default value is None. Normally there is no need for user
                         to set this property. For more information, please refer to
                         :ref:`api_guide_Name`.
@@ -533,7 +533,11 @@ def scaled_dot_product_attention(
                 key.flatten(2, 3).contiguous(),
                 value.flatten(2, 3).contiguous(),
             )
-
+    else:
+        assert q_heads == k_heads == v_heads, (
+            f"The number of groups in query({q_heads}) must be equal to the number of groups in key({k_heads}) "
+            f"and the number of groups in value({v_heads}) if GQA disabled."
+        )
     bs, seq_len_q, num_heads_q, head_dim_q = query.shape
     _, seq_len_k, num_heads_k, head_dim_k = key.shape
 

--- a/python/paddle/nn/functional/sdpa.py
+++ b/python/paddle/nn/functional/sdpa.py
@@ -492,7 +492,7 @@ def scaled_dot_product_attention(
                         Currently only support "p2p" for distribution usage.
         scale(float, optional): The scaling factor used in the calculation of attention weights.
                         If None, scale = 1 / sqrt(head_dim).
-        enable_gqa(bool, optional): Whether enable GQA(Generic Query Attention) mode. Default is True.
+        enable_gqa(bool, optional): Whether enable GQA(Group Query Attention) mode. Default is True.
         name(str|None, optional): The default value is None. Normally there is no need for user
                         to set this property. For more information, please refer to
                         :ref:`api_guide_Name`.

--- a/python/paddle/nn/functional/sdpa.py
+++ b/python/paddle/nn/functional/sdpa.py
@@ -579,8 +579,7 @@ def scaled_dot_product_attention(
         return out
 
     if not paddle.base.in_dygraph_mode():
-        with paddle.base.dygraph.guard():
-            qkv_place = (paddle.framework._current_expected_place(),) * 3
+        qkv_place = (paddle.framework._current_expected_place_(),) * 3
     else:
         qkv_place = (query.place, key.place, value.place)
 

--- a/python/paddle/nn/functional/sdpa.py
+++ b/python/paddle/nn/functional/sdpa.py
@@ -558,10 +558,11 @@ def scaled_dot_product_attention(
         )
         return out
 
-    qkv_place = (query.place, key.place, value.place)
     if not paddle.base.in_dygraph_mode():
         with paddle.base.dygraph.guard():
             qkv_place = (paddle.framework._current_expected_place(),) * 3
+    else:
+        qkv_place = (query.place, key.place, value.place)
 
     param = SDPParams(
         query_shape=query.shape,
@@ -580,6 +581,12 @@ def scaled_dot_product_attention(
     if len(_config) == 0:
         init_config()
 
+    is_zero_size = (
+        query.shape.numel() == 0
+        or key.shape.numel() == 0
+        or value.shape.numel() == 0
+    )
+
     if attn_mask is not None:
         if attn_mask.dtype == paddle.bool:
             attn_mask = paddle.where(
@@ -589,9 +596,14 @@ def scaled_dot_product_attention(
             )
         if attn_mask.ndim == 3:
             attn_mask = paddle.unsqueeze(attn_mask, axis=1)
-        mask_shape = (bs, num_heads_q, seq_len_q, seq_len_k)
-        attn_mask = attn_mask.expand(mask_shape)
-    sdp_func_name = select_sdp_for_sdpa(param)
+        if attn_mask.shape.numel() != 0:
+            mask_shape = (bs, num_heads_q, seq_len_q, seq_len_k)
+            attn_mask = attn_mask.expand(mask_shape)
+
+    if is_zero_size:
+        sdp_func_name = "math"
+    else:
+        sdp_func_name = select_sdp_for_sdpa(param)
 
     _logger.debug("Selected backend:" + sdp_func_name)
     if sdp_func_name == "flash_attn":

--- a/python/paddle/nn/functional/sdpa.py
+++ b/python/paddle/nn/functional/sdpa.py
@@ -41,22 +41,34 @@ _config = {}
 
 def init_config():
     global _config
-    _config = {
-        "flash_attn": {
-            "MINIMUM_SM_VERSION": (8, 0),
-            "MAXIMUM_SM_VERSION": (12, 1),
-            "support_dtypes": (paddle.float16, paddle.bfloat16)
-            if paddle.device.is_bf16_supported()
-            else (paddle.float16,),
-        },
-        "mem_efficient_attn": {
-            "MINIMUM_SM_VERSION": (5, 0),
-            "MAXIMUM_SM_VERSION": (12, 1),
-            "support_dtypes": (paddle.float16, paddle.bfloat16, paddle.float)
-            if paddle.device.is_bf16_supported()
-            else (paddle.float16, paddle.float),
-        },
-    }
+    with paddle.base.dygraph.guard():
+        is_bf16_natively_supported = False
+        if paddle.base.is_compiled_with_cuda():
+            is_bf16_natively_supported = (
+                paddle.cuda.get_device_capability()[0] >= 8
+            )
+        else:
+            is_bf16_natively_supported = paddle.device.is_bf16_supported()
+        _config = {
+            "flash_attn": {
+                "MINIMUM_SM_VERSION": (8, 0),
+                "MAXIMUM_SM_VERSION": (12, 1),
+                "support_dtypes": (paddle.float16, paddle.bfloat16)
+                if is_bf16_natively_supported
+                else (paddle.float16,),
+            },
+            "mem_efficient_attn": {
+                "MINIMUM_SM_VERSION": (5, 0),
+                "MAXIMUM_SM_VERSION": (12, 1),
+                "support_dtypes": (
+                    paddle.float16,
+                    paddle.bfloat16,
+                    paddle.float,
+                )
+                if is_bf16_natively_supported
+                else (paddle.float16, paddle.float),
+            },
+        }
 
 
 @dataclass
@@ -508,31 +520,18 @@ def scaled_dot_product_attention(
         query = query.unsqueeze(0)
         key = key.unsqueeze(0)
         value = value.unsqueeze(0)
+    k_heads, q_heads, v_heads = (
+        key.shape[2],
+        query.shape[2],
+        value.shape[2],
+    )
     if enable_gqa:
-        k_heads, q_heads, v_heads = (
-            key.shape[2],
-            query.shape[2],
-            value.shape[2],
-        )
-
         assert q_heads % k_heads == 0, (
             f"The number of groups in query({q_heads}) must be divisible by the number of groups in key({k_heads}) if GQA enabled."
         )
         assert k_heads == v_heads, (
             f"The number of groups in key({k_heads}) must be equal to the number of groups in value({v_heads}) if GQA enabled."
         )
-        # repeat_interleave does not support float16 on GPU, so we manually expand the tensor
-        if k_heads != q_heads:
-            repeats = q_heads // k_heads
-            key, value = key.unsqueeze(3), value.unsqueeze(3)
-            key, value = (
-                key.expand([-1, -1, -1, repeats, -1]),
-                value.expand([-1, -1, -1, repeats, -1]),
-            )
-            key, value = (
-                key.flatten(2, 3).contiguous(),
-                value.flatten(2, 3).contiguous(),
-            )
     else:
         assert q_heads == k_heads == v_heads, (
             f"The number of groups in query({q_heads}) must be equal to the number of groups in key({k_heads}) "
@@ -559,6 +558,11 @@ def scaled_dot_product_attention(
         )
         return out
 
+    qkv_place = (query.place, key.place, value.place)
+    if not paddle.base.in_dygraph_mode():
+        with paddle.base.dygraph.guard():
+            qkv_place = (paddle.framework._current_expected_place(),) * 3
+
     param = SDPParams(
         query_shape=query.shape,
         key_shape=key.shape,
@@ -571,7 +575,7 @@ def scaled_dot_product_attention(
         query_stop_gradient=query.stop_gradient,
         strides=(query.stride(), key.stride(), value.stride()),
         dtype=(query.dtype, key.dtype, value.dtype),
-        place=(query.place, key.place, value.place),
+        place=qkv_place,
     )
     if len(_config) == 0:
         init_config()
@@ -612,6 +616,19 @@ def scaled_dot_product_attention(
             memory_efficient_attention,
         )
 
+        # repeat_interleave does not support float16 on GPU, so we manually expand the tensor
+        if k_heads != q_heads:
+            repeats = q_heads // k_heads
+            key, value = key.unsqueeze(3), value.unsqueeze(3)
+            key, value = (
+                key.expand([-1, -1, -1, repeats, -1]),
+                value.expand([-1, -1, -1, repeats, -1]),
+            )
+            key, value = (
+                key.flatten(2, 3).contiguous(),
+                value.flatten(2, 3).contiguous(),
+            )
+
         if is_causal:
             bias_input = LowerTriangularMask()
         elif attn_mask is not None:
@@ -629,6 +646,18 @@ def scaled_dot_product_attention(
         )
 
     elif sdp_func_name == "math":
+        # repeat_interleave does not support float16 on GPU, so we manually expand the tensor
+        if k_heads != q_heads:
+            repeats = q_heads // k_heads
+            key, value = key.unsqueeze(3), value.unsqueeze(3)
+            key, value = (
+                key.expand([-1, -1, -1, repeats, -1]),
+                value.expand([-1, -1, -1, repeats, -1]),
+            )
+            key, value = (
+                key.flatten(2, 3).contiguous(),
+                value.flatten(2, 3).contiguous(),
+            )
         out = _math_attention(
             query,
             key,

--- a/python/paddle/nn/functional/sdpa.py
+++ b/python/paddle/nn/functional/sdpa.py
@@ -71,6 +71,26 @@ def init_config():
         }
 
 
+def _repeat_kv(key: Tensor, value: Tensor, num_repeats: int):
+    """
+    Repeat key and value tensors along the num_heads(3) dimension. The layout
+    of key and value should be [batch_size, seq_len, num_heads, head_dim].
+    """
+    if num_repeats == 1:
+        return key, value
+    # repeat_interleave does not support float16 on GPU, so we manually expand the tensor
+    key, value = key.unsqueeze(3), value.unsqueeze(3)
+    key, value = (
+        key.expand([-1, -1, -1, num_repeats, -1]),
+        value.expand([-1, -1, -1, num_repeats, -1]),
+    )
+    key, value = (
+        key.flatten(2, 3).contiguous(),
+        value.flatten(2, 3).contiguous(),
+    )
+    return key, value
+
+
 @dataclass
 class SDPParams:
     query_shape: paddle.Size
@@ -628,18 +648,8 @@ def scaled_dot_product_attention(
             memory_efficient_attention,
         )
 
-        # repeat_interleave does not support float16 on GPU, so we manually expand the tensor
-        if k_heads != q_heads:
-            repeats = q_heads // k_heads
-            key, value = key.unsqueeze(3), value.unsqueeze(3)
-            key, value = (
-                key.expand([-1, -1, -1, repeats, -1]),
-                value.expand([-1, -1, -1, repeats, -1]),
-            )
-            key, value = (
-                key.flatten(2, 3).contiguous(),
-                value.flatten(2, 3).contiguous(),
-            )
+        repeats = q_heads // k_heads
+        key, value = _repeat_kv(key, value, repeats)
 
         if is_causal:
             bias_input = LowerTriangularMask()
@@ -658,18 +668,8 @@ def scaled_dot_product_attention(
         )
 
     elif sdp_func_name == "math":
-        # repeat_interleave does not support float16 on GPU, so we manually expand the tensor
-        if k_heads != q_heads:
-            repeats = q_heads // k_heads
-            key, value = key.unsqueeze(3), value.unsqueeze(3)
-            key, value = (
-                key.expand([-1, -1, -1, repeats, -1]),
-                value.expand([-1, -1, -1, repeats, -1]),
-            )
-            key, value = (
-                key.flatten(2, 3).contiguous(),
-                value.flatten(2, 3).contiguous(),
-            )
+        repeats = q_heads // k_heads
+        key, value = _repeat_kv(key, value, repeats)
         out = _math_attention(
             query,
             key,

--- a/python/paddle/nn/functional/sdpa.py
+++ b/python/paddle/nn/functional/sdpa.py
@@ -41,34 +41,26 @@ _config = {}
 
 def init_config():
     global _config
-    with paddle.base.dygraph.guard():
-        is_bf16_natively_supported = False
-        if paddle.base.is_compiled_with_cuda():
-            is_bf16_natively_supported = (
-                paddle.cuda.get_device_capability()[0] >= 8
+    _config = {
+        "flash_attn": {
+            "MINIMUM_SM_VERSION": (8, 0),
+            "MAXIMUM_SM_VERSION": (12, 1),
+            "support_dtypes": (paddle.float16, paddle.bfloat16)
+            if paddle.device.is_bf16_supported(including_emulation=False)
+            else (paddle.float16,),
+        },
+        "mem_efficient_attn": {
+            "MINIMUM_SM_VERSION": (5, 0),
+            "MAXIMUM_SM_VERSION": (12, 1),
+            "support_dtypes": (
+                paddle.float16,
+                paddle.bfloat16,
+                paddle.float,
             )
-        else:
-            is_bf16_natively_supported = paddle.device.is_bf16_supported()
-        _config = {
-            "flash_attn": {
-                "MINIMUM_SM_VERSION": (8, 0),
-                "MAXIMUM_SM_VERSION": (12, 1),
-                "support_dtypes": (paddle.float16, paddle.bfloat16)
-                if is_bf16_natively_supported
-                else (paddle.float16,),
-            },
-            "mem_efficient_attn": {
-                "MINIMUM_SM_VERSION": (5, 0),
-                "MAXIMUM_SM_VERSION": (12, 1),
-                "support_dtypes": (
-                    paddle.float16,
-                    paddle.bfloat16,
-                    paddle.float,
-                )
-                if is_bf16_natively_supported
-                else (paddle.float16, paddle.float),
-            },
-        }
+            if paddle.device.is_bf16_supported(including_emulation=False)
+            else (paddle.float16, paddle.float),
+        },
+    }
 
 
 def _repeat_kv(key: Tensor, value: Tensor, num_repeats: int):

--- a/test/legacy_test/test_compat_scaled_dot_product_attention.py
+++ b/test/legacy_test/test_compat_scaled_dot_product_attention.py
@@ -327,5 +327,162 @@ class TestCompatSDPABF16(unittest.TestCase):
         return paddle.bfloat16
 
 
+@unittest.skipIf(
+    not is_flashattn_supported(),
+    "compat.sdpa test requires CUDA 11.4+ and SM 8.0+",
+)
+class TestCompatSDPAStaticFP16(unittest.TestCase):
+    def setUp(self):
+        paddle.enable_static()
+        self.place = get_device_place()
+        self.dtype = "float16"
+        self.rtol = 1e-2
+        self.atol = 1e-2
+
+        self.B = 2
+        self.S = 128
+        self.H = 8
+        self.D = 16
+
+        self.shape_bnsd = (self.B, self.H, self.S, self.D)
+
+    def tearDown(self):
+        paddle.disable_static()
+
+    def _get_feed(self, shapes):
+        feed = {}
+        for name, shape in shapes.items():
+            feed[name] = np.random.randn(*shape).astype(self.dtype)
+        return feed
+
+    def test_static_bnsd(self):
+        """Test standard BNSD shape in static graph"""
+        main_prog = paddle.static.Program()
+        startup_prog = paddle.static.Program()
+
+        with paddle.static.program_guard(main_prog, startup_prog):
+            q = paddle.static.data(
+                name="q", shape=self.shape_bnsd, dtype=self.dtype
+            )
+            k = paddle.static.data(
+                name="k", shape=self.shape_bnsd, dtype=self.dtype
+            )
+            v = paddle.static.data(
+                name="v", shape=self.shape_bnsd, dtype=self.dtype
+            )
+
+            out_compat = compat_sdpa(q, k, v, scale=None, enable_gqa=False)
+            out_naive = _attention_naive_bnsd(
+                q, k, v, scale=None, enable_gqa=False
+            )
+
+            exe = paddle.static.Executor(self.place)
+            exe.run(startup_prog)
+
+            feed = self._get_feed(
+                {
+                    "q": self.shape_bnsd,
+                    "k": self.shape_bnsd,
+                    "v": self.shape_bnsd,
+                }
+            )
+
+            res_compat, res_naive = exe.run(
+                program=main_prog, feed=feed, fetch_list=[out_compat, out_naive]
+            )
+
+            np.testing.assert_allclose(
+                res_compat,
+                res_naive,
+                rtol=self.rtol,
+                atol=self.atol,
+                err_msg="Static graph BNSD output mismatch",
+            )
+
+    def test_static_gqa(self):
+        """Test GQA (Grouped Query Attention) in static graph"""
+        H_GQA = 2
+        shape_q = (self.B, self.H, self.S, self.D)
+        shape_kv = (self.B, H_GQA, self.S, self.D)
+
+        main_prog = paddle.static.Program()
+        startup_prog = paddle.static.Program()
+
+        with paddle.static.program_guard(main_prog, startup_prog):
+            q = paddle.static.data(name="q", shape=shape_q, dtype=self.dtype)
+            k = paddle.static.data(name="k", shape=shape_kv, dtype=self.dtype)
+            v = paddle.static.data(name="v", shape=shape_kv, dtype=self.dtype)
+
+            out_compat = compat_sdpa(q, k, v, scale=None, enable_gqa=True)
+            out_naive = _attention_naive_bnsd(
+                q, k, v, scale=None, enable_gqa=True
+            )
+
+            exe = paddle.static.Executor(self.place)
+            exe.run(startup_prog)
+
+            feed = self._get_feed({"q": shape_q, "k": shape_kv, "v": shape_kv})
+
+            res_compat, res_naive = exe.run(
+                program=main_prog, feed=feed, fetch_list=[out_compat, out_naive]
+            )
+
+            np.testing.assert_allclose(
+                res_compat,
+                res_naive,
+                rtol=self.rtol,
+                atol=self.atol,
+                err_msg="Static graph GQA output mismatch",
+            )
+
+    def test_static_mask_broadcast(self):
+        """Test 3D Mask Broadcasting in static graph"""
+        shape_mask = (self.B, self.S, self.S)
+
+        main_prog = paddle.static.Program()
+        startup_prog = paddle.static.Program()
+
+        with paddle.static.program_guard(main_prog, startup_prog):
+            q = paddle.static.data(
+                name="q", shape=self.shape_bnsd, dtype=self.dtype
+            )
+            k = paddle.static.data(
+                name="k", shape=self.shape_bnsd, dtype=self.dtype
+            )
+            v = paddle.static.data(
+                name="v", shape=self.shape_bnsd, dtype=self.dtype
+            )
+            mask = paddle.static.data(
+                name="mask", shape=shape_mask, dtype=self.dtype
+            )
+
+            out_compat = compat_sdpa(q, k, v, attn_mask=mask)
+            out_naive = _attention_naive_bnsd(q, k, v, attn_mask=mask)
+
+            exe = paddle.static.Executor(self.place)
+            exe.run(startup_prog)
+
+            feed = self._get_feed(
+                {
+                    "q": self.shape_bnsd,
+                    "k": self.shape_bnsd,
+                    "v": self.shape_bnsd,
+                    "mask": shape_mask,
+                }
+            )
+
+            res_compat, res_naive = exe.run(
+                program=main_prog, feed=feed, fetch_list=[out_compat, out_naive]
+            )
+
+            np.testing.assert_allclose(
+                res_compat,
+                res_naive,
+                rtol=self.rtol,
+                atol=self.atol,
+                err_msg="Static graph Mask output mismatch",
+            )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_scaled_dot_product_attention.py
+++ b/test/legacy_test/test_scaled_dot_product_attention.py
@@ -331,6 +331,10 @@ class TestSDPKernelFlags(unittest.TestCase):
             pass
 
 
+@unittest.skipIf(
+    not paddle.device.is_available(),
+    "Skip test on CPU for cpu does not support fp16 matmul",
+)
 class TestZeroSizeBase(unittest.TestCase):
     def setUp(self) -> None:
         self.query_shape = [1, 0, 32, 128]

--- a/test/legacy_test/test_scaled_dot_product_attention.py
+++ b/test/legacy_test/test_scaled_dot_product_attention.py
@@ -331,5 +331,103 @@ class TestSDPKernelFlags(unittest.TestCase):
             pass
 
 
+class TestZeroSizeBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.query_shape = [1, 0, 32, 128]
+        self.key_shape = [1, 1024, 32, 128]
+        self.value_shape = [1, 1024, 32, 128]
+        self.attn_mask_shape = None
+        self.is_scausal = True
+        self.expected_out_shape = [1, 0, 32, 128]
+        self.dtype = 'float16'
+
+    def prepare_input(self):
+        kwargs = {
+            "query": paddle.randn(shape=self.query_shape, dtype=self.dtype),
+            "key": paddle.randn(shape=self.key_shape, dtype=self.dtype),
+            "value": paddle.randn(shape=self.value_shape, dtype=self.dtype),
+            "attn_mask": paddle.randn(
+                shape=self.attn_mask_shape, dtype=self.dtype
+            )
+            if self.attn_mask_shape
+            else None,
+            "is_causal": self.is_scausal,
+        }
+        return kwargs
+
+    def test_dygraph(self):
+        paddle.disable_static()
+        kwargs = self.prepare_input()
+        out = scaled_dot_product_attention(**kwargs)
+        self.assertEqual(out.shape, self.expected_out_shape)
+
+    def test_static(self):
+        paddle.enable_static()
+        with paddle.static.program_guard(
+            paddle.static.Program(), paddle.static.Program()
+        ):
+            kwargs = self.prepare_input()
+            out = scaled_dot_product_attention(**kwargs)
+            exe = paddle.static.Executor()
+            outs = exe.run(fetch_list=[out])
+            self.assertEqual(list(outs[0].shape), self.expected_out_shape)
+        paddle.disable_static()
+
+
+class TestZeroSizeCase2(TestZeroSizeBase):
+    def setUp(self):
+        self.query_shape = [2, 0, 12, 64]
+        self.key_shape = [2, 64, 12, 64]
+        self.value_shape = [2, 64, 12, 64]
+        self.attn_mask_shape = None
+        self.is_scausal = True
+        self.expected_out_shape = [2, 0, 12, 64]
+        self.dtype = 'float16'
+
+
+class TestZeroSizeCase3(TestZeroSizeBase):
+    def setUp(self):
+        self.query_shape = [1, 2048, 8, 0]
+        self.key_shape = [1, 2048, 2, 0]
+        self.value_shape = [1, 2048, 2, 0]
+        self.attn_mask_shape = [1, 1, 2048, 0]
+        self.is_scausal = True
+        self.expected_out_shape = [1, 2048, 8, 0]
+        self.dtype = 'float16'
+
+
+class TestZeroSizeCase4(TestZeroSizeBase):
+    def setUp(self):
+        self.query_shape = [1, 2048, 8, 16]
+        self.key_shape = [1, 2048, 2, 16]
+        self.value_shape = [1, 2048, 2, 0]
+        self.attn_mask_shape = [1, 1, 2048, 2048]
+        self.is_scausal = True
+        self.expected_out_shape = [1, 2048, 8, 0]
+        self.dtype = 'float16'
+
+
+class TestZeroSizeCase5(TestZeroSizeBase):
+    def setUp(self):
+        self.query_shape = [2, 1, 8, 96]
+        self.key_shape = [2, 100, 8, 96]
+        self.value_shape = [2, 100, 8, 0]
+        self.attn_mask_shape = None
+        self.is_scausal = False
+        self.expected_out_shape = [2, 1, 8, 0]
+        self.dtype = 'float16'
+
+
+class TestZeroSizeCase6(TestZeroSizeBase):
+    def setUp(self):
+        self.query_shape = [2, 1, 8, 96]
+        self.key_shape = [2, 101, 8, 96]
+        self.value_shape = [2, 101, 8, 0]
+        self.attn_mask_shape = None
+        self.is_scausal = False
+        self.expected_out_shape = [2, 1, 8, 0]
+        self.dtype = 'float16'
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
本 PR 修复了 SDPA 在静态图下报错问题和 https://github.com/PaddlePaddle/Paddle/pull/76446 引入的不兼容升级，具体包括：
- 静态图下使用 `paddle.framework._current_expected_place_()` 作为 qkv 的place 选择 SDPA 后端
- 根据 `paddle.device.is_bf16_supported(including_emulation=False)` 判断当前 cuda device 是否支持 BF16
- `paddle.nn.F.SDPA` 参数 `enable_gqa` 默认为 True，以对齐升级前 SDPA 的行为
- 当 `enable_gqa` 为 True 时，后置 repeat_head 的行为，对于支持 GQA 的后端直接透传 QKV
- 支持 0-size Tensor 输入

card-94386