### PR TITLE
Remove hard-coded hardware in sdpa

### DIFF
--- a/python/paddle/nn/functional/flash_attention.py
+++ b/python/paddle/nn/functional/flash_attention.py
@@ -185,12 +185,6 @@ def _select_sdp(head_dim: int) -> str:
     if "xpu" in place:
         return "flash_attn"
 
-    if "iluvatar_gpu" in place:
-        return "flash_attn"
-
-    if "metax_gpu" in place:
-        return "flash_attn"
-
     enabled_backends = _get_enabled_backends()
     if not enabled_backends:
         raise AssertionError(

--- a/python/paddle/nn/functional/sdpa.py
+++ b/python/paddle/nn/functional/sdpa.py
@@ -147,9 +147,11 @@ def check_all_tensors_on_device(params: SDPParams):
     """
     Check all input tensors are placed on the GPU device.
     """
-    if not params.place[0].is_gpu_place():
+    if not (
+        params.place[0].is_gpu_place() or params.place[0].is_custom_place()
+    ):
         _logger.debug(
-            "All input tensors should be placed on GPU place, but "
+            "All input tensors should be placed on GPU or custom place, but "
             f"query place: {params.place[0]}, key place: "
             f"{params.place[1]}, value place: {params.place[2]}"
         )
@@ -193,6 +195,11 @@ def check_flash_attention_hardware_support(device_id: int):
     """
     Check flash attention requires CUDA support and SM between 8.0 and 12.1.
     """
+    if SDPBackend.FLASH_ATTENTION and paddle.is_compiled_with_custom_device(
+        paddle.device.get_all_device_type()[0]
+    ):
+        return True
+
     if not check_cuda_is_available():
         _logger.debug("Flash attention requires CUDA support.")
         return False
@@ -408,12 +415,6 @@ def select_sdp_for_sdpa(param: SDPParams) -> str:
 
     place = paddle.get_device()
     if "xpu" in place:
-        return "flash_attn"
-
-    if "iluvatar_gpu" in place:
-        return "flash_attn"
-
-    if "metax_gpu" in place:
         return "flash_attn"
 
     enabled_backends = _get_enabled_backends()

--- a/test/legacy_test/test_flash_attention.py
+++ b/test/legacy_test/test_flash_attention.py
@@ -1978,6 +1978,31 @@ class TestFlashAttentionAlignment(unittest.TestCase):
             err_msg='Memory efficient attention output does not match expected values',
         )
 
+    def test_auto_attention(self):
+        paddle.disable_static()
+        query = paddle.to_tensor(self.query)
+        key = paddle.to_tensor(self.key)
+        value = paddle.to_tensor(self.value)
+        mask = None
+
+        # auto-select the attention implementation
+        output = paddle.nn.functional.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            attn_mask=mask,
+            dropout_p=0.0,
+            is_causal=False,
+        )
+
+        np.testing.assert_allclose(
+            output.numpy(),
+            self.expected_output_without_mask,
+            rtol=self.rtol,
+            atol=self.atol,
+            err_msg='Auto attention output does not match expected values',
+        )
+
 
 @unittest.skipIf(
     not is_flashattn_supported(),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Remove hard-coded hardware in sdpa. These two apis can automatically select attention backends on Metax and Iluvatar.