### PR TITLE
 remove CUDA 11.0 message in sparse/gpu/matmul_kernel.cu [fluid_ops]

### DIFF
--- a/paddle/phi/kernels/sparse/gpu/matmul_grad_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/matmul_grad_kernel.cu
@@ -74,18 +74,6 @@ void MatmulCooDenseGradKernel(const Context& dev_ctx,
         true, false, static_cast<T>(1), x, dout, static_cast<T>(0), dy);
 #endif
   }
-#else
-#ifdef PADDLE_WITH_CUDA
-  PADDLE_THROW(common::errors::Unimplemented(
-      "backward of 'sparse.matmul' use cusparseSDDMM, which is supported from "
-      "CUDA 11.3"));
-#elif defined(PADDLE_WITH_HIP)
-  PADDLE_THROW(
-      common::errors::Unimplemented("backward of 'sparse.matmul' use "
-                                    "rocsparse_sddmm with transpose, which is "
-                                    "supported from "
-                                    "ROCM 4.3.0"));
-#endif
 #endif
 }
 
@@ -125,18 +113,6 @@ void MatmulCsrDenseGradKernel(const Context& dev_ctx,
     sparse_blas.SPMM(
         true, false, static_cast<T>(1), x, dout, static_cast<T>(0), dy);
   }
-#else
-#ifdef PADDLE_WITH_CUDA
-  PADDLE_THROW(common::errors::Unimplemented(
-      "backward of 'sparse.matmul' use cusparseSDDMM, which is supported from "
-      "CUDA 11.3"));
-#elif defined(PADDLE_WITH_HIP)
-  PADDLE_THROW(
-      common::errors::Unimplemented("backward of 'sparse.matmul' use "
-                                    "rocsparse_sddmm with transpose, which is "
-                                    "supported from "
-                                    "ROCM 4.3.0"));
-#endif
 #endif
 }
 
@@ -162,7 +138,7 @@ void MatmulCsrCsrGradKernel(const Context& dev_ctx,
   // dx{SparseCsr} = dout{SparseCsr} * y'{SparseCsr}
   if (dx) {
     // cusparseSpGEMM only support CUSPARSE_OPERATION_NON_TRANSPOSE.
-    // transopse y before cusparseSpGEMM computation.
+    // transpose y before cusparseSpGEMM computation.
     SparseCsrTensor trans_y;
     TransposeCsrKernel<T, Context>(dev_ctx, y, perm, &trans_y);
 
@@ -173,19 +149,13 @@ void MatmulCsrCsrGradKernel(const Context& dev_ctx,
   // dy{SparseCsr} = x'{SparseCsr} * dout{SparseCsr}
   if (dy) {
     // cusparseSpGEMM only support CUSPARSE_OPERATION_NON_TRANSPOSE.
-    // transopse x before cusparseSpGEMM computation.
+    // transpose x before cusparseSpGEMM computation.
     SparseCsrTensor trans_x;
     TransposeCsrKernel<T, Context>(dev_ctx, x, perm, &trans_x);
 
     sparse_blas.SPGEMM(
         false, false, static_cast<T>(1), trans_x, dout, static_cast<T>(0), dy);
   }
-#else
-#ifdef PADDLE_WITH_CUDA
-  PADDLE_THROW(common::errors::Unimplemented(
-      "backward of 'sparse.matmul' use cusparseSpGEMM, which is supported from "
-      "CUDA 11.0"));
-#endif
 #endif
 }
 

--- a/paddle/phi/kernels/sparse/gpu/matmul_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/matmul_kernel.cu
@@ -91,16 +91,6 @@ void MatmulKernelImpl(const Context& dev_ctx,
   auto sparse_blas = funcs::sparse::GetSparseBlas<Context, T>(dev_ctx);
   sparse_blas.SPMM(
       false, false, static_cast<T>(1), x, y, static_cast<T>(0), out);
-#else
-#ifdef PADDLE_WITH_CUDA
-  PADDLE_THROW(common::errors::Unimplemented(
-      "forward of 'sparse.matmul' use cusparseSpMM, "
-      "which is supported from CUDA 11.0"));
-#elif defined(PADDLE_WITH_HIP)
-  PADDLE_THROW(common::errors::Unimplemented(
-      "forward of 'sparse.matmul' use rocsparse_spmm, "
-      "which is supported from ROCM 4.2.0"));
-#endif
 #endif
 }
 

--- a/paddle/phi/kernels/sparse/gpu/mv_grad_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/mv_grad_kernel.cu
@@ -93,10 +93,6 @@ void MvCooGradKernel(const Context &dev_ctx,
 
     auto sparse_blas = funcs::sparse::GetSparseBlas<Context, T>(dev_ctx);
     sparse_blas.SPMV(true, static_cast<T>(1), x, dout, static_cast<T>(0), dvec);
-#else
-    PADDLE_THROW(common::errors::Unimplemented(
-        " vec.grad of 'sparse.mv' use cusparseSpMV, "
-        "which is supported from CUDA 11.0"));
 #endif
   }
 }
@@ -141,10 +137,6 @@ void MvCsrGradKernel(const Context &dev_ctx,
 
     auto sparse_blas = funcs::sparse::GetSparseBlas<Context, T>(dev_ctx);
     sparse_blas.SPMV(true, static_cast<T>(1), x, dout, static_cast<T>(0), dvec);
-#else
-    PADDLE_THROW(common::errors::Unimplemented(
-        " vec.grad of 'sparse.mv' use cusparseSpMV, "
-        "which is supported from CUDA 11.0"));
 #endif
   }
 }

--- a/paddle/phi/kernels/sparse/gpu/mv_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/mv_kernel.cu
@@ -53,9 +53,6 @@ void MvKernelImpl(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out);
   auto sparse_blas = funcs::sparse::GetSparseBlas<Context, T>(dev_ctx);
   sparse_blas.SPMV(false, static_cast<T>(1), x, vec, static_cast<T>(0), out);
-#else
-  PADDLE_THROW(common::errors::Unimplemented(
-      " 'sparse.mv' use cusparseSpMV, which is supported from CUDA 11.0"));
 #endif
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
 CUDA, ROCM 版本在范围内，提示信息没有使用，移除提示信息
