### PR TITLE
[CI][SOT] Fix SOT CI always skipped in non-develop branch

### DIFF
--- a/ci/determine_sot_ci_trigger.sh
+++ b/ci/determine_sot_ci_trigger.sh
@@ -42,7 +42,7 @@ function determine_sot_ci_trigger() {
     )
 
     run_sot_ut="OFF"
-    for change_file in $(git diff --name-only upstream/develop);
+    for change_file in $(git diff --name-only upstream/${BRANCH});
     do
         for sot_file in ${SOT_FILE_LIST[@]};
         do


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

修复检测 SOT 跳过逻辑中硬编码的 `develop` 分支名，应当根据具体分支来检测 commit，避免 SOT 在 release 分支被永远跳过

<img width="838" height="202" alt="image" src="https://github.com/user-attachments/assets/6fb416be-8387-4a04-80d9-35f4148e5a99" />

<!-- PCard-66972 -->