### PR TITLE
[Cpp API Compatibility] Add `Tensor.reset` API

### DIFF
--- a/paddle/phi/api/include/compat/ATen/core/TensorBase.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBase.h
@@ -227,6 +227,8 @@ class PADDLE_API TensorBase {
     }
   }
 
+  void reset() { tensor_.reset(); }
+
   // Return a `TensorAccessor` for CPU `Tensor`s. You have to specify scalar
   // type and
   // dimension.

--- a/test/cpp/compat/compat_basic_test.cc
+++ b/test/cpp/compat/compat_basic_test.cc
@@ -354,3 +354,35 @@ TEST(TensorBaseTest, LayoutAPI) {
   oss << tensor.layout();
   ASSERT_EQ(oss.str(), "Strided");
 }
+
+TEST(TensorBaseTest, ResetAPI) {
+  // Test reset() API
+  at::TensorBase tensor = at::ones({2, 3}, at::kFloat);
+
+  // Verify tensor is defined before reset
+  ASSERT_TRUE(tensor.defined());
+  ASSERT_NE(tensor.data_ptr(), nullptr);
+  ASSERT_EQ(tensor.numel(), 6);
+
+  // Call reset()
+  tensor.reset();
+
+  // Verify tensor is no longer defined after reset
+  ASSERT_FALSE(tensor.defined());
+
+  // Test reset on already undefined tensor (should not crash)
+  at::TensorBase empty_tensor;
+  ASSERT_FALSE(empty_tensor.defined());
+  empty_tensor.reset();
+  ASSERT_FALSE(empty_tensor.defined());
+
+  // Test reset on tensor after assignment
+  at::TensorBase tensor2 = at::ones({3, 4}, at::kDouble);
+  at::TensorBase tensor3 = tensor2;
+  ASSERT_TRUE(tensor2.defined());
+  ASSERT_TRUE(tensor3.defined());
+
+  tensor2.reset();
+  ASSERT_FALSE(tensor2.defined());
+  ASSERT_TRUE(tensor3.defined());  // tensor3 should still be valid
+}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure


### PR Types
New features


### Description
新增 `reset` 接口
由于我在同一个代码行加接口，因此上一个pr合入后出现了代码冲突，变基时不小心操作失误（指强推失误），把之前的更改删了，幸好是在Windows上操作，Linux还有备份，但是pr没了，这里补交一个pr
