### PR TITLE
[DLPack] Fix behavior when pass `stream` to `__dlpack__`

### DIFF
--- a/paddle/fluid/pybind/cuda_streams_py.cc
+++ b/paddle/fluid/pybind/cuda_streams_py.cc
@@ -14,6 +14,7 @@
 
 #include "paddle/fluid/pybind/cuda_streams_py.h"
 #include <string>
+#include <utility>
 #include <vector>
 #include "glog/logging.h"
 #include "paddle/phi/api/profiler/event.h"
@@ -61,6 +62,19 @@ PY_STREAM_TYPE set_current_stream(PY_STREAM_TYPE stream) {
   return original_stream;
 }
 
+PY_STREAM_TYPE get_legacy_default_stream(int device_id) {
+  static thread_local std::map<int, phi::CUDAStream> legacy_default_streams;
+  if (device_id == -1) {
+    device_id = phi::backends::gpu::GetCurrentDeviceId();
+  }
+  phi::GPUPlace place(device_id);
+
+  legacy_default_streams.try_emplace(
+      device_id, place, static_cast<gpuStream_t>(0));
+
+  return &legacy_default_streams.at(device_id);
+}
+
 #endif
 }  // namespace platform
 namespace pybind {
@@ -77,6 +91,19 @@ void BindCudaStream(py::module *m_ptr) {
 #else
         PADDLE_THROW(common::errors::Unavailable(
             "Paddle do not support _get_current_stream "
+            "Cannot visit device synchronize."));
+#endif
+      },
+      py::return_value_policy::reference);
+
+  m.def(
+      "_get_legacy_default_stream",
+      [](int device_id) {
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+        return platform::get_legacy_default_stream(device_id);
+#else
+        PADDLE_THROW(common::errors::Unavailable(
+            "Paddle do not support _get_legacy_default_stream "
             "Cannot visit device synchronize."));
 #endif
       },

--- a/python/paddle/base/core.py
+++ b/python/paddle/base/core.py
@@ -302,6 +302,7 @@ try:
         _get_amp_op_list,
         _get_current_stream,
         _get_eager_deletion_vars,
+        _get_legacy_default_stream,
         _get_phi_kernel_name,
         _get_registered_phi_kernels,
         _get_stream_from_external,

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -1562,10 +1562,14 @@ def monkey_patch_tensor():
 
             current_stream = paddle.device.current_stream()
 
-            if (
-                consumer_stream.stream_base.raw_stream
-                != current_stream.stream_base.raw_stream
-            ):
+            def is_same_stream(
+                lhs: paddle.device.Stream, rhs: paddle.device.Stream
+            ) -> bool:
+                return (
+                    lhs.stream_base.raw_stream == rhs.stream_base.raw_stream
+                ) and (lhs.device == rhs.device)
+
+            if not is_same_stream(consumer_stream, current_stream):
                 event = paddle.device.Event()
                 event.record(current_stream)
                 consumer_stream.wait_event(event)

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -1529,7 +1529,7 @@ def monkey_patch_tensor():
         elif self.place.is_gpu_place() and stream != -1:
             is_rocm = paddle.is_compiled_with_rocm()
             is_cuda = paddle.is_compiled_with_cuda()
-            consumer_stream: int | None = (
+            consumer_stream: paddle.device.Stream | None = (
                 None  # None indicates the legacy default stream
             )
             if not (is_rocm or is_cuda):
@@ -1555,15 +1555,18 @@ def monkey_patch_tensor():
                 or (is_rocm and stream == 0)
             ):
                 assert stream > 2, "stream should be a valid stream pointer."
-                consumer_stream = stream
+                consumer_stream = paddle.device.get_stream_from_external(stream)
 
             current_stream = paddle.device.current_stream()
-            current_raw_stream = current_stream.stream_base.raw_stream
 
             if (
                 # All paddle created stream is not legacy default stream,
                 # so we need to synchronize explicitly.
-                consumer_stream is None or consumer_stream != current_raw_stream
+                consumer_stream is None
+                or (
+                    consumer_stream.stream_base.raw_stream
+                    != current_stream.stream_base.raw_stream
+                )
             ):
                 event = paddle.device.Event()
                 event.record(current_stream)

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -1551,19 +1551,24 @@ def monkey_patch_tensor():
                 # For ROCm, stream=0 means default stream
                 or (is_rocm and stream == 0)
             ):
