### PR TITLE
[API Compatibilty] Remove useless attn_mask expand and support select fa when attn_mask is not None for SDPA

### DIFF
--- a/python/paddle/nn/functional/sdpa.py
+++ b/python/paddle/nn/functional/sdpa.py
@@ -630,12 +630,11 @@ def scaled_dot_product_attention(
         key, value = _repeat_kv(key, value, repeats)
 
         if is_causal:
-            bias_input = LowerTriangularMask()
+            attn_mask = LowerTriangularMask()
         elif attn_mask is not None:
             # memory_efficient_attention does not support broadcast num_heads dim when batch_size dim is not 1
             if (
-                attn_mask is not None
-                and attn_mask.dim() == 4
+                attn_mask.dim() == 4
                 and attn_mask.shape[0] != 1
                 and attn_mask.shape[1] != num_heads_q
             ):
@@ -647,14 +646,11 @@ def scaled_dot_product_attention(
                         attn_mask.shape[3],
                     ]
                 )
-            bias_input = attn_mask
-        else:
-            bias_input = None
         out = memory_efficient_attention(
             query,
             key,
             value,
-            attn_bias=bias_input,
+            attn_bias=attn_mask,
             p=dropout_p,
             scale=scale,
             training=training,

--- a/python/paddle/nn/functional/sdpa.py
+++ b/python/paddle/nn/functional/sdpa.py
@@ -157,16 +157,6 @@ def check_all_tensors_on_device(params: SDPParams):
     return True
 
 
-def check_for_attn_mask(params: SDPParams):
-    """
-    Check flash attention does not support attn_mask.
-    """
-    if params.attn_mask_shape is not None:
-        _logger.debug("Flash attention does not support attn_mask.")
-        return False
-    return True
-
-
 def check_head_dim_size_flash(params: SDPParams):
     """
     Check the dimension of head in query, key, and value should be equal and all less than 256.
@@ -372,7 +362,6 @@ def check_scale_is_None(params: SDPParams) -> bool:
 def can_use_flash_attention(params: SDPParams = False) -> bool:
     general_constraints = [
         check_all_tensors_on_device,
-        check_for_attn_mask,
         check_head_dim_size_flash,
         check_flash_causal_non_square_seqlens,
         check_dtypes_low_precision_fa,
@@ -602,11 +591,6 @@ def scaled_dot_product_attention(
                 paddle.to_tensor(0.0, dtype=query.dtype),
                 paddle.to_tensor(-float('inf'), dtype=query.dtype),
             )
-        if attn_mask.ndim == 3:
-            attn_mask = paddle.unsqueeze(attn_mask, axis=1)
-        if attn_mask.shape.numel() != 0:
-            mask_shape = (bs, num_heads_q, seq_len_q, seq_len_k)
-            attn_mask = attn_mask.expand(mask_shape)
 
     if is_zero_size:
         sdp_func_name = "math"
@@ -618,6 +602,12 @@ def scaled_dot_product_attention(
         fixed_seed_offset = None
         return_softmax = False
         rng_name = ""
+        if attn_mask is not None:
+            if attn_mask.ndim == 2:
+                attn_mask = attn_mask.expand([bs, 1, *attn_mask.shape])
+            elif attn_mask.ndim == 3:
+                attn_mask = paddle.unsqueeze(attn_mask, axis=1)
+
         out, _, _, _ = _C_ops.flash_attn(
             query,
             key,
@@ -642,6 +632,21 @@ def scaled_dot_product_attention(
         if is_causal:
             bias_input = LowerTriangularMask()
         elif attn_mask is not None:
+            # memory_efficient_attention does not support broadcast num_heads dim when batch_size dim is not 1
+            if (
+                attn_mask is not None
+                and attn_mask.dim() == 4
+                and attn_mask.shape[0] != 1
+                and attn_mask.shape[1] != num_heads_q
+            ):
+                attn_mask = attn_mask.expand(
+                    [
+                        attn_mask.shape[0],
+                        num_heads_q,
+                        attn_mask.shape[2],
+                        attn_mask.shape[3],
+                    ]
+                )
             bias_input = attn_mask
         else:
             bias_input = None

--- a/test/legacy_test/test_scaled_dot_product_attention.py
+++ b/test/legacy_test/test_scaled_dot_product_attention.py
@@ -23,6 +23,13 @@ from paddle.nn.functional import (
     sdp_kernel,
 )
 
+fa_available = paddle.framework._global_flags().get(
+    "FLAGS_flash_attn_available", False
+)
+mea_available = paddle.framework._global_flags().get(
+    "FLAGS_mem_efficient_attn_available", False
+)
+
 
 def attention_naive(q, k, v, causal=False):
     qt = paddle.transpose(q, [0, 2, 1, 3])
@@ -521,6 +528,234 @@ class TestZeroSizeCase14(TestZeroSizeBase):
         self.is_causal = True
         self.expected_out_shape = [0, 32, 0, 64]
         self.dtype = 'float16'
+
+
+@unittest.skipIf(
+    not mea_available,
+    "Memory efficient attention is not available, skip TestMemEffAttnMaskBroadcasting",
+)
+class TestMemEffAttnMaskBroadcasting(unittest.TestCase):
+    """
+    Test case specifically for validating mask broadcasting logic in memory_efficient_attention.
+    Target issue: Fix crash when mask shape is [B, 1, S, S] and Query is [B, H, S, D] where B > 1.
+    """
+
+    def setUp(self):
+        self.place = get_device_place()
+        self.dtype = 'float32'  # cutlass usually supports fp32/fp16
+        self.dropout = 0.0
+        self.causal = False
+
+        # Key configuration to trigger the bug:
+        # 1. Batch Size > 1
+        # 2. Query Heads > 1
+        # 3. Mask Heads == 1 (Requires broadcast)
+        self.batch_size = 3
+        self.seq_len = 8
+        self.num_heads = 4
+        self.head_dim = 16
+
+        self.q_shape = (
+            self.batch_size,
+            self.seq_len,
+            self.num_heads,
+            self.head_dim,
+        )
+        # Mask shape: [Batch, 1, Seq, Seq]
+        # This matches Query on Batch (3==3), but mismatch on Heads (1!=4)
+        self.mask_shape = (self.batch_size, 1, self.seq_len, self.seq_len)
+
+    def test_broadcast_mask_batch_match_head_broadcast(self):
+        paddle.disable_static()
+
+        # Create Inputs
+        query = np.random.random(self.q_shape).astype(self.dtype)
+        key = np.random.random(self.q_shape).astype(self.dtype)
+        value = np.random.random(self.q_shape).astype(self.dtype)
+        mask = np.random.random(self.mask_shape).astype(self.dtype)
+
+        q = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        # Create Reference Inputs (Clone)
+        q_ref = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k_ref = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v_ref = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m_ref = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        # 1. Run with Memory Efficient Attention (The one you fixed)
+        # We enforce ONLY mem_efficient to make sure we hit the modified code path
+        with sdp_kernel(
+            enable_math=False, enable_flash=False, enable_mem_efficient=True
+        ):
+            out = scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=m,
+                dropout_p=self.dropout,
+                is_causal=self.causal,
+            )
+
+        # 2. Run with Naive Math Implementation (Reference)
+        # Using the helper function defined in your file
+        out_ref = attention_naive_with_mask(q_ref, k_ref, v_ref, m_ref)
+
+        # 3. Validation
+        # Check Output values
+        np.testing.assert_allclose(
+            out.numpy(), out_ref.numpy(), rtol=5e-3, atol=1e-3
+        )
+
+        # Check Gradients (Optional but good practice)
+        out.backward()
+        out_ref.backward()
+        np.testing.assert_allclose(
+            q.grad.numpy(), q_ref.grad.numpy(), rtol=5e-3, atol=1e-3
+        )
+
+    def test_broadcast_mask_double_broadcast(self):
+        """
+        Test extreme case: [1, 1, S, S] -> [B, H, S, S]
+        This was technically supported before, but good to regression test.
+        """
+        paddle.disable_static()
+
+        # Mask shape: [1, 1, Seq, Seq]
+        broadcast_mask_shape = (1, 1, self.seq_len, self.seq_len)
+
+        query = np.random.random(self.q_shape).astype(self.dtype)
+        mask = np.random.random(broadcast_mask_shape).astype(self.dtype)
+
+        q = paddle.to_tensor(query, place=self.place)
+        k = paddle.to_tensor(query, place=self.place)  # shared for simplicity
+        v = paddle.to_tensor(query, place=self.place)
+        m = paddle.to_tensor(mask, place=self.place)
+
+        # Should pass without error
+        with sdp_kernel(
+            enable_math=False, enable_flash=False, enable_mem_efficient=True
+        ):
+            out = scaled_dot_product_attention(
+                q, k, v, attn_mask=m, dropout_p=self.dropout
+            )
+        self.assertEqual(out.shape, list(self.q_shape))
+
+
+@unittest.skipIf(
+    not fa_available,
+    "Flash attention is not available, skip TestFlashAttnMaskLogic",
+)
+class TestFlashAttnMaskLogic(unittest.TestCase):
+    """
+    Test case specifically for validating mask unsqueeze logic in flash_attention path.
+    Target logic:
+      - 2D Mask [S, S] -> Unsqueeze to [1, 1, S, S]
+      - 3D Mask [B, S, S] -> Unsqueeze to [B, 1, S, S]
+    """
+
+    def setUp(self):
+        self.place = get_device_place()
+        # FlashAttn usually requires fp16 or bf16 on most cards.
+        # Using float16 to ensure we hit the FA kernel logic.
+        self.dtype = 'float16'
+        self.dropout = 0.0
+        self.causal = False
+
+        self.batch_size = 2
+        self.seq_len = 128
+        self.num_heads = 4
+        self.head_dim = 32
+
+        self.q_shape = (
+            self.batch_size,
+            self.seq_len,
+            self.num_heads,
+            self.head_dim,
+        )
+        # Note: K/V shape is same as Q here for simplicity
+
+    def _run_test_with_mask_shape(self, mask_shape):
+        paddle.disable_static()
+
+        # 1. Create Inputs in FP16
+        query = np.random.random(self.q_shape).astype("float16")
+        key = np.random.random(self.q_shape).astype("float16")
+        value = np.random.random(self.q_shape).astype("float16")
+        mask = np.random.random(mask_shape).astype("float16")
+
+        q = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        # 2. Create Reference Inputs (Cast to FP32 for higher precision reference)
+        q_ref = paddle.cast(q, 'float32')
+        k_ref = paddle.cast(k, 'float32')
+        v_ref = paddle.cast(v, 'float32')
+        m_ref = paddle.cast(m, 'float32')
+        if m_ref.ndim == 2:
+            m_ref = m_ref.unsqueeze([0, 1])
+        elif m_ref.ndim == 3:
+            m_ref = m_ref.unsqueeze(1)
+
+        # 3. Run with Flash Attention (Force Enable)
+        # This will trigger your Python logic: if ndim==2/3 -> unsqueeze -> call _C_ops.flash_attn
+        try:
+            with sdp_kernel(
+                enable_math=False, enable_flash=True, enable_mem_efficient=False
+            ):
+                out = scaled_dot_product_attention(
+                    q,
+                    k,
+                    v,
+                    attn_mask=m,
+                    dropout_p=self.dropout,
+                    is_causal=self.causal,
+                )
+        except RuntimeError as e:
+            # Skip if hardware doesn't support FA (e.g. old GPU or dim mismatch restrictions)
+            if "No available backend" in str(e) or "not support" in str(e):
+                print(
+                    f"Skipping FlashAttn test for shape {mask_shape} due to hardware/library constraints."
+                )
+                return
+            raise e
+
+        # 4. Run with Naive Math Implementation (Reference)
+        # Paddle's basic math ops handle broadcasting automatically:
+        # [B, H, S, S] + [S, S] -> Works
+        # [B, H, S, S] + [B, S, S] -> Works
+        out_ref = attention_naive_with_mask(q_ref, k_ref, v_ref, m_ref)
+
+        # 5. Validation
+        # Cast FA output back to FP32 for comparison
+        out_fp32 = paddle.cast(out, 'float32')
+
+        # Relax tolerance slightly for FP16 vs FP32 comparison
+        np.testing.assert_allclose(
+            out_fp32.numpy(), out_ref.numpy(), rtol=1e-2, atol=1e-2
+        )
+
+    def test_flash_attn_2d_mask(self):
+        """
+        Test passing a [S, S] mask to Flash Attention.
+        Should internally unsqueeze to [1, 1, S, S].
+        """
+        # Shape: [Seq, Seq]
+        mask_shape = (self.seq_len, self.seq_len)
+        self._run_test_with_mask_shape(mask_shape)
+
+    def test_flash_attn_3d_mask(self):
+        """
+        Test passing a [B, S, S] mask to Flash Attention.
+        Should internally unsqueeze to [B, 1, S, S].
+        """
+        # Shape: [Batch, Seq, Seq]
+        mask_shape = (self.batch_size, self.seq_len, self.seq_len)
+        self._run_test_with_mask_shape(mask_shape)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- 当 attn_mask 为 None 时，支持选择 flash_attention 作为后端
- 当 attn_mask dim shape 不为 `[bs, num_heads, seq_len, seq_len]`时：
  - FA expand 为四维，且只对 bs 维度进行广播，不对 num_heads 广播
  - mem efficient 不进行 expand，除非 attn_mask 为四维张量，并且 bs 维度不需要广播，但是 num_heads 维度需要广播，这种情况 kernel 无法自动广播，需要在传入前处理
  - math 后端不手动 expand，依赖计算过程中的自动广播