### PR TITLE
[CppExtension] lazy initialize `CCACHE_HOME`

### DIFF
--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -420,6 +420,8 @@ class BuildExtension(build_ext):
         self.output_dir = kwargs.get("output_dir", None)
         # whether containing cuda source file in Extensions
         self.contain_cuda_file = False
+        # Initialize ccache_home to avoid race condition in multi-thread compilation
+        _get_ccache_home()
 
     def initialize_options(self) -> None:
         super().initialize_options()

--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -95,7 +95,17 @@ if core.is_compiled_with_rocm():
     ROCM_HOME = find_rocm_home()
     CUDA_HOME = ROCM_HOME
 
-CCACHE_HOME = find_ccache_home()
+# Initialize as None, will be set when actually needed
+_CCACHE_HOME = None
+_CCACHE_HOME_INITIALIZED = False
+
+
+def _get_ccache_home():
+    global _CCACHE_HOME, _CCACHE_HOME_INITIALIZED
+    if not _CCACHE_HOME_INITIALIZED:
+        _CCACHE_HOME = find_ccache_home()
+        _CCACHE_HOME_INITIALIZED = True
+    return _CCACHE_HOME
 
 
 def setup(**attr: Any) -> None:
@@ -491,9 +501,10 @@ class BuildExtension(build_ext):
                             "Not found ROCM runtime, \
                             please use `export ROCM_PATH= XXX` to specify it."
                         )
-                        if CCACHE_HOME is not None:
+                        ccache_home = _get_ccache_home()
+                        if ccache_home is not None:
                             hipcc_cmd = os.path.join(ROCM_HOME, 'bin', 'hipcc')
-                            hipcc_cmd = f'{CCACHE_HOME} {hipcc_cmd}'
+                            hipcc_cmd = f'{ccache_home} {hipcc_cmd}'
                         else:
                             hipcc_cmd = os.path.join(ROCM_HOME, 'bin', 'hipcc')
                         self.set_executable('compiler_so', hipcc_cmd)
@@ -519,9 +530,10 @@ class BuildExtension(build_ext):
                             "Not found CUDA runtime, \
                             please use `export CUDA_HOME= XXX` to specify it."
                         )
-                        if CCACHE_HOME is not None:
+                        ccache_home = _get_ccache_home()
+                        if ccache_home is not None:
                             nvcc_cmd = os.path.join(CUDA_HOME, 'bin', 'nvcc')
-                            nvcc_cmd = f'{CCACHE_HOME} {nvcc_cmd}'
+                            nvcc_cmd = f'{ccache_home} {nvcc_cmd}'
                         else:
                             nvcc_cmd = os.path.join(CUDA_HOME, 'bin', 'nvcc')
                         self.set_executable('compiler_so', nvcc_cmd)
@@ -532,10 +544,11 @@ class BuildExtension(build_ext):
                     cflags = prepare_unix_cudaflags(cflags)
                 # cxx compile Cpp source
                 else:
-                    if CCACHE_HOME is not None:
-                        # self.set_executable('compiler_so', [CCACHE_HOME, *self.executables['compiler_so']])
+                    ccache_home = _get_ccache_home()
+                    if ccache_home is not None:
+                        # self.set_executable('compiler_so', [ccache_home, *self.executables['compiler_so']])
                         self.set_executable(
-                            'compiler_so', [CCACHE_HOME, *self.compiler_so]
+                            'compiler_so', [ccache_home, *self.compiler_so]
                         )
 
                     if isinstance(cflags, dict):
@@ -602,8 +615,9 @@ class BuildExtension(build_ext):
             nvcc_cmd = os.path.join(CUDA_HOME, 'bin', 'nvcc')
 
             cmd = []
-            if CCACHE_HOME:
-                cmd.append(CCACHE_HOME)
+            ccache_home = _get_ccache_home()
+            if ccache_home:
+                cmd.append(ccache_home)
             cmd.append(nvcc_cmd)
 
             cmd.extend(objects)

--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 import os
 import copy
 import concurrent
+import functools
 import re
 import warnings
 import collections
@@ -95,17 +96,10 @@ if core.is_compiled_with_rocm():
     ROCM_HOME = find_rocm_home()
     CUDA_HOME = ROCM_HOME
 
-# Initialize as None, will be set when actually needed
-_CCACHE_HOME = None
-_CCACHE_HOME_INITIALIZED = False
 
-
+@functools.cache
 def _get_ccache_home():
-    global _CCACHE_HOME, _CCACHE_HOME_INITIALIZED
-    if not _CCACHE_HOME_INITIALIZED:
-        _CCACHE_HOME = find_ccache_home()
-        _CCACHE_HOME_INITIALIZED = True
-    return _CCACHE_HOME
+    return find_ccache_home()
 
 
 def setup(**attr: Any) -> None:

--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -546,7 +546,6 @@ class BuildExtension(build_ext):
                 else:
                     ccache_home = _get_ccache_home()
                     if ccache_home is not None:
-                        # self.set_executable('compiler_so', [ccache_home, *self.executables['compiler_so']])
                         self.set_executable(
                             'compiler_so', [ccache_home, *self.compiler_so]
                         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
fixes #75836
Replaced the global `CCACHE_HOME` initialization with a lazy loading mechanism (`_get_ccache_home`).
This prevents `find_ccache_home()` from executing during `import paddle`, avoiding unnecessary overhead and potential warnings when C++ extension compilation is not required.
Updated `unix_custom_compile_single_file` and `unix_custom_link_shared_object` to use the new lazy

> When a program has nothing surprising to say, it should say nothing.
