### PR TITLE
fix StridedSliceRawGradStrided for 0-size

### DIFF
--- a/paddle/phi/kernels/stride/strided_slice_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/strided_slice_grad_kernel.cc
@@ -44,7 +44,7 @@ void StridedSliceRawGradStridedKernel(const Context& dev_ctx,
   PD_VISIT_ALL_TYPES(x_grad->dtype(), "StridedSliceRawGradStridedKernel", ([&] {
                        phi::StridedTensorFill<data_t>(*x_grad, 0, x_grad);
                      }));
-  if (x_grad->numel() == 0) return;
+  if (out_grad.numel() == 0) return;
   DenseTensor tmp;
   tmp.set_layout(out_grad.layout());
   tmp.set_lod(out_grad.lod());


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
StridedSliceRawGradStrided 原本判断输入是否是0size，但是实际上应该判断输出。

pcard-93269