### PR TITLE
[0 size] fix std and var for 0_size

### DIFF
--- a/paddle/phi/kernels/cpu/std_var_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/std_var_grad_kernel.cc
@@ -37,6 +37,10 @@ void VarGradKernel(const Context& dev_ctx,
                    bool unbiased,
                    double correction,
                    DenseTensor* x_grad) {
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   int rank = x.dims().size();
   if (rank == 0 || axis.size() == 0) {
     const auto dof = static_cast<double>(x.numel()) - correction;
@@ -105,6 +109,10 @@ void StdGradKernel(const Context& dev_ctx,
                    bool unbiased,
                    double correction,
                    DenseTensor* x_grad) {
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   // grad_var = (grad / (out * 2)).masked_fill_(out == 0, 0);
   DenseTensor two_tensor =
       phi::FullLike<T, Context>(dev_ctx, out, static_cast<T>(2.0));

--- a/paddle/phi/kernels/gpu/std_var_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/std_var_grad_kernel.cu
@@ -37,6 +37,10 @@ void VarGradKernel(const Context& dev_ctx,
                    bool unbiased,
                    double correction,
                    DenseTensor* x_grad) {
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   int rank = x.dims().size();
   if (rank == 0 || axis.size() == 0) {
     const auto dof = static_cast<double>(x.numel()) - correction;
@@ -105,6 +109,10 @@ void StdGradKernel(const Context& dev_ctx,
                    bool unbiased,
                    double correction,
                    DenseTensor* x_grad) {
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<T>(x_grad);
+    return;
+  }
   // grad_var = (grad / (out * 2)).masked_fill_(out == 0, 0);
   DenseTensor two_tensor =
       phi::FullLike<T, Context>(dev_ctx, out, static_cast<T>(2.0));

--- a/test/legacy_test/test_std_layer.py
+++ b/test/legacy_test/test_std_layer.py
@@ -407,5 +407,22 @@ class TestVarAPI_Backward2(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestStdAPI_Backward_ZeroSize1(unittest.TestCase):
+    def test_api(self):
+        paddle.disable_static()
+        self.shape = [1, 3, 0, 10]
+        self.axis = [1, 3]
+        self.x = np.random.uniform(-1, 1, self.shape).astype('float64')
+        paddle.set_device(paddle.CPUPlace())
+
+        out_ref = ref_std(self.x, self.axis, True, False)
+        x = paddle.to_tensor(self.x)
+        x.stop_gradient = False
+        out = paddle.std(x, self.axis, True, False)
+
+        out.sum().backward()
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_variance_layer.py
+++ b/test/legacy_test/test_variance_layer.py
@@ -622,5 +622,22 @@ class TestVarAPI_Backward2(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestVarAPI_Backward_ZeroSize1(unittest.TestCase):
+    def test_api(self):
+        paddle.disable_static()
+        self.shape = [1, 3, 0, 10]
+        self.axis = [1, 3]
+        self.x = np.random.uniform(-1, 1, self.shape).astype('float64')
+        paddle.set_device(paddle.CPUPlace())
+
+        out_ref = ref_var(self.x, self.axis, True, False)
+        x = paddle.to_tensor(self.x)
+        x.stop_gradient = False
+        out = paddle.var(x, self.axis, True, False)
+
+        out.sum().backward()
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复paddle.std 和 paddle.var 的 0-size 问题