### PR TITLE
Refine index_add and index_select_grad kernel

### DIFF
--- a/paddle/phi/kernels/gpu/index_add_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_add_kernel.cu
@@ -49,6 +49,33 @@ __global__ void index_add_cuda_kernel(const T* input,
   }
 }
 
+template <typename T, typename IndexT>
+__global__ void index_add_deterministic_cuda_kernel(const T* input,
+                                                    const IndexT* index,
+                                                    const T* add_value,
+                                                    int64_t index_size,
+                                                    int64_t stride,
+                                                    int64_t pre_size,
+                                                    int64_t output_dim_size,
+                                                    T* output) {
+  int64_t num_columns = pre_size * stride;
+  CUDA_KERNEL_LOOP_TYPE(col_idx, num_columns, int64_t) {
+    int64_t pre_idx = col_idx / stride;
+    int64_t post_idx = col_idx % stride;
+
+    for (int64_t k = 0; k < index_size; ++k) {
+      IndexT src_dim_idx = index[k];
+      IndexT actual_dim_idx =
+          (src_dim_idx < 0 ? src_dim_idx + output_dim_size : src_dim_idx);
+
+      int64_t val_idx = (pre_idx * index_size + k) * stride + post_idx;
+      int64_t out_idx =
+          (pre_idx * output_dim_size + actual_dim_idx) * stride + post_idx;
+      output[out_idx] += add_value[val_idx];
+    }
+  }
+}
+
 template <typename T, typename Context>
 void IndexAddKernel(const Context& dev_ctx,
                     const DenseTensor& x,
@@ -86,44 +113,73 @@ void IndexAddKernel(const Context& dev_ctx,
   int64_t numel = add_value.numel();
   auto stream = dev_ctx.stream();
 
-  unsigned int block_dim = PADDLE_CUDA_NUM_THREADS;
-  dim3 grid_dim = dim3((numel + block_dim - 1) / block_dim);
-  phi::backends::gpu::LimitGridDim(dev_ctx, &grid_dim);
-
   // copy input to output.
   // todo(@limin29): inplace do not need copy.
   phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, output);
 
-  if (FLAGS_cudnn_deterministic) {
-    VLOG(2) << "Run grad kernel of index_add with single thread.";
-    block_dim = 1;
-    grid_dim.x = 1;
-  }
   auto index_dim_size = input_dim[dim];
-  if (index_type == phi::DataType::INT64) {
-    const int64_t* index_data = index.data<int64_t>();
-    index_add_cuda_kernel<T, int64_t>
-        <<<grid_dim, block_dim, 0, stream>>>(in_data,
-                                             index_data,
-                                             add_value_data,
-                                             numel,
-                                             stride,
-                                             size,
-                                             delta,
-                                             out_data,
-                                             index_dim_size);
+
+  if (FLAGS_cudnn_deterministic) {
+    int64_t pre_size = numel / (size * stride);
+    int64_t num_columns = pre_size * stride;
+
+    unsigned int block_dim = PADDLE_CUDA_NUM_THREADS;
+    dim3 grid_dim = dim3((num_columns + block_dim - 1) / block_dim);
+    phi::backends::gpu::LimitGridDim(dev_ctx, &grid_dim);
+
+    if (index_type == phi::DataType::INT64) {
+      const int64_t* index_data = index.data<int64_t>();
+      index_add_deterministic_cuda_kernel<T, int64_t>
+          <<<grid_dim, block_dim, 0, stream>>>(in_data,
+                                               index_data,
+                                               add_value_data,
+                                               size,
+                                               stride,
+                                               pre_size,
+                                               index_dim_size,
+                                               out_data);
+    } else {
+      const int* index_data = index.data<int>();
+      index_add_deterministic_cuda_kernel<T, int>
+          <<<grid_dim, block_dim, 0, stream>>>(in_data,
+                                               index_data,
+                                               add_value_data,
+                                               size,
+                                               stride,
+                                               pre_size,
+                                               index_dim_size,
+                                               out_data);
+    }
   } else {
-    const int* index_data = index.data<int>();
-    index_add_cuda_kernel<T, int>
-        <<<grid_dim, block_dim, 0, stream>>>(in_data,
-                                             index_data,
-                                             add_value_data,
-                                             numel,
-                                             stride,
-                                             size,
-                                             delta,
-                                             out_data,
-                                             index_dim_size);
+    unsigned int block_dim = PADDLE_CUDA_NUM_THREADS;
+    dim3 grid_dim = dim3((numel + block_dim - 1) / block_dim);
+    phi::backends::gpu::LimitGridDim(dev_ctx, &grid_dim);
+
+    if (index_type == phi::DataType::INT64) {
+      const int64_t* index_data = index.data<int64_t>();
+      index_add_cuda_kernel<T, int64_t>
+          <<<grid_dim, block_dim, 0, stream>>>(in_data,
+                                               index_data,
+                                               add_value_data,
+                                               numel,
+                                               stride,
+                                               size,
+                                               delta,
+                                               out_data,
+                                               index_dim_size);
+    } else {
+      const int* index_data = index.data<int>();
+      index_add_cuda_kernel<T, int>
+          <<<grid_dim, block_dim, 0, stream>>>(in_data,
+                                               index_data,
+                                               add_value_data,
+                                               numel,
+                                               stride,
+                                               size,
+                                               delta,
+                                               out_data,
+                                               index_dim_size);
+    }
   }
 }
 

--- a/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
@@ -52,6 +52,33 @@ __global__ void index_select_grad_cuda_kernel(const T* output_grad,
   }
 }
 
