### PR TITLE
[CINN] Close fmad compile config in cinn

### DIFF
--- a/paddle/cinn/runtime/flags.cc
+++ b/paddle/cinn/runtime/flags.cc
@@ -165,7 +165,7 @@ PD_DEFINE_bool(cinn_compile_with_nvrtc,
 
 PD_DEFINE_bool(
     cinn_nvrtc_cubin_with_fmad,
-    BoolFromEnv("FLAGS_cinn_nvrtc_cubin_with_fmad", true),
+    BoolFromEnv("FLAGS_cinn_nvrtc_cubin_with_fmad", false),
     "Whether nvrtc enables fmad when compile to cubin. This flag only works "
     "when FLAGS_nvrtc_compile_to_cubin=true. Fmad is the cuda speed up "
     "technique which contract fp multiplication and addition/subtraction into "


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
默认关闭 CINN 中 nvrtc 编译时的 fmad 编译配置，减少精度 diff。