### PR TITLE
Fix name error for fwd subgraph guard

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -760,6 +760,18 @@ PHI_DEFINE_EXPORTED_string(
     dump_api_python_stack_path,
     "",
     "Dump api forward python call stack to the dir path");
+/**
+ * Debug related FLAG
+ * Name: dump_api_and_gradnode_python_stack_dir
+ * Since Version: 3.3
+ * Value Range: string, default=""
+ * Example:
+ * Note: Dump api and gradnode forward python call stack to the dir path.
+ */
+PHI_DEFINE_EXPORTED_string(
+    dump_api_and_gradnode_python_stack_dir,
+    "",
+    "Dump api and gradnode forward python call stack to the dir path");
 
 /**
  * Debug related FLAG

--- a/paddle/common/flags_native.cc
+++ b/paddle/common/flags_native.cc
@@ -329,6 +329,8 @@ void FlagRegistry::InitLinkedFlags() {
       {"enable_unique_name", "true"}};
   linked_flags_["dump_grad_node_forward_stack_path"] = {
       {"enable_unique_name", "true"}, {"call_stack_level", "3"}};
+  linked_flags_["dump_api_and_gradnode_python_stack_dir"] = {
+      {"enable_unique_name", "true"}, {"call_stack_level", "3"}};
 }
 
 bool FlagRegistry::SetFlagValue(const std::string& name,
@@ -376,6 +378,20 @@ bool FlagRegistry::UpdateLinkedFlags(const std::string& name,
       } else {
         return false;
       }
+    }
+    // Custom rule for Flags
+    if (name == "dump_api_and_gradnode_python_stack_dir") {
+      std::string fwd_path;
+      std::string bwd_path;
+      if (value.back() == '/') {
+        fwd_path = value + "api_call_stack";
+        bwd_path = value + "gradnode_call_stack";
+      } else {
+        fwd_path = value + "/api_call_stack";
+        bwd_path = value + "/gradnode_call_stack";
+      }
+      flags_["dump_api_python_stack_path"]->SetValueFromString(fwd_path);
+      flags_["dump_grad_node_forward_stack_path"]->SetValueFromString(bwd_path);
     }
   } else {
     return false;

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -505,7 +505,7 @@ paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize> {}:
   if (FLAGS_check_cuda_error) [[unlikely]] {{
     egr::CUDAErrorCheck(\"{} (\"+egr::GetGradNodeHexAddress(this)+\") finish\");
   }}
-    VLOG(4) << \"\\n\"<<separator<<\"Finish_AD_API_GRAD: {}\"<<separator;
+    VLOG(3) << \"\\n\"<<separator<<\"Finish_AD_API_GRAD: {}\"<<separator;
 
 
   // Return

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -412,7 +412,7 @@ std::vector<paddle::Tensor> RunBackward(
   // Dump the all call stack into
   // FLAGS_dump_grad_node_forward_stack_path
   if (need_dump_forward_stack) {
-    SaveStringToFile(
+    SaveStringToFileWithPID(
         FLAGS_dump_grad_node_forward_stack_path, debug_call_stack, "append");
   }
   std::deque<GradNodeBase*> ready_queue;

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -1754,7 +1754,7 @@ void SaveStringToFileWithPID(const std::string& filename,
 
 void SavePythonCallStackToFile(const std::string& file_name,
                                const std::string& api_name) {
-  SaveStringToFileWithPID(
+  SaveStringToFile(
       file_name,
       api_name + " : \n" + egr::Controller::Instance().GetPythonStack(),
       "append");

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -1745,7 +1745,7 @@ const std::string FormatTensor(const paddle::Tensor& t) {
 
 void SaveStringToFileWithPID(const std::string& filename,
                              const std::string& content,
-                             const std::string& mode = "trunc") {
+                             const std::string& mode) {
   pid_t pid = getprocessid();
   // Create the new filename with PID suffix
   std::string newFilename = filename + "." + std::to_string(pid);
@@ -1754,7 +1754,7 @@ void SaveStringToFileWithPID(const std::string& filename,
 
 void SavePythonCallStackToFile(const std::string& file_name,
                                const std::string& api_name) {
-  SaveStringToFile(
+  SaveStringToFileWithPID(
       file_name,
       api_name + " : \n" + egr::Controller::Instance().GetPythonStack(),
       "append");

--- a/paddle/fluid/eager/utils.h
+++ b/paddle/fluid/eager/utils.h
@@ -436,6 +436,9 @@ void SaveDebugInfo(std::string dir_path,
 void SaveStringToFile(const std::string& file_path,
                       const std::string& str,
                       const std::string& mode = "trunc");
+void SaveStringToFileWithPID(const std::string& filename,
+                             const std::string& content,
+                             const std::string& mode = "trunc");
 TEST_API void SaveTensorMD5CheckSumToFile(const std::string& file_path,
                                           const paddle::Tensor& t);
 TEST_API void SaveTensorMD5CheckSumToFile(

--- a/paddle/fluid/pybind/eager_custom_python_api.h
+++ b/paddle/fluid/pybind/eager_custom_python_api.h
@@ -35,7 +35,7 @@ static PyObject *eager_api_linear(PyObject *self,
     auto &bias = GetTensorFromArgs("linear", "Bias", args, 2, true);
 
     tstate = PyEval_SaveThread();
-
+    SetPythonStack();
     if (bias.is_dist_tensor() || bias.has_allocation()) {
       const phi::distributed::ProcessMesh *mesh = nullptr;
       if (InputsContainDistTensor(&mesh, x, weight, bias)) {

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -579,7 +579,7 @@ PyObject* eager_api_run_custom_op(PyObject* self,
   const auto& attrs = paddle::OpMetaInfoHelper::GetAttrs(vec_map[0]);
   const auto& outputs = paddle::OpMetaInfoHelper::GetOutputs(vec_map[0]);
   const auto& inplace_map = paddle::OpMetaInfoHelper::GetInplaceMap(vec_map[0]);
-
+  SetPythonStack();
   for (size_t i = 0; i < inputs.size(); ++i) {
     const auto& input = inputs.at(i);
     // Parse op_type first, so that use i + 1

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -828,7 +828,7 @@ static PyObject* tensor_method_clone(TensorObject* self,
             "We can only support initialized tensor in clone, however we got "
             "uninitialized tensor %s, please check your code.",
             self->tensor.name()));
-
+    SetPythonStack();
     out = assign_ad_func(self->tensor);
   }
   return ToPyObject(out);

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -37,7 +37,6 @@ from typing_extensions import ParamSpec
 import paddle
 
 from .. import pir
-from ..utils.download import check_and_create_dir
 from . import core, unique_name
 from .libpaddle import DataType
 from .proto import (
@@ -8625,22 +8624,6 @@ def pir_op_name_guard(op_name: str) -> Generator[None, None, None]:
     finally:
         if paddle.framework.in_pir_mode() and core._is_bwd_prim_enabled():
             pir.set_comp_op_name(original_comp_op_name)
-
-
-@signature_safe_contextmanager
-def capture_backward_subgraph_guard(
-    dump_dir_path: str, need_dump_grad_tensors: bool = False
-) -> Generator[None, None, None]:
-    assert dump_dir_path is not None, "The dump_dir_path should not be None"
-    # for multi process
-    check_and_create_dir(dump_dir_path)
-    paddle.base.core.eager._start_capture_backward_viz_subgraph(
-        dump_dir_path, need_dump_grad_tensors
-    )
-    try:
-        yield
-    finally:
-        paddle.base.core.eager._stop_capture_backward_viz_subgraph()
 
 
 @signature_safe_contextmanager

--- a/python/paddle/utils/__init__.py
+++ b/python/paddle/utils/__init__.py
@@ -24,7 +24,7 @@ from . import (  # noqa: F401
 )
 from .deprecated import deprecated
 from .environments import strtobool as strtobool
-from .fwd_graph_utils import capture_fwd_graph_guard  # noqa: F401
+from .fwd_graph_utils import capture_forward_subgraph_guard  # noqa: F401
 from .install_check import run_check
 from .layers_utils import (  # noqa: F401
     _contain_var,

--- a/python/paddle/utils/__init__.py
+++ b/python/paddle/utils/__init__.py
@@ -22,6 +22,7 @@ from . import (  # noqa: F401
     layers_utils,
     unique_name,
 )
+from .bwd_graph_utils import capture_backward_subgraph_guard  # noqa: F401
 from .deprecated import deprecated
 from .environments import strtobool as strtobool
 from .fwd_graph_utils import capture_forward_subgraph_guard  # noqa: F401

--- a/python/paddle/utils/bwd_graph_utils.py
+++ b/python/paddle/utils/bwd_graph_utils.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+from paddle.base.wrapped_decorator import signature_safe_contextmanager
+
+from .download import check_and_create_dir
+
+
+@signature_safe_contextmanager
+def capture_backward_subgraph_guard(
+    dump_dir_path: str, need_dump_grad_tensors: bool = False
+):
+    assert dump_dir_path is not None, "The dump_dir_path should not be None"
+    check_and_create_dir(dump_dir_path)
+    paddle.base.core.eager._start_capture_backward_viz_subgraph(
+        dump_dir_path, need_dump_grad_tensors
+    )
+    try:
+        yield
+    finally:
+        paddle.base.core.eager._stop_capture_backward_viz_subgraph()

--- a/python/paddle/utils/fwd_graph_utils.py
+++ b/python/paddle/utils/fwd_graph_utils.py
@@ -247,7 +247,7 @@ def capture_stderr():
 
 
 @signature_safe_contextmanager
-def capture_fwd_graph_guard(file_path: str):
+def capture_forward_subgraph_guard(file_path: str):
     log = ""
     stderr_buffer = io.StringIO()
     origin_enable_unique_name_status = paddle.framework.get_flags(

--- a/test/custom_op/test_custom_relu_op_setup.py
+++ b/test/custom_op/test_custom_relu_op_setup.py
@@ -343,7 +343,7 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
             {"FLAGS_tensor_md5_checksum_output_path": "./tmp_md5.txt"}
         )
         with (
-            paddle.utils.capture_fwd_graph_guard("./tmp_subgraph"),
+            paddle.utils.capture_forward_subgraph_guard("./tmp_subgraph"),
             paddle.base.framework.capture_backward_subgraph_guard(
                 "./tmp_debug_info"
             ),

--- a/test/custom_op/test_custom_relu_op_setup.py
+++ b/test/custom_op/test_custom_relu_op_setup.py
@@ -344,9 +344,7 @@ class TestNewCustomOpSetUpInstall(unittest.TestCase):
         )
         with (
             paddle.utils.capture_forward_subgraph_guard("./tmp_subgraph"),
-            paddle.base.framework.capture_backward_subgraph_guard(
-                "./tmp_debug_info"
-            ),
+            paddle.utils.capture_backward_subgraph_guard("./tmp_debug_info"),
         ):
             x = paddle.randn([5, 5])
             x.stop_gradient = False

--- a/test/legacy_test/test_backward_dump_debug_info.py
+++ b/test/legacy_test/test_backward_dump_debug_info.py
@@ -153,7 +153,7 @@ os.environ['GLOG_v'] = '6'
 os.environ['FLAGS_dump_grad_node_forward_stack_path']="call_stack.log"
 os.environ['FLAGS_call_stack_level']='3'
 os.environ['FLAGS_dump_api_python_stack_path']="forward_call_stack"
-
+os.environ['FLAGS_dump_api_and_gradnode_python_stack_dir']="./"
 import paddle
 import paddle.nn.functional as F
 import paddle.nn as nn

--- a/test/legacy_test/test_backward_dump_debug_info.py
+++ b/test/legacy_test/test_backward_dump_debug_info.py
@@ -144,6 +144,35 @@ paddle.base.core.set_vlog_level(4)
             text=True,
         )
 
+    def test_dump_call_stack(self):
+        code = """
+import os
+os.environ['FLAGS_dump_api_and_gradnode_python_stack_dir']="{dir}"
+import paddle
+x = paddle.randn([5, 5], dtype='float32')
+y = paddle.randn([5, 5], dtype='float32')
+x.stop_gradient = False
+y.stop_gradient = False
+z = x + y
+h = x * z
+w = h + y
+grads = paddle.autograd.backward(
+    [x, y],
+    [None, None],
+)
+paddle.base.core.set_vlog_level(4)
+        """
+        process = subprocess.run(
+            [sys.executable, '-c', code.format(dir="./")],
+            capture_output=True,
+            text=True,
+        )
+        process = subprocess.run(
+            [sys.executable, '-c', code.format(dir=".")],
+            capture_output=True,
+            text=True,
+        )
+
     def test_manual_vlog(self):
         if 'Windows' == platform.system():
             return
@@ -153,7 +182,7 @@ os.environ['GLOG_v'] = '6'
 os.environ['FLAGS_dump_grad_node_forward_stack_path']="call_stack.log"
 os.environ['FLAGS_call_stack_level']='3'
 os.environ['FLAGS_dump_api_python_stack_path']="forward_call_stack"
-os.environ['FLAGS_dump_api_and_gradnode_python_stack_dir']="./"
+
 import paddle
 import paddle.nn.functional as F
 import paddle.nn as nn

--- a/test/legacy_test/test_capture_backward_subgraph.py
+++ b/test/legacy_test/test_capture_backward_subgraph.py
@@ -111,7 +111,7 @@ class TestCaptureBackwardSubGraphGuard(unittest.TestCase):
             paddle.base.framework.capture_backward_subgraph_guard(
                 dump_dir_path, True
             ),
-            paddle.utils.capture_fwd_graph_guard("./dy2st_subraph"),
+            paddle.utils.capture_forward_subgraph_guard("./dy2st_subraph"),
         ):
             res = func(x, y)
             z = res + x

--- a/test/legacy_test/test_capture_backward_subgraph.py
+++ b/test/legacy_test/test_capture_backward_subgraph.py
@@ -40,9 +40,7 @@ class TestCaptureBackwardSubGraphGuard(unittest.TestCase):
         z.stop_gradient = False
         w.stop_gradient = True
         y = y + y
-        with paddle.base.framework.capture_backward_subgraph_guard(
-            dump_dir_path, True
-        ):
+        with paddle.utils.capture_backward_subgraph_guard(dump_dir_path, True):
             conv_x = paddle.randn((2, 3, 8, 8), dtype='float32')
             conv_w = paddle.randn((6, 3, 3, 3), dtype='float16')
 
@@ -108,9 +106,7 @@ class TestCaptureBackwardSubGraphGuard(unittest.TestCase):
             {"FLAGS_tensor_md5_checksum_output_path": "./dy2st_md5.txt"}
         )
         with (
-            paddle.base.framework.capture_backward_subgraph_guard(
-                dump_dir_path, True
-            ),
+            paddle.utils.capture_backward_subgraph_guard(dump_dir_path, True),
             paddle.utils.capture_forward_subgraph_guard("./dy2st_subraph"),
         ):
             res = func(x, y)

--- a/test/legacy_test/test_capture_fwd_graph.py
+++ b/test/legacy_test/test_capture_fwd_graph.py
@@ -26,7 +26,7 @@ class TestCaptureFwdGraph(unittest.TestCase):
             return
         x = paddle.rand([3, 9, 5])
         file_path = "./fwd_graph"
-        with paddle.utils.capture_fwd_graph_guard(file_path):
+        with paddle.utils.capture_forward_subgraph_guard(file_path):
             out0, out1, out2 = paddle.split(x, num_or_sections=3, axis=1)
             y = out0 + out1
             z = out1 - out2


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
#### 规范化命名：
- 捕获反向子图的guard命名为`paddle.utils.capture_backward_subgraph_guard`
- 捕获前向子图的guard命名为`paddle.utils.capture_forward_subgraph_guard`
#### 新增flags 
`dump_api_and_gradnode_python_stack_dir` 用于指定将api和gradnode导出的前向栈放置的目目录地址，使用例子：
``` bash
export FLAGS_dump_api_and_gradnode_python_stack_dir=./dump_call_stack # dir path 
python xxxx
```
调用栈的会被导出到dump_call_stack目录下
<img width="810" height="114" alt="image" src="https://github.com/user-attachments/assets/3af3b033-7c97-4248-aa67-e99eedc36ef6" />
 
#### 部分动态图api没有python栈的问题

- ```  paddle/fluid/pybind/eager_custom_python_api.h的linear ```
- ``` eager_api_run_custom_op ```
-  ``` tensor_method_clone ```