### PR TITLE
[CI] Deprecated the bos download usage in `static-check` workflow

### DIFF
--- a/.github/workflows/_Static-Check.yml
+++ b/.github/workflows/_Static-Check.yml
@@ -19,6 +19,7 @@ env:
   ci_scripts: /paddle/ci
   BRANCH: ${{ github.event.pull_request.base.ref }}
   CI_name: static-check
+  CFS_DIR: /home/data/cfs
   no_proxy: "bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
 
 defaults:
@@ -86,6 +87,7 @@ jobs:
             -e no_proxy \
             -e CI_name \
             -e GITHUB_API_TOKEN \
+            -e CFS_DIR \
             -w /paddle --network host ${docker_image}
 
       - name: Download paddle.tar.gz and merge target branch
@@ -95,8 +97,8 @@ jobs:
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf  * .[^.]*
           set -e
-          echo "Downloading build.tar.gz"
-          wget -q --tries=5 --no-proxy https://paddle-github-action.bj.bcebos.com/PR/build/${PR_ID}/${COMMIT_ID}/build.tar.gz --no-check-certificate
+          echo "Downloading build.tar.gz from cfs"
+          cp ${CFS_DIR}/build_bos/${PR_ID}/${COMMIT_ID}/build.tar.gz .
           echo "Extracting build.tar.gz"
           git config --global --add safe.directory ${work_dir}
           tar --use-compress-program="pzstd -1" -xpf build.tar.gz --strip-components=1


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Deprecated the bos download usage in `static-check` workflow