### PR TITLE
Revert "[CINN] Exclude `stop_gradient` and `struct_name` from compilation cache key"

### DIFF
--- a/paddle/cinn/hlir/framework/pir/fusion_info.cc
+++ b/paddle/cinn/hlir/framework/pir/fusion_info.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "paddle/cinn/hlir/framework/pir/fusion_info.h"
-#include <unordered_set>
 #include "paddle/common/enforce.h"
 #include "paddle/common/flags.h"
 #include "paddle/pir/include/core/dialect.h"
@@ -22,12 +21,8 @@
 PD_DECLARE_bool(enable_cinn_compile_cache);
 namespace cinn::hlir::framework::pir {
 
-constexpr static const char* kOpCallStack = "op_callstack";
-constexpr static const char* kSymShapeStr = "sym_shape_str";
-constexpr static const char* kStructName = "struct_name";
-constexpr static const char* kStopGradient = "stop_gradient";
-static const std::unordered_set<std::string> kExcludedAttrs = {
-    kOpCallStack, kSymShapeStr, kStructName, kStopGradient};
+constexpr static char* kOpCallStack = "op_callstack";
+constexpr static char* kSymShapeStr = "sym_shape_str";
 
 std::size_t AttributeInfo::hash() const {
   // Use stable attribute information to calculate hash instead of pointer
@@ -102,7 +97,8 @@ OperationInfo::OperationInfo(const ::pir::Operation& op) {
       attributes.begin(), attributes.end());
   attr_infos_.reserve(attributes.size());
   for (const auto& [attr_name, attr_value] : order_attributes) {
-    if (!attr_value || kExcludedAttrs.count(attr_name)) continue;
+    if (!attr_value || attr_name == kOpCallStack || attr_name == kSymShapeStr)
+      continue;
     attr_infos_.emplace_back(attr_name, attr_value);
   }
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

Reverts PaddlePaddle/Paddle#76825

<!-- PCard-66972 -->