### PR TITLE
[CodeStyle][Xdoctest][56] Fix example code(`paddle.distributed.CountFilterEntry`)

### DIFF
--- a/python/paddle/distributed/entry_attr.py
+++ b/python/paddle/distributed/entry_attr.py
@@ -107,18 +107,15 @@ class ProbabilityEntry(EntryAttr):
 class CountFilterEntry(EntryAttr):
     """
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
+            >>> # doctest: +SKIP('sparse_embedding is not fully supported in static graph mode')
             >>> import paddle
             >>> paddle.enable_static()
-
             >>> sparse_feature_dim = 1024
             >>> embedding_size = 64
-
             >>> entry = paddle.distributed.CountFilterEntry(10)
-
             >>> input = paddle.static.data(name='ins', shape=[1], dtype='int64')
-
             >>> emb = paddle.static.nn.sparse_embedding(
             ...     input=input,
             ...     size=[sparse_feature_dim, embedding_size],


### PR DESCRIPTION
### PR Category
Docs

### PR Types
Bug fixes

### Description

Fix example code for `paddle.distributed.CountFilterEntry` to pass xdoctest validation.

#### Changes:
- Change `.. code-block:: python` to `.. code-block:: pycon`
- Add `# doctest: +SKIP` directive for sparse_embedding in static graph mode
- Clean up unnecessary blank lines

#### Local Verification:
Tested with xdoctest tool:
```bash
xdoctest --debug --options "+IGNORE_WHITESPACE" --style "freeform" \
--global-exec "import paddle\npaddle.device.set_device('cpu')" test.py
Fixes #76268



---