### PR TITLE
Simplify reduce kernels using unified Ops structs

### DIFF
--- a/paddle/phi/kernels/funcs/reduce_gpu_kernel.h
+++ b/paddle/phi/kernels/funcs/reduce_gpu_kernel.h
@@ -37,7 +37,13 @@
 #include "paddle/phi/kernels/reduce_min_kernel.h"
 #include "paddle/phi/kernels/reduce_sum_kernel.h"
 
+#include "paddle/phi/kernels/primitive/reduce_primitives.h"
+
+#ifdef PADDLE_WITH_HIP
+#define WARP_SIZE 64
+#else
 #define WARP_SIZE 32
+#endif
 
 // The GPUReduceScheduler splits tensors with indices exceeding 32-bit range to
 // ensure that all incoming tensors can be addressed within 32-bit index space.
@@ -616,7 +622,6 @@ struct ReduceExecutor {
   ReduceOp reducer;
   ReduceConfig config;
   MPType ident;
-  MPType factor;
 
   // Data access calculators for input and output indexing.
   InputCalculator input_calc;
@@ -640,7 +645,6 @@ struct ReduceExecutor {
   ReduceExecutor(ReduceOp reducer,
                  ReduceConfig config,
                  MPType ident,
-                 MPType factor,
                  InputCalculator input_calc,
                  OutputCalculator output_calc,
                  const void* src,
@@ -656,7 +660,6 @@ struct ReduceExecutor {
       : reducer(reducer),
         config(config),
         ident(ident),
-        factor(factor),
         input_calc(input_calc),
         output_calc(output_calc),
         src(src),
@@ -741,7 +744,7 @@ struct ReduceExecutor {
         if (accumulate) {
 #pragma unroll
           for (int i = 0; i < kOutputVecSize; i++) {
-            value[i] = reducer((*acc)[i], value[i]);
+            value[i] = reducer.reduce((*acc)[i], value[i]);
           }
         }
         if (final_output) {
@@ -789,7 +792,7 @@ struct ReduceExecutor {
       end += shift;
       if (threadIdx.x >= shift && threadIdx.x < align_elements &&
           config.ShouldReduceTail()) {
-        value = reducer(value, LoadData(data + threadIdx.x));
+        value = reducer.compute(value, LoadData(data + threadIdx.x));
       }
       end -= align_elements;
       data += align_elements;
@@ -814,7 +817,7 @@ struct ReduceExecutor {
 
 #pragma unroll
       for (IndexType i = 0; i < kInputVecSize; i++) {
-        value_list[i] = reducer(value_list[i], values_vec.val[i]);
+        value_list[i] = reducer.compute(value_list[i], values_vec.val[i]);
       }
       idx += stride;
     }
@@ -826,13 +829,13 @@ struct ReduceExecutor {
       int idx = tail_start + threadIdx.x;
       if (idx < end) {
         const auto value = LoadData(data + idx);
-        value_list[0] = reducer(value_list[0], value);
+        value_list[0] = reducer.compute(value_list[0], value);
       }
     }
 
 #pragma unroll
     for (int i = 1; i < kInputVecSize; i++) {
-      value_list[0] = reducer(value_list[0], value_list[i]);
+      value_list[0] = reducer.reduce(value_list[0], value_list[i]);
     }
 
     return value_list[0];
@@ -870,7 +873,8 @@ struct ReduceExecutor {
       for (IndexType i = 0; i < kVecSize; i++) {
 #pragma unroll
         for (IndexType j = 0; j < kOutputVecSize; j++) {
-          value_list[i][j] = reducer(value_list[i][j], values[i].val[j]);
+          value_list[i][j] =
+              reducer.compute(value_list[i][j], values[i].val[j]);
         }
       }
       idx += stride * kVecSize;
@@ -895,7 +899,7 @@ struct ReduceExecutor {
       }
 #pragma unroll
       for (IndexType j = 0; j < kOutputVecSize; j++) {
-        value_list[i][j] = reducer(value_list[i][j], values[i].val[j]);
+        value_list[i][j] = reducer.compute(value_list[i][j], values[i].val[j]);
       }
       idx += stride;
     }
@@ -904,7 +908,7 @@ struct ReduceExecutor {
     for (int i = 1; i < kVecSize; i++) {
 #pragma unroll
       for (IndexType j = 0; j < kOutputVecSize; j++) {
-        value_list[0][j] = reducer(value_list[0][j], value_list[i][j]);
+        value_list[0][j] = reducer.reduce(value_list[0][j], value_list[i][j]);
       }
     }
     return value_list[0];
@@ -916,6 +920,10 @@ struct ReduceExecutor {
     using MPTypeVec = std::array<MPType, kOutputVecSize>;
     int dim_x = blockDim.x;
     MPTypeVec* shared = reinterpret_cast<MPTypeVec*>(shared_memory);
+
+    unsigned mask = 0u;
+    CREATE_SHFL_MASK(mask, true);
+
     if (dim_x > WARP_SIZE) {
       IndexType address_base = static_cast<IndexType>(threadIdx.x) +
                                static_cast<IndexType>(threadIdx.y) *
@@ -929,7 +937,7 @@ struct ReduceExecutor {
           MPTypeVec other = shared[address_base + offset];
 #pragma unroll
           for (int i = 0; i < kOutputVecSize; i++) {
-            value[i] = reducer(value[i], other[i]);
+            value[i] = reducer.reduce(value[i], other[i]);
           }
           shared[address_base] = value;
         }
@@ -939,14 +947,11 @@ struct ReduceExecutor {
 
     __syncthreads();
 
-    unsigned mask = 0u;
-    CREATE_SHFL_MASK(mask, true);
     for (int offset = 1; offset < dim_x; offset <<= 1) {
 #pragma unroll
       for (int i = 0; i < kOutputVecSize; i++) {
-        MPType other =
-            phi::backends::gpu::CudaShuffleDownSync(mask, value[i], offset);
-        value[i] = reducer(value[i], other);
+        MPType other = reducer.shfl_sync(mask, value[i], offset);
+        value[i] = reducer.reduce(value[i], other);
       }
     }
     return value;
@@ -965,7 +970,7 @@ struct ReduceExecutor {
         MPTypeVec other = shared[config.SharedMemoryOffset(offset)];
 #pragma unroll
         for (int i = 0; i < kOutputVecSize; i++) {
-          value[i] = reducer(value[i], other[i]);
+          value[i] = reducer.reduce(value[i], other[i]);
         }
         shared[config.SharedMemoryOffset(0)] = value;
       }
@@ -995,7 +1000,7 @@ struct ReduceExecutor {
       std::array<MPType, kOutputVecSize> ret;
 #pragma unroll
       for (int i = 0; i < kOutputVecSize; i++) {
-        ret[i] = reducer(*(out[i]), value[i]);
+        ret[i] = reducer.reduce(*(out[i]), value[i]);
       }
       return ret;
     } else {
@@ -1038,7 +1043,7 @@ struct ReduceExecutor {
       std::array<IndexType, kOutputVecSize> base_offset) const {
 #pragma unroll
     for (int i = 0; i < kOutputVecSize; i++) {
-      SetResults(static_cast<OutScalarT>(value[i] * factor), base_offset[i]);
+      SetResults(reducer.post_process(value[i]), base_offset[i]);
     }
   }
 
@@ -1093,7 +1098,7 @@ struct ReduceExecutor {
           MPTypeVec next = reduce_buffer[idx];
 #pragma unroll
           for (int i = 0; i < kOutputVecSize; i++) {
-            value[i] = reducer(value[i], next[i]);
+            value[i] = reducer.reduce(value[i], next[i]);
           }
         }
       } else {
@@ -1105,7 +1110,7 @@ struct ReduceExecutor {
           MPTypeVec next = reduce_buffer[idx];
 #pragma unroll
           for (int i = 0; i < kOutputVecSize; i++) {
-            value[i] = reducer(value[i], next[i]);
+            value[i] = reducer.reduce(value[i], next[i]);
           }
         }
       }
@@ -1133,7 +1138,7 @@ struct ReduceExecutor {
           if (accumulate) {
 #pragma unroll
             for (int i = 0; i < kOutputVecSize; i++) {
-              value[i] = reducer((*acc)[i], value[i]);
+              value[i] = reducer.reduce((*acc)[i], value[i]);
             }
           }
           if (final_output) {
@@ -1221,14 +1226,12 @@ template <typename Tx,
           int kInputVecSize = kVecSize,
           typename ReduceOp,
           typename ident_t = double>
-inline void GPUReduceScheduler(
-    const KPDevice& dev_ctx,
-    const DenseTensorIterator& iter,
-    const ReduceOp& reducer,
-    ident_t ident = 0,
-    typename phi::dtype::MPTypeTrait<Ty>::Type factor = 1,
-    AccumulationBuffer* acc_buf_ptr = nullptr,
-    int64_t base_idx = 0) {
+inline void GPUReduceScheduler(const KPDevice& dev_ctx,
+                               const DenseTensorIterator& iter,
+                               const ReduceOp& reducer,
+                               ident_t ident = 0,
+                               AccumulationBuffer* acc_buf_ptr = nullptr,
+                               int64_t base_idx = 0) {
   auto stream = dev_ctx.stream();
 
   using MPType = typename phi::dtype::MPTypeTrait<Ty>::Type;
@@ -1270,13 +1273,7 @@ inline void GPUReduceScheduler(
     for (auto& sub_iter : iter.with_32bit_indexing()) {
       int64_t sub_iter_base_idx = sub_iter.view_offsets()[0];
       GPUReduceScheduler<Tx, Ty, kVecSize, kInputVecSize, ReduceOp>(
-          dev_ctx,
-          sub_iter,
-          reducer,
-          ident,
-          factor,
-          acc_buf_ptr,
-          sub_iter_base_idx);
+          dev_ctx, sub_iter, reducer, ident, acc_buf_ptr, sub_iter_base_idx);
     }
     return;
   }
@@ -1324,7 +1321,6 @@ inline void GPUReduceScheduler(
       reducer,
       config,
       ident,
-      factor,
       input_calc,
       output_calc,
       in_data,
@@ -1347,14 +1343,11 @@ inline void GPUReduceScheduler(
 namespace funcs {
 template <typename Tx,
           typename Ty,
-          template <typename>
-          class ReduceOp,
-          typename TransformOp,
-          bool IsMean = false>
+          template <typename, typename, typename>
+          class ReduceOp>
 void ReduceGpuKernel(const KPDevice& dev_ctx,
                      const phi::DenseTensor& x,
                      phi::DenseTensor* y,
-                     const TransformOp& transform,
                      const std::vector<int>& origin_reduce_dims) {
   if (x.numel() == 0) {
     dev_ctx.Alloc<Ty>(y);
@@ -1370,13 +1363,6 @@ void ReduceGpuKernel(const KPDevice& dev_ctx,
 
   auto x_dim = common::vectorize<int64_t>(x.dims());
 
-  if (x_dim.size() == 0) {
-    std::vector<const DenseTensor*> inputs = {&x};
-    std::vector<DenseTensor*> outputs = {&viewed_result};
-    funcs::ElementwiseKernel<Ty>(dev_ctx, inputs, &outputs, transform);
-    return;
-  }
-
   DenseTensorIteratorConfig dense_iter_config;
   dense_iter_config.is_reduction(true);
   dense_iter_config.add_output(viewed_result);
@@ -1387,39 +1373,47 @@ void ReduceGpuKernel(const KPDevice& dev_ctx,
   constexpr int kVecSize = 4;
   constexpr int kInputVecSize = kVecSize;
   using MPType = typename phi::dtype::MPTypeTrait<Ty>::Type;
-  auto reducer = ReduceOp<MPType>();
 
-  MPType factor = 1.0f;
-  if (IsMean) {
-    factor = static_cast<MPType>(iter.num_output_elements()) /
-             static_cast<MPType>(iter.numel());
-  }
+  // Initialize reducer.
+  ReduceOp reducer = [&iter]() {
+    if constexpr (std::is_same_v<ReduceOp<Tx, MPType, Ty>,
+                                 kps::MeanOps<Tx, MPType, Ty>>) {
+      MPType factor = static_cast<MPType>(iter.num_output_elements()) /
+                      static_cast<MPType>(iter.numel());
+      return ReduceOp<Tx, MPType, Ty>{factor};
+    } else {
+      return ReduceOp<Tx, MPType, Ty>{};
+    }
+  }();
 
   // Initialize ident value.
   Tx ident = []() {
-    if constexpr (std::is_same_v<ReduceOp<MPType>, kps::MaxFunctor<MPType>>) {
+    if constexpr (std::is_same_v<ReduceOp<Tx, MPType, Ty>,
+                                 kps::MaxOps<Tx, MPType, Ty>>) {
       return std::numeric_limits<Tx>::lowest();
     }
 
-    if constexpr (std::is_same_v<ReduceOp<MPType>, kps::MinFunctor<MPType>>) {
+    if constexpr (std::is_same_v<ReduceOp<Tx, MPType, Ty>,
+                                 kps::MinOps<Tx, MPType, Ty>>) {
       return std::numeric_limits<Tx>::max();
     }
 
-    if constexpr (std::is_same_v<ReduceOp<MPType>,
-                                 kps::LogicalAndFunctor<MPType>>) {
+    if constexpr (std::is_same_v<ReduceOp<Tx, MPType, Ty>,
+                                 kps::LogicalAndOps<Tx, MPType, Ty>>) {
       return Tx{1};
     }
 
-    if constexpr (std::is_same_v<ReduceOp<MPType>, kps::MulFunctor<MPType>>) {
+    if constexpr (std::is_same_v<ReduceOp<Tx, MPType, Ty>,
+                                 kps::ProdOps<Tx, MPType, Ty>>) {
       return Tx{1};
     }
 
-    // AddFunctor, LogicalOrFunctor and others
+    // SumOps, MeanOps, LogicalOrOps and others
     return Tx{0};
   }();
 
-  GPUReduceScheduler<Tx, Ty, kVecSize, kInputVecSize, ReduceOp<MPType>>(
-      dev_ctx, iter, reducer, ident, factor);
+  GPUReduceScheduler<Tx, Ty, kVecSize, kInputVecSize, ReduceOp<Tx, MPType, Ty>>(
+      dev_ctx, iter, reducer, ident);
 
   return;
 }

--- a/paddle/phi/kernels/gpu/fused_token_prune_kernel.cu
+++ b/paddle/phi/kernels/gpu/fused_token_prune_kernel.cu
@@ -144,13 +144,9 @@ void FusedTokenPruneOpCUDAKernel(const Context& dev_ctx,
 
   // 2. Reduce sum
   const std::vector<int64_t> reduce_dims{1, 2};
-  phi::Reduce<T, kps::AddFunctor, kps::IdentityFunctor>(dev_ctx,
-                                                        attn_tmp,
-                                                        false,
-                                                        reduce_dims,
-                                                        false,
-                                                        attn_accu.dtype(),
-                                                        &attn_accu);
+  phi::Reduce<T, kps::SumOps>(
+      dev_ctx, attn_tmp, false, reduce_dims, attn_accu.dtype(), &attn_accu);
+
   // 3. Prepare token indices
   phi::backends::gpu::GpuLaunchConfig config =
       phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, bsz * max_seq_len);

--- a/paddle/phi/kernels/gpu/reduce.h
+++ b/paddle/phi/kernels/gpu/reduce.h
@@ -45,104 +45,90 @@ void Reduce(const KPDevice& dev_ctx,
   for (auto i : reduce_dims) {
     reduce_num *= (x.dims())[i];
   }
-
-// CUDA and HIP use ReduceGpuKernel API
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-  constexpr bool is_identity_v =
-      std::is_same_v<TransformOp<T, T>, kps::IdentityFunctor<T, T>>;
-
-  if constexpr (is_identity_v) {
-    if (out_dtype != phi::DataType::UNDEFINED && out_dtype != x.dtype()) {
-      if (x.dtype() == phi::DataType::BFLOAT16 &&
-          out_dtype == phi::DataType::FLOAT32) {
-        phi::funcs::ReduceGpuKernel<phi::bfloat16,
-                                    float,
-                                    ReduceOp,
-                                    TransformOp<phi::bfloat16, float>,
-                                    IsMean>(
-            dev_ctx,
-            x,
-            out,
-            TransformOp<phi::bfloat16, float>(reduce_num),
-            reduce_dims);
-      } else if (x.dtype() == phi::DataType::FLOAT16 &&
-                 out_dtype == phi::DataType::FLOAT32) {
-        phi::funcs::ReduceGpuKernel<phi::float16,
-                                    float,
-                                    ReduceOp,
-                                    TransformOp<phi::float16, float>,
-                                    IsMean>(
-            dev_ctx,
-            x,
-            out,
-            TransformOp<phi::float16, float>(reduce_num),
-            reduce_dims);
-      } else {
-        auto tmp_tensor = phi::Cast<T>(dev_ctx, x, out_dtype);
-        tmp_tensor.set_strides(x.strides());
-
-        PD_VISIT_BOOL_AND_FLOATING_AND_COMPLEX_AND_4_TYPES(
-            phi::DataType::INT32,
-            phi::DataType::INT64,
-            phi::DataType::FLOAT16,
-            phi::DataType::BFLOAT16,
-            out_dtype,
-            "ReduceGpuKernel",
-            ([&] {
-              using MPType = typename phi::dtype::MPTypeTrait<data_t>::Type;
-              phi::funcs::ReduceGpuKernel<data_t,
-                                          data_t,
-                                          ReduceOp,
-                                          TransformOp<data_t, MPType>,
-                                          IsMean>(
-                  dev_ctx,
-                  tmp_tensor,
-                  out,
-                  TransformOp<data_t, MPType>(reduce_num),
-                  reduce_dims);
-            }));
-      }
-    } else {
-      using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-      phi::funcs::
-          ReduceGpuKernel<T, T, ReduceOp, TransformOp<T, MPType>, IsMean>(
-              dev_ctx, x, out, TransformOp<T, MPType>(reduce_num), reduce_dims);
-    }
+#ifdef PADDLE_WITH_XPU_KP
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  funcs::ReduceKernel<T, T, ReduceOp, TransformOp<T, MPType>, IsMean>(
+      dev_ctx, x, out, TransformOp<T, MPType>(reduce_num), reduce_dims);
+#else
+  if (out_dtype != phi::DataType::UNDEFINED && out_dtype != x.dtype()) {
+    auto tmp_tensor = phi::Cast<T>(dev_ctx, x, out_dtype);
+    PD_VISIT_BOOL_AND_FLOATING_AND_COMPLEX_AND_4_TYPES(
+        phi::DataType::INT32,
+        phi::DataType::INT64,
+        phi::DataType::FLOAT16,
+        phi::DataType::BFLOAT16,
+        out_dtype,
+        "ReduceKernel",
+        ([&] {
+          using MPType = typename phi::dtype::MPTypeTrait<data_t>::Type;
+          funcs::ReduceKernel<data_t,
+                              data_t,
+                              ReduceOp,
+                              TransformOp<data_t, MPType>,
+                              IsMean>(dev_ctx,
+                                      tmp_tensor,
+                                      out,
+                                      TransformOp<data_t, MPType>(reduce_num),
+                                      reduce_dims);
+        }));
   } else {
-    if (out_dtype != phi::DataType::UNDEFINED && out_dtype != x.dtype()) {
+    using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+    funcs::ReduceKernel<T, T, ReduceOp, TransformOp<T, MPType>, IsMean>(
+        dev_ctx, x, out, TransformOp<T, MPType>(reduce_num), reduce_dims);
+  }
+#endif
+}
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+template <typename T, template <typename, typename, typename> class ReduceOp>
+void Reduce(const KPDevice& dev_ctx,
+            const DenseTensor& x,
+            bool reduce_all,
+            const std::vector<int64_t>& dims,
+            DataType out_dtype,
+            DenseTensor* out) {
+  reduce_all = recompute_reduce_all(x, dims, reduce_all);
+  std::vector<int> reduce_dims =
+      funcs::details::GetReduceDim(dims, x.dims().size(), reduce_all);
+
+  int64_t reduce_num = 1;
+  for (auto i : reduce_dims) {
+    reduce_num *= (x.dims())[i];
+  }
+
+  if (out_dtype != phi::DataType::UNDEFINED && out_dtype != x.dtype()) {
+    if (x.dtype() == phi::DataType::BFLOAT16 &&
+        out_dtype == phi::DataType::FLOAT32) {
+      phi::funcs::ReduceGpuKernel<phi::bfloat16, float, ReduceOp>(
+          dev_ctx, x, out, reduce_dims);
+    } else if (x.dtype() == phi::DataType::FLOAT16 &&
+               out_dtype == phi::DataType::FLOAT32) {
+      phi::funcs::ReduceGpuKernel<phi::float16, float, ReduceOp>(
+          dev_ctx, x, out, reduce_dims);
+    } else {
       auto tmp_tensor = phi::Cast<T>(dev_ctx, x, out_dtype);
+      tmp_tensor.set_strides(x.strides());
+
       PD_VISIT_BOOL_AND_FLOATING_AND_COMPLEX_AND_4_TYPES(
           phi::DataType::INT32,
           phi::DataType::INT64,
           phi::DataType::FLOAT16,
           phi::DataType::BFLOAT16,
           out_dtype,
-          "ReduceKernel",
+          "ReduceGpuKernel",
           ([&] {
             using MPType = typename phi::dtype::MPTypeTrait<data_t>::Type;
-            funcs::ReduceKernel<data_t,
-                                data_t,
-                                ReduceOp,
-                                TransformOp<data_t, MPType>,
-                                IsMean>(dev_ctx,
-                                        tmp_tensor,
-                                        out,
-                                        TransformOp<data_t, MPType>(reduce_num),
-                                        reduce_dims);
+            phi::funcs::ReduceGpuKernel<data_t, data_t, ReduceOp>(
+                dev_ctx, tmp_tensor, out, reduce_dims);
           }));
-    } else {
-      using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-      funcs::ReduceKernel<T, T, ReduceOp, TransformOp<T, MPType>, IsMean>(
-          dev_ctx, x, out, TransformOp<T, MPType>(reduce_num), reduce_dims);
     }
+  } else {
+    using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+    phi::funcs::ReduceGpuKernel<T, T, ReduceOp>(dev_ctx, x, out, reduce_dims);
   }
-// XPU use ReduceKernel API
-#else
-  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  funcs::ReduceKernel<T, T, ReduceOp, TransformOp<T, MPType>, IsMean>(
-      dev_ctx, x, out, TransformOp<T, MPType>(reduce_num), reduce_dims);
-#endif
 }
+#endif
+
 }  // namespace phi
 
 #endif

--- a/paddle/phi/kernels/kps/reduce_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_kernel.cu
@@ -66,8 +66,14 @@ void ProdKernel(const Context& dev_ctx,
   }
 
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
+
+#ifdef PADDLE_WITH_XPU_KP
   phi::Reduce<T, kps::MulFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);
+#else
+  phi::Reduce<T, kps::ProdOps>(
+      dev_ctx, x, reduce_all, dims.GetData(), out_dtype, out);
+#endif
 }
 
 template <typename T, typename Context>
@@ -79,8 +85,13 @@ void AllRawKernel(const Context& dev_ctx,
                   DenseTensor* out) {
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = phi::DataType::BOOL;
+#ifdef PADDLE_WITH_XPU_KP
   phi::Reduce<T, kps::LogicalAndFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);
+#else
+  phi::Reduce<T, kps::LogicalAndOps>(
+      dev_ctx, x, reduce_all, dims, out_dtype, out);
+#endif
 }
 
 template <typename T, typename Context>
@@ -92,8 +103,12 @@ void AMaxRawKernel(const Context& dev_ctx,
                    DenseTensor* out) {
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = x.dtype();
+#ifdef PADDLE_WITH_XPU_KP
   phi::Reduce<T, kps::MaxFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);
+#else
+  phi::Reduce<T, kps::MaxOps>(dev_ctx, x, reduce_all, dims, out_dtype, out);
+#endif
 }
 
 template <typename T, typename Context>
@@ -105,8 +120,12 @@ void AMinRawKernel(const Context& dev_ctx,
                    DenseTensor* out) {
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = x.dtype();
+#ifdef PADDLE_WITH_XPU_KP
   phi::Reduce<T, kps::MinFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);
+#else
+  phi::Reduce<T, kps::MinOps>(dev_ctx, x, reduce_all, dims, out_dtype, out);
+#endif
 }
 
 template <typename T, typename Context>
@@ -118,8 +137,13 @@ void AnyRawKernel(const Context& dev_ctx,
                   DenseTensor* out) {
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = phi::DataType::BOOL;
+#ifdef PADDLE_WITH_XPU_KP
   phi::Reduce<T, kps::LogicalOrFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims, keep_dim, out_dtype, out);
+#else
+  phi::Reduce<T, kps::LogicalOrOps>(
+      dev_ctx, x, reduce_all, dims, out_dtype, out);
+#endif
 }
 
 template <typename T, typename Context>
@@ -151,8 +175,13 @@ void MeanRawKernel(const Context& dev_ctx,
 
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = x.dtype();
+#ifdef PADDLE_WITH_XPU_KP
   phi::Reduce<T, kps::AddFunctor, kps::IdentityFunctor, true>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);
+#else
+  phi::Reduce<T, kps::MeanOps>(
+      dev_ctx, x, reduce_all, dims.GetData(), out_dtype, out);
+#endif
 }
 
 template <typename T, typename Context>
@@ -164,8 +193,13 @@ void MinRawKernel(const Context& dev_ctx,
                   DenseTensor* out) {
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = x.dtype();
+#ifdef PADDLE_WITH_XPU_KP
   phi::Reduce<T, kps::MinFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);
+#else
+  phi::Reduce<T, kps::MinOps>(
+      dev_ctx, x, reduce_all, dims.GetData(), out_dtype, out);
+#endif
 }
 
 #ifndef PADDLE_WITH_XPU_KP
@@ -249,8 +283,13 @@ void SumRawKernel(const Context& dev_ctx,
   }
 
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
+#ifdef PADDLE_WITH_XPU_KP
   phi::Reduce<T, kps::AddFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);
+#else
+  phi::Reduce<T, kps::SumOps>(
+      dev_ctx, x, reduce_all, dims.GetData(), out_dtype, out);
+#endif
 }
 }  // namespace phi
 

--- a/paddle/phi/kernels/legacy/kps/reduce_max_kernel.cu
+++ b/paddle/phi/kernels/legacy/kps/reduce_max_kernel.cu
@@ -27,8 +27,13 @@ PADDLE_API void MaxRawKernel(const Context& dev_ctx,
                              DenseTensor* out) {
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
   auto out_dtype = x.dtype();
+#ifdef PADDLE_WITH_XPU_KP
   phi::Reduce<T, kps::MaxFunctor, kps::IdentityFunctor>(
       dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);
+#else
+  phi::Reduce<T, kps::MaxOps>(
+      dev_ctx, x, reduce_all, dims.GetData(), out_dtype, out);
+#endif
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/primitive/reduce_primitives.h
+++ b/paddle/phi/kernels/primitive/reduce_primitives.h
@@ -1,0 +1,237 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <complex>
+#include <type_traits>
+#include "paddle/phi/common/amp_type_traits.h"
+#include "paddle/phi/core/enforce.h"
+#include "paddle/phi/kernels/funcs/eigen/extensions.h"
+
+// #include "paddle/phi/kernels/primitive/compute_primitives.h"
+
+namespace phi {
+namespace kps {
+
+template <typename InT, typename MPType = InT, typename OutT = MPType>
+struct SumOps {
+  inline DEVICE MPType compute(MPType a, InT b) const {
+    return reduce(a, static_cast<MPType>(b));
+  }
+
+  inline DEVICE MPType reduce(MPType a, MPType b) const { return a + b; }
+
+  inline DEVICE OutT post_process(MPType a) const {
+    return static_cast<OutT>(a);
+  }
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  inline DEVICE MPType shfl_sync(unsigned mask, MPType data, int offset) const {
+    return phi::backends::gpu::CudaShuffleDownSync(mask, data, offset);
+  }
+#endif
+
+  SumOps() {}
+};
+
+template <typename InT, typename MPType = InT, typename OutT = MPType>
+struct ProdOps {
+  inline DEVICE MPType compute(MPType a, InT b) const {
+    return reduce(a, static_cast<MPType>(b));
+  }
+
+  inline DEVICE MPType reduce(MPType a, MPType b) const { return a * b; }
+
+  inline DEVICE OutT post_process(MPType a) const {
+    return static_cast<OutT>(a);
+  }
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  inline DEVICE MPType shfl_sync(unsigned mask, MPType data, int offset) const {
+    return phi::backends::gpu::CudaShuffleDownSync(mask, data, offset);
+  }
+#endif
+
+  ProdOps() {}
+};
+
+template <typename InT, typename MPType = InT, typename OutT = MPType>
+struct MeanOps {
+  MPType factor;
+
+  inline DEVICE MPType compute(MPType a, InT b) const {
+    return reduce(a, static_cast<MPType>(b));
+  }
+
+  inline DEVICE MPType reduce(MPType a, MPType b) const { return a + b; }
+
+  inline DEVICE OutT post_process(MPType a) const {
+    return static_cast<OutT>(a * factor);
+  }
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  inline DEVICE MPType shfl_sync(unsigned mask, MPType data, int offset) const {
+    return phi::backends::gpu::CudaShuffleDownSync(mask, data, offset);
+  }
+#endif
+
+  explicit MeanOps(MPType factor) : factor(factor) {}
+};
+
+template <typename InT, typename MPType = InT, typename OutT = MPType>
+struct MinOps {
+  inline DEVICE MPType compute(MPType a, InT b) const {
+    return reduce(a, static_cast<MPType>(b));
+  }
+
+  inline DEVICE MPType reduce(MPType a, MPType b) const {
+    if constexpr ((std::is_floating_point<InT>::value) &&
+                  (!(std::is_same<InT, int32_t>::value ||
+                     (std::is_same<InT, int64_t>::value)))) {
+      if (isnan(a)) {
+        return a;
+      }
+      if (isnan(b)) {
+        return b;
+      }
+    }
+    return (a < b ? a : b);
+  }
+
+  inline DEVICE OutT post_process(MPType a) const {
+    return static_cast<OutT>(a);
+  }
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  inline DEVICE MPType shfl_sync(unsigned mask, MPType data, int offset) const {
+    return phi::backends::gpu::CudaShuffleDownSync(mask, data, offset);
+  }
+#endif
+
+  MinOps() {}
+};
+
+template <>
+struct MinOps<bool, bool, bool> {
+  inline DEVICE bool compute(bool a, bool b) const { return reduce(a, b); }
+
+  inline DEVICE bool reduce(bool a, bool b) const { return a & b; }
+
+  inline DEVICE bool post_process(bool a) const { return a; }
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  inline DEVICE bool shfl_sync(unsigned mask, bool data, int offset) const {
+    return phi::backends::gpu::CudaShuffleDownSync(mask, data, offset);
+  }
+#endif
+
+  MinOps() {}
+};
+
+template <typename InT, typename MPType = InT, typename OutT = MPType>
+struct MaxOps {
+  MPType factor;
+
+  inline DEVICE MPType compute(MPType a, InT b) const {
+    return reduce(a, static_cast<MPType>(b));
+  }
+
+  inline DEVICE MPType reduce(MPType a, MPType b) const {
+    if constexpr ((std::is_floating_point<InT>::value) &&
+                  (!(std::is_same<InT, int32_t>::value ||
+                     (std::is_same<InT, int64_t>::value)))) {
+      if (isnan(a)) {
+        return a;
+      }
+      if (isnan(b)) {
+        return b;
+      }
+    }
+    return (a > b ? a : b);
+  }
+
+  inline DEVICE OutT post_process(MPType a) const {
+    return static_cast<OutT>(a);
+  }
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  inline DEVICE MPType shfl_sync(unsigned mask, MPType data, int offset) const {
+    return phi::backends::gpu::CudaShuffleDownSync(mask, data, offset);
+  }
+#endif
+
+  MaxOps() {}
+};
+
+template <>
+struct MaxOps<bool, bool, bool> {
+  inline DEVICE bool compute(bool a, bool b) const { return reduce(a, b); }
+
+  inline DEVICE bool reduce(bool a, bool b) const { return a | b; }
+
+  inline DEVICE bool post_process(bool a) const { return a; }
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  inline DEVICE bool shfl_sync(unsigned mask, bool data, int offset) const {
+    return phi::backends::gpu::CudaShuffleDownSync(mask, data, offset);
+  }
+#endif
+
+  MaxOps() {}
+};
+
+template <typename InT, typename MPType = InT, typename OutT = MPType>
+struct LogicalAndOps {
+  inline DEVICE MPType compute(MPType a, InT b) const {
+    return reduce(a, static_cast<MPType>(b));
+  }
+
+  inline DEVICE MPType reduce(MPType a, MPType b) const { return (b && a); }
+
+  inline DEVICE OutT post_process(MPType a) const {
+    return static_cast<OutT>(a);
+  }
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  inline DEVICE MPType shfl_sync(unsigned mask, MPType data, int offset) const {
+    return phi::backends::gpu::CudaShuffleDownSync(mask, data, offset);
+  }
+#endif
+
+  LogicalAndOps() {}
+};
+
+template <typename InT, typename MPType = InT, typename OutT = MPType>
+struct LogicalOrOps {
+  inline DEVICE MPType compute(MPType a, InT b) const {
+    return reduce(a, static_cast<MPType>(b));
+  }
+
+  inline DEVICE MPType reduce(MPType a, MPType b) const { return (b || a); }
+
+  inline DEVICE OutT post_process(MPType a) const {
+    return static_cast<OutT>(a);
+  }
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  inline DEVICE MPType shfl_sync(unsigned mask, MPType data, int offset) const {
+    return phi::backends::gpu::CudaShuffleDownSync(mask, data, offset);
+  }
+#endif
+
+  LogicalOrOps() {}
+};
+}  // namespace kps
+}  // namespace phi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-89071

simplify reduce kernels using unified Ops structs.

