### PR TITLE
[XPU] fix complex stream issue temporarily

### DIFF
--- a/paddle/phi/kernels/funcs/fft_fill_conj_xpu.h
+++ b/paddle/phi/kernels/funcs/fft_fill_conj_xpu.h
@@ -94,7 +94,8 @@ void FFTFillConj(const DeviceContext& dev_ctx,
              _is_fft_axis.get(),
              rank * sizeof(bool),
              XPUMemcpyKind::XPU_HOST_TO_DEVICE);
-
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait(dev_ctx.x_context()->xpu_stream));
   int r = xfft_internal::xpu::FFTFillConj(
       dst->numel(),
       reinterpret_cast<cuFloatComplex*>(src_data),
@@ -107,6 +108,7 @@ void FFTFillConj(const DeviceContext& dev_ctx,
       static_cast<int64_t>(last_axis_size),
       static_cast<int64_t>(rank));
   PADDLE_ENFORCE_XPU_SUCCESS(r);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
 }
 
 template <typename DeviceContext, typename C>
@@ -122,6 +124,8 @@ void FFTFillConjGrad(const DeviceContext& dev_ctx,
     stride_to_last_axis *= ddim[i + 1];
   }
   int64_t stride_second_to_last_axis = stride_to_last_axis * ddim[axes.back()];
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait(dev_ctx.x_context()->xpu_stream));
   int r = xfft_internal::xpu::FFTFillConjGrad(
       x_grad->numel(),
       reinterpret_cast<cuFloatComplex*>(x_grad->data<C>()),
@@ -130,6 +134,7 @@ void FFTFillConjGrad(const DeviceContext& dev_ctx,
       stride_to_last_axis,
       double_length);
   PADDLE_ENFORCE_XPU_SUCCESS(r);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
 }
 
 }  // namespace funcs

--- a/paddle/phi/kernels/xpu/complex_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/complex_grad_kernel.cc
@@ -54,12 +54,15 @@ void RealGradKernel(const Context& dev_ctx,
       dev_ctx.template Alloc<T>(dx, static_cast<size_t>(numel * sizeof(T)));
   DenseTensor imag = Fill<phi::dtype::Real<T>, Context>(
       dev_ctx, common::vectorize<int>(dout.dims()), phi::dtype::Real<T>(0.0));
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait(dev_ctx.x_context()->xpu_stream));
   int r = xfft_internal::xpu::combine_as_complex(
       numel,
       const_cast<phi::dtype::Real<T>*>(dout.data<phi::dtype::Real<T>>()),
       imag.data<phi::dtype::Real<T>>(),
       reinterpret_cast<cuFloatComplex*>(dx_data));
   PADDLE_ENFORCE_XPU_SUCCESS(r);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
 }
 
 template <typename T, typename Context>
@@ -75,12 +78,15 @@ void ImagGradKernel(const Context& dev_ctx,
       dev_ctx.template Alloc<T>(dx, static_cast<size_t>(numel * sizeof(T)));
   DenseTensor real = Fill<phi::dtype::Real<T>, Context>(
       dev_ctx, common::vectorize<int>(dout.dims()), phi::dtype::Real<T>(0.0));
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait(dev_ctx.x_context()->xpu_stream));
   int r = xfft_internal::xpu::combine_as_complex(
       numel,
       real.data<phi::dtype::Real<T>>(),
       const_cast<phi::dtype::Real<T>*>(dout.data<phi::dtype::Real<T>>()),
       reinterpret_cast<cuFloatComplex*>(dx_data));
   PADDLE_ENFORCE_XPU_SUCCESS(r);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
 }
 
 template <typename T, typename Context>
@@ -116,14 +122,15 @@ void ComplexGradKernel(const Context& dev_ctx,
   imag_dout.Resize(dout.dims());
   T* real_data = dev_ctx.template Alloc<T>(&real_dout);
   T* imag_data = dev_ctx.template Alloc<T>(&imag_dout);
-
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait(dev_ctx.x_context()->xpu_stream));
   int r = xfft_internal::xpu::complex_spilt_float(
       numel,
       reinterpret_cast<cuFloatComplex*>(const_cast<C*>(dout.data<C>())),
       real_data,
       imag_data);
   PADDLE_ENFORCE_XPU_SUCCESS(r);
