### PR TITLE
fix dlpack insert synchronize when stream == -1

### DIFF
--- a/python/paddle/base/dygraph/tensor_patch_methods.py
+++ b/python/paddle/base/dygraph/tensor_patch_methods.py
@@ -1487,7 +1487,7 @@ def monkey_patch_tensor():
     def __dlpack__(
         self,
         *,
-        stream: int | None = None,
+        stream: int | None = -1,
         max_version: tuple[int, int] | None = None,
         dl_device: tuple[IntEnum, int] | None = None,
         copy: bool | None = None,
@@ -1523,7 +1523,10 @@ def monkey_patch_tensor():
                 "If gradients aren't required, use tensor.detach() to get a tensor without gradient."
             )
 
-        if stream is not None:
+        if stream is not None and type(stream) is not int:
+            raise TypeError("stream must be ``int`` or ``none``")
+
+        if stream != -1:
             if self.place.is_gpu_place():
                 current_stream = paddle.device.cuda.current_stream()
                 if stream != current_stream:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
在使用 cutedsl 的 from_dlpack 时，会传入 stream = -1，当前的时间会插入 sync，单测测试性能较差，该 PR 是优化了 sync。