### PR TITLE
[CINN] Simplify overly long shape expressions

### DIFF
--- a/paddle/pir/include/dialect/shape/utils/dim_expr_util.h
+++ b/paddle/pir/include/dialect/shape/utils/dim_expr_util.h
@@ -48,6 +48,6 @@ IR_API DimExprCompareResult Compare(const DimExpr& lhs, const DimExpr& rhs);
 IR_API std::unordered_set<std::string> CollectDimExprSymbols(
     const DimExpr& dim_expr);
 
-IR_API int64_t CollectDimExprSymbolsCnt(const DimExpr& dim_expr);
+IR_API int64_t CountExprSymbols(const DimExpr& dim_expr);
 
 }  // namespace symbol

--- a/paddle/pir/include/dialect/shape/utils/dim_expr_util.h
+++ b/paddle/pir/include/dialect/shape/utils/dim_expr_util.h
@@ -48,4 +48,6 @@ IR_API DimExprCompareResult Compare(const DimExpr& lhs, const DimExpr& rhs);
 IR_API std::unordered_set<std::string> CollectDimExprSymbols(
     const DimExpr& dim_expr);
 
+IR_API int64_t CollectDimExprSymbolsCnt(const DimExpr& dim_expr);
+
 }  // namespace symbol

--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -1413,18 +1413,20 @@ class SubstituteDimExprHelper final {
 
   template <template <typename> class OpT>
   std::optional<DimExpr> SubstituteSubOperands(const OpT<DimExpr>& dim_expr) {
-    const std::unordered_set<DimExpr> operands_set{dim_expr.operands->begin(),
-                                                   dim_expr.operands->end()};
-
-    auto CanReplaceSubOperands = [&operands_set](const OpT<DimExpr>& dim_expr) {
-      for (const auto& operand : *dim_expr.operands) {
-        if (operands_set.find(operand) == operands_set.end()) return false;
-      }
-      return true;
-    };
-
+    OpT<DimExpr> new_dim = dim_expr;
+    bool is_use = false;
     for (const auto& kv : pattern_to_replacement_) {
       if (!kv.first.isa<OpT<DimExpr>>()) continue;
+      const std::unordered_set<DimExpr> operands_set{new_dim.operands->begin(),
+                                                     new_dim.operands->end()};
+      auto CanReplaceSubOperands =
+          [&operands_set](const OpT<DimExpr>& dim_expr) {
+            for (const auto& operand : *dim_expr.operands) {
+              if (operands_set.find(operand) == operands_set.end())
+                return false;
+            }
+            return true;
+          };
       const auto& dim_expr_pattern = kv.first.dyn_cast<OpT<DimExpr>>();
       if (!CanReplaceSubOperands(dim_expr_pattern)) continue;
 
@@ -1436,9 +1438,10 @@ class SubstituteDimExprHelper final {
           ret_operands->push_back(operand);
         }
       }
-      return SimplifyDimExpr(OpT<DimExpr>{ret_operands});
+      new_dim = OpT<DimExpr>{ret_operands};
+      is_use = true;
     }
-
+    if (is_use) return SimplifyDimExpr(new_dim);
     return std::nullopt;
   }
 
@@ -1546,6 +1549,20 @@ void CollectListDimExprSymbolsImpl(const List<DimExpr>& dim_exprs,
     ret->insert(symbols.begin(), symbols.end());
   }
 }
