### PR TITLE
feat(gpu): support unpadded lse in flash_attn and update submodule

### DIFF
--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -727,7 +727,7 @@ void FlashAttnInferMeta(const MetaTensor& q,
           {batch_size, num_heads, seqlen_q_rounded, seqlen_k_rounded});
     }
     if (softmax_lse) {
-      softmax_lse->set_dims({batch_size, num_heads, seqlen_q_rounded});
+      softmax_lse->set_dims({batch_size, num_heads, q.dims()[1]});
     }
   }
   if (out_dims.size() == 3) {  // when use flash_attn_unpadded
@@ -740,7 +740,7 @@ void FlashAttnInferMeta(const MetaTensor& q,
       softmax->set_dims({num_heads, seqlen_q_rounded, seqlen_k_rounded});
     }
     if (softmax_lse) {
-      softmax_lse->set_dims({num_heads, seqlen_q_rounded});
+      softmax_lse->set_dims({num_heads, batch_and_seq_size});
     }
   }
   if (seed_offset) {
@@ -803,14 +803,6 @@ void CalcReducedAttnScoresInferMeta(const MetaTensor& q,
                  common::errors::InvalidArgument(
                      "calc_reduced_attn_scores must receive input q and "
                      "softmax_lse with consistent batch_size!"));
-
-  auto round_multiple = [](int64_t x, int64_t m) {
-    return (x + m - 1) / m * m;
-  };
-  PADDLE_ENFORCE(round_multiple(q.dims()[1], 128) == softmax_lse.dims()[2],
-                 common::errors::InvalidArgument(
-                     "calc_reduced_attn_scores must receive input q and "
-                     "softmax_lse with corresponding seq_len!"));
 
   PADDLE_ENFORCE(q.dims()[2] == softmax_lse.dims()[1],
                  common::errors::InvalidArgument(

--- a/paddle/phi/kernels/gpu/calc_reduced_attn_kernel.cu
+++ b/paddle/phi/kernels/gpu/calc_reduced_attn_kernel.cu
@@ -46,7 +46,9 @@ struct CalcReducedAttnScoresParams : public FlashAttnParamsBase {
                             /*_causal=*/false,
                             q_dtype,
                             paddle::optional<DenseTensor>{},
-                            paddle::optional<DenseTensor>{}) {}
+                            paddle::optional<DenseTensor>{},
+                            /*_unpadded_lse=*/false,
+                            /*_total_q*/ 0) {}
 };
 #endif
 

--- a/paddle/phi/kernels/gpu/flash_attn_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_grad_kernel.cu
@@ -248,6 +248,7 @@ void FlashAttnUnpaddedGradBaseKernel(
   const int64_t head_size = dims[2];
   const int64_t total_k = k.dims()[0];
   const int64_t num_heads_k = k.dims()[1];
+  const int64_t total_q = dims[0];
 
   bool is_mha = (num_heads == num_heads_k);
 
@@ -310,7 +311,9 @@ void FlashAttnUnpaddedGradBaseKernel(
                            q.dtype(),
                            attn_mask,
                            nullptr,  // startend_row_indices,
-                           seed_offset.data<int64_t>());
+                           seed_offset.data<int64_t>(),
+                           /*unpadded_lse*/ true,
+                           total_q);
 
   VLOG(10) << "FlashAttn bwd seed: " << params.seed
            << ", offset: " << params.offset;
@@ -373,7 +376,13 @@ void FlashAttnUnpaddedGradBaseKernel(
       max_seqlen_k * kdk->strides()[0],
       max_seqlen_k * kdv->strides()[0],
       max_seqlen_q * dout.strides()[0],
-      varlen_padded);
+#ifdef PADDLE_WITH_CUDA
+      varlen_padded,
+      params.total_q
+#else
+      varlen_padded
+#endif
+  );
   CheckFlashAttnStatus(succ);
   if (!is_mha) {
     if (dk) {
@@ -643,7 +652,9 @@ void FlashAttnGradBaseKernel(
                            q.dtype(),
                            attn_mask,
                            startend_row_indices,
-                           seed_offset.data<int64_t>());
+                           seed_offset.data<int64_t>(),
+                           /*unpadded_lse*/ false,
+                           /*total_q*/ 0);
 
   VLOG(10) << "[FlashAttn Backward" << version << "] q.shape=[" << q.dims()
            << "], k.shape=[" << k.dims() << "], v.shape=[" << v.dims() << "]";

--- a/paddle/phi/kernels/gpu/flash_attn_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_kernel.cu
@@ -110,6 +110,7 @@ void FlashAttnUnpaddedBaseKernel(
   const int64_t num_heads = dims[1];
   const int64_t head_size = dims[2];
   const int64_t num_heads_k = k.dims()[1];
+  const int64_t total_q = dims[0];
 
   // TODO(umiswing): add shape check
 
@@ -137,7 +138,9 @@ void FlashAttnUnpaddedBaseKernel(
                               nullptr,  // startend_row_indices
                               softmax,
                               softmax_lse,
-                              seed_offset);
+                              seed_offset,
+                              /*_unpadded_lse*/ true,
+                              /*_total_q*/ total_q);
 
   VLOG(10) << "FlashAttn fwd seed: " << params.seed
            << ", offset: " << params.offset;
@@ -183,7 +186,13 @@ void FlashAttnUnpaddedBaseKernel(
       max_seqlen_k * k.strides()[0],
       max_seqlen_k * v.strides()[0],
       max_seqlen_q * out->strides()[0],
-      varlen_padded);
+#ifdef PADDLE_WITH_CUDA
+      varlen_padded,
+      params.total_q
+#else
+      varlen_padded
+#endif
+  );
   CheckFlashAttnStatus(succ);
 #else
   RaiseNotSupportedError();
