### PR TITLE
use std namespace for min in fp8_quant_blockwise_kernel

### DIFF
--- a/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
@@ -749,8 +749,8 @@ void FP8QuantBlockWiseKernelImpl(const Context &dev_ctx,
     const int sm_count = phi::backends::gpu::GetGPUMultiProcessors(device_id);
     const size_t min_grid_x = sm_count * 8;
     const size_t min_block_x = 1024;
-    const size_t gridx = min(min_grid_x, src_rows);
-    const size_t blockx = min(min_block_x, src_cols / 128 * 32);
+    const size_t gridx = std::min(min_grid_x, src_rows);
+    const size_t blockx = std::min(min_block_x, src_cols / 128 * 32);
 
     quant_per_token_per_block_padding<NvType,
                                       ScaleT,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Use std namespace for min in fp8_quant_blockwise_kernel, as custom device compilers require.