### PR TITLE
[XPU][MaskedSelect] Fix masked_select_grad true_count and empty-out h…

### DIFF
--- a/paddle/phi/kernels/xpu/masked_select_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/masked_select_grad_kernel.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
 
@@ -26,10 +27,20 @@ void MaskedSelectGradKernel(const Context& dev_ctx,
                             const DenseTensor& out_grad,
                             DenseTensor* x_grad) {
   using XPUType = typename XPUTypeTrait<T>::Type;
+  dev_ctx.template Alloc<T>(x_grad);
+  if (x_grad && x_grad->numel() == 0) {
+    return;
+  }
+  // If out_grad is empty (e.g. mask all false), x_grad should be all zeros.
+  if (out_grad.numel() == 0 && x_grad) {
+    phi::Full<T, Context>(
+        dev_ctx, phi::IntArray(common::vectorize(x_grad->dims())), 0, x_grad);
+    return;
+  }
+
   auto* mask_data = mask.data<bool>();
   auto* input_data = reinterpret_cast<const XPUType*>(out_grad.data<T>());
-  auto* out_data =
-      reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(x_grad));
+  auto* out_data = reinterpret_cast<XPUType*>(x_grad->data<T>());
 
   auto mask_shape = common::vectorize<int64_t>(mask.dims());
   auto xshape = common::vectorize<int64_t>(x_grad->dims());
@@ -40,13 +51,14 @@ void MaskedSelectGradKernel(const Context& dev_ctx,
     xshape = std::vector<int64_t>({1});
   }
 
+  const int64_t out_size = out_grad.numel();
   int r = xpu::masked_select_grad(dev_ctx.x_context(),
                                   input_data,
                                   mask_data,
                                   out_data,
                                   xshape,
                                   mask_shape,
-                                  1);
+                                  out_size);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "masked_select_grad");
 }
 

--- a/test/xpu/test_masked_select_op_xpu.py
+++ b/test/xpu/test_masked_select_op_xpu.py
@@ -132,6 +132,43 @@ class TestMaskedSelectAPI(unittest.TestCase):
         del os.environ['XPUSIM_SKIP_RUN']
 
 
+class TestMaskedSelectGradAPI(unittest.TestCase):
+    def test_getitem_bool_mask_int64_grad(self):
+        paddle.disable_static(paddle.XPUPlace(0))
+        x_np = np.array([1, 2], dtype=np.int64)
+        mask_np = np.array([True, True], dtype=np.bool_)
+        dout_np = np.array([3, 4], dtype=np.int64)
+
+        x = paddle.to_tensor(x_np)
+        x.stop_gradient = False
+        mask = paddle.to_tensor(mask_np)
+        out = x[mask]
+        out_grad = paddle.to_tensor(dout_np)
+        out_grad.stop_gradient = True
+        (x_grad,) = paddle.grad(
+            outputs=[out], inputs=[x], grad_outputs=[out_grad]
+        )
+        np.testing.assert_array_equal(x_grad.numpy(), dout_np)
+        paddle.enable_static()
+
+    def test_getitem_bool_mask_int64_grad_empty_out(self):
+        paddle.disable_static(paddle.XPUPlace(0))
+        x_np = np.array([1, 2], dtype=np.int64)
+        mask_np = np.array([False, False], dtype=np.bool_)
+
+        x = paddle.to_tensor(x_np)
+        x.stop_gradient = False
+        mask = paddle.to_tensor(mask_np)
+        out = x[mask]
+        out_grad = paddle.empty([0], dtype="int64")
+        out_grad.stop_gradient = True
+        (x_grad,) = paddle.grad(
+            outputs=[out], inputs=[x], grad_outputs=[out_grad]
+        )
+        np.testing.assert_array_equal(x_grad.numpy(), np.zeros_like(x_np))
+        paddle.enable_static()
+
+
 class TestMaskedSelectError(unittest.TestCase):
     def test_error(self):
         with paddle.static.program_guard(


### PR DESCRIPTION
### PR Category

Custom Device

### PR Types

Bug fixes

### Description

- Fix XPU masked_select_grad to pass the correct true_count (`out_grad.numel()`) to the underlying XDNN API instead of a constant.
- Add an early return for empty out_grad (e.g. all-false mask) by filling x_grad with zeros to avoid XDNN invalid-parameter errors.
- Add XPU unit tests in paddle/test/xpu/test_masked_select_op_xpu.py covering Tensor.__getitem__ bool-mask int64 grad for both non-empty and empty output cases.