### PR TITLE
Support n dimension not aligned to 128 for fp8_quant_blockwise.

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2161,34 +2161,43 @@ void Fp8QuantBlockwiseInferMeta(const MetaTensor& X,
                         "Input(X) <= 65535 * 128, but got %d",
                         rows));
 
-  PADDLE_ENFORCE_EQ(cols % 128,
-                    0,
-                    common::errors::InvalidArgument(
-                        "The last dim of Input(X) should be exactly divided "
-                        "by 128 , but got %d",
-                        cols));
+  PADDLE_ENFORCE_EQ(
+      cols % 4,
+      0,
+      common::errors::InvalidArgument(
+          "The last dimension of Input(X) should be divisible by 4, "
+          "but received last dimension is %d.",
+          cols));
 
-  if (rows % 128 != 0) {
+  if (rows % 128 != 0 || cols % 128 != 0) {
     PADDLE_ENFORCE_EQ(
         input_transpose,
         0,
-        common::errors::InvalidArgument("When rows is not aligned to 128, only "
-                                        "supports input_transpose=False, "
-                                        "but received input_transpose=%d.",
-                                        input_transpose));
+        common::errors::InvalidArgument(
+            "When rows(%d) or cols(%d) is not aligned to 128, "
+            "input_transpose should be False, but received input_transpose=%d.",
+            rows,
+            cols,
+            input_transpose));
+
     PADDLE_ENFORCE_EQ(return_transpose_only,
                       0,
                       common::errors::InvalidArgument(
-                          "When rows is not aligned to 128, only supports "
-                          "return_transpose_only=False, "
-                          "but received return_transpose_only=%d.",
+                          "When rows(%d) or cols(%d) is not aligned to 128, "
+                          "return_transpose_only should be False, but received "
+                          "return_transpose_only=%d.",
+                          rows,
+                          cols,
                           return_transpose_only));
+
     PADDLE_ENFORCE_EQ(using_1x128_vec_quant,
                       1,
                       common::errors::InvalidArgument(
-                          "When rows is not aligned to 128, only supports "
-                          "using_1x128_vec_quant=True, "
-                          "but received using_1x128_vec_quant=%d.",
+                          "When rows(%d) or cols(%d) is not aligned to 128, "
+                          "using_1x128_vec_quant should be True, but received "
+                          "using_1x128_vec_quant=%d.",
+                          rows,
+                          cols,
                           using_1x128_vec_quant));
   }
 
@@ -2263,7 +2272,6 @@ void Fp8QuantBlockwiseInferMeta(const MetaTensor& X,
                               scale_transposed_outer_dim));
         scale_transposed_outer_dim /= 4;
       }
