### PR TITLE
fix xpu AddGradKernel

### DIFF
--- a/paddle/phi/kernels/xpu/elementwise_add_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_add_grad_kernel.cc
@@ -86,7 +86,7 @@ void MixedPrecisionAddGradKernel(const Context& dev_ctx,
       if (dx->IsSharedBufferWith(*dz)) {
         dx->clear();
         dx->Resize(x.dims());
-        dev_ctx.template Alloc<T>(dx);
+        dx_data = dev_ctx.template Alloc<T>(dx);
       }
       std::vector<int> reduce_dims =
           funcs::GetReduceDim(dx->dims(), dz_dims, axis);
@@ -208,7 +208,7 @@ void AddGradKernel(const Context& dev_ctx,
       if (dx->IsSharedBufferWith(*dz)) {
         dx->clear();
         dx->Resize(x.dims());
-        dev_ctx.template Alloc<T>(dx);
+        dx_data = dev_ctx.template Alloc<T>(dx);
       }
       std::vector<int> reduce_dims =
           funcs::GetReduceDim(dx->dims(), dz_dims, axis);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
修复https://github.com/PaddlePaddle/Paddle/pull/76512 引入的Bug。
代码逻辑如下：
```
T* dx_data = dev_ctx.template Alloc<T>(dx);
if (dx->IsSharedBufferWith(*dz)) {
  dx->clear();
  dx->Resize(x.dims());
  dev_ctx.template Alloc<T>(dx); 
}
int ret = xpu::reduce_sum<XPUType>(
          ……
          reinterpret_cast<XPUType*>(dx_data),
          ……);
```