+
+void CollectUnaryDimExprSymbolsCntImpl(const DimExpr& dim_expr, int64_t* cnt) {
+  int64_t cnt_result = CollectDimExprSymbolsCnt(dim_expr);
+  *cnt += cnt_result;
+}
+
+void CollectListDimExprSymbolsCntImpl(const List<DimExpr>& dim_exprs,
+                                      int64_t* cnt) {
+  for (const auto& dim_expr : *dim_exprs) {
+    int64_t cnt_result = CollectDimExprSymbolsCnt(dim_expr);
+    *cnt += cnt_result;
+  }
+}
+
 }  // namespace
 
 std::unordered_set<std::string> CollectDimExprSymbols(const DimExpr& dim_expr) {
@@ -1581,4 +1598,36 @@ std::unordered_set<std::string> CollectDimExprSymbols(const DimExpr& dim_expr) {
   return symbols;
 }
 
+int64_t CollectDimExprSymbolsCnt(const DimExpr& dim_expr) {
+  int64_t cnt = 0;
+  // clang-format off
+  auto lambdas = common::Overloaded{
+      [&](std::int64_t dim_expr) { return; },
+      [&](const std::string& dim_expr) { cnt += 1; },
+      [&](const Negative<DimExpr>& dim_expr) {
+        CollectUnaryDimExprSymbolsCntImpl(dim_expr->data, &cnt);
+      },
+      [&](const Add<DimExpr>& dim_expr) {
+        CollectListDimExprSymbolsCntImpl(dim_expr.operands, &cnt);
+      },
+      [&](const Mul<DimExpr>& dim_expr) {
+        CollectListDimExprSymbolsCntImpl(dim_expr.operands, &cnt);
+      },
+      [&](const Div<DimExpr>& dim_expr) {
+        CollectUnaryDimExprSymbolsCntImpl(dim_expr->lhs, &cnt);
+        CollectUnaryDimExprSymbolsCntImpl(dim_expr->rhs, &cnt);
+      },
+      [&](const Max<DimExpr>& dim_expr) {
+        CollectListDimExprSymbolsCntImpl(dim_expr.operands, &cnt);
+      },
+      [&](const Min<DimExpr>& dim_expr) {
+        CollectListDimExprSymbolsCntImpl(dim_expr.operands, &cnt);
+      },
+      [&](const Broadcast<DimExpr>& dim_expr) {
+        CollectListDimExprSymbolsCntImpl(dim_expr.operands, &cnt);
+      }};
+  // clang-format on
+  std::visit(lambdas, dim_expr.variant());
+  return cnt;
+}
 }  // namespace symbol

--- a/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
+++ b/paddle/pir/src/dialect/shape/utils/dim_expr_util.cc
@@ -1550,15 +1550,14 @@ void CollectListDimExprSymbolsImpl(const List<DimExpr>& dim_exprs,
   }
 }
 
