### PR TITLE
[0-size Tensor ] Add 0-size Tensor support for paddle.Tensor.__rtruediv__ API on xpu.

### DIFF
--- a/paddle/phi/kernels/xpu/elementwise.h
+++ b/paddle/phi/kernels/xpu/elementwise.h
@@ -198,10 +198,14 @@ void XPUElementwiseGrad(const XPUContext& dev_ctx,
     dy_data = dev_ctx.template Alloc<T>(dy);
   }
   if (dz.numel() == 0) {
-    phi::Full<T, XPUContext>(
-        dev_ctx, phi::IntArray(common::vectorize(dx->dims())), 0, dx);
-    phi::Full<T, XPUContext>(
-        dev_ctx, phi::IntArray(common::vectorize(dy->dims())), 0, dy);
+    if (dx) {
+      phi::Full<T, XPUContext>(
+          dev_ctx, phi::IntArray(common::vectorize(x.dims())), 0, dx);
+    }
+    if (dy) {
+      phi::Full<T, XPUContext>(
+          dev_ctx, phi::IntArray(common::vectorize(y.dims())), 0, dy);
+    }
     return;
   }
 

--- a/test/xpu/test_elementwise_div_op_xpu.py
+++ b/test/xpu/test_elementwise_div_op_xpu.py
@@ -219,6 +219,32 @@ class XPUTestElementwiseDivOp(XPUOpTestWrapper):
                 (out_result,) = exe.run(feed={'x': x}, fetch_list=[out])
                 self.assertEqual((out_result == (2 / x)).all(), True)
 
+    class TestElementwiseDivBroadcastZeroSize(unittest.TestCase):
+        def test_rtruediv_with_scalar(self):
+            main_prog = base.Program()
+            startup_prog = base.Program()
+            with base.program_guard(main_prog, startup_prog):
+                x = paddle.static.data(name='x', dtype='float32', shape=[0, 1358])
+                x.stop_gradient = False
+                scalar = 1.0
+                out = scalar / x
+                loss = paddle.sum(out)
+                x_grad = paddle.static.gradients([loss], [x])[0]
+                exe = base.Executor(base.XPUPlace(0))
+                exe.run(startup_prog)
+                x_np = np.random.uniform(0.1, 100.0, size=(0, 1358)).astype('float32')
+                out_np, x_grad_np = exe.run(
+                    main_prog,
+                    feed={'x': x_np},
+                    fetch_list=[out, x_grad],
+                )
+
+            self.assertEqual(out_np.shape, (0, 1358))
+            self.assertEqual(out_np.size, 0)
+            np.testing.assert_allclose(out_np, 1.0 / x_np, rtol=1e-06, atol=0.0)
+            self.assertEqual(x_grad_np.shape, (0, 1358))
+            self.assertEqual(x_grad_np.size, 0)
+            np.testing.assert_allclose(x_grad_np, -1.0 / (x_np * x_np), rtol=1e-06, atol=0.0)
 
 support_types = get_xpu_op_support_types('elementwise_div')
 for stype in support_types:


### PR DESCRIPTION
PR Category
Operator Mechanism 

PR types
Bug fixes

Description
利用PaddleAPITest 发现 __rtruediv__算子对0-size Tensor 支持不足
编写单测复现问题
<img width="890" height="442" alt="image" src="https://github.com/user-attachments/assets/cabb292f-8a5b-4aef-8d93-2d5669905a73" />
修复后单测通过
<img width="515" height="113" alt="image" src="https://github.com/user-attachments/assets/6c1f614c-69d1-457c-982e-b9d8ded0d758" />
