### PR TITLE
[large tensor] fix slice like x[:, [1,2]]

### DIFF
--- a/paddle/phi/kernels/funcs/stride_utils.h
+++ b/paddle/phi/kernels/funcs/stride_utils.h
@@ -633,21 +633,21 @@ inline std::
   dims.reserve(self.dims().size());
   inv_perm.resize(self.dims().size());
 
-  for (int64_t i = 0; i < self.dims().size(); ++i) {
+  for (int i = 0; i < static_cast<int>(self.dims().size()); ++i) {
     if (indices[i].initialized()) {
-      dims.push_back(static_cast<int>(i));
+      dims.push_back(i);
       transposed_indices.emplace_back(indices[i]);
     }
   }
 
-  for (int64_t i = 0; i < self.dims().size(); ++i) {
+  for (int i = 0; i < static_cast<int>(self.dims().size()); ++i) {
     if (!indices[i].initialized()) {
-      dims.push_back(static_cast<int>(i));
+      dims.push_back(i);
       transposed_indices.emplace_back();
     }
   }
 
-  for (int64_t i = 0; i < self.dims().size(); ++i) {
+  for (int i = 0; i < static_cast<int>(self.dims().size()); ++i) {
     inv_perm[dims[i]] = i;
   }
 

--- a/paddle/phi/kernels/gpu/index_elementwise_get_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_kernel.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/index_elementwise_get_kernel.h"
+#include <cstdio>
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -20,7 +21,7 @@
 #include "paddle/phi/kernels/funcs/stride_utils.h"
 
 namespace phi {
-template <typename T, typename IndexT = int, typename OffsetT = uint32_t>
+template <typename T, typename OffsetT = uint32_t>
 void GPUIndexElementwiseGetKernel(const phi::GPUContext& dev_ctx,
                                   const DenseTensor& input,
                                   const std::vector<const DenseTensor*>& index,
@@ -36,7 +37,7 @@ void GPUIndexElementwiseGetKernel(const phi::GPUContext& dev_ctx,
   std::vector<int64_t> stride_tmp;
   funcs::cal_shape_stride(index_dims, &num_indices, &shape_tmp, &stride_tmp);
 
-  auto index_ptrs = funcs::GetIndexDataPtrs<IndexT>(index);
+  auto index_ptrs = funcs::GetIndexDataPtrs<int64_t>(index);
 
   auto sizes = std::array<int64_t, DDim::kMaxRank>{};
   auto strides = std::array<int64_t, DDim::kMaxRank>{};
@@ -171,26 +172,27 @@ void IndexElementwiseGetKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out);
   if (out->numel() == 0) return;
 
-  if (funcs::IsInUint32Range(out->numel())) {
-    GPUIndexElementwiseGetKernel<T, int64_t>(dev_ctx,
-                                             x,
-                                             index,
-                                             input_dims,
-                                             input_strides,
-                                             index_dims,
-                                             index_stride,
-                                             slice_offset,
-                                             out);
+  if (funcs::IsInUint32Range(x.numel()) &&
+      funcs::IsInUint32Range(out->numel())) {
+    GPUIndexElementwiseGetKernel<T>(dev_ctx,
+                                    x,
+                                    index,
+                                    input_dims,
+                                    input_strides,
+                                    index_dims,
+                                    index_stride,
+                                    slice_offset,
+                                    out);
   } else {
-    GPUIndexElementwiseGetKernel<T, int64_t, uint64_t>(dev_ctx,
-                                                       x,
-                                                       index,
-                                                       input_dims,
-                                                       input_strides,
-                                                       index_dims,
-                                                       index_stride,
-                                                       slice_offset,
-                                                       out);
+    GPUIndexElementwiseGetKernel<T, uint64_t>(dev_ctx,
+                                              x,
+                                              index,
+                                              input_dims,
+                                              input_strides,
+                                              index_dims,
+                                              index_stride,
+                                              slice_offset,
+                                              out);
   }
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复slice的大Tensor 问题，仅在类似 x[:, [1,2]] 这种情况下出现

第一批有问题的case共52个，其中45个本PR合入后可以修复，3个是与torch行为不一致（paddle行为对齐numpy），1个是反向问题。

pcard-93269