### PR TITLE
[API Compatibilty] Fix size performance degradation

### DIFF
--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -37,6 +37,7 @@ limitations under the License. */
 #include "paddle/fluid/pybind/eager.h"
 #include "paddle/fluid/pybind/op_function_common.h"
 #include "paddle/fluid/pybind/pir.h"
+#include "paddle/fluid/pybind/size.h"
 #include "paddle/fluid/pybind/tensor_py.h"
 #include "paddle/phi/api/ext/op_meta_info.h"
 #include "paddle/phi/common/data_type.h"
@@ -48,7 +49,6 @@ limitations under the License. */
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/pir/include/core/attribute.h"
 #include "paddle/pir/include/core/value.h"
-
 COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_int32(check_nan_inf_level);
 COMMON_DECLARE_int32(call_stack_level);
@@ -2644,29 +2644,35 @@ paddle::experimental::IntArray CastPyArg2IntArray(PyObject* obj,
     return paddle::experimental::IntArray({});
   }
 
-  // obj could be: int, float, bool, paddle.Tensor
+  if (PyObject_CheckLong(obj)) {
+    return paddle::experimental::IntArray({PyObject_ToInt64(obj)});
+  }
+
+  if (PyList_Check(obj) || PyTuple_Check(obj) ||
+      Py_TYPE(obj) == &paddle::pybind::Paddle_SizeType) {
+    std::vector<int64_t> value = CastPyArg2Longs(obj, op_type, arg_pos);
+    return paddle::experimental::IntArray(value);
+  }
+
   PyTypeObject* type = obj->ob_type;
-  auto type_name = std::string(type->tp_name);
-  if (type_name == "list" || type_name == "tuple" ||
-      type_name == "numpy.ndarray" ||
-      type_name == "paddle.base.libpaddle.Size") {
+  std::string type_name(type->tp_name);
+
+  if (type_name == "numpy.ndarray") {
     std::vector<int64_t> value = CastPyArg2Longs(obj, op_type, arg_pos);
     return paddle::experimental::IntArray(value);
   } else if (type_name == "paddle.Tensor" || type_name == "Tensor") {
     paddle::Tensor& value = GetTensorFromPyObject(
         op_type, "" /*arg_name*/, obj, arg_pos, false /*dispensable*/);
     return paddle::experimental::IntArray(value);
-  } else if (PyObject_CheckLong(obj)) {
-    return paddle::experimental::IntArray({PyObject_ToInt64(obj)});
-  } else {
-    PADDLE_THROW(common::errors::InvalidType(
-        "%s(): argument (position %d) must be "
-        "list or int, but got %s",
-        op_type,
-        arg_pos + 1,
-        ((PyTypeObject*)obj->ob_type)->tp_name));  // NOLINT
   }
-  // Fake a IntArray
+
+  PADDLE_THROW(
+      common::errors::InvalidType("%s(): argument (position %d) must be "
+                                  "list, tuple, int, or Tensor, but got %s",
+                                  op_type,
+                                  arg_pos + 1,
+                                  type_name.c_str()));  // NOLINT
+
   return paddle::experimental::IntArray({1});
 }
 paddle::experimental::IntArray CastPyArg2IntArray(

--- a/paddle/fluid/pybind/size.cc
+++ b/paddle/fluid/pybind/size.cc
@@ -20,8 +20,6 @@
 
 namespace paddle::pybind {
 
-extern PyTypeObject Paddle_SizeType;
-
 static const char* paddle_size_doc =
     R"DOC(The result type of a call to ``paddle.Tensor.size()``.
 It describes the size of all dimensions of the original tensor. As a subclass of `list`,

--- a/paddle/fluid/pybind/size.h
+++ b/paddle/fluid/pybind/size.h
@@ -17,6 +17,7 @@
 #include "pybind11/pybind11.h"
 
 namespace paddle::pybind {
+extern PyTypeObject Paddle_SizeType;
 
 void BindSize(pybind11::module* m);
 PyObject* Paddle_Size_NewFromInt64Array(const int64_t* data, Py_ssize_t len);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
card-94387

优化 https://github.com/PaddlePaddle/Paddle/pull/76361 引入的性能损失。

性能损失主要来自 `CastPyArg2IntArray` 在 Python 和 C++之间做参数转换时，原本实现使用字符串进行比较， Size 的类型名`paddle.base.libpaddle.Size` 比较长，无法利用 SSO 机制进行优化。本 PR 使用指针比较来判断 PyObj 的类型，避免了堆上构造字符串的开销，同时将热点分支（单个 int、list/tuple/Size）前置，在慢分支中再构造字符串比较

#### 测试报告 单位 (us)

| 测试场景 (Test Case)      | 1. 基准 (List)  (修改前) | 2. 初始 PR (Size)  (优化前) | 3. 最终优化 (Size)  (当前) | 性能恢复情况 |
|-----------------------|---------------------|------------------------|----------------------|--------|
| 元素索引 (s[0])           | 0.0257              | 0.1142 (⬇️ 4.4x)       | 0.0277               | ✅ 完全恢复 |
| 切片获取 (s[1:3])         | 0.0700              | 0.1858 (⬇️ 2.6x)       | 0.0827               | ✅ 基本恢复 |
| 获取长度 (len(s))         | 0.0455              | 0.1390 (⬇️ 3.0x)       | 0.0455               | ✅ 完全持平 |
| 相加 (s + s)            | 0.0524              | 0.1958 (⬇️ 3.7x)       | 0.0669               | ✅ 基本恢复 |
| 属性访问 (t.shape)        | 0.2013              | 0.2896 (⬇️ 1.4x)       | 0.1834               | ✅ 完全持平 |
| Interpolate (传 shape) | 35.91               | 45.70(⬇️ 1.27x)        | 36.50                | ✅ 基本恢复 |

