### PR TITLE
[CINN] Exclude `stop_gradient` and `struct_name` from compilation cache key

### DIFF
--- a/paddle/cinn/hlir/framework/pir/fusion_info.cc
+++ b/paddle/cinn/hlir/framework/pir/fusion_info.cc
@@ -22,11 +22,11 @@ PD_DECLARE_bool(enable_cinn_compile_cache);
 
 namespace cinn::hlir::framework::pir {
 
-constexpr static char* kOpCallStack = "op_callstack";
-constexpr static char* kSymShapeStr = "sym_shape_str";
-constexpr static char* kStructName = "struct_name";
-constexpr static char* kStopGradient = "stop_gradient";
-static std::unordered_set<std::string> kExcludedAttrs = {
+constexpr static const char* kOpCallStack = "op_callstack";
+constexpr static const char* kSymShapeStr = "sym_shape_str";
+constexpr static const char* kStructName = "struct_name";
+constexpr static const char* kStopGradient = "stop_gradient";
+static const std::unordered_set<std::string> kExcludedAttrs = {
     kOpCallStack, kSymShapeStr, kStructName, kStopGradient};
 
 std::size_t AttributeInfo::hash() const { return attr_.hash(); }

--- a/paddle/cinn/hlir/framework/pir/fusion_info.cc
+++ b/paddle/cinn/hlir/framework/pir/fusion_info.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/cinn/hlir/framework/pir/fusion_info.h"
+#include <unordered_set>
 #include "paddle/common/enforce.h"
 #include "paddle/common/flags.h"
 #include "paddle/pir/include/core/ir_printer.h"
@@ -23,6 +24,10 @@ namespace cinn::hlir::framework::pir {
 
 constexpr static char* kOpCallStack = "op_callstack";
 constexpr static char* kSymShapeStr = "sym_shape_str";
+constexpr static char* kStructName = "struct_name";
+constexpr static char* kStopGradient = "stop_gradient";
+static std::unordered_set<std::string> kExcludedAttrs = {
+    kOpCallStack, kSymShapeStr, kStructName, kStopGradient};
 
 std::size_t AttributeInfo::hash() const { return attr_.hash(); }
 
@@ -66,8 +71,7 @@ OperationInfo::OperationInfo(const ::pir::Operation& op) {
       attributes.begin(), attributes.end());
   attr_infos_.reserve(attributes.size());
   for (const auto& [attr_name, attr_value] : order_attributes) {
-    if (!attr_value || attr_name == kOpCallStack || attr_name == kSymShapeStr)
-      continue;
+    if (!attr_value || kExcludedAttrs.count(attr_name)) continue;
     attr_infos_.emplace_back(attr_name, attr_value);
   }
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

编译 cache key 中排除掉以下 attributes，避免 cache key 难以命中的问题

- `struct_name`，不影响图结构、计算语义
- `stop_gradient`，仅用于组网反向计算的拓扑结构确定，但一旦确定了，其计算是固定的，并不影响计算逻辑，不影响生成的 kernel

<!-- PCard-66972 -->