### PR TITLE
[CINN] Preload `libnvrtc-builtins.so` to avoid dynload failed on CUDA 13.0

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -846,13 +846,13 @@ if __is_metainfo_generated and is_compiled_with_cuda():
 
                 from .version import cuda as cuda_version
 
-                cuda_majar_version = cuda_version().split('.')[0]
+                cuda_major_version = cuda_version().split('.')[0]
 
                 lib_paths = []
                 lib_paths += glob.glob(
                     os.path.join(
                         nvidia_package_path,
-                        f'cu{cuda_majar_version}',
+                        f'cu{cuda_major_version}',
                         'lib',
                         lib_glob,
                     )

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -840,6 +840,32 @@ if __is_metainfo_generated and is_compiled_with_cuda():
             cuda_cccl_path = package_dir + "/.." + "/nvidia/cuda_cccl/include/"
             set_flags({"FLAGS_cuda_cccl_dir": cuda_cccl_path})
 
+            def _preload_nvidia_lib(nvidia_package_path: str, lib_glob: str):
+                import ctypes
+                import glob
+
+                from .version import cuda as cuda_version
+
+                cuda_majar_version = cuda_version().split('.')[0]
+
+                lib_paths = glob.glob(
+                    os.path.join(nvidia_package_path, 'lib', lib_glob)
+                )
+                lib_paths += glob.glob(
+                    os.path.join(
+                        nvidia_package_path,
+                        f'cu{cuda_majar_version}',
+                        'lib',
+                        lib_glob,
+                    )
+                )
+
+                for lib_path in lib_paths:
+                    ctypes.CDLL(lib_path)
+                    break
+
+            _preload_nvidia_lib(nvidia_package_path, "libnvrtc-builtins.so.*")
+
     elif (
         platform.system() == 'Windows'
         and platform.machine() in ('x86_64', 'AMD64')

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -865,7 +865,7 @@ if __is_metainfo_generated and is_compiled_with_cuda():
                     ctypes.CDLL(lib_path)
                     break
 
-            _preload_nvidia_lib(nvidia_package_path, "libnvrtc_builtins.so.*")
+            _preload_nvidia_lib(nvidia_package_path, "libnvrtc-builtins.so.*")
 
     elif (
         platform.system() == 'Windows'

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -865,7 +865,7 @@ if __is_metainfo_generated and is_compiled_with_cuda():
                     ctypes.CDLL(lib_path)
                     break
 
-            _preload_nvidia_lib(nvidia_package_path, "libnvrtc-builtins.so.*")
+            _preload_nvidia_lib(nvidia_package_path, "libnvrtc_builtins.so.*")
 
     elif (
         platform.system() == 'Windows'

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -848,9 +848,7 @@ if __is_metainfo_generated and is_compiled_with_cuda():
 
                 cuda_majar_version = cuda_version().split('.')[0]
 
-                lib_paths = glob.glob(
-                    os.path.join(nvidia_package_path, 'lib', lib_glob)
-                )
+                lib_paths = []
                 lib_paths += glob.glob(
                     os.path.join(
                         nvidia_package_path,
@@ -858,6 +856,9 @@ if __is_metainfo_generated and is_compiled_with_cuda():
                         'lib',
                         lib_glob,
                     )
+                )
+                lib_paths += glob.glob(
+                    os.path.join(nvidia_package_path, 'lib', lib_glob)
                 )
 
                 for lib_path in lib_paths:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

`libnvrtc` 会通过 `dlopen` 之类的方式加载 `libnvrtc-builtins`，但既没有显式链接，也没有 patchelf 到 RPATH 里，这里参考 pytorch/pytorch#167614 提前将 `libnvrtc-builtins.so` 加载到内存中，确保 `libnvrtc` 可以找到 `libnvrtc-builtins`

<!-- PCard-66972 -->