### PR TITLE
Remove redundant headers in Paddle CPU

### DIFF
--- a/paddle/phi/backends/all_context.h
+++ b/paddle/phi/backends/all_context.h
@@ -21,9 +21,16 @@ limitations under the License. */
 // path replacement after implementing phi DeviceContext
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
 #include "paddle/phi/backends/custom/custom_context.h"
+#endif
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
+    defined(PADDLE_WITH_CUSTOM_DEVICE)
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#endif
 #include "paddle/phi/backends/onednn/onednn_context.h"
+#ifdef PADDLE_WITH_XPU
 #include "paddle/phi/backends/xpu/xpu_context.h"
+#endif
 
 namespace phi {}  // namespace phi

--- a/paddle/phi/backends/all_context.h
+++ b/paddle/phi/backends/all_context.h
@@ -24,8 +24,7 @@ limitations under the License. */
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
 #include "paddle/phi/backends/custom/custom_context.h"
 #endif
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
-    defined(PADDLE_WITH_CUSTOM_DEVICE)
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #endif
 #include "paddle/phi/backends/onednn/onednn_context.h"

--- a/paddle/phi/backends/device_memory_alignment.h
+++ b/paddle/phi/backends/device_memory_alignment.h
@@ -21,7 +21,9 @@ limitations under the License. */
 #include "paddle/phi/core/enforce.h"
 
 #include "paddle/phi/backends/gpu/gpu_info.h"
+#ifdef PADDLE_WITH_XPU
 #include "paddle/phi/backends/xpu/xpu_info.h"
+#endif
 
 namespace phi {
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1579,70 +1579,39 @@ if (
     headers += list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.hpp', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.cuh', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/deep_gemm', recursive=True))
-if (
-    '@WITH_GPU@' == 'OFF'
-    and '@WITH_ROCM@' == 'OFF'
-    and '@WITH_XPU@' == 'OFF'
-):  # Custom Device
-    headers += list(
-        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
-    )
-    headers += list(
-        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/custom')
-    )
-    headers += list(
-        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/gpu', recursive=True)
-    )
-    headers += list(
-        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')
-    )
-    headers += [
-        os.path.join(
-            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/afs_api.h'
-        ),
-        os.path.join(
-            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/dynamic_loader.h',
-        ),
-        os.path.join(
-            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklml.h'
-        ),
-        os.path.join(
-            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklrt.h'
-        ),
-        os.path.join(
-            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/lapack.h'
-        ),
-        os.path.join(
-            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/hml.h'
-        ),
-    ]
-else:
-    headers += list(
-        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
-    )
-    headers += list(
-        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')
-    )
-    headers += [
-        os.path.join(
-            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/afs_api.h'
-        ),
-        os.path.join(
-            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/dynamic_loader.h',
-        ),
-        os.path.join(
-            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklml.h'
-        ),
-        os.path.join(
-            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklrt.h'
-        ),
-        os.path.join(
-            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/lapack.h'
-        ),
-        os.path.join(
-            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/hml.h'
-        ),
-    ]
+
+headers += list(
+    find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
+)
+headers += list(
+    find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/custom')
+)
+headers += list(
+    find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/gpu', recursive=True)
+)
+headers += list(
+    find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')
+)
+headers += [
+    os.path.join(
+        '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/afs_api.h'
+    ),
+    os.path.join(
+        '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/dynamic_loader.h',
+    ),
+    os.path.join(
+        '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklml.h'
+    ),
+    os.path.join(
+        '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklrt.h'
+    ),
+    os.path.join(
+        '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/lapack.h'
+    ),
+    os.path.join(
+        '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/hml.h'
+    ),
+]
 
 headers += list(find_files('*.h', '${PYBIND_INCLUDE_DIR}', True)) # pybind headers
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1597,7 +1597,6 @@ if '${WITH_CUSTOM_DEVICE}' == 'ON':
             '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/afs_api.h'
         ),
         os.path.join(
-            paddle_source_dir,
             '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/dynamic_loader.h',
         ),
         os.path.join(

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1533,21 +1533,8 @@ if '${WITH_GPU}' == 'ON' or '${WITH_ROCM}' == 'ON':
     # externalErrorMsg.pb for External Error message
     headers += list(find_files('*.pb', '${externalError_INCLUDE_DIR}'))
     headers += list(
-        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends', recursive=True)
     )
-    headers += list(
-        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/gpu, recursive=True')
-    )
-    headers += list(
-        find_files(
-            '*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload'
-        )
-    )
-    headers += list(
-        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')
-    )
-
-
 
 if '${WITH_XPU}' == 'ON':
     headers += [

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1536,7 +1536,7 @@ if '${WITH_GPU}' == 'ON' or '${WITH_ROCM}' == 'ON':
         find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
     )
     headers += list(
-        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/gpu')
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/gpu, recursive=True')
     )
     headers += list(
         find_files(
@@ -1587,7 +1587,35 @@ if '${WITH_CUSTOM_DEVICE}' == 'ON':
         find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/custom')
     )
     headers += list(
-        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/gpu')
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/gpu', recursive=True)
+    )
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')
+    )
+    headers += [
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/afs_api.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/dynamic_loader.h',
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklml.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklrt.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/lapack.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/hml.h'
+        ),
+    ]
+else:
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
+    )
     )
     headers += list(
         find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1463,7 +1463,7 @@ headers = (
     # phi level api headers (low level api, for training only)
     list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi')) +  # phi extension header
     list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/include', recursive=True)) +  # phi include headers
-    list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends', recursive=True)) +  # phi backends headers
+    list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends')) +  # phi backends headers
     list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/core', recursive=True)) +  # phi core headers
     list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/infermeta', recursive=True)) +  # phi infermeta headers
     list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/kernels', recursive=True)) +  # phi kernels headers
@@ -1532,6 +1532,21 @@ if '${WITH_OPENVINO}' == 'ON':
 if '${WITH_GPU}' == 'ON' or '${WITH_ROCM}' == 'ON':
     # externalErrorMsg.pb for External Error message
     headers += list(find_files('*.pb', '${externalError_INCLUDE_DIR}'))
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
+    )
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/gpu')
+    )
+    headers += list(
+        find_files(
+            '*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload'
+        )
+    )
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')
+    )
+
 
 
 if '${WITH_XPU}' == 'ON':
