### PR TITLE
[CppExtension] Force link `libpaddle.so` to avoid `as-needed` optimization when user only uses phi headers

### DIFF
--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -574,7 +574,15 @@ def normalize_extension_kwargs(kwargs, use_cuda=False):
         # On Linux, GCC support '-l:xxx.so' to specify the library name
         # without `lib` prefix.
         if OS_NAME.startswith('linux'):
-            extra_link_args.append(f'-l:{_get_core_name()}')
+            # Force link libpaddle.so to avoid "as-needed" optimization
+            # when user only uses phi headers.
+            extra_link_args.extend(
+                [
+                    '-Wl,--no-as-needed',
+                    f'-l:{_get_core_name()}',
+                    '-Wl,--as-needed',
+                ]
+            )
         # ----------------------- MacOS Platform ----------------------- #
         else:
             # See _reset_so_rpath for details.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

对于非 `#include "paddle/extension.h"` 的 Paddle 自定义算子，而是基于兼容性 API 的自定义算子，是有可能不依赖 `libpaddle.so` 自身的符号的，而是间接依赖 `libphi_core.so` 的符号，在这种情况下 `libpaddle.so` 的链接就可能被优化掉，进而导致找不到 `libphi_core.so` 里的符号，显式添加 `extra_link_args=["-l:libphi_core.so"]` 链接 `libphi_core.so` 可以解决问题，但是这需要用户了解 Paddle 内部各个动态库的链接关系和名字，为避免这一点，在链接 `libpaddle.so` 关掉 `as-needed` 优化

<!-- PCard-66972 -->