### PR TITLE
fix framework/data_type.h

### DIFF
--- a/paddle/fluid/framework/data_type.cc
+++ b/paddle/fluid/framework/data_type.cc
@@ -13,15 +13,9 @@
 // limitations under the License.
 
 #include "paddle/fluid/framework/data_type.h"
-
 #include <string>
-
-#include "paddle/phi/common/bfloat16.h"
-#include "paddle/phi/common/float16.h"
 #include "paddle/phi/common/pstring.h"
 
-using float16 = phi::dtype::float16;
-using bfloat16 = phi::dtype::bfloat16;
 using pstring = phi::dtype::pstring;
 
 namespace paddle::framework {

--- a/paddle/fluid/framework/data_type.h
+++ b/paddle/fluid/framework/data_type.h
@@ -18,12 +18,7 @@ limitations under the License. */
 #include <typeindex>
 
 #include "paddle/fluid/platform/enforce.h"
-#include "paddle/phi/common/bfloat16.h"
-#include "paddle/phi/common/complex.h"
 #include "paddle/phi/common/data_type.h"
-#include "paddle/phi/common/float16.h"
-#include "paddle/phi/common/float8_e4m3fn.h"
-#include "paddle/phi/common/float8_e5m2.h"
 #include "paddle/phi/core/framework/framework.pb.h"
 #include "paddle/utils/test_macros.h"
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
paddle/phi/common/data_type.h 已包含 paddle/phi/common/bfloat16.h 等文件，不用再包含