@@ -1540,6 +1555,20 @@ if '${WITH_XPU}' == 'ON':
         if '/include/xpu/kernel/' not in h
     ] # xdnn api headers
     headers += list(find_files('*.hpp', '@PADDLE_BINARY_DIR@/third_party/xpu/src/extern_xpu/xpu', recursive=True)) # xre headers with .hpp extension
+    headers += list(
+        find_files('*.h', '@PADDLE_BINARY_DIR@/paddle/phi/backends/cpu')
+    )
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/xpu')
+    )
+    headers += list(
+        find_files(
+            '*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload'
+        )
+    )
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')
+    )
 
 if (
     '@WITH_GPU@' == 'ON'
@@ -1550,6 +1579,40 @@ if (
     headers += list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.hpp', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.cuh', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/deep_gemm', recursive=True))
+if '${WITH_CUSTOM_DEVICE}' == 'ON':
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
+    )
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/custom')
+    )
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/gpu')
+    )
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')
+    )
+    headers += [
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/afs_api.h'
+        ),
+        os.path.join(
+            paddle_source_dir,
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/dynamic_loader.h',
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklml.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklrt.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/lapack.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/hml.h'
+        ),
+    ]
 
 headers += list(find_files('*.h', '${PYBIND_INCLUDE_DIR}', True)) # pybind headers
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1579,7 +1579,11 @@ if (
     headers += list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.hpp', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.cuh', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/deep_gemm', recursive=True))
-if '${WITH_CUSTOM_DEVICE}' == 'ON':
+if (
+    '@WITH_GPU@' == 'OFF'
+    and '@WITH_ROCM@' == 'OFF'
+    and '@WITH_XPU@' == 'OFF'
+):  # Custom Device
     headers += list(
         find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
     )

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1616,7 +1616,6 @@ else:
     headers += list(
         find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
     )
-    )
     headers += list(
         find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')
     )

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1579,11 +1579,7 @@ if (
     headers += list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.hpp', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.cuh', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/deep_gemm', recursive=True))
-if (
-    '@WITH_GPU@' == 'OFF'
-    and '@WITH_ROCM@' == 'OFF'
-    and '@WITH_XPU@' == 'OFF'
-):  # Custom Device
+if True:  # Custom Device
     headers += list(
         find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
     )

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1579,39 +1579,70 @@ if (
     headers += list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.hpp', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.cuh', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/deep_gemm', recursive=True))
-
-headers += list(
-    find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
-)
-headers += list(
-    find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/custom')
-)
-headers += list(
-    find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/gpu', recursive=True)
-)
-headers += list(
-    find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')
-)
-headers += [
-    os.path.join(
-        '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/afs_api.h'
-    ),
-    os.path.join(
-        '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/dynamic_loader.h',
-    ),
-    os.path.join(
-        '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklml.h'
-    ),
-    os.path.join(
-        '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklrt.h'
-    ),
-    os.path.join(
-        '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/lapack.h'
-    ),
-    os.path.join(
-        '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/hml.h'
-    ),
-]
+if (
+    '@WITH_GPU@' == 'OFF'
+    and '@WITH_ROCM@' == 'OFF'
+    and '@WITH_XPU@' == 'OFF'
+):  # Custom Device
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
+    )
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/custom')
+    )
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/gpu', recursive=True)
+    )
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')
+    )
+    headers += [
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/afs_api.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/dynamic_loader.h',
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklml.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklrt.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/lapack.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/hml.h'
+        ),
+    ]
+else:
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
+    )
+    headers += list(
+        find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/onednn')
+    )
+    headers += [
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/afs_api.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/dynamic_loader.h',
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklml.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/mklrt.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/lapack.h'
+        ),
+        os.path.join(
+            '@PADDLE_SOURCE_DIR@/paddle/phi/backends/dynload/hml.h'
+        ),
+    ]
 
 headers += list(find_files('*.h', '${PYBIND_INCLUDE_DIR}', True)) # pybind headers
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1579,7 +1579,11 @@ if (
     headers += list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.hpp', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.cuh', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/deep_gemm', recursive=True))
-if True:
+if (
+    '@WITH_GPU@' == 'OFF'
+    and '@WITH_ROCM@' == 'OFF'
+    and '@WITH_XPU@' == 'OFF'
+):  # Custom Device
     headers += list(
         find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
     )

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1579,7 +1579,7 @@ if (
     headers += list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.hpp', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/cutlass/', recursive=True))
     headers += list(find_files('*.cuh', '@PADDLE_SOURCE_DIR@/paddle/fluid/fp8/deep_gemm/include/deep_gemm', recursive=True))
