### PR TITLE
[ThirdParty] Search `libnccl.so.2` before `libnccl.so` in dynamic loader

### DIFF
--- a/paddle/phi/backends/dynload/dynamic_loader.cc
+++ b/paddle/phi/backends/dynload/dynamic_loader.cc
@@ -943,7 +943,7 @@ void* GetNCCLDsoHandle() {
 #else
 #ifdef PADDLE_WITH_PIP_CUDA_LIBRARIES
   return GetDsoHandleFromSearchPath(
-      FLAGS_nccl_dir, "libnccl.so;libnccl.so.2", true, {}, warning_msg);
+      FLAGS_nccl_dir, "libnccl.so.2;libnccl.so", true, {}, warning_msg);
 #else
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
   return GetDsoHandleFromSearchPath(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Fix nccl search order in GetNCCLDsoHandle