### PR TITLE
[CI] Add workflow to cleanup L2 ccache weekly

### DIFF
--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -53,14 +53,6 @@ jobs:
             -e no_proxy \
             -w /paddle --network host ${docker_image}
 
-      - name: Install ccache inside container
-        run: |
-          docker exec -t ${container_name} bash -c '
-            source ${{ github.workspace }}/../../../proxy
-            apt-get update
-            apt-get install -y ccache
-          '
-
       - name: Cleanup L2 ccache inside container
         run: |
           docker exec -t ${container_name} bash -c '

--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -7,6 +7,10 @@ on:
     - cron: "0 0 * * 0" # Weekly on Sundays
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 env:
   TASK: cleanup-ccache-weekly
   no_proxy: "bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"

--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -2,7 +2,7 @@ name: Cleanup ccache
 
 on:
   schedule:
-    - cron: "0 16 * * FRI" # Weekly on Saturday at 00:00 UTC+8
+    - cron: "0 16 * * Sat" # Weekly on Sunday at 00:00 UTC+8
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -1,8 +1,6 @@
 name: Cleanup ccache
 
 on:
-  pull_request:
-    branches: [develop] # Remove before merge, just for testing
   schedule:
     - cron: "0 16 * * FRI" # Weekly on Saturday at 00:00 UTC+8
   workflow_dispatch:

--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -28,7 +28,8 @@ jobs:
           PADDLE_ROOT: /paddle
           CCACHE_MAXSIZE: 50G
           CCACHE_LIMIT_MULTIPLE: 0.8
-          CCACHE_DIR: "/home/data/cfs/.ccache/l2"
+          CCACHE_DIR: "/home/data/shared/.ccache/l1" # L1 cache on machine shared dir
+          CCACHE_SECONDARY_STORAGE: "file:///home/data/cfs/.ccache/l2" # L2 cache on cfs
         run: |
           set -x
           container_name=${TASK}-$(date +%s)
@@ -67,7 +68,7 @@ jobs:
             echo "Current ccache stats before cleanup:"
             ccache -s
             # Trim L2 ccache to free up space, trim all caches exceeding 15days
-            ccache --evict-older-than 15d
+            ccache --trim-dir ${CCACHE_SECONDARY_STORAGE} --evict-older-than 15d
             # Show ccache stats after cleanup
             echo "Current ccache stats after cleanup:"
             ccache -s

--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [develop] # Remove before merge, just for testing
   schedule:
-    - cron: "0 0 * * 0" # Weekly on Sundays
+    - cron: "0 16 * * FRI" # Weekly on Saturday at 00:00 UTC+8
   workflow_dispatch:
 
 concurrency:
@@ -61,7 +61,7 @@ jobs:
         run: |
           docker exec -t ${container_name} bash -c '
             CFS_CCACHE_DIR="${CCACHE_SECONDARY_STORAGE#file://}"
-            ccache --trim-dir ${CFS_CCACHE_DIR} --trim-max-size 57G
+            ccache --trim-dir ${CFS_CCACHE_DIR} --trim-max-size 200G
           '
 
       - name: Terminate and delete the container

--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -57,17 +57,7 @@ jobs:
         run: |
           docker exec -t ${container_name} bash -c '
             CFS_CCACHE_DIR="/home/data/cfs/.ccache/l2"
-            find $CFS_CCACHE_DIR -name "stats" -type f -delete
-            # Show current ccache stats
-            echo "Current L2 ccache size before cleanup:"
-            du -sh ${CFS_CCACHE_DIR}
-            ccache -s
-            # Trim L2 ccache to free up space
-            ccache --trim-dir ${CFS_CCACHE_DIR} --trim-max-size 200G
-            # Show ccache stats after cleanup
-            echo "Current ccache size after cleanup:"
-            du -sh ${CFS_CCACHE_DIR}
-            ccache -s
+            ccache --trim-dir ${CCACHE_SECONDARY_STORAGE} --trim-max-size 57G
           '
 
       - name: Terminate and delete the container

