### PR TITLE
Refactor view_grad_kernel to use ReshapeStridedKernel

### DIFF
--- a/paddle/phi/kernels/stride/view_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/view_grad_kernel.cc
@@ -11,12 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "paddle/phi/kernels/view_grad_kernel.h"
+#include "paddle/common/ddim.h"
 #include "paddle/common/flags.h"
-#include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/funcs/strided_reshape_utils.h"
-#include "paddle/phi/kernels/funcs/strided_utils.h"
+#include "paddle/phi/kernels/reshape_grad_kernel.h"
+#include "paddle/phi/kernels/reshape_kernel.h"
 #include "paddle/phi/kernels/view_kernel.h"
 
 COMMON_DECLARE_bool(use_stride_kernel);
@@ -34,34 +33,8 @@ void ViewShapeGradKernel(const Context& dev_ctx,
         "FLAGS_use_stride_kernel is closed. Strided kernel "
         "be called, something wrong has happened!"));
   }
-  DDim target_dims = input.dims();
-  DDim target_stride;
-
-  if (ReshapeStride(
-          out_grad.dims(), out_grad.strides(), target_dims, target_stride)) {
-    input_grad->set_meta(out_grad.meta());
-    input_grad->Resize(target_dims);
-    input_grad->set_strides(target_stride);
-    input_grad->set_offset(out_grad.offset());
-    input_grad->ResetHolder(out_grad.Holder());
-    input_grad->ShareInplaceVersionCounterWith(out_grad);
-  } else {
-    DenseTensor contiguous_tmp;
-    DenseTensor tmp_out_grad = out_grad;
-
-    contiguous_tmp.set_meta(tmp_out_grad.meta());
-
-    PD_VISIT_ALL_TYPES(out_grad.dtype(), "ViewShapeGradKernel", ([&] {
-                         phi::StridedTensorContiguous<data_t>(tmp_out_grad,
-                                                              &contiguous_tmp);
-                       }));
-
-    input_grad->set_meta(contiguous_tmp.meta());
-    input_grad->Resize(target_dims);
-    input_grad->set_strides(DenseTensorMeta::calc_strides(target_dims));
-    input_grad->set_offset(0);
-    input_grad->ResetHolder(contiguous_tmp.Holder());
-  }
+  ReshapeStridedKernel(
+      dev_ctx, out_grad, common::vectorize(input.dims()), input_grad);
 }
 
 template <typename Context>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
在 view shape 的反向中，当 out_grad 不连续时需要手动转连续后再 view，view grad 反向的语义与 reshape操作一致。本 PR 在view grad 的反向中复用 ReshapeStridedKernel 以规避手写 kernel 可能存在的问题