@@ -381,27 +390,30 @@ void FlashAttnBaseKernel(
                         head_size > 128
                     ? 2
                     : FLAGS_flash_attn_version;
-  FlashAttnFwdParamsV2<T> params = FlashAttnFwdParamsV2<T>(dev_ctx,
-                                                           version,
-                                                           batch_size,
-                                                           seqlen_q,
-                                                           seqlen_k,
-                                                           num_heads,
-                                                           num_heads_k,
-                                                           head_size,
-                                                           dropout,
-                                                           softmax_scale,
-                                                           causal,
-                                                           return_softmax,
-                                                           q.dtype(),
-                                                           is_test,
-                                                           rng_name,
-                                                           fixed_seed_offset,
-                                                           attn_mask,
-                                                           startend_row_indices,
-                                                           softmax,
-                                                           softmax_lse,
-                                                           seed_offset);
+  FlashAttnFwdParamsV2<T> params =
+      FlashAttnFwdParamsV2<T>(dev_ctx,
+                              version,
+                              batch_size,
+                              seqlen_q,
+                              seqlen_k,
+                              num_heads,
+                              num_heads_k,
+                              head_size,
+                              dropout,
+                              softmax_scale,
+                              causal,
+                              return_softmax,
+                              q.dtype(),
+                              is_test,
+                              rng_name,
+                              fixed_seed_offset,
+                              attn_mask,
+                              startend_row_indices,
+                              softmax,
+                              softmax_lse,
+                              seed_offset,
+                              /*_unpadded_lse*/ false,
+                              /*_total_q*/ 0);
 
   VLOG(10) << "[FlashAttn Forward" << version << "] q.shape=[" << q.dims()
            << "], k.shape=[" << k.dims() << "], v.shape=[" << v.dims() << "]";

--- a/paddle/phi/kernels/gpu/flash_attn_utils.h
+++ b/paddle/phi/kernels/gpu/flash_attn_utils.h
@@ -141,6 +141,7 @@ struct FlashAttnParamsBase {
   bool is_fp8;
   float softmax_scale;
   std::vector<int64_t> softmax_lse_dims;
+  std::vector<int64_t> dpsum_dims;
 
   bool causal;
   std::vector<int64_t> mask_dims;
@@ -148,6 +149,9 @@ struct FlashAttnParamsBase {
 
   const DenseTensor* startend_row_indices;
   std::vector<int64_t> startend_row_indices_dims;
+
+  bool unpadded_lse;
+  int total_q;
 
   FlashAttnParamsBase(const int _version,
                       const int _is_fwd,
@@ -161,7 +165,9 @@ struct FlashAttnParamsBase {
                       const bool _causal,
                       const DataType q_dtype,
                       const paddle::optional<DenseTensor>& attn_mask,
-                      const paddle::optional<DenseTensor>& startend_row_indices)
+                      const paddle::optional<DenseTensor>& startend_row_indices,
+                      const bool _unpadded_lse,
+                      const int _total_q)
       : version(_version),
         is_fwd(_is_fwd),
         batch_size(_batch_size),
@@ -173,7 +179,9 @@ struct FlashAttnParamsBase {
         softmax_scale(_scale),
         causal(_causal),
         attn_mask_tensor(attn_mask.get_ptr()),
-        startend_row_indices(startend_row_indices.get_ptr()) {
+        startend_row_indices(startend_row_indices.get_ptr()),
+        unpadded_lse(_unpadded_lse),
+        total_q(_total_q) {
     is_bf16 = q_dtype == DataType::BFLOAT16;
 
     // TODO(GuoxiaWang): check q, k, v dtype
@@ -191,7 +199,11 @@ struct FlashAttnParamsBase {
     seqlen_q_rounded = round_multiple(max_seqlen_q, kBlockM);
     seqlen_k_rounded = round_multiple(max_seqlen_k, 128);
 
-    softmax_lse_dims = {batch_size, num_heads, seqlen_q_rounded};
+    softmax_lse_dims = unpadded_lse ? std::vector<int64_t>{num_heads, total_q}
+                                    : std::vector<int64_t>{
+                                          batch_size, num_heads, max_seqlen_q};
+
+    dpsum_dims = std::vector<int64_t>{batch_size, num_heads, seqlen_q_rounded};
 
     if (attn_mask_tensor) {
       PADDLE_ENFORCE_EQ(
@@ -251,7 +263,9 @@ struct FlashAttnFwdParamsV2 : public FlashAttnParamsBase {
       const paddle::optional<DenseTensor>& startend_row_indices,
       DenseTensor* _softmax,
       DenseTensor* _softmax_lse,
-      DenseTensor* _seed_offset)
+      DenseTensor* _seed_offset,
+      const bool _unpadded_lse,
+      const int _total_q)
       : FlashAttnParamsBase(_version,
                             /*is_fwd=*/true,
                             _batch_size,
@@ -264,7 +278,9 @@ struct FlashAttnFwdParamsV2 : public FlashAttnParamsBase {
                             _causal,
                             q_dtype,
                             attn_mask,
-                            startend_row_indices),
+                            startend_row_indices,
+                            _unpadded_lse,
+                            _total_q),
         dropout(_dropout),
         return_softmax(_return_softmax),
         softmax(_softmax),
@@ -339,7 +355,9 @@ struct FlashAttnBwdParamsV2 : public FlashAttnParamsBase {
       const DataType q_dtype,
       const paddle::optional<DenseTensor>& attn_mask,
       const paddle::optional<DenseTensor>& startend_row_indices,
-      const int64_t* seed_offset_data)
+      const int64_t* seed_offset_data,
+      const bool _unpadded_lse,
+      const int _total_q)
       : FlashAttnParamsBase(_version,
                             /*is_fwd=*/false,
                             _batch_size,
@@ -352,7 +370,9 @@ struct FlashAttnBwdParamsV2 : public FlashAttnParamsBase {
                             _causal,
                             q_dtype,
                             attn_mask,
-                            startend_row_indices),
+                            startend_row_indices,
+                            _unpadded_lse,
+                            _total_q),
         dropout(_dropout) {
     seed = static_cast<uint64_t>(seed_offset_data[0]);
     offset = static_cast<uint64_t>(seed_offset_data[1]);
@@ -362,7 +382,7 @@ struct FlashAttnBwdParamsV2 : public FlashAttnParamsBase {
     rng_state = Empty<int64_t>(dev_ctx, {2});
 
     // gradient of softmax_lse
-    softmax_d = Empty<float>(dev_ctx, softmax_lse_dims);
+    softmax_d = Empty<float>(dev_ctx, dpsum_dims);
 
     if (_version == 3) {
       softmax_lse_log2 = Empty<float>(dev_ctx, softmax_lse_dims);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
对flashattn&flashmask v2，修改fwd和bwd的LSE的shape。
1. For variable seqlen case, keep LSE in (H, total_q_seqlen) format instead of current (B, H, max_q_seqlen). This helps to save memory when variance of sequence length within the batch is large, e.g. during long sequence training.
2. For common case, keep LSE in (B, H, q_seqlen) format instead of current (B, H, q_seqlen_rounded).
