### PR TITLE
Fix: Reduce FC memory in Sharding3 save

### DIFF
--- a/python/paddle/distributed/flex_checkpoint/dcp/full_param.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/full_param.py
@@ -522,9 +522,14 @@ class SingleCommGroupFullParamAssembler(BaseAssembler):
             else:
                 local_tensor = paddle.empty(item.slice_shape, dtype=item.dtype)
 
+            in_cpu = local_tensor.place.is_cpu_place()
+            if in_cpu:
+                local_tensor = local_tensor.cuda()
             paddle.distributed.broadcast(
                 local_tensor, src=cur_src_rank, group=self.process_group
             )
+            if in_cpu:
+                local_tensor = local_tensor.cpu()
 
             shard_desc = ShardedWeightDesc(
                 key=item.tensor_name,

--- a/python/paddle/distributed/flex_checkpoint/dcp/full_param.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/full_param.py
@@ -522,13 +522,13 @@ class SingleCommGroupFullParamAssembler(BaseAssembler):
             else:
                 local_tensor = paddle.empty(item.slice_shape, dtype=item.dtype)
 
-            in_cpu = local_tensor.place.is_cpu_place()
-            if in_cpu:
+            on_cpu = local_tensor.place.is_cpu_place()
+            if on_cpu:
                 local_tensor = local_tensor.cuda()
             paddle.distributed.broadcast(
                 local_tensor, src=cur_src_rank, group=self.process_group
             )
-            if in_cpu:
+            if on_cpu:
                 local_tensor = local_tensor.cpu()
 
             shard_desc = ShardedWeightDesc(

--- a/test/flex_checkpoint/model_full_param_logic.py
+++ b/test/flex_checkpoint/model_full_param_logic.py
@@ -25,6 +25,9 @@ from paddle.distributed.fleet.meta_parallel import (
     SharedLayerDesc,
     VocabParallelEmbedding,
 )
+from paddle.distributed.fleet.meta_parallel.sharding.group_sharded_stage3 import (
+    GroupShardedStage3,
+)
 
 
 class SimpleMLP(nn.Layer):
@@ -45,6 +48,20 @@ class SimpleMLP(nn.Layer):
         x = self.linear2(x)
         x = paddle.matmul(x, self.llm_head.weight, transpose_y=True)
         return x
+
+
+class MLP(paddle.nn.Layer):
+    def __init__(self, linear_size=1000, param_attr=None, bias_attr=None):
+        super().__init__()
+        self._linear1 = nn.Linear(linear_size, linear_size)
+        self._linear2 = nn.Linear(linear_size, linear_size)
+        self._linear3 = nn.Linear(linear_size, 10)
+
+    def forward(self, inputs):
+        y = self._linear1(inputs)
+        y = self._linear2(y)
+        y = self._linear3(y)
+        return y
 
 
 class SimpleMLPPipeline(PipelineLayer):
@@ -361,9 +378,38 @@ class TestFullParamHVGroupLogic(TestFullParamLogic):
         self.run_full_param_with_aoa_test(memory_growth_threshold=1)
 
 
+class TestFullParamLogicWithSharding3:
+    def __init__(self):
+        paddle.distributed.init_parallel_env()
+
+    def run_test(self):
+        model = MLP()
+        opt = paddle.optimizer.AdamW(parameters=model.parameters())
+        model = GroupShardedStage3(model, opt, segment_size=256)
+        model.train()
+        x = paddle.randn([4, 1000])
+        loss = model(x).mean()
+        loss.backward()
+        opt.step()
+        opt.clear_grad()
+        model.get_all_parameters(convert2cpu=True)
+        param_md5_list = []
+        for param in model.parameters():
+            param_md5_list.append(param._md5sum())
+        full_param_iter = model.full()
+        full_param = dict(full_param_iter)
+        full_param_md5_list = []
+        for name, param in full_param.items():
+            full_param_md5_list.append(param._md5sum())
+        assert param_md5_list == full_param_md5_list
+
+
 if __name__ == '__main__':
     test_using_hv_group = int(os.getenv("test_using_hv_group", "0")) == 1
+    test_with_sharding3 = int(os.getenv("test_with_sharding3", "0")) == 1
     if test_using_hv_group:
         TestFullParamHVGroupLogic().run_test()
+    elif test_with_sharding3:
+        TestFullParamLogicWithSharding3().run_test()
     else:
         TestFullParamLogic().run_test()

--- a/test/flex_checkpoint/test_model_full_param.py
+++ b/test/flex_checkpoint/test_model_full_param.py
@@ -152,6 +152,15 @@ TEST_CONFIGS = {
             "test_using_hv_group": 1,
         },
     ],
+    "sharding3_with_convert2cpu_tests": [
+        {
+            "world_size": 2,
+            "tp": 1,
+            "pp": 1,
+            "sharding_degree": 2,
+            "has_bias": "True",
+        },
+    ],
 }
 
 
@@ -270,6 +279,21 @@ class TestFullParamHVGroupWith4Devices(test_base.CommunicationTestDistBase):
         for config in TEST_CONFIGS["4_card_hv_group_tests"]:
             envs = {k: str(v) for k, v in config.items()}
             envs["test_using_hv_group"] = "1"
+            self.run_test_case(
+                "model_full_param_logic.py",
+                user_defined_envs=envs,
+            )
+
+
+class TestFullParamWithSharding3(test_base.CommunicationTestDistBase):
+    def setUp(self):
+        super().setUp(num_of_devices=2, timeout=240)
+
+    def test_full_param(self):
+        for config in TEST_CONFIGS["sharding3_with_convert2cpu_tests"]:
+            envs = {k: str(v) for k, v in config.items()}
+            envs["test_using_hv_group"] = "0"
+            envs["test_with_sharding3"] = "1"
             self.run_test_case(
                 "model_full_param_logic.py",
                 user_defined_envs=envs,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
在sharding stage3的FC save中，将重组param的过程保持convert2cpu，在通信同步时逐个load到GPU上，以减少一次性load的显存开销。
card-92763