### PR TITLE
[Stride] Fix reduce shem_size bug

### DIFF
--- a/paddle/phi/kernels/stride/reduce_stride_base.cu.h
+++ b/paddle/phi/kernels/stride/reduce_stride_base.cu.h
@@ -843,10 +843,30 @@ void ReduceStrideImpl(const Context& dev_ctx,
   DenseTensor reduce_buf_tensor;
   DenseTensor reduce_sem_tensor;
 
+  PADDLE_ENFORCE_LT(
+      reduce_stride_conf.gm_size(),
+      std::numeric_limits<int32_t>::max(),
+      ::common::errors::InvalidArgument(
+          "reduce_stride_conf.gm_size() should be less than int32_t"));
+
+  PADDLE_ENFORCE_LT(
+      reduce_stride_conf.sem_size(),
+      std::numeric_limits<int32_t>::max(),
+      ::common::errors::InvalidArgument(
+          "reduce_stride_conf.sem_size() should be less than int32_t"));
+
   std::vector<int> reduce_buf_size = {
       static_cast<int>(reduce_stride_conf.gm_size() / phi::SizeOf(x.dtype()))};
   std::vector<int> reduce_sem_size = {
       static_cast<int>(reduce_stride_conf.sem_size() / phi::SizeOf(x.dtype()))};
+
+  if (reduce_buf_size[0] == 0) {
+    reduce_buf_size[0] = phi::SizeOf(x.dtype());
+  }
+
+  if (reduce_sem_size[0] == 0) {
+    reduce_sem_size[0] = phi::SizeOf(x.dtype());
+  }
 
   if (reduce_stride_conf.enable_g_reduce()) {
     reduce_buf_tensor.Resize(common::make_ddim(reduce_buf_size));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复reduce stride kernel前向可能出现的分配空的share_mem问题

pcard-67164