### PR TITLE
[CI] Add a workflow to cherry-pick PR by add label with `cherry-pick: <target_branch>` format

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -126,7 +126,7 @@ jobs:
 
           Cherry-pick of #$PR_NUMBER
 
-          Close and reopen this PR to trigger CIs."
+          Close and reopen this PR to trigger CI checks."
 
               # Check if PR already exists
               EXISTING_PR=$(gh pr list --base "$TARGET_BRANCH" --head "$NEW_BRANCH" --json url --jq '.[0].url')

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -10,9 +10,18 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   cherry-pick:
-    if: github.event.pull_request.merged == true
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        github.event.action == 'labeled' ||
+        contains(join(github.event.pull_request.labels.*.name, ' '), 'cherry-pick')
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -64,7 +73,7 @@ jobs:
           fi
 
           # Loop through labels
-          echo "$LABELS" | while read -r label; do
+          while read -r label; do
             if [[ "$label" == cherry-pick:* ]]; then
               TARGET_BRANCH=$(echo "${label#cherry-pick:}" | xargs)
 
@@ -153,7 +162,7 @@ jobs:
                 else
                   echo "Failed to create PR."
                   post_comment "❌ Cherry-pick failed: Could not create PR to \`$TARGET_BRANCH\`."
-                  exit 1
+                  continue
                 fi
               fi
 
@@ -161,4 +170,4 @@ jobs:
               git checkout "$ORIGINAL_HEAD_SHA"
               git branch -D "$NEW_BRANCH"
             fi
