### PR TITLE
[Compat][Bugfix] Fix `Tensor::bitwise_right_shift` dtype

### DIFF
--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -217,8 +217,7 @@ class Tensor : public TensorBase {
 
   at::Tensor bitwise_right_shift(const Scalar& other) const {
     return Tensor(paddle::experimental::bitwise_right_shift(
-        tensor_,
-        paddle::experimental::full({}, other, paddle::DataType::INT64)));
+        tensor_, paddle::experimental::full({}, other, other.dtype())));
   }
 
   at::Tensor slice(int64_t dim = 0,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

Fix the compat capability problem