### PR TITLE
Add stride parameter validation in CorrelationInferMeta

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -988,6 +988,21 @@ void CorrelationInferMeta(const MetaTensor& input1,
                         "Input(Y) of CorrelationOp must be 4 dims."
                         "But received dims is %d.",
                         in2_dims.size()));
+
+  PADDLE_ENFORCE_GT(stride1,
+                    0,
+                    common::errors::InvalidArgument(
+                        "stride1 of CorrelationOp must be greater than 0. "
+                        "But received stride1 = %d.",
+                        stride1));
+
+  PADDLE_ENFORCE_GT(stride2,
+                    0,
+                    common::errors::InvalidArgument(
+                        "stride2 of CorrelationOp must be greater than 0. "
+                        "But received stride2 = %d.",
+                        stride2));
+
   std::vector<int64_t> output_shape = CorrelationOutputSize(in_dims[0],
                                                             in_dims[2],
                                                             in_dims[3],


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Add validation checks for `stride1` and `stride2` parameters in `CorrelationInferMeta` to ensure they are greater than 0.

  **Problem:**
  When calling `paddle.incubate.layers.correlation()` with `stride2=0` (or `stride1=0`), the program crashes with `FatalError: Erroneous arithmetic operation` due to division by zero in `CorrelationOutputSize` function.

  **Solution:**
  Add `PADDLE_ENFORCE_GT` checks for `stride1` and `stride2` parameters in `CorrelationInferMeta` to validate that they are greater than 0 before being used in calculations.

  **Result:**
  - Before fix: `FatalError: Erroneous arithmetic operation` (SIGFPE crash)
  - After fix: `ValueError: stride2 of CorrelationOp must be greater than 0. But received stride2 = 0.`
