### PR TITLE
[CodeStyle][Xdoctest][230] Fix example code

### DIFF
--- a/python/paddle/base/param_attr.py
+++ b/python/paddle/base/param_attr.py
@@ -288,7 +288,7 @@ class WeightNormParamAttr(ParamAttr):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 


### PR DESCRIPTION
Fix example code for paddle.static.WeightNormParamAttr by changing code-block type from 'python' to 'pycon' to properly support xdoctest validation.

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->


### Description
<!-- Describe what you’ve done -->
https://github.com/yuzhixuanyu34-dotcom/Paddle/pull/new/fix-weightnorm-docstring-230