### PR TITLE
[CUDAExtension] Ensure object files are generated under build_temp

### DIFF
--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -843,8 +843,10 @@ class BuildExtension(build_ext):
         else:
             self.compiler.__class__.compile = unix_custom_single_compiler
 
+        # Ensure object files are generated under build_temp, not build_lib,
+        # to avoid accidental inclusion into wheel contents.
         self.compiler.object_filenames = object_filenames_with_cuda(
-            self.compiler.object_filenames, self.build_lib
+            self.compiler.object_filenames, self.build_temp
         )
         self._record_op_info()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
避免编译 cuda 文件生成的 .o 放在 build/lib 目录下，因为这个目录会被 wheel 打包进去