### PR TITLE
[CodeStyle][Xdoctest][254-256] Fix example code(`paddle.text.Imdb`,`paddle.text.Movielens`,`paddle.text.UCIHousing`)

### DIFF
--- a/python/paddle/text/datasets/imdb.py
+++ b/python/paddle/text/datasets/imdb.py
@@ -53,9 +53,8 @@ class Imdb(Dataset):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
-            >>> # doctest: +TIMEOUT(75)
             >>> import paddle
             >>> from paddle.text.datasets import Imdb
 
@@ -77,17 +76,16 @@ class Imdb(Dataset):
             ...     model = SimpleNet()
             ...     image, label = model(doc, label)
             ...     print(doc.shape, label.shape)
-            [121] [1]
-            [115] [1]
-            [386] [1]
-            [471] [1]
-            [585] [1]
-            [206] [1]
-            [221] [1]
-            [324] [1]
-            [166] [1]
-            [598] [1]
-
+            paddle.Size([121]) paddle.Size([1])
+            paddle.Size([115]) paddle.Size([1])
+            paddle.Size([386]) paddle.Size([1])
+            paddle.Size([471]) paddle.Size([1])
+            paddle.Size([585]) paddle.Size([1])
+            paddle.Size([206]) paddle.Size([1])
+            paddle.Size([221]) paddle.Size([1])
+            paddle.Size([324]) paddle.Size([1])
+            paddle.Size([166]) paddle.Size([1])
+            paddle.Size([598]) paddle.Size([1])
     """
 
     data_file: str | None

--- a/python/paddle/text/datasets/imdb.py
+++ b/python/paddle/text/datasets/imdb.py
@@ -55,6 +55,7 @@ class Imdb(Dataset):
 
         .. code-block:: pycon
 
+            >>> # doctest: +TIMEOUT(75)
             >>> import paddle
             >>> from paddle.text.datasets import Imdb
 

--- a/python/paddle/text/datasets/movielens.py
+++ b/python/paddle/text/datasets/movielens.py
@@ -118,9 +118,8 @@ class Movielens(Dataset):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
-            >>> # doctest: +TIMEOUT(75)
             >>> import paddle
             >>> from paddle.text.datasets import Movielens
 
@@ -143,17 +142,16 @@ class Movielens(Dataset):
             ...     model = SimpleNet()
             ...     category, title, rating = model(category, title, rating)
             ...     print(category.shape, title.shape, rating.shape)
-            [] [] []
-            [] [] []
-            [] [] []
-            [] [] []
-            [] [] []
-            [] [] []
-            [] [] []
-            [] [] []
-            [] [] []
-            [] [] []
-
+            paddle.Size([]) paddle.Size([]) paddle.Size([])
+            paddle.Size([]) paddle.Size([]) paddle.Size([])
+            paddle.Size([]) paddle.Size([]) paddle.Size([])
+            paddle.Size([]) paddle.Size([]) paddle.Size([])
+            paddle.Size([]) paddle.Size([]) paddle.Size([])
+            paddle.Size([]) paddle.Size([]) paddle.Size([])
+            paddle.Size([]) paddle.Size([]) paddle.Size([])
+            paddle.Size([]) paddle.Size([]) paddle.Size([])
+            paddle.Size([]) paddle.Size([]) paddle.Size([])
+            paddle.Size([]) paddle.Size([]) paddle.Size([])
     """
 
     mode: _MovieLensDataSetMode

--- a/python/paddle/text/datasets/movielens.py
+++ b/python/paddle/text/datasets/movielens.py
@@ -120,6 +120,7 @@ class Movielens(Dataset):
 
         .. code-block:: pycon
 
+            >>> # doctest: +TIMEOUT(75)
             >>> import paddle
             >>> from paddle.text.datasets import Movielens
 

--- a/python/paddle/text/datasets/uci_housing.py
+++ b/python/paddle/text/datasets/uci_housing.py
@@ -65,7 +65,7 @@ class UCIHousing(Dataset):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.text.datasets import UCIHousing
@@ -89,16 +89,16 @@ class UCIHousing(Dataset):
             ...     model = SimpleNet()
             ...     feature, target = model(feature, target)
             ...     print(feature.shape, target.numpy())
-            [] [24.]
-            [] [21.6]
-            [] [34.7]
-            [] [33.4]
-            [] [36.2]
-            [] [28.7]
-            [] [22.9]
-            [] [27.1]
-            [] [16.5]
-            [] [18.9]
+            paddle.Size([]) [24.]
+            paddle.Size([]) [21.6]
+            paddle.Size([]) [34.7]
+            paddle.Size([]) [33.4]
+            paddle.Size([]) [36.2]
+            paddle.Size([]) [28.7]
+            paddle.Size([]) [22.9]
+            paddle.Size([]) [27.1]
+            paddle.Size([]) [16.5]
+            paddle.Size([]) [18.9]
 
     """
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Deprecations | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

修复以下 API 的示例代码，适配 xdoctest 自动测试：
1. paddle.text.Imdb：移除不支持的 +TIMEOUT 指令，修改预期输出为paddle.Size格式；
2. paddle.text.Movielens：移除不支持的 +TIMEOUT 指令，修改预期输出为paddle.Size格式；
3. paddle.text.UCIHousing：修改预期输出为paddle.Size格式。
4. 上面示例代码对应 API Docstring 中的 .. code-block:: python 修改为 .. code-block:: pycon

修改后的示例代码已通过本地 xdoctest 验证，无运行报错，输出匹配。

### Related links

- #76545

@ooooo-create