### PR TITLE
[CodeStyle][large-tensor] fix some clang-tidy narrowing conversion errors

### DIFF
--- a/paddle/cinn/hlir/pe/transform.cc
+++ b/paddle/cinn/hlir/pe/transform.cc
@@ -309,8 +309,9 @@ std::vector<Tensor> Matmul(const Tensor& A,
                            const std::string& name) {
   std::vector<Expr> shape_A = A->shape;
   std::vector<Expr> shape_B = B->shape;
-  int a_dim = shape_A.size();
-  int b_dim = shape_B.size();
+  // NOTE(large-tensor): tensor dimensions are small integers
+  int a_dim = static_cast<int>(shape_A.size());
+  int b_dim = static_cast<int>(shape_B.size());
   PADDLE_ENFORCE_EQ(
       a_dim == 3U || a_dim == 2U,
       true,
@@ -347,7 +348,8 @@ std::vector<Tensor> Matmul(const Tensor& A,
   auto temp = Compute(
       output_shape,
       [=](const std::vector<Expr>& indice) {
-        int out_dim = indice.size();
+        // NOTE(large-tensor): tensor dimensions are small integers
+        int out_dim = static_cast<int>(indice.size());
         std::vector<Expr> A_indice;
         std::vector<Expr> B_indice;
         PADDLE_ENFORCE_EQ(
@@ -458,13 +460,15 @@ ir::Tensor Concat(const std::vector<ir::Tensor>& input_tensors,
                   int axis,
                   const std::string& name) {
   // input size 1 is valid for Concat
-  int input_size = input_tensors.size();
+  // NOTE(large-tensor): input size is a small integer
+  int input_size = static_cast<int>(input_tensors.size());
   PADDLE_ENFORCE_GE(input_size,
                     1U,
                     ::common::errors::InvalidArgument(
                         "Concat should have at least 1 input tensors"));
   std::vector<Expr> output_shape = input_tensors[0]->shape;
-  int input_dim = output_shape.size();
+  // NOTE(large-tensor): tensor dimensions are small integers
+  int input_dim = static_cast<int>(output_shape.size());
   PADDLE_ENFORCE_EQ(
       axis >= -input_dim && axis < input_dim,
       true,
@@ -518,8 +522,9 @@ std::vector<Tensor> MatmulV2(const Tensor& A,
                              const cinn::common::Target& target) {
   std::vector<Expr> shape_A = A->shape;
   std::vector<Expr> shape_B = B->shape;
-  int a_dim = shape_A.size();
-  int b_dim = shape_B.size();
+  // NOTE(large-tensor): tensor dimensions are small integers
+  int a_dim = static_cast<int>(shape_A.size());
+  int b_dim = static_cast<int>(shape_B.size());
   PADDLE_ENFORCE_EQ(
       a_dim == 3U || a_dim == 2U,
       true,
@@ -566,7 +571,8 @@ std::vector<Tensor> MatmulV2(const Tensor& A,
       packedB_shape,
       [=](const std::vector<Expr>& indice) {
         std::vector<Expr> indice_b;
-        int indice_dim = indice.size();
+        // NOTE(large-tensor): tensor dimensions are small integers
+        int indice_dim = static_cast<int>(indice.size());
         PADDLE_ENFORCE_GE(indice_dim,
                           3,
                           ::common::errors::InvalidArgument(
@@ -590,7 +596,8 @@ std::vector<Tensor> MatmulV2(const Tensor& A,
       [=](const std::vector<Expr>& indice) {
         std::vector<Expr> indice_a;
         std::vector<Expr> indice_b;
-        int out_dim = indice.size();
+        // NOTE(large-tensor): tensor dimensions are small integers
+        int out_dim = static_cast<int>(indice.size());
         PADDLE_ENFORCE_EQ(
             out_dim == 3U || out_dim == 2U,
             true,
@@ -635,8 +642,9 @@ std::vector<Tensor> MatmulMKL(const Tensor& A,
                         "Mkl should be used in the cpu environment."));
   std::vector<Expr> shape_A = A->shape;
   std::vector<Expr> shape_B = B->shape;
-  int a_dim = shape_A.size();
-  int b_dim = shape_B.size();
+  // NOTE(large-tensor): tensor dimensions are small integers
+  int a_dim = static_cast<int>(shape_A.size());
+  int b_dim = static_cast<int>(shape_B.size());
   PADDLE_ENFORCE_EQ(
       a_dim == 3U || a_dim == 2U,
       true,
@@ -930,8 +938,9 @@ std::vector<Tensor> MulMKL(const Tensor& A,
                         "Mkl should be used in the cpu environment."));
   std::vector<Expr> shape_A = A->shape;
   std::vector<Expr> shape_B = B->shape;
-  int a_dim = shape_A.size();
-  int b_dim = shape_B.size();
+  // NOTE(large-tensor): tensor dimensions are small integers
+  int a_dim = static_cast<int>(shape_A.size());
+  int b_dim = static_cast<int>(shape_B.size());
   PADDLE_ENFORCE_EQ(
       a_dim,
       2U,

--- a/paddle/cinn/hlir/pe/transform.cc
+++ b/paddle/cinn/hlir/pe/transform.cc
@@ -69,8 +69,8 @@ std::vector<std::vector<int>> GetMatmulNewShapes(
   auto& new_y_shape = new_shape[1];
   auto& out_shape = new_shape[2];
 
-  int x_dim = x_shape.size(), y_dim = y_shape.size();
-  int max_dim = std::max(x_shape.size(), y_shape.size());
+  size_t x_dim = x_shape.size(), y_dim = y_shape.size();
+  size_t max_dim = std::max(x_shape.size(), y_shape.size());
   int out_dim = max_dim >= 3 ? 3 : (max_dim <= 2 ? 2 : max_dim);
 
   auto get_input_shape = [out_dim](const std::vector<int>& old_shape) {

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/binary_infer_sym.cc
@@ -973,6 +973,7 @@ bool GatherOpInferSymbolicShape(pir::Operation *op,
             "3 when the axis is not set."));
     const auto &axis_shape_or_data =
         infer_context->GetShapeOrDataForValue(op->operand_source(2));
+    // NOTE(large-tensor): axis is a small integer
     axis =
         static_cast<int>(axis_shape_or_data.data().value()[0].Get<int64_t>());
   }
@@ -983,7 +984,10 @@ bool GatherOpInferSymbolicShape(pir::Operation *op,
   const std::vector<symbol::DimExpr> &index_sym_shape =
       index_shape_or_data.shape();
 
-  if (axis < 0) axis += input_sym_shape.size();
+  if (axis < 0) {
+    // NOTE(large-tensor): tensor rank is a small integer
+    axis += static_cast<int>(input_sym_shape.size());
+  }
 
   const auto &out_sym_shape = [&] {
     std::vector<symbol::DimExpr> out_sym_shape;

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/cinn_op_infer_sym.cc
@@ -83,7 +83,10 @@ bool ConcatOpInferSymbolicShape(pir::Operation *op,
         infer_context->GetShapeOrDataForValue(input_values[0]).shape();
 
     size_t rank = out_dims.size();
-    axis = axis >= 0 ? axis : std::max(int64_t(0), int64_t(axis + rank));
+    // NOTE(large-tensor): axis is a small integer.
+    axis = axis >= 0
+               ? axis
+               : static_cast<int>(std::max(int64_t(0), int64_t(axis + rank)));
 
     for (size_t i = 1; i < input_size; ++i) {
       const auto &operand_shape_or_data =

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/infer_sym_slice_utils.cc
@@ -22,7 +22,7 @@ void SliceDfsImpl(const ExprVec &datas,
                   int64_t start,
                   int64_t end,
                   int64_t cur_visit_axis,
-                  int offset,
+                  int64_t offset,
                   ExprVec *result) {
   int64_t begin = 0;
   int64_t stop = shape.at(cur_visit_axis);

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -739,7 +739,8 @@ bool BroadcastTensorsOpInferSymbolicShape(
   // 1. Find Output rank = max(Inputs rank)
   int target_rank = 0;
   for (const auto &input_shape_or_data : input_shape_or_data_list) {
-    int tmp_rank = input_shape_or_data.shape().size();
+    // NOTE(large-tensor): tensor rank is a small integer
+    int tmp_rank = static_cast<int>(input_shape_or_data.shape().size());
     target_rank = std::max(target_rank, tmp_rank);
   }
   // 2. Output dim(axis=x) = max(Inputs dim(axis=x))
@@ -748,7 +749,8 @@ bool BroadcastTensorsOpInferSymbolicShape(
   for (int i = 0; i < target_rank; i++) {
     auto tmp_dim = symbol::DimExpr{1};
     for (const auto &input_shape_or_data : input_shape_or_data_list) {
-      int axis = input_shape_or_data.shape().size();
+      // NOTE(large-tensor): tensor rank is a small integer
+      int axis = static_cast<int>(input_shape_or_data.shape().size());
       axis = i - target_rank + axis;
       if (axis >= 0) {
         infer_context->AddBroadcastableCstr(input_shape_or_data.shape()[axis],
@@ -1142,7 +1144,10 @@ bool CrossEntropyWithSoftmaxOpInferSymbolicShape(
   const auto &index_dim = index_shape.shape();
   const auto &attributes = op->attributes();
   int axis = attributes.at("axis").dyn_cast<pir::Int32Attribute>().data();
-  if (axis < 0) axis += input_shape.shape().size();
+  if (axis < 0) {
+    // NOTE(large-tensor): tensor rank is a small integer
+    axis += static_cast<int>(input_shape.shape().size());
+  }
   bool soft_label =
       attributes.at("soft_label").dyn_cast<pir::BoolAttribute>().data();
   PADDLE_ENFORCE(!soft_label || input_dim.size() == index_dim.size(),
@@ -1196,7 +1201,8 @@ bool ConcatOpInferSymbolicShape(pir::Operation *op,
   const auto &shape_data_list =
       x_shape.dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
 
-  size_t rank = shape_data_list.at(0).shape().size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int rank = static_cast<int>(shape_data_list.at(0).shape().size());
   const int64_t axis = [&] {
     int64_t axis = axis_expr.data()->at(0).dyn_cast<int64_t>();
     return axis >= 0 ? axis : std::max(int64_t(0), int64_t(axis + rank));
@@ -1215,8 +1221,8 @@ bool ConcatOpInferSymbolicShape(pir::Operation *op,
 
   const std::vector<symbol::DimExpr> &out_dims = [&] {
     std::vector<symbol::DimExpr> out_dims = shape_data_list.at(0).shape();
-    for (size_t i = 0; i < rank; ++i) {
-      if (i != static_cast<size_t>(axis)) {
+    for (int i = 0; i < rank; ++i) {
+      if (i != axis) {
         details::BuildCstrEqForTensorListAlongAxis(
             infer_context, shape_data_list, i);
         continue;
@@ -2750,7 +2756,7 @@ bool GroupNormOpInferSymbolicShape(
 
   infer_context->SetShapeOrDataForValue(op->result(0), x_shape);
 
-  int64_t channel_idx;
+  size_t channel_idx;
   std::string data_format =
       op->attribute<pir::StrAttribute>("data_format").AsString();
   if (data_format == "NHWC") {
@@ -2866,9 +2872,10 @@ bool LerpOpInferSymbolicShape(pir::Operation *op,
   std::vector<symbol::DimExpr> x_shape = x_shape_or_data.shape();
   std::vector<symbol::DimExpr> y_shape = y_shape_or_data.shape();
   std::vector<symbol::DimExpr> w_shape = w_shape_or_data.shape();
-  int x_ndims = x_shape.size();
-  int y_ndims = y_shape.size();
-  int w_ndims = w_shape.size();
+  // NOTE(large-tensor): tensor dimensions are small integers
+  int x_ndims = static_cast<int>(x_shape.size());
+  int y_ndims = static_cast<int>(y_shape.size());
+  int w_ndims = static_cast<int>(w_shape.size());
   std::vector<symbol::DimExpr> out1_shape;
   std::vector<symbol::DimExpr> out2_shape;
   int diffxy = x_ndims - y_ndims;
@@ -3422,7 +3429,8 @@ bool RmsNormOpInferSymbolicShape(
       infer_context->GetShapeOrDataForValue(op->operand_source(1));
 
   std::vector<symbol::DimExpr> x_dims = x_shape_or_data.shape();
-  int begin_norm_axis = x_dims.size() - 1;
+  // NOTE(large-tensor): tensor indices are small integers
+  int begin_norm_axis = static_cast<int>(x_dims.size() - 1);
 
   // Flatten x_dims to 2D and get dim[1]
   symbol::DimExpr matrix_dim_1 = x_dims[begin_norm_axis];
@@ -4109,7 +4117,7 @@ bool RnnOpInferSymbolicShape(pir::Operation *op,
                         "The rank of PreState in RNN  must be 3. But "
                         "the received rank is %d.",
                         pre_state_shape_or_data_list[0].shape().size()));
-  for (size_t i = 0; i < 3; ++i) {
+  for (int i = 0; i < 3; ++i) {
     details::BuildCstrEqForTensorListAlongAxis(
         infer_context, pre_state_shape_or_data_list, i);
   }
@@ -4381,7 +4389,8 @@ bool StackOpInferSymbolicShape(pir::Operation *op,
       infer_context->GetShapeOrDataForValue(operand_source)
           .dyn_cast<symbol::TensorListShapeOrDataDimExprs>();
 
-  size_t rank = shape_data_list.at(0).shape().size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int rank = static_cast<int>(shape_data_list.at(0).shape().size());
   if (axis < 0) axis += rank + 1;
   const symbol::ShapeOrDataDimExprs shape_data = [&] {
     std::vector<symbol::DimExpr> result_shape = {};
@@ -4415,7 +4424,7 @@ bool StackOpInferSymbolicShape(pir::Operation *op,
     } else {
       // case 2: data is empty, eg: shape_data_list =
       // [[shape:{5,6,7},data:{}],...]
-      for (size_t i = 0; i < rank; ++i) {
+      for (int i = 0; i < rank; ++i) {
         details::BuildCstrEqForTensorListAlongAxis(
             infer_context, shape_data_list, i);
       }
@@ -4796,9 +4805,10 @@ bool WhereOpInferSymbolicShape(pir::Operation *op,
   const std::vector<pir::Value> &operands = {
       op->operand_source(0), op->operand_source(1), op->operand_source(2)};
 
-  size_t rank = x_shape.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int rank = static_cast<int>(x_shape.size());
 
-  for (size_t i = 0; i < rank; ++i) {
+  for (int i = 0; i < rank; ++i) {
     paddle::dialect::details::BuildCstrEqForTensorListAlongAxis(
         infer_context, operands, i);
   }
@@ -4886,7 +4896,8 @@ bool YoloLossOpInferSymbolicShape(
       infer_context->GetShapeOrDataForValue(op->operand_source(2)).shape();
   const std::vector<int> &anchors_mask =
       paddle::dialect::details::GetVectorAttr<int>(op, "anchor_mask");
-  int mask_num = anchors_mask.size();
+  // NOTE(large-tensor): mask number is a small integer
+  int mask_num = static_cast<int>(anchors_mask.size());
   int class_num = op->attribute<pir::Int32Attribute>("class_num").data();
 
   PADDLE_ENFORCE_EQ(x_shape.size(),

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -3725,7 +3725,7 @@ bool NceOpInferSymbolicShape(pir::Operation *op,
     infer_context->AddEqualCstr(weight_shape[0], bias_shape[0]);
   }
 
-  int num_total_classes =
+  int64_t num_total_classes =
       op->attribute<pir::Int64Attribute>("num_total_classes").data();
   infer_context->AddEqualCstr(symbol::DimExpr(num_total_classes),
                               weight_shape[0]);
@@ -3737,7 +3737,7 @@ bool NceOpInferSymbolicShape(pir::Operation *op,
           symbol::TensorShapeOrDataDimExprs(out_shape)});
 
   bool is_test = op->attribute<pir::BoolAttribute>("is_test").data();
-  int num_neg_samples =
+  int64_t num_neg_samples =
       op->attribute<pir::Int64Attribute>("num_neg_samples").data();
   if (!is_test) {
     std::vector<symbol::DimExpr> sample_out_shape = {x_shape[0]};

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/nullary_infer_sym.cc
@@ -337,7 +337,11 @@ bool EyeOpInferSymbolicShape(pir::Operation *op,
   symbol::DimExpr num_columns_dim;
   symbol::DimExpr num_rows_dim;
   if (op->HasAttribute("num_rows")) {
-    int num_rows_int = op->attribute<pir::Int64Attribute>("num_rows").data();
+    int64_t num_rows_int64 =
+        op->attribute<pir::Int64Attribute>("num_rows").data();
+    // TODO(large-tensor): num_rows may exceed INT_MAX
+    PADDLE_ENFORCE_LE_INT_MAX(num_rows_int64, "num_rows");
+    int num_rows_int = static_cast<int>(num_rows_int64);
     num_rows_dim = symbol::DimExpr(num_rows_int);
   } else if (op->operand_source(0)) {
     const auto &num_rows_shape_or_data =
@@ -351,8 +355,11 @@ bool EyeOpInferSymbolicShape(pir::Operation *op,
   }
 
   if (op->HasAttribute("num_columns")) {
-    int num_columns_int =
+    int64_t num_columns_int64 =
         op->attribute<pir::Int64Attribute>("num_columns").data();
+    // TODO(large-tensor): num_columns may exceed INT_MAX
+    PADDLE_ENFORCE_LE_INT_MAX(num_columns_int64, "num_columns");
+    int num_columns_int = static_cast<int>(num_columns_int64);
     if (num_columns_int == -1) {
       num_columns_dim = num_rows_dim;
     } else {

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -339,6 +339,7 @@ bool MinMaxOpInferSymbolicShape(pir::Operation *op,
     keepdims = GetBoolAttr(op, "keepdims");
     const auto &axis_shape_or_data =
         infer_context->GetShapeOrDataForValue(op->operand_source(1));
+    // NOTE(large-tensor): axis is a small integer.
     axis = static_cast<int>(
         axis_shape_or_data.data().value().at(0).Get<int64_t>());
   }

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -235,7 +235,8 @@ bool AffineGridOpInferSymbolicShape(
         op->attribute<paddle::dialect::IntArrayAttribute>("output_shape")
             .data()
             .GetData();
-    output_shape_size = output_shape.size();
+    // NOTE(large-tensor): output shape size is a small integer
+    output_shape_size = static_cast<int>(output_shape.size());
     for (const auto &i : output_shape) {
       output_shape_data.push_back(symbol::DimExpr{i});
     }
@@ -245,7 +246,8 @@ bool AffineGridOpInferSymbolicShape(
 
     output_shape_data = details::GetOrCreateExprVecFromData(
         output_shape_or_data, infer_context);
-    output_shape_size = output_shape_data.size();
+    // NOTE(large-tensor): output shape size is a small integer
+    output_shape_size = static_cast<int>(output_shape_data.size());
   } else {
     PADDLE_THROW(common::errors::InvalidArgument(
         "The input arguments must have the shape of output, please check!"));
@@ -346,7 +348,8 @@ bool MinMaxOpInferSymbolicShape(pir::Operation *op,
   const auto &input_sym_shape =
       infer_context->GetShapeOrDataForValue(op->operand_source(0)).shape();
 
-  int rank = input_sym_shape.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int rank = static_cast<int>(input_sym_shape.size());
   if (axis < 0) axis += rank;
 
   const auto &out_sym_shape = [&] {
@@ -476,7 +479,8 @@ bool AsStridedOpInferSymbolicShape(
   const std::vector<int> &shape =
       paddle::dialect::details::GetVectorAttr<int>(op, "dims");
 
-  int rank = shape.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int rank = static_cast<int>(shape.size());
   std::vector<symbol::DimExpr> out_shape;
   for (int i = 0; i < rank; ++i) {
     symbol::DimExpr out_unknown = infer_context->GetNextSymName();
@@ -1013,8 +1017,9 @@ bool DiagEmbedOpInferSymbolicShape(
   int offset = attributes.at("offset").dyn_cast<pir::Int32Attribute>().data();
 
   const auto &x_dims = operand_shape_or_data.shape();
-  int dim1_ = dim1 < 0 ? x_dims.size() + dim1 + 1 : dim1;
-  int dim2_ = dim2 < 0 ? x_dims.size() + dim2 + 1 : dim2;
+  // NOTE(large-tensor): tensor dimensions are small integers
+  int dim1_ = dim1 < 0 ? static_cast<int>(x_dims.size()) + dim1 + 1 : dim1;
+  int dim2_ = dim2 < 0 ? static_cast<int>(x_dims.size()) + dim2 + 1 : dim2;
   int64_t offset_ = static_cast<int64_t>(std::abs(offset));
   symbol::DimExpr new_dim_len =
       symbol::DimExpr(offset_) + x_dims.at(x_dims.size() - 1);
@@ -1042,8 +1047,9 @@ bool DiagonalOpInferSymbolicShape(
   int offset = attributes.at("offset").dyn_cast<pir::Int32Attribute>().data();
 
   const auto &x_dims = operand_shape_or_data.shape();
-  int axis1_ = axis1 < 0 ? x_dims.size() + axis1 : axis1;
-  int axis2_ = axis2 < 0 ? x_dims.size() + axis2 : axis2;
+  // NOTE(large-tensor): tensor dimensions are small integers
+  int axis1_ = axis1 < 0 ? static_cast<int>(x_dims.size()) + axis1 : axis1;
+  int axis2_ = axis2 < 0 ? static_cast<int>(x_dims.size()) + axis2 : axis2;
 
   auto out_dims = x_dims;
   auto axis1_size = out_dims.at(axis1_);
@@ -1211,7 +1217,8 @@ bool FrameOpInferSymbolicShape(pir::Operation *op,
   if (axis == 0) {
     seq_length = x_shape[0];
     start_axis = 1;
-    end_axis = x_rank - 1;
+    // NOTE(large-tensor): tensor rank is a small integer
+    end_axis = static_cast<int>(x_rank - 1);
   } else {
     seq_length = x_shape[x_rank - 1];
     start_axis = 0;
@@ -1515,7 +1522,8 @@ bool FlattenOpInferSymbolicShape(
 
   const auto &x_shape =
       infer_context->GetShapeOrDataForValue(op->operand_source(0)).shape();
-  int in_dims_size = x_shape.size();
+  // NOTE(large-tensor): tensor dimensions are small integers
+  int in_dims_size = static_cast<int>(x_shape.size());
 
   if (in_dims_size == 0) {
     PADDLE_ENFORCE_EQ(
@@ -1777,7 +1785,8 @@ bool KthvalueOpInferSymbolicShape(
   bool keepdim = GetBoolAttr(op, "keepdim");
 
   const auto &input_dims = operand_shape_or_data.shape();
-  const int &dim_size = input_dims.size();
+  // NOTE(large-tensor): tensor dimensions are small integers
+  const int dim_size = static_cast<int>(input_dims.size());
   if (axis < 0) axis += dim_size;
   std::vector<symbol::DimExpr> out_dims;
   for (int i = 0; i < axis; i++) {
@@ -1817,7 +1826,8 @@ bool InverseOpInferSymbolicShape(
   const auto &input_shape =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   std::vector<symbol::DimExpr> input_dims = input_shape.shape();
-  int input_rank = input_dims.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int input_rank = static_cast<int>(input_dims.size());
 
   infer_context->AddEqualCstr(input_dims[input_rank - 2],
                               input_dims[input_rank - 1]);
@@ -1870,7 +1880,8 @@ bool LrnOpInferSymbolicShape(pir::Operation *op,
   const auto &x_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   const std::vector<symbol::DimExpr> &x_shape = x_shape_or_data.shape();
-  int x_size = x_shape.size();
+  // NOTE(large-tensor): tensor dimensions are small integers
+  int x_size = static_cast<int>(x_shape.size());
   PADDLE_ENFORCE_EQ(
       x_size,
       4,
@@ -1902,7 +1913,8 @@ bool LuOpInferSymbolicShape(pir::Operation *op,
   const auto &x_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   const std::vector<symbol::DimExpr> &x_shape = x_shape_or_data.shape();
-  int x_rank = x_shape.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int x_rank = static_cast<int>(x_shape.size());
 
   PADDLE_ENFORCE_GE(
       x_rank,
@@ -1990,7 +2002,8 @@ bool ModeOpInferSymbolicShape(pir::Operation *op,
   int axis = op->attribute<pir::Int32Attribute>("axis").data();
   bool keepdim = op->attribute<pir::BoolAttribute>("keepdim").data();
 
-  int dim_size = x_shape.size();
+  // NOTE(large-tensor): tensor dimensions are small integers
+  int dim_size = static_cast<int>(x_shape.size());
 
   if (axis < 0) {
     axis += dim_size;
@@ -2028,7 +2041,8 @@ bool MaxoutOpInferSymbolicShape(pir::Operation *op,
   int axis = op->attribute<pir::Int32Attribute>("axis").data();
 
   if (axis < 0) {
-    axis += x_shape.size();
+    // NOTE(large-tensor): tensor rank is a small integer
+    axis += static_cast<int>(x_shape.size());
   }
 
   std::vector<symbol::DimExpr> output_shape = x_shape;
@@ -2244,7 +2258,8 @@ bool MatrixPowerOpInferSymbolicShape(
   const auto &x_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   const std::vector<symbol::DimExpr> &x_shape = x_shape_or_data.shape();
-  const int n_dim = x_shape.size();
+  // NOTE(large-tensor): tensor dimensions are small integers
+  const int n_dim = static_cast<int>(x_shape.size());
 
   PADDLE_ENFORCE_GE(n_dim,
                     2,
@@ -2449,7 +2464,10 @@ bool NormOpInferSymbolicShape(pir::Operation *op,
   bool is_test = op->attribute<pir::BoolAttribute>("is_test").data();
 
   if (!is_test) {
-    if (axis < 0) axis += x_shape.size();
+    if (axis < 0) {
+      // NOTE(large-tensor): tensor rank is a small integer
+      axis += static_cast<int>(x_shape.size());
+    }
 
     auto norm_shape = x_shape;
     norm_shape[axis] = symbol::DimExpr(1);
@@ -2467,7 +2485,8 @@ bool NonzeroOpInferSymbolicShape(
   const auto &x_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   const auto &x_shape = x_shape_or_data.shape();
-  int rank = x_shape.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int rank = static_cast<int>(x_shape.size());
 
   PADDLE_ENFORCE_GE(
       rank,
@@ -2554,7 +2573,8 @@ bool OverlapAddOpInferSymbolicShape(
   const auto &x_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   const std::vector<symbol::DimExpr> &x_dims = x_shape_or_data.shape();
-  const int x_rank = x_dims.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  const int x_rank = static_cast<int>(x_dims.size());
 
   int hop_length = op->attribute<pir::Int32Attribute>("hop_length").data();
   int axis = op->attribute<pir::Int32Attribute>("axis").data();
@@ -2741,7 +2761,8 @@ bool PNormOpInferSymbolicShape(pir::Operation *op,
   const auto &x_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   const auto &x_shape = x_shape_or_data.shape();
-  int x_rank = x_shape.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int x_rank = static_cast<int>(x_shape.size());
 
   int axis = op->attribute<pir::Int32Attribute>("axis").data();
   bool keepdim = op->attribute<pir::BoolAttribute>("keepdim").data();
@@ -2776,7 +2797,7 @@ bool PNormOpInferSymbolicShape(pir::Operation *op,
     }
   } else {
     if (keepdim) {
-      for (int i = 0; i < x_rank; ++i) {
+      for (unsigned int i = 0; i < x_rank; ++i) {
         if (i == axis) {
           out_shape.emplace_back(symbol::DimExpr(1));
         } else {
@@ -2784,7 +2805,7 @@ bool PNormOpInferSymbolicShape(pir::Operation *op,
         }
       }
     } else {
-      for (int i = 0; i < x_rank; ++i) {
+      for (unsigned int i = 0; i < x_rank; ++i) {
         if (i != axis) {
           out_shape.emplace_back(x_shape[i]);
         }
@@ -2996,7 +3017,8 @@ bool QrOpInferSymbolicShape(pir::Operation *op,
   const auto &x_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   const std::vector<symbol::DimExpr> &x_shape = x_shape_or_data.shape();
-  int x_rank = x_shape.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  unsigned int x_rank = static_cast<unsigned int>(x_shape.size());
 
   PADDLE_ENFORCE_GE(
       x_rank,
@@ -3065,7 +3087,8 @@ bool RepeatInterleaveOpInferSymbolicShape(
   // what should I do if axis is null
   int axis = attributes.at("axis").dyn_cast<pir::Int32Attribute>().data();
 
-  int x_rank = operand_shape_or_data.shape().size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int x_rank = static_cast<int>(operand_shape_or_data.shape().size());
   if (axis < 0) axis += x_rank;
 
   const auto &out_sym_shape = [&] {
@@ -3575,7 +3598,8 @@ bool SplitWithNumOpInferSymbolicShape(
 
   const auto &x_s_or_d =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
-  int rank = x_s_or_d.shape().size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int rank = static_cast<int>(x_s_or_d.shape().size());
 
   const auto &out_s_d = [&](int64_t split_axis, int64_t res_num) {
     symbol::DimExpr input_axis_dim = x_s_or_d.shape().at(split_axis);
@@ -4320,7 +4344,8 @@ bool UniqueOpInferSymbolicShape(pir::Operation *op,
   const auto &x_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   const auto &x_dims_sym = x_shape_or_data.shape();
-  const size_t rank = x_dims_sym.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  const int rank = static_cast<int>(x_dims_sym.size());
   const std::vector<int> axes =
       paddle::dialect::details::GetVectorAttr<int>(op, "axis");
 
@@ -4388,7 +4413,8 @@ bool UniqueConsecutiveOpInferSymbolicShape(
   const auto &x_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   const auto &x_dims_sym = x_shape_or_data.shape();
-  const size_t rank = x_dims_sym.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  const int rank = static_cast<int>(x_dims_sym.size());
   const std::vector<int> axes =
       paddle::dialect::details::GetVectorAttr<int>(op, "axis");
   const bool return_inverse = GetBoolAttr(op, "return_inverse");

--- a/paddle/phi/infermeta/fusion.cc
+++ b/paddle/phi/infermeta/fusion.cc
@@ -1010,9 +1010,16 @@ void FusedAttentionInferMeta(const MetaTensor& x,
                             "and must satisfy the limitations: "
                             "(num_head * dim_head == dim_embed)"));
     }
-    num_heads = y_dim[1];
-    dim_head = y_dim[2];
-    hidden_size = y_dim[3];
+    // TODO(large-tensor): num_heads, dim_head, hidden_size may exceed INT_MAX
+    int64_t num_heads_int64 = y_dim[1];
+    int64_t dim_head_int64 = y_dim[2];
+    int64_t hidden_size_int64 = y_dim[3];
+    PADDLE_ENFORCE_LE_INT_MAX(num_heads_int64, "num_heads");
+    PADDLE_ENFORCE_LE_INT_MAX(dim_head_int64, "dim_head");
+    PADDLE_ENFORCE_LE_INT_MAX(hidden_size_int64, "hidden_size");
+    num_heads = static_cast<int>(num_heads_int64);
+    dim_head = static_cast<int>(dim_head_int64);
+    hidden_size = static_cast<int>(hidden_size_int64);
   }
 
   PADDLE_ENFORCE_EQ(

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -351,13 +351,11 @@ void ArgMinMaxInferMeta(const MetaTensor& x,
       vec = {};
     }
   } else {
-    for (int64_t i = 0; i < int_axis; i++)
-      vec.emplace_back(x_dims[static_cast<int>(i)]);
+    for (int64_t i = 0; i < int_axis; i++) vec.emplace_back(x_dims[i]);
     if (keepdims) {
       vec.emplace_back(static_cast<int64_t>(1));
     }
-    for (int64_t i = int_axis + 1; i < x_rank; i++)
-      vec.emplace_back(x_dims[static_cast<int>(i)]);
+    for (int64_t i = int_axis + 1; i < x_rank; i++) vec.emplace_back(x_dims[i]);
   }
 
   out->set_dims(common::make_ddim(vec));
@@ -834,7 +832,7 @@ void CSplitInferMeta(const MetaTensor& x, int nranks, MetaTensor* out) {
 void DecodeJpegInferMeta(const MetaTensor& x,
                          const std::string& mode,
                          MetaTensor* out) {
-  std::vector<int> out_dims;
+  std::vector<int64_t> out_dims;
 
   if (mode == "unchanged") {
     out_dims = {-1, -1, -1};
@@ -1117,7 +1115,7 @@ void EigInferMeta(const MetaTensor& x, MetaTensor* out_w, MetaTensor* out_v) {
                         x_dims[rank - 2],
                         x_dims[rank - 1]));
 
-  std::vector<int> batch_dims_vec{};
+  std::vector<int64_t> batch_dims_vec{};
   for (int i = 0; i < rank - 1; ++i) {
     batch_dims_vec.emplace_back(x_dims[i]);
   }
@@ -1835,12 +1833,14 @@ void FoldInferMeta(const MetaTensor& x,
           "It is expected dilations_size equals to 2, but got size %d",
           dilations.size()));
 
-  int output_height = output_sizes[0];
-  int output_width = output_sizes[1];
-  int kernel_height = kernel_sizes[0];
-  int kernel_width = kernel_sizes[1];
-  int dilation_height = dilations[0];
-  int dilation_width = dilations[1];
+  // NOTE(large-tensor): output_sizes, kernel_sizes, dilations are small
+  // integers
+  int64_t output_height = output_sizes[0];
+  int64_t output_width = output_sizes[1];
+  int64_t kernel_height = kernel_sizes[0];
+  int64_t kernel_width = kernel_sizes[1];
+  int64_t dilation_height = dilations[0];
+  int64_t dilation_width = dilations[1];
   int64_t stride_height = strides[0];
   int64_t stride_width = strides[1];
 
@@ -1879,13 +1879,13 @@ void FoldInferMeta(const MetaTensor& x,
                     0,
                     common::errors::InvalidArgument(
                         "The `output_height` should be greater than zero, "
-                        "but received output_height: %d .",
+                        "but received output_height: %ld .",
                         output_height));
   PADDLE_ENFORCE_GT(output_width,
                     0,
                     common::errors::InvalidArgument(
                         "The `output_width` should be greater than zero, "
-                        "but received output_width: %d .",
+                        "but received output_width: %ld .",
                         output_width));
   // check dilations
   PADDLE_ENFORCE_GT(
@@ -1905,30 +1905,31 @@ void FoldInferMeta(const MetaTensor& x,
           dilations[0],
           dilations[1]));
 
-  std::vector<int> out_dims;
+  std::vector<int64_t> out_dims;
   // batch_size
   out_dims.push_back(in_dims[0]);  // NOLINT
   // output_plane
   int64_t output_channels = in_dims[1] / (kernel_width * kernel_height);
   out_dims.push_back(output_channels);
 
-  int blocks_height = (output_sizes[0] + 2 * paddings[0] -
-                       (dilations[0] * (kernel_sizes[0] - 1) + 1)) /
-                          strides[0] +
-                      1;
-  int blocks_width = (output_sizes[1] + 2 * paddings[1] -
-                      (dilations[1] * (kernel_sizes[1] - 1) + 1)) /
-                         strides[1] +
-                     1;
+  int64_t blocks_height =
+      (output_height + 2 * static_cast<int64_t>(paddings[0]) -
+       (dilation_height * (kernel_height - 1) + 1)) /
+          stride_height +
+      1;
+  int64_t blocks_width = (output_width + 2 * static_cast<int64_t>(paddings[1]) -
+                          (dilation_width * (kernel_width - 1) + 1)) /
+                             stride_width +
+                         1;
 
   // check output height and width
   PADDLE_ENFORCE_GT(
       blocks_height,
       0,
       common::errors::InvalidArgument(
-          "The sliding blocks calculated from input spatial size (%d, %d), "
+          "The sliding blocks calculated from input spatial size (%ld, %ld), "
           "kernel_sizes (%d, %d), strides (%d, %d), dilations (%d, %d), "
-          "is (%d, %d), which should be a positive integer.",
+          "is (%ld, %ld), which should be a positive integer.",
           in_dims[2],
           in_dims[3],
           kernel_sizes[0],
@@ -1944,9 +1945,9 @@ void FoldInferMeta(const MetaTensor& x,
       blocks_width,
       0,
       common::errors::InvalidArgument(
-          "The sliding blocks calculated from input spatial size (%d, %d), "
+          "The sliding blocks calculated from input spatial size (%ld, %ld), "
           "kernel_sizes (%d, %d), strides (%d, %d), dilations (%d, %d), "
-          "is (%d, %d), which should be a positive integer.",
+          "is (%ld, %ld), which should be a positive integer.",
           in_dims[2],
           in_dims[3],
           kernel_sizes[0],
@@ -1962,10 +1963,10 @@ void FoldInferMeta(const MetaTensor& x,
       blocks_height * blocks_width,
       in_dims[2],
       common::errors::InvalidArgument(
-          "Given input output_size (%d, %d), "
+          "Given input output_size (%ld, %ld), "
           "kernel_sizes (%d, %d), strides (%d, %d), dilations (%d, %d), "
           "which should be expected size of input's dimension "
-          "2 to match the calculated number of %d * %d = %d, but got %d",
+          "2 to match the calculated number of %ld * %ld = %ld, but got %ld",
           output_height,
           output_width,
           kernel_sizes[0],
@@ -2683,8 +2684,8 @@ void LUInferMeta(const MetaTensor& x,
   if (x_rank == 2) {
     infos->set_dims(common::make_ddim({}));
   } else {
-    auto Infos_dim =
-        std::vector<int>(dims_vec.begin(), dims_vec.begin() + x_rank - 2);
+    std::vector<int64_t> Infos_dim(
+        dims_vec.begin(), dims_vec.begin() + static_cast<size_t>(x_rank - 2));
     infos->set_dims(common::make_ddim(Infos_dim));
   }
   infos->set_dtype(DataType::INT32);
@@ -2692,8 +2693,8 @@ void LUInferMeta(const MetaTensor& x,
     PADDLE_ENFORCE_NOT_NULL(pivots,
                             common::errors::InvalidArgument(
                                 "Output(Pivots) should not be nullptr."));
-    auto Pivots_dim =
-        std::vector<int>(dims_vec.begin(), dims_vec.begin() + x_rank - 1);
+    std::vector<int64_t> Pivots_dim(
+        dims_vec.begin(), dims_vec.begin() + static_cast<size_t>(x_rank - 1));
     Pivots_dim[x_rank - 2] = min_mn;
     pivots->set_dims(common::make_ddim(Pivots_dim));
     pivots->set_dtype(DataType::INT32);
@@ -3070,13 +3071,11 @@ void MinMaxWithIndexInferMeta(const MetaTensor& x,
       vec = {};
     }
   } else {
-    for (int64_t i = 0; i < int_axis; i++)
-      vec.emplace_back(x_dims[static_cast<int>(i)]);
+    for (int64_t i = 0; i < int_axis; i++) vec.emplace_back(x_dims[i]);
     if (keepdims) {
       vec.emplace_back(static_cast<int64_t>(1));
     }
-    for (int64_t i = int_axis + 1; i < x_rank; i++)
-      vec.emplace_back(x_dims[static_cast<int>(i)]);
+    for (int64_t i = int_axis + 1; i < x_rank; i++) vec.emplace_back(x_dims[i]);
   }
 
   val_out->set_dims(common::make_ddim(vec));
@@ -3967,7 +3966,8 @@ void QrInferMeta(const MetaTensor& x,
                  MetaTensor* q,
                  MetaTensor* r) {
   auto x_dims = x.dims();
-  int x_rank = x_dims.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int x_rank = static_cast<int>(x_dims.size());
   PADDLE_ENFORCE_GE(
       x_dims.size(),
       2,
@@ -5453,7 +5453,7 @@ void SvdvalsInferMeta(const MetaTensor& x, MetaTensor* s) {
   auto SDDim = [](const DDim& x_dim, int64_t k) {
     auto x_vec = common::vectorize(x_dim);
     x_vec.erase(x_vec.end() - 2, x_vec.end());
-    x_vec.push_back(static_cast<int>(k));
+    x_vec.push_back(k);
     return common::make_ddim(x_vec);
   };
 
@@ -5479,21 +5479,21 @@ void SvdInferMeta(const MetaTensor& x,
                   MetaTensor* u,
                   MetaTensor* s,
                   MetaTensor* vh) {
-  auto UDDim = [](const DDim& x_dim, int k) {
+  auto UDDim = [](const DDim& x_dim, int64_t k) {
     // get x_dim and return the ddim of U
     auto x_vec = common::vectorize(x_dim);
     x_vec[x_vec.size() - 1] = k;
     return common::make_ddim(x_vec);
   };
 
-  auto VHDDim = [](const DDim& x_dim, int k) {
+  auto VHDDim = [](const DDim& x_dim, int64_t k) {
     // get x_dim and return the ddim of U
     auto x_vec = common::vectorize(x_dim);
     x_vec[x_vec.size() - 2] = k;
     return common::make_ddim(x_vec);
   };
 
-  auto SDDim = [](const DDim& x_dim, int k) {
+  auto SDDim = [](const DDim& x_dim, int64_t k) {
     // get x_dim and return the ddim of U
     auto x_vec = common::vectorize(x_dim);
     x_vec[x_vec.size() - 2] = k;
@@ -5502,7 +5502,8 @@ void SvdInferMeta(const MetaTensor& x,
   };
 
   auto in_dims = x.dims();
-  int x_rank = in_dims.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int x_rank = static_cast<int>(in_dims.size());
   PADDLE_ENFORCE_GE(
       in_dims.size(),
       2,

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -5383,6 +5383,8 @@ void PartialConcatInferMeta(const std::vector<const MetaTensor*>& xs,
                             MetaConfig config) {
   int64_t batch_size = -1;
   int64_t input_len = -1;
+  // TODO(large-tensor): change start_index to int64_t
+  int64_t start_index_int64 = start_index;
 
   auto inputs_num = xs.size();
   PADDLE_ENFORCE_GT(inputs_num,
@@ -5427,12 +5429,12 @@ void PartialConcatInferMeta(const std::vector<const MetaTensor*>& xs,
           start_index));
 
   if (start_index < 0) {
-    start_index += input_len;
+    start_index_int64 += input_len;
   }
 
   if (length > 0) {
     PADDLE_ENFORCE_GE(input_len,
-                      start_index + length,
+                      start_index_int64 + length,
                       common::errors::OutOfRange(
                           "start_index + length is larger than input length"));
   }
@@ -5440,7 +5442,7 @@ void PartialConcatInferMeta(const std::vector<const MetaTensor*>& xs,
   std::vector<int64_t> out_dims(2);
   out_dims[0] = batch_size;
   // colnum = input_num * length
-  out_dims[1] = (length < 0) ? input_len - start_index : length;
+  out_dims[1] = (length < 0) ? input_len - start_index_int64 : length;
   out_dims[1] *= inputs_num;
   DDim out_dim = common::make_ddim(out_dims);
   out->set_dims(out_dim);
@@ -5448,10 +5450,10 @@ void PartialConcatInferMeta(const std::vector<const MetaTensor*>& xs,
 }
 
 void SvdvalsInferMeta(const MetaTensor& x, MetaTensor* s) {
-  auto SDDim = [](const DDim& x_dim, int k) {
+  auto SDDim = [](const DDim& x_dim, int64_t k) {
     auto x_vec = common::vectorize(x_dim);
     x_vec.erase(x_vec.end() - 2, x_vec.end());
-    x_vec.push_back(k);
+    x_vec.push_back(static_cast<int>(k));
     return common::make_ddim(x_vec);
   };
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
#### 修复原则
1. 如果从理论上本身数值就应该是较小的仅仅是以int64_t暂时储存（比如ndim），则直接使用static_cast，并添加NOTE表示他是小整数。
2. 如果从可以安全地把所有地方修改为int64_t，则直接修改。
3. 如果数值存在超出int32_t范围的可能性，但是没有直接修改为int64_t的条件，则使用ENFORCE并添加TODO。


pcard-93269