### PR TITLE
[PIR] Avoid hash collision for specialized python op

### DIFF
--- a/python/paddle/static/python_op.py
+++ b/python/paddle/static/python_op.py
@@ -159,7 +159,7 @@ class ConstantParams:
 
 
 @dataclass
-class OriginalFunction(FunctionPack[P1, R1]):
+class OriginalFunctionPack(FunctionPack[P1, R1]):
     def __post_init__(self):
         self._specialized_fns: dict[ConstantParams, FunctionPack[P1, R1]] = {}
 
@@ -212,7 +212,7 @@ class OriginalFunction(FunctionPack[P1, R1]):
 
 class FunctionRegistry:
     def __init__(self):
-        self._registry: dict[str, OriginalFunction[Any, Any]] = {}
+        self._registry: dict[str, OriginalFunctionPack[Any, Any]] = {}
 
     def register(
         self,
@@ -221,16 +221,16 @@ class FunctionRegistry:
         infer_meta: Callable[..., Any],
     ):
         if name not in self._registry:
-            self._registry[name] = OriginalFunction(fn, infer_meta)
+            self._registry[name] = OriginalFunctionPack(fn, infer_meta)
             return self._registry[name]
         fn_pack = self._registry[name]
-        if infer_meta is not fn_pack.infer_meta:
+        if fn is not fn_pack.fn or infer_meta is not fn_pack.infer_meta:
             raise ValueError(
-                f"Function '{name}' is already registered with a different infer_meta."
+                f"Function '{name}' is already registered with a different implementation."
             )
         return fn_pack
 
-    def get(self, name: str) -> OriginalFunction[Any, Any]:
+    def get(self, name: str) -> OriginalFunctionPack[Any, Any]:
         if name not in self._registry:
             raise KeyError(f"Function '{name}' is not registered.")
         return self._registry[name]

--- a/python/paddle/static/python_op.py
+++ b/python/paddle/static/python_op.py
@@ -18,8 +18,9 @@ import inspect
 import sys
 import types
 from collections.abc import Mapping, Sequence
-from functools import partial, wraps
-from typing import Any, Callable, TypeVar, overload
+from dataclasses import dataclass
+from functools import cached_property, partial, wraps
+from typing import Any, Callable, Generic, TypeVar, overload
 
 from typing_extensions import ParamSpec
 
