### PR TITLE
respect to MAX_JOBS env when using cpp extension

### DIFF
--- a/python/paddle/utils/cpp_extension/__init__.py
+++ b/python/paddle/utils/cpp_extension/__init__.py
@@ -18,6 +18,7 @@ from .cpp_extension import (
     BuildExtension,  # noqa: F401
     CppExtension,
     CUDAExtension,
+    _compute_worker_number,  # noqa: F401
     _get_cuda_arch_flags,  # noqa: F401
     _get_num_workers,  # noqa: F401
     _get_pybind11_abi_build_flags,  # noqa: F401

--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -665,7 +665,9 @@ class BuildExtension(build_ext):
             worker_number = _compute_worker_number(
                 requested_workers, os.cpu_count(), len(objects)
             )
-            print(f"Using {worker_number} workers for compilation. HINT: export MAX_JOBS=n to set the number of workers")
+            print(
+                f"Using {worker_number} workers for compilation. HINT: export MAX_JOBS=n to set the number of workers"
+            )
             with ThreadPoolExecutor(max_workers=worker_number) as executor:
                 # Submit all compilation tasks to the thread pool.
                 futures = {

--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -662,13 +662,9 @@ class BuildExtension(build_ext):
             cc_args = self._get_cc_args(pp_opts, debug, extra_preargs)
             # Create a thread pool
             requested_workers = _get_num_workers(verbose=bool(self.verbose))
-            cpu_count = os.cpu_count() or 1
-            if requested_workers is None:
-                worker_number = min(cpu_count, len(objects))
-            else:
-                worker_number = max(
-                    1, min(requested_workers, cpu_count, len(objects))
-                )
+            worker_number = _compute_worker_number(
+                requested_workers, os.cpu_count(), len(objects)
+            )
             print(f"Using {worker_number} workers for compilation...")
             with ThreadPoolExecutor(max_workers=worker_number) as executor:
                 # Submit all compilation tasks to the thread pool.
@@ -1606,3 +1602,14 @@ def _get_num_workers(verbose: bool) -> int | None:
             file=sys.stderr,
         )
     return None
+
+
+def _compute_worker_number(
+    requested_workers: int | None, cpu_count: int | None, num_objects: int
+) -> int:
+    cpu_count = cpu_count or 1
+    if requested_workers is None:
+        worker_number = min(cpu_count, num_objects)
+    else:
+        worker_number = max(1, min(requested_workers, cpu_count, num_objects))
+    return worker_number

--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -661,7 +661,15 @@ class BuildExtension(build_ext):
             )
             cc_args = self._get_cc_args(pp_opts, debug, extra_preargs)
             # Create a thread pool
-            worker_number = min(os.cpu_count(), len(objects))
+            requested_workers = _get_num_workers(verbose=bool(self.verbose))
+            cpu_count = os.cpu_count() or 1
+            if requested_workers is None:
+                worker_number = min(cpu_count, len(objects))
+            else:
+                worker_number = max(
+                    1, min(requested_workers, cpu_count, len(objects))
+                )
+            print(f"Using {worker_number} workers for compilation...")
             with ThreadPoolExecutor(max_workers=worker_number) as executor:
                 # Submit all compilation tasks to the thread pool.
                 futures = {

--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -665,7 +665,7 @@ class BuildExtension(build_ext):
             worker_number = _compute_worker_number(
                 requested_workers, os.cpu_count(), len(objects)
             )
-            print(f"Using {worker_number} workers for compilation...")
+            print(f"Using {worker_number} workers for compilation. HINT: export MAX_JOBS=n to set the number of workers")
             with ThreadPoolExecutor(max_workers=worker_number) as executor:
                 # Submit all compilation tasks to the thread pool.
                 futures = {


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Improvements

### Description
respect to MAX_JOBS when compiling cpp extension.
the context is that when building FastDeploy on a machine that have less RAM, but many cpu cores. default behavior of building cpp extension is using all available cpu cores, thus cause OOM when building FastDeploy. This PR allows developers manually config max jobs through env"

```bash
cd FastDeploy
MAX_JOBS=24 bash build.sh
# Output
# Using 24 workers for compilation. HINT: export MAX_JOBS=n to set the number of workers
```

please ignore the following
PCard-66972

