### PR TITLE
[CodeStyle][Xdoctest] Fix example code(binary_cross_entropy_with_logits)

### DIFF
--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -851,7 +851,7 @@ def save(
             >>> path = 'example/model.pdparams'
             >>> paddle.save(obj, path)
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example-3
 
             >>> # example 3: static graph

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -851,7 +851,7 @@ def save(
             >>> path = 'example/model.pdparams'
             >>> paddle.save(obj, path)
 
-        .. code-block:: pycon
+        .. code-block:: python
             :name: code-example-3
 
             >>> # example 3: static graph

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -807,7 +807,7 @@ def binary_cross_entropy_with_logits(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Docs

### Description
Update the code-block type from `python` to `pycon` for `paddle.nn.functional.binary_cross_entropy_with_logits` to support proper xdoctest verification and syntax highlighting.

**Verification:**
Verified locally with xdoctest passed.

<img width="1654" height="1122" alt="image" src="https://github.com/user-attachments/assets/2e3b24f2-2cab-4724-bca9-9baca87de533" />

Task: #76545
