### PR TITLE
[Dy2St] Guard `is_grad_enabled` status to avoid incorrect cache hits

### DIFF
--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -200,6 +200,13 @@ void BindGuardTree(pybind11::module *m) {
           },
           py::arg("frame"));
 
+  py::class_<CheckGuardNode<0>,
+             GuardNodeBase,
+             std::shared_ptr<CheckGuardNode<0>>>(*m, "CheckGuardNode0")
+      .def_property_readonly("exprs",
+                             [](CheckGuardNode<0> &self) { return self.exprs; })
+      .def("get_guard_name", &CheckGuardNode<0>::get_guard_name);
+
   py::class_<CheckGuardNode<1>,
              GuardNodeBase,
              std::shared_ptr<CheckGuardNode<1>>>(*m, "CheckGuardNode1")
@@ -213,6 +220,17 @@ void BindGuardTree(pybind11::module *m) {
       .def_property_readonly("exprs",
                              [](CheckGuardNode<2> &self) { return self.exprs; })
       .def("get_guard_name", &CheckGuardNode<2>::get_guard_name);
+
+  py::class_<IsGradEnabledGuardNode,
+             CheckGuardNode<0>,
+             std::shared_ptr<IsGradEnabledGuardNode>>(
+      *m, "IsGradEnabledGuardNode", R"DOC(IsGradEnabledGuardNode Class.)DOC")
+      .def(py::init<bool,
+                    const std::vector<std::shared_ptr<GuardNodeBase>> &,
+                    const std::optional<int> &>(),
+           py::arg("is_grad_enabled"),
+           py::arg("next_guard_nodes") = py::list(),
+           py::arg("return_cache_index") = py::none());
 
   py::class_<LegacyGuardNode,
              CheckGuardNode<1>,

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/fluid/pybind/sot/guards.h"
 #include <optional>
+#include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/phi/api/include/tensor.h"
 
 #if SOT_IS_SUPPORTED
@@ -483,6 +484,11 @@ bool LegacyGuardNode::check(std::array<PyObject*, 1> values) {
   PyObject* value = values[0];
   HANDLE_NULL_VALUE(value);
   return guard->check(value);
+}
+
+bool IsGradEnabledGuardNode::check(std::array<PyObject*, 0> values) {
+  bool current_is_grad_enabled = egr::Controller::Instance().HasGrad();
+  return current_is_grad_enabled == is_grad_enabled_;
 }
 
 std::optional<int> ExprGuardNode::lookup(FrameProxy* frame) {

--- a/paddle/fluid/pybind/sot/guards.h
+++ b/paddle/fluid/pybind/sot/guards.h
@@ -641,6 +641,21 @@ class LegacyGuardNode : public CheckGuardNode<1> {
   bool check(std::array<PyObject*, 1> values) override;
 };
 
+class IsGradEnabledGuardNode : public CheckGuardNode<0> {
+ public:
+  bool is_grad_enabled_;
+  explicit IsGradEnabledGuardNode(
+      bool is_grad_enabled,
+      std::vector<std::shared_ptr<GuardNodeBase>> next_guard_nodes,
+      std::optional<int> return_cache_index)
+      : CheckGuardNode<0>({}, next_guard_nodes, return_cache_index) {
+    is_grad_enabled_ = is_grad_enabled;
+  }
+  virtual ~IsGradEnabledGuardNode() = default;
+  std::string get_guard_name() const override { return "IsGradEnabledGuard"; };
+  bool check(std::array<PyObject*, 0> values) override;
+};
+
 class GuardTree {
  public:
   GuardTree(const std::vector<std::vector<std::shared_ptr<GuardNodeBase>>>&

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -278,6 +278,7 @@ class CacheKey:
         'input_args_with_spec',
         'input_kwargs_with_spec',
         'class_instance',
+        'is_grad_enabled',
         'kwargs',
         '_spec_names_id',
         '_pir_flags',
@@ -305,6 +306,7 @@ class CacheKey:
         self.input_args_with_spec = input_args_with_spec
         self.input_kwargs_with_spec = input_kwargs_with_spec
         self.class_instance = class_instance
+        self.is_grad_enabled = paddle.is_grad_enabled()
         # NOTE: `kwargs` is usually not considered as basic member for `__hash__`
         self.kwargs = kwargs
         self._spec_names_id = _hash_spec_names(
@@ -363,6 +365,7 @@ class CacheKey:
                 is_train,
                 self._pir_flags,
                 use_pir_api(),
+                self.is_grad_enabled,
             )
         )
 

--- a/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/function_graph.py
@@ -350,10 +350,32 @@ class FunctionGraph:
             inputs,
         )
 
+    def load_builtin_stringified_guards(self) -> list[StringifiedExpression]:
+        return [
+            # paddle.is_grad_enabled()
+            StringifiedExpression(
+                f"paddle.is_grad_enabled() is {paddle.is_grad_enabled()}",
+                [],
+                free_vars={"paddle": paddle},
+            )
+        ]
+
+    def load_builtin_guard_chain(
+        self,
+    ) -> list[paddle.framework.core.GuardNodeBase]:
+        is_current_grad_enabled = paddle.is_grad_enabled()
+        return [
+            # paddle.is_grad_enabled()
+            paddle.framework.core.IsGradEnabledGuardNode(
+                is_current_grad_enabled
+            ),
+        ]
+
     @property
     @event_register("guard_chain")
     def guard_chain(self) -> list[paddle.framework.core.GuardNodeBase]:
         guard_chain: list[paddle.framework.core.GuardNodeBase] = []
+        guard_chain.extend(self.load_builtin_guard_chain())
 
         with EventGuard("guard_fn: find vars and make faster guard"):
             for variable in find_traceable_vars(
@@ -367,6 +389,7 @@ class FunctionGraph:
     def guard_fn(self) -> Guard:
         with switch_symbol_registry():
             guards: list[StringifiedExpression] = []
+            guards.extend(self.load_builtin_stringified_guards())
             with EventGuard("guard_fn: find vars and make stringified guard"):
                 for variable in find_traceable_vars(
                     self.input_variables + list(self._global_guarded_variables)

--- a/test/dygraph_to_static/test_jit_recompute.py
+++ b/test/dygraph_to_static/test_jit_recompute.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from dygraph_to_static_utils import (
+    Dy2StTestBase,
+)
+
+import paddle
+
+
+class ManualPyLayerRecompute(paddle.autograd.PyLayer):
+    @staticmethod
+    def forward(ctx, fn, x, y):
+        ctx.fn = fn
+        ctx.save_for_backward(x, y)
+        with paddle.no_grad():
+            out = fn(x, y)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        x, y = ctx.saved_tensor()
+        with paddle.enable_grad():
+            x.stop_gradient = False
+            y.stop_gradient = False
+            out = ctx.fn(x, y)
+        grad_inputs = paddle.autograd.grad(out, [x, y], grad_out)
+        return (*grad_inputs,)
+
+
+class TestManualPyLayerRecompute(Dy2StTestBase):
+    def test_recompute(self):
+        @paddle.jit.to_static()
+        def fn(x, y):
+            return x * y + paddle.sin(x)
+
+        x = paddle.randn([3, 3])
+        x.stop_gradient = False
+        y = paddle.randn([3, 3])
+        y.stop_gradient = False
+
+        out = ManualPyLayerRecompute.apply(fn, x, y)
+        out.backward()
+        grad_x1 = x.grad.numpy()
+        grad_y1 = y.grad.numpy()
+
+        x.clear_gradient()
+        y.clear_gradient()
+
+        out2 = fn(x, y)
+        out2.backward()
+        grad_x2 = x.grad.numpy()
+        grad_y2 = y.grad.numpy()
+
+        x.clear_gradient()
+        y.clear_gradient()
+
+        np.testing.assert_allclose(grad_x1, grad_x2, rtol=1e-05)
+        np.testing.assert_allclose(grad_y1, grad_y2, rtol=1e-05)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/sot/test_guard_global_status.py
+++ b/test/sot/test_guard_global_status.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+from test_case_base import (
+    TestCaseBase,
+    test_instruction_translator_cache_context,
+)
+
+import paddle
+
+
+class TestGuardIsGradEnabled(TestCaseBase):
+    def test_switch_is_grad_enabled(self):
+        def fn(x):
+            return x + 1
+
+        with test_instruction_translator_cache_context() as ctx:
+            self.assertEqual(ctx.translate_count, 0)
+            with paddle.no_grad():
+                self.assert_results(fn, 1)
+            self.assertEqual(ctx.translate_count, 1)
+            with paddle.enable_grad():
+                self.assert_results(fn, 1)
+            self.assertEqual(ctx.translate_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

在过去，动转静组网阶段是无法感知 dygraph tracer 上是否 grad enabled 状态的，因此原始组网总是按照有梯度来，在实际执行前根据 `layer.training` 来选择特化是否带反向的 program，但这实际上是不对的，或者说是动静不统一的，因为 `layer.training` 只是用于标识 Dropout 这类 OP 的行为属性而已，并非是是否有梯度的标识，但这在之前确实只有这种方式来构造一个 infer only 的图

#67966 将 grad enabled 状态从 dygraph tracer 上解耦出来，使得静态图也可以感知这一状态之后，实际上是让动静进一步统一了，因为这一状态主要影响组网，会对产生的「原始」前向图产生影响（主要是 `stop_gradients` 属性），因此应当将其加到 guard 里，本 PR 也主要是完成这一件事，包括 SOT 和 AST

但是由于过去主要感知 `layer.training` 来确定是否要添加反向，可能会产生一种边界 case，即在用户使用 `net.eval()` 后，在 grad enabled 为 True 的情况下，动态图是会产生梯度的，但转静目前两者的耦合会导致无法产生梯度，因为这一行为已经是公开用法，而且 `net.eval()` 情形下需要梯度应该是基本不会存在的需求，因此暂时不改动

<!-- PCard-66972 -->