### PR TITLE
Support startend_row_indices head == q head in flashmask

### DIFF
--- a/python/paddle/nn/functional/flash_attention.py
+++ b/python/paddle/nn/functional/flash_attention.py
@@ -1943,9 +1943,10 @@ def flashmask_attention(
         )
         assert startend_row_indices.shape[1] in [
             1,
+            query.shape[2],
             key.shape[2],
         ], (
-            "startend_row_indices head_num must be equal to 1(broadcast) or head_num_k."
+            "startend_row_indices head_num must be equal to 1(broadcast) or head_num_q or head_num_k."
         )
 
         if block_mask is not None:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
support startend_row_indices head == q head in flashmask