### PR TITLE
[CUDAExtension] Support `dlink` and `dlink_libraries` args for compatibility

### DIFF
--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -33,6 +33,8 @@ import threading
 import warnings
 from importlib import machinery
 
+import paddle
+
 try:
     from subprocess import DEVNULL  # py3
 except ImportError:
@@ -627,6 +629,25 @@ def normalize_extension_kwargs(kwargs, use_cuda=False):
                 )
             extra_compile_args = copy.deepcopy(extra_compile_args)
             extra_compile_args["nvcc"] = nvcc_options
+
+    dlink_libraries = kwargs.get('dlink_libraries', [])
+    dlink = kwargs.get('dlink', False) or dlink_libraries
+    if dlink:
+        extra_compile_args = kwargs.get('extra_compile_args', {})
+
+        extra_compile_args_dlink = extra_compile_args.get('nvcc_dlink', [])
+        extra_compile_args_dlink += ['-dlink']
+        extra_compile_args_dlink += [f'-L{x}' for x in library_dirs]
+        extra_compile_args_dlink += [f'-l{x}' for x in dlink_libraries]
+        if (
+            paddle.version.cuda() != "False"
+            and float(paddle.version.cuda()) >= 11.2
+        ):
+            extra_compile_args_dlink += [
+                '-dlto'
+            ]  # Device Link Time Optimization started from cuda 11.2
+
+        extra_compile_args['nvcc_dlink'] = extra_compile_args_dlink
 
     kwargs['extra_compile_args'] = extra_compile_args
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Support `dlink` and `dlink_libraries` args for compatibility
对齐 torch 对 dlink 的支持情况，给 CUDAExtension 处理了 `dlink` 和 `dlink_libraries` 两个参数，搭配之前 https://github.com/PaddlePaddle/Paddle/pull/76532 的 `extra_compile_args` 中的 `nvcc_dlink` 设置

和 Torch 一样只支持了 Linux 系统。
Torch 在 `cpp_extension.py` 支持了两者后端: `ninja` 和 `standard distutils`，在 ninja 后端支持了 `dlink`.
Paddle 在 `distutils` 的基础上，patch 了一些自定义方法，在 host 侧链接之前，进行 relocatable device code linking  