-if True:  # Custom Device
+if True:
     headers += list(
         find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/phi/backends/cpu')
     )

--- a/setup.py
+++ b/setup.py
@@ -2438,34 +2438,6 @@ def get_headers():
         os.path.join(paddle_source_dir, 'paddle/phi/backends/dynload/lapack.h'),
         os.path.join(paddle_source_dir, 'paddle/phi/backends/dynload/hml.h'),
     ]
-    # else:
-    #     headers += list(
-    #         find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
-    #     )
-    #     headers += list(
-    #         find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
-    #     )
-    #     headers += [
-    #         os.path.join(
-    #             paddle_source_dir, 'paddle/phi/backends/dynload/afs_api.h'
-    #         ),
-    #         os.path.join(
-    #             paddle_source_dir,
-    #             'paddle/phi/backends/dynload/dynamic_loader.h',
-    #         ),
-    #         os.path.join(
-    #             paddle_source_dir, 'paddle/phi/backends/dynload/mklml.h'
-    #         ),
-    #         os.path.join(
-    #             paddle_source_dir, 'paddle/phi/backends/dynload/mklrt.h'
-    #         ),
-    #         os.path.join(
-    #             paddle_source_dir, 'paddle/phi/backends/dynload/lapack.h'
-    #         ),
-    #         os.path.join(
-    #             paddle_source_dir, 'paddle/phi/backends/dynload/hml.h'
-    #         ),
-    #     ]
     # pybind headers
     headers += list(find_files('*.h', env_dict.get("PYBIND_INCLUDE_DIR"), True))
     return headers

--- a/setup.py
+++ b/setup.py
@@ -2441,9 +2441,6 @@ def get_headers():
             os.path.join(
                 paddle_source_dir, 'paddle/phi/backends/dynload/hml.h'
             ),
-            os.path.join(
-                paddle_source_dir, 'paddle/phi/backends/dynload/magma.h'
-            ),
         ]
     # pybind headers
     headers += list(find_files('*.h', env_dict.get("PYBIND_INCLUDE_DIR"), True))

--- a/setup.py
+++ b/setup.py
@@ -2409,11 +2409,7 @@ def get_headers():
             )
         )
 
