### PR TITLE
[Infra] Setup `ty` environment root path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,3 +197,6 @@ module = [
     "xlsxwriter"
 ]
 ignore_missing_imports = true
+
+[tool.ty.environment]
+root = ["./python"]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

对于 pylance 开发，我们一般设置是：

```jsonc
// .vscode/settings.json
{
  "python.languageServer": "Pylance",
  "python.analysis.typeCheckingMode": "basic"
}
```

同时通过 `.env` 设置 `PYTHONPATH`

```text
# .env
PYTHONPATH=python
```

但 ty 并不遵守这些，要切换到 ty，可以通过如下方式设置：

安装 vscode ty 扩展

禁用 pylance

```jsonc
// .vscode/settings.json
{
  "python.languageServer": "None"
}
```

设置 ty 的搜索路径 https://docs.astral.sh/ty/reference/typing-faq/#why-cant-ty-resolve-my-imports

```toml
# pyproject.toml
[tool.ty.environment]
root = ["./python"]
```

本 PR 将后者提交上来，以便 pylance 无缝切到 ty

<!-- PCard-66972 -->