### PR TITLE
[CI] Increase frequency for ccache cleanup (weekly -> daily) and increase L2 ccache size (200G->500G)

### DIFF
--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           docker exec -t ${container_name} bash -c '
             CFS_CCACHE_DIR="${CCACHE_SECONDARY_STORAGE#file://}"
-            ccache --trim-dir ${CFS_CCACHE_DIR} --trim-max-size 400G
+            ccache --trim-dir ${CFS_CCACHE_DIR} --trim-max-size 500G
           '
 
       - name: Terminate and delete the container

--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -2,7 +2,7 @@ name: Cleanup ccache
 
 on:
   schedule:
-    - cron: "0 16 * * Sat" # Weekly on Sunday at 00:00 UTC+8
+    - cron: "0 18 * * *" # Daily at 02:00 UTC+8
   workflow_dispatch:
 
 concurrency:
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TASK: cleanup-ccache-weekly
+  TASK: cleanup-ccache-nightly
   no_proxy: "bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
 
 defaults:
@@ -59,7 +59,7 @@ jobs:
         run: |
           docker exec -t ${container_name} bash -c '
             CFS_CCACHE_DIR="${CCACHE_SECONDARY_STORAGE#file://}"
-            ccache --trim-dir ${CFS_CCACHE_DIR} --trim-max-size 200G
+            ccache --trim-dir ${CFS_CCACHE_DIR} --trim-max-size 400G
           '
 
       - name: Terminate and delete the container


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

对 #77282 的 ccache 清理 workflow 进行修改

<img width="1144" height="236" alt="image" src="https://github.com/user-attachments/assets/c19a3de9-25cd-484a-8b9f-4957a35ee6e6" />

根据手动触发清理所需时间、大小对清理频率、限制上限做出调整，这里下面两行隔了不到 2 个工作日，就产生了 70G 需要清理的缓存，清理时间达到了 2.5h，为了避免清理时间过长，提升清理频率，同时提升 ccache size 上限，避免频繁清理仍需要的缓存项

特别是 release/3.3 的 H-Coverage 与 develop 共用 L2 ccache，如果缓存过小，高频开发的 develop 容易把低频开发的 release/3.3 缓存驱逐掉，导致 release/3.3 PR 合入过慢（未来其他 release 有同样问题）

- 频率提升，由 weekly（每周日 0 点）改为 daily（每日 2 点）
- 提升 L2 上限，从 200G->500G

<!-- PCard-66972 -->