### PR TITLE
[Custom Device] Fix custom device all to all

### DIFF
--- a/paddle/phi/backends/custom/custom_device.cc
+++ b/paddle/phi/backends/custom/custom_device.cc
@@ -972,7 +972,9 @@ class CustomDevice : public DeviceInterface {
       }
       const phi::stream::Stream stream_wrapper(
           Place(AllocationType::CUSTOM, Type()), stream);
-      MemoryCopyD2D(rank,
+
+      int current_device_id = GetDevice();
+      MemoryCopyD2D(current_device_id,
                     recv_buf[rank],
                     send_buf[rank],
                     send_count[rank] * phi::SizeOf(send_dtype[rank]),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix custom device all-to-all.
Using the global rank in CCLAllToAll causes issues in multi-node multi-GPU setups.
MemoryCopyD2D inside CCLAllToAll should use the local device ID instead of the global rank.