### PR TITLE
[Compat] Move `GenericTuple` impl after `IValue` defination to avoid reference to not complete class

### DIFF
--- a/paddle/phi/api/include/compat/ATen/core/ivalue.h
+++ b/paddle/phi/api/include/compat/ATen/core/ivalue.h
@@ -96,13 +96,12 @@ using GenericList = std::vector<IValue>;
 struct GenericTuple {
   std::vector<IValue> elements;
 
-  GenericTuple() = default;
-  GenericTuple(std::vector<IValue> elems)  // NOLINT
-      : elements(std::move(elems)) {}
+  GenericTuple();
+  GenericTuple(std::vector<IValue> elems);  // NOLINT
 
-  size_t size() const { return elements.size(); }
-  IValue& operator[](size_t idx) { return elements[idx]; }
-  const IValue& operator[](size_t idx) const { return elements[idx]; }
+  size_t size() const;
+  IValue& operator[](size_t idx);
+  const IValue& operator[](size_t idx) const;
 };
 
 class IValue {
@@ -535,6 +534,16 @@ class IValue {
   template <typename T>
   friend T generic_to(const IValue& ivalue, _fake_type<T>);
 };
+
+inline GenericTuple::GenericTuple() = default;
+inline GenericTuple::GenericTuple(std::vector<IValue> elems)  // NOLINT
+    : elements(std::move(elems)) {}
+
+inline size_t GenericTuple::size() const { return elements.size(); }
+inline IValue& GenericTuple::operator[](size_t idx) { return elements[idx]; }
+inline const IValue& GenericTuple::operator[](size_t idx) const {
+  return elements[idx];
+}
 
 template <>
 inline bool generic_to(const IValue& ivalue, _fake_type<bool>) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

修复编译 `GenericTuple` 时 `IValue` 类型不完整的问题

```
 /usr/include/c++/13/bits/stl_vector.h(370): error: expression must be a pointer to a complete object type
            _M_impl._M_end_of_storage - _M_impl._M_start);
            ^
            detected during:
              instantiation of "std::_Vector_base<_Tp, _Alloc>::~_Vector_base() noexcept [with _Tp=torch::IValue, _Alloc=std::allocator<torch::IValue>]" at line 101 of /root/paddlejob/tmpspace/nyakku/FlashMLA/.meowda/venvs/paddle-py310/lib/python3.10/site-packages/paddle/include/paddle/phi/api/include/compat/ATen/core/ivalue.h
              instantiation of class "std::vector<_Tp, _Alloc> [with _Tp=torch::IValue, _Alloc=std::allocator<torch::IValue>]" at line 101 of /root/paddlejob/tmpspace/nyakku/FlashMLA/.meowda/venvs/paddle-py310/lib/python3.10/site-packages/paddle/include/paddle/phi/api/include/compat/ATen/core/ivalue.h
```

<!-- PCard-66972 -->