### PR TITLE
[API Compatibility No.24] [Code Generation] Support inplace API sinking to C++ mechanism

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -590,9 +590,7 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         check_remaining_params_validity_str = "    // NO NEED"
         if need_parse_python_api_args:
             check_remaining_params_validity_str = (
-                CHECK_REMAINING_ARGS_VALID_TEMPLATE.format(
-                    len(forward_inplace_map)
-                )
+                CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("false")
             )
         pre_process_str = "    // NO NEED"
         if need_parse_python_api_args and len(dygraph_pre_process) > 0:
@@ -805,6 +803,11 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                     dygraph_function_call_str,
                 )
             )
+
+            if need_parse_python_api_args and args_mapper_func is None:
+                check_remaining_params_validity_str = (
+                    CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("true")
+                )
 
             # map of output position and input position
             return_str = "    std::map<ssize_t, ssize_t> inplace_var_idx_map;"

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -130,7 +130,7 @@ PARSE_PYTHON_C_ARGS_KWARGS_TEMPLATE = """
     PyObject* {}_obj = GetItemFromArgsOrKWArgs(args, {}, kwargs, {}, nargs,&remaining_kwargs,false);
     {} {} = {}({}_obj, \"{}\", {});"""
 
-CHECK_REMAINING_ARGS_VALID_TEMPLATE = """    CheckRemainingParamsValidity(args,kwargs,remaining_kwargs,nargs);
+CHECK_REMAINING_ARGS_VALID_TEMPLATE = """    CheckRemainingParamsValidity(args, kwargs, remaining_kwargs, nargs, {});
 """
 CALL_PRE_PROCESS_TEMPLATE = """    {};
 """
@@ -590,7 +590,9 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         check_remaining_params_validity_str = "    // NO NEED"
         if need_parse_python_api_args:
             check_remaining_params_validity_str = (
-                CHECK_REMAINING_ARGS_VALID_TEMPLATE
+                CHECK_REMAINING_ARGS_VALID_TEMPLATE.format(
+                    len(forward_inplace_map)
+                )
             )
         pre_process_str = "    // NO NEED"
         if need_parse_python_api_args and len(dygraph_pre_process) > 0:

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -148,8 +148,11 @@ RECORD_EVENT_TEMPLATE = (
 )
 
 
-RETURN_INPLACE_PYOBJECT_TEMPLATE = """
+RETURN_INPLACE_INDEX_PYOBJECT_TEMPLATE = """
     inplace_var_idx_map[{}] = {};
+"""
+RETURN_INPLACE_NAME_PYOBJECT_TEMPLATE = """
+    inplace_var_name_map[{}] = {};
 """
 
 
@@ -801,15 +804,43 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                 )
             )
 
+            # map of output position and input position
             return_str = "    std::map<ssize_t, ssize_t> inplace_var_idx_map;"
             for inplace_input, inplace_output in forward_inplace_map.items():
