### PR TITLE
[SOT] Fix sot size getitem

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/container.py
@@ -1122,3 +1122,30 @@ class DictVariable(ContainerVariable):
 class SizeVariable(ListVariable):
     def get_py_type(self):
         return paddle.Size
+
+    def getitem(self, key):
+        self.graph.add_global_guarded_variable(key)
+        key_val = key.get_py_value()
+
+        if isinstance(key_val, int):
+            res = self.proxy.get(key_val)
+            if self.proxy.is_empty(res):
+                raise InnerError(f"Size {self} out of range (index={key_val})")
+            return res
+
+        elif isinstance(key_val, slice):
+            items = self.proxy.get_all()
+            sliced_items = items[key_val]
+
+            return SizeVariable(
+                sliced_items,
+                self.graph,
+                tracker=GetItemTracker(
+                    self, key_val, changed=self.proxy.check_changed(key_val)
+                ),
+            )
+
+        else:
+            raise InnerError(
+                f"Unsupported key type {key.__class__.__name__} for SizeVariable"
+            )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
SOT 中 SizeVariable 切片索引错误地返回 ListVariable 导致缓存未命中，引发动转静性能下降 5~10%

TODO: 重写 copy、append等方法，同样需要返回 SizeVar，增加 numel 等方法

关联 PR：
- https://github.com/PaddlePaddle/Paddle/pull/76361