### PR TITLE
[Compat] Allow call to function decorated with `custom_op`

### DIFF
--- a/python/paddle/library.py
+++ b/python/paddle/library.py
@@ -70,6 +70,11 @@ class CustomOpDef:
         )
         return fn
 
+    def __call__(self, *args, **kwargs):
+        PYTHON_OP_REGISTRY.get_operator(f"{self._namespace}::{self._name}")(
+            *args, **kwargs
+        )
+
 
 @overload
 def custom_op(

--- a/python/paddle/library.py
+++ b/python/paddle/library.py
@@ -71,9 +71,9 @@ class CustomOpDef:
         return fn
 
     def __call__(self, *args, **kwargs):
-        PYTHON_OP_REGISTRY.get_operator(f"{self._namespace}::{self._name}")(
-            *args, **kwargs
-        )
+        return PYTHON_OP_REGISTRY.get_operator(
+            f"{self._namespace}::{self._name}"
+        )(*args, **kwargs)
 
 
 @overload

--- a/python/paddle/library.py
+++ b/python/paddle/library.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable, Iterable, Sequence
-from typing import Union, overload
+from typing import Any, Union, overload
 
 from typing_extensions import TypeAlias
 
@@ -70,7 +70,7 @@ class CustomOpDef:
         )
         return fn
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return PYTHON_OP_REGISTRY.get_operator(
             f"{self._namespace}::{self._name}"
         )(*args, **kwargs)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

之前通过 `@custom_op` 装饰后的函数不再可调用，本 PR 确保其仍然可以调用

<!-- PCard-66972 -->