### PR TITLE
[API Compatibility] Support positional wrap for fill_diagonal_

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1232,6 +1232,9 @@ def fill_diagonal_(
             >>> print(x.tolist())
             [[0.0, 2.0, 2.0], [2.0, 0.0, 2.0], [2.0, 2.0, 0.0], [2.0, 2.0, 2.0]]
     """
+    if isinstance(offset, bool) and wrap is False:
+        wrap = offset
+        offset = 0
     if in_dynamic_mode():
         if len(x.shape) == 2:
             return _C_ops.fill_diagonal_(x, value, offset, wrap)

--- a/test/legacy_test/test_tensor_fill_diagonal_.py
+++ b/test/legacy_test/test_tensor_fill_diagonal_.py
@@ -311,6 +311,23 @@ class TestFillDiagonalAlias(unittest.TestCase):
         with self.assertRaises((ValueError, TypeError)):
             x.fill_diagonal_(value=1.0, fill_value=2.0)
 
+    def test_positional_wrap_bool(self):
+        expected_np = np.array(
+            [
+                [1, 2, 2],
+                [2, 1, 2],
+                [2, 2, 1],
+                [2, 2, 2],
+                [1, 2, 2],
+                [2, 1, 2],
+                [2, 2, 1],
+            ]
+        ).astype('float32')
+        x = paddle.ones((7, 3), dtype='float32')
+        y = x * 2
+        y.fill_diagonal_(1, True)
+        self.assertTrue((y.numpy() == expected_np).all())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Bug fixes

### Description

- Interpret fill_diagonal_(value, True) as wrap=True (PyTorch-compatible positional usage).
- Add coverage for positional wrap in test_tensor_fill_diagonal_.py.
- Verify PaConvert case test_Tensor_fill_diagonal_.py::test_case_5 passes with the fix.
