### PR TITLE
[Cherry-Pick] Fix: Reduce FC memory in Sharding3 save

### DIFF
--- a/python/paddle/distributed/flex_checkpoint/dcp/full_param.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/full_param.py
@@ -522,9 +522,14 @@ class SingleCommGroupFullParamAssembler(BaseAssembler):
             else:
                 local_tensor = paddle.empty(item.slice_shape, dtype=item.dtype)
 
+            in_cpu = local_tensor.place.is_cpu_place()
+            if in_cpu:
+                local_tensor = local_tensor.cuda()
             paddle.distributed.broadcast(
                 local_tensor, src=cur_src_rank, group=self.process_group
             )
+            if in_cpu:
+                local_tensor = local_tensor.cpu()
 
             shard_desc = ShardedWeightDesc(
                 key=item.tensor_name,

--- a/python/paddle/distributed/flex_checkpoint/dcp/full_param.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/full_param.py
@@ -522,13 +522,13 @@ class SingleCommGroupFullParamAssembler(BaseAssembler):
             else:
                 local_tensor = paddle.empty(item.slice_shape, dtype=item.dtype)
 
-            in_cpu = local_tensor.place.is_cpu_place()
-            if in_cpu:
+            on_cpu = local_tensor.place.is_cpu_place()
+            if on_cpu:
                 local_tensor = local_tensor.cuda()
             paddle.distributed.broadcast(
                 local_tensor, src=cur_src_rank, group=self.process_group
             )
-            if in_cpu:
+            if on_cpu:
                 local_tensor = local_tensor.cpu()
 
             shard_desc = ShardedWeightDesc(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
在sharding stage3的FC save中，将重组param的过程保持convert2cpu，在通信同步时逐个load param到GPU上，以减少一次性load的显存开销。
Cherry-Pick from: https://github.com/PaddlePaddle/Paddle/pull/77065
card-92763