### PR TITLE
Reference Counting Fix for `PyList_SetItem` in `Paddle_Size_init`

### DIFF
--- a/paddle/fluid/pybind/size.cc
+++ b/paddle/fluid/pybind/size.cc
@@ -96,7 +96,6 @@ static int Paddle_Size_init(PyObject* self, PyObject* args, PyObject* kwargs) {
     PyObject* number = PyNumber_Index(item);
     if (number && PyLong_Check(number)) {
       if (PyList_SetItem(self, i, number) < 0) {
-        Py_DECREF(number);
         return -1;
       }
       continue;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
Fix #77447