### PR TITLE
Change return type of dims function to int64_t

### DIFF
--- a/paddle/phi/core/dense_tensor.h
+++ b/paddle/phi/core/dense_tensor.h
@@ -91,7 +91,7 @@ class PADDLE_API DenseTensor : public TensorBase,
   /// or [-ndim, -1]. \return The size of the tensor along the given dimension.
   /// \throws common::errors::OutOfRange if the tensor is empty or the index is
   /// out of range.
-  const int64_t dims(int dim) const {
+  int64_t dims(int dim) const {
     int ndim = meta_.dims.size();
 
     // Ensure the tensor has at least one dimension


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->

Pcard-75624

删除 <https://github.com/PaddlePaddle/Paddle/pull/76331> 引入的`const`返回值修饰，避免在DCU等环境下编译的时候出现大量警告


```
...
paddle/phi/CMakeFiles/phi_gpu.dir/kernels/gpu/phi_gpu_generated_where_kernel.cu.o
In file included from /work/Paddle/paddle/phi/kernels/gpu/where_kernel.cu:15:
In file included from /work/Paddle/paddle/phi/kernels/where_kernel.h:17:
/work/Paddle/paddle/phi/core/dense_tensor.h:94:3: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
  const int64_t dims(int dim) const {
```