### PR TITLE
[Dy2St] Fix dy2st recompilation triggered by dictionary order

### DIFF
--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -395,7 +395,13 @@ def make_hashable(x, error_msg=None):
             # means different value will lead to different hash code.
             return hash(x.tostring())
         elif isinstance(x, dict):
-            return tuple(map(make_hashable, x.values()))
+            # dict is order-insensitive
+            return tuple(
+                (make_hashable(k), make_hashable(v))
+                for k, v in sorted(
+                    x.items(), key=lambda kv: make_hashable(kv[0])
+                )
+            )
 
         error_msg = error_msg or "Requires a hashable object."
         raise ValueError(f"{error_msg} But received type: {type_name(x)}")

--- a/test/dygraph_to_static/test_cache_program.py
+++ b/test/dygraph_to_static/test_cache_program.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from collections import Counter
+from collections import Counter, OrderedDict
 
 import numpy as np
 from dygraph_to_static_utils import (
@@ -78,6 +78,39 @@ class TestCacheProgram2(TestCacheProgram):
         self.batch_num = 5
         self.dygraph_class = Linear
         self.data = np.random.random((4, 10)).astype('float32')
+
+
+class TestCacheProgram3(TestCacheProgram):
+    def setUp(self):
+        class DummpyModel(paddle.nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.linear = paddle.nn.Linear(3, 4)
+
+            def forward(self, x_dict):
+                x, y = x_dict["x"], x_dict["y"]
+                return (x * y).sum()
+
+        self.batch_num = 2
+        self.dygraph_class = DummpyModel
+        self.data = [
+            {"x": paddle.randn(7, 3), "y": paddle.randn(1, 3)},
+            {"y": paddle.randn(1, 3), "x": paddle.randn(7, 3)},
+        ]
+
+    @test_ast_only
+    def test_cache(self):
+        static_net = paddle.jit.to_static(self.dygraph_class(), full_graph=True)
+        _ = static_net(self.data[0])
+        cache1 = OrderedDict({**static_net.forward._program_cache._caches})
+        _ = static_net(self.data[1])
+        cache2 = static_net.forward._program_cache._caches
+
+        self.assertEqual(
+            cache1,
+            cache2,
+            msg=f"\ncache1({cache1})\n should be equal to \ncache2({cache2})",
+        )
 
 
 class TestCacheProgramWithOptimizer(Dy2StTestBase):

--- a/test/dygraph_to_static/test_cache_program.py
+++ b/test/dygraph_to_static/test_cache_program.py
@@ -82,7 +82,7 @@ class TestCacheProgram2(TestCacheProgram):
 
 class TestCacheProgram3(TestCacheProgram):
     def setUp(self):
-        class DummpyModel(paddle.nn.Layer):
+        class DummyModel(paddle.nn.Layer):
             def __init__(self):
                 super().__init__()
                 self.linear = paddle.nn.Linear(3, 4)

--- a/test/dygraph_to_static/test_cache_program.py
+++ b/test/dygraph_to_static/test_cache_program.py
@@ -92,7 +92,7 @@ class TestCacheProgram3(TestCacheProgram):
                 return (x * y).sum()
 
         self.batch_num = 2
-        self.dygraph_class = DummpyModel
+        self.dygraph_class = DummyModel
         self.data = [
             {"x": paddle.randn(7, 3), "y": paddle.randn(1, 3)},
             {"y": paddle.randn(1, 3), "x": paddle.randn(7, 3)},

--- a/test/dygraph_to_static/test_cache_program.py
+++ b/test/dygraph_to_static/test_cache_program.py
@@ -80,7 +80,7 @@ class TestCacheProgram2(TestCacheProgram):
         self.data = np.random.random((4, 10)).astype('float32')
 
 
-class TestCacheProgram3(TestCacheProgram):
+class TestCacheProgramWithDictInput(TestCacheProgram):
     def setUp(self):
         class DummyModel(paddle.nn.Layer):
             def __init__(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

Pcard-75624

修复输入dict内元素顺序变化导致触发不必要的动转静的问题，通过将dict内的items按key进行排序保证顺序无关