### PR TITLE
[DLPack][TVM FFI] Rename C exchange API to `__dlpack_c_exchange_api__`

### DIFF
--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -1601,6 +1601,7 @@ def monkey_patch_tensor():
                 return core.dlpack_exchange_api_ptr()
         except Exception:
             pass
+        # For tvm ffi 0.1.4 only, in tvm ffi 0.1.5+, replaced by `__dlpack_c_exchange_api__`
         return core.dlpack_exchange_api_pycapsule()
 
     if not hasattr(core, "eager"):
@@ -1652,7 +1653,9 @@ def monkey_patch_tensor():
         ("__dlpack_device__", __dlpack_device__),
         ("get_device", get_device),
         ("__tvm_ffi_env_stream__", __tvm_ffi_env_stream__),
+        # For TVM FFI 0.1.0-0.1.4, Replaced by `__c_dlpack_exchange_api__` in TVM FFI 0.1.5+
         ("__c_dlpack_exchange_api__", _get_c_dlpack_exchange_api()),
+        ("__dlpack_c_exchange_api__", core.dlpack_exchange_api_pycapsule()),
         ("device", device),
     ):
         setattr(core.eager.Tensor, method_name, method)

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -1653,7 +1653,7 @@ def monkey_patch_tensor():
         ("__dlpack_device__", __dlpack_device__),
         ("get_device", get_device),
         ("__tvm_ffi_env_stream__", __tvm_ffi_env_stream__),
-        # For TVM FFI 0.1.0-0.1.4, Replaced by `__c_dlpack_exchange_api__` in TVM FFI 0.1.5+
+        # For TVM FFI 0.1.0-0.1.4, replaced by `__dlpack_c_exchange_api__` in TVM FFI 0.1.5+
         ("__c_dlpack_exchange_api__", _get_c_dlpack_exchange_api()),
         ("__dlpack_c_exchange_api__", core.dlpack_exchange_api_pycapsule()),
         ("device", device),

--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -19,6 +19,6 @@ xdoctest==1.3.0
 ubelt==1.3.3 # just for xdoctest
 mypy==1.18.2
 soundfile
-apache-tvm-ffi==0.1.4
+apache-tvm-ffi==0.1.5
 graphviz
 nvidia-ml-py3 ; platform_system != "Darwin"

--- a/test/dygraph_to_static/test_tensor_attr_consistency.py
+++ b/test/dygraph_to_static/test_tensor_attr_consistency.py
@@ -82,6 +82,7 @@ DYGRAPH_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(
         "__dlpack_device__",
         "__tvm_ffi_env_stream__",
         "__c_dlpack_exchange_api__",
+        "__dlpack_c_exchange_api__",
     ]
 )
 STATIC_ONLY_TENSOR_ATTRS_ALLOW_LIST = OrderedSet(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

- DLPack discussion dmlc/dlpack#179
- DLPack implementation dmlc/dlpack#180
- TVM FFI implementation apache/tvm-ffi#315
- PyTorch implementation pytorch/pytorch#169724

For better compatibility, we expose APIs as below:

- `Tensor.__c_dlpack_exchange_api__: int | types.CapsuleType`
   - When tvm ffi is available and its version in `{(0.1.0), (0.1.1), (0.1.2), (0.1.3)}`, returns `int`
   - Otherwise, returns `types.CapsuleType`
- `Tensor.__dlpack_c_exchange_api__: types.CapsuleType`

### TODOs

- Bump DLPack to v1.3 after dmlc/dlpack#180 merged

<!-- PCard-66972 -->