### PR TITLE
[cmake] Discard `FindPythonInterp` 和 `FindPythonLibs`

### DIFF
--- a/cmake/external/python.cmake
+++ b/cmake/external/python.cmake
@@ -16,9 +16,18 @@ include(python_module)
 
 check_py_version(${PY_VERSION})
 
-# Find Python with minimum PY_VERSION specified or will raise error!
-find_package(PythonInterp ${PY_VERSION} REQUIRED)
-find_package(PythonLibs ${PY_VERSION} REQUIRED)
+# Find Python 3 with minimum PY_VERSION specified or will raise error!
+find_package(Python ${PY_VERSION} REQUIRED COMPONENTS Interpreter Development)
+
+# Backward-compat: populate legacy variables used across the build
+set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+set(PYTHON_INCLUDE_DIR ${Python_INCLUDE_DIRS})
+set(PYTHON_INCLUDE_DIRS ${Python_INCLUDE_DIRS})
+set(PYTHON_LIBRARIES ${Python_LIBRARIES})
+
+message(STATUS "Found Python: ${Python_EXECUTABLE}")
+message(STATUS "Python include path: ${Python_INCLUDE_DIRS}")
+message(STATUS "Python libraries: ${Python_LIBRARIES}")
 
 if(WIN32)
   execute_process(
@@ -68,12 +77,11 @@ add_library(python SHARED IMPORTED GLOBAL)
 set_property(TARGET python PROPERTY IMPORTED_LOCATION ${PYTHON_LIBRARIES})
 
 set(py_env "")
-if(PYTHONINTERP_FOUND)
+if(Python_Interpreter_FOUND)
   find_python_module(pip REQUIRED)
   find_python_module(numpy REQUIRED)
   find_python_module(wheel REQUIRED)
   find_python_module(google.protobuf REQUIRED)
-  find_package(NumPy REQUIRED)
   if(${PY_GOOGLE.PROTOBUF_VERSION} AND ${PY_GOOGLE.PROTOBUF_VERSION}
                                        VERSION_LESS "3.0.0")
     message(
@@ -81,7 +89,7 @@ if(PYTHONINTERP_FOUND)
         "Found Python Protobuf ${PY_GOOGLE.PROTOBUF_VERSION} < 3.0.0, "
         "please use pip to upgrade protobuf. pip install -U protobuf")
   endif()
-endif(PYTHONINTERP_FOUND)
+endif()
 
-include_directories(${PYTHON_INCLUDE_DIR})
-include_directories(${PYTHON_NUMPY_INCLUDE_DIR})
+target_include_directories(python INTERFACE ${PYTHON_INCLUDE_DIRS}
+                                            ${NumPy_INCLUDE_DIRS})

--- a/paddle/fluid/eager/CMakeLists.txt
+++ b/paddle/fluid/eager/CMakeLists.txt
@@ -62,6 +62,9 @@ if(NOT ((NOT WITH_PYTHON) AND ON_INFER))
     backward
     SRCS backward.cc
     DEPS grad_tensor_holder utils autograd_meta grad_node_info phi common)
+  if(WITH_PYTHON)
+    target_include_directories(backward PRIVATE ${PYTHON_INCLUDE_DIRS})
+  endif()
 endif()
 
 cc_library(

--- a/paddle/fluid/eager/pylayer/CMakeLists.txt
+++ b/paddle/fluid/eager/pylayer/CMakeLists.txt
@@ -2,3 +2,4 @@ cc_library(
   py_layer_node
   SRCS py_layer_node.cc
   DEPS pybind phi common grad_node_info)
+target_include_directories(py_layer_node PRIVATE ${PYTHON_INCLUDE_DIRS})

--- a/paddle/fluid/operators/CMakeLists.txt
+++ b/paddle/fluid/operators/CMakeLists.txt
@@ -126,6 +126,7 @@ set(GLOB_OPERATOR_DEPS ${OPERATOR_DEPS} CACHE INTERNAL "Global Op dependencies")
 
 if (WITH_PYTHON)
   cc_library(py_func_op SRCS py_func_op.cc DEPS op_registry python pybind)
+  target_include_directories(py_func_op PRIVATE ${PYTHON_INCLUDE_DIRS})
 endif()
 
 set(GLOB_OP_LIB ${OP_LIBRARY} CACHE INTERNAL "Global OP library")

--- a/paddle/fluid/operators/generator/CMakeLists.txt
+++ b/paddle/fluid/operators/generator/CMakeLists.txt
@@ -14,8 +14,8 @@ set(sparse_bw_op_yaml_file ${ops_yaml_dir}/sparse_backward.yaml)
 set(static_bw_op_yaml_file ${ops_yaml_dir}/legacy/static_backward.yaml)
 set(fused_bw_op_yaml_file ${ops_yaml_dir}/fused_backward.yaml)
 
-if(NOT PYTHONINTERP_FOUND)
-  find_package(PythonInterp REQUIRED)
+if(NOT Python_Interpreter_FOUND)
+  find_package(Python REQUIRED COMPONENTS Interpreter)
 endif()
 
 function(install_py_pyyaml)

--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -648,6 +648,8 @@ if(WITH_PYTHON)
     target_compile_options(${SHARD_LIB_NAME} PRIVATE -Wno-maybe-uninitialized)
   endif()
 
+  target_include_directories(${SHARD_LIB_NAME} PRIVATE ${PYTHON_INCLUDE_DIRS})
+
   # cc_test do not respect deps, whole archive to link symbols that may need by test
   if(WITH_TESTING)
     #set_target_properties(${SHARD_LIB_NAME} PROPERTIES LINK_FLAGS "-Wl,--whole-archive")

--- a/paddle/phi/api/lib/CMakeLists.txt
+++ b/paddle/phi/api/lib/CMakeLists.txt
@@ -142,8 +142,8 @@ set(phi_tensor_operants_source_file_tmp ${phi_tensor_operants_source_file}.tmp)
 set(operants_manager_header_file_tmp ${operants_manager_header_file}.tmp)
 set(operants_manager_source_file_tmp ${operants_manager_source_file}.tmp)
 
-if(NOT PYTHONINTERP_FOUND)
-  find_package(PythonInterp REQUIRED)
+if(NOT Python_Interpreter_FOUND)
+  find_package(Python REQUIRED COMPONENTS Interpreter)
 endif()
 
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install pyyaml)

--- a/paddle/utils/CMakeLists.txt
+++ b/paddle/utils/CMakeLists.txt
@@ -12,6 +12,9 @@ if(NOT ((NOT WITH_PYTHON) AND ON_INFER))
   cc_library(
     pybind_util
     SRCS pybind.cc
-    DEPS phi common)
+    DEPS phi common python)
+  if(WITH_PYTHON)
+    target_include_directories(pybind_util PRIVATE ${PYTHON_INCLUDE_DIRS})
+  endif()
 endif()
 cc_library(md5 SRCS md5.cc)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->

cmake 替换 python 的查找方式，并对直接运行 python 做兼容

#### 替换原因：
* [`FindPythonInterp`](https://cmake.org/cmake/help/v3.18/module/FindPythonInterp.html) 和 [`FindPythonLibs`](https://cmake.org/cmake/help/v3.18/module/FindPythonLibs.html) 均已在 cmake 3.12 中标记为弃用, 同时 paddle 已经把 cmake 最低要求更新为 3.18+

#### 其他影响
* 目前在 mac 环境下测试，大小和编译时间均保持不变

> [!NOTE]
> 这个 pr 一同调整了 python 的全局 include
