### PR TITLE
[API] Explicitly convert NumPy array to scalar on non-0d Tensor

### DIFF
--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -260,7 +260,7 @@ def monkey_patch_math_tensor():
             or var.dtype == core.DataType.BFLOAT16
         ):
             var = var.astype('float32')
-        return int(np.array(var))
+        return int(np.array(var).item())
 
     def _int_(var: Tensor) -> int:
         numel = np.prod(var.shape)
@@ -271,7 +271,7 @@ def monkey_patch_math_tensor():
             or var.dtype == core.DataType.BFLOAT16
         ):
             var = var.astype('float32')
-        return int(np.array(var))
+        return int(np.array(var).item())
 
     def _len_(var: Tensor) -> int:
         assert var.ndim > 0, "len() of a 0-D tensor is wrong"
@@ -293,7 +293,7 @@ def monkey_patch_math_tensor():
             or var.dtype == core.DataType.BFLOAT16
         ):
             var = var.astype('float32')
-        return int(np.array(var))
+        return int(np.array(var).item())
 
     @property
     def _ndim(var: Tensor) -> int:

--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -236,7 +236,7 @@ def monkey_patch_math_tensor():
         assert var._is_initialized(), "variable's tensor is not initialized"
         if not var.is_complex():
             var = var.astype('complex64')
-        return complex(np.array(var))
+        return complex(np.array(var).item())
 
     def _float_(var: Tensor) -> float:
         numel = np.prod(var.shape)
@@ -249,7 +249,7 @@ def monkey_patch_math_tensor():
             or var.dtype == core.DataType.BFLOAT16
         ):
             var = var.astype('float32')
-        return float(np.array(var))
+        return float(np.array(var).item())
 
     def _long_(var: Tensor) -> int:
         numel = np.prod(var.shape)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

NumPy 1.25 弃用并在 2.4 移除了对于非 0D array 的隐式转换为 scalar 的操作[^1]：

```pycon
>>> import numpy as np
>>> int(np.array([1]))  # 1D，报错
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    int(np.array([1]))
    ~~~^^^^^^^^^^^^^^^
TypeError: only 0-dimensional arrays can be converted to Python scalars
>>> int(np.array(1))  # 0D，不会报错
1
```

而我们 Tensor 的 `__int__`、`__long__`、`__float__`、`__index__`、`__complex__` 都用了这种隐式行为，因此会报错

由于 SOT Python 3.14 依赖最新版的 NumPy（2.4），因此触发了该报错，CI 挂掉了

[^1]: https://github.com/numpy/numpy/releases/tag/v2.4.0

<!-- PCard-66972 -->