-                dlpack_stream = (
-                    paddle.device.current_stream()
-                )  # TODO: This should be the default stream
+                consumer_stream = paddle.device.Stream(
+                    stream_base=core._get_legacy_default_stream(
+                        paddle.framework._current_expected_place_().get_device_id()
+                    )
+                )
             else:
                 assert stream > 2, "stream should be a valid stream pointer."
-                dlpack_stream = paddle.device.get_stream_from_external(stream)
+                consumer_stream = paddle.device.get_stream_from_external(stream)
 
             current_stream = paddle.device.current_stream()
 
-            if dlpack_stream != current_stream:
+            if (
+                consumer_stream.stream_base.raw_stream
+                != current_stream.stream_base.raw_stream
+            ):
                 event = paddle.device.Event()
                 event.record(current_stream)
-                current_stream.synchronize()
+                consumer_stream.wait_event(event)
         elif self.place.is_cpu_place():
             assert stream is None, "CPU tensor stream must be None."
 

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -1529,9 +1529,6 @@ def monkey_patch_tensor():
         elif self.place.is_gpu_place() and stream != -1:
             is_rocm = paddle.is_compiled_with_rocm()
             is_cuda = paddle.is_compiled_with_cuda()
-            consumer_stream: paddle.device.Stream | None = (
-                None  # None indicates the legacy default stream
-            )
             if not (is_rocm or is_cuda):
                 raise RuntimeError(
                     "DLPack with stream synchronization is only supported "
@@ -1547,27 +1544,23 @@ def monkey_patch_tensor():
                 )
             if is_rocm and stream in {1, 2}:
                 raise ValueError("For ROCm, stream=1 or 2 is not supported.")
-            if not (
+            if (
                 stream is None
                 # For CUDA, stream=1 means default stream
                 or (is_cuda and stream == 1)
                 # For ROCm, stream=0 means default stream
                 or (is_rocm and stream == 0)
             ):
+                dlpack_stream = (
+                    paddle.device.current_stream()
+                )  # TODO: This should be the default stream
+            else:
                 assert stream > 2, "stream should be a valid stream pointer."
-                consumer_stream = paddle.device.get_stream_from_external(stream)
+                dlpack_stream = paddle.device.get_stream_from_external(stream)
 
             current_stream = paddle.device.current_stream()
 
-            if (
-                # All paddle created stream is not legacy default stream,
-                # so we need to synchronize explicitly.
-                consumer_stream is None
-                or (
-                    consumer_stream.stream_base.raw_stream
-                    != current_stream.stream_base.raw_stream
-                )
-            ):
+            if dlpack_stream != current_stream:
                 event = paddle.device.Event()
                 event.record(current_stream)
                 current_stream.synchronize()

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -1529,6 +1529,9 @@ def monkey_patch_tensor():
         elif self.place.is_gpu_place() and stream != -1:
             is_rocm = paddle.is_compiled_with_rocm()
             is_cuda = paddle.is_compiled_with_cuda()
+            consumer_stream: paddle.device.Stream | None = (
+                None  # None indicates the legacy default stream
+            )
             if not (is_rocm or is_cuda):
                 raise RuntimeError(
                     "DLPack with stream synchronization is only supported "
@@ -1544,23 +1547,27 @@ def monkey_patch_tensor():
                 )
             if is_rocm and stream in {1, 2}:
                 raise ValueError("For ROCm, stream=1 or 2 is not supported.")
-            if (
+            if not (
                 stream is None
                 # For CUDA, stream=1 means default stream
                 or (is_cuda and stream == 1)
                 # For ROCm, stream=0 means default stream
                 or (is_rocm and stream == 0)
             ):
-                dlpack_stream = (
-                    paddle.device.current_stream()
-                )  # TODO: This should be the default stream
-            else:
                 assert stream > 2, "stream should be a valid stream pointer."
-                dlpack_stream = paddle.device.get_stream_from_external(stream)
+                consumer_stream = paddle.device.get_stream_from_external(stream)
 
             current_stream = paddle.device.current_stream()
 
-            if dlpack_stream != current_stream:
+            if (
+                # All paddle created stream is not legacy default stream,
+                # so we need to synchronize explicitly.
+                consumer_stream is None
+                or (
+                    consumer_stream.stream_base.raw_stream
+                    != current_stream.stream_base.raw_stream
+                )
+            ):
                 event = paddle.device.Event()
                 event.record(current_stream)
                 current_stream.synchronize()

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -49,6 +49,8 @@ from .math_op_patch import monkey_patch_math_tensor
 if TYPE_CHECKING:
     from enum import IntEnum
 
+    from typing_extensions import CapsuleType
+
     from paddle import Tensor
     from paddle._typing import DTypeLike, PlaceLike, TensorIndex
 
@@ -1491,7 +1493,7 @@ def monkey_patch_tensor():
         max_version: tuple[int, int] | None = None,
         dl_device: tuple[IntEnum, int] | None = None,
         copy: bool | None = None,
-    ):
+    ) -> CapsuleType:
         """
         Creates a DLPack capsule of the current tensor to be exported to other libraries.
         Args:
@@ -1512,24 +1514,58 @@ def monkey_patch_tensor():
         """
 
         if self.is_sparse():
