### PR TITLE
[API Compatibility] fix attention mask broadcasting for memory-efficient attention and support 3d attn_mask for mea and math

### DIFF
--- a/python/paddle/nn/functional/sdpa.py
+++ b/python/paddle/nn/functional/sdpa.py
@@ -632,15 +632,14 @@ def scaled_dot_product_attention(
         if is_causal:
             attn_mask = LowerTriangularMask()
         elif attn_mask is not None:
-            # memory_efficient_attention does not support broadcast num_heads dim when batch_size dim is not 1
-            if (
-                attn_mask.dim() == 4
-                and attn_mask.shape[0] != 1
-                and attn_mask.shape[1] != num_heads_q
+            # if need broadcast, memory_efficient_attention requires to
+            # broadcast first two dim simultaneously
+            if attn_mask.dim() == 4 and (
+                attn_mask.shape[0] != bs ^ attn_mask.shape[1] != num_heads_q
             ):
                 attn_mask = attn_mask.expand(
                     [
-                        attn_mask.shape[0],
+                        bs,
                         num_heads_q,
                         attn_mask.shape[2],
                         attn_mask.shape[3],

--- a/python/paddle/nn/functional/sdpa.py
+++ b/python/paddle/nn/functional/sdpa.py
@@ -634,6 +634,8 @@ def scaled_dot_product_attention(
         elif attn_mask is not None:
             # if need broadcast, memory_efficient_attention requires to
             # broadcast first two dim simultaneously
+            if attn_mask.dim() == 3:
+                attn_mask = attn_mask.unsqueeze(axis=1)
             if attn_mask.dim() == 4 and (
                 attn_mask.shape[0] != bs ^ attn_mask.shape[1] != num_heads_q
             ):
@@ -658,6 +660,8 @@ def scaled_dot_product_attention(
     elif sdp_func_name == "math":
         repeats = q_heads // k_heads if k_heads != 0 else 1
         key, value = _repeat_kv(key, value, repeats)
+        if attn_mask is not None and attn_mask.dim() == 3:
+            attn_mask = attn_mask.unsqueeze(axis=1)
         out = _math_attention(
             query,
             key,

--- a/test/legacy_test/test_scaled_dot_product_attention.py
+++ b/test/legacy_test/test_scaled_dot_product_attention.py
@@ -901,6 +901,10 @@ class TestFlashAttnMaskLogic(unittest.TestCase):
         self._run_test_with_mask_shape(mask_shape)
 
 
+@unittest.skipIf(
+    paddle.device.is_compiled_with_xpu(),
+    "SDPA on XPU force select FA backend, skip math broadcast test.",
+)
 class TestMathAttnMaskBroadcasting(unittest.TestCase):
     """
     Test case specifically for validating mask broadcasting logic in math_attention.

--- a/test/legacy_test/test_scaled_dot_product_attention.py
+++ b/test/legacy_test/test_scaled_dot_product_attention.py
@@ -616,6 +616,50 @@ class TestMemEffAttnMaskBroadcasting(unittest.TestCase):
             q.grad.numpy(), q_ref.grad.numpy(), rtol=5e-3, atol=1e-3
         )
 
+    def test_broadcast_mask_head_match_batch_broadcast(self):
+        paddle.disable_static()
+
+        query = np.random.random(self.q_shape).astype(self.dtype)
+        key = np.random.random(self.q_shape).astype(self.dtype)
+        value = np.random.random(self.q_shape).astype(self.dtype)
+        mask = np.random.random(
+            [1, self.num_heads, self.seq_len, self.seq_len]
+        ).astype(self.dtype)
+
+        q = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        q_ref = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k_ref = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v_ref = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m_ref = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        with sdp_kernel(
+            enable_math=False, enable_flash=False, enable_mem_efficient=True
+        ):
+            out = scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=m,
+                dropout_p=self.dropout,
+                is_causal=self.causal,
+            )
+
+        out_ref = attention_naive_with_mask(q_ref, k_ref, v_ref, m_ref)
+
+        np.testing.assert_allclose(
+            out.numpy(), out_ref.numpy(), rtol=5e-3, atol=1e-3
+        )
+
+        out.backward()
+        out_ref.backward()
+        np.testing.assert_allclose(
+            q.grad.numpy(), q_ref.grad.numpy(), rtol=5e-3, atol=1e-3
+        )
+
     def test_broadcast_mask_double_broadcast(self):
         """
         Test extreme case: [1, 1, S, S] -> [B, H, S, S]

--- a/test/legacy_test/test_scaled_dot_product_attention.py
+++ b/test/legacy_test/test_scaled_dot_product_attention.py
@@ -47,6 +47,8 @@ def attention_naive(q, k, v, causal=False):
 
 
 def attention_naive_with_mask(q, k, v, attn_bias):
+    if attn_bias is not None and attn_bias.dim() == 3:
+        attn_bias = paddle.unsqueeze(attn_bias, axis=1)
     qt = paddle.transpose(q, [0, 2, 1, 3])
     kt = paddle.transpose(k, [0, 2, 1, 3])
     vt = paddle.transpose(v, [0, 2, 1, 3])
@@ -687,6 +689,103 @@ class TestMemEffAttnMaskBroadcasting(unittest.TestCase):
             )
         self.assertEqual(out.shape, list(self.q_shape))
 
+    def _run_test_with_shape(self, mask_shape, case_name):
+        """
+        Helper function to run test with a specific mask shape.
+        Handles data creation, running both MEA and Naive implementations, and validation.
+        """
+        paddle.disable_static()
+
+        # 1. Prepare Inputs
+        query = np.random.random(self.q_shape).astype(self.dtype)
+        key = np.random.random(self.q_shape).astype(self.dtype)
+        value = np.random.random(self.q_shape).astype(self.dtype)
+        mask = np.random.random(mask_shape).astype(self.dtype)
+
+        q = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        q_ref = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k_ref = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v_ref = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m_ref = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        # 2. Run Memory Efficient Attention (Target)
+        with sdp_kernel(
+            enable_math=False, enable_flash=False, enable_mem_efficient=True
+        ):
+            out = scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=m,
+                is_causal=self.causal,
+            )
+
+        # 3. Run Naive Math (Reference)
+        # Note: Standard broadcasting rules apply for the reference implementation
+        # 2D [S, S] broadcasts to [B, H, S, S]
+        # 3D [B, S, S] broadcasts to [B, H, S, S]
+        out_ref = attention_naive_with_mask(q_ref, k_ref, v_ref, m_ref)
+
+        # 4. Validation
+        np.testing.assert_allclose(
+            out.numpy(),
+            out_ref.numpy(),
+            rtol=5e-3,
+            atol=1e-3,
+            err_msg=f"Output mismatch in case: {case_name}",
+        )
+
+        out.backward()
+        out_ref.backward()
+        np.testing.assert_allclose(
+            q.grad.numpy(),
+            q_ref.grad.numpy(),
+            rtol=5e-3,
+            atol=1e-3,
+            err_msg=f"Gradient mismatch in case: {case_name}",
+        )
+
+    def test_2d_mask(self):
+        """
+        Case: 2D Mask [Seq, Seq]
+        Expectation: Automatically broadcasts to [B, H, Seq, Seq]
+        """
+        mask_shape = (self.seq_len, self.seq_len)
+        self._run_test_with_shape(mask_shape, "test_2d_mask")
+
+    def test_3d_mask_batch_match(self):
+        """
+        Case: 3D Mask [B, Seq, Seq] where B > 1 matches Query
+        Expectation: Broadcasts to [B, H, Seq, Seq]
+        """
+        mask_shape = (self.batch_size, self.seq_len, self.seq_len)
+        self._run_test_with_shape(mask_shape, "test_3d_mask_batch_match")
+
+    def test_3d_mask_batch_broadcast(self):
+        """
+        Case: 3D Mask [1, Seq, Seq]
+        Expectation: Broadcasts to [B, H, Seq, Seq]
+        """
+        mask_shape = (1, self.seq_len, self.seq_len)
+        self._run_test_with_shape(mask_shape, "test_3d_mask_batch_broadcast")
+
+    def test_4d_mask_full_match(self):
+        """
+        Case: 4D Mask [B, H, Seq, Seq] (Full Match)
+        Expectation: Works natively without broadcasting
+        """
+        mask_shape = (
+            self.batch_size,
+            self.num_heads,
+            self.seq_len,
+            self.seq_len,
+        )
+        self._run_test_with_shape(mask_shape, "test_4d_mask_full_match")
+
 
 @unittest.skipIf(
     not fa_available,
@@ -800,6 +899,254 @@ class TestFlashAttnMaskLogic(unittest.TestCase):
         # Shape: [Batch, Seq, Seq]
         mask_shape = (self.batch_size, self.seq_len, self.seq_len)
         self._run_test_with_mask_shape(mask_shape)
+
+
+class TestMathAttnMaskBroadcasting(unittest.TestCase):
+    """
+    Test case specifically for validating mask broadcasting logic in math_attention.
+    Target issue: Fix crash when mask shape is [B, 1, S, S] and Query is [B, H, S, D] where B > 1.
+    """
+
+    def setUp(self):
+        self.place = get_device_place()
+        self.dtype = 'float32'
+        self.dropout = 0.0
+        self.causal = False
+
+        # Key configuration to trigger the bug:
+        # 1. Batch Size > 1
+        # 2. Query Heads > 1
+        # 3. Mask Heads == 1 (Requires broadcast)
+        self.batch_size = 3
+        self.seq_len = 8
+        self.num_heads = 4
+        self.head_dim = 16
+
+        self.q_shape = (
+            self.batch_size,
+            self.seq_len,
+            self.num_heads,
+            self.head_dim,
+        )
+        # Mask shape: [Batch, 1, Seq, Seq]
+        # This matches Query on Batch (3==3), but mismatch on Heads (1!=4)
+        self.mask_shape = (self.batch_size, 1, self.seq_len, self.seq_len)
+
+    def test_broadcast_mask_batch_match_head_broadcast(self):
+        paddle.disable_static()
+
+        # Create Inputs
+        query = np.random.random(self.q_shape).astype(self.dtype)
+        key = np.random.random(self.q_shape).astype(self.dtype)
+        value = np.random.random(self.q_shape).astype(self.dtype)
+        mask = np.random.random(self.mask_shape).astype(self.dtype)
+
+        q = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        # Create Reference Inputs (Clone)
+        q_ref = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k_ref = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v_ref = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m_ref = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        with sdp_kernel(
+            enable_math=True, enable_flash=False, enable_mem_efficient=False
+        ):
+            out = scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=m,
+                dropout_p=self.dropout,
+                is_causal=self.causal,
+            )
+
+        # 2. Run with Naive Math Implementation (Reference)
+        # Using the helper function defined in your file
+        out_ref = attention_naive_with_mask(q_ref, k_ref, v_ref, m_ref)
+
+        # 3. Validation
+        # Check Output values
+        np.testing.assert_allclose(
+            out.numpy(), out_ref.numpy(), rtol=5e-3, atol=1e-3
+        )
+
+        # Check Gradients (Optional but good practice)
+        out.backward()
+        out_ref.backward()
+        np.testing.assert_allclose(
+            q.grad.numpy(), q_ref.grad.numpy(), rtol=5e-3, atol=1e-3
+        )
+
+    def test_broadcast_mask_head_match_batch_broadcast(self):
+        paddle.disable_static()
+
+        query = np.random.random(self.q_shape).astype(self.dtype)
+        key = np.random.random(self.q_shape).astype(self.dtype)
+        value = np.random.random(self.q_shape).astype(self.dtype)
+        mask = np.random.random(
+            [1, self.num_heads, self.seq_len, self.seq_len]
+        ).astype(self.dtype)
+
+        q = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        q_ref = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k_ref = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v_ref = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m_ref = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        with sdp_kernel(
+            enable_math=True, enable_flash=False, enable_mem_efficient=False
+        ):
+            out = scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=m,
+                dropout_p=self.dropout,
+                is_causal=self.causal,
+            )
+
+        out_ref = attention_naive_with_mask(q_ref, k_ref, v_ref, m_ref)
+
+        np.testing.assert_allclose(
+            out.numpy(), out_ref.numpy(), rtol=5e-3, atol=1e-3
+        )
+
+        out.backward()
+        out_ref.backward()
+        np.testing.assert_allclose(
+            q.grad.numpy(), q_ref.grad.numpy(), rtol=5e-3, atol=1e-3
+        )
+
+    def test_broadcast_mask_double_broadcast(self):
+        """
+        Test extreme case: [1, 1, S, S] -> [B, H, S, S]
+        This was technically supported before, but good to regression test.
+        """
+        paddle.disable_static()
+
+        # Mask shape: [1, 1, Seq, Seq]
+        broadcast_mask_shape = (1, 1, self.seq_len, self.seq_len)
+
+        query = np.random.random(self.q_shape).astype(self.dtype)
+        mask = np.random.random(broadcast_mask_shape).astype(self.dtype)
+
+        q = paddle.to_tensor(query, place=self.place)
+        k = paddle.to_tensor(query, place=self.place)  # shared for simplicity
+        v = paddle.to_tensor(query, place=self.place)
+        m = paddle.to_tensor(mask, place=self.place)
+
+        # Should pass without error
+        with sdp_kernel(
+            enable_math=True, enable_flash=False, enable_mem_efficient=False
+        ):
+            out = scaled_dot_product_attention(
+                q, k, v, attn_mask=m, dropout_p=self.dropout
+            )
+        self.assertEqual(out.shape, list(self.q_shape))
+
+    def _run_test_with_shape(self, mask_shape, case_name):
+        """
+        Helper function to run test with a specific mask shape.
+        Handles data creation, running both MEA and Naive implementations, and validation.
+        """
+        paddle.disable_static()
+
+        # 1. Prepare Inputs
+        query = np.random.random(self.q_shape).astype(self.dtype)
+        key = np.random.random(self.q_shape).astype(self.dtype)
+        value = np.random.random(self.q_shape).astype(self.dtype)
+        mask = np.random.random(mask_shape).astype(self.dtype)
+
+        q = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        q_ref = paddle.to_tensor(query, place=self.place, stop_gradient=False)
+        k_ref = paddle.to_tensor(key, place=self.place, stop_gradient=False)
+        v_ref = paddle.to_tensor(value, place=self.place, stop_gradient=False)
+        m_ref = paddle.to_tensor(mask, place=self.place, stop_gradient=False)
+
+        with sdp_kernel(
+            enable_math=True, enable_flash=False, enable_mem_efficient=False
+        ):
+            out = scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=m,
+                is_causal=self.causal,
+            )
+
+        # 3. Run Naive Math (Reference)
+        # Note: Standard broadcasting rules apply for the reference implementation
+        # 2D [S, S] broadcasts to [B, H, S, S]
+        # 3D [B, S, S] broadcasts to [B, H, S, S]
+        out_ref = attention_naive_with_mask(q_ref, k_ref, v_ref, m_ref)
+
+        # 4. Validation
+        np.testing.assert_allclose(
+            out.numpy(),
+            out_ref.numpy(),
+            rtol=5e-3,
+            atol=1e-3,
+            err_msg=f"Output mismatch in case: {case_name}",
+        )
+
+        out.backward()
+        out_ref.backward()
+        np.testing.assert_allclose(
+            q.grad.numpy(),
+            q_ref.grad.numpy(),
+            rtol=5e-3,
+            atol=1e-3,
+            err_msg=f"Gradient mismatch in case: {case_name}",
+        )
+
+    def test_2d_mask(self):
+        """
+        Case: 2D Mask [Seq, Seq]
+        Expectation: Automatically broadcasts to [B, H, Seq, Seq]
+        """
+        mask_shape = (self.seq_len, self.seq_len)
+        self._run_test_with_shape(mask_shape, "test_2d_mask")
+
+    def test_3d_mask_batch_match(self):
+        """
+        Case: 3D Mask [B, Seq, Seq] where B > 1 matches Query
+        Expectation: Broadcasts to [B, H, Seq, Seq]
+        """
+        mask_shape = (self.batch_size, self.seq_len, self.seq_len)
+        self._run_test_with_shape(mask_shape, "test_3d_mask_batch_match")
+
+    def test_3d_mask_batch_broadcast(self):
+        """
+        Case: 3D Mask [1, Seq, Seq]
+        Expectation: Broadcasts to [B, H, Seq, Seq]
+        """
+        mask_shape = (1, self.seq_len, self.seq_len)
+        self._run_test_with_shape(mask_shape, "test_3d_mask_batch_broadcast")
+
+    def test_4d_mask_full_match(self):
+        """
+        Case: 4D Mask [B, H, Seq, Seq] (Full Match)
+        Expectation: Works natively without broadcasting
+        """
+        mask_shape = (
+            self.batch_size,
+            self.num_heads,
+            self.seq_len,
+            self.seq_len,
+        )
+        self._run_test_with_shape(mask_shape, "test_4d_mask_full_match")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
1. 完善 MEA 后端 attn_mask 的处理逻辑
- 如果 attn_mask 为三维，则expand 为四维
- 如果前两维中只有一维需要广播，则expand 前两维度

参考 MEA 中对于广播的断言逻辑：

https://github.com/PaddlePaddle/Paddle/blob/e95659057ad844911536c8659aeeeba60c5b4ac4/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention_utils.h#L23-L87

2. 完善 math 对于三维 attn_mask 的支持逻辑，当attn_mask 为三维时，手动 expand 到四维，否则无法正确广播