+template <typename T, typename IndexT>
+__global__ void index_select_grad_deterministic_cuda_kernel(
+    const T* output_grad,
+    T* input_grad,
+    const IndexT* index,
+    int64_t index_size,
+    int64_t stride,
+    int64_t pre_size,
+    int64_t input_dim_size) {
+  int64_t num_columns = pre_size * stride;
+  CUDA_KERNEL_LOOP_TYPE(col_idx, num_columns, int64_t) {
+    int64_t pre_idx = col_idx / stride;
+    int64_t post_idx = col_idx % stride;
+
+    for (int64_t k = 0; k < index_size; ++k) {
+      IndexT src_dim_idx = index[k];
+      if (src_dim_idx < 0) {
+        src_dim_idx += input_dim_size;
+      }
+      int64_t out_grad_idx = (pre_idx * index_size + k) * stride + post_idx;
+      int64_t in_grad_idx =
+          (pre_idx * input_dim_size + src_dim_idx) * stride + post_idx;
+      input_grad[in_grad_idx] += output_grad[out_grad_idx];
+    }
+  }
+}
+
 template <typename T, typename Context>
 void IndexSelectGradKernel(const Context& dev_ctx,
                            const DenseTensor& x,
@@ -92,46 +119,71 @@ void IndexSelectGradKernel(const Context& dev_ctx,
   if (numel == 0) {
     return;
   }
-  int64_t index_nums = index.numel();
   int64_t out_nums = out_grad.numel();
 
   auto stream = dev_ctx.stream();
-
-  unsigned int block_dim = PADDLE_CUDA_NUM_THREADS;
-  dim3 grid_dim = dim3((out_nums + block_dim - 1) / block_dim);
-  phi::backends::gpu::LimitGridDim(dev_ctx, &grid_dim);
 
   funcs::SetConstant<phi::GPUContext, T> index_select_grad_init;
   index_select_grad_init(dev_ctx, x_grad, static_cast<T>(0));
 
   if (FLAGS_cudnn_deterministic) {
-    VLOG(2) << "Run grad kernel of index_select with single thread.";
-    block_dim = 1;
-    grid_dim.x = 1;
-  }
+    int64_t pre_size = out_nums / (size * stride);
+    int64_t num_columns = pre_size * stride;
 
-  if (index_type == phi::DataType::INT64) {
-    const int64_t* index_data = index.data<int64_t>();
-    index_select_grad_cuda_kernel<T, int64_t>
-        <<<grid_dim, block_dim, 0, stream>>>(output_grad_data,
-                                             in_grad_data,
-                                             index_data,
-                                             out_nums,
-                                             stride,
-                                             size,
-                                             delta,
-                                             input_dim[dim]);
+    unsigned int block_dim = PADDLE_CUDA_NUM_THREADS;
+    dim3 grid_dim = dim3((num_columns + block_dim - 1) / block_dim);
+    phi::backends::gpu::LimitGridDim(dev_ctx, &grid_dim);
+
+    if (index_type == phi::DataType::INT64) {
+      const int64_t* index_data = index.data<int64_t>();
+      index_select_grad_deterministic_cuda_kernel<T, int64_t>
+          <<<grid_dim, block_dim, 0, stream>>>(output_grad_data,
+                                               in_grad_data,
+                                               index_data,
+                                               size,
+                                               stride,
+                                               pre_size,
+                                               input_dim[dim]);
+    } else {
+      const int* index_data = index.data<int>();
+      index_select_grad_deterministic_cuda_kernel<T, int>
+          <<<grid_dim, block_dim, 0, stream>>>(output_grad_data,
+                                               in_grad_data,
+                                               index_data,
+                                               size,
+                                               stride,
+                                               pre_size,
+                                               input_dim[dim]);
+    }
+
   } else {
-    const int* index_data = index.data<int>();
-    index_select_grad_cuda_kernel<T, int>
-        <<<grid_dim, block_dim, 0, stream>>>(output_grad_data,
-                                             in_grad_data,
-                                             index_data,
-                                             out_nums,
-                                             stride,
-                                             size,
-                                             delta,
-                                             input_dim[dim]);
+    unsigned int block_dim = PADDLE_CUDA_NUM_THREADS;
+    dim3 grid_dim = dim3((out_nums + block_dim - 1) / block_dim);
+    phi::backends::gpu::LimitGridDim(dev_ctx, &grid_dim);
+
+    if (index_type == phi::DataType::INT64) {
+      const int64_t* index_data = index.data<int64_t>();
+      index_select_grad_cuda_kernel<T, int64_t>
+          <<<grid_dim, block_dim, 0, stream>>>(output_grad_data,
+                                               in_grad_data,
+                                               index_data,
+                                               out_nums,
+                                               stride,
+                                               size,
+                                               delta,
+                                               input_dim[dim]);
+    } else {
+      const int* index_data = index.data<int>();
+      index_select_grad_cuda_kernel<T, int>
+          <<<grid_dim, block_dim, 0, stream>>>(output_grad_data,
+                                               in_grad_data,
+                                               index_data,
+                                               out_nums,
+                                               stride,
+                                               size,
+                                               delta,
+                                               input_dim[dim]);
+    }
   }
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
优化确定性场景下（FLAGS_cudnn_deterministic=1），index_add 与 index_select_grad kernel  的性能。

优化方案：
- 利用独立性：index_add 操作中，不同的前置维度和后置维度的数据是相互独立的，互不干扰，将 Block 的并行维度设置为 input_numel / add_value stride 达到高并发目的；
- 消除随机性：将 axis 维度的循环放入单个线程内执行，累加的顺序严格遵循 index 数组的顺序。

优化效果：
x shape: paddle.Size([8192, 512])
index shape: paddle.Size([6477])
优化前：1.16s，优化后：3.41ms

确定性测试：开启 FLAGS_cudnn_deterministic=1，循环测试100轮：
<img width="1658" height="923" alt="image" src="https://github.com/user-attachments/assets/30a95ad1-05e7-4e57-8e42-9da2262eb95d" />
