### PR TITLE
[large tensor] fix GetDesiredGridDim and add enforce in layer_norm kernel

### DIFF
--- a/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
+++ b/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
@@ -51,7 +51,8 @@ static dim3 GetDesiredGridDim(int64_t grid_size) {
   int64_t grid_y = 1;
   if (grid_x > 2147483648LL) {
     grid_y = 1024;
-    grid_x = (grid_x + grid_y - 1) / grid_x;
+    grid_x = (grid_x + grid_y - 1) / grid_y;
+    PADDLE_ENFORCE_LE_INT_MAX(grid_x, "grid_x");
   }
   grid_dim.x = static_cast<uint32_t>(grid_x);
   grid_dim.y = static_cast<uint32_t>(grid_y);
@@ -1731,11 +1732,17 @@ static void LayerNormBackward(
   auto stream = dev_ctx.stream();
   const int kMaxBlockDim = 512;
   const int kMaxBlockNum = 128;
+  // TODO(large-tensor): generic backward kernel launch uses int32 grid dim
+  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
   int gradient_flag = ((d_x != nullptr ? 1 : 0) << 2) |
                       ((d_scale != nullptr ? 1 : 0) << 1) |
                       ((d_bias != nullptr ? 1 : 0));
   if (gradient_flag == 0) return;
   if (batch_size == 1) {
+    // TODO(large-tensor): batch_size==1 path uses int32 grid dim
+    PADDLE_ENFORCE_LE_INT_MAX(
+        (feature_size + kMaxBlockDim - 1) / kMaxBlockDim,
+        "(feature_size + kMaxBlockDim - 1) / kMaxBlockDim");
     LayerNormBackwardWhenBatchSizeIsOne<T, U, ScaleBiasWithSameTypeX>
         <<<(feature_size + kMaxBlockDim - 1) / kMaxBlockDim,
            kMaxBlockDim,

--- a/paddle/phi/kernels/fusion/gpu/attention_layer.norm.h
+++ b/paddle/phi/kernels/fusion/gpu/attention_layer.norm.h
@@ -48,6 +48,8 @@ class AttnLayerNorm {
                       const float quant_max_bound = 127.0,
                       const float quant_min_bound = -127.0) {
     auto stream = dev_ctx_.stream();
+    // TODO(large-tensor): generic kernel launch uses int32 grid dim
+    PADDLE_ENFORCE_LE_INT_MAX(batch_size_, "batch_size");
 
     switch (funcs::GetDesiredBlockDim(feature_size_)) {
       FIXED_BLOCK_DIM_CASE(

--- a/paddle/phi/kernels/fusion/gpu/fused_layernorm_residual_dropout_bias.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_layernorm_residual_dropout_bias.h
@@ -896,6 +896,8 @@ void LaunchLayernormResidualDropoutBias(
       PADDLE_ENFORCE_GPU_SUCCESS(GPU(MemsetAsync)(
           mask_data, 0, rows * cols * sizeof(MaskType), dev_ctx.stream()));
     }
+    // TODO(large-tensor): generic kernel launch uses int32 grid dim
+    PADDLE_ENFORCE_LE_INT_MAX(rows, "rows");
     auto kGridDim = funcs::GetDesiredGridDim(rows);
     // call layernorm forward
     switch (funcs::GetDesiredBlockDim(cols)) {

--- a/paddle/phi/kernels/gpu/layer_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_kernel.cu
@@ -472,8 +472,10 @@ void LayerNormDirectCUDAFunctor<T, U>::operator()(
     float eps) {
   const auto x_dims = common::make_ddim(input_shape);
   auto matrix_dim = common::flatten_to_2d(x_dims, begin_norm_axis);
-  int64_t batch_size = static_cast<int64_t>(matrix_dim[0]);
-  int64_t feature_size = static_cast<int64_t>(matrix_dim[1]);
+  int64_t batch_size = matrix_dim[0];
+  int64_t feature_size = matrix_dim[1];
+  // TODO(large-tensor): generic kernel launch uses int32 grid dim
+  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
   switch (funcs::GetDesiredBlockDim(feature_size)) {
     FIXED_BLOCK_DIM_CASE(
         funcs::LayerNormForward<T, U, kBlockDim>
@@ -519,7 +521,8 @@ static inline LayerNormKernelVariant LayerNormKernelDispatch(
 #endif
   if ((hidden_size >= 768 && hidden_size <= 2048 && hidden_size % 256 == 0 ||
        hidden_size == 4096) &&
-      scale != nullptr && bias != nullptr) {
+      x_numel <= std::numeric_limits<int>::max() && scale != nullptr &&
+      bias != nullptr) {
     return LayerNormKernelVariant::FAST_LN_V1;
   }
 
@@ -577,8 +580,10 @@ void LayerNormKernel(const Context& dev_ctx,
   }
 
   auto matrix_dim = common::flatten_to_2d(x_dims, begin_norm_axis);
-  int64_t batch_size = static_cast<int64_t>(matrix_dim[0]);
-  int64_t feature_size = static_cast<int64_t>(matrix_dim[1]);
+  int64_t batch_size = matrix_dim[0];
+  // TODO(large-tensor): generic kernel launch uses int32 grid dim
+  PADDLE_ENFORCE_LE_INT_MAX(batch_size, "batch_size");
+  int64_t feature_size = matrix_dim[1];
   auto stream = dev_ctx.stream();
   auto place = x.place();
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
- GetDesiredGridDim 函数在batch_size大于int32上限时有bug，导致grid_x被恒定设置为1，应该改为分母是grid_y，表示grid_x被grid_y向上整除。
- 添加一些必要的ENFORCE拦截错误。


pcard-93269