### PR TITLE
[Typing][CI] Fold changed API list in logs when exceeding 50 items

### DIFF
--- a/tools/sampcd_processor_utils.py
+++ b/tools/sampcd_processor_utils.py
@@ -655,7 +655,16 @@ def get_docstring(
     if len(docstrings_to_test) == 0 and len(whl_error) == 0:
         logger.warning("-----API_PR.spec is the same as API_DEV.spec-----")
         log_exit(0)
-    logger.info("API_PR is diff from API_DEV: %s", docstrings_to_test.keys())
+
+    if len(docstrings_to_test) > 50:
+        logger.info("::group::API_PR is diff from API_DEV")
+        logger.info(docstrings_to_test.keys())
+        logger.info("::endgroup::")
+    else:
+        logger.info(
+            "API_PR is diff from API_DEV: %s", docstrings_to_test.keys()
+        )
+
     logger.info("Total api: %s", len(docstrings_to_test.keys()))
 
     return docstrings_to_test, whl_error


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

目前 typing 检查是跑全量检查的，此时会展示所有 diff 的 API，而这基本没有意义，而且会干扰 log，因此在超过 50 个 API 时这里的 log 进行折叠，这对于 typing 场景来说每次都会折叠

Before:

<img width="1125" height="717" alt="image" src="https://github.com/user-attachments/assets/3b2cc37b-a029-4fa5-9a29-208c06adb967" />

After:

<img width="692" height="162" alt="image" src="https://github.com/user-attachments/assets/8e16bb12-3c5f-47c9-bb20-6f821fc183eb" />

<!-- PCard-66972 -->