### PR TITLE
update paddle/phi/infermeta/binary.cc [fluid_ops]

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -3945,7 +3945,6 @@ void RmsNormInferMeta(const MetaTensor& x,
 
   auto matrix_dim = common::flatten_to_2d(x_dim, begin_norm_axis);
   auto before_norm_dims = slice_ddim(x_dim, 0, begin_norm_axis);
-  int64_t right = matrix_dim[1];
 
   PADDLE_ENFORCE_EQ(epsilon >= 0.0f && epsilon <= 0.001f,
                     true,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
更新 paddle/phi/infermeta/binary.cc，变量未使用
```
paddle/phi/infermeta/binary.cc:3948:11: warning: unused variable ‘right’ [-Wunused-variable]
 3948 |   int64_t right = matrix_dim[1];
      |           ^~~~~
```