### PR TITLE
Add env-driven flag refresh after custom device load

### DIFF
--- a/paddle/common/flags.h
+++ b/paddle/common/flags.h
@@ -408,5 +408,3 @@ PADDLE_API ExportedFlagInfoMap* GetMutableExportedFlagInfoMap();
       name, true, ::std::string, string, default_value, doc)
 
 }  // namespace phi
-
-namespace paddle::flags {}  // namespace paddle::flags

--- a/paddle/common/flags.h
+++ b/paddle/common/flags.h
@@ -19,6 +19,7 @@
 #include <map>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #ifdef PADDLE_WITH_GFLAGS
 #include "gflags/gflags.h"
@@ -106,6 +107,9 @@
 
 namespace paddle {
 namespace flags {
+
+PADDLE_API void SetFlagsFromEnv(const std::vector<std::string>& flags,
+                                bool error_fatal);
 
 /**
  * @brief Parse commandline flags.
@@ -404,3 +408,5 @@ PADDLE_API ExportedFlagInfoMap* GetMutableExportedFlagInfoMap();
       name, true, ::std::string, string, default_value, doc)
 
 }  // namespace phi
+
+namespace paddle::flags {}  // namespace paddle::flags

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -11,6 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
+#include <algorithm>
 #include <csignal>
 #include <fstream>
 #include <string>
@@ -109,6 +110,21 @@ bool InitGflags(std::vector<std::string> args) {
     VLOG(8) << "After Parse: argc is " << argc;
   });
   return succeeded;
+}
+
+void InitGflagsFromEnv() {
+  std::vector<std::string> env_flags;
+  const auto &flag_map = phi::GetExportedFlagInfoMap();
+  env_flags.reserve(flag_map.size());
+  for (const auto &pair : flag_map) {
+    env_flags.push_back(pair.second.name);
+  }
+#ifdef __APPLE__
+  env_flags.erase(
+      std::remove(env_flags.begin(), env_flags.end(), "use_pinned_memory"),
+      env_flags.end());
+#endif
+  paddle::flags::SetFlagsFromEnv(env_flags, false);
 }
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_XPU)

--- a/paddle/fluid/platform/init.h
+++ b/paddle/fluid/platform/init.h
@@ -26,6 +26,8 @@ namespace framework {
 
 PADDLE_API bool InitGflags(std::vector<std::string> argv);
 
+PADDLE_API void InitGflagsFromEnv();
+
 PADDLE_API void InitGLOG(const std::string& prog_name);
 
 TEST_API void InitDevices();

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3290,6 +3290,7 @@ All parameter, weight, gradient are variables in Paddle.
 #endif
 
   m.def("init_gflags", framework::InitGflags);
+  m.def("init_gflags_from_env", framework::InitGflagsFromEnv);
   m.def("init_glog", framework::InitGLOG);
   m.def("init_memory_method", framework::InitMemoryMethod);
   m.def("load_op_meta_info_and_register_op", [](const std::string dso_name) {

--- a/python/paddle/base/__init__.py
+++ b/python/paddle/base/__init__.py
@@ -198,6 +198,7 @@ def __bootstrap__():
     # don't init_p2p when in unittest to save time.
     core.init_memory_method()
     core.init_devices()
+    core.init_gflags_from_env()
     core.init_tensor_operants()
     core.init_default_kernel_signatures()
 

--- a/test/legacy_test/test_flags_env.py
+++ b/test/legacy_test/test_flags_env.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+import unittest
+
+from op_test import is_custom_device
+
+from paddle.base import core
+
+
+def _read_flag_from_subprocess(flag_name: str, env: dict) -> str:
+    code = f"""
+import paddle
+v = paddle.get_flags(\"{flag_name}\")
+if isinstance(v, dict):
+    v = v.get(\"{flag_name}\")
+print(v)
+"""
+    return subprocess.check_output(
+        [sys.executable, "-c", code],
+        env=env,
+        text=True,
+    ).strip()
+
+
+class TestFlagsEnv(unittest.TestCase):
+    @unittest.skipIf(
+        not (core.is_compiled_with_cuda() or is_custom_device()),
+        "core is not compiled with CUDA",
+    )
+    def test_env_cudnn_deterministic_take_effect(self):
+        env = os.environ.copy()
+        env["FLAGS_cudnn_deterministic"] = "1"
+        output = _read_flag_from_subprocess("FLAGS_cudnn_deterministic", env)
+        self.assertIn(output, {"True", "1"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Custom device flags are registered only after the plugin .so is loaded. The initial env parsing runs earlier and therefore misses those flags, so FLAGS_* environment variables have no effect for custom device flags.

This PR introduces a post-device-load env refresh that reads all exported flags from `ExportedFlagInfoMap` and applies env values. This ensures custom device flags are picked up without relying on core.globals() timing.

- Add `InitGflagsFromEnv` to refresh exported flags from environment variables after device initialization.
- Expose the new API to Python as core.init_gflags_from_env.
- Invoke the refresh step after core.init_devices() to include custom device flags.
- Declare `SetFlagsFromEnv` in headers for reuse.