### PR TITLE
[XPU]Support CudaGraph & Set Stream In Begin Capture And Reset Stream In End Capture

### DIFF
--- a/paddle/phi/backends/xpu/cuda_graph.cc
+++ b/paddle/phi/backends/xpu/cuda_graph.cc
@@ -223,16 +223,14 @@ std::unique_ptr<CUDAGraph> CUDAGraph::EndCapture() {
     int device_id = phi::backends::xpu::GetXPUCurrentDeviceId();
     phi::backends::xpu::XPUDeviceGuard guard(device_id);
 
-    // Restore original stream if needed
-    if (original_stream_ != nullptr) {
-      phi::XPUContext *dev_ctx = phi::get_xpu_context(device_id);
-      dev_ctx->SetStream(original_stream_, 0);
-    }
+    phi::XPUContext *dev_ctx = phi::get_xpu_context(device_id);
+    dev_ctx->SetStream(original_stream_, 0);
 
     // Destroy the created stream
     PADDLE_ENFORCE_XPU_SUCCESS(xpu_stream_destroy(created_stream_));
     created_stream_ = nullptr;
     stream_created_ = false;
+    capturing_graph_->stream_ = original_stream_;
   }
   capturing_thread_id_ = paddle::none;
   return std::move(capturing_graph_);