-                return_str += RETURN_INPLACE_PYOBJECT_TEMPLATE.format(
+                return_str += RETURN_INPLACE_INDEX_PYOBJECT_TEMPLATE.format(
                     inplace_returns_pos_map[inplace_output],
                     inplace_args_pos_map[inplace_input],
                 )
-            return_str += (
-                "    return ToPyObject(ad_func_out, args, inplace_var_idx_map);"
-            )
+            if len(forward_outputs_position_map) == 1:
+                # single output
+                # map of output position and input arg name
+                return_str += "    std::map<ssize_t, std::vector<std::string>> inplace_var_name_map;"
+                if not need_parse_python_api_args:
+                    for (
+                        inplace_input,
+                        inplace_output,
+                    ) in forward_inplace_map.items():
+                        return_str += (
+                            RETURN_INPLACE_NAME_PYOBJECT_TEMPLATE.format(
+                                inplace_returns_pos_map[inplace_output],
+                                '{"' + inplace_input + '"}',
+                            )
+                        )
+                else:
+                    for (
+                        inplace_input,
+                        inplace_output,
+                    ) in forward_inplace_map.items():
+                        return_str += (
+                            RETURN_INPLACE_NAME_PYOBJECT_TEMPLATE.format(
+                                inplace_returns_pos_map[inplace_output],
+                                _get_keywords(inplace_input, args_alias_map),
+                            )
+                        )
+                return_str += "    return ToPyObject(ad_func_out, args, kwargs, inplace_var_idx_map, inplace_var_name_map);"
+            else:
+                # multiple output
+                return_str += "    return ToPyObject(ad_func_out, args, inplace_var_idx_map);"
 
             # Generate Python-C Function Definition
             python_c_inplace_func_str = PYTHON_C_FUNCTION_TEMPLATE.format(

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -355,6 +355,8 @@ PYTHON_C_FUNCTION_DECLARE_TEMPLATE = """
 PyObject *eager_api_{name}(PyObject *self, PyObject *args, PyObject *kwargs);
 """
 
+INPLACE_GET_PYOBJECT_TEMPLATE = "    PyObject* {}_obj = GetItemFromArgsOrKWArgs(args, {}, kwargs, {}, nargs, &remaining_kwargs, false);\n"
+
 
 #####################
 # Generator Classes #
@@ -809,34 +811,43 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                     CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("true")
                 )
 
-            # map of output position and input position
-            return_str = "    std::map<ssize_t, ssize_t> inplace_var_idx_map;"
-            for inplace_input, inplace_output in forward_inplace_map.items():
-                return_str += RETURN_INPLACE_INDEX_PYOBJECT_TEMPLATE.format(
-                    inplace_returns_pos_map[inplace_output],
-                    inplace_args_pos_map[inplace_input],
-                )
-            # map of output position and input arg name
-            return_str += "    std::map<ssize_t, std::vector<std::string>> inplace_var_name_map;"
-            if not need_parse_python_api_args:
-                for (
-                    inplace_input,
-                    inplace_output,
-                ) in forward_inplace_map.items():
-                    return_str += RETURN_INPLACE_NAME_PYOBJECT_TEMPLATE.format(
-                        inplace_returns_pos_map[inplace_output],
-                        '{"' + inplace_input + '"}',
-                    )
+            # count args & kwargs
+            if need_parse_python_api_args:
+                return_str = "    remaining_kwargs = kwargs ? static_cast<int>(PyDict_Size(kwargs)) : 0;\n"
             else:
-                for (
-                    inplace_input,
-                    inplace_output,
-                ) in forward_inplace_map.items():
-                    return_str += RETURN_INPLACE_NAME_PYOBJECT_TEMPLATE.format(
-                        inplace_returns_pos_map[inplace_output],
+                return_str = "    int nargs = args ? static_cast<int>(PyTuple_Size(args)) : 0;\n"
+                return_str += "    int remaining_kwargs = kwargs ? static_cast<int>(PyDict_Size(kwargs)) : 0;\n"
+
+            # get inplace PyObjects from args & kwargs
+            for inplace_input, inplace_output in forward_inplace_map.items():
+                if need_parse_python_api_args:
+                    return_str += INPLACE_GET_PYOBJECT_TEMPLATE.format(
+                        inplace_input,
+                        inplace_args_pos_map[inplace_input],
                         _get_keywords(inplace_input, args_alias_map),
                     )
-            return_str += "    return ToPyObject(ad_func_out, args, kwargs, inplace_var_idx_map, inplace_var_name_map);"
+                else:
+                    return_str += INPLACE_GET_PYOBJECT_TEMPLATE.format(
+                        inplace_input,
+                        inplace_args_pos_map[inplace_input],
+                        '{"' + inplace_input + '"}',
+                    )
+
+            if len(forward_inplace_map) < 2:
+                # return single object
+                return_str += (
+                    f"    Py_INCREF({next(iter(forward_inplace_map))}_obj);\n"
+                )
+                return_str += (
+                    f"    return {next(iter(forward_inplace_map))}_obj;"
+                )
+            else:
+                # return multiple objects, need to be converted into a PyTuple
+                return_str += "    return ToPyObjectTuple({{{}}});".format(
+                    ", ".join(
+                        [f"{name}_obj" for name in forward_inplace_map.keys()]
+                    )
+                )
 
             # Generate Python-C Function Definition
             python_c_inplace_func_str = PYTHON_C_FUNCTION_TEMPLATE.format(

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -811,36 +811,27 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                     inplace_returns_pos_map[inplace_output],
                     inplace_args_pos_map[inplace_input],
                 )
-            if len(forward_outputs_position_map) == 1:
-                # single output
-                # map of output position and input arg name
-                return_str += "    std::map<ssize_t, std::vector<std::string>> inplace_var_name_map;"
-                if not need_parse_python_api_args:
-                    for (
-                        inplace_input,
-                        inplace_output,
-                    ) in forward_inplace_map.items():
-                        return_str += (
-                            RETURN_INPLACE_NAME_PYOBJECT_TEMPLATE.format(
-                                inplace_returns_pos_map[inplace_output],
-                                '{"' + inplace_input + '"}',
-                            )
-                        )
-                else:
-                    for (
-                        inplace_input,
-                        inplace_output,
-                    ) in forward_inplace_map.items():
-                        return_str += (
-                            RETURN_INPLACE_NAME_PYOBJECT_TEMPLATE.format(
-                                inplace_returns_pos_map[inplace_output],
-                                _get_keywords(inplace_input, args_alias_map),
-                            )
-                        )
-                return_str += "    return ToPyObject(ad_func_out, args, kwargs, inplace_var_idx_map, inplace_var_name_map);"
+            # map of output position and input arg name
+            return_str += "    std::map<ssize_t, std::vector<std::string>> inplace_var_name_map;"
+            if not need_parse_python_api_args:
+                for (
+                    inplace_input,
+                    inplace_output,
+                ) in forward_inplace_map.items():
+                    return_str += RETURN_INPLACE_NAME_PYOBJECT_TEMPLATE.format(
+                        inplace_returns_pos_map[inplace_output],
+                        '{"' + inplace_input + '"}',
+                    )
             else:
-                # multiple output
-                return_str += "    return ToPyObject(ad_func_out, args, inplace_var_idx_map);"
+                for (
+                    inplace_input,
+                    inplace_output,
+                ) in forward_inplace_map.items():
+                    return_str += RETURN_INPLACE_NAME_PYOBJECT_TEMPLATE.format(
+                        inplace_returns_pos_map[inplace_output],
+                        _get_keywords(inplace_input, args_alias_map),
+                    )
+            return_str += "    return ToPyObject(ad_func_out, args, kwargs, inplace_var_idx_map, inplace_var_name_map);"
 
             # Generate Python-C Function Definition
             python_c_inplace_func_str = PYTHON_C_FUNCTION_TEMPLATE.format(

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -825,20 +825,28 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                         '{"' + inplace_input + '"}',
                     )
 
-            if len(forward_inplace_map) < 2:
-                # return single object
+            if (
+                len(forward_outputs_position_map)
+                - len(self.intermediate_outputs)
+                > 1
+            ):
+                # multiple outputs
+                return_str += (
+                    "    std::map<size_t, PyObject*> inplace_obj_idx_map;\n"
+                )
+                for (
+                    inplace_input,
+                    inplace_output,
+                ) in forward_inplace_map.items():
+                    return_str += f"    inplace_obj_idx_map[{inplace_returns_pos_map[inplace_output]}] = {inplace_input}_obj;\n"
+                return_str += "    return ToPyObjectTuple(ad_func_out, inplace_obj_idx_map);"
+            else:
+                # single output
                 return_str += (
                     f"    Py_INCREF({next(iter(forward_inplace_map))}_obj);\n"
                 )
                 return_str += (
                     f"    return {next(iter(forward_inplace_map))}_obj;"
-                )
-            else:
-                # return multiple objects, need to be converted into a PyTuple
-                return_str += "    return ToPyObjectTuple({{{}}});".format(
-                    ", ".join(
-                        [f"{name}_obj" for name in forward_inplace_map.keys()]
-                    )
                 )
 
             # Generate Python-C Function Definition
@@ -915,6 +923,9 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
 
         # Initialized orig_forward_inputs_list, orig_forward_returns_list, orig_forward_attrs_list
         self.CollectOriginalForwardInfo()
+
+        # Initialized intermediate_outputs
+        self.ParseIntermediate()
         if not no_parse_python_api_info:
             self.InitAndParsePythonAPIInfo()
         if SkipAPIGeneration(self.forward_api_name):

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -148,14 +148,6 @@ RECORD_EVENT_TEMPLATE = (
 )
 
 
-RETURN_INPLACE_INDEX_PYOBJECT_TEMPLATE = """
-    inplace_var_idx_map[{}] = {};
-"""
-RETURN_INPLACE_NAME_PYOBJECT_TEMPLATE = """
-    inplace_var_name_map[{}] = {};
-"""
-
-
 PYTHON_C_FUNCTION_TEMPLATE = """
 PyObject * eager_api_{}(PyObject *self, PyObject *args, PyObject *kwargs) {{
   {}

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1074,6 +1074,49 @@ PyObject* ToPyObject(PyObject* args, ssize_t arg_idx) {
   return obj;
 }
 
+PyObject* ToPyObject(
+    const paddle::Tensor& value,
+    PyObject* args,
+    PyObject* kwargs,
+    const std::map<ssize_t, ssize_t>& inplace_var_idx_map,
+    const std::map<ssize_t, std::vector<std::string>>& inplace_var_name_map) {
+  if (!inplace_var_idx_map.empty() && inplace_var_idx_map.count(0)) {
+    return ToPyObject(
+        args, kwargs, inplace_var_idx_map.at(0), inplace_var_name_map.at(0));
+  } else {
+    return ToPyObject(value);
+  }
+}
+
+PyObject* ToPyObject(PyObject* args,
+                     PyObject* kwargs,
+                     ssize_t arg_idx,
+                     std::vector<std::string> arg_names) {
+  // For inplace op, directly return the input PyObject of the inplace tensor.
+  // Used for apis with single output
+  // [Parameter]
+  // args: Input PyObject.
+  // kwargs: Input PyObject (keyword arg).
+  // arg_idx: Index of inplace PyObject in input args. Used to find the input
+  // arg_names: Name list of inplace PyObject in input args. Used to find the
+  // input
+  if (PyTuple_Size(args) > arg_idx) {
+    // inplace PyObject in args
+    PyObject* obj = PyTuple_GET_ITEM(args, arg_idx);
+    Py_INCREF(obj);
+    return obj;
+  } else {
+    // inplace PyObject in kwargs
+    for (size_t i = 0; i < arg_names.size(); i++) {
+      PyObject* obj = PyDict_GetItemString(kwargs, arg_names[i].c_str());
+      if (obj) {
+        Py_INCREF(obj);
+        return obj;
+      }
+    }
+  }
+}
+
 PyObject* ToPyObject(const std::vector<bool>& value) {
   PyObject* result = PyList_New((Py_ssize_t)value.size());
 

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1025,6 +1025,17 @@ std::vector<std::string> CastPyArg2VectorOfString(PyObject* obj,
   }
 }
 
+PyObject* ToPyObjectTuple(const std::vector<PyObject*>& value) {
+  size_t len = value.size();
+  PyObject* result = PyTuple_New(len);
+
+  for (size_t i = 0; i < len; i++) {
+    PyTuple_SET_ITEM(result, i, value.at(i));
+  }
+
+  return result;
+}
+
 PyObject* ToPyObject(bool value) {
   if (value) {
     Py_INCREF(Py_True);
@@ -1072,49 +1083,6 @@ PyObject* ToPyObject(PyObject* args, ssize_t arg_idx) {
   PyObject* obj = PyTuple_GET_ITEM(args, arg_idx);
   Py_INCREF(obj);
   return obj;
-}
-
-PyObject* ToPyObject(
-    const paddle::Tensor& value,
-    PyObject* args,
-    PyObject* kwargs,
-    const std::map<ssize_t, ssize_t>& inplace_var_idx_map,
-    const std::map<ssize_t, std::vector<std::string>>& inplace_var_name_map) {
-  if (!inplace_var_idx_map.empty() && inplace_var_idx_map.count(0)) {
-    return ToPyObject(
-        args, kwargs, inplace_var_idx_map.at(0), inplace_var_name_map.at(0));
-  } else {
-    return ToPyObject(value);
-  }
-}
-
-PyObject* ToPyObject(PyObject* args,
-                     PyObject* kwargs,
-                     ssize_t arg_idx,
-                     std::vector<std::string> arg_names) {
-  // For inplace op, directly return the input PyObject of the inplace tensor.
-  // Used for apis with single output
-  // [Parameter]
-  // args: Input PyObject.
-  // kwargs: Input PyObject (keyword arg).
-  // arg_idx: Index of inplace PyObject in input args. Used to find the input
-  // arg_names: Name list of inplace PyObject in input args. Used to find the
-  // input
-  if (PyTuple_Size(args) > arg_idx) {
-    // inplace PyObject in args
-    PyObject* obj = PyTuple_GET_ITEM(args, arg_idx);
-    Py_INCREF(obj);
-    return obj;
-  } else {
-    // inplace PyObject in kwargs
-    for (size_t i = 0; i < arg_names.size(); i++) {
-      PyObject* obj = PyDict_GetItemString(kwargs, arg_names[i].c_str());
-      if (obj) {
-        Py_INCREF(obj);
-        return obj;
-      }
-    }
-  }
 }
 
 PyObject* ToPyObject(const std::vector<bool>& value) {

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1030,6 +1030,7 @@ PyObject* ToPyObjectTuple(const std::vector<PyObject*>& value) {
   PyObject* result = PyTuple_New(len);
 
   for (size_t i = 0; i < len; i++) {
+    Py_INCREF(value.at(i));
     PyTuple_SET_ITEM(result, i, value.at(i));
   }
 

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1025,18 +1025,6 @@ std::vector<std::string> CastPyArg2VectorOfString(PyObject* obj,
   }
 }
 
-PyObject* ToPyObjectTuple(const std::vector<PyObject*>& value) {
-  size_t len = value.size();
-  PyObject* result = PyTuple_New(len);
-
-  for (size_t i = 0; i < len; i++) {
-    Py_INCREF(value.at(i));
-    PyTuple_SET_ITEM(result, i, value.at(i));
-  }
-
-  return result;
-}
-
 PyObject* ToPyObject(bool value) {
   if (value) {
     Py_INCREF(Py_True);

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -123,6 +123,7 @@ std::shared_ptr<jit::Function> CastPyArg2JitFunction(PyObject* obj,
 void SetPythonStack();
 std::string GetPythonStack();
 
+PyObject* ToPyObjectTuple(const std::vector<PyObject*>& value);
 PyObject* ToPyObject(int value);
 PyObject* ToPyObject(uint32_t value);
 PyObject* ToPyObject(bool value);
@@ -136,16 +137,6 @@ PyObject* ToPyObject(const paddle::Tensor& value,
                      PyObject* args,
                      const std::map<ssize_t, ssize_t>& inplace_var_idx_map);
 PyObject* ToPyObject(PyObject* args, ssize_t arg_idx);
-PyObject* ToPyObject(
-    const paddle::Tensor& value,
-    PyObject* args,
-    PyObject* kwargs,
-    const std::map<ssize_t, ssize_t>& inplace_var_idx_map,
-    const std::map<ssize_t, std::vector<std::string>>& inplace_var_name_map);
-PyObject* ToPyObject(PyObject* args,
-                     PyObject* kwargs,
-                     ssize_t arg_idx,
-                     std::vector<std::string> arg_names);
 PyObject* ToPyObject(const std::vector<bool>& value);
 PyObject* ToPyObject(const std::vector<int>& value);
 PyObject* ToPyObject(const std::vector<int64_t>& value);
@@ -294,27 +285,6 @@ struct TupleTensorResult {
       PyTuple_SET_ITEM(result, N - 1, ToPyObject(std::get<N - 1>(out)));
     }
   }
-
-  static void Run(
-      const Tuple& out,
-      PyObject* result,
-      PyObject* args,
-      PyObject* kwargs,
-      const std::map<ssize_t, ssize_t>& inplace_var_idx_map,
-      const std::map<ssize_t, std::vector<std::string>>& inplace_var_name_map) {
-    TupleTensorResult<Tuple, N - 1>::Run(
-        out, result, args, kwargs, inplace_var_idx_map, inplace_var_name_map);
-    if (!inplace_var_idx_map.empty() && inplace_var_idx_map.count(N - 1)) {
-      PyTuple_SET_ITEM(result,
-                       N - 1,
-                       ToPyObject(args,
-                                  kwargs,
-                                  inplace_var_idx_map.at(N - 1),
-                                  inplace_var_name_map.at(N - 1)));
-    } else {
-      PyTuple_SET_ITEM(result, N - 1, ToPyObject(std::get<N - 1>(out)));
-    }
-  }
 };
 
 template <typename Tuple>
@@ -329,25 +299,6 @@ struct TupleTensorResult<Tuple, 1> {
                   const std::map<ssize_t, ssize_t>& inplace_var_idx_map) {
     if (!inplace_var_idx_map.empty() && inplace_var_idx_map.count(0)) {
       PyTuple_SET_ITEM(result, 0, ToPyObject(args, inplace_var_idx_map.at(0)));
-    } else {
-      PyTuple_SET_ITEM(result, 0, ToPyObject(std::get<0>(out)));
-    }
-  }
-
-  static void Run(
-      const Tuple& out,
-      PyObject* result,
-      PyObject* args,
-      PyObject* kwargs,
-      const std::map<ssize_t, ssize_t>& inplace_var_idx_map,
-      const std::map<ssize_t, std::vector<std::string>>& inplace_var_name_map) {
-    if (!inplace_var_idx_map.empty() && inplace_var_idx_map.count(0)) {
-      PyTuple_SET_ITEM(result,
-                       0,
-                       ToPyObject(args,
-                                  kwargs,
-                                  inplace_var_idx_map.at(0),
-                                  inplace_var_name_map.at(0)));
     } else {
       PyTuple_SET_ITEM(result, 0, ToPyObject(std::get<0>(out)));
     }
@@ -383,34 +334,6 @@ PyObject* ToPyObject(const std::tuple<Args...>& out,
 
   TupleTensorResult<decltype(out), sizeof...(Args)>::Run(
       out, result, args, inplace_var_idx_map);
-
-  return result;
-}
-
-template <typename... Args>
-PyObject* ToPyObject(
-    const std::tuple<Args...>& out,
-    PyObject* args,
-    PyObject* kwargs,
-    const std::map<ssize_t, ssize_t>& inplace_var_idx_map,
-    const std::map<ssize_t, std::vector<std::string>>& inplace_var_name_map) {
-  // For inplace op, directly return the input PyObject of the inplace tensor.
-  // [Parameter]
-  // out: Outputs tuple after executing op.
-  // args: Input PyObject.
-  // kwargs: Input PyObject.
-  // inplace_var_idx_map: Index of Tensors in inplace_map, e.g. {{value_idx,
-  // arg_idx}}.
-  // - value_idx: Index of inplace tensor in outputs tuple. Used to find the
-  // output inplace tensor.
-  // - arg_idx: Index of inplace PyObject in input args. Used to find the input
-  // inplace PyObject.
-  // inplace_var_name_map: Name of Tensors in inplace_map
-  auto len = sizeof...(Args);
-  PyObject* result = PyTuple_New(len);
-
-  TupleTensorResult<decltype(out), sizeof...(Args)>::Run(
-      out, result, args, kwargs, inplace_var_idx_map, inplace_var_name_map);
 
   return result;
 }

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -123,7 +123,6 @@ std::shared_ptr<jit::Function> CastPyArg2JitFunction(PyObject* obj,
 void SetPythonStack();
 std::string GetPythonStack();
 
-PyObject* ToPyObjectTuple(const std::vector<PyObject*>& value);
 PyObject* ToPyObject(int value);
 PyObject* ToPyObject(uint32_t value);
 PyObject* ToPyObject(bool value);
@@ -285,6 +284,19 @@ struct TupleTensorResult {
       PyTuple_SET_ITEM(result, N - 1, ToPyObject(std::get<N - 1>(out)));
     }
   }
+
+  static void Run(const Tuple& out,
+                  PyObject* result,
+                  const std::map<size_t, PyObject*>& inplace_obj_idx_map) {
+    TupleTensorResult<Tuple, N - 1>::Run(out, result, inplace_obj_idx_map);
+    auto it = inplace_obj_idx_map.find(N - 1);
+    if (it != inplace_obj_idx_map.end()) {
+      Py_INCREF(it->second);
+      PyTuple_SET_ITEM(result, N - 1, it->second);
+    } else {
+      PyTuple_SET_ITEM(result, N - 1, ToPyObject(std::get<N - 1>(out)));
+    }
+  }
 };
 
 template <typename Tuple>
@@ -303,7 +315,32 @@ struct TupleTensorResult<Tuple, 1> {
       PyTuple_SET_ITEM(result, 0, ToPyObject(std::get<0>(out)));
     }
   }
+
+  static void Run(const Tuple& out,
+                  PyObject* result,
+                  const std::map<size_t, PyObject*>& inplace_obj_idx_map) {
+    auto it = inplace_obj_idx_map.find(0);
+    if (it != inplace_obj_idx_map.end()) {
+      Py_INCREF(it->second);
+      PyTuple_SET_ITEM(result, 0, it->second);
+    } else {
+      PyTuple_SET_ITEM(result, 0, ToPyObject(std::get<0>(out)));
+    }
+  }
 };
+
+template <typename... Args>
+PyObject* ToPyObjectTuple(
+    const std::tuple<Args...>& out,
+    const std::map<size_t, PyObject*>& inplace_obj_idx_map) {
+  auto len = sizeof...(Args);
+  PyObject* result = PyTuple_New(len);
+
+  TupleTensorResult<decltype(out), sizeof...(Args)>::Run(
+      out, result, inplace_obj_idx_map);
+
+  return result;
+}
 
 template <typename... Args>
 PyObject* ToPyObject(const std::tuple<Args...>& out) {

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -294,6 +294,27 @@ struct TupleTensorResult {
       PyTuple_SET_ITEM(result, N - 1, ToPyObject(std::get<N - 1>(out)));
     }
   }
+
+  static void Run(
+      const Tuple& out,
+      PyObject* result,
+      PyObject* args,
+      PyObject* kwargs,
+      const std::map<ssize_t, ssize_t>& inplace_var_idx_map,
+      const std::map<ssize_t, std::vector<std::string>>& inplace_var_name_map) {
+    TupleTensorResult<Tuple, N - 1>::Run(
+        out, result, args, kwargs, inplace_var_idx_map, inplace_var_name_map);
+    if (!inplace_var_idx_map.empty() && inplace_var_idx_map.count(N - 1)) {
+      PyTuple_SET_ITEM(result,
+                       N - 1,
+                       ToPyObject(args,
+                                  kwargs,
+                                  inplace_var_idx_map.at(N - 1),
+                                  inplace_var_name_map.at(N - 1)));
+    } else {
+      PyTuple_SET_ITEM(result, N - 1, ToPyObject(std::get<N - 1>(out)));
+    }
+  }
 };
 
 template <typename Tuple>
@@ -308,6 +329,25 @@ struct TupleTensorResult<Tuple, 1> {
                   const std::map<ssize_t, ssize_t>& inplace_var_idx_map) {
     if (!inplace_var_idx_map.empty() && inplace_var_idx_map.count(0)) {
       PyTuple_SET_ITEM(result, 0, ToPyObject(args, inplace_var_idx_map.at(0)));
+    } else {
+      PyTuple_SET_ITEM(result, 0, ToPyObject(std::get<0>(out)));
+    }
+  }
+
+  static void Run(
+      const Tuple& out,
+      PyObject* result,
+      PyObject* args,
+      PyObject* kwargs,
+      const std::map<ssize_t, ssize_t>& inplace_var_idx_map,
+      const std::map<ssize_t, std::vector<std::string>>& inplace_var_name_map) {
+    if (!inplace_var_idx_map.empty() && inplace_var_idx_map.count(0)) {
+      PyTuple_SET_ITEM(result,
+                       0,
+                       ToPyObject(args,
+                                  kwargs,
+                                  inplace_var_idx_map.at(0),
+                                  inplace_var_name_map.at(0)));
     } else {
       PyTuple_SET_ITEM(result, 0, ToPyObject(std::get<0>(out)));
     }
@@ -343,6 +383,34 @@ PyObject* ToPyObject(const std::tuple<Args...>& out,
 
   TupleTensorResult<decltype(out), sizeof...(Args)>::Run(
       out, result, args, inplace_var_idx_map);
+
+  return result;
+}
+
+template <typename... Args>
+PyObject* ToPyObject(
+    const std::tuple<Args...>& out,
+    PyObject* args,
+    PyObject* kwargs,
+    const std::map<ssize_t, ssize_t>& inplace_var_idx_map,
+    const std::map<ssize_t, std::vector<std::string>>& inplace_var_name_map) {
+  // For inplace op, directly return the input PyObject of the inplace tensor.
+  // [Parameter]
+  // out: Outputs tuple after executing op.
+  // args: Input PyObject.
+  // kwargs: Input PyObject.
+  // inplace_var_idx_map: Index of Tensors in inplace_map, e.g. {{value_idx,
+  // arg_idx}}.
+  // - value_idx: Index of inplace tensor in outputs tuple. Used to find the
+  // output inplace tensor.
+  // - arg_idx: Index of inplace PyObject in input args. Used to find the input
+  // inplace PyObject.
+  // inplace_var_name_map: Name of Tensors in inplace_map
+  auto len = sizeof...(Args);
+  PyObject* result = PyTuple_New(len);
+
+  TupleTensorResult<decltype(out), sizeof...(Args)>::Run(
+      out, result, args, kwargs, inplace_var_idx_map, inplace_var_name_map);
 
   return result;
 }

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -136,6 +136,16 @@ PyObject* ToPyObject(const paddle::Tensor& value,
                      PyObject* args,
                      const std::map<ssize_t, ssize_t>& inplace_var_idx_map);
 PyObject* ToPyObject(PyObject* args, ssize_t arg_idx);
+PyObject* ToPyObject(
+    const paddle::Tensor& value,
+    PyObject* args,
+    PyObject* kwargs,
+    const std::map<ssize_t, ssize_t>& inplace_var_idx_map,
+    const std::map<ssize_t, std::vector<std::string>>& inplace_var_name_map);
+PyObject* ToPyObject(PyObject* args,
+                     PyObject* kwargs,
+                     ssize_t arg_idx,
+                     std::vector<std::string> arg_names);
 PyObject* ToPyObject(const std::vector<bool>& value);
 PyObject* ToPyObject(const std::vector<int>& value);
 PyObject* ToPyObject(const std::vector<int64_t>& value);

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -1602,18 +1602,18 @@ void CheckRemainingParamsValidity(PyObject* args,
                                   PyObject* kwargs,
                                   int remaining_kwargs,
                                   int nargs,
-                                  int inplace_map_size) {
+                                  bool is_inplace) {
   const std::string ignored_arg_name = "name";
   const std::string ignored_arg_out = "out";
   if (remaining_kwargs == 0) return;
   PyObject* name = PyDict_GetItemString(kwargs, ignored_arg_name.c_str());
   PyObject* out = PyDict_GetItemString(kwargs, ignored_arg_out.c_str());
   // inplace api with name remaining
-  if (inplace_map_size > 0 && remaining_kwargs == 1 && name) return;
+  if (is_inplace && remaining_kwargs == 1 && name) return;
   // non-inplace api with name or out remaining
-  if (inplace_map_size == 0 && remaining_kwargs == 1 && (name || out)) return;
+  if (!is_inplace && remaining_kwargs == 1 && (name || out)) return;
   // non-inplace api with both name and out remaining
-  if (inplace_map_size == 0 && remaining_kwargs == 2 && (name && out)) return;
+  if (!is_inplace && remaining_kwargs == 2 && (name && out)) return;
   // too many args
   PADDLE_THROW(common::errors::InvalidArgument("has too many arguments"));
   return;

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -1582,38 +1582,19 @@ PyObject* GetItemFromArgsOrKWArgs(PyObject* args,
 void CheckRemainingParamsValidity(PyObject* args,
                                   PyObject* kwargs,
                                   int remaining_kwargs,
-                                  int nargs) {
-  const std::string ignored_arg_name = "name";
-  const std::string ignored_arg_out = "out";
-  if (remaining_kwargs == 0) return;
-  PyObject* name = PyDict_GetItemString(kwargs, ignored_arg_name.c_str());
-  PyObject* out = PyDict_GetItemString(kwargs, ignored_arg_out.c_str());
-  if (remaining_kwargs == 1 && (name || out)) {
-    return;
-  } else if (remaining_kwargs == 2 && (name && out)) {
-    return;
-  } else {
-    PADDLE_THROW(common::errors::InvalidArgument("has too many arguments"));
-  }
-  return;
-}
-
-void CheckRemainingParamsValidity(PyObject* args,
-                                  PyObject* kwargs,
-                                  int remaining_kwargs,
                                   int nargs,
-                                  bool is_inplace) {
+                                  bool inplace) {
   const std::string ignored_arg_name = "name";
   const std::string ignored_arg_out = "out";
   if (remaining_kwargs == 0) return;
   PyObject* name = PyDict_GetItemString(kwargs, ignored_arg_name.c_str());
   PyObject* out = PyDict_GetItemString(kwargs, ignored_arg_out.c_str());
   // inplace api with name remaining
-  if (is_inplace && remaining_kwargs == 1 && name) return;
+  if (inplace && remaining_kwargs == 1 && name) return;
   // non-inplace api with name or out remaining
-  if (!is_inplace && remaining_kwargs == 1 && (name || out)) return;
+  if (!inplace && remaining_kwargs == 1 && (name || out)) return;
   // non-inplace api with both name and out remaining
-  if (!is_inplace && remaining_kwargs == 2 && (name && out)) return;
+  if (!inplace && remaining_kwargs == 2 && (name && out)) return;
   // too many args
   PADDLE_THROW(common::errors::InvalidArgument("has too many arguments"));
   return;

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -1597,4 +1597,25 @@ void CheckRemainingParamsValidity(PyObject* args,
   }
   return;
 }
+
+void CheckRemainingParamsValidity(PyObject* args,
+                                  PyObject* kwargs,
+                                  int remaining_kwargs,
+                                  int nargs,
+                                  int inplace_map_size) {
+  const std::string ignored_arg_name = "name";
+  const std::string ignored_arg_out = "out";
+  if (remaining_kwargs == 0) return;
+  PyObject* name = PyDict_GetItemString(kwargs, ignored_arg_name.c_str());
+  PyObject* out = PyDict_GetItemString(kwargs, ignored_arg_out.c_str());
+  // inplace api with name remaining
+  if (inplace_map_size > 0 && remaining_kwargs == 1 && name) return;
+  // non-inplace api with name or out remaining
+  if (inplace_map_size == 0 && remaining_kwargs == 1 && (name || out)) return;
+  // non-inplace api with both name and out remaining
+  if (inplace_map_size == 0 && remaining_kwargs == 2 && (name && out)) return;
+  // too many args
+  PADDLE_THROW(common::errors::InvalidArgument("has too many arguments"));
+  return;
+}
 }  // namespace paddle::pybind

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -1589,13 +1589,12 @@ void CheckRemainingParamsValidity(PyObject* args,
   if (remaining_kwargs == 0) return;
   PyObject* name = PyDict_GetItemString(kwargs, ignored_arg_name.c_str());
   PyObject* out = PyDict_GetItemString(kwargs, ignored_arg_out.c_str());
-  // inplace api with name remaining
-  if (inplace && remaining_kwargs == 1 && name) return;
-  // non-inplace api with name or out remaining
-  if (!inplace && remaining_kwargs == 1 && (name || out)) return;
-  // non-inplace api with both name and out remaining
-  if (!inplace && remaining_kwargs == 2 && (name && out)) return;
-  // too many args
+  if (inplace) {
+    if (remaining_kwargs == 1 && name) return;
+  } else {
+    if (remaining_kwargs == 1 && (name || out)) return;
+    if (remaining_kwargs == 2 && (name && out)) return;
+  }
   PADDLE_THROW(common::errors::InvalidArgument("has too many arguments"));
   return;
 }

--- a/paddle/fluid/pybind/op_function_common.h
+++ b/paddle/fluid/pybind/op_function_common.h
@@ -305,6 +305,12 @@ void CheckRemainingParamsValidity(PyObject* args,
                                   PyObject* kwargs,
                                   const int remaining_kwargs,
                                   const int nargs);
+void CheckRemainingParamsValidity(PyObject* args,
+                                  PyObject* kwargs,
+                                  const int remaining_kwargs,
+                                  const int nargs,
+                                  const int inplace_map_size);
+
 static inline void CheckParamsCount(const int nargs,
                                     const int remaining_kwargs,
                                     const int max_args) {

--- a/paddle/fluid/pybind/op_function_common.h
+++ b/paddle/fluid/pybind/op_function_common.h
@@ -304,12 +304,8 @@ PyObject* GetItemFromArgsOrKWArgs(PyObject* args,
 void CheckRemainingParamsValidity(PyObject* args,
                                   PyObject* kwargs,
                                   const int remaining_kwargs,
-                                  const int nargs);
-void CheckRemainingParamsValidity(PyObject* args,
-                                  PyObject* kwargs,
-                                  const int remaining_kwargs,
                                   const int nargs,
-                                  const bool is_inplace);
+                                  const bool inplace = false);
 
 static inline void CheckParamsCount(const int nargs,
                                     const int remaining_kwargs,

--- a/paddle/fluid/pybind/op_function_common.h
+++ b/paddle/fluid/pybind/op_function_common.h
@@ -309,7 +309,7 @@ void CheckRemainingParamsValidity(PyObject* args,
                                   PyObject* kwargs,
                                   const int remaining_kwargs,
                                   const int nargs,
-                                  const int inplace_map_size);
+                                  const bool is_inplace);
 
 static inline void CheckParamsCount(const int nargs,
                                     const int remaining_kwargs,

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -259,6 +259,11 @@
   args_alias:
     use_default_mapping : True
 
+- op : abs_
+  name : [paddle.abs_, paddle.Tensor.abs_]
+  args_alias:
+    use_default_mapping : True
+
 - op : index_put
   name : [paddle.index_put,paddle.Tensor.index_put]
   args_alias :

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -3113,6 +3113,15 @@ def abs(
 ) -> Tensor
 """,
 )
+add_doc_and_signature(
+    "abs_",
+    """
+    Inplace version of ``abs`` API, the output Tensor will be inplaced with input ``x``.
+""",
+    """
+def abs_(x: Tensor, name: str | None = None) -> Tensor
+""",
+)
 # lubingxin
 
 # chenhuangrun

--- a/python/paddle/tensor/ops.py
+++ b/python/paddle/tensor/ops.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 from paddle._C_ops import (  # noqa: F401
     abs,
+    abs_,
     acos,
     acosh,
     asin,
@@ -56,7 +57,6 @@ __inplace_unary_func__ = [
     'floor_',
     'reciprocal_',
     'sigmoid_',
-    'abs_',
     'sin_',
     'sinh_',
     'asin_',

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -97,6 +97,82 @@ class TestInplace(unittest.TestCase):
             loss.backward()
 
 
+class TestInplaceCompatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2026)
+        self.shape = [10, 20, 1]
+        self.dtype = "float32"
+        self.x_np = np.random.uniform(-5, 5, self.shape).astype(self.dtype)
+
+    def numpy_api_processing(self, var):
+        return np.abs(var)
+
+    def inplace_api(self):
+        return paddle.abs_
+
+    def test_inplace_compatibility_dygraph(self):
+        paddle.disable_static()
+        ref_out = self.numpy_api_processing(self.x_np)
+        x = paddle.to_tensor(self.x_np)
+        out1 = self.inplace_api()(x=x)
+        out2 = self.inplace_api()(input=x)
+        np.testing.assert_allclose(out1.numpy(), ref_out, rtol=1e-05)
+        np.testing.assert_allclose(out2.numpy(), ref_out, rtol=1e-05)
+
+    def test_inplace_compatibility_static(self):
+        paddle.enable_static()
+        ref_out = self.numpy_api_processing(self.x_np)
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.base.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
+            out1 = self.inplace_api()(x=x)
+            out2 = self.inplace_api()(input=x)
+            fetch_list = [out1, out2]
+            exe = paddle.base.Executor()
+            fetches = exe.run(
+                main,
+                feed={"x": self.x_np},
+                fetch_list=fetch_list,
+            )
+            np.testing.assert_allclose(fetches[0], ref_out, rtol=1e-05)
+            np.testing.assert_allclose(fetches[1], ref_out, rtol=1e-05)
+
+
+class TestStaticInplace(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2026)
+        self.shape = [10, 20, 1]
+        self.dtype = "float32"
+        self.x_np = np.random.uniform(-5, 5, self.shape).astype(self.dtype)
+
+    def numpy_api_processing(self, var):
+        return np.abs(var)
+
+    def inplace_api_processing(self, var):
+        return paddle.abs_(var)
+
+    def test_inplace_static(self):
+        paddle.enable_static()
+        ref_out = self.numpy_api_processing(self.x_np)
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.base.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
+            out = self.inplace_api_processing(x)
+            fetch_list = [out, x]
+            exe = paddle.base.Executor()
+            fetches = exe.run(
+                main,
+                feed={"x": self.x_np},
+                fetch_list=fetch_list,
+            )
+            # test inplace output value
+            np.testing.assert_allclose(fetches[0], ref_out, rtol=1e-05)
+            # test inplace behavior
+            np.testing.assert_allclose(fetches[1], fetches[0], rtol=1e-05)
+
+
 class TestDygraphInplace(unittest.TestCase):
     def setUp(self):
         self.init_data()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
<!-- Describe what you’ve done -->
1. **python_c_gen.py**: Add name parsing for args used for inplace. Add arg names and kwargs to `ToPyObject()` for single output inplace api.
2. **eager_utils.cc**: Add args for `ToPyObject`. Add kwargs parsing logic if there are too few args.
3. **eager_utils.h**: Add function declarations.

---

Related discussion: #76431

Attachments: 
[inplace API下沉报错的代码检查报告.md](https://github.com/user-attachments/files/24270448/inplace.API.md)