@@ -135,6 +136,109 @@ def eliminate_positional_or_keyword_only(
     return new_fn
 
 
+@dataclass
+class FunctionPack(Generic[P1, R1]):
+    fn: Callable[P1, R1]
+    infer_meta: Callable[..., Any]
+
+    def id(self) -> int:
+        return id(self.fn)
+
+
+class ConstantParams:
+    def __init__(self, params: dict[str, Any]):
+        self.params = params
+
+    def __hash__(self):
+        return custom_hash(self.params)
+
+    def __eq__(self, other):
+        if not isinstance(other, ConstantParams):
+            return False
+        return self.params == other.params
+
+
+@dataclass
+class OriginalFunction(FunctionPack[P1, R1]):
+    def __post_init__(self):
+        self._specialized_fns: dict[ConstantParams, FunctionPack[P1, R1]] = {}
+
+    @cached_property
+    def fn_eliminated(self) -> Callable[P1, R1]:
+        return eliminate_positional_or_keyword_only(self.fn)
+
+    @cached_property
+    def infer_meta_eliminated(self) -> Callable[..., Any]:
+        return eliminate_positional_or_keyword_only(self.infer_meta)
+
+    def get_bound_args(self, /, *args: P1.args, **kwargs: P1.kwargs):
+        sig = inspect.signature(self.fn)
+        bound_args = sig.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        return bound_args.arguments
+
+    def separate_mutable_and_const_params(
+        self, /, *args: P1.args, **kwargs: P1.kwargs
+    ) -> tuple[dict[str, paddle.pir.Value], dict[str, Any]]:
+        params = self.get_bound_args(*args, **kwargs)
+
+        mutable_params = {}
+        const_params = {}
+
+        # TODO: Support container types like list, dict, tuple
+        for k, v in params.items():
+            if isinstance(v, paddle.pir.Value):
+                mutable_params[k] = v
+            else:
+                const_params[k] = v
+
+        return mutable_params, const_params
+
+    def specialize(self, const_params: dict[str, Any]) -> FunctionPack[P1, R1]:
+        const_params_wrapper = ConstantParams(const_params)
+        if const_params_wrapper in self._specialized_fns:
+            return self._specialized_fns[const_params_wrapper]
+
+        specialized_fn = partial(self.fn_eliminated, **const_params)
+        specialized_infer_meta = partial(
+            self.infer_meta_eliminated, **const_params
+        )
+        specialized_fn_pack = FunctionPack(
+            specialized_fn, specialized_infer_meta
+        )
+        self._specialized_fns[const_params_wrapper] = specialized_fn_pack
+        return specialized_fn_pack
+
+
+class FunctionRegistry:
+    def __init__(self):
+        self._registry: dict[str, OriginalFunction[Any, Any]] = {}
+
+    def register(
+        self,
+        name: str,
+        fn: Callable[P1, R1],
+        infer_meta: Callable[..., Any],
+    ):
+        if name not in self._registry:
+            self._registry[name] = OriginalFunction(fn, infer_meta)
+            return self._registry[name]
+        fn_pack = self._registry[name]
+        if infer_meta is not fn_pack.infer_meta:
+            raise ValueError(
+                f"Function '{name}' is already registered with a different infer_meta."
+            )
+        return fn_pack
+
+    def get(self, name: str) -> OriginalFunction[Any, Any]:
+        if name not in self._registry:
+            raise KeyError(f"Function '{name}' is not registered.")
+        return self._registry[name]
+
+
+FUNCTION_REGISTRY = FunctionRegistry()
+
+
 def bind_constants(fn, infer_meta, *args, **kwargs):
     sig = inspect.signature(fn)
     bound_args = sig.bind(*args, **kwargs)
@@ -172,38 +276,28 @@ def run_in_dynamic_mode(fn):
 
 def custom_hash(obj):
     # Compute a hash for various types of objects, including unhashable ones.
-    # This may not be collision-free, but should work for distinguishing different
-    # constant parameters in most practical scenarios.
+    # This may not be collision-free. For example, hash(-1) is same as hash(-2).
+    # We use dict to resolve collisions in ConstantParams.
 
-    # TODO: We should avoid hash collisions more strictly if necessary. For example,
-    # hash(-1) == hash(-2)
+    # Handle basic types
     if isinstance(obj, (int, float, str, bool, bytes)):
         return hash(obj)
 
-    # Hashing for common hashable types
-    if isinstance(obj, (tuple, frozenset)):
-        try:
-            return hash(obj)
-        except TypeError:
-            pass
+    # Handle sequences (like list, tuple, set, frozenset)
+    if isinstance(obj, (Sequence, frozenset, set)):
+        type_id_map = {list: 1, tuple: 2, frozenset: 3, set: 4}
+        type_id = type_id_map.get(type(obj), 0)
+        return hash((type_id, *tuple(custom_hash(item) for item in obj)))
 
-    # Unhashable types
-    if isinstance(obj, (Sequence, set)):
-        try:
-            return hash((0, *tuple(custom_hash(item) for item in obj)))
-        except TypeError:
-            pass
-
-    # Unhashable Mapping
+    # Handle mappings (like dict)
     if isinstance(obj, Mapping):
-        try:
-            items_hashed = tuple(
-                sorted((custom_hash(k), custom_hash(v)) for k, v in obj.items())
-            )
-            return hash((1, *items_hashed))
-        except TypeError:
-            pass
+        type_id = 5
+        items_hashed = tuple(
+            sorted((custom_hash(k), custom_hash(v)) for k, v in obj.items())
+        )
+        return hash((type_id, *items_hashed))
 
+    # Fallback: try to use the built-in hash, or use id() if unhashable
     try:
         return hash(obj)
     except TypeError:
@@ -264,28 +358,25 @@ def register_op(
             if paddle.in_dynamic_mode():
                 return real_fn(*args, **kwargs)
 
-            (
-                mutable_arg_names,
-                bound_constants_fn,
-                bound_constants_infer_meta,
-                mutable_args,
-                const_params,
-            ) = bind_constants(real_fn, infer_meta, *args, **kwargs)
-            assert len(mutable_arg_names) == len(input_names), (
-                f"Number of mutable arguments ({len(mutable_arg_names)}) does not match "
+            fn_pack = FUNCTION_REGISTRY.register(op_name, real_fn, infer_meta)
+            mutable_params, const_params = (
+                fn_pack.separate_mutable_and_const_params(*args, **kwargs)
+            )
+            specialized_fn_pack = fn_pack.specialize(const_params)
+
+            assert len(mutable_params) == len(input_names), (
+                f"Number of mutable arguments ({len(mutable_params)}) does not match "
                 f"the number of input names ({len(input_names)})."
             )
 
-            const_params_hash = custom_hash(const_params)
-
             out = _C_ops._run_python_op(
-                *mutable_args,
-                name=f"{op_name}_{const_params_hash}",
+                *mutable_params.values(),
+                name=f"{op_name}_{specialized_fn_pack.id()}",
                 input_names=input_names,
                 output_names=output_names,
                 attrs={
-                    "infer_meta_fn_ptr": bound_constants_infer_meta,
-                    "fn_ptr": run_in_dynamic_mode(bound_constants_fn),
+                    "infer_meta_fn_ptr": specialized_fn_pack.infer_meta,
+                    "fn_ptr": run_in_dynamic_mode(specialized_fn_pack.fn),
                 },
                 inplace_map=inplace_map or {},
             )

--- a/test/dygraph_to_static/test_python_op.py
+++ b/test/dygraph_to_static/test_python_op.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from collections.abc import Callable
 
 import numpy as np
 from dygraph_to_static_utils import (
@@ -57,9 +58,25 @@ def fn_with_numpy_operation(x: Tensor, y: Tensor) -> Tensor:
     return paddle.to_tensor(x_np_reduce + y_np_reduce).cast(paddle.int32)
 
 
+@paddle.static.register_op(
+    name="fn_with_constant",
+    infer_meta=lambda x, c: paddle.static.MetaTensor(
+        dtype=x.dtype, shape=[np.prod(x.shape).item()]
+    ),
+    input_names=["x"],
+    output_names=["out"],
+)
+def fn_with_constant(x: paddle.Tensor, c: int):
+    return paddle.to_tensor(x.flatten() + c)
+
+
 class PythonOpTestMixin:
+    inputs: dict[str, paddle.Tensor]
+    constants: dict[str, object]
+    fn: Callable[..., paddle.Tensor]
+
     def run_in_dygraph(self):
-        return self.fn(**self.inputs)
+        return self.fn(**self.inputs, **self.constants)
 
     @static_guard()
     def run_in_static(self):
@@ -69,7 +86,7 @@ class PythonOpTestMixin:
                 k: paddle.static.data(name=k, shape=v.shape, dtype=v.dtype)
                 for k, v in self.inputs.items()
             }
-            out_value = self.fn(**input_values)
+            out_value = self.fn(**input_values, **self.constants)
             exe = paddle.static.Executor()
         (out,) = exe.run(
             main_program,
@@ -89,6 +106,7 @@ class TestFnWithBreakgraph(unittest.TestCase, PythonOpTestMixin):
             "x": paddle.randn([2, 3, 4]),
             "y": paddle.randn([2, 3, 4]),
         }
+        self.constants = {}
 
 
 class TestFnWithNumPyOperation(unittest.TestCase, PythonOpTestMixin):
@@ -98,6 +116,25 @@ class TestFnWithNumPyOperation(unittest.TestCase, PythonOpTestMixin):
             "x": paddle.randn([7, 8, 9]),
             "y": paddle.randn([7, 8, 9]),
         }
+        self.constants = {}
+
+
+class TestFnWithConstant1(unittest.TestCase, PythonOpTestMixin):
+    def setUp(self):
+        self.fn = fn_with_constant
+        self.inputs = {
+            "x": paddle.randn([4, 5, 6]),
+        }
+        self.constants = {"c": -1}
+
+
+class TestFnWithConstant2(unittest.TestCase, PythonOpTestMixin):
+    def setUp(self):
+        self.fn = fn_with_constant
+        self.inputs = {
+            "x": paddle.randn([4, 5, 6]),
+        }
+        self.constants = {"c": -2}  # Note that hash(-1) == hash(-2)
 
 
 def fn_use_2_register_op(x: Tensor, y: Tensor) -> Tensor:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

使用 dict 内置的 hash 冲突解决方式来避免 `custom_hash` 的冲突，将特化时的 cache key 包装为 `ConstParams` 并重写 hash、eq 来实现

而在下层注册 op info，则在 op name 后附加 cache value 的 id（`specialized_fn_pack.id()`），确保下层注册时候不会冲突

<!-- PCard-66972 -->