### PR TITLE
[3.3][DLPack] Remove stride normalization when convert to DLPack (#77052)

### DIFF
--- a/paddle/fluid/framework/dlpack_tensor.cc
+++ b/paddle/fluid/framework/dlpack_tensor.cc
@@ -300,10 +300,6 @@ struct PaddleDLMTensor {
 template <typename T>
 static void deleter(T *self) {
   if (self && self->manager_ctx) {
-    delete[] self->dl_tensor
-        .shape;  // delete shape allocated in ToDLPack manually
-    delete[] self->dl_tensor
-        .strides;  // delete strides allocated in ToDLPack manually
     delete static_cast<PaddleDLMTensor<T> *>(self->manager_ctx);
   }
 }
@@ -326,30 +322,13 @@ T *ToDLPackImpl(const phi::DenseTensor &src, uint64_t flags) {
   pdDLMTensor->tensor.manager_ctx = pdDLMTensor;
   pdDLMTensor->tensor.deleter = &deleter<T>;
 
-  // init ndim
   using DimType = decltype(pdDLMTensor->tensor.dl_tensor.ndim);  // int32_t
-  auto _shape = src.dims();
-  pdDLMTensor->tensor.dl_tensor.ndim = static_cast<DimType>(_shape.size());
-  DimType ndim = pdDLMTensor->tensor.dl_tensor.ndim;
-
-  // init shape
-  int64_t *shape = new int64_t[ndim];
-  for (DimType i = 0; i < ndim; ++i) {
-    shape[i] = _shape[i];
-  }
-  pdDLMTensor->tensor.dl_tensor.shape = shape;
-
-  // init strides
-  auto _strides = src.strides();
-  int64_t *strides = new int64_t[ndim];
-  for (int i = 0; i < src.dims().size(); i++) {
-    strides[i] = _strides[i];
-    if (shape[i] < 2) {
-      strides[i] = 1;
-    }
-  }
+  pdDLMTensor->tensor.dl_tensor.ndim = static_cast<DimType>(src.dims().size());
   pdDLMTensor->tensor.dl_tensor.data = const_cast<void *>(src.data());
-  pdDLMTensor->tensor.dl_tensor.strides = strides;
+  pdDLMTensor->tensor.dl_tensor.shape =
+      const_cast<int64_t *>(pdDLMTensor->handle.dims().Get());
+  pdDLMTensor->tensor.dl_tensor.strides =
+      const_cast<int64_t *>(pdDLMTensor->handle.strides().Get());
   pdDLMTensor->tensor.dl_tensor.device = PlaceToDLDevice(src.place());
   pdDLMTensor->tensor.dl_tensor.dtype = PhiDataTypeToDLDataType(src.dtype());
   pdDLMTensor->tensor.dl_tensor.byte_offset = 0;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

#77052 的 cherry-pick，修复 DLPack strides 问题

<!-- PCard-66972 -->