-    if (
-        env_dict.get("WITH_GPU") == 'OFF'
-        and env_dict.get("WITH_ROCM") == 'OFF'
-        and env_dict.get("WITH_XPU") == 'OFF'
-    ):  # Custom Device
+    if True:  # Custom Device
         headers += list(
             find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
         )

--- a/setup.py
+++ b/setup.py
@@ -2409,71 +2409,63 @@ def get_headers():
             )
         )
 
-    if True:
-        headers += list(
-            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
+    # if True:
+    headers += list(
+        find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
+    )
+    headers += list(
+        find_files('*.h', paddle_source_dir + '/paddle/phi/backends/custom')
+    )
+    headers += list(
+        find_files(
+            '*.h',
+            paddle_source_dir + '/paddle/phi/backends/gpu, recursive=True',
         )
-        headers += list(
-            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/custom')
-        )
-        headers += list(
-            find_files(
-                '*.h',
-                paddle_source_dir + '/paddle/phi/backends/gpu, recursive=True',
-            )
-        )
-        headers += list(
-            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
-        )
-        headers += [
-            os.path.join(
-                paddle_source_dir, 'paddle/phi/backends/dynload/afs_api.h'
-            ),
-            os.path.join(
-                paddle_source_dir,
-                'paddle/phi/backends/dynload/dynamic_loader.h',
-            ),
-            os.path.join(
-                paddle_source_dir, 'paddle/phi/backends/dynload/mklml.h'
-            ),
-            os.path.join(
-                paddle_source_dir, 'paddle/phi/backends/dynload/mklrt.h'
-            ),
-            os.path.join(
-                paddle_source_dir, 'paddle/phi/backends/dynload/lapack.h'
-            ),
-            os.path.join(
-                paddle_source_dir, 'paddle/phi/backends/dynload/hml.h'
-            ),
-        ]
-    else:
-        headers += list(
-            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
-        )
-        headers += list(
-            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
-        )
-        headers += [
-            os.path.join(
-                paddle_source_dir, 'paddle/phi/backends/dynload/afs_api.h'
-            ),
-            os.path.join(
-                paddle_source_dir,
-                'paddle/phi/backends/dynload/dynamic_loader.h',
-            ),
-            os.path.join(
-                paddle_source_dir, 'paddle/phi/backends/dynload/mklml.h'
-            ),
-            os.path.join(
-                paddle_source_dir, 'paddle/phi/backends/dynload/mklrt.h'
-            ),
-            os.path.join(
-                paddle_source_dir, 'paddle/phi/backends/dynload/lapack.h'
-            ),
-            os.path.join(
-                paddle_source_dir, 'paddle/phi/backends/dynload/hml.h'
-            ),
-        ]
+    )
+    headers += list(
+        find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
+    )
+    headers += [
+        os.path.join(
+            paddle_source_dir, 'paddle/phi/backends/dynload/afs_api.h'
+        ),
+        os.path.join(
+            paddle_source_dir,
+            'paddle/phi/backends/dynload/dynamic_loader.h',
+        ),
+        os.path.join(paddle_source_dir, 'paddle/phi/backends/dynload/mklml.h'),
+        os.path.join(paddle_source_dir, 'paddle/phi/backends/dynload/mklrt.h'),
+        os.path.join(paddle_source_dir, 'paddle/phi/backends/dynload/lapack.h'),
+        os.path.join(paddle_source_dir, 'paddle/phi/backends/dynload/hml.h'),
+    ]
+    # else:
+    #     headers += list(
+    #         find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
+    #     )
+    #     headers += list(
+    #         find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
+    #     )
+    #     headers += [
+    #         os.path.join(
+    #             paddle_source_dir, 'paddle/phi/backends/dynload/afs_api.h'
+    #         ),
+    #         os.path.join(
+    #             paddle_source_dir,
+    #             'paddle/phi/backends/dynload/dynamic_loader.h',
+    #         ),
+    #         os.path.join(
+    #             paddle_source_dir, 'paddle/phi/backends/dynload/mklml.h'
+    #         ),
+    #         os.path.join(
+    #             paddle_source_dir, 'paddle/phi/backends/dynload/mklrt.h'
+    #         ),
+    #         os.path.join(
+    #             paddle_source_dir, 'paddle/phi/backends/dynload/lapack.h'
+    #         ),
+    #         os.path.join(
+    #             paddle_source_dir, 'paddle/phi/backends/dynload/hml.h'
+    #         ),
+    #     ]
     # pybind headers
     headers += list(find_files('*.h', env_dict.get("PYBIND_INCLUDE_DIR"), True))
     return headers

--- a/setup.py
+++ b/setup.py
@@ -2030,14 +2030,12 @@ def get_headers():
             find_files('*.h', paddle_source_dir + '/paddle/phi')
         )
         + list(  # phi include header
-            find_files('*.h', paddle_source_dir + '/paddle/phi/include')
+            find_files(
+                '*.h', paddle_source_dir + '/paddle/phi/include', recursive=True
+            )
         )
         + list(  # phi backends headers
-            find_files(
-                '*.h',
-                paddle_source_dir + '/paddle/phi/backends',
-                recursive=True,
-            )
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends')
         )
         + list(  # phi core headers
             find_files(

--- a/setup.py
+++ b/setup.py
@@ -2409,35 +2409,76 @@ def get_headers():
             )
         )
 