--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -1,0 +1,82 @@
+name: Cleanup ccache
+
+on:
+  pull_request:
+    branches: [develop] # Remove before merge, just for testing
+  schedule:
+    - cron: "0 0 * * 0" # Weekly on Sundays
+  workflow_dispatch:
+
+env:
+  TASK: cleanup-ccache-weekly
+  no_proxy: "bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  cleanup-ccache:
+    name: Cleanup L2 ccache
+    runs-on:
+      group: GZ_BD-CPU
+
+    steps:
+      - name: Launch container
+        env:
+          work_dir: /paddle
+          PADDLE_ROOT: /paddle
+          CCACHE_MAXSIZE: 50G
+          CCACHE_LIMIT_MULTIPLE: 0.8
+          CCACHE_DIR: "/home/data/cfs/.ccache/l2"
+        run: |
+          set -x
+          container_name=${TASK}-$(date +%s)
+          echo "container_name=${container_name}" >> ${{ github.env }}
+          docker_image=ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddle:cuda129-coverage-test
+          docker run -d -t --name ${container_name} \
+            -v "/home/data/cfs:/home/data/cfs" \
+            -v "/home/data/cfs/.cache:/root/.cache" \
+            -v "/home/data/shared:/home/data/shared" \
+            -v "/dev/shm:/dev/shm" \
+            -v "${{ github.workspace }}/../../..:${{ github.workspace }}/../../.." \
+            -v ${{ github.workspace }}:/paddle \
+            -e work_dir \
+            -e PADDLE_ROOT \
+            -e GITHUB_ENV \
+            -e CACHE_DIR \
+            -e CCACHE_DIR \
+            -e CCACHE_SECONDARY_STORAGE \
+            -e CCACHE_MAXSIZE \
+            -e CCACHE_LIMIT_MULTIPLE \
+            -e no_proxy \
+            -w /paddle --network host ${docker_image}
+
+      - name: Install ccache inside container
+        run: |
+          docker exec -t ${container_name} bash -c '
+            source ${{ github.workspace }}/../../../proxy
+            apt-get update
+            apt-get install -y ccache
+          '
+
+      - name: Cleanup L2 ccache inside container
+        run: |
+          docker exec -t ${container_name} bash -c '
+            # Show current ccache stats
+            echo "Current ccache stats before cleanup:"
+            ccache -s
+            # Trim L2 ccache to free up space, trim all caches exceeding 15days
+            ccache --evict-older-than 15d
+            # Show ccache stats after cleanup
+            echo "Current ccache stats after cleanup:"
+            ccache -s
+          '
+
+      - name: Terminate and delete the container
+        if: always()
+        run: |
+          set +e
+          docker exec -t ${{ env.container_name }} /bin/bash -c 'rm -rf * .[^.]*'
+          docker stop ${{ env.container_name }}
+          docker rm ${{ env.container_name }}

--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Cleanup L2 ccache inside container
         run: |
           docker exec -t ${container_name} bash -c '
-            CFS_CCACHE_DIR="/home/data/cfs/.ccache/l2"
-            ccache --trim-dir ${CCACHE_SECONDARY_STORAGE} --trim-max-size 57G
+            CFS_CCACHE_DIR="${CCACHE_SECONDARY_STORAGE#file://}"
+            ccache --trim-dir ${CFS_CCACHE_DIR} --trim-max-size 57G
           '
 
       - name: Terminate and delete the container

--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           docker exec -t ${container_name} bash -c '
             CFS_CCACHE_DIR="/home/data/cfs/.ccache/l2"
+            find $CFS_CCACHE_DIR -name "stats" -type f -delete
             # Show current ccache stats
             echo "Current L2 ccache size before cleanup:"
             du -sh ${CFS_CCACHE_DIR}

--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -64,13 +64,16 @@ jobs:
       - name: Cleanup L2 ccache inside container
         run: |
           docker exec -t ${container_name} bash -c '
+            CFS_CCACHE_DIR="/home/data/cfs/.ccache/l2"
             # Show current ccache stats
-            echo "Current ccache stats before cleanup:"
+            echo "Current L2 ccache size before cleanup:"
+            du -sh ${CFS_CCACHE_DIR}
             ccache -s
-            # Trim L2 ccache to free up space, trim all caches exceeding 15days
-            ccache --trim-dir ${CCACHE_SECONDARY_STORAGE} --evict-older-than 15d
+            # Trim L2 ccache to free up space
+            ccache --trim-dir ${CFS_CCACHE_DIR} --trim-max-size 200G
             # Show ccache stats after cleanup
-            echo "Current ccache stats after cleanup:"
+            echo "Current ccache size after cleanup:"
+            du -sh ${CFS_CCACHE_DIR}
             ccache -s
           '
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

完成 #77174 的 TODO，实现 weekly L2 ccache 自动清理到 200G，限制到 57G 时的清理效果如下：

<img width="1107" height="95" alt="image" src="https://github.com/user-attachments/assets/1d50adbe-05c4-4c17-a7f5-b73fe5778818" />

<!-- PCard-66972 -->