### PR TITLE
[API Compat] Add alias for `ChainDataset`, `ConcatDataset`, `Dataset`, `IterableDataset`

### DIFF
--- a/python/paddle/utils/data.py
+++ b/python/paddle/utils/data.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from paddle.io import (
+    ChainDataset as ChainDataset,
+    ConcatDataset as ConcatDataset,
+    Dataset as Dataset,
+    IterableDataset as IterableDataset,
+)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Add alias for `ChainDataset`, `ConcatDataset`, `Dataset`, `IterableDataset` in `paddle.io` (alias in `paddle.utils.data`)

#77275

**Used AI Studio**

---

目前可通过如下方式导入
```python
import paddle.utils.data
paddle.utils.data.Dataset
```
```python
from paddle.utils.data import Dataset
Dataset
```

不支持以下方式导入：
```python
import paddle
paddle.utils.data.DatasetDataset
```

```python
import paddle.utils
paddle.utils.data.DatasetDataset
```

后续会进一步调研支持。