### PR TITLE
Fix FP8 quantization scale to 2^N

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/quant_utils.h
+++ b/paddle/phi/kernels/fusion/gpu/quant_utils.h
@@ -129,8 +129,8 @@ struct HighPrecisionFloatScaleLimitsTrait<half, true> {
 // amax: The evaluation of amax(abs(tile)) for the quantization tile.
 // eps: An epsilon used as a floor for amax.
 template <typename IType, typename OType, bool Power2Scaling = false>
-__device__ __forceinline__ float ComputeScale(const float amax,
-                                              const float eps) {
+__device__ __forceinline__ float ComputeScaleImpl(const float amax,
+                                                  const float eps) {
   constexpr float fp8_max = F8LimitsTrait<OType>::max;
 
   // Clamping amax to avoid division by small numbers
@@ -171,6 +171,22 @@ __device__ __forceinline__ float ComputeScale(const float amax,
   }
   return scale;
 }
+
+template <bool Power2Scaling>
+__device__ __forceinline__ float RoundPower2Scale(float scale) {
+  return __CUDA_ARCH__ != 900 && Power2Scaling &&
+                 (scale == static_cast<float>(0x1.0p127))
+             ? static_cast<float>(1.0f)
+             : scale;
+}
+
+template <typename IType, typename OType, bool Power2Scaling = false>
+__device__ __forceinline__ float ComputeScale(const float amax,
+                                              const float eps) {
+  return RoundPower2Scale<Power2Scaling>(
+      ComputeScaleImpl<IType, OType, Power2Scaling>(amax, eps));
+}
+
 // -------------------------------------- From Kitchen
 // ----------------------------------
 

--- a/paddle/phi/kernels/fusion/gpu/quant_utils.h
+++ b/paddle/phi/kernels/fusion/gpu/quant_utils.h
@@ -174,10 +174,14 @@ __device__ __forceinline__ float ComputeScaleImpl(const float amax,
 
 template <bool Power2Scaling>
 __device__ __forceinline__ float RoundPower2Scale(float scale) {
+#ifdef __CUDA_ARCH__
   return __CUDA_ARCH__ != 900 && Power2Scaling &&
                  (scale == static_cast<float>(0x1.0p127))
              ? static_cast<float>(1.0f)
              : scale;
+#else
+  return scale;
+#endif
 }
 
 template <typename IType, typename OType, bool Power2Scaling = false>

--- a/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_and_quant_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/moe_gate_dispatch_and_quant_kernel.cu
@@ -41,8 +41,8 @@ constexpr int64_t WarpSize = 32;
           use_pad)
 
 template <bool Power2Scaling>
-__device__ __forceinline__ float ScaleWrapper(const float amax,
-                                              const float eps = 0.f) {
+__device__ __forceinline__ float ScaleWrapperImpl(const float amax,
+                                                  const float eps = 0.f) {
   constexpr float fp8_max = 448.0f;
   float amax_mod = fmaxf(amax, eps);
   if (amax_mod == 0.f) {
@@ -69,6 +69,13 @@ __device__ __forceinline__ float ScaleWrapper(const float amax,
     scale = ldexpf(1.0f, normal_biased_exp);
   }
   return scale;
+}
+
+template <bool Power2Scaling>
+__device__ __forceinline__ float ScaleWrapper(const float amax,
+                                              const float eps = 0.f) {
+  return RoundPower2Scale<Power2Scaling>(
+      ScaleWrapperImpl<Power2Scaling>(amax, eps));
 }
 
 template <int VecSize, bool Power2Scaling>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Distributed Strategy

### PR Types
Others

### Description
Fix FP8 quantization scale to 2^N.