### PR TITLE
[API Compatiblity] Support paddle.fft.fftfreq and rfftfreq 

### DIFF
--- a/python/paddle/fft.py
+++ b/python/paddle/fft.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from paddle import Tensor
-    from paddle._typing import DTypeLike
+    from paddle._typing import DTypeLike, PlaceLike
 
     _NormalizeMode = Literal["forward", "backward", "ortho"]
 __all__ = [
@@ -1468,6 +1468,10 @@ def fftfreq(
     n: int,
     d: float = 1.0,
     dtype: DTypeLike | None = None,
+    *,
+    out: paddle.Tensor | None = None,
+    device: PlaceLike | None = None,
+    requires_grad: bool = False,
     name: str | None = None,
 ) -> Tensor:
     """
@@ -1487,6 +1491,11 @@ def fftfreq(
         d (float, optional): Sample spacing (inverse of the sampling rate). Defaults is 1.
         dtype (str, optional): The data type of returns. Defaults is the data type of returns
             of ``paddle.get_default_dtype()``.
+        out(Tensor, optional): The output tensor.
+        device(PlaceLike|None, optional): The desired device of returned tensor.
+            if None, uses the current device for the default tensor type (see paddle.device.set_device()).
+            device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
+        requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
         name (str, optional): The default value is None.  Normally there is no need for user to set
             this property. For more information, please refer to :ref:`api_guide_Name`.
 
@@ -1508,19 +1517,34 @@ def fftfreq(
     if d * n == 0:
         raise ValueError("d or n should not be 0.")
 
-    dtype = paddle.framework.get_default_dtype()
+    if dtype is None:
+        dtype = paddle.framework.get_default_dtype()
     val = 1.0 / (n * d)
     pos_max = (n + 1) // 2
     neg_max = n // 2
-    indices = paddle.arange(-neg_max, pos_max, dtype=dtype, name=name)
+    indices = paddle.arange(
+        -neg_max,
+        pos_max,
+        dtype=dtype,
+        device=device,
+        requires_grad=requires_grad,
+        name=name,
+    )
     indices = paddle.roll(indices, -neg_max, name=name)
-    return indices * val
+    ret = indices * val
+    if out is not None:
+        paddle.assign(ret, out)
+    return ret
 
 
 def rfftfreq(
     n: int,
     d: float = 1.0,
     dtype: DTypeLike | None = None,
+    *,
+    out: paddle.Tensor | None = None,
+    device: PlaceLike | None = None,
+    requires_grad: bool = False,
     name: str | None = None,
 ) -> Tensor:
     """
@@ -1541,6 +1565,11 @@ def rfftfreq(
         d (float, optional): Sample spacing (inverse of the sampling rate). Defaults is 1.
         dtype (str, optional): The data type of returns. Defaults is the data type of returns
             of ``paddle.get_default_dtype()``.
+        out(Tensor, optional): The output tensor.
+        device(PlaceLike|None, optional): The desired device of returned tensor.
+            if None, uses the current device for the default tensor type (see paddle.device.set_device()).
+            device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
+        requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
         name (str, optional): The default value is None.  Normally there is no need for user to set
             this property. For more information, please refer to :ref:`api_guide_Name`.
 
@@ -1563,11 +1592,22 @@ def rfftfreq(
     if d * n == 0:
         raise ValueError("d or n should not be 0.")
 
-    dtype = paddle.framework.get_default_dtype()
+    if dtype is None:
+        dtype = paddle.framework.get_default_dtype()
     val = 1.0 / (n * d)
     pos_max = 1 + n // 2
-    indices = paddle.arange(0, pos_max, dtype=dtype, name=name)
-    return indices * val
+    indices = paddle.arange(
+        0,
+        pos_max,
+        dtype=dtype,
+        device=device,
+        requires_grad=requires_grad,
+        name=name,
+    )
+    ret = indices * val
+    if out is not None:
+        paddle.assign(ret, out)
+    return ret
 
 
 @param_two_alias(["x", "input"], ["axes", "dim"])

--- a/test/fft/test_fft_compat.py
+++ b/test/fft/test_fft_compat.py
@@ -166,6 +166,7 @@ class TestFFTAliasBase(unittest.TestCase):
                     atol=1e-08,
                     err_msg=f"Static graph mismatch (Alias Args) for {self.paddle_api.__name__} on {place}",
                 )
+        paddle.disable_static()
 
 
 class TestFFT_Alias(TestFFTAliasBase):
@@ -360,6 +361,67 @@ class TestIFFTShift_Alias(TestFFTAliasBase):
         self.is_real_input = False
         self.is_nd_or_shift = True
         self.test_dim_val = (0, 1)
+
+
+class TestFftfreq(unittest.TestCase):
+    def test_basic_usage(self):
+        result = paddle.fft.fftfreq(n=10, d=1.0)
+        self.assertEqual(result.shape, [10])
+
+        expected = paddle.to_tensor(
+            [0.0, 0.1, 0.2, 0.3, 0.4, -0.5, -0.4, -0.3, -0.2, -0.1],
+            dtype='float32',
+        )
+        self.assertTrue(paddle.allclose(result, expected))
+
+    def test_all_parameters(self):
+        out = paddle.zeros([10], dtype='float32')
+
+        result = paddle.fft.fftfreq(
+            n=10,
+            d=2.0,
+            dtype='float64',
+            out=out,
+            device='cpu',
+            requires_grad=True,
+        )
+
+        self.assertTrue(result.place.is_cpu_place())
+        self.assertFalse(result.stop_gradient)
+        self.assertEqual(result.dtype, paddle.float64)
+
+        expected = paddle.to_tensor(
+            [0.0, 0.05, 0.1, 0.15, 0.2, -0.25, -0.2, -0.15, -0.1, -0.05],
+            dtype='float64',
+        )
+        self.assertTrue(paddle.allclose(result, expected))
+
+
+class TestRfftfreq(unittest.TestCase):
+    def test_basic_usage(self):
+        result = paddle.fft.rfftfreq(n=10, d=1.0)
+        self.assertEqual(result.shape, [6])  # 1 + n//2 = 6
+
+        expected = paddle.arange(0, 6) * (1.0 / (10 * 1.0))
+        self.assertTrue(paddle.allclose(result, expected))
+
+    def test_all_parameters(self):
+        out = paddle.zeros([6], dtype='float32')
+
+        result = paddle.fft.rfftfreq(
+            n=10,
+            d=2.0,
+            dtype='float64',
+            out=out,
+            device='cpu',
+            requires_grad=True,
+        )
+        self.assertTrue(result.place.is_cpu_place())
+        self.assertFalse(result.stop_gradient)
+        self.assertEqual(result.dtype, paddle.float64)
+
+        expected = paddle.arange(0, 6, dtype='float64') * (1.0 / (10 * 2.0))
+        self.assertTrue(paddle.allclose(result, expected))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
为paddle.fft.fftfreq and rfftfreq 添加out，device，requires_grad参数