### PR TITLE
[API Compatibility No.22] Add squeeze_ dim/axis alias mapping -part

### DIFF
--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -399,11 +399,6 @@
   args_alias :
     use_default_mapping : True
 
-- op : squeeze_
-  name : [paddle.squeeze_, paddle.Tensor.squeeze_]
-  args_alias :
-    use_default_mapping : True
-
 - op : sum
   name : [paddle.sum, paddle.Tensor.sum]
   args_alias :

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -399,11 +399,6 @@
   args_alias :
     use_default_mapping : True
 
-- op : squeeze
-  name : [paddle.squeeze, paddle.Tensor.squeeze]
-  args_alias :
-    use_default_mapping : True
-
 - op : squeeze_
   name : [paddle.squeeze_, paddle.Tensor.squeeze_]
   args_alias :

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -402,7 +402,6 @@
 - op : squeeze_
   name : [paddle.squeeze_, paddle.Tensor.squeeze_]
   args_alias :
-    axis : [dim]
     use_default_mapping : True
 
 - op : sum

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -399,6 +399,11 @@
   args_alias :
     use_default_mapping : True
 
+- op : squeeze
+  name : [paddle.squeeze, paddle.Tensor.squeeze]
+  args_alias :
+    use_default_mapping : True
+
 - op : squeeze_
   name : [paddle.squeeze_, paddle.Tensor.squeeze_]
   args_alias :

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -399,6 +399,16 @@
   args_alias :
     use_default_mapping : True
 
+- op : squeeze
+  name : []
+  args_alias :
+    use_default_mapping : True
+
+- op : squeeze_
+  name : [paddle.squeeze_, paddle.Tensor.squeeze_]
+  args_alias :
+    use_default_mapping : True
+
 - op : sum
   name : [paddle.sum, paddle.Tensor.sum]
   args_alias :

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -399,14 +399,10 @@
   args_alias :
     use_default_mapping : True
 
-- op : squeeze
-  name : []
-  args_alias :
-    use_default_mapping : True
-
 - op : squeeze_
   name : [paddle.squeeze_, paddle.Tensor.squeeze_]
   args_alias :