-          done
+          done <<< "$LABELS"

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,164 @@
+name: Cherry Pick
+
+on:
+  pull_request_target:
+    branches: [develop]
+    types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  cherry-pick:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Cherry Pick
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          # Function to post comment
+          post_comment() {
+            gh pr comment "$PR_NUMBER" --body "$1"
+          }
+
+          # Configure git for the original author
+          echo "Fetching author info for $PR_AUTHOR..."
+          AUTHOR_INFO=$(gh api "/users/$PR_AUTHOR" --jq '{email: .email, name: .name}')
+          AUTHOR_EMAIL=$(echo "$AUTHOR_INFO" | jq -r '.email')
+          AUTHOR_NAME=$(echo "$AUTHOR_INFO" | jq -r '.name')
+
+          if [ "$AUTHOR_EMAIL" = "null" ] || [ -z "$AUTHOR_EMAIL" ]; then
+            AUTHOR_EMAIL="${PR_AUTHOR}@users.noreply.github.com"
+            echo "Author email not found, using default: $AUTHOR_EMAIL"
+          fi
+          if [ "$AUTHOR_NAME" = "null" ] || [ -z "$AUTHOR_NAME" ]; then
+            AUTHOR_NAME="${PR_AUTHOR}"
+            echo "Author name not found, using username: $AUTHOR_NAME"
+          fi
+
+          git config user.name "$AUTHOR_NAME"
+          git config user.email "$AUTHOR_EMAIL"
+
+          # Capture current SHA to return to later
+          ORIGINAL_HEAD_SHA=$(git rev-parse HEAD)
+
+          # Get labels
+          LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
+
+          if [ -z "$LABELS" ]; then
+            echo "No labels found."
+            exit 0
+          fi
+
+          # Loop through labels
+          echo "$LABELS" | while read -r label; do
+            if [[ "$label" == cherry-pick:* ]]; then
+              TARGET_BRANCH=$(echo "${label#cherry-pick:}" | xargs)
+
+              if [ -z "$TARGET_BRANCH" ]; then
+                echo "Empty target branch for label '$label', skipping."
+                continue
+              fi
+
+              echo "Processing cherry-pick to $TARGET_BRANCH"
+
+              # Check if target branch exists on remote
+              if ! git ls-remote --exit-code --heads origin "$TARGET_BRANCH"; then
+                echo "Target branch $TARGET_BRANCH does not exist."
+                post_comment "❌ Cherry-pick failed: Target branch \`$TARGET_BRANCH\` does not exist."
+                continue
+              fi
+
+              # Create a new branch for the cherry-pick
+              NEW_BRANCH="cherry-pick/$PR_NUMBER/$TARGET_BRANCH"
+
+              # Clean up local branch if it exists (from previous run)
+              if git show-ref --verify --quiet "refs/heads/$NEW_BRANCH"; then
+                git branch -D "$NEW_BRANCH"
+              fi
+
+              # Fetch the target branch and checkout a new branch from it
+              git fetch origin "$TARGET_BRANCH"
+              git checkout -b "$NEW_BRANCH" "origin/$TARGET_BRANCH"
+
+              # Cherry pick
+              # Try standard cherry-pick first (for squash merges or single commits)
+              if git cherry-pick "$MERGE_COMMIT_SHA"; then
+                echo "Cherry-pick successful."
+              else
+                echo "Standard cherry-pick failed, trying with -m 1 (for merge commits)..."
+                git cherry-pick --abort
+                if git cherry-pick -m 1 "$MERGE_COMMIT_SHA"; then
+                  echo "Cherry-pick with -m 1 successful."
+                else
+                  echo "Cherry-pick failed."
+                  git cherry-pick --abort
+                  post_comment "❌ Cherry-pick failed: Conflicts detected when cherry-picking to \`$TARGET_BRANCH\`. Please resolve manually."
+
+                  # Cleanup
+                  git checkout "$ORIGINAL_HEAD_SHA"
+                  git branch -D "$NEW_BRANCH"
+                  continue
+                fi
+              fi
+
+              # Push
+              # Check if remote branch already exists, if so, force push? Or maybe fail?
+              # Force push is better to update the PR if we are re-running.
+              git push origin "$NEW_BRANCH" --force
+
+              # Create PR
+              NEW_TITLE="[$TARGET_BRANCH] $PR_TITLE"
+              NEW_BODY="$PR_BODY
+
+          Cherry-pick of #$PR_NUMBER
+
+          Close and reopen this PR to trigger CIs."
+
+              # Check if PR already exists
+              EXISTING_PR=$(gh pr list --base "$TARGET_BRANCH" --head "$NEW_BRANCH" --json url --jq '.[0].url')
+
+              if [ -n "$EXISTING_PR" ]; then
+                echo "PR already exists: $EXISTING_PR"
+                post_comment "ℹ️ Cherry-pick PR already exists: $EXISTING_PR"
+              else
+                # Create PR using gh CLI, ignoring errors because of "Resource not accessible" false positives
+                gh pr create --base "$TARGET_BRANCH" --head "$NEW_BRANCH" --title "$NEW_TITLE" --body "$NEW_BODY" || true
+
+                # Wait a bit for eventual consistency
+                sleep 2
+
+                # Search for the created PR
+                CREATED_PR_URL=$(gh pr list --head "$NEW_BRANCH" --state all --json url --jq '.[0].url')
+
+                if [ -n "$CREATED_PR_URL" ]; then
+                  echo "Created PR: $CREATED_PR_URL"
+                  post_comment "✅ Cherry-pick successful! Created PR: $CREATED_PR_URL"
+
+                  # Request review
+                  gh pr review-request "$CREATED_PR_URL" --reviewer "$PR_AUTHOR" || true
+                else
+                  echo "Failed to create PR."
+                  post_comment "❌ Cherry-pick failed: Could not create PR to \`$TARGET_BRANCH\`."
+                  exit 1
+                fi
+              fi
+
+              # Cleanup for next loop
+              git checkout "$ORIGINAL_HEAD_SHA"
+              git branch -D "$NEW_BRANCH"
+            fi
+          done


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

添加一条流水线，用于自动将 develop PR cherry-pick 到其它分支，只需在 PR 上打 label `cherry-pick: <target_branch>` 即可，比如 `cherry-pick: release/3.3`，则会在 PR 合入后自动将 PR cherry-pick 到 `release/3.3` 分支，只需要在 GitHub 上点击操作，无需本地操作

cherry-pick PR 由于是 GitHub Action 提的，因此需要 close/reopen 一下 PR 才能触发 CI

以下是在自己仓库所做的实验：

原始 PR：

<img width="938" height="349" alt="image" src="https://github.com/user-attachments/assets/f0083017-aed7-4203-8bf0-6b7603a598fe" />

原始 PR 下的回复：

<img width="926" height="163" alt="image" src="https://github.com/user-attachments/assets/d5f42da8-21cb-47db-8237-302baf4e1d84" />

GitHub Action 提的 PR：

<img width="936" height="502" alt="image" src="https://github.com/user-attachments/assets/1d94d329-0ad6-4e2d-9c54-f52f276dc937" />

<sup>Co-authored with GitHub Copilot</sup>

<!-- PCard-66972 -->