### PR TITLE
[Precision Depth Alignment] align paddle.lerp forward and backward

### DIFF
--- a/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/lerp_grad_kernel.h"
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -27,6 +28,8 @@
 #include "paddle/phi/kernels/funcs/reduce_function.h"
 #include "paddle/phi/kernels/gpu/reduce.h"
 #include "paddle/phi/kernels/reduce_sum_kernel.h"
+
+COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
 
 namespace phi {
 
@@ -64,6 +67,7 @@ __global__ void LerpGradScalarKernelImpl(const T* weight,
                                          const int64_t x_size,
                                          const int64_t y_size) {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  // using MPType = T;
   MPType weight_scalar = static_cast<MPType>(weight[0]);
   CUDA_KERNEL_LOOP_TYPE(idx, out_size, int64_t) {
     MPType temp_dx = weight_scalar * static_cast<MPType>(dout[idx]);
@@ -75,6 +79,54 @@ __global__ void LerpGradScalarKernelImpl(const T* weight,
     if (dy) {
       if (idx < y_size) {
         dy[idx] = static_cast<T>(temp_dx);
+      }
+    }
+  }
+}
+
+template <typename T>
+__global__ void LerpGradKernelCompatibleImpl(const T* weight,
+                                             const T* dout,
+                                             T* dx,
+                                             T* dy,
+                                             const int64_t out_size,
+                                             const int64_t x_size,
+                                             const int64_t y_size) {
+  CUDA_KERNEL_LOOP_TYPE(idx, out_size, int64_t) {
+    T weight_value = weight[idx];
+    T remaining_weight_value = static_cast<T>(1) - weight[idx];
+    if (dx) {
+      if (idx < x_size) {
+        dx[idx] = remaining_weight_value * dout[idx];
+      }
+    }
+    if (dy) {
+      if (idx < y_size) {
+        dy[idx] = weight_value * dout[idx];
+      }
+    }
+  }
+}
+
+template <typename T>
+__global__ void LerpGradScalarKernelCompatibleImpl(const T* weight,
+                                                   const T* dout,
+                                                   T* dx,
+                                                   T* dy,
+                                                   const int64_t out_size,
+                                                   const int64_t x_size,
+                                                   const int64_t y_size) {
+  double weight_scalar = static_cast<double>(weight[0]);
+  double remaining_weight_scalar = 1 - weight_scalar;
+  CUDA_KERNEL_LOOP_TYPE(idx, out_size, int64_t) {
+    if (dx) {
+      if (idx < x_size) {
+        dx[idx] = remaining_weight_scalar * static_cast<double>(dout[idx]);
+      }
+    }
+    if (dy) {
+      if (idx < y_size) {
+        dy[idx] = weight_scalar * static_cast<double>(dout[idx]);
       }
     }
   }
@@ -130,16 +182,29 @@ void SwitchKernel(const Context& dev_ctx,
 
     auto gpu_config =
         phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, out_size);
-    LerpGradScalarKernelImpl<T><<<gpu_config.GetGridSize(),
-                                  gpu_config.GetBlockSize(),
-                                  0,
-                                  dev_ctx.stream()>>>(weight_data,
-                                                      out_grad_data,
-                                                      x_grad_data,
-                                                      y_grad_data,
-                                                      out_size,
-                                                      x_grad_size,
-                                                      y_grad_size);
+    if (FLAGS_use_accuracy_compatible_kernel) {
+      LerpGradScalarKernelCompatibleImpl<T><<<gpu_config.GetGridSize(),
+                                              gpu_config.GetBlockSize(),
+                                              0,
+                                              dev_ctx.stream()>>>(weight_data,
+                                                                  out_grad_data,
+                                                                  x_grad_data,
+                                                                  y_grad_data,
+                                                                  out_size,
+                                                                  x_grad_size,
+                                                                  y_grad_size);
+    } else {
+      LerpGradScalarKernelImpl<T><<<gpu_config.GetGridSize(),
+                                    gpu_config.GetBlockSize(),
+                                    0,
+                                    dev_ctx.stream()>>>(weight_data,
+                                                        out_grad_data,
+                                                        x_grad_data,
+                                                        y_grad_data,
+                                                        out_size,
+                                                        x_grad_size,
+                                                        y_grad_size);
+    }
   } else {
     //    broadcast weight with out_grad's dimensions
     const std::vector<const DenseTensor*> in_tensors = {&weight, &out_grad};
@@ -155,16 +220,29 @@ void SwitchKernel(const Context& dev_ctx,
     const int64_t weight_size = weight.numel();
     auto gpu_config =
         phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, out_size);
-    LerpGradKernelImpl<T><<<gpu_config.GetGridSize(),
-                            gpu_config.GetBlockSize(),
-                            0,
-                            dev_ctx.stream()>>>(weight_data,
-                                                out_grad_data,
-                                                x_grad_data,
-                                                y_grad_data,
-                                                out_size,
-                                                x_grad_size,
-                                                y_grad_size);
+    if (FLAGS_use_accuracy_compatible_kernel) {
+      LerpGradKernelCompatibleImpl<T><<<gpu_config.GetGridSize(),
+                                        gpu_config.GetBlockSize(),
+                                        0,
+                                        dev_ctx.stream()>>>(weight_data,
+                                                            out_grad_data,
+                                                            x_grad_data,
+                                                            y_grad_data,
+                                                            out_size,
+                                                            x_grad_size,
+                                                            y_grad_size);
+    } else {
+      LerpGradKernelImpl<T><<<gpu_config.GetGridSize(),
+                              gpu_config.GetBlockSize(),
+                              0,
+                              dev_ctx.stream()>>>(weight_data,
+                                                  out_grad_data,
+                                                  x_grad_data,
+                                                  y_grad_data,
+                                                  out_size,
+                                                  x_grad_size,
+                                                  y_grad_size);
+    }
   }
 }
 

--- a/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
@@ -17,6 +17,7 @@
 #include "paddle/common/flags.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
+#include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 #include "paddle/phi/common/amp_type_traits.h"
@@ -59,32 +60,6 @@ __global__ void LerpGradKernelImpl(const T* weight,
 }
 
 template <typename T>
-__global__ void LerpGradScalarKernelImpl(const T* weight,
-                                         const T* dout,
-                                         T* dx,
-                                         T* dy,
-                                         const int64_t out_size,
-                                         const int64_t x_size,
-                                         const int64_t y_size) {
-  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  // using MPType = T;
-  MPType weight_scalar = static_cast<MPType>(weight[0]);
-  CUDA_KERNEL_LOOP_TYPE(idx, out_size, int64_t) {
-    MPType temp_dx = weight_scalar * static_cast<MPType>(dout[idx]);
-    if (dx) {
-      if (idx < x_size) {
-        dx[idx] = static_cast<T>(static_cast<MPType>(dout[idx]) - temp_dx);
-      }
-    }
-    if (dy) {
-      if (idx < y_size) {
-        dy[idx] = static_cast<T>(temp_dx);
-      }
-    }
-  }
-}
-
-template <typename T>
 __global__ void LerpGradKernelCompatibleImpl(const T* weight,
                                              const T* dout,
                                              T* dx,
@@ -108,25 +83,50 @@ __global__ void LerpGradKernelCompatibleImpl(const T* weight,
   }
 }
 
-template <typename T>
-__global__ void LerpGradScalarKernelCompatibleImpl(const T* weight,
+template <typename T, typename WeightT = T>
+__global__ void LerpGradScalarKernelImpl(const WeightT* weight,
+                                         const T* dout,
+                                         T* dx,
+                                         T* dy,
+                                         const int64_t out_size,
+                                         const int64_t x_size,
+                                         const int64_t y_size) {
+  double weight_scalar = static_cast<double>(weight[0]);
+  CUDA_KERNEL_LOOP_TYPE(idx, out_size, int64_t) {
+    double temp_dx = weight_scalar * static_cast<double>(dout[idx]);
+    if (dx) {
+      if (idx < x_size) {
+        dx[idx] = static_cast<T>(static_cast<double>(dout[idx]) - temp_dx);
+      }
+    }
+    if (dy) {
+      if (idx < y_size) {
+        dy[idx] = static_cast<T>(temp_dx);
+      }
+    }
+  }
+}
+
+template <typename T, typename WeightT = T>
+__global__ void LerpGradScalarKernelCompatibleImpl(const WeightT* weight,
                                                    const T* dout,
                                                    T* dx,
                                                    T* dy,
                                                    const int64_t out_size,
                                                    const int64_t x_size,
                                                    const int64_t y_size) {
-  double weight_scalar = static_cast<double>(weight[0]);
-  double remaining_weight_scalar = 1 - weight_scalar;
+  T weight_scalar = static_cast<T>(weight[0]);
+  T remaining_weight_scalar =
+      static_cast<T>(1 - static_cast<double>(weight[0]));
   CUDA_KERNEL_LOOP_TYPE(idx, out_size, int64_t) {
     if (dx) {
       if (idx < x_size) {
-        dx[idx] = remaining_weight_scalar * static_cast<double>(dout[idx]);
+        dx[idx] = remaining_weight_scalar * dout[idx];
       }
     }
     if (dy) {
       if (idx < y_size) {
-        dy[idx] = weight_scalar * static_cast<double>(dout[idx]);
+        dy[idx] = weight_scalar * dout[idx];
       }
     }
   }
@@ -175,15 +175,29 @@ void SwitchKernel(const Context& dev_ctx,
                   T* y_grad_data) {
   if (weight.numel() == 1) {
     //    condition when weight is a scalar
-    const T* weight_data = weight.data<T>();
     const T* out_grad_data = out_grad.data<T>();
     const int64_t out_size = out_grad.numel();
     const int64_t weight_size = weight.numel();
 
     auto gpu_config =
         phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, out_size);
-    if (FLAGS_use_accuracy_compatible_kernel) {
-      LerpGradScalarKernelCompatibleImpl<T><<<gpu_config.GetGridSize(),
+
+    if (weight.dtype() == DataType::FLOAT64) {
+      const double* weight_data = weight.data<double>();
+      if (FLAGS_use_accuracy_compatible_kernel) {
+        LerpGradScalarKernelCompatibleImpl<T, double>
+            <<<gpu_config.GetGridSize(),
+               gpu_config.GetBlockSize(),
+               0,
+               dev_ctx.stream()>>>(weight_data,
+                                   out_grad_data,
+                                   x_grad_data,
+                                   y_grad_data,
+                                   out_size,
+                                   x_grad_size,
+                                   y_grad_size);
+      } else {
+        LerpGradScalarKernelImpl<T, double><<<gpu_config.GetGridSize(),
                                               gpu_config.GetBlockSize(),
                                               0,
                                               dev_ctx.stream()>>>(weight_data,
@@ -193,17 +207,33 @@ void SwitchKernel(const Context& dev_ctx,
                                                                   out_size,
                                                                   x_grad_size,
                                                                   y_grad_size);
+      }
     } else {
-      LerpGradScalarKernelImpl<T><<<gpu_config.GetGridSize(),
-                                    gpu_config.GetBlockSize(),
-                                    0,
-                                    dev_ctx.stream()>>>(weight_data,
-                                                        out_grad_data,
-                                                        x_grad_data,
-                                                        y_grad_data,
-                                                        out_size,
-                                                        x_grad_size,
-                                                        y_grad_size);
+      const T* weight_data = weight.data<T>();
+      if (FLAGS_use_accuracy_compatible_kernel) {
+        LerpGradScalarKernelCompatibleImpl<T>
+            <<<gpu_config.GetGridSize(),
+               gpu_config.GetBlockSize(),
+               0,
+               dev_ctx.stream()>>>(weight_data,
+                                   out_grad_data,
+                                   x_grad_data,
+                                   y_grad_data,
+                                   out_size,
+                                   x_grad_size,
+                                   y_grad_size);
+      } else {
+        LerpGradScalarKernelImpl<T><<<gpu_config.GetGridSize(),
+                                      gpu_config.GetBlockSize(),
+                                      0,
+                                      dev_ctx.stream()>>>(weight_data,
+                                                          out_grad_data,
+                                                          x_grad_data,
+                                                          y_grad_data,
+                                                          out_size,
+                                                          x_grad_size,
+                                                          y_grad_size);
+      }
     }
   } else {
     //    broadcast weight with out_grad's dimensions

--- a/paddle/phi/kernels/gpu/lerp_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_kernel.cu
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/amp_type_traits.h"
+#include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/expand_kernel.h"
 #include "paddle/phi/kernels/funcs/broadcast_function.h"
@@ -33,28 +34,29 @@ struct LerpElementWiseDirectCUDAFunctor {
   }
 };
 
-template <typename T>
+template <typename T, typename WeightT = T>
 struct LerpScalarDirectCUDAFunctor {
-  const T *weight_;
+  const WeightT* weight_;
 
-  HOSTDEVICE inline LerpScalarDirectCUDAFunctor(const T *weight)
+  HOSTDEVICE inline LerpScalarDirectCUDAFunctor(const WeightT* weight)
       : weight_(weight) {}
 
   HOSTDEVICE inline T operator()(const T x, const T y) const {
+    T weight_scalar = static_cast<T>(weight_[0]);
     if (abs(static_cast<float>(weight_[0])) < 0.5f) {
-      return x + weight_[0] * (y - x);
+      return x + weight_scalar * (y - x);
     } else {
-      return y - (y - x) * (static_cast<T>(1) - weight_[0]);
+      return y - (y - x) * (static_cast<T>(1) - weight_scalar);
     }
   }
 };
 
 template <typename T, typename Context>
-void LerpKernel(const Context &dev_ctx,
-                const DenseTensor &x,
-                const DenseTensor &y,
-                const DenseTensor &weight,
-                DenseTensor *out) {
+void LerpKernel(const Context& dev_ctx,
+                const DenseTensor& x,
+                const DenseTensor& y,
+                const DenseTensor& weight,
+                DenseTensor* out) {
   if (out && out->numel() == 0) {
     dev_ctx.template Alloc<T>(out);
     return;
@@ -70,16 +72,22 @@ void LerpKernel(const Context &dev_ctx,
           rank));
 
   dev_ctx.template Alloc<T>(out);
-  std::vector<DenseTensor *> outputs = {out};
+  std::vector<DenseTensor*> outputs = {out};
 
-  std::vector<const DenseTensor *> inputs;
+  std::vector<const DenseTensor*> inputs;
   if (weight.numel() == 1) {
-    const T *weight_ptr = weight.data<T>();
     inputs.reserve(2);
     inputs.emplace_back(&x);
     inputs.emplace_back(&y);
-    auto functor = LerpScalarDirectCUDAFunctor<T>(weight_ptr);
-    funcs::BroadcastKernel<T>(dev_ctx, inputs, &outputs, functor);
+    if (weight.dtype() == DataType::FLOAT64) {
+      const double* weight_ptr = weight.data<double>();
+      auto functor = LerpScalarDirectCUDAFunctor<T, double>(weight_ptr);
+      funcs::BroadcastKernel<T>(dev_ctx, inputs, &outputs, functor);
+    } else {
+      const T* weight_ptr = weight.data<T>();
+      auto functor = LerpScalarDirectCUDAFunctor<T>(weight_ptr);
+      funcs::BroadcastKernel<T>(dev_ctx, inputs, &outputs, functor);
+    }
   } else {
     inputs.reserve(3);
     auto functor = LerpElementWiseDirectCUDAFunctor<T>();

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -3163,6 +3163,7 @@
     func : LerpInferMeta
   kernel :
     func : lerp
+    data_type : x
   inplace : (x -> out)
   backward : lerp_grad
   interfaces : paddle::dialect::InferSymbolicShapeInterface

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5037,7 +5037,10 @@ def lerp(
 
     """
     if isinstance(weight, float):
-        weight = paddle.full(shape=[], fill_value=weight, dtype="float64")
+        if x.is_cuda:
+            weight = paddle.full(shape=[], fill_value=weight, dtype="float64")
+        else:
+            weight = paddle.full(shape=[], fill_value=weight, dtype=x.dtype)
 
     if in_dynamic_or_pir_mode():
         return _C_ops.lerp(x, y, weight)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5037,7 +5037,7 @@ def lerp(
 
     """
     if isinstance(weight, float):
-        if x.is_cuda:
+        if x.is_cuda and in_dynamic_mode():
             weight = paddle.full(shape=[], fill_value=weight, dtype="float64")
         else:
             weight = paddle.full(shape=[], fill_value=weight, dtype=x.dtype)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -5037,7 +5037,7 @@ def lerp(
 
     """
     if isinstance(weight, float):
-        weight = paddle.full(shape=[], fill_value=weight, dtype=x.dtype)
+        weight = paddle.full(shape=[], fill_value=weight, dtype="float64")
 
     if in_dynamic_or_pir_mode():
         return _C_ops.lerp(x, y, weight)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

#### 受影响的 API：
- `paddle.lerp` 对齐全部非广播 case（共 23 个）

#### 修改内容
反向无法对齐的原因有以下两点：
- paddle 使用 dx=dout-dy，dy=w\*dout，一次乘法和一次减法，torch使用 dx=dout\*(1-w)，dy=w\*dout两次乘法一次减法。这部分通过添加Flag对齐PyTorch。
- weight 为 python float 传入时，会被预处理成Tensor，原本的实现是根据a来确定数据类型，但是python float 实际是double，所以这里改成了恒为f64,此时会导致以下问题：
  - kernel 内部无法再假设weight数据类型为T，需要判断是否为f64,增加分支来判断。
  - 前向需要同步实现数据类型的判断逻辑。

虽然 torch 的 weight 传入是double，但是仅在计算 1-w时使用f64（即使w不是f64也要转成f64,此时会有预期内的精度损失）,其他运算仍然使用T（低于f32精度时也没有精度提升），所以整体的修改逻辑如下：
- python float 转 f64 Tensor
- f64 Tensor 走 WeightT=double分支，否则走WeightT=T分支
- 计算1-w时永远使用static_cast<T>(1 - static_cast<double>(w))，这里与WeightT是什么无关。
- 后续所有计算统一使用T


Pcard-67164