### PR TITLE
[Debug] fix paddle.device bug

### DIFF
--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -2138,7 +2138,7 @@ class Device(str):
                     dev_index = int(idx)
                 else:
                     dev_type = t
-                    dev_index = 0 if t != "cpu" else None
+                    dev_index = None
 
         elif isinstance(type, int):
             dev_type = "cuda"
@@ -2150,7 +2150,7 @@ class Device(str):
         else:
             raise TypeError(f"Unsupported type for Device: {type}")
 
-        s = f"{dev_type}:{dev_index}" if dev_type != "cpu" else "cpu"
+        s = f"{dev_type}:{dev_index}" if dev_index else dev_type
         obj = str.__new__(cls, s)
         obj._dev_type = dev_type
         obj._index = dev_index

--- a/test/legacy_test/test_paddle_device.py
+++ b/test/legacy_test/test_paddle_device.py
@@ -26,19 +26,19 @@ class TestDevice(unittest.TestCase):
         self.assertIsNone(d.index)
 
         d = Device("cuda")
-        self.assertEqual(str(d), "cuda:0")
+        self.assertEqual(str(d), "cuda")
         self.assertEqual(d.type, "cuda")
-        self.assertEqual(d.index, 0)
+        self.assertEqual(d.index, None)
 
         d = Device("gpu")
-        self.assertEqual(str(d), "gpu:0")
+        self.assertEqual(str(d), "gpu")
         self.assertEqual(d.type, "gpu")
-        self.assertEqual(d.index, 0)
+        self.assertEqual(d.index, None)
 
         d = Device("xpu")
-        self.assertEqual(str(d), "xpu:0")
+        self.assertEqual(str(d), "xpu")
         self.assertEqual(d.type, "xpu")
-        self.assertEqual(d.index, 0)
+        self.assertEqual(d.index, None)
 
     def test_str_with_index(self):
         d = Device("cuda", 1)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
对齐paddle.device和torch.device在输入不给idx的时候的逻辑
>>> str(torch.device('cuda'))
'cuda'
>>> paddle.device('cuda')
'cuda'
