### PR TITLE
[Compat] Always set `is_package` to `True` for `CachedTorchModuleLoader`

### DIFF
--- a/python/paddle/compat/proxy.py
+++ b/python/paddle/compat/proxy.py
@@ -311,17 +311,13 @@ class TorchProxyMetaFinder:
         # Always treat cached modules as packages to allow submodules to be loaded.
         # This is necessary because some modules (e.g. torch._C) are not packages
         # but have submodules (e.g. torch._C._dynamo) attached to them.
-        is_pkg = True
         spec = importlib.util.spec_from_loader(
             fullname,
             CachedTorchModuleLoader(),
             origin=getattr(module, "__file__", None),
-            is_package=is_pkg,
+            is_package=True,
         )
-        if is_pkg:
-            spec.submodule_search_locations = list(
-                getattr(module, "__path__", [])
-            )
+        spec.submodule_search_locations = list(getattr(module, "__path__", []))
         return spec
 
     def _find_spec_for_torch_module(self, fullname: str):

--- a/python/paddle/compat/proxy.py
+++ b/python/paddle/compat/proxy.py
@@ -298,19 +298,31 @@ class TorchProxyMetaFinder:
         )
 
     def _find_spec_for_cached_torch_module(self, fullname: str):
+        module = TORCH_MODULES_CACHE[fullname]
+
         # Return cached module before enable proxy
         class CachedTorchModuleLoader(importlib.abc.Loader):
             def create_module(self, spec):
-                return TORCH_MODULES_CACHE[fullname]
+                return module
 
             def exec_module(self, module):
                 pass
 
-        return importlib.util.spec_from_loader(
+        # Always treat cached modules as packages to allow submodules to be loaded.
+        # This is necessary because some modules (e.g. torch._C) are not packages
+        # but have submodules (e.g. torch._C._dynamo) attached to them.
+        is_pkg = True
+        spec = importlib.util.spec_from_loader(
             fullname,
             CachedTorchModuleLoader(),
-            origin=getattr(TORCH_MODULES_CACHE[fullname], "__file__", None),
+            origin=getattr(module, "__file__", None),
+            is_package=is_pkg,
         )
+        if is_pkg:
+            spec.submodule_search_locations = list(
+                getattr(module, "__path__", [])
+            )
+        return spec
 
     def _find_spec_for_torch_module(self, fullname: str):
         # Map the requested torch fullname to the corresponding paddle fullname.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

对于如下场景，当前会报错：

```python
import torch

import paddle

paddle.enable_compat(scope={"deep_gemm"})

import torch._dynamo as _dynamo
# ModuleNotFoundError: No module named 'torch._C._dynamo'; 'torch._C' is not a package
```

原因是即便要返回原来 cached `torch._C` 模块，但是新建的 spec 上的 `is_package` 是 False，认为其没有子模块，因而报错

值得注意的是，即便是原始的 spec，`is_package` 也是 False，这是因为 `torch._C` 本身是一个 pybind11 定义的 `.so`，其加载方式与其他模块不同，会有显式的子模块加载逻辑，而当我们将 `torch._C` 从 cache 里取出时，并不会触发首次加载 `.so` 的逻辑，这导致了子模块找不到，进而报错

为了确保所有子模块可以加载，这里将从 cache 中取出时，永远设置 `is_package` 为 True，以避免子模块找不到的问题

<!-- PCard-66972 -->