-    # if True:
-    headers += list(
-        find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
-    )
-    headers += list(
-        find_files('*.h', paddle_source_dir + '/paddle/phi/backends/custom')
-    )
-    headers += list(
-        find_files(
-            '*.h',
-            paddle_source_dir + '/paddle/phi/backends/gpu, recursive=True',
+    if (
+        env_dict.get("WITH_GPU") == 'OFF'
+        and env_dict.get("WITH_ROCM") == 'OFF'
+        and env_dict.get("WITH_XPU") == 'OFF'
+    ):  # Custom Device
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
         )
-    )
-    headers += list(
-        find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
-    )
-    headers += [
-        os.path.join(
-            paddle_source_dir, 'paddle/phi/backends/dynload/afs_api.h'
-        ),
-        os.path.join(
-            paddle_source_dir,
-            'paddle/phi/backends/dynload/dynamic_loader.h',
-        ),
-        os.path.join(paddle_source_dir, 'paddle/phi/backends/dynload/mklml.h'),
-        os.path.join(paddle_source_dir, 'paddle/phi/backends/dynload/mklrt.h'),
-        os.path.join(paddle_source_dir, 'paddle/phi/backends/dynload/lapack.h'),
-        os.path.join(paddle_source_dir, 'paddle/phi/backends/dynload/hml.h'),
-    ]
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/custom')
+        )
+        headers += list(
+            find_files(
+                '*.h',
+                paddle_source_dir + '/paddle/phi/backends/gpu',
+                recursive=True,
+            )
+        )
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
+        )
+        headers += [
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/afs_api.h'
+            ),
+            os.path.join(
+                paddle_source_dir,
+                'paddle/phi/backends/dynload/dynamic_loader.h',
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/mklml.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/mklrt.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/lapack.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/hml.h'
+            ),
+        ]
+    else:
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
+        )
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
+        )
+        headers += [
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/afs_api.h'
+            ),
+            os.path.join(
+                paddle_source_dir,
+                'paddle/phi/backends/dynload/dynamic_loader.h',
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/mklml.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/mklrt.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/lapack.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/hml.h'
+            ),
+        ]
     # pybind headers
     headers += list(find_files('*.h', env_dict.get("PYBIND_INCLUDE_DIR"), True))
     return headers

--- a/setup.py
+++ b/setup.py
@@ -2030,9 +2030,7 @@ def get_headers():
             find_files('*.h', paddle_source_dir + '/paddle/phi')
         )
         + list(  # phi include header
-            find_files(
-                '*.h', paddle_source_dir + '/paddle/phi/include', recursive=True
-            )
+            find_files('*.h', paddle_source_dir + '/paddle/phi/include')
         )
         + list(  # phi backends headers
             find_files(
@@ -2326,6 +2324,20 @@ def get_headers():
         headers += list(
             find_files('*.pb', env_dict.get("externalError_INCLUDE_DIR"))
         )
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
+        )
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/gpu')
+        )
+        headers += list(
+            find_files(
+                '*.h', paddle_source_dir + '/paddle/phi/backends/dynload'
+            )
+        )
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
+        )
 
     if env_dict.get("WITH_XPU") == 'ON':
         headers += [
@@ -2344,6 +2356,20 @@ def get_headers():
                 recursive=True,
             )
         )  # xre headers with .hpp extension
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
+        )
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/xpu')
+        )
+        headers += list(
+            find_files(
+                '*.h', paddle_source_dir + '/paddle/phi/backends/dynload'
+            )
+        )
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
+        )
 
     if (
         env_dict.get("WITH_GPU") == 'ON'
@@ -2381,6 +2407,44 @@ def get_headers():
                 recursive=True,
             )
         )