-
     } else {
       PADDLE_ENFORCE_EQ(
           scale_inner_dim % 4,

--- a/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
@@ -595,6 +595,93 @@ template <typename T,
           bool output_scale_transpose,
           bool use_pow2_scale,
           bool using_ue8m0_scale>
+__global__ void quant_per_token_per_block(const T *input,
+                                          __nv_fp8_e4m3 *quanted_res,
+                                          ScaleT *quanted_scale,
+                                          const int rows,
+                                          const int cols,
+                                          const int padded_rows,
+                                          const float epsilon) {
+  const size_t bid = blockIdx.x;
+  const size_t tid = threadIdx.x;
+  const size_t warp_id = tid / 32;
+  const size_t lane_id = tid % 32;
+  const size_t num_warp = blockDim.x / 32;
+  static constexpr int NUM_PER_THREADS = 128 / 32;  // 4
+  const size_t end_iter = (cols + 127) / 128;       // warp_iter_num
+
+  AlignedVector<T, NUM_PER_THREADS> load_vec;
+  AlignedVector<float, NUM_PER_THREADS> load_vec_float;
+  AlignedVector<__nv_fp8_e4m3, NUM_PER_THREADS> res_vec;
+
+  for (size_t token_idx = bid; token_idx < rows; token_idx += gridDim.x) {
+    const T *input_now = input + token_idx * cols;
+    __nv_fp8_e4m3 *quanted_res_now = quanted_res + token_idx * cols;
+    // deal a block per warp
+    for (size_t iter = warp_id; iter < end_iter; iter += num_warp) {
+      size_t idx;
+      if constexpr (using_ue8m0_scale) {
+        idx = output_scale_transpose
+                  ? (iter / 4) * padded_rows * 4 + token_idx * 4 + (iter % 4)
+                  : token_idx * padded_rows * 4 + iter;
+      } else {
+        idx = output_scale_transpose ? iter * padded_rows + token_idx
+                                     : token_idx * end_iter + iter;
+      }
+      const size_t offset = iter * 128 + lane_id * NUM_PER_THREADS;
+
+      const bool is_valid_data = offset < cols;
+
+      if (is_valid_data) {
+        Load<T, NUM_PER_THREADS>(input_now + offset, &load_vec);
+      } else {
+#pragma unroll
+        for (int vid = 0; vid < NUM_PER_THREADS; vid++) load_vec[vid] = T(0.f);
+      }
+
+      // get max value per thread
+      float max_value_thread = -5e4;
+#pragma unroll
+      for (int vid = 0; vid < NUM_PER_THREADS; vid++) {
+        load_vec_float[vid] = static_cast<float>(load_vec[vid]);
+        max_value_thread = fmax(fabs(load_vec_float[vid]), max_value_thread);
+      }
+
+#pragma unroll
+      for (uint32_t offset = 16; offset > 0; offset /= 2) {
+        float other = __shfl_down_sync(0xFFFFFFFF, max_value_thread, offset);
+        max_value_thread = fmax(max_value_thread, other);
+      }
+      max_value_thread = __shfl_sync(0xFFFFFFFF, max_value_thread, 0);
+
+      float blockwise_scale = ScaleWrapper < use_pow2_scale ||
+                              using_ue8m0_scale > (max_value_thread, epsilon);
+      float scale_to_store = 1.0f / blockwise_scale;
+      // quant
+#pragma unroll
+      for (int vid = 0; vid < NUM_PER_THREADS; vid++) {
+        res_vec[vid] =
+            static_cast<__nv_fp8_e4m3>(load_vec_float[vid] * blockwise_scale);
+      }
+      // store
+      if (is_valid_data) {
+        Store<__nv_fp8_e4m3, NUM_PER_THREADS>(res_vec,
+                                              quanted_res_now + offset);
+      }
+
+      if (lane_id == 0) {
+        StoreScale<ScaleT, using_ue8m0_scale>(
+            quanted_scale, idx, scale_to_store);
+      }
+    }
+  }
+}
+
+template <typename T,
+          typename ScaleT,
+          bool output_scale_transpose,
+          bool use_pow2_scale,
+          bool using_ue8m0_scale>
 __global__ void quant_per_token_per_block_padding(
     const T *const input,
     __nv_fp8_e4m3 *const quanted_res,
@@ -691,7 +778,67 @@ void FP8QuantBlockWiseKernelImpl(const Context &dev_ctx,
 
   using NvType = typename CudaTypeTraits<T>::Type;
 
-  if (src_rows % 128 == 0) {
+  if (src_cols % 128 != 0) {
+    PD_CHECK(
+        !input_transpose && !return_transpose_only,
+        "When cols is not aligned to 128, only supports: input_transpose=False "
+        "and return_transpose_only=False.");
+    PD_CHECK(using_1x128_vec_quant,
+             "When cols is not aligned to 128, only supports: "
+             "using_1x128_vec_quant.");
+    PD_CHECK(src_cols % 4 == 0, "src_cols must be divisible by 4.");
+
+    const int device_id = phi::backends::gpu::GetCurrentDeviceId();
+    const int sm_count = phi::backends::gpu::GetGPUMultiProcessors(device_id);
+    const size_t min_grid_x = sm_count * 8;
+    const size_t min_block_x = 1024;
+    const size_t gridx = std::min(min_grid_x, src_rows);
+    const size_t blockx = std::min(min_block_x, (src_cols + 127) / 128 * 32);
+
+    quant_per_token_per_block<NvType,
+                              ScaleT,
+                              output_scale_transpose,
+                              using_pow2_scale,
+                              using_ue8m0_scale>
+        <<<gridx, blockx, 0, dev_ctx.stream()>>>(
+            reinterpret_cast<const NvType *>(X.data<T>()),
+            reinterpret_cast<__nv_fp8_e4m3 *>(out->data<phi::float8_e4m3fn>()),
+            reinterpret_cast<ScaleT *>(scale->data<ScaleT>()),
+            src_rows,
+            src_cols,
+            quanted_cols,
+            epsilon);
+  } else if (src_rows % 128 != 0) {
+    PD_CHECK(
+        !input_transpose && !return_transpose_only,
+        "When rows is not aligned to 128, only supports: input_transpose=False "
+        "and return_transpose_only=False.");
+    PD_CHECK(using_1x128_vec_quant,
+             "When rows is not aligned to 128, only supports: "
+             "using_1x128_vec_quant.");
+    PD_CHECK(src_cols % 128 == 0, "src_cols must be divisible by 128.");
+
+    const int device_id = phi::backends::gpu::GetCurrentDeviceId();
+    const int sm_count = phi::backends::gpu::GetGPUMultiProcessors(device_id);
+    const size_t min_grid_x = sm_count * 8;
+    const size_t min_block_x = 1024;
+    const size_t gridx = std::min(min_grid_x, src_rows);
+    const size_t blockx = std::min(min_block_x, src_cols / 128 * 32);
+
+    quant_per_token_per_block_padding<NvType,
+                                      ScaleT,
+                                      output_scale_transpose,
+                                      using_pow2_scale,
+                                      using_ue8m0_scale>
+        <<<gridx, blockx, 0, dev_ctx.stream()>>>(
+            reinterpret_cast<const NvType *>(X.data<T>()),
+            reinterpret_cast<__nv_fp8_e4m3 *>(out->data<phi::float8_e4m3fn>()),
+            reinterpret_cast<ScaleT *>(scale->data<ScaleT>()),
+            src_rows,
+            src_cols,
+            quanted_cols,
+            epsilon);
+  } else {
     dim3 block, grid;
     if constexpr (using_1x128_vec_quant) {
       block.x = 32;
@@ -735,36 +882,6 @@ void FP8QuantBlockWiseKernelImpl(const Context &dev_ctx,
         quanted_cols,
         quanted_rows,
         epsilon);
-  } else {
-    PD_CHECK(
-        !input_transpose && !return_transpose_only,
-        "When rows is not aligned to 128, only supports: input_transpose=False "
-        "and return_transpose_only=False.");
-    PD_CHECK(using_1x128_vec_quant,
-             "When rows is not aligned to 128, only supports: "
-             "using_1x128_vec_quant.");
-    PD_CHECK(src_cols % 128 == 0, "src_cols must be divisible by 128");
-
-    const int device_id = phi::backends::gpu::GetCurrentDeviceId();
-    const int sm_count = phi::backends::gpu::GetGPUMultiProcessors(device_id);
-    const size_t min_grid_x = sm_count * 8;
-    const size_t min_block_x = 1024;
-    const size_t gridx = min(min_grid_x, src_rows);
-    const size_t blockx = min(min_block_x, src_cols / 128 * 32);
-
-    quant_per_token_per_block_padding<NvType,
-                                      ScaleT,
-                                      output_scale_transpose,
-                                      using_pow2_scale,
-                                      using_ue8m0_scale>
-        <<<gridx, blockx, 0, dev_ctx.stream()>>>(
-            reinterpret_cast<const NvType *>(X.data<T>()),
-            reinterpret_cast<__nv_fp8_e4m3 *>(out->data<phi::float8_e4m3fn>()),
-            reinterpret_cast<ScaleT *>(scale->data<ScaleT>()),
-            src_rows,
-            src_cols,
-            quanted_cols,
-            epsilon);
   }
 }
 

--- a/test/legacy_test/test_fp8_quant.py
+++ b/test/legacy_test/test_fp8_quant.py
@@ -257,6 +257,29 @@ class TestFP8QuantizationUnalignedFP16(TestFP8Quantization):
         self.assertEqual(self.x.dtype, paddle.float16)
 
 
+class TestFP8QuantizatioUnalignedNBF16(TestFP8Quantization):
+    def setUp(self):
+        paddle.seed(42)
+        self.m = 129
+        self.n = 508
+        self.dtype_options = paddle.bfloat16
+        self.quant_method_options = ["1x128"]
+        self.rmse_threshold = 3e-2
+
+        self.x = paddle.randn((self.m, self.n), dtype=self.dtype_options)
+
+        self.input_transpose_options = [False]
+        self.return_transpose_only_options = [False]
+        self.output_scale_transpose_options = [True, False]
+        self.using_pow2_scale_options = [True, False]
+        self.using_ue8m0_scale_options = [True, False]
+
+    def test_quantization_accuracy(self):
+        rmses = self.eval_all(self.x)
+        for r in rmses:
+            self.assertLessEqual(r, self.rmse_threshold)
+
+
 # 0 size
 class TestFP8QuantizationZeroSizeBF16(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
card-89071

本 PR 框架支持了 N 非 128 对齐，N % 4 == 0 的场景。

比起 FD，多支持了 ：output_scale_transpose、use_pow2_scale、using_ue8m0_scale、M pad 到 4。