### PR TITLE
[API Compatibility No.36] Add bernoulli input alias and out support -part

### DIFF
--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -56,8 +56,13 @@ if TYPE_CHECKING:
 __all__ = []
 
 
+@param_one_alias(["x", "input"])
 def bernoulli(
-    x: Tensor, p: float | None = None, name: str | None = None
+    x: Tensor,
+    p: float | None = None,
+    name: str | None = None,
+    *,
+    out: Tensor | None = None,
 ) -> Tensor:
     r"""
 
@@ -71,11 +76,17 @@ def bernoulli(
             1-x_i,&y=0
         \end{cases}.
 
+    .. note::
+        Alias Support: The parameter name ``input`` can be used as an alias for ``x``.
+        For example, ``bernoulli(input=tensor_x, ...)`` is equivalent to ``bernoulli(x=tensor_x, ...)``.
+
     Args:
         x (Tensor): The input Tensor, it's data type should be float32, float64.
+            alias: ``input``.
         p (float|None, optional): If ``p`` is given, the success probability will always be ``p``. Default is None, which means
             to use the success probability specified by input ``x``.
         name (str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
+        out (Tensor|None, optional): The output Tensor. If set, the result will be stored in this Tensor. Default is None.
 
     Returns:
         Tensor, A Tensor filled samples from Bernoulli distribution, whose shape and dtype are same as ``x``.
@@ -115,16 +126,29 @@ def bernoulli(
         x = paddle.full_like(x, p)
 
     if in_dynamic_or_pir_mode():
-        return _C_ops.bernoulli(x)
+        out_tensor = _C_ops.bernoulli(x)
+        if out is not None:
+            paddle.assign(out_tensor, out)
+            return out
+        return out_tensor
     else:
         check_variable_and_dtype(
             x, "x", ["float32", "float64", "float16", "uint16"], "bernoulli"
         )
 
+        if out is not None:
+            check_variable_and_dtype(
+                out,
+                "out",
+                ["float32", "float64", "float16", "uint16"],
+                "bernoulli",
+            )
+
         helper = LayerHelper("randint", **locals())
-        out = helper.create_variable_for_type_inference(
-            dtype=x.dtype
-        )  # maybe set out to int32 ?
+        if out is None:
+            out = helper.create_variable_for_type_inference(
+                dtype=x.dtype
+            )  # maybe set out to int32 ?
         helper.append_op(
             type='bernoulli', inputs={"X": x}, outputs={'Out': out}, attrs={}
         )

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -1193,5 +1193,76 @@ class TestBitwiseXorAPI_Compatibility(unittest.TestCase):
                 np.testing.assert_array_equal(out, ref_out)
 
 
+class TestBernoulliAPI_Compatibility(unittest.TestCase):
+    def setUp(self):
+        paddle.enable_static()
+        self.shape = [2, 3]
+        self.dtype = 'float32'
+        self.init_data()
+
+    def init_data(self):
+        self.np_x = np.array([[0.0, 1.0, 0.0], [1.0, 0.0, 1.0]]).astype(
+            self.dtype
+        )
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        paddle_dygraph_out = []
+
+        # Position args (args)
+        out1 = paddle.bernoulli(x)
+        paddle_dygraph_out.append(out1)
+
+        # Paddle keyword args
+        out2 = paddle.bernoulli(x=x)
+        paddle_dygraph_out.append(out2)
+
+        # Torch keyword args
+        out3 = paddle.bernoulli(input=x)
+        paddle_dygraph_out.append(out3)
+
+        # Mixed args + out parameter
+        out4 = paddle.empty_like(x)
+        out5 = paddle.bernoulli(x, out=out4)
+        paddle_dygraph_out.append(out4)
+        paddle_dygraph_out.append(out5)
+
+        # Torch keyword args + out parameter
+        out6 = paddle.empty_like(x)
+        out7 = paddle.bernoulli(input=x, out=out6)
+        paddle_dygraph_out.append(out6)
+        paddle_dygraph_out.append(out7)
+
+        ref_out = self.np_x
+        for out in paddle_dygraph_out:
+            np.testing.assert_allclose(ref_out, out.numpy())
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.base.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
+
+            # Position args
+            out1 = paddle.bernoulli(x)
+            # Paddle keyword args
+            out2 = paddle.bernoulli(x=x)
+            # Torch keyword args
+            out3 = paddle.bernoulli(input=x)
+
+            exe = paddle.base.Executor(paddle.CPUPlace())
+            fetches = exe.run(
+                main,
+                feed={"x": self.np_x},
+                fetch_list=[out1, out2, out3],
+            )
+            ref_out = self.np_x
+            for out in fetches:
+                np.testing.assert_allclose(out, ref_out)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -1225,18 +1225,28 @@ class TestBernoulliAPI_Compatibility(unittest.TestCase):
         # Mixed args + out parameter
         out4 = paddle.empty_like(x)
         out5 = paddle.bernoulli(x, out=out4)
+        self.assertIs(out5, out4)
         paddle_dygraph_out.append(out4)
         paddle_dygraph_out.append(out5)
 
         # Torch keyword args + out parameter
         out6 = paddle.empty_like(x)
         out7 = paddle.bernoulli(input=x, out=out6)
+        self.assertIs(out7, out6)
         paddle_dygraph_out.append(out6)
         paddle_dygraph_out.append(out7)
 
         ref_out = self.np_x
         for out in paddle_dygraph_out:
             np.testing.assert_allclose(ref_out, out.numpy())
+
+        # p override: deterministic outputs
+        out8 = paddle.bernoulli(x, p=0.0)
+        np.testing.assert_allclose(np.zeros_like(self.np_x), out8.numpy())
+        out9 = paddle.empty_like(x)
+        out10 = paddle.bernoulli(input=x, p=1.0, out=out9)
+        self.assertIs(out10, out9)
+        np.testing.assert_allclose(np.ones_like(self.np_x), out10.numpy())
         paddle.enable_static()
 
     def test_static_Compatibility(self):
@@ -1262,6 +1272,40 @@ class TestBernoulliAPI_Compatibility(unittest.TestCase):
             ref_out = self.np_x
             for out in fetches:
                 np.testing.assert_allclose(out, ref_out)
+
+
+class TestBernoulliOldStaticOut(unittest.TestCase):
+    def test_out_and_out_none_old_static(self):
+        from paddle.pir_utils import OldIrGuard
+
+        paddle.enable_static()
+        np_x = np.array(
+            [[0.0, 1.0, 0.0], [1.0, 0.0, 1.0]], dtype='float32'
+        )
+        with OldIrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.base.program_guard(main, startup):
+                x = paddle.static.data(
+                    name="x", shape=np_x.shape, dtype='float32'
+                )
+                out_holder = paddle.static.create_global_var(
+                    shape=np_x.shape,
+                    value=0.0,
+                    dtype='float32',
+                    persistable=False,
+                )
+                out1 = paddle.bernoulli(x, out=out_holder)
+                out2 = paddle.bernoulli(x)
+                self.assertEqual(out1.name, out_holder.name)
+
+            exe = paddle.base.Executor(paddle.CPUPlace())
+            fetches = exe.run(
+                main, feed={"x": np_x}, fetch_list=[out1, out2]
+            )
+            for out in fetches:
+                np.testing.assert_allclose(out, np_x)
+        paddle.disable_static()
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -1279,9 +1279,7 @@ class TestBernoulliOldStaticOut(unittest.TestCase):
         from paddle.pir_utils import OldIrGuard
 
         paddle.enable_static()
-        np_x = np.array(
-            [[0.0, 1.0, 0.0], [1.0, 0.0, 1.0]], dtype='float32'
-        )
+        np_x = np.array([[0.0, 1.0, 0.0], [1.0, 0.0, 1.0]], dtype='float32')
         with OldIrGuard():
             main = paddle.static.Program()
             startup = paddle.static.Program()
@@ -1300,9 +1298,7 @@ class TestBernoulliOldStaticOut(unittest.TestCase):
                 self.assertEqual(out1.name, out_holder.name)
 
             exe = paddle.base.Executor(paddle.CPUPlace())
-            fetches = exe.run(
-                main, feed={"x": np_x}, fetch_list=[out1, out2]
-            )
+            fetches = exe.run(main, feed={"x": np_x}, fetch_list=[out1, out2])
             for out in fetches:
                 np.testing.assert_allclose(out, np_x)
         paddle.disable_static()


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

New features

### Description

- Add input alias for paddle.bernoulli to align with PyTorch naming.
- Add out parameter support in dygraph and static modes.
- Add API compatibility tests for bernoulli alias and out usage.
