### PR TITLE
[API Compatibility No.29] Add parameter alias support for as_strided -part 

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -33,6 +33,7 @@ from paddle.utils.decorator_utils import (
     index_add_decorator,
     param_one_alias,
     param_two_alias,
+    param_two_alias_one_default,
     reshape_decorator,
     tensor_split_decorator,
     view_decorator,
@@ -7805,6 +7806,9 @@ def unflatten(
     return x
 
 
+@param_two_alias_one_default(
+    ["x", "input"], ["shape", "size"], ["offset", 'storage_offset']
+)
 @dygraph_only
 def as_strided(
     x: Tensor,
@@ -7826,10 +7830,10 @@ def as_strided(
          :alt: Legend
 
     Args:
-        x (Tensor): An N-D Tensor. The data type is ``float32``, ``float64``, ``int32``, ``int64`` or ``bool``
-        shape (list|tuple): Define the target shape. Each element of it should be integer.
+        x (Tensor): An N-D Tensor. The data type is ``float32``, ``float64``, ``int32``, ``int64`` or ``bool``. Alias: ``input``.
+        shape (list|tuple): Define the target shape. Each element of it should be integer. Alias: ``size``.
         stride (list|tuple): Define the target stride. Each element of it should be integer.
-        offset (int, optional): Define the target Tensor's offset from x's holder. Default: 0.
+        offset (int, optional): Define the target Tensor's offset from x's holder. Default: 0. Alias: ``storage_offset``.
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -33,7 +33,6 @@ from paddle.utils.decorator_utils import (
     index_add_decorator,
     param_one_alias,
     param_two_alias,
-    param_two_alias_one_default,
     reshape_decorator,
     tensor_split_decorator,
     view_decorator,
@@ -7806,8 +7805,12 @@ def unflatten(
     return x
 
 
-@param_two_alias_one_default(
-    ["x", "input"], ["shape", "size"], ["offset", 'storage_offset']
+@ParamAliasDecorator(
+    {
+        "x": ["input"],
+        "shape": ["size"],
+        "offset": ["storage_offset"],
+    }
 )
 @dygraph_only
 def as_strided(

--- a/test/legacy_test/test_as_strided.py
+++ b/test/legacy_test/test_as_strided.py
@@ -114,10 +114,10 @@ class TestAsStridedAlias(unittest.TestCase):
                 )
 
                 # 3. Test alias: size -> shape
-                out_dims = paddle.as_strided(
+                out_size = paddle.as_strided(
                     x=x, size=shape, stride=stride, offset=offset
                 )
-                np.testing.assert_array_equal(out_ref.numpy(), out_dims.numpy())
+                np.testing.assert_array_equal(out_ref.numpy(), out_size.numpy())
 
                 # 4. Test alias: storage_offset -> offset
                 out_offset = paddle.as_strided(

--- a/test/legacy_test/test_as_strided.py
+++ b/test/legacy_test/test_as_strided.py
@@ -89,5 +89,50 @@ class TestAsStrided_ZeroSize(unittest.TestCase):
                 )
 
 
+class TestAsStridedAlias(unittest.TestCase):
+    def test_as_strided_alias(self):
+        self.shape = [32, 32]
+        self.typelist = ['float32', 'float64', 'int32', 'int64', 'float16']
+        with base.dygraph.guard():
+            for dtype in self.typelist:
+                x_np = np.random.random(self.shape).astype(dtype)
+                x = paddle.to_tensor(x_np)
+                shape = (3, 4)
+                stride = (32, 1)
+                offset = 0
+                # 1. Standard call (Benchmark)
+                out_ref = paddle.as_strided(
+                    x, shape=shape, stride=stride, offset=offset
+                )
+
+                # 2. Test alias: input -> x
+                out_input = paddle.as_strided(
+                    input=x, shape=shape, stride=stride, offset=offset
+                )
+                np.testing.assert_array_equal(
+                    out_ref.numpy(), out_input.numpy()
+                )
+
+                # 3. Test alias: size -> shape
+                out_dims = paddle.as_strided(
+                    x=x, size=shape, stride=stride, offset=offset
+                )
+                np.testing.assert_array_equal(out_ref.numpy(), out_dims.numpy())
+
+                # 4. Test alias: storage_offset -> offset
+                out_offset = paddle.as_strided(
+                    x=x, shape=shape, stride=stride, storage_offset=offset
+                )
+                np.testing.assert_array_equal(
+                    out_ref.numpy(), out_offset.numpy()
+                )
+
+                # 5. Test both aliases: input -> x, shape -> repeat_times
+                out_both = paddle.as_strided(
+                    input=x, size=shape, stride=stride, storage_offset=offset
+                )
+                np.testing.assert_array_equal(out_ref.numpy(), out_both.numpy())
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
1 API: Applied @param_two_alias_one_default to paddle.as_strided in python/paddle/tensor/manipulation.py to map input to x, size to shape and storage_offset to offset.
2 Test: Added TestTileAlias in test/legacy_test/test_as_strided_op.py to verify the correctness of the new argument aliases.
3 Doc: Updated the docstring of paddle.as_strided to explicitly document the alias support.