### PR TITLE
Fix LN because fast_ln_v2 do not support big tensor

### DIFF
--- a/paddle/phi/kernels/funcs/fast_ln_v1.h
+++ b/paddle/phi/kernels/funcs/fast_ln_v1.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+/* Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/paddle/phi/kernels/gpu/layer_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_grad_kernel.cu
@@ -31,11 +31,13 @@ static inline LayerNormGadKernelVariant LayerNormGradKernelDispatch(
     const paddle::DataType output_type,
     const paddle::DataType compute_type,
     const uint32_t hidden_size,
+    const int64_t x_numel,
     const DenseTensor *scale) {
 #if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
   if (scale != nullptr && input_type != paddle::DataType::FLOAT32 &&
-      hidden_size != 4096 && hidden_size > 1024) {
-    // using fast_ln_v2 only sm > 70
+      hidden_size != 4096 && hidden_size > 1024 &&
+      x_numel <= std::numeric_limits<uint32_t>::max()) {
+    // using fast_ln_v2 only sm > 70 and x_numel <= uint32_max
     auto prop = funcs::fast_ln_v2::GetDeviceProp();
     if (prop->major > 7 &&
         funcs::fast_ln_v2::has_fast_ln_v2_bwd_kernel(
@@ -185,8 +187,13 @@ void LayerNormGradKernel(const Context &dev_ctx,
   } while (0)
 
   auto compute_dtype = phi::CppTypeToDataType<U>::Type();
-  auto kernel_variant = LayerNormGradKernelDispatch(
-      scale_bias_dtype, x_dtype, x_dtype, compute_dtype, feature_size, scale);
+  auto kernel_variant = LayerNormGradKernelDispatch(scale_bias_dtype,
+                                                    x_dtype,
+                                                    x_dtype,
+                                                    compute_dtype,
+                                                    feature_size,
+                                                    x.numel(),
+                                                    scale);
   switch (kernel_variant) {
 #if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
     case LayerNormGadKernelVariant::FAST_LN_V2:

--- a/paddle/phi/kernels/gpu/layer_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_kernel.cu
@@ -498,6 +498,7 @@ static inline LayerNormKernelVariant LayerNormKernelDispatch(
     const paddle::DataType output_type,
     const paddle::DataType compute_type,
     const uint32_t hidden_size,
+    const int64_t x_numel,
     const DenseTensor *scale,
     const DenseTensor *bias) {
   if (scale == nullptr || bias == nullptr) {
@@ -505,8 +506,9 @@ static inline LayerNormKernelVariant LayerNormKernelDispatch(
   }
 #if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
   if (input_type != paddle::DataType::FLOAT32 && hidden_size != 4096 &&
-      hidden_size <= 102400) {
-    // using fast_ln_v2 only sm > 70
+      hidden_size <= 102400 &&
+      x_numel <= std::numeric_limits<uint32_t>::max()) {
+    // using fast_ln_v2 only sm > 70 and x_numel <= uint32_max
     auto prop = funcs::fast_ln_v2::GetDeviceProp();
     if (prop->major > 7 &&
         funcs::fast_ln_v2::has_fast_ln_v2_fwd_kernel(
@@ -646,6 +648,7 @@ void LayerNormKernel(const Context &dev_ctx,
                                                 y_dtype,
                                                 compute_dtype,
                                                 feature_size,
+                                                x.numel(),
                                                 scale,
                                                 bias);
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
 Layernorm 中使用的fast_ln_v2可能不支持大Tensor场景，在dispatch的时候如果numel超过uint32，则不使用fast_ln_v2