### PR TITLE
add rms_norm api

### DIFF
--- a/python/paddle/nn/functional/__init__.py
+++ b/python/paddle/nn/functional/__init__.py
@@ -141,6 +141,7 @@ from .norm import (
     layer_norm,
     local_response_norm,
     normalize,
+    rms_norm,
 )
 from .pooling import (
     adaptive_avg_pool1d,
@@ -291,6 +292,7 @@ __all__ = [
     'temporal_shift',
     'batch_norm',
     'layer_norm',
+    'rms_norm',
     'instance_norm',
     'class_center_sample',
     'sparse_attention',

--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -461,6 +461,108 @@ def layer_norm(
         return helper.append_activation(layer_norm_out)
 
 
+def rms_norm(
+    input: Tensor,
+    normalized_shape: int | Sequence[int],
+    weight: Tensor | None = None,
+    epsilon: float = 1e-5,
+    name: str | None = None,
+) -> tuple[Tensor, Tensor]:
+    """
+    Applies Layer Normalization over the last dimension of the input tensor using CUDA implementation.
+    Args:
+        input (Tensor): Input tensor of shape [rows, cols] or higher dimensions (flattened to 2D).
+        normalized_shape(int|list|tuple): Input shape from an expected input of
+            size :math:`[*, normalized_shape[0], normalized_shape[1], ..., normalized_shape[-1]]`.
+            If it is a single integer, this module will normalize over the last dimension
+            which is expected to be of that specific size.
+        weight(Tensor, optional): The weight tensor of rms_norm. Default: None.
+        epsilon(float, optional): The small value added to the variance to prevent division by zero. Default: 1e-05.
+        name (str, optional): Name of the operator.
+    Returns:
+        out (Tensor): Normalized tensor of same shape as input.
+        invvar (Tensor): Tensor of shape [rows], the inverse standard deviation of each row.
+    Examples:
+        .. code-block:: python
+            >>> import paddle
+            >>> paddle.seed(2023)
+            >>> input = paddle.rand((2, 2, 2, 3))
+            >>> weight = paddle.rand(3)
+            >>> out, invvar = paddle.nn.functional.rms_norm(input, input.shape[-1], weight)
+            >>> print(out)
+            Tensor(shape=[2, 2, 2, 3], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+            [[[[0.00656056, 1.59749460, 0.33684930],
+            [0.25545901, 1.32124639, 0.22778045]],
+            [[0.35059106, 0.71675038, 0.41430289],
+            [0.36390519, 0.92316359, 0.09792893]]],
+            [[[0.06212470, 0.88866514, 0.82781523],
+            [0.10534675, 0.11984488, 0.95332414]],
+            [[0.36815676, 0.31728131, 0.49593782],
+            [0.32557520, 0.77431172, 0.47854698]]]])
+            >>> print(invvar)
+            Tensor(shape=[8], dtype=float32, place=Place(gpu:0), stop_gradient=True,
+            [3.05103183, 2.21827126, 1.68399811, 1.66563344,
+             5.00298595, 1.69471145, 1.68923950, 1.72844732])
+    """
+    input_shape = list(input.shape)
+    input_ndim = len(input_shape)
+    if isinstance(normalized_shape, numbers.Integral):
+        normalized_shape = [normalized_shape]
+    elif isinstance(normalized_shape, tuple):
+        normalized_shape = list(normalized_shape)
+    elif not isinstance(normalized_shape, list):
+        raise ValueError(
+            "`normalized_shape` should be int, list of ints or tuple of ints."
+        )
+
+    normalized_ndim = len(normalized_shape)
+    begin_norm_axis = input_ndim - normalized_ndim
+    if input_ndim < normalized_ndim or (
+        not paddle.utils.is_same_shape(
+            input_shape[begin_norm_axis:], normalized_shape
+        )
+    ):
+        str_normalized_shape = str(normalized_shape)
+        raise ValueError(
+            'Given normalized_shape is '
+            + str_normalized_shape
+            + ', expected input with shape [*, '
+            + str_normalized_shape[1:]
+            + ', but got input shape '
+            + str(input_shape)
+        )
+
+    if normalized_ndim != 1:
+        raise ValueError(
+            'Given len(normalized_shape) is '
+            + normalized_ndim
+            + ', expected len(normalized_shape) is 1.'
+        )
+
+    if weight is None:
+        raise ValueError("weight must not be None.")
+
+    if in_dynamic_or_pir_mode():
+        return _C_ops.fused_rms_norm_ext(input, weight, epsilon)
+
+    helper = LayerHelper('rms_norm_nzs', **locals())
+    from paddle.base.data_feeder import convert_dtype
+
+    dtype = convert_dtype(input.dtype)
+    out = helper.create_variable_for_type_inference(dtype)
+    invvar = helper.create_variable_for_type_inference('float32')
+
+    inputs = {'input': input, 'weight': weight}
+
+    helper.append_op(
+        type='rms_norm_nzs',
+        inputs=inputs,
+        outputs={'out': out, 'invvar': invvar},
+        attrs={'epsilon': epsilon},
+    )
+    return out, invvar
+
+
 def instance_norm(
     x: Tensor,
     running_mean: Tensor | None = None,

--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -482,27 +482,6 @@ def rms_norm(
     Returns:
         out (Tensor): Normalized tensor of same shape as input.
         invvar (Tensor): Tensor of shape [rows], the inverse standard deviation of each row.
-    Examples:
-        .. code-block:: python
-            >>> import paddle
-            >>> paddle.seed(2023)
-            >>> input = paddle.rand((2, 2, 2, 3))
-            >>> weight = paddle.rand(3)
-            >>> out, invvar = paddle.nn.functional.rms_norm(input, input.shape[-1], weight)
-            >>> print(out)
-            Tensor(shape=[2, 2, 2, 3], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-            [[[[0.00656056, 1.59749460, 0.33684930],
-            [0.25545901, 1.32124639, 0.22778045]],
-            [[0.35059106, 0.71675038, 0.41430289],
-            [0.36390519, 0.92316359, 0.09792893]]],
-            [[[0.06212470, 0.88866514, 0.82781523],
-            [0.10534675, 0.11984488, 0.95332414]],
-            [[0.36815676, 0.31728131, 0.49593782],
-            [0.32557520, 0.77431172, 0.47854698]]]])
-            >>> print(invvar)
-            Tensor(shape=[8], dtype=float32, place=Place(gpu:0), stop_gradient=True,
-            [3.05103183, 2.21827126, 1.68399811, 1.66563344,
-             5.00298595, 1.69471145, 1.68923950, 1.72844732])
     """
     input_shape = list(input.shape)
     input_ndim = len(input_shape)

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -575,6 +575,7 @@ if(NOT WITH_GPU
    OR ((WITH_GPU) AND (CUDA_VERSION VERSION_LESS 11.8))
 )# Restrict the use of older versions of CUB
   list(REMOVE_ITEM TEST_OPS test_incubate_fused_rmsnorm_ext)
+  list(REMOVE_ITEM TEST_OPS test_rms_norm)
 endif()
 
 if(NOT WITH_GPU

--- a/test/legacy_test/test_rms_norm.py
+++ b/test/legacy_test/test_rms_norm.py
@@ -1,0 +1,160 @@
+#  Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.nn.functional import rms_norm
+
+
+class TestRMSNorm(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2023)
+        np.random.seed(2023)
+
+    def rms_norm_reference(self, x, scale, bias=None, epsilon=1e-5):
+        variance = paddle.mean(paddle.square(x), axis=-1, keepdim=True)
+        rms = paddle.sqrt(variance + epsilon)
+        y = x / rms
+        y = y * scale.reshape([1, -1])
+        if bias is not None:
+            y = y + bias.reshape([1, -1])
+
+        return y, paddle.flatten(1.0 / rms)
+
+    def test_2d_input(self):
+        rows, cols = 32, 64
+        x = paddle.randn([rows, cols])
+        scale = paddle.randn([cols])
+
+        y_fused, invvar_fused = rms_norm(x, (cols,), scale)
+
+        y_ref, invvar_ref = self.rms_norm_reference(x, scale)
+
+        np.testing.assert_allclose(y_fused, y_ref, rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(
+            invvar_fused, invvar_ref, rtol=1e-5, atol=1e-5
+        )
+
+    def test_3d_input(self):
+        batch, rows, cols = 16, 32, 64
+        x = paddle.randn([batch, rows, cols])
+        scale = paddle.randn([cols])
+
+        y_fused, invvar_fused = rms_norm(x, (cols,), scale)
+
+        y_ref, invvar_ref = self.rms_norm_reference(x, scale)
+
+        np.testing.assert_allclose(
+            y_fused.astype("float32"),
+            y_ref.astype("float32"),
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        np.testing.assert_allclose(
+            invvar_fused, invvar_ref, rtol=1e-5, atol=1e-5
+        )
+
+    def test_without_bias(self):
+        rows, cols = 32, 64
+        x = paddle.randn([rows, cols])
+        scale = paddle.randn([cols])
+
+        y_fused, invvar_fused = rms_norm(x, (cols,), scale)
+
+        y_ref, invvar_ref = self.rms_norm_reference(x, scale)
+
+        np.testing.assert_allclose(y_fused, y_ref, rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(
+            invvar_fused, invvar_ref, rtol=1e-5, atol=1e-5
+        )
+
+    def test_3d_backward(self):
+        batch, rows, cols = 8, 16, 32
+        x = paddle.randn([batch, rows, cols], dtype='float32')
+        x.stop_gradient = False
+        scale = paddle.randn([cols], dtype='float32')
+        scale.stop_gradient = False
+
+        y_fused, invvar = rms_norm(x, (cols,), scale)
+
+        loss = paddle.mean(y_fused)
+        loss.backward()
+
+        x_grad_fused = x.grad.clone()
+        scale_grad_fused = scale.grad.clone()
+
+        x.clear_gradient()
+        scale.clear_gradient()
+
+        y_ref, invvar_ref = self.rms_norm_reference(x, scale)
+        loss_ref = paddle.mean(y_ref)
+        loss_ref.backward()
+
+        x_grad_ref = x.grad
+        scale_grad_ref = scale.grad
+
+        np.testing.assert_allclose(
+            x_grad_fused, x_grad_ref, rtol=1e-4, atol=1e-4
+        )
+        np.testing.assert_allclose(
+            scale_grad_fused, scale_grad_ref, rtol=1e-4, atol=1e-4
+        )
+
+    def test_backward(self):
+        rows, cols = 16, 32
+        test_type = ['bfloat16', 'float32']
+        for x_type in test_type:
+            for scale_type in test_type:
+                x = paddle.randn([rows, cols], dtype=x_type)
+                x.stop_gradient = False
+                scale = paddle.randn([cols], dtype=scale_type)
+                scale.stop_gradient = False
+
+                y_fused, invvar = rms_norm(x, (cols,), scale)
+
+                loss = paddle.mean(y_fused)
+                loss.backward()
+
+                x_grad_fused = x.grad.clone()
+                scale_grad_fused = scale.grad.clone()
+
+                x.clear_gradient()
+                scale.clear_gradient()
+
+                y_ref, invvar_ref = self.rms_norm_reference(x, scale)
+                loss_ref = paddle.mean(y_ref)
+                loss_ref.backward()
+
+                x_grad_ref = x.grad
+                scale_grad_ref = scale.grad
+
+                np.testing.assert_allclose(
+                    x_grad_fused.astype("float32"),
+                    x_grad_ref.astype("float32"),
+                    rtol=1e-4,
+                    atol=1e-4,
+                )
+                np.testing.assert_allclose(
+                    scale_grad_fused.astype("float32"),
+                    scale_grad_ref.astype("float32"),
+                    rtol=1e-4,
+                    atol=1e-4,
+                )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/xpu/test_rms_norm_xpu.py
+++ b/test/xpu/test_rms_norm_xpu.py
@@ -40,7 +40,7 @@ class TestFusedRMSNorm(unittest.TestCase):
         x = paddle.randn([rows, cols])
         scale = paddle.randn([cols])
 
-        y_fused, invvar_fused = rms_norm(x, scale)
+        y_fused, invvar_fused = rms_norm(x, (cols,), scale)
 
         y_ref, invvar_ref = self.rms_norm_reference(x, scale)
 
@@ -54,7 +54,7 @@ class TestFusedRMSNorm(unittest.TestCase):
         x = paddle.randn([batch, rows, cols])
         scale = paddle.randn([cols])
 
-        y_fused, invvar_fused = rms_norm(x, scale)
+        y_fused, invvar_fused = rms_norm(x, (cols,), scale)
 
         y_ref, invvar_ref = self.rms_norm_reference(x, scale)
 
@@ -73,7 +73,7 @@ class TestFusedRMSNorm(unittest.TestCase):
         x = paddle.randn([rows, cols])
         scale = paddle.randn([cols])
 
-        y_fused, invvar_fused = rms_norm(x, scale)
+        y_fused, invvar_fused = rms_norm(x, (cols,), scale)
 
         y_ref, invvar_ref = self.rms_norm_reference(x, scale)
 
@@ -89,7 +89,7 @@ class TestFusedRMSNorm(unittest.TestCase):
         scale = paddle.randn([cols], dtype='float32')
         scale.stop_gradient = False
 
-        y_fused, invvar = rms_norm(x, scale)
+        y_fused, invvar = rms_norm(x, (cols,), scale)
 
         loss = paddle.mean(y_fused)
         loss.backward()
@@ -126,7 +126,7 @@ class TestFusedRMSNorm(unittest.TestCase):
             scale = paddle.randn([cols], dtype=scale_type)
             scale.stop_gradient = False
 
-            y_fused, invvar = rms_norm(x, scale)
+            y_fused, invvar = rms_norm(x, (cols,), scale)
 
             loss = paddle.mean(y_fused)
             loss.backward()

--- a/test/xpu/test_rms_norm_xpu.py
+++ b/test/xpu/test_rms_norm_xpu.py
@@ -1,0 +1,168 @@
+#  Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.nn.functional import rms_norm
+
+
+class TestFusedRMSNorm(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(2023)
+        np.random.seed(2023)
+
+    def rms_norm_reference(self, x, scale, bias=None, epsilon=1e-5):
+        variance = paddle.mean(paddle.square(x), axis=-1, keepdim=True)
+        rms = paddle.sqrt(variance + epsilon)
+        y = x / rms
+        y = y * scale.reshape([1, -1])
+        if bias is not None:
+            y = y + bias.reshape([1, -1])
+
+        return y, paddle.flatten(1.0 / rms)
+
+    def test_2d_input(self):
+        rows, cols = 32, 64
+        x = paddle.randn([rows, cols])
+        scale = paddle.randn([cols])
+
+        y_fused, invvar_fused = rms_norm(x, scale)
+
+        y_ref, invvar_ref = self.rms_norm_reference(x, scale)
+
+        np.testing.assert_allclose(y_fused, y_ref, rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(
+            invvar_fused, invvar_ref, rtol=1e-5, atol=1e-5
+        )
+
+    def test_3d_input(self):
+        batch, rows, cols = 16, 32, 64
+        x = paddle.randn([batch, rows, cols])
+        scale = paddle.randn([cols])
+
+        y_fused, invvar_fused = rms_norm(x, scale)
+
+        y_ref, invvar_ref = self.rms_norm_reference(x, scale)
+
+        np.testing.assert_allclose(
+            y_fused.astype("float32"),
+            y_ref.astype("float32"),
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        np.testing.assert_allclose(
+            invvar_fused, invvar_ref, rtol=1e-5, atol=1e-5
+        )
+
+    def test_without_bias(self):
+        rows, cols = 32, 64
+        x = paddle.randn([rows, cols])
+        scale = paddle.randn([cols])
+
+        y_fused, invvar_fused = rms_norm(x, scale)
+
+        y_ref, invvar_ref = self.rms_norm_reference(x, scale)
+
+        np.testing.assert_allclose(y_fused, y_ref, rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(
+            invvar_fused, invvar_ref, rtol=1e-5, atol=1e-5
+        )
+
+    def test_3d_backward(self):
+        batch, rows, cols = 8, 16, 32
+        x = paddle.randn([batch, rows, cols], dtype='float32')
+        x.stop_gradient = False
+        scale = paddle.randn([cols], dtype='float32')
+        scale.stop_gradient = False
+
+        y_fused, invvar = rms_norm(x, scale)
+
+        loss = paddle.mean(y_fused)
+        loss.backward()
+
+        x_grad_fused = x.grad.clone()
+        scale_grad_fused = scale.grad.clone()
+
+        x.clear_gradient()
+        scale.clear_gradient()
+
+        y_ref, invvar_ref = self.rms_norm_reference(x, scale)
+        loss_ref = paddle.mean(y_ref)
+        loss_ref.backward()
+
+        x_grad_ref = x.grad
+        scale_grad_ref = scale.grad
+
+        np.testing.assert_allclose(
+            x_grad_fused, x_grad_ref, rtol=1e-4, atol=1e-4
+        )
+        np.testing.assert_allclose(
+            scale_grad_fused, scale_grad_ref, rtol=1e-4, atol=1e-4
+        )
+
+    def test_backward(self):
+        rows, cols = 16, 32
+        test_type = ['float16', 'bfloat16', 'float32']
+        for x_type in test_type:
+            # for scale_type in test_type:
+            # FIXME(yangjianbang): XPU fused_rms_norm does not support x_type != scale_type
+            scale_type = x_type
+            x = paddle.randn([rows, cols], dtype=x_type)
+            x.stop_gradient = False
+            scale = paddle.randn([cols], dtype=scale_type)
+            scale.stop_gradient = False
+
+            y_fused, invvar = rms_norm(x, scale)
+
+            loss = paddle.mean(y_fused)
+            loss.backward()
+
+            x_grad_fused = x.grad.clone()
+            scale_grad_fused = scale.grad.clone()
+
+            x.clear_gradient()
+            scale.clear_gradient()
+
+            if x_type == 'bfloat16':
+                # FIXME(yangjianbang): XPU sqrt_grad does not support bfloat16
+                x_fp32 = x.cast("float32")
+                scale_fp32 = scale.cast("float32")
+                y_ref, invvar_ref = self.rms_norm_reference(x_fp32, scale_fp32)
+            else:
+                y_ref, invvar_ref = self.rms_norm_reference(x, scale)
+            loss_ref = paddle.mean(y_ref)
+            loss_ref.backward()
+
+            x_grad_ref = x.grad
+            scale_grad_ref = scale.grad
+
+            np.testing.assert_allclose(
+                x_grad_fused.astype("float32"),
+                x_grad_ref.astype("float32"),
+                rtol=1e-4,
+                atol=1e-4,
+            )
+            np.testing.assert_allclose(
+                scale_grad_fused.astype("float32"),
+                scale_grad_ref.astype("float32"),
+                rtol=1e-4,
+                atol=1e-4,
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
新增一个 rms_norm API，接口相关参数与Torch对齐。
目前 paddle.nn.functional.rms_norm 虽然参数与Torch一致，但是paddle当前api功能并不完善。
1. 不支持 weight为None；
2. normalized_shape只支持最后一个维度的归一化；
```
Args:
  input (Tensor): Input tensor of shape [rows, cols] or higher dimensions (flattened to 2D).
  normalized_shape(int|list|tuple): Input shape from an expected input of size.
      If it is a single integer, this module will normalize over the last dimension which is expected to be of that specific size.
  weight(Tensor, optional): The weight tensor of rms_norm. Default: None.
  epsilon(float, optional): The small value added to the variance to prevent division by zero. Default: 1e-05.
  name (str, optional): Name of the operator.
Returns:
  out (Tensor): Normalized tensor of same shape as input.
  invvar (Tensor): Tensor of shape [rows], the inverse standard deviation of each row.
```