### PR TITLE
Custom Device 

### DIFF
--- a/paddle/phi/backends/gpu/forwards.h
+++ b/paddle/phi/backends/gpu/forwards.h
@@ -69,7 +69,7 @@ using cusparseHandle_t = struct cusparseContext *;
 
 #ifdef PADDLE_WITH_CUDA
 // Forward declaration of cuFFT types.
-using cufftHandle = int;
+using cufftHandle = unsigned int;
 #endif
 
 // Forward declaration of NCCL types.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Paddle 源码中cufftHandle的类型别名声明为`int`类型，与沐曦cufftHandle的类型定义`unsigned int`有冲突，编译不通过。

1、Paddle 源码中cufftHandle的类型别名声明有漏洞，应该修改为`unsigned int`。
https://github.com/PaddlePaddle/Paddle/blob/977b4804c9006d67adfaf465d5c48ca39a0b9d9f/paddle/phi/backends/gpu/forwards.h#L72
2、NVIDIA官方cufftHandle定义为unsigned int类型：
<img width="2776" height="612" alt="image" src="https://github.com/user-attachments/assets/d40bd62e-c00b-42e1-bf21-d1c309dcfd3f" />
3、沐曦平台定义：
typedef unsigned int cufftHandle;与官方定义一致。


