### PR TITLE
[API Compatibility No.23] Add unsqueeze_ dim/axis API compat -part

### DIFF
--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -427,9 +427,3 @@
   name : [paddle.triu, paddle.Tensor.triu]
   args_alias :
     use_default_mapping : True
-
-- op : unsqueeze_
-  name : [paddle.unsqueeze_, paddle.Tensor.unsqueeze_]
-  args_alias :
-    axis : [dim]
-    use_default_mapping : True

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -427,3 +427,8 @@
   name : [paddle.triu, paddle.Tensor.triu]
   args_alias :
     use_default_mapping : True
+
+- op : unsqueeze
+  name : [paddle.Tensor.unsqueeze_]
+  args_alias :
+    use_default_mapping : True

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -428,7 +428,8 @@
   args_alias :
     use_default_mapping : True
 
-- op : unsqueeze
-  name : [paddle.Tensor.unsqueeze_]
+- op : unsqueeze_
+  name : [paddle.unsqueeze_, paddle.Tensor.unsqueeze_]
   args_alias :
+    axis : [dim]
     use_default_mapping : True

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -4342,3 +4342,18 @@ def i1e(
 ) -> Tensor
 """,
 )
+
+add_doc_and_signature(
+    "unsqueeze_",
+    r"""
+    Inplace version of ``unsqueeze`` API, the output Tensor will be inplaced with input ``x``.
+    Please refer to :ref:`api_paddle_tensor_unsqueeze`.
+""",
+    """
+def unsqueeze_(
+    x: Tensor,
+    axis: int | Sequence[int] | Tensor,
+    name: str | None = None,
+) -> Tensor
+""",
+)

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4115,6 +4115,7 @@ def unsqueeze(
         return out
 
 
+@param_two_alias(["x", "input"], ["axis", "dim"])
 @inplace_apis_in_dygraph_only
 def unsqueeze_(
     x: Tensor, axis: int | Sequence[int] | Tensor, name: str | None = None

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -1193,5 +1193,79 @@ class TestBitwiseXorAPI_Compatibility(unittest.TestCase):
                 np.testing.assert_array_equal(out, ref_out)
 
 
+# Edit By AI Agent
+# Test unsqueeze_ compatibility
+class TestUnsqueezeInplaceAPI_Compatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+        paddle.enable_static()
+        self.shape = [2, 3]
+        self.dtype = 'float32'
+        self.init_data()
+
+    def init_data(self):
+        self.np_x = np.random.randn(*self.shape).astype(self.dtype)
+
+    def _make_tensor(self):
+        return paddle.to_tensor(self.np_x)
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        paddle_dygraph_out = []
+
+        # Position args (args)
+        x1 = self._make_tensor()
+        out1 = paddle.unsqueeze_(x1, 0)
+        paddle_dygraph_out.append(out1)
+
+        # Paddle keyword args (kwargs)
+        x2 = self._make_tensor()
+        out2 = paddle.unsqueeze_(x2, axis=0)
+        paddle_dygraph_out.append(out2)
+
+        # Torch keyword args
+        x3 = self._make_tensor()
+        out3 = paddle.unsqueeze_(x3, dim=0)
+        paddle_dygraph_out.append(out3)
+
+        # Tensor method - kwargs
+        x4 = self._make_tensor()
+        out4 = x4.unsqueeze_(dim=0)
+        paddle_dygraph_out.append(out4)
+
+        # Numpy reference output
+        ref_out = np.expand_dims(self.np_x, axis=0)
+
+        for out in paddle_dygraph_out:
+            np.testing.assert_allclose(ref_out, out.numpy())
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.base.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
+
+            # Position args
+            out1 = paddle.unsqueeze_(x, 0)
+            # Paddle keyword args
+            out2 = paddle.unsqueeze_(x, axis=0)
+            # Torch keyword args
+            out3 = paddle.unsqueeze_(x, dim=0)
+            # Tensor method
+            out4 = x.unsqueeze_(dim=0)
+
+            exe = paddle.base.Executor(paddle.CPUPlace())
+            fetches = exe.run(
+                main,
+                feed={"x": self.np_x},
+                fetch_list=[out1, out2, out3, out4],
+            )
+            ref_out = np.expand_dims(self.np_x, axis=0)
+            for out in fetches:
+                np.testing.assert_allclose(out, ref_out)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/gen_pybind11_stub.py
+++ b/tools/gen_pybind11_stub.py
@@ -730,9 +730,8 @@ class OpsYamlBaseAPI:
         python_api_info: dict[str, list[str]],
     ):
         if name in python_api_info:
-            return self.make_python_api_function(
-                name, python_api_info[raw_name]
-            )
+            api_names = python_api_info.get(raw_name, python_api_info[name])
+            return self.make_python_api_function(name, api_names)
         else:
             return self.make_op_function(
                 raw_name, inputs, attrs, output_type_list


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category

User Experience

### PR Types

New features

### Description

  - Add C++ alias mapping for `paddle.Tensor.unsqueeze_` to accept `dim` as `axis`.
  - Keep `paddle.unsqueeze_` Python wrapper with param alias for backward compatibility.
  - Add doc signature for `unsqueeze_`.
  - Add API compatibility test for inplace unsqueeze.