### PR TITLE
[XPU] add synchronize when copy from/to pinned memory

### DIFF
--- a/paddle/phi/core/memory/memcpy.cc
+++ b/paddle/phi/core/memory/memcpy.cc
@@ -399,6 +399,7 @@ void Copy<phi::XPUPinnedPlace, phi::XPUPlace>(phi::XPUPinnedPlace dst_place,
                     reinterpret_cast<cudaStream_t>(stream));
 
   } else {
+    cudaDeviceSynchronize();
     phi::RecordEvent record_event(
         "cudaMemcpy:XPU->XPUPinned", phi::TracerEventType::UserDefined, 1);
     cudaMemcpy(dst, src, num, cudaMemcpyDeviceToHost);
@@ -435,6 +436,7 @@ void Copy<phi::XPUPlace, phi::XPUPinnedPlace>(phi::XPUPlace dst_place,
                     cudaMemcpyHostToDevice,
                     reinterpret_cast<cudaStream_t>(stream));
   } else {
+    cudaDeviceSynchronize();
     phi::RecordEvent record_event(
         "cudaMemcpy:XPUPinned->XPU", phi::TracerEventType::UserDefined, 1);
     cudaMemcpy(dst, src, num, cudaMemcpyHostToDevice);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
There is no implicit sync on non-default stream when copy from pinned memory to device.