+    axis : [dim]
     use_default_mapping : True
 
 - op : sum

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -3693,6 +3693,16 @@ add_doc_and_signature(
 def abs_(x: Tensor, name: str | None = None) -> Tensor
 """,
 )
+add_doc_and_signature(
+    "squeeze_",
+    """
+    Inplace version of ``squeeze`` API, the output Tensor will be inplaced with input ``x``.
+    Please refer to :ref:`api_paddle_tensor_squeeze`.
+""",
+    """
+def squeeze_(x: Tensor, axis: int | Sequence[int] | None = None, name: str | None = None) -> Tensor
+""",
+)
 # lubingxin
 
 # chenhuangrun

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -24,7 +24,7 @@ from typing_extensions import overload
 
 import paddle
 from paddle import _C_ops
-from paddle._C_ops import index_put, index_put_, roll, squeeze_  # noqa: F401
+from paddle._C_ops import index_put, index_put_, roll  # noqa: F401
 from paddle.tensor import fill_constant
 from paddle.utils.decorator_utils import (
     ParamAliasDecorator,
@@ -4094,6 +4094,7 @@ def unsqueeze(
         return out
 
 
+@param_one_alias(["axis", "dim"])
 @inplace_apis_in_dygraph_only
 def unsqueeze_(
     x: Tensor, axis: int | Sequence[int] | Tensor, name: str | None = None
@@ -4114,6 +4115,28 @@ def unsqueeze_(
             for item in axes
         ]
     return _C_ops.unsqueeze_(input, axes)
+
+
+@param_one_alias(["axis", "dim"])
+@inplace_apis_in_dygraph_only
+def squeeze_(
+    x: Tensor, axis: int | Sequence[int] | None = None, name: str | None = None
+) -> Tensor:
+    """
+    Inplace version of ``squeeze`` API, the output Tensor will be inplaced with input ``x``.
+    Please refer to :ref:`api_paddle_tensor_squeeze`.
+    """
+    if axis is None:
+        axis = []
+    elif isinstance(axis, int):
+        axis = [axis]
+    elif isinstance(axis, tuple):
+        axis = list(axis)
+
+    input = x
+    axes = axis
+    if in_dynamic_mode():
+        return _C_ops.squeeze_(input, axes)
 
 
 def _take_along_axis_wrapper(

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -24,7 +24,7 @@ from typing_extensions import overload
 
 import paddle
 from paddle import _C_ops
-from paddle._C_ops import index_put, index_put_, roll  # noqa: F401
+from paddle._C_ops import index_put, index_put_, roll, squeeze_  # noqa: F401
 from paddle.tensor import fill_constant
 from paddle.utils.decorator_utils import (
     ParamAliasDecorator,
@@ -3485,27 +3485,6 @@ def squeeze(
         )
 
         return out
-
-
-@inplace_apis_in_dygraph_only
-def squeeze_(
-    x: Tensor, axis: int | Sequence[int] | None = None, name: str | None = None
-) -> Tensor:
-    """
-    Inplace version of ``squeeze`` API, the output Tensor will be inplaced with input ``x``.
-    Please refer to :ref:`api_paddle_tensor_squeeze`.
-    """
-    if axis is None:
-        axis = []
-    elif isinstance(axis, int):
-        axis = [axis]
-    elif isinstance(axis, tuple):
-        axis = list(axis)
-
-    input = x
-    axes = axis
-    if in_dynamic_mode():
-        return _C_ops.squeeze_(input, axes)
 
 
 @param_two_alias(["x", "input"], ["axis", "dim"])

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -904,6 +904,10 @@ class TestSqueezeInplaceAPI_Compatibility(unittest.TestCase):
         out4 = x4.squeeze_(dim=2)
         paddle_dygraph_out.append(out4)
 
+        x5 = paddle.to_tensor(self.np_input)
+        out5 = x5.squeeze_(axis=(2,))
+        paddle_dygraph_out.append(out5)
+
         for out in paddle_dygraph_out:
             np.testing.assert_allclose(ref_out, out.numpy())
         paddle.enable_static()
@@ -917,12 +921,13 @@ class TestSqueezeInplaceAPI_Compatibility(unittest.TestCase):
             out1 = paddle.squeeze_(x, axis=2)
             out2 = paddle.squeeze_(x, dim=2)
             out3 = x.squeeze_(dim=2)
+            out4 = x.squeeze_(axis=(2,))
 
             exe = paddle.base.Executor(paddle.CPUPlace())
             fetches = exe.run(
                 main,
                 feed={"x": self.np_input},
-                fetch_list=[out1, out2, out3],
+                fetch_list=[out1, out2, out3, out4],
             )
             ref_out = np.squeeze(self.np_input, axis=2)
             for out in fetches:

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -872,6 +872,63 @@ class TestSquareAPI_Compatibility(unittest.TestCase):
                 np.testing.assert_allclose(out, ref_out)
 
 
+class TestSqueezeInplaceAPI_Compatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+        paddle.enable_static()
+        self.shape = [1, 3, 1, 2]
+        self.dtype = 'float32'
+        self.init_data()
+
+    def init_data(self):
+        self.np_input = np.random.randint(0, 8, self.shape).astype(self.dtype)
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        ref_out = np.squeeze(self.np_input, axis=2)
+        paddle_dygraph_out = []
+
+        x1 = paddle.to_tensor(self.np_input)
+        out1 = paddle.squeeze_(x1, axis=2)
+        paddle_dygraph_out.append(out1)
+
+        x2 = paddle.to_tensor(self.np_input)
+        out2 = paddle.squeeze_(x2, dim=2)
+        paddle_dygraph_out.append(out2)
+
+        x3 = paddle.to_tensor(self.np_input)
+        out3 = x3.squeeze_(axis=2)
+        paddle_dygraph_out.append(out3)
+
+        x4 = paddle.to_tensor(self.np_input)
+        out4 = x4.squeeze_(dim=2)
+        paddle_dygraph_out.append(out4)
+
+        for out in paddle_dygraph_out:
+            np.testing.assert_allclose(ref_out, out.numpy())
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.base.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
+
+            out1 = paddle.squeeze_(x, axis=2)
+            out2 = paddle.squeeze_(x, dim=2)
+            out3 = x.squeeze_(dim=2)
+
+            exe = paddle.base.Executor(paddle.CPUPlace())
+            fetches = exe.run(
+                main,
+                feed={"x": self.np_input},
+                fetch_list=[out1, out2, out3],
+            )
+            ref_out = np.squeeze(self.np_input, axis=2)
+            for out in fetches:
+                np.testing.assert_allclose(out, ref_out)
+
+
 class TestTanAPI_Compatibility(unittest.TestCase):
     def setUp(self):
         np.random.seed(123)

--- a/tools/gen_pybind11_stub.py
+++ b/tools/gen_pybind11_stub.py
@@ -730,9 +730,8 @@ class OpsYamlBaseAPI:
         python_api_info: dict[str, list[str]],
     ):
         if name in python_api_info:
-            return self.make_python_api_function(
-                name, python_api_info[raw_name]
-            )
+            api_names = python_api_info.get(raw_name, python_api_info[name])
+            return self.make_python_api_function(name, api_names)
         else:
             return self.make_op_function(
                 raw_name, inputs, attrs, output_type_list


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category

User Experience

### PR Types

New features

### Description

  - Add C++-side alias mapping for `paddle.Tensor.squeeze_` so `dim` maps to `axis`.
  - Remove Python-level wrapper for `squeeze_` and rely on generated C++ bindings.
  - Add doc signature entry for `squeeze_`.
  - Add API compatibility test for inplace squeeze with `dim`.
