### PR TITLE
[SOT][3.13] Trim trailing `TO_BOOL` when graph size fallback and dont breakgraph when `POP_JUMP_IF_NONE`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -400,6 +400,8 @@ class FunctionGraph:
         ]
         for seq in need_trim_opcode_sequences:
             seq_len = len(seq)
+            if len(restore_instr_names) < seq_len:
+                continue
             if restore_instr_names[-seq_len:] == seq:
                 restore_instrs = restore_instrs[:-seq_len]
                 restore_instr_names = restore_instr_names[:-seq_len]

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -393,10 +393,16 @@ class FunctionGraph:
         restore_instr_names = [
             instr.opname for instr in restore_instrs[:current_idx]
         ]
-        # NOTE(SigureMo): Trailing KW_NAMES is no need to restore in Python 3.11+
-        if restore_instr_names[-1:] == ["KW_NAMES"]:
-            restore_instrs = restore_instrs[:-1]
-            restore_instr_names = restore_instr_names[:-1]
+        # NOTE(SigureMo): Some trailing instructions are no need to restore
+        need_trim_opcode_sequences = [
+            ["KW_NAMES"],  # Python 3.11
+            ["TO_BOOL"],  # Python 3.13+
+        ]
+        for seq in need_trim_opcode_sequences:
+            seq_len = len(seq)
+            if restore_instr_names[-seq_len:] == seq:
+                restore_instrs = restore_instrs[:-seq_len]
+                restore_instr_names = restore_instr_names[:-seq_len]
 
         self.pycode_gen.extend_instrs(restore_instrs)
         nop = self.pycode_gen.add_instr("NOP")

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -400,7 +400,7 @@ class FunctionGraph:
         ]
         for seq in need_trim_opcode_sequences:
             seq_len = len(seq)
-            if len(restore_instr_names) < seq_len:
+            if len(restore_instrs) < seq_len:
                 continue
             if restore_instr_names[-seq_len:] == seq:
                 restore_instrs = restore_instrs[:-seq_len]

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -212,8 +212,12 @@ def pop_jump_if_op_wrapper(fns: list[Callable[[Any], Any]]):
 
     """
 
-    @if_break_graph_decorator
-    def inner(self: OpcodeExecutorBase, instr: Instruction):
+    @if_break_graph_decorator(fns)
+    def inner(
+        self: OpcodeExecutorBase,
+        instr: Instruction,
+        prepared_jump_condition: VariableBase,
+    ):
         """
         Inner function that represents the wrapped POP_JUMP_IF opcode operation.
 