+
+    if env_dict.get("WITH_CUSTOM_DEVICE") == 'ON':
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
+        )
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/custom')
+        )
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/gpu')
+        )
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
+        )
+        headers += [
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/afs_api.h'
+            ),
+            os.path.join(
+                paddle_source_dir,
+                'paddle/phi/backends/dynload/dynamic_loader.h',
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/mklml.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/mklrt.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/lapack.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/hml.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/magma.h'
+            ),
+        ]
     # pybind headers
     headers += list(find_files('*.h', env_dict.get("PYBIND_INCLUDE_DIR"), True))
     return headers

--- a/setup.py
+++ b/setup.py
@@ -2323,21 +2323,11 @@ def get_headers():
             find_files('*.pb', env_dict.get("externalError_INCLUDE_DIR"))
         )
         headers += list(
-            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
-        )
-        headers += list(
             find_files(
                 '*.h',
-                paddle_source_dir + '/paddle/phi/backends/gpu, recursive=True',
+                paddle_source_dir + '/paddle/phi/backends',
+                recursive=True,
             )
-        )
-        headers += list(
-            find_files(
-                '*.h', paddle_source_dir + '/paddle/phi/backends/dynload'
-            )
-        )
-        headers += list(
-            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
         )
 
     if env_dict.get("WITH_XPU") == 'ON':

--- a/setup.py
+++ b/setup.py
@@ -2409,11 +2409,7 @@ def get_headers():
             )
         )
 
-    if (
-        env_dict.get("WITH_GPU") == 'OFF'
-        and env_dict.get("WITH_ROCM") == 'OFF'
-        and env_dict.get("WITH_XPU") == 'OFF'
-    ):  # Custom Device
+    if True:
         headers += list(
             find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
         )

--- a/setup.py
+++ b/setup.py
@@ -2409,7 +2409,11 @@ def get_headers():
             )
         )
 
-    if True:  # Custom Device
+    if (
+        env_dict.get("WITH_GPU") == 'OFF'
+        and env_dict.get("WITH_ROCM") == 'OFF'
+        and env_dict.get("WITH_XPU") == 'OFF'
+    ):  # Custom Device
         headers += list(
             find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
         )

--- a/setup.py
+++ b/setup.py
@@ -2409,7 +2409,11 @@ def get_headers():
             )
         )
 
-    if env_dict.get("WITH_CUSTOM_DEVICE") == 'ON':
+    if (
+        env_dict.get("WITH_GPU") == 'OFF'
+        and env_dict.get("WITH_ROCM") == 'OFF'
+        and env_dict.get("WITH_XPU") == 'OFF'
+    ):  # Custom Device
         headers += list(
             find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
         )

--- a/setup.py
+++ b/setup.py
@@ -2326,7 +2326,10 @@ def get_headers():
             find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
         )
         headers += list(
-            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/gpu')
+            find_files(
+                '*.h',
+                paddle_source_dir + '/paddle/phi/backends/gpu, recursive=True',
+            )
         )
         headers += list(
             find_files(
@@ -2414,7 +2417,38 @@ def get_headers():
             find_files('*.h', paddle_source_dir + '/paddle/phi/backends/custom')
         )
         headers += list(
-            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/gpu')
+            find_files(
+                '*.h',
+                paddle_source_dir + '/paddle/phi/backends/gpu, recursive=True',
+            )
+        )
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')
+        )
+        headers += [
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/afs_api.h'
+            ),
+            os.path.join(
+                paddle_source_dir,
+                'paddle/phi/backends/dynload/dynamic_loader.h',
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/mklml.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/mklrt.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/lapack.h'
+            ),
+            os.path.join(
+                paddle_source_dir, 'paddle/phi/backends/dynload/hml.h'
+            ),
+        ]
+    else:
+        headers += list(
+            find_files('*.h', paddle_source_dir + '/paddle/phi/backends/cpu')
         )
         headers += list(
             find_files('*.h', paddle_source_dir + '/paddle/phi/backends/onednn')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Remove redundant headers in Paddle CPU for Custom Device, most of which located in the paddle/phi/backends/dynload directory. The CPU package itself should not include headers like paddle/phi/backends/dynload/cudnn.h. Now, when CustomDevice users compile custom operators using CUDAExtension and require headers like cudnn, they will directly reference headers located under PaddleCustomDevice.