### PR TITLE
将randint_kernel.cc中的std::uniform_int_distribution<T>改为funcs::uniform_int_transform<T, uint32_t>以解决不同环境下输出不同的问题

### DIFF
--- a/paddle/phi/kernels/cpu/randint_kernel.cc
+++ b/paddle/phi/kernels/cpu/randint_kernel.cc
@@ -18,6 +18,7 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/distribution_helper.h"
 
 namespace phi {
 
@@ -39,9 +40,9 @@ void RandintKernel(const Context& dev_ctx,
   } else {
     engine = dev_ctx.GetGenerator()->GetCPUEngine();
   }
-  std::uniform_int_distribution<T> dist(low, high - 1);
+  funcs::uniform_int_transform<T, uint32_t> dist(low, high);
   for (int64_t i = 0; i < numel; ++i) {
-    data[i] = dist(*engine);
+    data[i] = dist((*engine)());
   }
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
改进了cpu下的randint_kernel.cc，原本使用的是std::uniform_int_distribution<T>，由于拒绝采样方式不同，存在不同环境输出结果不同的问题，现在改用funcs::uniform_int_transform<T, uint32_t>，与gpu下randint使用的采样方式一直，均为取模后加上最小值

### Related links

- #76756
