### PR TITLE
[Compat][DeepEP] Fix `setup.py` to expose `paddle/fluid/distributed/collective` header files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2288,7 +2288,7 @@ def get_headers():
         + list(
             find_files(
                 '*.h',
-                paddle_source_dir + 'paddle/fluid/distributed/collective',
+                paddle_source_dir + '/paddle/fluid/distributed/collective',
             )
         )
     )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
路径少了一个 `/` 