-
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
   if (dx) {
     if (x.dims() == dout.dims()) {
       dx->ShareDataWith(real_dout);

--- a/paddle/phi/kernels/xpu/complex_kernel.cc
+++ b/paddle/phi/kernels/xpu/complex_kernel.cc
@@ -40,11 +40,14 @@ void ConjKernel(const Context& dev_ctx,
   }
   dev_ctx.template Alloc<T>(out);
   if (std::is_same_v<T, phi::complex64>) {
+    PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
+    PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait(dev_ctx.x_context()->xpu_stream));
     int r = xfft_internal::xpu::Conj(
         x.numel(),
         reinterpret_cast<cuFloatComplex*>(const_cast<T*>(x.data<T>())),
         reinterpret_cast<cuFloatComplex*>(out->data<T>()));
     PADDLE_ENFORCE_XPU_SUCCESS(r);
+    PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
   } else {
     using XPUType = typename XPUCopyTypeTrait<T>::Type;
     const auto* input_data = x.data<T>();
@@ -69,12 +72,15 @@ void RealKernel(const Context& dev_ctx,
   phi::DenseTensor imag;
   imag.Resize(x.dims());
   dev_ctx.template Alloc<phi::dtype::Real<T>>(&imag);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait(dev_ctx.x_context()->xpu_stream));
   int r = xfft_internal::xpu::complex_spilt_float(
       out->numel(),
       reinterpret_cast<cuFloatComplex*>(const_cast<T*>(x.data<T>())),
       out->data<phi::dtype::Real<T>>(),
       imag.data<phi::dtype::Real<T>>());
   PADDLE_ENFORCE_XPU_SUCCESS(r);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
 }
 
 template <typename T, typename Context>
@@ -90,12 +96,15 @@ void ImagKernel(const Context& dev_ctx,
   phi::DenseTensor real;
   real.Resize(x.dims());
   dev_ctx.template Alloc<phi::dtype::Real<T>>(&real);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait(dev_ctx.x_context()->xpu_stream));
   int r = xfft_internal::xpu::complex_spilt_float(
       out->numel(),
       reinterpret_cast<cuFloatComplex*>(const_cast<T*>(x.data<T>())),
       real.data<phi::dtype::Real<T>>(),
       out->data<phi::dtype::Real<T>>());
   PADDLE_ENFORCE_XPU_SUCCESS(r);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
 }
 
 template <typename T, typename Context>
@@ -138,12 +147,15 @@ void ComplexKernel(const Context& dev_ctx,
   }
 
   dev_ctx.template Alloc<C>(out);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait(dev_ctx.x_context()->xpu_stream));
   int r = xfft_internal::xpu::combine_as_complex(
       out->numel(),
       x_data,
       y_data,
       reinterpret_cast<cuFloatComplex*>(out->data<C>()));
   PADDLE_ENFORCE_XPU_SUCCESS(r);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
 }
 }  // namespace phi
 

--- a/paddle/phi/kernels/xpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_kernel.cc
@@ -145,12 +145,15 @@ void RemainderKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
   }
 
   dev_ctx.template Alloc<T>(out);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait(dev_ctx.x_context()->xpu_stream));
   int r = xfft_internal::xpu::RemainderFunctor(
       out->numel(),
       reinterpret_cast<cuFloatComplex*>(x_data),
       reinterpret_cast<cuFloatComplex*>(y_data),
       reinterpret_cast<cuFloatComplex*>(out->data<T>()));
   PADDLE_ENFORCE_XPU_SUCCESS(r);
+  PADDLE_ENFORCE_XPU_SUCCESS(xpu_wait());
 }
 #endif
 


### PR DESCRIPTION
### PR Category
Custom Device


### PR Types
Bug fixes


### Description
修复复数相关算子接口未传入context或者stream的bug。当前临时解决方案：在算子前后加上xpu_wait()
