### PR TITLE
[API Compatibility No.9] Align Tensor.cumsum_ dim alias -part

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -3516,6 +3516,8 @@ def cumsum(
         return _cum_sum_(**kwargs)
 
 
+# Edit by AI Agent
+@param_one_alias(["axis", "dim"])
 @inplace_apis_in_dygraph_only
 def cumsum_(
     x: Tensor,
@@ -3526,6 +3528,9 @@ def cumsum_(
     r"""
     Inplace version of ``cumprod`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_cumprod`.
+
+    .. note::
+        Alias Support: The parameter name ``dim`` can be used as an alias for ``axis``.
     """
     if axis is None:
         flatten = True

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -1193,5 +1193,25 @@ class TestBitwiseXorAPI_Compatibility(unittest.TestCase):
                 np.testing.assert_array_equal(out, ref_out)
 
 
+class TestTensorCumsumInplaceCompatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+        self.data = np.random.randint(1, 5, size=(3, 4)).astype('int64')
+
+    def test_dygraph_dim_alias(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.data)
+        y = x.cumsum_(dim=1)
+        np.testing.assert_allclose(np.cumsum(self.data, axis=1), y.numpy())
+        paddle.enable_static()
+
+    def test_dygraph_axis(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.data)
+        y = x.cumsum_(axis=0)
+        np.testing.assert_allclose(np.cumsum(self.data, axis=0), y.numpy())
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

New features

### Description

- Add dim→axis alias support for `paddle.Tensor.cumsum_`.
- Add API compatibility tests for inplace cumsum dim/axis usage.
