### PR TITLE
[CppExtension] Update `ccache` installation document link

### DIFF
--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -708,7 +708,7 @@ def find_ccache_home():
 
     if ccache_path is None:
         warning_message = "No ccache found. Please be aware that recompiling all source files may be required. "
-        warning_message += "You can download and install ccache from: https://github.com/ccache/ccache/blob/master/doc/INSTALL.md"
+        warning_message += "You can download and install ccache from: https://github.com/ccache/ccache/blob/master/doc/install.md"
         warnings.warn(warning_message)
 
     return ccache_path


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Improvements

### Description

Update ccache installation document link from `https://github.com/ccache/ccache/blob/master/doc/INSTALL.md` to `https://github.com/ccache/ccache/blob/master/doc/install.md` as all document files in ccache was rename to lowercase. 
Ref: https://github.com/ccache/ccache/commit/c55a6acc7e52cbf32dbcadc7acc5c9423efffe19

