### PR TITLE
[PIR] Remove unnecessary `#pragma once` in cc file

### DIFF
--- a/paddle/fluid/pybind/native_meta_tensor.cc
+++ b/paddle/fluid/pybind/native_meta_tensor.cc
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
-
 #include "paddle/phi/api/ext/native_meta_tensor.h"
 #include "paddle/fluid/pybind/native_meta_tensor.h"
 #include "paddle/utils/pybind.h"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
cc文件不使用#pragma once
