### PR TITLE
[CodeStyle][large-tensor] fix some clang-tidy narrowing conversion errors(part 2)

### DIFF
--- a/paddle/common/ddim.cc
+++ b/paddle/common/ddim.cc
@@ -31,7 +31,8 @@ DDim::DDim(const int64_t* d, int n) : rank_(n) {
 }
 
 DDim::DDim(std::initializer_list<int64_t> init_list)
-    : DDim(init_list.begin(), init_list.size()) {}
+    // NOTE(large-tensor): tensor rank is a small integer
+    : DDim(init_list.begin(), static_cast<int>(init_list.size())) {}
 
 int64_t& DDim::at(int idx) {
   PADDLE_ENFORCE_GE(idx,

--- a/paddle/fluid/framework/ir/onednn/quant_dequant_onednn_pass.cc
+++ b/paddle/fluid/framework/ir/onednn/quant_dequant_onednn_pass.cc
@@ -411,7 +411,7 @@ void QuantDequantOnednnPass::RemoveFakeOps(
 
 void QuantDequantOnednnPass::TransposeWeight(phi::DenseTensor* input) const {
   const auto in_dims = input->dims();
-  std::vector<int> out_dim_v;
+  std::vector<int64_t> out_dim_v;
   std::vector<int> axis;
   for (int i = in_dims.size() - 1; i >= 0; i--) {
     axis.push_back(i);

--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
@@ -106,8 +106,8 @@ symbol::ShapeOrDataDimExprs Pool2dRawInferSymbolicShape(
                     common::errors::InvalidArgument(
                         "the rank of input minus the size of kernel_size "
                         "must be equal to 2 in Op(pool). "
-                        "But received: the rank of input is %d and the "
-                        "rank of kernel_size is %d.",
+                        "But received: the rank of input is %zu and the "
+                        "rank of kernel_size is %zu.",
                         x_dims.size(),
                         kernel_size.size()));
 
@@ -280,41 +280,45 @@ bool AffineGridOpInferSymbolicShape(
 bool AllOpInferSymbolicShape(pir::Operation *op,
                              pir::InferSymbolicShapeContext *infer_context) {
   const auto &axis = details::GetVectorAttr(op, "axis");
-  return details::ReduceInferDim(op,
-                                 infer_context,
-                                 axis,
-                                 GetBoolAttr(op, "keepdim"), /*keepdim*/
-                                 axis.size() == 0 /*reduce_all*/);
+  return details::ReduceInferDim(
+      op,
+      infer_context,
+      axis,
+      GetBoolAttr(op, "keepdim"), /*keepdim*/
+      static_cast<int>(axis.size()) == 0 /*reduce_all*/);
 }
 
 bool AmaxOpInferSymbolicShape(pir::Operation *op,
                               pir::InferSymbolicShapeContext *infer_context) {
   const auto &axis = details::GetVectorAttr(op, "axis");
-  return details::ReduceInferDim(op,
-                                 infer_context,
-                                 axis,
-                                 GetBoolAttr(op, "keepdim"), /*keepdim*/
-                                 axis.size() == 0 /*reduce_all*/);
+  return details::ReduceInferDim(
+      op,
+      infer_context,
+      axis,
+      GetBoolAttr(op, "keepdim"), /*keepdim*/
+      static_cast<int>(axis.size()) == 0 /*reduce_all*/);
 }
 
 bool AminOpInferSymbolicShape(pir::Operation *op,
                               pir::InferSymbolicShapeContext *infer_context) {
   const auto &axis = details::GetVectorAttr(op, "axis");
-  return details::ReduceInferDim(op,
-                                 infer_context,
-                                 axis,
-                                 GetBoolAttr(op, "keepdim"), /*keepdim*/
-                                 axis.size() == 0 /*reduce_all*/);
+  return details::ReduceInferDim(
+      op,
+      infer_context,
+      axis,
+      GetBoolAttr(op, "keepdim"), /*keepdim*/
+      static_cast<int>(axis.size()) == 0 /*reduce_all*/);
 }
 
 bool AnyOpInferSymbolicShape(pir::Operation *op,
                              pir::InferSymbolicShapeContext *infer_context) {
   const auto &axis = details::GetVectorAttr(op, "axis");
-  return details::ReduceInferDim(op,
-                                 infer_context,
-                                 axis,
-                                 GetBoolAttr(op, "keepdim"), /*keepdim*/
-                                 axis.size() == 0 /*reduce_all*/);
+  return details::ReduceInferDim(
+      op,
+      infer_context,
+      axis,
+      GetBoolAttr(op, "keepdim"), /*keepdim*/
+      static_cast<int>(axis.size()) == 0 /*reduce_all*/);
 }
 
 bool MinMaxOpInferSymbolicShape(pir::Operation *op,
@@ -865,9 +869,9 @@ bool CropOpInferSymbolicShape(pir::Operation *op,
   PADDLE_ENFORCE_EQ(in_shape.size(),
                     x_shape.size(),
                     common::errors::InvalidArgument(
-                        "The number of elements (%d) of attribute 'shape' for "
+                        "The number of elements (%zu) of attribute 'shape' for "
                         "CropTensor must be equal to the number of "
-                        "dimensions (%d) of the input.",
+                        "dimensions (%zu) of the input.",
                         in_shape.size(),
                         x_shape.size()));
   PADDLE_ENFORCE_EQ(
@@ -937,7 +941,8 @@ bool DetOpInferSymbolicShape(pir::Operation *op,
   const auto &x_shape_or_data =
       infer_context->GetShapeOrDataForValue(op->operand_source(0));
   const auto &x_shape = x_shape_or_data.shape();
-  int x_shape_size = x_shape.size();
+  // NOTE(large-tensor): tensor rank is a small integer
+  int x_shape_size = static_cast<int>(x_shape.size());
   PADDLE_ENFORCE_GE(
       x_shape_size,
       2,
@@ -1021,14 +1026,19 @@ bool DiagEmbedOpInferSymbolicShape(
   int dim1_ = dim1 < 0 ? static_cast<int>(x_dims.size()) + dim1 + 1 : dim1;
   int dim2_ = dim2 < 0 ? static_cast<int>(x_dims.size()) + dim2 + 1 : dim2;
   int64_t offset_ = static_cast<int64_t>(std::abs(offset));
+  // NOTE(large-tensor): tensor rank is a small integer
   symbol::DimExpr new_dim_len =
       symbol::DimExpr(offset_) + x_dims.at(x_dims.size() - 1);
 
   const auto &out_dims = [&] {
     std::vector<symbol::DimExpr> out_dims = x_dims;
     out_dims.pop_back();
-    out_dims.insert(out_dims.begin() + std::min(dim1_, dim2_), new_dim_len);
-    out_dims.insert(out_dims.begin() + std::max(dim1_, dim2_), new_dim_len);
+    out_dims.insert(
+        out_dims.begin() + static_cast<size_t>(std::min(dim1_, dim2_)),
+        new_dim_len);
+    out_dims.insert(
+        out_dims.begin() + static_cast<size_t>(std::max(dim1_, dim2_)),
+        new_dim_len);
     return out_dims;
   }();
   symbol::ShapeOrDataDimExprs shape_data{
@@ -1054,8 +1064,10 @@ bool DiagonalOpInferSymbolicShape(
   auto out_dims = x_dims;
   auto axis1_size = out_dims.at(axis1_);
   auto axis2_size = out_dims.at(axis2_);
-  out_dims.erase(out_dims.begin() + std::max(axis1_, axis2_));
-  out_dims.erase(out_dims.begin() + std::min(axis1_, axis2_));
+  out_dims.erase(out_dims.begin() +
+                 static_cast<size_t>(std::max(axis1_, axis2_)));
+  out_dims.erase(out_dims.begin() +
+                 static_cast<size_t>(std::min(axis1_, axis2_)));
 
   symbol::DimExprBuilder builder;
   symbol::DimExpr zero{0};
@@ -1218,11 +1230,12 @@ bool FrameOpInferSymbolicShape(pir::Operation *op,
     seq_length = x_shape[0];
     start_axis = 1;
     // NOTE(large-tensor): tensor rank is a small integer
-    end_axis = static_cast<int>(x_rank - 1);
+    end_axis = static_cast<int>(x_rank) - 1;
   } else {
     seq_length = x_shape[x_rank - 1];
     start_axis = 0;
-    end_axis = x_rank - 2;
+    // NOTE(large-tensor): tensor rank is a small integer
+    end_axis = static_cast<int>(x_rank) - 2;
   }
   if (seq_length.isa<int64_t>()) {
     PADDLE_ENFORCE_LE(frame_length,
@@ -1236,7 +1249,7 @@ bool FrameOpInferSymbolicShape(pir::Operation *op,
 
   // It won't go into for loop when x_rank == 1U.
   for (int i = start_axis; i <= end_axis; i++) {
-    out_shape.push_back(x_shape[i]);
+    out_shape.push_back(x_shape[static_cast<size_t>(i)]);
   }
 
   n_frames = symbol::DimExpr((seq_length - frame_length) / hop_length + 1);
@@ -1559,14 +1572,14 @@ bool FlattenOpInferSymbolicShape(
   std::vector<symbol::DimExpr> out_shape;
   out_shape.reserve(in_dims_size - stop_axis + start_axis + 1);
   for (int i = 0; i < start_axis; ++i) {
-    out_shape.push_back(x_shape.at(i));
+    out_shape.push_back(x_shape.at(static_cast<size_t>(i)));
   }
   for (int i = start_axis; i <= stop_axis; i++) {
-    outer = outer * x_shape.at(i);
+    outer = outer * x_shape.at(static_cast<size_t>(i));
   }
   out_shape.push_back(outer);
   for (int i = stop_axis + 1; i < in_dims_size; i++) {
-    out_shape.push_back(x_shape.at(i));
+    out_shape.push_back(x_shape.at(static_cast<size_t>(i)));
   }
 
   symbol::ShapeOrDataDimExprs out_shape_data{
@@ -1790,13 +1803,13 @@ bool KthvalueOpInferSymbolicShape(
   if (axis < 0) axis += dim_size;
   std::vector<symbol::DimExpr> out_dims;
   for (int i = 0; i < axis; i++) {
-    out_dims.emplace_back(input_dims.at(i));
+    out_dims.emplace_back(input_dims.at(static_cast<size_t>(i)));
   }
   if (keepdim && dim_size > 0) {
     out_dims.emplace_back(symbol::DimExpr(1));
   }
   for (int i = axis + 1; i < dim_size; i++) {
-    out_dims.emplace_back(input_dims.at(i));
+    out_dims.emplace_back(input_dims.at(static_cast<size_t>(i)));
   }
   symbol::ShapeOrDataDimExprs shape_data{
       symbol::TensorShapeOrDataDimExprs(out_dims)};
@@ -1867,7 +1880,7 @@ bool LogsumexpOpInferSymbolicShape(
   bool keepdim = GetBoolAttr(op, "keepdim");
   std::vector<int> axis_in = details::GetVectorAttr<int>(op, "axis");
   std::vector<int64_t> axis;
-  axis.reserve(axis_in.size());
+  axis.reserve(static_cast<size_t>(axis_in.size()));
   std::for_each(axis_in.begin(), axis_in.end(), [&axis](const int &t) {
     axis.push_back(static_cast<int64_t>(t));
   });
@@ -1926,8 +1939,8 @@ bool LuOpInferSymbolicShape(pir::Operation *op,
       op->result(0),
       symbol::ShapeOrDataDimExprs{symbol::TensorShapeOrDataDimExprs(x_shape)});
 
-  const auto &m = x_shape[x_rank - 1];
-  const auto &n = x_shape[x_rank - 2];
+  const auto &m = x_shape[static_cast<size_t>(x_rank - 1)];
+  const auto &n = x_shape[static_cast<size_t>(x_rank - 2)];
   symbol::DimExprBuilder builder;
   symbol::DimExpr min_mn = builder.Min(m, n);
 
@@ -1937,8 +1950,8 @@ bool LuOpInferSymbolicShape(pir::Operation *op,
         symbol::ShapeOrDataDimExprs{
             symbol::TensorShapeOrDataDimExprs({symbol::DimExpr(1)})});
   } else {
-    std::vector<symbol::DimExpr> infos_shape(x_shape.begin(),
-                                             x_shape.begin() + x_rank - 2);
+    std::vector<symbol::DimExpr> infos_shape(
+        x_shape.begin(), x_shape.begin() + static_cast<size_t>(x_rank - 2));
     infer_context->SetShapeOrDataForValue(
         op->result(2),
         symbol::ShapeOrDataDimExprs{
@@ -1947,9 +1960,9 @@ bool LuOpInferSymbolicShape(pir::Operation *op,
 
   bool pivot = op->attribute<pir::BoolAttribute>("pivot").data();
   if (pivot) {
-    std::vector<symbol::DimExpr> pivots_shape(x_shape.begin(),
-                                              x_shape.begin() + x_rank - 1);
-    pivots_shape[x_rank - 2] = min_mn;
+    std::vector<symbol::DimExpr> pivots_shape(
+        x_shape.begin(), x_shape.begin() + static_cast<size_t>(x_rank - 1));
+    pivots_shape[static_cast<size_t>(x_rank - 2)] = min_mn;
     infer_context->SetShapeOrDataForValue(
         op->result(1),
         symbol::ShapeOrDataDimExprs{
@@ -2011,13 +2024,13 @@ bool ModeOpInferSymbolicShape(pir::Operation *op,
 
   std::vector<symbol::DimExpr> out_dims;
   for (int i = 0; i < axis; i++) {
-    out_dims.emplace_back(x_shape[i]);
+    out_dims.emplace_back(x_shape[static_cast<size_t>(i)]);
   }
   if (keepdim && dim_size > 0) {
     out_dims.emplace_back(symbol::DimExpr(1));
   }
   for (int i = axis + 1; i < dim_size; i++) {
-    out_dims.emplace_back(x_shape[i]);
+    out_dims.emplace_back(x_shape[static_cast<size_t>(i)]);
   }
 
   symbol::TensorShapeOrDataDimExprs out_shape(out_dims);
@@ -2081,7 +2094,7 @@ bool MaxPoolWithIndexOpInferSymbolicShape(
     kernel_size_.emplace_back(kernel_size[i]);
   }
   if (global_pooling) {
-    kernel_size_.resize(x_shape.size() - 2);
+    kernel_size_.resize(static_cast<size_t>(x_shape.size() - 2));
     for (size_t i = 0; i < kernel_size_.size(); ++i) {
       paddings[i] = 0;
       kernel_size_[i] = x_shape[i + 2];
@@ -2293,7 +2306,7 @@ bool MatrixRankOpInferSymbolicShape(
 
   // Ensure the rank of input x is at least 2
   PADDLE_ENFORCE_GE(x_shape.size(),
-                    2,
+                    2U,
                     common::errors::InvalidArgument(
                         "The dims of input must be greater than 2."));
 

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -2234,7 +2234,10 @@ void GatherNdInferMeta(const MetaTensor& x,
   for (int i = 0; i < index_dims_size - 1; ++i) {
     result_dims.emplace_back(index_dims[i]);
   }
-  for (int64_t i = index_dims[index_dims_size - 1]; i < x_dims_size; ++i) {
+  // NOTE(large-tensor): i < x_dims_size <= INT_MAX
+  for (int i = static_cast<int>(index_dims[index_dims_size - 1]);
+       i < x_dims_size;
+       ++i) {
     result_dims.emplace_back(x_dims[i]);
   }
 

--- a/paddle/phi/infermeta/spmd_rules/dim_trans.cc
+++ b/paddle/phi/infermeta/spmd_rules/dim_trans.cc
@@ -502,7 +502,7 @@ InferFromDimTrans(const DistMetaTensor& input,
   // get the map from sharded input dimensions to output dimensions.
   // key is src dim, value is dst dim.
   std::vector<int64_t> dim_map_src2tgt(ndim, -1);
-  std::unordered_map<int, std::vector<int>> dim_map_dst2src;
+  std::unordered_map<int64_t, std::vector<int64_t>> dim_map_dst2src;
   for (int64_t i = 0, n = static_cast<int64_t>(dim_trans.size()); i < n; i++) {
     std::vector<std::shared_ptr<DimTrans>> dims =
         GetDimTrans(dim_trans[i],
@@ -536,7 +536,7 @@ InferFromDimTrans(const DistMetaTensor& input,
   for (int64_t i = 0; i < ndim; i++) {
     int64_t mesh_dim = input_dims_mapping[i];
     if (mesh_dim > -1 && shardable[i][mesh_dim] && dim_map_src2tgt[i] > -1) {
-      int dst_dim = dim_map_src2tgt[i];
+      int64_t dst_dim = dim_map_src2tgt[i];
       out_dims_mapping[dst_dim].push_back(input_dims_mapping[i]);
 
       auto src_dim = dim_map_dst2src[dst_dim];
@@ -594,7 +594,7 @@ InferFromDimTransCoShard(
   // get the map from sharded input dimensions to output dimensions.
   // key is src dim, value is dst dim.
   std::vector<int64_t> dim_map_src2tgt(ndim, -1);
-  std::unordered_map<int, std::vector<int>> dim_map_dst2src;
+  std::unordered_map<int64_t, std::vector<int64_t>> dim_map_dst2src;
   for (int64_t i = 0, n = static_cast<int64_t>(dim_trans.size()); i < n; i++) {
     std::vector<std::shared_ptr<DimTrans>> dims =
         GetDimTransCoShard(dim_trans[i],
@@ -638,7 +638,7 @@ InferFromDimTransCoShard(
       }
     }
     if (!is_unshardable) {
-      int dst_dim = dim_map_src2tgt[i];
+      int64_t dst_dim = dim_map_src2tgt[i];
       const auto& src_dims = dim_map_dst2src[dst_dim];
       auto min_dim_it = std::min_element(src_dims.begin(), src_dims.end());
       int64_t min_dim = *min_dim_it;

--- a/paddle/phi/kernels/array_kernel.cc
+++ b/paddle/phi/kernels/array_kernel.cc
@@ -148,7 +148,8 @@ void ArrayPopKernel(const Context& dev_ctx,
                                       "but the received is %d",
                                       array.size()));
   if (index < 0) {
-    index += array.size();
+    // NOTE(large-tensor): array size is a small integer
+    index += static_cast<int>(array.size());
   }
 
   out->ShareDataWith(array[index]);

--- a/paddle/phi/kernels/onednn/flatten_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/flatten_grad_kernel.cc
@@ -35,9 +35,10 @@ void FlattenGradKernel(const Context& dev_ctx,
 
   auto reorder_src_memory_p = reorder_handler.AcquireSrcMemory(
       out_grad.mem_desc(), funcs::to_void_cast(out_grad.data<T>()));
+  // NOTE(large-tensor): tensor rank is a small integer
   auto reorder_dst_memory_p = reorder_handler.AcquireDstMemory(
       x_grad,
-      funcs::GetPlainOneDNNFormat(out_grad_vec_dims.size()),
+      funcs::GetPlainOneDNNFormat(static_cast<int>(out_grad_vec_dims.size())),
       dev_ctx.GetPlace());
   auto reorder_p = reorder_handler.AcquireReorder(reorder_dst_memory_p,
                                                   reorder_src_memory_p);

--- a/paddle/phi/kernels/onednn/reshape_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/reshape_grad_kernel.cc
@@ -37,9 +37,10 @@ void ReshapeGradKernel(const Context& dev_ctx,
 
   auto reorder_src_memory_p = reorder_handler.AcquireSrcMemory(
       out_grad.mem_desc(), funcs::to_void_cast(out_grad.data<T>()));
+  // NOTE(large-tensor): tensor rank is a small integer
   auto reorder_dst_memory_p = reorder_handler.AcquireDstMemory(
       x_grad,
-      funcs::GetPlainOneDNNFormat(out_grad_vec_dims.size()),
+      funcs::GetPlainOneDNNFormat(static_cast<int>(out_grad_vec_dims.size())),
       dev_ctx.GetPlace());
   auto reorder_p = reorder_handler.AcquireReorder(reorder_dst_memory_p,
                                                   reorder_src_memory_p);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->



pcard-93269