### PR TITLE
[API Compatibilty][CustomDevice] Remove force set grad to None 

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -977,9 +977,7 @@ static PyObject* tensor_clear_gradient(TensorObject* self,
               static_cast<phi::distributed::DistTensor*>(grad->impl().get())
                   ->unsafe_mutable_value();
         }
-        bool is_mismatched = self->tensor.place() != grad_t->place() ||
-                             self->tensor.dtype() != grad_t->dtype();
-        if (set_to_zero && !is_mismatched) {
+        if (set_to_zero) {
           EagerSetDeviceId();
           auto* dev_ctx =
               phi::DeviceContextPool::Instance().Get(grad_t->place());

--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -549,7 +549,7 @@ class TestTensorDataSetter(unittest.TestCase):
 
     def test_new_shape_same_dtype_same_place(self):
         x: paddle.Tensor = paddle.tensor([[1, 2], [3, 4]], dtype="float32")
-        y = paddle.tensor([2], dtype="float32")
+        y = paddle.rand([3, 4, 5], dtype="float32")
         x.requires_grad = True
 
         loss = x.sum()
@@ -569,7 +569,6 @@ class TestTensorDataSetter(unittest.TestCase):
             True,
             "x's requires_grad should be True after data setting.",
         )
-
         with self.assertRaises(RuntimeError):
             loss = x.sum()
             loss.backward()
@@ -595,8 +594,7 @@ class TestTensorDataSetter(unittest.TestCase):
         np.testing.assert_equal(x.grad.numpy(), x_grad_expected.numpy())
         assert x.grad.dtype == x_grad_expected.dtype
 
-        x.clear_gradient(set_to_zero=True)
-        # dtype changed, clear_gradient must set grad to None
+        x.clear_gradient(False)
         assert x.grad is None
         z = x.sum()
         z.backward()
@@ -627,8 +625,7 @@ class TestTensorDataSetter(unittest.TestCase):
         assert x.grad.dtype == x_grad_expected.dtype
         assert x.grad.place == x_grad_expected.place
 
-        x.clear_gradient(set_to_zero=True)
-        # place changed, clear_gradient must set grad to None
+        x.clear_gradient(False)
         assert x.grad is None
         loss = x.sum()
         loss.backward()
@@ -638,4 +635,4 @@ class TestTensorDataSetter(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(argv=["", "TestTensorDataSetter"])
+    unittest.main()

--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -569,7 +569,7 @@ class TestTensorDataSetter(unittest.TestCase):
             True,
             "x's requires_grad should be True after data setting.",
         )
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises((ValueError, RuntimeError)):
             loss = x.sum()
             loss.backward()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
1. 移除当device或者dtype 不匹配清除梯度时强制grad 为 None
2. 放宽当新 Tensor shape 与旧 Tensor 不一致时求反向的异常类型（适配 CustomDevice）