### PR TITLE
[DeepEP] Resolve Pybind11 global type conflicts

### DIFF
--- a/paddle/fluid/pybind/deep_ep_api.cc
+++ b/paddle/fluid/pybind/deep_ep_api.cc
@@ -32,7 +32,7 @@ namespace paddle::pybind {
 
 void BindDeepEPApi(pybind11::module *m) {
 #ifdef PADDLE_WITH_DEEP_EP
-  pybind11::class_<deep_ep::Config>(*m, "Config")
+  pybind11::class_<deep_ep::Config>(*m, "Config", py::module_local())
       .def(pybind11::init<int, int, int, int, int>(),
            py::arg("num_sms") = 20,
            py::arg("num_max_nvl_chunked_send_tokens") = 6,
@@ -50,7 +50,7 @@ void BindDeepEPApi(pybind11::module *m) {
   m->def("get_low_latency_nvl_size_hint_two_stage",
          &deep_ep::get_low_latency_nvl_size_hint_two_stage);
 
-  pybind11::class_<deep_ep::EventHandle>(*m, "EventHandle")
+  pybind11::class_<deep_ep::EventHandle>(*m, "EventHandle", py::module_local())
       .def(pybind11::init<>())
       .def("current_stream_wait", &deep_ep::EventHandle::current_stream_wait)
       .def("calc_stream_wait", &deep_ep::EventHandle::CalcStreamWait)
@@ -64,7 +64,7 @@ void BindDeepEPApi(pybind11::module *m) {
   m->def("get_event_handle_from_custom_stream",
          &deep_ep::GetEventHandleFromCustomStream);
 
-  pybind11::class_<deep_ep::Buffer>(*m, "Buffer")
+  pybind11::class_<deep_ep::Buffer>(*m, "Buffer", py::module_local())
       .def(pybind11::init<int, int, int64_t, int64_t, bool, int>())
       .def("is_available", &deep_ep::Buffer::is_available)
       .def("get_num_rdma_ranks", &deep_ep::Buffer::get_num_rdma_ranks)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Resolve Pybind11 global type conflicts，避免在 paddlefleet 中 import 内部的 deep_ep 时出现 `generic_type: type "Config" is already registered!`