### PR TITLE
[API Compatibility] Add test for `paddle.io` alias in `paddle.utils.data`

### DIFF
--- a/test/legacy_test/test_paddle_io_alias.py
+++ b/test/legacy_test/test_paddle_io_alias.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+
+class TestAlias(unittest.TestCase):
+    def setUp(self):
+        from paddle.io import Dataset as IoDataset
+        from paddle.utils.data import Dataset as UtilsDataset
+
+        self.ioObject = IoDataset
+        self.utilsObject = UtilsDataset
+
+    def test_compatibility(self):
+        self.assertTrue(type(self.ioObject) == type(self.utilsObject))
+
+
+class TestChainDatasetAlias(TestAlias):
+    def setUp(self):
+        from paddle.io import ChainDataset as IoChainDataset
+        from paddle.utils.data import ChainDataset as UtilsChainDataset
+
+        self.ioObject = IoChainDataset
+        self.utilsObject = UtilsChainDataset
+
+
+class TestConcatDatasetAlias(TestAlias):
+    def setUp(self):
+        from paddle.io import ConcatDataset as IoConcatDataset
+        from paddle.utils.data import ConcatDataset as UtilsConcatDataset
+
+        self.ioObject = IoConcatDataset
+        self.utilsObject = UtilsConcatDataset
+
+
+class TestIterableDatasetAlias(TestAlias):
+    def setUp(self):
+        from paddle.io import IterableDataset as IoIterableDataset
+        from paddle.utils.data import IterableDataset as UtilsIterableDataset
+
+        self.ioObject = IoIterableDataset
+        self.utilsObject = UtilsIterableDataset
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Add test to ensure the class imported from `paddle.utils.data` is the same as the original ones in `paddle.io`
- Currently tests cover `ChainDataset`, `ConcatDataset`, `Dataset`, `IterableDataset`

See Also: #77391
See Also: #77275

**Used AI Studio**