@@ -222,19 +226,18 @@ def pop_jump_if_op_wrapper(fns: list[Callable[[Any], Any]]):
             instr: The instruction to be executed.
 
         """
-        pred_obj = self.stack.pop()
+        tos = self.stack.pop()
 
         try:
-            self._graph.add_global_guarded_variable(pred_obj)
-            res = pred_obj
-            for fn in fns:
-                res = BuiltinVariable(
-                    fn, graph=self._graph, tracker=DanglingTracker()
-                )(res)
+            self._graph.add_global_guarded_variable(tos)
 
-            assert isinstance(res, (ConstantVariable, SymbolicVariable))
-            if isinstance(res, SymbolicVariable):
-                constraint_node, symbolic_vars = res.create_constraint_tree()
+            assert isinstance(
+                prepared_jump_condition, (ConstantVariable, SymbolicVariable)
+            )
+            if isinstance(prepared_jump_condition, SymbolicVariable):
+                constraint_node, symbolic_vars = (
+                    prepared_jump_condition.create_constraint_tree()
+                )
                 if not all(
                     var.value.is_backed() for var in symbolic_vars.values()
                 ):
@@ -243,49 +246,70 @@ def pop_jump_if_op_wrapper(fns: list[Callable[[Any], Any]]):
                             f"Symbolic variable {symbolic_vars} is not backed."
                         )
                     )
-                is_jump = res.get_example_value()
+                is_jump = prepared_jump_condition.get_example_value()
                 if not is_jump:
                     constraint_node = LogicalNotConstraintNode(constraint_node)
                 for var in symbolic_vars.values():
                     var.add_constraint((constraint_node, symbolic_vars))
             else:
-                is_jump = res.get_py_value()
+                is_jump = prepared_jump_condition.get_py_value()
             assert isinstance(is_jump, bool)
             if is_jump:
                 assert instr.jump_to is not None
                 self.jump_to(instr.jump_to)
         except BreakGraphError:
             raise FallbackError(
-                f"Currently don't support predicate {pred_obj.__class__.__name__}"
+                f"Currently don't support predicate {tos.__class__.__name__}"
             )
 
     return inner
 
 
-def if_break_graph_decorator(normal_jump: Callable):
-    """
-    A decorator function that breaks off the graph when a JUMP-related instruction is encountered.
+def if_break_graph_decorator(prepare_jump: list[Callable[[Any], Any]]):
+    def decorator(normal_jump: Callable):
+        """
+        A decorator function that breaks off the graph when a JUMP-related instruction is encountered.
 
-    Args:
-        normal_jump: The normal jump operation.
+        Args:
+            normal_jump: The normal jump operation.
 
-    Returns:
-        The wrapped jump operation.
+        Returns:
+            The wrapped jump operation.
 
-    """
+        """
 
-    def inner(self: OpcodeExecutor, instr: Instruction):
-        result = self.stack.top
-        if isinstance(result, (TensorVariable, NumPyArrayVariable)):
-            # fallback when in OpcodeExecutor
-            # raise error in OpcodeInlineExecutor
-            log(3, "[BreakGraph] break graph for if jump tensor\n")
-            self._break_graph_when_if(result, instr)
-            return Stop(state="BreakGraph")
-        else:
-            return normal_jump(self, instr)
+        def inner(self: OpcodeExecutor, instr: Instruction):
+            tos = self.stack.top
+            jump_condition = tos
+            need_break_graph = False
 
-    return inner
+            # Prepare jump condition
+            try:
+                for fn in prepare_jump:
+                    jump_condition = BuiltinVariable(
+                        fn, graph=self._graph, tracker=DanglingTracker()
+                    )(jump_condition)
+            except BreakGraphError:
+                need_break_graph = True
+
+            need_break_graph = need_break_graph or isinstance(
+                jump_condition, (TensorVariable, NumPyArrayVariable)
+            )
+
+            if need_break_graph:
+                log(3, "[BreakGraph] break graph for if jump tensor\n")
+                if self.vframe.code in NO_BREAKGRAPH_CODES:
+                    raise InnerError(
+                        f"{self.vframe.code.co_name} should not break graph, but got a jump on tensor '{tos}'"
+                    )
+                self._break_graph_when_if(tos, instr)
+                return Stop(state="BreakGraph")
+            else:
+                return normal_jump(self, instr, jump_condition)
+
+        return inner
+
+    return decorator
 
 
 def call_break_graph_decorator(push_n: int | Callable[[int | None], int]):
@@ -1710,8 +1734,10 @@ class OpcodeExecutorBase:
             )(left, right)
         )
 
-    @if_break_graph_decorator
-    def JUMP_IF_FALSE_OR_POP(self, instr: Instruction):
+    @if_break_graph_decorator([])
+    def JUMP_IF_FALSE_OR_POP(
+        self, instr: Instruction, prepared_jump_condition: VariableBase
+    ):
         pred_obj = self.stack.top
         if isinstance(pred_obj, (ConstantVariable, ContainerVariable)):
             self._graph.add_global_guarded_variable(pred_obj)
@@ -1726,8 +1752,10 @@ class OpcodeExecutorBase:
             "Currently don't support predicate a non-const / non-tensor obj."
         )
 
-    @if_break_graph_decorator
-    def JUMP_IF_TRUE_OR_POP(self, instr: Instruction):
+    @if_break_graph_decorator([])
+    def JUMP_IF_TRUE_OR_POP(
+        self, instr: Instruction, prepared_jump_condition: VariableBase
+    ):
         pred_obj = self.stack.top
         if isinstance(pred_obj, (ConstantVariable, ContainerVariable)):
             self._graph.add_global_guarded_variable(pred_obj)

--- a/test/sot/test_11_jumps.py
+++ b/test/sot/test_11_jumps.py
@@ -22,7 +22,6 @@ import paddle
 from paddle.jit.sot.psdb import check_no_breakgraph
 
 
-@check_no_breakgraph
 def pop_jump_if_false(x: bool, y: paddle.Tensor):
     if x:
         y += 1
@@ -31,22 +30,18 @@ def pop_jump_if_false(x: bool, y: paddle.Tensor):
     return y
 
 
-@check_no_breakgraph
 def pop_jump_if_true(x: bool, y: bool, z: paddle.Tensor):
     return (x or y) and z
 
 
-@check_no_breakgraph
 def jump_if_false_or_pop(x: bool, y: paddle.Tensor):
     return x and (y + 1)
 
 
-@check_no_breakgraph
 def jump_if_true_or_pop(x: bool, y: paddle.Tensor):
     return x or (y + 1)
 
 
-@check_no_breakgraph
 def jump_absolute(x: int, y: paddle.Tensor):
     while x > 0:
         y += 1

--- a/test/sot/test_24_exceptions.py
+++ b/test/sot/test_24_exceptions.py
@@ -901,33 +901,33 @@ class TestAssertException(TestCaseBase):
             self.try_assert, paddle.to_tensor(10), paddle.to_tensor(-1)
         )
 
-    @strict_mode_guard(False)
+    @strict_mode_guard(NOT_ALLOW_FALLBACK)
     def test_assert_true(self):
         @check_no_breakgraph
-        def try_assert_except(x):
+        def try_assert_except(x, y):
             x += 1
             try:
                 x += 2
-                assert x > -10000
+                assert y > -10000
                 x += 3
             except:
                 x += 4
 
-        self.assert_results(try_assert_except, paddle.to_tensor(10))
+        self.assert_results(try_assert_except, paddle.to_tensor(10), 10)
 
-    @strict_mode_guard(False)
+    @strict_mode_guard(NOT_ALLOW_FALLBACK)
     def test_assert_false(self):
         @check_no_breakgraph
-        def try_assert_except(x):
+        def try_assert_except(x, y):
             try:
                 x += 5
-                assert x < -10000
+                assert y < -10000
             except AssertionError:
                 x += 6
 
             return x
 
-        self.assert_results(try_assert_except, paddle.to_tensor(10))
+        self.assert_results(try_assert_except, paddle.to_tensor(10), 10)
 
 
 class TestGuard(TestCaseBase):

--- a/test/sot/test_case_base.py
+++ b/test/sot/test_case_base.py
@@ -37,35 +37,41 @@ def test_instruction_translator_cache_context():
 
 
 class TestCaseBase(unittest.TestCase):
-    def assert_nest_match(self, x, y):
-        cls_x = type(x)
-        cls_y = type(y)
-        msg = f"type mismatch, x is {cls_x}, y is {cls_y}"
-        self.assertIs(cls_x, cls_y, msg=msg)
+    def assert_nest_match(self, actual, expected):
+        cls_actual = type(actual)
+        cls_expected = type(expected)
+        msg = (
+            f"type mismatch, actual is {cls_actual}, expected is {cls_expected}"
+        )
+        self.assertIs(cls_actual, cls_expected, msg=msg)
 
         container_types = (tuple, list, dict, set)
-        if cls_x in container_types:
-            msg = f"length mismatch, x is {len(x)}, y is {len(y)}"
+        if cls_actual in container_types:
+            msg = f"length mismatch, actual is {len(actual)}, expected is {len(expected)}"
             self.assertEqual(
-                len(x),
-                len(y),
+                len(actual),
+                len(expected),
                 msg=msg,
             )
-            if cls_x in (tuple, list):
-                for x_item, y_item in zip(x, y):
-                    self.assert_nest_match(x_item, y_item)
-            elif cls_x is dict:
-                for x_key, y_key in zip(x.keys(), y.keys()):
-                    self.assert_nest_match(x_key, y_key)
-                    self.assert_nest_match(x[x_key], y[y_key])
-            elif cls_x is set:
+            if cls_actual in (tuple, list):
+                for actual_item, expected_item in zip(actual, expected):
+                    self.assert_nest_match(actual_item, expected_item)
+            elif cls_actual is dict:
+                for actual_key, expected_key in zip(
+                    actual.keys(), expected.keys()
+                ):
+                    self.assert_nest_match(actual_key, expected_key)
+                    self.assert_nest_match(
+                        actual[actual_key], expected[expected_key]
+                    )
+            elif cls_actual is set:
                 # TODO: Nested set is not supported yet
-                self.assertEqual(x, y)
-        elif cls_x in (np.ndarray, paddle.Tensor):
+                self.assertEqual(actual, expected)
+        elif cls_actual in (np.ndarray, paddle.Tensor):
             # TODO: support assert_allclose github error log
-            np.testing.assert_allclose(x, y, rtol=1e-6, atol=1e-8)
+            np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-8)
         else:
-            self.assertEqual(x, y)
+            self.assertEqual(actual, expected)
 
     def assert_results(self, func, *args, **kwargs):
         sym_output = symbolic_translate(func)(*args, **kwargs)

--- a/test/sot/test_min_graph_size.py
+++ b/test/sot/test_min_graph_size.py
@@ -93,6 +93,10 @@ def restore_same_arg_when_fallback(x):
     return add_with_breakgraph(x, x)
 
 
+def trim_trailing_to_bool(x, y):
+    return x and y
+
+
 class TestMinGraphSize(TestCaseBase):
     @strict_mode_guard(False)
     @min_graph_size_guard(10)
@@ -130,6 +134,12 @@ class TestMinGraphSize(TestCaseBase):
     def test_restore_same_arg_when_fallback(self):
         x = paddle.to_tensor(1)
         self.assert_results(restore_same_arg_when_fallback, x)
+
+    @min_graph_size_guard(10)
+    def test_trim_trailing_to_bool(self):
+        x = paddle.to_tensor(False)
+        y = paddle.to_tensor(False)
+        self.assert_results(trim_trailing_to_bool, x, y)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

1. 修复 3.13+ 新增的 `TO_BOOL` 在 restore original code（graph size < MIN_GRAPH_SIZE 时的 fallback）应当删掉，与 3.11 的 `KW_NAMES` 相同
2. 3.11+ 的 `POP_JUMP_*IF_*NONE` 会提前判断是否是 Tensor，进而导致打断，本 PR 提前 apply prepare fn 后再判断是否是 Tensor，`tensor is None` 明显是个常量，不应该打断
3. 之前 `check_no_breakgraph`，并没考虑 jump breakgraph，因此修复了下，部分单测本来就应该打断的已经移除装饰器，`POP_JUMP_IF_NONE` 的 case 则确保没有打断

<!-- PCard-66972 -->