### PR TITLE
[CUDAExtension] Fix compatibility for `PADDLE_CUDA_ARCH_LIST`

### DIFF
--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -512,7 +512,7 @@ def _get_cuda_arch_flags(cflags: list[str] | None = None) -> list[str]:
                 "Paddle is not compiled with CUDA or Custom Device, cannot determine CUDA arch."
             )
     else:
-        _arch_list = _arch_list.replace(' ', ';')
+        _arch_list = _arch_list.replace(' ', ';').replace(',', ';')
         for named_arch, archival in named_arches.items():
             _arch_list = _arch_list.replace(named_arch, archival)
         arch_list = _arch_list.split(';')

--- a/test/compat/test_cpp_extension_api.py
+++ b/test/compat/test_cpp_extension_api.py
@@ -58,6 +58,18 @@ class TestGetCudaArchFlags(unittest.TestCase):
         self.assertIn("-gencode=arch=compute_90,code=sm_90", flags)
         self.assertIn("-gencode=arch=compute_90,code=compute_90", flags)
 
+        os.environ["PADDLE_CUDA_ARCH_LIST"] = "8.6,9.0+PTX"
+        flags = _get_cuda_arch_flags()
+        self.assertIn("-gencode=arch=compute_86,code=sm_86", flags)
+        self.assertIn("-gencode=arch=compute_90,code=sm_90", flags)
+        self.assertIn("-gencode=arch=compute_90,code=compute_90", flags)
+
+        os.environ["PADDLE_CUDA_ARCH_LIST"] = "8.6 9.0+PTX"
+        flags = _get_cuda_arch_flags()
+        self.assertIn("-gencode=arch=compute_86,code=sm_86", flags)
+        self.assertIn("-gencode=arch=compute_90,code=sm_90", flags)
+        self.assertIn("-gencode=arch=compute_90,code=compute_90", flags)
+
     def test_auto_detect(self):
         if "PADDLE_CUDA_ARCH_LIST" in os.environ:
             del os.environ["PADDLE_CUDA_ARCH_LIST"]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
兼容之前的 PADDLE_CUDA_ARCH_LIST 格式，兼容 `os.environ['PADDLE_CUDA_ARCH_LIST'] = '8.0,9.0'`