### PR TITLE
[3.3][CINN] Preload `libnvrtc-builtins.so` to avoid dynload failed on CUDA 13.0 (#77287)

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -839,6 +839,33 @@ if __is_metainfo_generated and is_compiled_with_cuda():
             cuda_cccl_path = package_dir + "/.." + "/nvidia/cuda_cccl/include/"
             set_flags({"FLAGS_cuda_cccl_dir": cuda_cccl_path})
 
+            def _preload_nvidia_lib(nvidia_package_path: str, lib_glob: str):
+                import ctypes
+                import glob
+
+                from .version import cuda as cuda_version
+
+                cuda_major_version = cuda_version().split('.')[0]
+
+                lib_paths = []
+                lib_paths += glob.glob(
+                    os.path.join(
+                        nvidia_package_path,
+                        f'cu{cuda_major_version}',
+                        'lib',
+                        lib_glob,
+                    )
+                )
+                lib_paths += glob.glob(
+                    os.path.join(nvidia_package_path, 'lib', lib_glob)
+                )
+
+                for lib_path in lib_paths:
+                    ctypes.CDLL(lib_path)
+                    break
+
+            _preload_nvidia_lib(nvidia_package_path, "libnvrtc-builtins.so.*")
+
     elif (
         platform.system() == 'Windows'
         and platform.machine() in ('x86_64', 'AMD64')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

Cherry-pick of #77287

`libnvrtc` 会通过 `dlopen` 之类的方式加载 `libnvrtc-builtins`，但既没有显式链接，也没有 patchelf 到 RPATH 里，这里参考 pytorch/pytorch#167614 提前将 `libnvrtc-builtins.so` 加载到内存中，确保 `libnvrtc` 可以找到 `libnvrtc-builtins`

<!-- devPR:https://github.com/PaddlePaddle/Paddle/pull/77287 -->

<!-- PCard-66972 -->