-            raise AttributeError(
-                "Can't get __dlpack__ from a Tensor that requires gradients, "
-                "use tensor.detach() if gradients are not required."
+            raise BufferError(
+                "Can't get __dlpack__ from a Tensor from sparse storage."
             )
 
         if not self.stop_gradient:
-            raise RuntimeError(
+            raise BufferError(
                 "Can't get __dlpack__ from Tensor that requires gradients. "
                 "If gradients aren't required, use tensor.detach() to get a tensor without gradient."
             )
 
-        if stream is not None:
-            if self.place.is_gpu_place():
-                current_stream = paddle.device.cuda.current_stream()
-                if stream != current_stream:
-                    event = paddle.device.cuda.Event()
-                    event.record(current_stream)
-                    current_stream.synchronize()
+        if stream is not None and not isinstance(stream, int):
+            raise TypeError("stream must be an integer or None.")
+        elif self.place.is_gpu_place() and stream != -1:
+            is_rocm = paddle.is_compiled_with_rocm()
+            is_cuda = paddle.is_compiled_with_cuda()
+            if not (is_rocm or is_cuda):
+                raise RuntimeError(
+                    "DLPack with stream synchronization is only supported "
+                    "when Paddle is compiled with CUDA or ROCm."
+                )
+            if is_cuda and stream == 0:
+                raise ValueError(
+                    "For CUDA, stream=0 is ambiguityous, please use None for default stream."
+                )
+            if is_cuda and stream == 2:
+                raise ValueError(
+                    "For CUDA, stream=2 means per-thread default stream, which is not supported."
+                )
+            if is_rocm and stream in {1, 2}:
+                raise ValueError("For ROCm, stream=1 or 2 is not supported.")
+            if (
+                stream is None
+                # For CUDA, stream=1 means default stream
+                or (is_cuda and stream == 1)
+                # For ROCm, stream=0 means default stream
+                or (is_rocm and stream == 0)
+            ):
+                dlpack_stream = (
+                    paddle.device.current_stream()
+                )  # TODO: This should be the default stream
+            else:
+                assert stream > 2, "stream should be a valid stream pointer."
+                dlpack_stream = paddle.device.get_stream_from_external(stream)
+
+            current_stream = paddle.device.current_stream()
+
+            if dlpack_stream != current_stream:
+                event = paddle.device.Event()
+                event.record(current_stream)
+                current_stream.synchronize()
+        elif self.place.is_cpu_place():
+            assert stream is None, "CPU tensor stream must be None."
 
         if max_version is None or max_version[0] < 1:
             return self.get_tensor()._to_dlpack(dl_device=dl_device, copy=copy)

--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -1529,7 +1529,7 @@ def monkey_patch_tensor():
         elif self.place.is_gpu_place() and stream != -1:
             is_rocm = paddle.is_compiled_with_rocm()
             is_cuda = paddle.is_compiled_with_cuda()
-            consumer_stream: paddle.device.Stream | None = (
+            consumer_stream: int | None = (
                 None  # None indicates the legacy default stream
             )
             if not (is_rocm or is_cuda):
@@ -1555,18 +1555,15 @@ def monkey_patch_tensor():
                 or (is_rocm and stream == 0)
             ):
                 assert stream > 2, "stream should be a valid stream pointer."
-                consumer_stream = paddle.device.get_stream_from_external(stream)
+                consumer_stream = stream
 
             current_stream = paddle.device.current_stream()
+            current_raw_stream = current_stream.stream_base.raw_stream
 
             if (
                 # All paddle created stream is not legacy default stream,
                 # so we need to synchronize explicitly.
-                consumer_stream is None
-                or (
-                    consumer_stream.stream_base.raw_stream
-                    != current_stream.stream_base.raw_stream
-                )
+                consumer_stream is None or consumer_stream != current_raw_stream
             ):
                 event = paddle.device.Event()
                 event.record(current_stream)

--- a/test/legacy_test/test_dlpack_basic.py
+++ b/test/legacy_test/test_dlpack_basic.py
@@ -284,11 +284,32 @@ class TestDLPack(unittest.TestCase):
             s2.wait_event(e)
             x = paddle.to_tensor([1, 2, 3], dtype='float32')
             s1.synchronize()
-            dlpack_capsule = x.__dlpack__(stream=s1)
+            dlpack_capsule = x.__dlpack__(stream=s1.stream_base.raw_stream)
             y = paddle.from_dlpack(dlpack_capsule)
             np.testing.assert_array_equal(x.numpy(), y.numpy())
             self.assertTrue(s1.query(), "Stream s1 did not complete all tasks.")
             self.assertTrue(s2.query(), "Stream s2 did not complete all tasks.")
+
+    def test_dlpack_with_custom_stream_error(self):
+        if not (paddle.is_compiled_with_cuda()):
+            self.skipTest("Test requires CUDA support.")
+        with dygraph_guard():
+            x = paddle.to_tensor([1, 2, 3], dtype='float32')
+            with self.assertRaisesRegex(
+                TypeError, "stream must be an integer or None."
+            ):
+                dlpack_capsule = x.__dlpack__(stream=object())
+
+            with self.assertRaisesRegex(
+                ValueError, "For CUDA, stream=0 is ambiguityous"
+            ):
+                dlpack_capsule = x.__dlpack__(stream=0)
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "For CUDA, stream=2 means per-thread default stream, which is not supported.",
+            ):
+                dlpack_capsule = x.__dlpack__(stream=2)
 
 
 @unittest.skipIf(
@@ -300,14 +321,14 @@ class TestRaiseError(unittest.TestCase):
         sparse_tensor = paddle.sparse.sparse_coo_tensor(
             indices=[[0]], values=[1], shape=[3]
         )
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(BufferError):
             sparse_tensor.__dlpack__()
 
     def test_dlpack_requires_grad(self):
         tensor_with_grad = paddle.to_tensor(
             [1.0, 2.0, 3.0], stop_gradient=False
         )
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(BufferError):
             tensor_with_grad.__dlpack__()
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

之前的 `__dlpack__` 对 stream 实现乱写，新的实现遵循 `__dlpack__` 规范[^1] 进行实现

- `None` 表示 legacy default stream
- `-1` 表示不会同步
- `0-2` 在 CUDA 和 ROCm 有特殊语义，见规范
- `>2` 表示 stream ptr

由于 Paddle 之前并没有创建 legacy default stream 的方式，新增 `paddle.base.core._get_legacy_default_stream` 来创建

另外值得注意的是 pytorch/pytorch#163242 修改后 PyTorch 已经不符合规范了

[^1]: https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack__.html#dlpack

<!-- PCard-66972 -->