--- a/paddle/phi/backends/xpu/cuda_graph.cc
+++ b/paddle/phi/backends/xpu/cuda_graph.cc
@@ -217,6 +217,7 @@ void CUDAGraph::EndSegmentCapture() {
 }
 
 std::unique_ptr<CUDAGraph> CUDAGraph::EndCapture() {
+  EndSegmentCapture();
   // Destroy the created stream before reset
   if (stream_created_ && created_stream_ != nullptr) {
     int device_id = phi::backends::xpu::GetXPUCurrentDeviceId();
@@ -233,7 +234,6 @@ std::unique_ptr<CUDAGraph> CUDAGraph::EndCapture() {
     created_stream_ = nullptr;
     stream_created_ = false;
   }
-  EndSegmentCapture();
   capturing_thread_id_ = paddle::none;
   return std::move(capturing_graph_);
 }

--- a/paddle/phi/backends/xpu/cuda_graph.cc
+++ b/paddle/phi/backends/xpu/cuda_graph.cc
@@ -26,6 +26,10 @@ namespace backends {
 namespace xpu {
 
 std::unique_ptr<CUDAGraph> CUDAGraph::capturing_graph_{nullptr};
+XPUStream CUDAGraph::created_stream_{nullptr};
+XPUStream CUDAGraph::original_stream_{nullptr};
+bool CUDAGraph::stream_created_{false};
+
 paddle::optional<std::thread::id> CUDAGraph::capturing_thread_id_{paddle::none};
 std::vector<std::function<void()>> CUDAGraph::cudagraph_pre_capture_callbacks_;
 
@@ -126,16 +130,32 @@ void CUDAGraph::BeginCapture(phi::XPUPlace place,
   // Create CUDAGraph instance, which will create a new stream in constructor
   // and set it as the current device stream
   capturing_graph_.reset(new CUDAGraph());
-  capturing_graph_->place_ = place;
+
   // Get the stream from the device context after constructor has set it
   // The constructor has already created a new stream and set it as current
   // device stream
-  phi::XPUContext *dev_ctx = phi::get_xpu_context(place.GetDeviceId());
+  // Create a new stream and set it as the current device stream
+  int device_id = phi::backends::xpu::GetXPUCurrentDeviceId();
+  phi::backends::xpu::XPUDeviceGuard guard(device_id);
+
+  // Get current XPUContext and save original stream
+  phi::XPUContext *dev_ctx = phi::get_xpu_context(device_id);
+  XPUStream current_stream = dev_ctx->stream(0);
+
+  if (current_stream == nullptr) {
+    original_stream_ = current_stream;
+    // Create new stream
+    PADDLE_ENFORCE_XPU_SUCCESS(xpu_stream_create(&created_stream_));
+    stream_created_ = true;
+    // Set the new stream as current stream
+    dev_ctx->SetStream(created_stream_, 0);
+  }
   XPUStream actual_stream = dev_ctx->stream(0);
   PADDLE_ENFORCE_NOT_NULL(
       actual_stream,
       common::errors::PermissionDenied(
           "CUDA Graph cannot be captured in default CUDA stream 0."));
+  capturing_graph_->place_ = place;
   capturing_graph_->stream_ = actual_stream;
   capturing_graph_->capture_mode_ = mode;
   if (mode == xpuStreamCaptureModeThreadLocal) {
@@ -197,6 +217,22 @@ void CUDAGraph::EndSegmentCapture() {
 }
 
 std::unique_ptr<CUDAGraph> CUDAGraph::EndCapture() {
+  // Destroy the created stream before reset
+  if (stream_created_ && created_stream_ != nullptr) {
+    int device_id = phi::backends::xpu::GetXPUCurrentDeviceId();
+    phi::backends::xpu::XPUDeviceGuard guard(device_id);
+
+    // Restore original stream if needed
+    if (original_stream_ != nullptr) {
+      phi::XPUContext *dev_ctx = phi::get_xpu_context(device_id);
+      dev_ctx->SetStream(original_stream_, 0);
+    }
+
+    // Destroy the created stream
+    PADDLE_ENFORCE_XPU_SUCCESS(xpu_stream_destroy(created_stream_));
+    created_stream_ = nullptr;
+    stream_created_ = false;
+  }
   EndSegmentCapture();
   capturing_thread_id_ = paddle::none;
   return std::move(capturing_graph_);

--- a/paddle/phi/backends/xpu/cuda_graph.cc
+++ b/paddle/phi/backends/xpu/cuda_graph.cc
@@ -194,7 +194,6 @@ void CUDAGraph::EndSegmentCapture() {
       cudaGraphInstantiate(&exec_graph, graph, nullptr, nullptr, 0));
   capturing_graph_->graphs_.emplace_back(graph);
   capturing_graph_->exec_graphs_.emplace_back(exec_graph);
-#endif
 }
 
 std::unique_ptr<CUDAGraph> CUDAGraph::EndCapture() {
@@ -305,3 +304,4 @@ CUDAGraphNodeLauncher::GetParameterSettersForExecGraph(cudaGraph_t graph) {
 }  // namespace xpu
 }  // namespace backends
 }  // namespace phi
+#endif

--- a/paddle/phi/backends/xpu/cuda_graph.h
+++ b/paddle/phi/backends/xpu/cuda_graph.h
@@ -94,8 +94,7 @@ class gpuKernelParams {
   void **kernelParams;
 };
 
-using CUDAGraphExecuterSetter_t =
-    std::function<void(cudaGraphExec_t)>;  // 改用XPU图执行类型
+using CUDAGraphExecuterSetter_t = std::function<void(cudaGraphExec_t)>;
 
 class CUDAGraphNodeLauncher {
  public:

--- a/paddle/phi/backends/xpu/cuda_graph.h
+++ b/paddle/phi/backends/xpu/cuda_graph.h
@@ -164,48 +164,13 @@ class CUDAGraph {
   CUDAGraph() {
     ThrowErrorIfNotSupportCUDAGraph();
     id_ = UniqueID();
-
-    // Create a new stream and set it as the current device stream
-    int device_id = phi::backends::xpu::GetXPUCurrentDeviceId();
-    phi::backends::xpu::XPUDeviceGuard guard(device_id);
-
-    // Get current XPUContext and save original stream
-    phi::XPUContext *dev_ctx = phi::get_xpu_context(device_id);
-    XPUStream current_stream = dev_ctx->stream(0);
-
-    if (current_stream == nullptr) {
-      original_stream_ = current_stream;
-      // Create new stream
-      PADDLE_ENFORCE_XPU_SUCCESS(xpu_stream_create(&created_stream_));
-      stream_created_ = true;
-      // Set the new stream as current stream
-      dev_ctx->SetStream(created_stream_, 0);
-    }
   }
 
  public:
   static constexpr int64_t kDefaultPoolID = 0;
   static constexpr int64_t kInvalidPoolID = -1;
 
-  ~CUDAGraph() {
-    // Destroy the created stream before reset
-    if (stream_created_ && created_stream_ != nullptr) {
-      int device_id = phi::backends::xpu::GetXPUCurrentDeviceId();
-      phi::backends::xpu::XPUDeviceGuard guard(device_id);
-
-      // Restore original stream if needed
-      if (original_stream_ != nullptr) {
-        phi::XPUContext *dev_ctx = phi::get_xpu_context(device_id);
-        dev_ctx->SetStream(original_stream_, 0);
-      }
-
-      // Destroy the created stream
-      PADDLE_ENFORCE_XPU_SUCCESS(xpu_stream_destroy(created_stream_));
-      created_stream_ = nullptr;
-      stream_created_ = false;
-    }
-    Reset();
-  }
+  ~CUDAGraph() { Reset(); }
   CUDAGraphID ID() const { return id_; }
 
   static int64_t SetMemoryPoolID(int64_t pool_id) {
@@ -351,12 +316,12 @@ class CUDAGraph {
   bool is_first_run_{true};
 
   // Stream created for this CUDAGraph instance
-  XPUStream created_stream_{nullptr};
-  XPUStream original_stream_{nullptr};
-  bool stream_created_{false};
 
   static paddle::optional<std::thread::id> capturing_thread_id_;
   static std::unique_ptr<CUDAGraph> capturing_graph_;
+  static XPUStream created_stream_;
+  static XPUStream original_stream_;
+  static bool stream_created_;
 };
 
 class CUDAGraphCaptureModeGuard {

--- a/paddle/phi/core/platform/cuda_graph_with_memory_pool.cc
+++ b/paddle/phi/core/platform/cuda_graph_with_memory_pool.cc
@@ -423,7 +423,7 @@ void BeginCUDAGraphCapture(phi::XPUPlace place,
   if (old_value) {
     FLAGS_use_stream_safe_cuda_allocator = true;
   }
-  // 多流
+
   if (num_stream > 1) {
     // Set cuda graph allocator for all streams.
     // Establish dependencies between cuda graph stream and all other streams

--- a/python/paddle/device/cuda/graphs.py
+++ b/python/paddle/device/cuda/graphs.py
@@ -40,12 +40,8 @@ if (
     is_compiled_with_cuda()
     or is_compiled_with_rocm()
     or check_compiled_with_custom_device()
+    or is_compiled_with_xpu()
 ):
-    from paddle.base.core import CUDAGraph as CoreCUDAGraph
-
-    def is_cuda_graph_supported():
-        return True
-elif is_compiled_with_xpu():
     from paddle.base.core import CUDAGraph as CoreCUDAGraph
 
     def is_cuda_graph_supported():
@@ -78,7 +74,9 @@ class CUDAGraph:
         )
 
         self._graph = None
-        if place is None:
+        if place is None and check_compiled_with_custom_device():
+            place = current_expected_place()
+        elif place is None:
             if is_compiled_with_cuda():
                 device_id = int(os.environ.get('FLAGS_selected_gpus', 0))
                 place = CUDAPlace(device_id)

--- a/test/xpu/test_cudagraph_xpu.py
+++ b/test/xpu/test_cudagraph_xpu.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import pathlib
+import shutil
+import unittest
+
+import numpy as np
+from op_test import is_custom_device
+
+import paddle
+from paddle.device.cuda.graphs import CUDAGraph
+
+
+def can_use_cuda_graph():
+    return (
+        paddle.is_compiled_with_cuda()
+        or is_custom_device()
+        or paddle.is_compiled_with_xpu()
+    ) and not paddle.is_compiled_with_rocm()
+
+
+class TestCUDAGraphInDygraphMode(unittest.TestCase):
+    def random_tensor(self, shape):
+        return paddle.to_tensor(
+            np.random.randint(low=0, high=10, size=shape).astype("float32")
+        )
+
+    def test_cuda_graph_dynamic_graph(self):
+        if not can_use_cuda_graph():
+            return
+
+        shape = [2, 3]
+        x = self.random_tensor(shape)
+        z = self.random_tensor(shape)
+
+        g = CUDAGraph()
+        g.capture_begin()
+        y = x + 10
+        z.add_(x)
+        g.capture_end()
+
+        for _ in range(10):
+            z_np_init = z.numpy()
+            x_new = self.random_tensor(shape)
+            x.copy_(x_new, False)
+            g.replay()
+            x_np = x_new.numpy()
+            y_np = y.numpy()
+            z_np = z.numpy()
+            self.assertTrue((y_np - x_np == 10).all())
+            self.assertTrue((z_np - z_np_init == x_np).all())
+
+        g.reset()
+
+    def test_concat_and_split(self):
+        if not can_use_cuda_graph():
+            return
+
+        concat_num = 100
+        xs = []
+        xs_np = []
+
+        for i in range(concat_num):
+            x_np = np.random.random(size=[1]).astype(np.float32)
+            xs.append(paddle.to_tensor(x_np))
+            xs_np.append(x_np)
+
+        graph = CUDAGraph()
+        graph.capture_begin()
+        y = paddle.concat(xs)
+        zs = paddle.split(y, len(xs))
+        graph.capture_end()
+        graph.replay()
+
+        y_np = y.numpy()
+        y_np_expected = np.concatenate(xs_np)
+        np.testing.assert_array_equal(y_np, y_np_expected)
+        self.assertEqual(len(zs), len(xs_np))
+        for i, z in enumerate(zs):
+            np.testing.assert_array_equal(z.numpy(), xs_np[i])
+
+        output_dir = f'cuda_graph_dot_{os.getpid()}'
+        try:
+            graph.print_to_dot_files(pathlib.Path(output_dir))
+            graph.reset()
+            shutil.rmtree(output_dir)
+        except Exception as e:
+            msg = str(e)
+            sub_msg = "The print_to_dot_files() method is only supported when CUDA version >= 11.3"
+            self.assertTrue(sub_msg in msg)
+        finally:
+            graph.reset()
+
+    def test_dataloader(self):
+        if not can_use_cuda_graph():
+            return
+
+        class AutoIncDataset(paddle.io.Dataset):
+            def __init__(self, n, dtype):
+                self.n = n
+                self.dtype = dtype
+
+            def __len__(self):
+                return self.n
+
+            def __getitem__(self, idx):
+                return np.array([idx]).astype(self.dtype)
+
+        n = 100
+        dtype = 'int64'
+        dataset = AutoIncDataset(n, dtype)
+        data_loader = paddle.io.DataLoader(
+            dataset, batch_size=1, num_workers=2, use_buffer_reader=True
+        )
+        x = None
+        y = None
+
+        graph = None
+        for i, data in enumerate(data_loader):
+            if graph is None:
+                x = data
+                x = x.to("xpu")
+                graph = CUDAGraph()
+                graph.capture_begin()
+                y = x * x
+                graph.capture_end()
+            else:
+                x.copy_(data, False)
+                x = x.to("xpu")
+
+            graph.replay()
+            actual_x = np.array([[i]]).astype(dtype)
+            actual_y = np.array([[i * i]]).astype(dtype)
+            np.testing.assert_array_equal(actual_x, x.numpy())
+            np.testing.assert_array_equal(actual_y, y.numpy())
+
+    def test_dev_ctx_alloc(self):
+        if not can_use_cuda_graph():
+            return
+
+        x = paddle.to_tensor([2], dtype='float32')
+        graph = CUDAGraph()
+        graph.capture_begin()
+        y = paddle.cast(x, dtype='float16')
+        graph.capture_end()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
设置XPU 开启CudaGraph，在BeginCapture中将默认流切换为非默认流，在EndCapture中将流切回去，不影响其他模块执行。
pcard-67164