### PR TITLE
Cherry pick of 76998,76999

### DIFF
--- a/cmake/external/warprnnt.cmake
+++ b/cmake/external/warprnnt.cmake
@@ -25,9 +25,16 @@ set(SOURCE_DIR ${PADDLE_SOURCE_DIR}/third_party/warprnnt)
 set(WARPRNNT_PATCH_COMMAND "")
 set(WARPRNNT_CCBIN_OPTION "")
 if(WIN32)
-  set(WARPCTC_PATCH_CUDA_COMMAND
-      git checkout -- . && git checkout ${WARPRNNT_TAG} && git apply
-      ${PADDLE_SOURCE_DIR}/patches/warprnnt/CMakeLists.txt.cuda.patch)
+  if(CUDA_VERSION VERSION_GREATER_EQUAL 13)
+    set(WARPCTC_PATCH_CUDA_COMMAND
+        git checkout -- . && git checkout ${WARPRNNT_TAG} && git apply
+        ${PADDLE_SOURCE_DIR}/patches/warprnnt/CMakeLists.txt.cuda130.patch)
+  else()
+    set(WARPCTC_PATCH_CUDA_COMMAND
+        ${CMAKE_COMMAND} -E copy_if_different
+        ${PADDLE_SOURCE_DIR}/patches/warprnnt/CMakeLists.txt.cuda.patch
+        "<SOURCE_DIR>/")
+  endif()
 else()
   set(WARPCTC_PATCH_CUDA_COMMAND
       git checkout -- . && git checkout ${WARPRNNT_TAG} && patch -Nd

--- a/paddle/fluid/distributed/collective/deep_ep/CMakeLists.txt
+++ b/paddle/fluid/distributed/collective/deep_ep/CMakeLists.txt
@@ -14,10 +14,17 @@ if(WITH_NVSHMEM)
       kernels/internode_ll_two_stage.cu
       kernels/internode_ll.cu
       kernels/m2n_ll_two_stage.cu)
-  cc_library(
-    deepep_kernels
-    SRCS ${DEEPEP_KERNEL_SRCS}
-    DEPS nvshmem cudadevrt onednn)
+  if(WITH_ONEDNN)
+    cc_library(
+      deepep_kernels
+      SRCS ${DEEPEP_KERNEL_SRCS}
+      DEPS nvshmem cudadevrt onednn)
+  else()
+    cc_library(
+      deepep_kernels
+      SRCS ${DEEPEP_KERNEL_SRCS}
+      DEPS nvshmem cudadevrt)
+  endif()
 
   set_target_properties(deepep_kernels PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
   set_target_properties(deepep_kernels PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS

--- a/patches/warprnnt/CMakeLists.txt.cuda130.patch
+++ b/patches/warprnnt/CMakeLists.txt.cuda130.patch
@@ -1,0 +1,35 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e961d02..b58c46e 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -71,30 +71,6 @@ if (WITH_OMP)
+     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -fopenmp")
+ endif()
+ 
+-
+-# need to be at least 30 or __shfl_down in reduce wont compile
+-IF (CUDA_VERSION VERSION_LESS "11.0")
+-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_30,code=sm_30")
+-ENDIF()
+-
+-# sm35 is deprecated after cuda 12.0
+-IF (CUDA_VERSION VERSION_LESS "12.0")
+-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_35,code=sm_35")
+-ENDIF()
+-
+-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_50,code=sm_50")
+-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_52,code=sm_52")
+-
+-IF (CUDA_VERSION VERSION_GREATER "7.6")
+-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_60,code=sm_60")
+-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_61,code=sm_61")
+-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_62,code=sm_62")
+-ENDIF()
+-
+-IF ((CUDA_VERSION VERSION_GREATER "9.0") OR (CUDA_VERSION VERSION_EQUAL "9.0"))
+-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_70,code=sm_70")
+-ENDIF()
+-
+ IF ((CUDA_VERSION VERSION_GREATER "10.0") OR (CUDA_VERSION VERSION_EQUAL "10.0"))
+     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_75,code=sm_75")
+ ENDIF()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Cherry pick of 76998,76999
修改deepep按情况依赖onednn，这个是之前解决CI的deepep编译问题引入的onednn依赖，但是在fleet12的编译参数下有问题编不过，改为按是否编译onednn来添加依赖 