### PR TITLE
Fix index_select_grad_init global write out of memory.

### DIFF
--- a/paddle/phi/kernels/gpu/repeat_interleave_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/repeat_interleave_grad_kernel.cu
@@ -61,16 +61,33 @@ __global__ void index_select_grad_init(T* input_grad, int64_t numel) {
   T set_value[VecSize];
 #pragma unroll
   for (int i = 0; i < VecSize; i++) {
-    set_value[i] = 0;
+    set_value[i] = static_cast<T>(0);
   }
   const VecType* vec_value = reinterpret_cast<const VecType*>(&set_value[0]);
 
+  const int64_t vectorizable_limit = numel - VecSize;
+
 #pragma unroll
   for (int64_t i = tid; i < numel; i += blockDim.x * gridDim.x * VecSize) {
-    VecType* vec_output = reinterpret_cast<VecType*>(&input_grad[tid]);
-    *vec_output = *vec_value;
+    if constexpr (VecSize == 1) {
+      VecType* vec_output = reinterpret_cast<VecType*>(&input_grad[i]);
+      *vec_output = *vec_value;
+    } else {
+      // Hint compiler to prioritize the vectorized fast path for better
+      // performance.
+      if (__builtin_expect(i <= vectorizable_limit, 1)) {
+        VecType* vec_output = reinterpret_cast<VecType*>(&input_grad[i]);
+        *vec_output = *vec_value;
+      } else {
+#pragma unroll
+        for (int64_t j = i; j < numel; j++) {
+          input_grad[j] = static_cast<T>(0);
+        }
+      }
+    }
   }
 }
+
 template <typename T, typename Context>
 void RepeatInterleaveWithTensorIndexGradKernel(
     const Context& dev_ctx,
@@ -116,7 +133,13 @@ void RepeatInterleaveWithTensorIndexGradKernel(
   int64_t numel = x_grad->numel();
   int64_t out_nums = out_grad.numel();
   auto* out_grad_data = out_grad.data<T>();
+
   dev_ctx.template Alloc<T>(x_grad);
+
+  if (numel == 0) {
+    return;
+  }
+
   auto* in_grad_data = x_grad->data<T>();
   auto stream = dev_ctx.stream();
   int vec_size = 8;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Pcard-89071
Fix index_select_grad_init global write out of memory.

修复：
1. numel % VecSize !=0 场景，global 写越界。（有 mem check 报错）
2. tensor 比较大场景下错误赋值。
3. numel = 0 场景下 launch grid size 0。（有 mem check 报错）