### PR TITLE
[API Compitibilty] Add Tensor.data.setter

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -977,7 +977,9 @@ static PyObject* tensor_clear_gradient(TensorObject* self,
               static_cast<phi::distributed::DistTensor*>(grad->impl().get())
                   ->unsafe_mutable_value();
         }
-        if (set_to_zero) {
+        bool is_mismatched = self->tensor.place() != grad_t->place() ||
+                             self->tensor.dtype() != grad_t->dtype();
+        if (set_to_zero && !is_mismatched) {
           EagerSetDeviceId();
           auto* dev_ctx =
               phi::DeviceContextPool::Instance().Get(grad_t->place());

--- a/paddle/fluid/pybind/eager_properties.cc
+++ b/paddle/fluid/pybind/eager_properties.cc
@@ -240,7 +240,19 @@ int tensor_properties_set_data(TensorObject* self,
                                void* closure) {
   EAGER_TRY
   auto src = CastPyArg2Tensor(value, 0);
-  self->tensor = src;
+  auto grad_meta = egr::EagerUtils::autograd_meta(&self->tensor);
+  if (grad_meta) {
+    bool device_changed = self->tensor.place() != src.place();
+    bool dtype_changed = self->tensor.dtype() != src.dtype();
+    if (device_changed || dtype_changed) {
+      VLOG(4)
+          << "New tensor's place or dtype has changed, clear the old grad_node "
+             "info.";
+      grad_meta->ResetGradNode();
+    }
+  }
+  self->tensor.set_impl(src.impl());
+
   phi::DenseTensor tmp;
   if (self->tensor.is_dense_tensor()) {
     auto dense_tensor =

--- a/paddle/fluid/pybind/eager_properties.cc
+++ b/paddle/fluid/pybind/eager_properties.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 #include <string>
 #include <vector>
 
+#include "paddle/common/enforce.h"
 #include "paddle/fluid/eager/accumulation/accumulation_node.h"
 #include "paddle/fluid/eager/api/all.h"
 #include "paddle/fluid/eager/autograd_meta.h"
@@ -27,6 +28,7 @@ limitations under the License. */
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/compat/convert_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/memory/allocation/allocator.h"
 #include "paddle/phi/core/memory/memcpy.h"
 
@@ -240,34 +242,8 @@ int tensor_properties_set_data(TensorObject* self,
                                void* closure) {
   EAGER_TRY
   auto src = CastPyArg2Tensor(value, 0);
-  auto grad_meta = egr::EagerUtils::autograd_meta(&self->tensor);
-  if (grad_meta) {
-    bool device_changed = self->tensor.place() != src.place();
-    bool dtype_changed = self->tensor.dtype() != src.dtype();
-    if (device_changed || dtype_changed) {
-      VLOG(4)
-          << "New tensor's place or dtype has changed, clear the old grad_node "
-             "info.";
-      grad_meta->ResetGradNode();
-    }
-  }
   self->tensor.set_impl(src.impl());
 
-  phi::DenseTensor tmp;
-  if (self->tensor.is_dense_tensor()) {
-    auto dense_tensor =
-        static_cast<phi::DenseTensor*>(self->tensor.impl().get());
-    if (dense_tensor) {
-      dense_tensor->ShareInplaceVersionCounterWith(tmp);
-    }
-  } else if (self->tensor.is_dist_tensor()) {
-    auto dist_tensor =
-        static_cast<phi::distributed::DistTensor*>(self->tensor.impl().get())
-            ->unsafe_mutable_value();
-    if (dist_tensor) {
-      dist_tensor->ShareInplaceVersionCounterWith(tmp);
-    }
-  }
   return 0;
   EAGER_CATCH_AND_THROW_RETURN_NEG
 }

--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -530,9 +530,7 @@ class TestTensorDataSetter(unittest.TestCase):
 
         x_grad_expected = paddle.ones_like(x)
 
-        np.testing.assert_equal(
-            x.grad.numpy(), x_grad_expected.numpy(), strict=True
-        )
+        np.testing.assert_equal(x.grad.numpy(), x_grad_expected.numpy())
 
         x.data = y
 
@@ -547,9 +545,7 @@ class TestTensorDataSetter(unittest.TestCase):
         loss.backward()
         x_grad_expected = paddle.ones_like(x) * 2
 
-        np.testing.assert_equal(
-            x.grad.numpy(), x_grad_expected.numpy(), strict=True
-        )
+        np.testing.assert_equal(x.grad.numpy(), x_grad_expected.numpy())
 
     def test_new_shape_same_dtype_same_place(self):
         x: paddle.Tensor = paddle.tensor([[1, 2], [3, 4]], dtype="float32")
@@ -561,9 +557,8 @@ class TestTensorDataSetter(unittest.TestCase):
 
         x_grad_expected = paddle.ones_like(x)
 
-        np.testing.assert_equal(
-            x.grad.numpy(), x_grad_expected.numpy(), strict=True
-        )
+        np.testing.assert_equal(x.grad.numpy(), x_grad_expected.numpy())
+        assert x.grad.dtype == x_grad_expected.dtype
 
         x.data = y
 
@@ -583,39 +578,22 @@ class TestTensorDataSetter(unittest.TestCase):
         z = x.sum()
         z.backward()
         x_grad_expected = paddle.ones_like(x)
-        np.testing.assert_equal(
-            x.grad.numpy(), x_grad_expected.numpy(), strict=True
-        )
+        np.testing.assert_equal(x.grad.numpy(), x_grad_expected.numpy())
+        assert x.grad.dtype == x_grad_expected.dtype
 
     def test_same_shape_new_dtype_same_place(self):
         x = paddle.tensor([[1, 2], [3, 4]], dtype="float32")
+        x_grad_expected = paddle.ones_like(x)
         y = x.to(paddle.float16)
         x.requires_grad = True
 
         loss = x.sum()
+
+        x.data = y
+
         loss.backward()
-
-        x_grad_expected = paddle.ones_like(x)
-
-        np.testing.assert_equal(
-            x.grad.numpy(), x_grad_expected.numpy(), strict=True
-        )
-
-        x.data = y.data
-
-        self.assertEqual(x.data_ptr(), y.data_ptr())
-        np.testing.assert_allclose(x.numpy(), y.numpy())
-        self.assertEqual(
-            x.requires_grad,
-            True,
-            "x's requires_grad should be True after data setting.",
-        )
-        loss = x.sum()
-        loss.backward()
-        x_grad_expected = x_grad_expected * 2
-        np.testing.assert_equal(
-            x.grad.numpy(), x_grad_expected.numpy(), strict=True
-        )
+        np.testing.assert_equal(x.grad.numpy(), x_grad_expected.numpy())
+        assert x.grad.dtype == x_grad_expected.dtype
 
         x.clear_gradient(set_to_zero=True)
         # dtype changed, clear_gradient must set grad to None
@@ -623,9 +601,7 @@ class TestTensorDataSetter(unittest.TestCase):
         z = x.sum()
         z.backward()
         x_grad_expected = paddle.ones_like(x)
-        np.testing.assert_equal(
-            x.grad.numpy(), x_grad_expected.numpy(), strict=True
-        )
+        np.testing.assert_equal(x.grad.numpy(), x_grad_expected.numpy())
         assert x.dtype == x.grad.dtype
 
     def test_same_shape_same_dtype_new_place(self):
@@ -633,17 +609,10 @@ class TestTensorDataSetter(unittest.TestCase):
             return
         x = paddle.tensor([[1, 2], [3, 4]], dtype="float32").cuda()
         y = x.cpu()
+        x_grad_expected = paddle.ones_like(x)
         x.requires_grad = True
 
         loss = x.sum()
-        loss.backward()
-
-        x_grad_expected = paddle.ones_like(x)
-
-        np.testing.assert_equal(
-            x.grad.numpy(), x_grad_expected.numpy(), strict=True
-        )
-
         x.data = y.data
 
         self.assertEqual(x.data_ptr(), y.data_ptr())
@@ -653,6 +622,10 @@ class TestTensorDataSetter(unittest.TestCase):
             True,
             "x's requires_grad should be True after data setting.",
         )
+        loss.backward()
+        np.testing.assert_equal(x.grad.numpy(), x_grad_expected.numpy())
+        assert x.grad.dtype == x_grad_expected.dtype
+        assert x.grad.place == x_grad_expected.place
 
         x.clear_gradient(set_to_zero=True)
         # place changed, clear_gradient must set grad to None
@@ -660,11 +633,9 @@ class TestTensorDataSetter(unittest.TestCase):
         loss = x.sum()
         loss.backward()
         x_grad_expected = paddle.ones_like(x)
-        np.testing.assert_equal(
-            x.grad.numpy(), x_grad_expected.numpy(), strict=True
-        )
+        np.testing.assert_equal(x.grad.numpy(), x_grad_expected.numpy())
         assert x.grad.place == x.place
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(argv=["", "TestTensorDataSetter"])

--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -667,4 +667,4 @@ class TestTensorDataSetter(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(argv=["", "TestTensorDataSetter"])
+    unittest.main()

--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -516,5 +516,155 @@ class TestTensor(unittest.TestCase):
             )
 
 
+class TestTensorDataSetter(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+
+    def test_same_shape_same_dtype(self):
+        x = paddle.tensor([[1, 2], [3, 4]], dtype="float32")
+        y = paddle.rand_like(x)
+        x.requires_grad = True
+
+        loss = x.sum()
+        loss.backward(retain_graph=True)
+
+        x_grad_expected = paddle.ones_like(x)
+
+        np.testing.assert_equal(
+            x.grad.numpy(), x_grad_expected.numpy(), strict=True
+        )
+
+        x.data = y
+
+        self.assertEqual(x.data_ptr(), y.data_ptr())
+        np.testing.assert_allclose(x.numpy(), y.numpy())
+        self.assertEqual(
+            x.requires_grad,
+            True,
+            "x's requires_grad should be True after data setting.",
+        )
+
+        loss.backward()
+        x_grad_expected = paddle.ones_like(x) * 2
+
+        np.testing.assert_equal(
+            x.grad.numpy(), x_grad_expected.numpy(), strict=True
+        )
+
+    def test_new_shape_same_dtype_same_place(self):
+        x: paddle.Tensor = paddle.tensor([[1, 2], [3, 4]], dtype="float32")
+        y = paddle.tensor([2], dtype="float32")
+        x.requires_grad = True
+
+        loss = x.sum()
+        loss.backward()
+
+        x_grad_expected = paddle.ones_like(x)
+
+        np.testing.assert_equal(
+            x.grad.numpy(), x_grad_expected.numpy(), strict=True
+        )
+
+        x.data = y
+
+        self.assertEqual(x.data_ptr(), y.data_ptr())
+        np.testing.assert_allclose(x.numpy(), y.numpy())
+        self.assertEqual(
+            x.requires_grad,
+            True,
+            "x's requires_grad should be True after data setting.",
+        )
+
+        with self.assertRaises(RuntimeError):
+            loss = x.sum()
+            loss.backward()
+
+        x.clear_gradient()
+        z = x.sum()
+        z.backward()
+        x_grad_expected = paddle.ones_like(x)
+        np.testing.assert_equal(
+            x.grad.numpy(), x_grad_expected.numpy(), strict=True
+        )
+
+    def test_same_shape_new_dtype_same_place(self):
+        x = paddle.tensor([[1, 2], [3, 4]], dtype="float32")
+        y = x.to(paddle.float16)
+        x.requires_grad = True
+
+        loss = x.sum()
+        loss.backward()
+
+        x_grad_expected = paddle.ones_like(x)
+
+        np.testing.assert_equal(
+            x.grad.numpy(), x_grad_expected.numpy(), strict=True
+        )
+
+        x.data = y.data
+
+        self.assertEqual(x.data_ptr(), y.data_ptr())
+        np.testing.assert_allclose(x.numpy(), y.numpy())
+        self.assertEqual(
+            x.requires_grad,
+            True,
+            "x's requires_grad should be True after data setting.",
+        )
+        loss = x.sum()
+        loss.backward()
+        x_grad_expected = x_grad_expected * 2
+        np.testing.assert_equal(
+            x.grad.numpy(), x_grad_expected.numpy(), strict=True
+        )
+
+        x.clear_gradient(set_to_zero=True)
+        # dtype changed, clear_gradient must set grad to None
+        assert x.grad is None
+        z = x.sum()
+        z.backward()
+        x_grad_expected = paddle.ones_like(x)
+        np.testing.assert_equal(
+            x.grad.numpy(), x_grad_expected.numpy(), strict=True
+        )
+        assert x.dtype == x.grad.dtype
+
+    def test_same_shape_same_dtype_new_place(self):
+        if not paddle.device.is_compiled_with_cuda():
+            return
+        x = paddle.tensor([[1, 2], [3, 4]], dtype="float32").cuda()
+        y = x.cpu()
+        x.requires_grad = True
+
+        loss = x.sum()
+        loss.backward()
+
+        x_grad_expected = paddle.ones_like(x)
+
+        np.testing.assert_equal(
+            x.grad.numpy(), x_grad_expected.numpy(), strict=True
+        )
+
+        x.data = y.data
+
+        self.assertEqual(x.data_ptr(), y.data_ptr())
+        np.testing.assert_allclose(x.numpy(), y.numpy())
+        self.assertEqual(
+            x.requires_grad,
+            True,
+            "x's requires_grad should be True after data setting.",
+        )
+
+        x.clear_gradient(set_to_zero=True)
+        # place changed, clear_gradient must set grad to None
+        assert x.grad is None
+        loss = x.sum()
+        loss.backward()
+        x_grad_expected = paddle.ones_like(x)
+        np.testing.assert_equal(
+            x.grad.numpy(), x_grad_expected.numpy(), strict=True
+        )
+        assert x.grad.place == x.place
+
+
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(argv=["", "TestTensorDataSetter"])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->

修改 Tensor.data 的 setter 方法，在 setter 中仅替换 tensor_impl 的指针，而非用新 Tensor 替换 Self。
