### PR TITLE
[SOT] Fix `NotImplementedError` by skipping `NullVariable`

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -1099,7 +1099,9 @@ class OpcodeExecutorBase:
         level = self.stack.pop().get_py_value()
         globals_dict = self.vframe.globals.get_value()
         for key, val in globals_dict.items():
-            if isinstance(val, VariableBase):
+            if isinstance(val, VariableBase) and not isinstance(
+                val, NullVariable
+            ):
                 globals_dict[key] = val.get_py_value()
         try:
             value = __import__(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Pcard-94757 -->
https://github.com/PaddlePaddle/Paddle/pull/76766 导致 PaddleX 多个模型运行报错 raise NotImplementedError，

NullVariable 对应 CPython 栈里的那个 NULL 指针。它在真实 Python 层的 dict 里无对应物，必须跳过。