-void CollectUnaryDimExprSymbolsCntImpl(const DimExpr& dim_expr, int64_t* cnt) {
-  int64_t cnt_result = CollectDimExprSymbolsCnt(dim_expr);
+void CountUnaryExprSymbolsImpl(const DimExpr& dim_expr, int64_t* cnt) {
+  int64_t cnt_result = CountExprSymbols(dim_expr);
   *cnt += cnt_result;
 }
 
-void CollectListDimExprSymbolsCntImpl(const List<DimExpr>& dim_exprs,
-                                      int64_t* cnt) {
+void CountListExprSymbolsImpl(const List<DimExpr>& dim_exprs, int64_t* cnt) {
   for (const auto& dim_expr : *dim_exprs) {
-    int64_t cnt_result = CollectDimExprSymbolsCnt(dim_expr);
+    int64_t cnt_result = CountExprSymbols(dim_expr);
     *cnt += cnt_result;
   }
 }
@@ -1598,33 +1597,39 @@ std::unordered_set<std::string> CollectDimExprSymbols(const DimExpr& dim_expr) {
   return symbols;
 }
 
-int64_t CollectDimExprSymbolsCnt(const DimExpr& dim_expr) {
+int64_t CountExprSymbols(const DimExpr& dim_expr) {
   int64_t cnt = 0;
   // clang-format off
   auto lambdas = common::Overloaded{
       [&](std::int64_t dim_expr) { return; },
       [&](const std::string& dim_expr) { cnt += 1; },
       [&](const Negative<DimExpr>& dim_expr) {
-        CollectUnaryDimExprSymbolsCntImpl(dim_expr->data, &cnt);
+        CountUnaryExprSymbolsImpl(dim_expr->data, &cnt);
       },
       [&](const Add<DimExpr>& dim_expr) {
-        CollectListDimExprSymbolsCntImpl(dim_expr.operands, &cnt);
+        cnt += 1;
+        CountListExprSymbolsImpl(dim_expr.operands, &cnt);
       },
       [&](const Mul<DimExpr>& dim_expr) {
-        CollectListDimExprSymbolsCntImpl(dim_expr.operands, &cnt);
+        cnt += 1;
+        CountListExprSymbolsImpl(dim_expr.operands, &cnt);
       },
       [&](const Div<DimExpr>& dim_expr) {
-        CollectUnaryDimExprSymbolsCntImpl(dim_expr->lhs, &cnt);
-        CollectUnaryDimExprSymbolsCntImpl(dim_expr->rhs, &cnt);
+        cnt += 1;
+        CountUnaryExprSymbolsImpl(dim_expr->lhs, &cnt);
+        CountUnaryExprSymbolsImpl(dim_expr->rhs, &cnt);
       },
       [&](const Max<DimExpr>& dim_expr) {
-        CollectListDimExprSymbolsCntImpl(dim_expr.operands, &cnt);
+        cnt += 1;
+        CountListExprSymbolsImpl(dim_expr.operands, &cnt);
       },
       [&](const Min<DimExpr>& dim_expr) {
-        CollectListDimExprSymbolsCntImpl(dim_expr.operands, &cnt);
+        cnt += 1;
+        CountListExprSymbolsImpl(dim_expr.operands, &cnt);
       },
       [&](const Broadcast<DimExpr>& dim_expr) {
-        CollectListDimExprSymbolsCntImpl(dim_expr.operands, &cnt);
+        cnt += 1;
+        CountListExprSymbolsImpl(dim_expr.operands, &cnt);
       }};
   // clang-format on
   std::visit(lambdas, dim_expr.variant());

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -349,7 +349,15 @@ InferSymbolicShapeContext::SimplifyBroadcastForShapeOrData(
       if (dim_expr.isa<symbol::Broadcast<symbol::DimExpr>>()) {
         const auto& simplified_dim_expr = SimplifyBroadcast(
             dim_expr.Get<symbol::Broadcast<symbol::DimExpr>>());
-        simplified_dim_exprs.push_back(simplified_dim_expr);
+        int64_t simplified_dim_expr_node_cnt =
+            symbol::CollectDimExprSymbolsCnt(simplified_dim_expr);
+        if (simplified_dim_expr_node_cnt >= 30) {
+          auto new_dim = symbol::DimExpr{GetNextSymName()};
+          AddEqualCstr(simplified_dim_expr, new_dim);
+          simplified_dim_exprs.push_back(new_dim);
+        } else {
+          simplified_dim_exprs.push_back(simplified_dim_expr);
+        }
       } else {
         simplified_dim_exprs.push_back(dim_expr);
       }

--- a/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
+++ b/paddle/pir/src/dialect/shape/utils/shape_analysis.cc
@@ -350,7 +350,7 @@ InferSymbolicShapeContext::SimplifyBroadcastForShapeOrData(
         const auto& simplified_dim_expr = SimplifyBroadcast(
             dim_expr.Get<symbol::Broadcast<symbol::DimExpr>>());
         int64_t simplified_dim_expr_node_cnt =
-            symbol::CollectDimExprSymbolsCnt(simplified_dim_expr);
+            symbol::CountExprSymbols(simplified_dim_expr);
         if (simplified_dim_expr_node_cnt >= 30) {
           auto new_dim = symbol::DimExpr{GetNextSymName()};
           AddEqualCstr(simplified_dim_expr, new_dim);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

- 在 CINN 中，过长的 shape 表达式会导致符号推导过程耗时过长。
- 因此对BroadCast类表达式进行化简，当某个 shape 表达式包含超过 30 个动态符号时，将其替换为一个新的符号。