### PR TITLE
[SOT] Fix SOT compilation failure caused when `PY_VERSION` is not setting

### DIFF
--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -143,25 +143,15 @@ set(PYBIND_SRCS
     sot/frame_proxy.c
     sot/eval_frame.c
     sot/guards.cc
+    sot/cpython_internals/internals_3_11.c
+    sot/cpython_internals/internals_3_12.c
+    sot/cpython_internals/internals_3_13.c
+    sot/cpython_internals/internals_3_14.c
     op_callstack_utils.cc
     python_callable_registry.cc
     arg_pre_process.cc
     args_mapper.cc
     size.cc)
-
-if(${PY_VERSION} VERSION_GREATER_EQUAL "3.11" AND ${PY_VERSION} VERSION_LESS
-                                                  "3.12")
-  set(PYBIND_SRCS ${PYBIND_SRCS} sot/cpython_internals/internals_3_11.c)
-elseif(${PY_VERSION} VERSION_GREATER_EQUAL "3.12" AND ${PY_VERSION}
-                                                      VERSION_LESS "3.13")
-  set(PYBIND_SRCS ${PYBIND_SRCS} sot/cpython_internals/internals_3_12.c)
-elseif(${PY_VERSION} VERSION_GREATER_EQUAL "3.13" AND ${PY_VERSION}
-                                                      VERSION_LESS "3.14")
-  set(PYBIND_SRCS ${PYBIND_SRCS} sot/cpython_internals/internals_3_13.c)
-elseif(${PY_VERSION} VERSION_GREATER_EQUAL "3.14" AND ${PY_VERSION}
-                                                      VERSION_LESS "3.15")
-  set(PYBIND_SRCS ${PYBIND_SRCS} sot/cpython_internals/internals_3_14.c)
-endif()
 
 if(WITH_DISTRIBUTE)
   set(PYBIND_SRCS ${PYBIND_SRCS} dist_api.cc)

--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_11.c
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_11.c
@@ -14,6 +14,8 @@
 
 #include "paddle/fluid/pybind/sot/cpython_internals/internals_3_11.h"
 
+#if (PY_3_11_PLUS && !PY_3_12_PLUS)
+
 #include <internal/pycore_code.h>
 #include <internal/pycore_frame.h>
 #define Py_BUILD_CORE       // internal/pycore_opcode.h need this macro
@@ -264,3 +266,5 @@ PyFrameObject *_PyFrame_MakeAndSetFrameObject(_PyInterpreterFrame *frame) {
   frame->frame_obj = f;
   return f;
 }
+
+#endif  // (PY_3_11_PLUS && !PY_3_12_PLUS)

--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_11.h
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_11.h
@@ -14,9 +14,13 @@
 
 #pragma once
 
+#include "paddle/fluid/pybind/sot/macros.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#if (PY_3_11_PLUS && !PY_3_12_PLUS)
 
 #include <Python.h>
 
@@ -27,6 +31,8 @@ int Internal_PyInterpreterFrame_GetLine(_PyInterpreterFrame *frame);
 void Internal_PyFrame_Clear(_PyInterpreterFrame *frame);
 
 int Internal_PyFrame_FastToLocalsWithError(_PyInterpreterFrame *frame);
+
+#endif  // (PY_3_11_PLUS && !PY_3_12_PLUS)
 
 #ifdef __cplusplus
 }

--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_12.c
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_12.c
@@ -14,6 +14,8 @@
 
 #include "paddle/fluid/pybind/sot/cpython_internals/internals_3_12.h"
 
+#if (PY_3_12_PLUS && !PY_3_13_PLUS)
+
 #include <internal/pycore_code.h>
 #include <internal/pycore_frame.h>
 #define Py_BUILD_CORE       // internal/pycore_opcode.h need this macro
@@ -460,3 +462,5 @@ int Internal_PyFrame_FastToLocalsWithError(_PyInterpreterFrame *frame) {
   Py_DECREF(locals);
   return 0;
 }
+
+#endif  // (PY_3_12_PLUS && !PY_3_13_PLUS)

--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_12.h
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_12.h
@@ -14,9 +14,13 @@
 
 #pragma once
 
+#include "paddle/fluid/pybind/sot/macros.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#if (PY_3_12_PLUS && !PY_3_13_PLUS)
 
 #include <Python.h>
 
@@ -31,6 +35,8 @@ _PyInterpreterFrame *Internal_PyThreadState_PushFrame(PyThreadState *tstate,
                                                       size_t size);
 
 int Internal_PyFrame_FastToLocalsWithError(_PyInterpreterFrame *frame);
+
+#endif  // (PY_3_12_PLUS && !PY_3_13_PLUS)
 
 #ifdef __cplusplus
 }

--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_13.c
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_13.c
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 #include "paddle/fluid/pybind/sot/cpython_internals/internals_3_13.h"
-#include "paddle/fluid/pybind/sot/macros.h"
+
+#if (PY_3_13_PLUS && !PY_3_14_PLUS)
 
 #include <internal/pycore_code.h>
 #include <internal/pycore_frame.h>
@@ -304,3 +305,5 @@ PyObject *get_framelocals_mapping(_PyInterpreterFrame *frame) {
 
   return mapping;
 }
+
+#endif  // (PY_3_13_PLUS && !PY_3_14_PLUS)

--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_13.h
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_13.h
@@ -14,9 +14,13 @@
 
 #pragma once
 
+#include "paddle/fluid/pybind/sot/macros.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#if (PY_3_13_PLUS && !PY_3_14_PLUS)
 
 #include <Python.h>
 
@@ -32,6 +36,8 @@ _PyInterpreterFrame *Internal_PyThreadState_PushFrame(PyThreadState *tstate,
                                                       size_t size);
 
 PyObject *get_framelocals_mapping(_PyInterpreterFrame *frame);
+
+#endif  // (PY_3_13_PLUS && !PY_3_14_PLUS)
 
 #ifdef __cplusplus
 }

--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_14.c
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_14.c
@@ -13,9 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/pybind/sot/cpython_internals/internals_3_14.h"
+
+#if (PY_3_14_PLUS && !PY_3_15_PLUS)
+
 #include <internal/pycore_code.h>
 #include <internal/pycore_frame.h>
-#include "paddle/fluid/pybind/sot/macros.h"
 #define Py_BUILD_CORE       // internal/pycore_opcode.h need this macro
 #define NEED_OPCODE_TABLES  // To get _PyOpcode_Caches and _PyOpcode_Deopt
 
@@ -330,3 +332,5 @@ PyObject *get_framelocals_mapping(_PyInterpreterFrame *frame) {
 
   return mapping;
 }
+
+#endif  // (PY_3_14_PLUS && !PY_3_15_PLUS)

--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_14.h
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_14.h
@@ -14,9 +14,13 @@
 
 #pragma once
 
+#include "paddle/fluid/pybind/sot/macros.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#if (PY_3_14_PLUS && !PY_3_15_PLUS)
 
 #include <Python.h>
 
@@ -32,6 +36,8 @@ _PyInterpreterFrame *Internal_PyThreadState_PushFrame(PyThreadState *tstate,
                                                       size_t size);
 
 PyObject *get_framelocals_mapping(_PyInterpreterFrame *frame);
+
+#endif  // (PY_3_14_PLUS && !PY_3_15_PLUS)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->

cpython 内部方法改为条件编译选择版本

> [!NOTE]
> 在打包机上并没有配置 `PY_VERSION`, 并且目前项目的 cmakelist 中也没有比较合适的查找 python 版本的方法，所以先多编译几个 `.o` 的近似空文件

