### PR TITLE
【CINN】close mask_fill comp

### DIFF
--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -375,9 +375,8 @@ bool DecompProgram::enable_decomp_by_filter(const std::string& op_name) {
       flag = false;
     }
   }
-  std::set<std::string> default_comp_blacklist = {"pd_op.embedding",
-                                                  "pd_op.dropout",
-                                                  "pd_op.masked_fill"};
+  std::set<std::string> default_comp_blacklist = {
+      "pd_op.embedding", "pd_op.dropout", "pd_op.masked_fill"};
 
   auto from_flag_blacklist = StringSplit(FLAGS_prim_forward_blacklist);
   if (!from_flag_blacklist.empty())

--- a/paddle/fluid/primitive/base/decomp_trans.cc
+++ b/paddle/fluid/primitive/base/decomp_trans.cc
@@ -376,7 +376,8 @@ bool DecompProgram::enable_decomp_by_filter(const std::string& op_name) {
     }
   }
   std::set<std::string> default_comp_blacklist = {"pd_op.embedding",
-                                                  "pd_op.dropout"};
+                                                  "pd_op.dropout",
+                                                  "pd_op.masked_fill"};
 
   auto from_flag_blacklist = StringSplit(FLAGS_prim_forward_blacklist);
   if (!from_flag_blacklist.empty())


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
`masked_fill` 算子在动态shape场景下进行组合算子拆分时存在精度问题，故加入`default_comp_blacklist`。