### PR TITLE
fix backward of rms_norm

### DIFF
--- a/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
+++ b/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
@@ -1046,7 +1046,7 @@ void RMSNormBwdKernel(const Context& dev_ctx,
   }
 
   // 2. Compute dscale
-  if (scale_data) {
+  if (dscale_data) {
     constexpr int block_dim_x = 32;
     const int sm_count = dev_ctx.GetSMCount();
     if (M > 64 * 1024 && N / block_dim_x < sm_count / 2) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复rms_norm反向梯度计算中是否对weight进行反向计算的判断条件