### PR TITLE
[Bug Fix] Support casting lightweight float formats to complex types

### DIFF
--- a/paddle/phi/core/framework/data_type_transform.cc
+++ b/paddle/phi/core/framework/data_type_transform.cc
@@ -40,8 +40,11 @@ struct CastDataTypeFunctor {
                                  std::is_same_v<InType, phi::float8_e5m2> ||
                                  std::is_same_v<InType, phi::bfloat16> ||
                                  std::is_same_v<InType, phi::float16>)) {
-      // default value，only to avoid compile error
-      return OutType(0);
+      if constexpr (std::is_same_v<OutType, phi::complex64>) {
+        return OutType(static_cast<float>(in));
+      } else {
+        return OutType(static_cast<double>(in));
+      }
     } else {
       return static_cast<OutType>(in);
     }

--- a/paddle/phi/kernels/funcs/cascade_sum.h
+++ b/paddle/phi/kernels/funcs/cascade_sum.h
@@ -613,6 +613,24 @@ inline std::vector<int64_t> CastTargetStrides(
   return strides;
 }
 
+// phi::float16/bfloat16 are not std arithmetic types, so the
+// is_floating_point-gated constructor of dtype::complex rejects a direct
+// static_cast; widen through float first. The reverse direction compiles
+// because dtype::complex has an explicit operator float().
+template <typename Dst, typename Src>
+inline Dst CastElement(const Src& value) {
+  if constexpr ((std::is_same_v<Src, float16> ||
+                 std::is_same_v<
+                     Src,
+                     bfloat16>)&&(std::is_same_v<Dst, dtype::complex<float>> ||
+                                  std::is_same_v<Dst,
+                                                 dtype::complex<double>>)) {
+    return Dst(static_cast<float>(value));
+  } else {
+    return static_cast<Dst>(value);
+  }
+}
+
 // Reproduces `Tensor::to(dtype)` with MemoryFormat::Preserve (torch's
 // _to_copy): a non-overlapping-and-dense view keeps its exact strides, so a
 // transposed view stays transposed and the reduction still sees the original
@@ -635,7 +653,7 @@ void CastPreservingLayout(const Src* x_data,
     }
     buffer->resize(extent);
     for (int64_t k = 0; k < extent; ++k) {
-      (*buffer)[k] = static_cast<Dst>(x_data[k]);
+      (*buffer)[k] = CastElement<Dst>(x_data[k]);
     }
     return;
   }
@@ -649,7 +667,7 @@ void CastPreservingLayout(const Src* x_data,
     for (int i = 0; i < rank; ++i) {
       src += index[i] * x_strides[i];
     }
-    (*buffer)[k] = static_cast<Dst>(x_data[src]);
+    (*buffer)[k] = CastElement<Dst>(x_data[src]);
     for (int i = rank - 1; i >= 0; --i) {
       if (++index[i] < x_shape[i]) break;
       index[i] = 0;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Environment Adaptation


### PR Types
Bug fixes


### Description
继续修复 https://github.com/PaddlePaddle/Paddle/pull/75929 未解决的问题。

背景：轻量浮点格式（`float16`/`bfloat16`/`float8_e4m3fn`/`float8_e5m2`）不是标准算术类型，而 `phi::dtype::complex` 的通用构造函数被 `enable_if` 限制为仅接受 `std::is_floating_point || std::is_integral` 的类型，因此这些格式到 `complex64`/`complex128` 无法直接 `static_cast`，在 Windows（MSVC）下模板实例化即报 C2440 编译错误。

本 PR 共修复两处：

#### `paddle/phi/core/framework/data_type_transform.cc`

`CastDataTypeFunctor` 中轻量浮点 → 复数的分支此前仅返回 `OutType(0)` 占位以规避编译错误，导致该路径在 Windows 上运行时转换结果恒为 0。现改为先经 `float`/`double` 中转再构造复数（虚部为 0），得到正确的转换结果，与其他平台行为一致。

#### `paddle/phi/kernels/funcs/cascade_sum.h`

`reduce_sum` CPU kernel 的 `CastPreservingLayout` 直接 `static_cast<Dst>(src)` 转换元素。`SumRawKernel<float16>`/`SumRawKernel<bfloat16>` 会按 `compute_dtype` 实例化出 `float16/bfloat16 -> complex64/complex128` 的组合，编译失败。新增 `CastElement` 辅助函数，对该组合先经 `float` 中转再构造复数；反方向（complex → fp16/bf16）因 `phi::dtype::complex` 提供 `explicit operator float()` 不受影响。编译错误日志：

```shell
FAILED: paddle/phi/CMakeFiles/phi.dir/kernels/cpu/reduce_sum_kernel.cc.obj
paddle/phi/kernels/funcs/cascade_sum.h(638): error C2440: “static_cast”: 无法从“const Src”转换为“Dst”
        with
        [
            Src=phi::float16
        ]
        and
        [
            Dst=phi::`anonymous-namespace'::TryCascadeSum::<lambda_...>::()::data_t
        ]
paddle/phi/common/complex.h(128): note: “phi::dtype::complex<float>::complex”: 没有重载函数可以转换所有参数类型
```


### 是否引起精度变化
否
