### PR TITLE
[Code Generation] Fix get PyObject from kwargs

### DIFF
--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -1559,8 +1559,8 @@ PyObject* GetItemFromArgsOrKWArgs(PyObject* args,
       return arg;
     }
   } else {
-    // get item from kwargs if kwargs has unused items
-    if (kwargs && *remaining_kwargs > 0) {
+    // get item from kwargs
+    if (kwargs) {
       PyObject* arg = nullptr;
       for (const std::string& keyword : keywords) {
         arg = PyDict_GetItemString(kwargs, keyword.c_str());

--- a/test/auto_parallel/test_api_dist_branch.py
+++ b/test/auto_parallel/test_api_dist_branch.py
@@ -146,9 +146,6 @@ class TestDygraphAPIForDistTensorBranch(unittest.TestCase):
 
         local_out = paddle.bincount(local_x, weights=local_weight)
         dist_out = paddle.bincount(dist_x, weights=dist_weight)
-        # add keywords usage case after fix code gen bug
-        # dist_out = paddle.bincount(dist_x, weights=dist_weight)
-        dist_out = paddle.bincount(dist_x, dist_weight)
 
         self.check_tensor_eq(local_out, dist_out)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism


### PR Types
Bug fixes


### Description
<!-- Describe what you’ve done -->
- fix errors while using `GetItemFromArgsOrKWArgs` to get PyObject from kwargs


**说明：**

`GetItemFromArgsOrKWArgs`函数本身是为了从输入`args`和`kwargs`中提取给定对象的，为了检验`kwargs`的数量，接收传入参数`*remaining_kwargs`，每从`kwargs`中读取一次，`remaining_kwargs`都会减一。

然而在`kwargs`检验完毕之后，也会存在需要从输入中读取对象的情况，此时调用此函数，`remaining_kwargs`会继续减小，直到无法继续读取报错，理论上此时`remaining_kwargs`已经无意义。

**Used AI Studio**
