### PR TITLE
[CodeStyle][Xdoctest] change python to pycon - part3

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -139,7 +139,6 @@ def set_flags(flags: dict[str, bool | str | float]) -> None:
         flags (dict): A dict contains flags and its value.
 
     Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> paddle.set_flags({'FLAGS_eager_delete_tensor_gb': 1.0})
@@ -172,7 +171,6 @@ def get_flags(flags: str | Sequence[str]) -> dict[str, bool | str | float]:
         flag's value in Paddle.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
 
@@ -347,7 +345,6 @@ def in_dygraph_mode() -> bool:
         bool: Whether paddle runs in dynamic graph mode.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
             >>> print(paddle.in_dynamic_mode())  # dynamic mode is turn ON by default since paddle 2.0.
@@ -374,7 +371,6 @@ def in_pir_mode() -> bool:
         bool: Whether paddle runs in static graph mode and use pir api.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
 
@@ -403,7 +399,6 @@ def in_dynamic_or_pir_mode() -> bool:
         bool: Whether paddle runs in static graph mode and use pir api.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
 
@@ -488,7 +483,6 @@ def ipu_shard_guard(
         duplicated index.
 
     Examples:
-        .. code-block:: python
 
             >>> # doctest: +REQUIRES(env:IPU)
             >>> import paddle
@@ -553,7 +547,6 @@ def set_ipu_shard(call_func, index=-1, stage=-1):
         The wrapped call function.
 
     Examples:
-        .. code-block:: python
 
             >>> # doctest: +REQUIRES(env:IPU)
             >>> import paddle
@@ -615,7 +608,6 @@ def require_version(min_version: str, max_version: str | None = None) -> None:
         Exception: if the installed version is lower than ``min_version`` or higher than ``max_version``.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
 
@@ -929,7 +921,6 @@ def is_compiled_with_xpu() -> bool:
     Returns (bool): support xpu or not.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle.base as base
             >>> support_xpu = base.is_compiled_with_xpu()
@@ -955,7 +946,6 @@ def disable_signal_handler() -> None:
         None
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
             >>> paddle.disable_signal_handler()
@@ -971,7 +961,6 @@ def is_compiled_with_cinn() -> bool:
         Bool: `True` if CINN is currently available, otherwise `False`.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
             >>> support_cinn = paddle.device.is_compiled_with_cinn()
@@ -987,7 +976,6 @@ def is_compiled_with_cuda() -> bool:
         Bool: `True` if CUDA is currently available, otherwise `False`.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
             >>> support_gpu = paddle.device.is_compiled_with_cuda()
@@ -1003,7 +991,6 @@ def is_compiled_with_distribute() -> bool:
         Bool: `True` if distribute is currently available, otherwise `False`.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
             >>> support_distribute = paddle.device.is_compiled_with_distribute()
@@ -1019,7 +1006,6 @@ def is_compiled_with_rocm() -> bool:
         Bool: `True` if ROCm is currently available, otherwise `False`.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
             >>> support_gpu = paddle.device.is_compiled_with_rocm()
@@ -1057,7 +1043,6 @@ def cuda_places(
 
     Examples:
 
-        .. code-block:: python
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
@@ -1098,7 +1083,6 @@ def xpu_places(device_ids: Sequence[int] | None = None) -> list[core.XPUPlace]:
     Returns:
         list of paddle.XPUPlace: Created XPU place list.
     Examples:
-        .. code-block:: python
 
             >>> # doctest: +REQUIRES(env:XPU)
             >>> import paddle
@@ -1135,7 +1119,6 @@ def cpu_places(device_count: int | None = None) -> list[core.CPUPlace]:
 
     Examples:
 
-        .. code-block:: python
 
             >>> import paddle
             >>> import paddle.static as static
@@ -1170,7 +1153,6 @@ def cuda_pinned_places(
         list of base.CUDAPinnedPlace: Created list of CUDA pinned places.
 
     Examples:
-        .. code-block:: python
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle.base as base
@@ -1205,7 +1187,6 @@ def xpu_pinned_places(
         list of base.XPUPinnedPlace: Created list of XPU pinned places.
 
     Examples:
-        .. code-block:: python
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle.base as base
@@ -1263,7 +1244,6 @@ def name_scope(prefix: str | None = None) -> Generator[None, None, None]:
 
     Examples:
 
-        .. code-block:: python
 
             >>> import paddle
             >>> paddle.enable_static()
@@ -1742,7 +1722,6 @@ class Variable(metaclass=VariableMetaClass):
     Examples:
         In Static Graph Mode:
 
-        .. code-block:: python
             :name: code-example-1
 
             >>> import paddle.base as base
@@ -1754,7 +1733,6 @@ class Variable(metaclass=VariableMetaClass):
 
         In Dygraph  Mode:
 
-        .. code-block:: python
             :name: code-example-2
 
             >>> import paddle.base as base
@@ -1895,7 +1873,6 @@ class Variable(metaclass=VariableMetaClass):
              ( :ref:`api_guide_Variable_en` | dtype is same as current Variable), The detached Variable.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
 
@@ -1949,7 +1926,6 @@ class Variable(metaclass=VariableMetaClass):
             ndarray: dtype is same as current Variable
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.base as base
@@ -1984,7 +1960,6 @@ class Variable(metaclass=VariableMetaClass):
             NoneType: None
 
         Examples:
-            .. code-block:: python
 
                 >>> import numpy as np
                 >>> import paddle
@@ -2027,7 +2002,6 @@ class Variable(metaclass=VariableMetaClass):
             ndarray or tuple of ndarray: if Variable's type is DenseTensor, return numpy value of the gradient of current Variable, if Variable's type is SelectedRows, return tuple of ndarray, first element of tuple is numpy value of the gradient of current Variable, second element of tuple is numpy value of the rows of current Variable.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.base as base
@@ -2077,7 +2051,6 @@ class Variable(metaclass=VariableMetaClass):
         Returns:  None
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.base as base
@@ -2145,7 +2118,6 @@ class Variable(metaclass=VariableMetaClass):
             string: The formatted Variable string.
 
         Examples:
-            .. code-block:: python
 
                 >>> # doctest: +SKIP("This has diff in xdoctest env")
                 >>> import paddle
@@ -2210,7 +2182,6 @@ class Variable(metaclass=VariableMetaClass):
             str: The debug string.
 
         Examples:
-            .. code-block:: python
 
                 >>> # doctest: +SKIP("This has diff in xdoctest env")
                 >>> import paddle.base as base
@@ -2260,7 +2231,6 @@ class Variable(metaclass=VariableMetaClass):
         Returns the size in bytes of an element in the Tensor.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> paddle.enable_static()
@@ -2295,7 +2265,6 @@ class Variable(metaclass=VariableMetaClass):
         **Notes: This Property has default value as** ``True`` **in** Dygraph **mode, while Parameter's default value is False. However, in Static Graph Mode all Variable's default stop_gradient value is** ``False``
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.base as base
@@ -2337,7 +2306,6 @@ class Variable(metaclass=VariableMetaClass):
             **2. In** Dygraph **mode, this property should not be changed**
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle.base as base
                 >>> cur_program = base.Program()
@@ -2360,7 +2328,6 @@ class Variable(metaclass=VariableMetaClass):
         Indicating if current Variable is a Parameter
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> paddle.enable_static()
@@ -2387,7 +2354,6 @@ class Variable(metaclass=VariableMetaClass):
         **Notes: If it has two or more Variable share the same name in the same** :ref:`api_guide_Block_en` **, it means these Variable will share content in no-** Dygraph **mode. This is how we achieve Parameter sharing**
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle.base as base
                 >>> cur_program = base.Program()
@@ -2410,7 +2376,6 @@ class Variable(metaclass=VariableMetaClass):
         the gradient exists.**
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> paddle.enable_static()
@@ -2433,7 +2398,6 @@ class Variable(metaclass=VariableMetaClass):
         **Notes: This is a read-only property**
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle.base as base
                 >>> cur_program = base.Program()
@@ -2455,7 +2419,6 @@ class Variable(metaclass=VariableMetaClass):
         **Notes: This is a read-only property**
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle.base as base
                 >>> cur_program = base.Program()
@@ -2481,7 +2444,6 @@ class Variable(metaclass=VariableMetaClass):
             **2. Don't support this property in** Dygraph **mode, it's value should be** ``0(int)``
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.base as base
@@ -2509,7 +2471,6 @@ class Variable(metaclass=VariableMetaClass):
         **Notes: This is a read-only property**
 
         Examples:
-            .. code-block:: python
 
                 >>> # doctest: +SKIP("This has diff in xdoctest env")
                 >>> import paddle.base as base
@@ -2532,7 +2493,6 @@ class Variable(metaclass=VariableMetaClass):
         If `n` is the dimensions of `x` , `x.T` is equivalent to `x.transpose([n-1, n-2, ..., 0])`.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> paddle.enable_static()
@@ -2591,7 +2551,6 @@ class Variable(metaclass=VariableMetaClass):
             Variable, The cloned Variable.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
 
@@ -2854,7 +2813,6 @@ class Variable(metaclass=VariableMetaClass):
             Tensor, the value in given scope.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -2917,7 +2875,6 @@ class Variable(metaclass=VariableMetaClass):
             None
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -3016,7 +2973,6 @@ class Variable(metaclass=VariableMetaClass):
             Variable, the number of elements for current Variable
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
 
@@ -3222,7 +3178,6 @@ class Operator:
         Block.append_op or Block._prepend_op instead.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
 
@@ -3564,7 +3519,6 @@ class Operator:
             string: The formatted Operator string.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
 
@@ -4319,7 +4273,6 @@ class Block:
         use `Program._create_block()` to create a block.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
 
@@ -4359,7 +4312,6 @@ class Block:
             string: The formatted Block string.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
 
@@ -5999,7 +5951,6 @@ class Program:
         Program: An empty Program.
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
             >>> import paddle.static as static
@@ -6230,7 +6181,6 @@ class Program:
             None.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -6393,7 +6343,6 @@ class Program:
             string: The formatted Program string.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -6436,7 +6385,6 @@ class Program:
             ValueError: If any of required fields is not set and throw_on_error is True.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -6519,7 +6467,6 @@ class Program:
           recommend you to use :code:`clone` before using :code:`Optimizer.minimize`.
 
         Examples:
-            .. code-block:: python
                 :name: code-example-1
 
                 >>> import paddle
@@ -6553,7 +6500,6 @@ class Program:
                 print Program Descs inorder to make sure you have same print result
                 after :code:`clone`:
 
-            .. code-block:: python
                 :name: code-example-2
 
                 >>> import paddle
@@ -6571,7 +6517,6 @@ class Program:
 
 
             1. To clone a test program, the sample code is:
-                .. code-block:: python
                     :name: code-example-3
 
                     >>> import paddle
@@ -6624,7 +6569,6 @@ class Program:
 
 
             2. The clone method can be avoid if you create program for training and program for testing individually.
-                .. code-block:: python
                     :name: code-example-4
 
                     >>> import paddle
@@ -7044,7 +6988,6 @@ class Program:
             Program: A deserialized Program.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7099,7 +7042,6 @@ class Program:
 
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7137,7 +7079,6 @@ class Program:
 
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7174,7 +7115,6 @@ class Program:
 
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7202,7 +7142,6 @@ class Program:
             :ref:`api_guide_Block_en`: The :code:`index` block
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7227,7 +7166,6 @@ class Program:
              :ref:`api_guide_Block_en`: The :code:`index`  :ref:`api_guide_Block_en`
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7398,7 +7336,6 @@ class Program:
             iterable Tensors: The Generator will yield every Tensor in this program.
 
         Examples:
-            .. code-block:: python
 
                 >>> # doctest: +SKIP("This has diff in xdoctest env")
                 >>> import paddle
@@ -7426,7 +7363,6 @@ class Program:
             list[ :ref:`api_guide_parameter_en` ]: The list contains all parameters in this program.
 
         Examples:
-            .. code-block:: python
 
                 >>> # doctest: +SKIP("This has diff in xdoctest env")
                 >>> import paddle
@@ -7480,7 +7416,6 @@ class Program:
             dict: a dict contains the parameters and persistable buffers.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7579,7 +7514,6 @@ class Program:
             None
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7713,7 +7647,6 @@ class Parameter(Variable, metaclass=ParameterMetaClass):
         Returns(str): The debug string.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> paddle.enable_static()
@@ -7924,7 +7857,6 @@ class EagerParamBase(core.eager.Tensor):
         Returns(str): A readable string.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> linear = paddle.nn.Linear(3, 3)
@@ -7943,7 +7875,6 @@ class EagerParamBase(core.eager.Tensor):
         Deep copy parameter, it will always performs Tensor copy.
 
         Examples:
-            .. code-block:: python
 
                 >>> import paddle
                 >>> import copy
@@ -8016,7 +7947,6 @@ def default_startup_program() -> Program:
     Returns type:
 
     Examples:
-        .. code-block:: python
 
             >>> import paddle
 
@@ -8116,7 +8046,6 @@ def program_guard(
             Default: None.
 
     Examples:
-        .. code-block:: python
             :name: code-example-1
 
             >>> import paddle
@@ -8132,7 +8061,6 @@ def program_guard(
     to construct either of startup program or main program.
 
     Examples:
-        .. code-block:: python
             :name: code-example-2
 
             >>> import paddle
@@ -8253,7 +8181,6 @@ def device_guard(device: str | None = None) -> Generator[None, None, None]:
 
     Examples:
 
-        .. code-block:: python
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -139,6 +139,7 @@ def set_flags(flags: dict[str, bool | str | float]) -> None:
         flags (dict): A dict contains flags and its value.
 
     Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> paddle.set_flags({'FLAGS_eager_delete_tensor_gb': 1.0})
@@ -171,6 +172,7 @@ def get_flags(flags: str | Sequence[str]) -> dict[str, bool | str | float]:
         flag's value in Paddle.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -345,6 +347,7 @@ def in_dygraph_mode() -> bool:
         bool: Whether paddle runs in dynamic graph mode.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
             >>> print(paddle.in_dynamic_mode())  # dynamic mode is turn ON by default since paddle 2.0.
@@ -371,6 +374,7 @@ def in_pir_mode() -> bool:
         bool: Whether paddle runs in static graph mode and use pir api.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -399,6 +403,7 @@ def in_dynamic_or_pir_mode() -> bool:
         bool: Whether paddle runs in static graph mode and use pir api.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -483,6 +488,7 @@ def ipu_shard_guard(
         duplicated index.
 
     Examples:
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:IPU)
             >>> import paddle
@@ -547,6 +553,7 @@ def set_ipu_shard(call_func, index=-1, stage=-1):
         The wrapped call function.
 
     Examples:
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:IPU)
             >>> import paddle
@@ -608,6 +615,7 @@ def require_version(min_version: str, max_version: str | None = None) -> None:
         Exception: if the installed version is lower than ``min_version`` or higher than ``max_version``.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -921,6 +929,7 @@ def is_compiled_with_xpu() -> bool:
     Returns (bool): support xpu or not.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle.base as base
             >>> support_xpu = base.is_compiled_with_xpu()
@@ -946,6 +955,7 @@ def disable_signal_handler() -> None:
         None
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
             >>> paddle.disable_signal_handler()
@@ -961,6 +971,7 @@ def is_compiled_with_cinn() -> bool:
         Bool: `True` if CINN is currently available, otherwise `False`.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
             >>> support_cinn = paddle.device.is_compiled_with_cinn()
@@ -976,6 +987,7 @@ def is_compiled_with_cuda() -> bool:
         Bool: `True` if CUDA is currently available, otherwise `False`.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
             >>> support_gpu = paddle.device.is_compiled_with_cuda()
@@ -991,6 +1003,7 @@ def is_compiled_with_distribute() -> bool:
         Bool: `True` if distribute is currently available, otherwise `False`.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
             >>> support_distribute = paddle.device.is_compiled_with_distribute()
@@ -1006,6 +1019,7 @@ def is_compiled_with_rocm() -> bool:
         Bool: `True` if ROCm is currently available, otherwise `False`.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
             >>> support_gpu = paddle.device.is_compiled_with_rocm()
@@ -1043,6 +1057,7 @@ def cuda_places(
 
     Examples:
 
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
@@ -1083,6 +1098,7 @@ def xpu_places(device_ids: Sequence[int] | None = None) -> list[core.XPUPlace]:
     Returns:
         list of paddle.XPUPlace: Created XPU place list.
     Examples:
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:XPU)
             >>> import paddle
@@ -1119,6 +1135,7 @@ def cpu_places(device_count: int | None = None) -> list[core.CPUPlace]:
 
     Examples:
 
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.static as static
@@ -1153,6 +1170,7 @@ def cuda_pinned_places(
         list of base.CUDAPinnedPlace: Created list of CUDA pinned places.
 
     Examples:
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle.base as base
@@ -1187,6 +1205,7 @@ def xpu_pinned_places(
         list of base.XPUPinnedPlace: Created list of XPU pinned places.
 
     Examples:
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle.base as base
@@ -1244,6 +1263,7 @@ def name_scope(prefix: str | None = None) -> Generator[None, None, None]:
 
     Examples:
 
+        .. code-block:: pycon
 
             >>> import paddle
             >>> paddle.enable_static()
@@ -1722,17 +1742,17 @@ class Variable(metaclass=VariableMetaClass):
     Examples:
         In Static Graph Mode:
 
+        .. code-block:: pycon
             :name: code-example-1
 
             >>> import paddle.base as base
             >>> cur_program = base.Program()
             >>> cur_block = cur_program.current_block()
-            >>> new_variable = cur_block.create_var(name="X",
-            ...                                     shape=[-1, 23, 48],
-            ...                                     dtype='float32')
+            >>> new_variable = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
 
         In Dygraph  Mode:
 
+        .. code-block:: pycon
             :name: code-example-2
 
             >>> import paddle.base as base
@@ -1873,6 +1893,7 @@ class Variable(metaclass=VariableMetaClass):
              ( :ref:`api_guide_Variable_en` | dtype is same as current Variable), The detached Variable.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
 
@@ -1926,6 +1947,7 @@ class Variable(metaclass=VariableMetaClass):
             ndarray: dtype is same as current Variable
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.base as base
@@ -1960,6 +1982,7 @@ class Variable(metaclass=VariableMetaClass):
             NoneType: None
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import numpy as np
                 >>> import paddle
@@ -1971,7 +1994,7 @@ class Variable(metaclass=VariableMetaClass):
                 ...     tmp = paddle.to_tensor(x)
                 ...     # if we don't set tmp's stop_gradient as False then, all path to loss will has no gradient since
                 ...     # there is no one need gradient on it.
-                ...     tmp.stop_gradient=False
+                ...     tmp.stop_gradient = False
                 ...     inputs.append(tmp)
                 >>> ret = paddle.add_n(inputs)
                 >>> loss = paddle.sum(ret)
@@ -2002,6 +2025,7 @@ class Variable(metaclass=VariableMetaClass):
             ndarray or tuple of ndarray: if Variable's type is DenseTensor, return numpy value of the gradient of current Variable, if Variable's type is SelectedRows, return tuple of ndarray, first element of tuple is numpy value of the gradient of current Variable, second element of tuple is numpy value of the rows of current Variable.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.base as base
@@ -2013,7 +2037,7 @@ class Variable(metaclass=VariableMetaClass):
                 ...     inputs2 = []
                 ...     for _ in range(10):
                 ...         tmp = paddle.to_tensor(x)
-                ...         tmp.stop_gradient=False
+                ...         tmp.stop_gradient = False
                 ...         inputs2.append(tmp)
                 ...     ret2 = paddle.add_n(inputs2)
                 ...     loss2 = paddle.sum(ret2)
@@ -2023,11 +2047,7 @@ class Variable(metaclass=VariableMetaClass):
 
                 >>> # example2: return tuple of ndarray
                 >>> with base.dygraph.guard():
-                ...     embedding = paddle.nn.Embedding(
-                ...         20,
-                ...         32,
-                ...         weight_attr='emb.w',
-                ...         sparse=True)
+                ...     embedding = paddle.nn.Embedding(20, 32, weight_attr='emb.w', sparse=True)
                 ...     x_data = np.arange(12).reshape(4, 3).astype('int64')
                 ...     x_data = x_data.reshape((-1, 3, 1))
                 ...     x_tensor = paddle.to_tensor(x_data)
@@ -2051,6 +2071,7 @@ class Variable(metaclass=VariableMetaClass):
         Returns:  None
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.base as base
@@ -2118,6 +2139,7 @@ class Variable(metaclass=VariableMetaClass):
             string: The formatted Variable string.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> # doctest: +SKIP("This has diff in xdoctest env")
                 >>> import paddle
@@ -2127,9 +2149,7 @@ class Variable(metaclass=VariableMetaClass):
 
                 >>> cur_program = static.Program()
                 >>> cur_block = cur_program.current_block()
-                >>> new_variable = cur_block.create_var(name="X",
-                ...                                     shape=[-1, 23, 48],
-                ...                                     dtype='float32')
+                >>> new_variable = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
                 >>> print(new_variable._to_readable_code())
                 var X : DENSE_TENSOR.shape(-1, 23, 48).dtype(float32).stop_gradient(False)
         """
@@ -2182,6 +2202,7 @@ class Variable(metaclass=VariableMetaClass):
             str: The debug string.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> # doctest: +SKIP("This has diff in xdoctest env")
                 >>> import paddle.base as base
@@ -2190,9 +2211,7 @@ class Variable(metaclass=VariableMetaClass):
                 >>> paddle.enable_static()
                 >>> cur_program = base.Program()
                 >>> cur_block = cur_program.current_block()
-                >>> new_variable = cur_block.create_var(name="X",
-                ...                                     shape=[-1, 23, 48],
-                ...                                     dtype='float32')
+                >>> new_variable = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
                 >>> print(new_variable.to_string(True))
                 >>> print("=============with detail===============")
                 >>> print(new_variable.to_string(True, True))
@@ -2231,6 +2250,7 @@ class Variable(metaclass=VariableMetaClass):
         Returns the size in bytes of an element in the Tensor.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> paddle.enable_static()
@@ -2265,6 +2285,7 @@ class Variable(metaclass=VariableMetaClass):
         **Notes: This Property has default value as** ``True`` **in** Dygraph **mode, while Parameter's default value is False. However, in Static Graph Mode all Variable's default stop_gradient value is** ``False``
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.base as base
@@ -2306,13 +2327,12 @@ class Variable(metaclass=VariableMetaClass):
             **2. In** Dygraph **mode, this property should not be changed**
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle.base as base
                 >>> cur_program = base.Program()
                 >>> cur_block = cur_program.current_block()
-                >>> new_variable = cur_block.create_var(name="X",
-                ...                                     shape=[-1, 23, 48],
-                ...                                     dtype='float32')
+                >>> new_variable = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
                 >>> print("persistable of current Var is: {}".format(new_variable.persistable))
                 persistable of current Var is: False
         """
@@ -2328,12 +2348,11 @@ class Variable(metaclass=VariableMetaClass):
         Indicating if current Variable is a Parameter
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> paddle.enable_static()
-                >>> new_parameter = paddle.static.create_parameter(name="X",
-                ...                                     shape=[10, 23, 48],
-                ...                                     dtype='float32')
+                >>> new_parameter = paddle.static.create_parameter(name="X", shape=[10, 23, 48], dtype='float32')
                 >>> if new_parameter.is_parameter:
                 ...     print("Current var is a Parameter")
                 ... else:
@@ -2354,13 +2373,12 @@ class Variable(metaclass=VariableMetaClass):
         **Notes: If it has two or more Variable share the same name in the same** :ref:`api_guide_Block_en` **, it means these Variable will share content in no-** Dygraph **mode. This is how we achieve Parameter sharing**
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle.base as base
                 >>> cur_program = base.Program()
                 >>> cur_block = cur_program.current_block()
-                >>> new_variable = cur_block.create_var(name="X",
-                ...                                     shape=[-1, 23, 48],
-                ...                                     dtype='float32')
+                >>> new_variable = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
                 >>> print("name of current Var is: {}".format(new_variable.name))
                 name of current Var is: X
         """
@@ -2376,6 +2394,7 @@ class Variable(metaclass=VariableMetaClass):
         the gradient exists.**
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> paddle.enable_static()
@@ -2398,13 +2417,12 @@ class Variable(metaclass=VariableMetaClass):
         **Notes: This is a read-only property**
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle.base as base
                 >>> cur_program = base.Program()
                 >>> cur_block = cur_program.current_block()
-                >>> new_variable = cur_block.create_var(name="X",
-                ...                                     shape=[-1, 23, 48],
-                ...                                     dtype='float32')
+                >>> new_variable = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
                 >>> print("shape of current Var is: {}".format(new_variable.shape))
                 shape of current Var is: [-1, 23, 48]
         """
@@ -2419,13 +2437,12 @@ class Variable(metaclass=VariableMetaClass):
         **Notes: This is a read-only property**
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle.base as base
                 >>> cur_program = base.Program()
                 >>> cur_block = cur_program.current_block()
-                >>> new_variable = cur_block.create_var(name="X",
-                ...                                     shape=[-1, 23, 48],
-                ...                                     dtype='float32')
+                >>> new_variable = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
                 >>> print("Dtype of current Var is: {}".format(new_variable.dtype))
                 Dtype of current Var is: paddle.float32
         """
@@ -2444,6 +2461,7 @@ class Variable(metaclass=VariableMetaClass):
             **2. Don't support this property in** Dygraph **mode, it's value should be** ``0(int)``
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.base as base
@@ -2451,9 +2469,7 @@ class Variable(metaclass=VariableMetaClass):
                 >>> paddle.enable_static()
                 >>> cur_program = base.Program()
                 >>> cur_block = cur_program.current_block()
-                >>> new_variable = cur_block.create_var(name="X",
-                ...                                     shape=[-1, 23, 48],
-                ...                                     dtype='float32')
+                >>> new_variable = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
                 >>> print("LoD Level of current Var is: {}".format(new_variable.lod_level))
                 LoD Level of current Var is: 0
         """
@@ -2471,14 +2487,13 @@ class Variable(metaclass=VariableMetaClass):
         **Notes: This is a read-only property**
 
         Examples:
+            .. code-block:: pycon
 
                 >>> # doctest: +SKIP("This has diff in xdoctest env")
                 >>> import paddle.base as base
                 >>> cur_program = base.Program()
                 >>> cur_block = cur_program.current_block()
-                >>> new_variable = cur_block.create_var(name="X",
-                ...                                     shape=[-1, 23, 48],
-                ...                                     dtype='float32')
+                >>> new_variable = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
                 >>> print("Type of current Var is: {}".format(new_variable.type))
                 Type of current Var is: VarType.DENSE_TENSOR
         """
@@ -2493,6 +2508,7 @@ class Variable(metaclass=VariableMetaClass):
         If `n` is the dimensions of `x` , `x.T` is equivalent to `x.transpose([n-1, n-2, ..., 0])`.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> paddle.enable_static()
@@ -2551,6 +2567,7 @@ class Variable(metaclass=VariableMetaClass):
             Variable, The cloned Variable.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
 
@@ -2813,6 +2830,7 @@ class Variable(metaclass=VariableMetaClass):
             Tensor, the value in given scope.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -2828,16 +2846,22 @@ class Variable(metaclass=VariableMetaClass):
                 >>> prog = paddle.static.default_main_program()
                 >>> exe.run(static.default_startup_program())
                 >>> inputs = np.ones((10, 10), dtype='float32')
-                >>> exe.run(prog, feed={'x': inputs}, fetch_list=[y, ])
+                >>> exe.run(
+                ...     prog,
+                ...     feed={'x': inputs},
+                ...     fetch_list=[
+                ...         y,
+                ...     ],
+                ... )
                 >>> path = 'temp/tensor_'
                 >>> for var in prog.list_vars():
                 ...     if var.persistable:
                 ...         t = var.get_value()
-                ...         paddle.save(t, path+var.name+'.pdtensor')
+                ...         paddle.save(t, path + var.name + '.pdtensor')
 
                 >>> for var in prog.list_vars():
                 ...     if var.persistable:
-                ...         t_load = paddle.load(path+var.name+'.pdtensor')
+                ...         t_load = paddle.load(path + var.name + '.pdtensor')
                 ...         var.set_value(t_load)
         """
         # The 'framework' is a low-level module, and 'executor'
@@ -2875,6 +2899,7 @@ class Variable(metaclass=VariableMetaClass):
             None
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -2890,16 +2915,22 @@ class Variable(metaclass=VariableMetaClass):
                 >>> prog = paddle.static.default_main_program()
                 >>> exe.run(static.default_startup_program())
                 >>> inputs = np.ones((10, 10), dtype='float32')
-                >>> exe.run(prog, feed={'x': inputs}, fetch_list=[y, ])
+                >>> exe.run(
+                ...     prog,
+                ...     feed={'x': inputs},
+                ...     fetch_list=[
+                ...         y,
+                ...     ],
+                ... )
                 >>> path = 'temp/tensor_'
                 >>> for var in prog.list_vars():
                 ...     if var.persistable:
                 ...         t = var.get_value()
-                ...         paddle.save(t, path+var.name+'.pdtensor')
+                ...         paddle.save(t, path + var.name + '.pdtensor')
 
                 >>> for var in prog.list_vars():
                 ...     if var.persistable:
-                ...         t_load = paddle.load(path+var.name+'.pdtensor')
+                ...         t_load = paddle.load(path + var.name + '.pdtensor')
                 ...         var.set_value(t_load)
 
         """
@@ -2973,6 +3004,7 @@ class Variable(metaclass=VariableMetaClass):
             Variable, the number of elements for current Variable
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
 
@@ -3178,6 +3210,7 @@ class Operator:
         Block.append_op or Block._prepend_op instead.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -3188,9 +3221,7 @@ class Operator:
             >>> var2 = cur_block.create_var(name="var2", shape=[-1, 23, 48], dtype='float32')
             >>> var3 = cur_block.create_var(name="var3", shape=[-1, 23, 48], dtype='float32')
             >>> var1 += var2 + var3
-            >>> cur_block.append_op(type="sum",
-            ...                     inputs={"X": [var1, var2, var3]},
-            ...                     outputs={"Out": [var1]})
+            >>> cur_block.append_op(type="sum", inputs={"X": [var1, var2, var3]}, outputs={"Out": [var1]})
     """
 
     OP_WITHOUT_KERNEL_SET = {
@@ -3519,18 +3550,15 @@ class Operator:
             string: The formatted Operator string.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
 
                 >>> paddle.enable_static()
                 >>> cur_program = paddle.static.Program()
                 >>> cur_block = cur_program.current_block()
-                >>> var = cur_block.create_var(name="X",
-                ...                            shape=[-1, 23, 48],
-                ...                            dtype='float32')
-                >>> new_op = cur_block.append_op(type="abs",
-                ...                              inputs={"X": [var]},
-                ...                              outputs={"Out": [var]})
+                >>> var = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
+                >>> new_op = cur_block.append_op(type="abs", inputs={"X": [var]}, outputs={"Out": [var]})
                 >>> print(new_op._to_readable_code())
         """
         assert isinstance(skip_op_callstack, bool), (
@@ -4273,18 +4301,15 @@ class Block:
         use `Program._create_block()` to create a block.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> paddle.enable_static()
             >>> cur_program = paddle.static.Program()
             >>> cur_block = cur_program.current_block()
-            >>> var = cur_block.create_var(name="X",
-            ...                            shape=[-1, 23, 48],
-            ...                            dtype='float32')
-            >>> cur_block.append_op(type="abs",
-            ...                     inputs={"X": [var]},
-            ...                     outputs={"Out": [var]})
+            >>> var = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
+            >>> cur_block.append_op(type="abs", inputs={"X": [var]}, outputs={"Out": [var]})
     """
 
     def __init__(self, program, idx):
@@ -4312,18 +4337,15 @@ class Block:
             string: The formatted Block string.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
 
                 >>> paddle.enable_static()
                 >>> cur_program = paddle.static.Program()
                 >>> cur_block = cur_program.current_block()
-                >>> new_var = cur_block.create_var(name="X",
-                ...                                shape=[-1, 23, 48],
-                ...                                dtype='float32')
-                >>> new_op = cur_block.append_op(type="abs",
-                ...                     inputs={"X": [new_var]},
-                ...                     outputs={"Out": [new_var]})
+                >>> new_var = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
+                >>> new_op = cur_block.append_op(type="abs", inputs={"X": [new_var]}, outputs={"Out": [new_var]})
                 >>> print(cur_block._to_readable_code())
         """
         assert isinstance(skip_op_callstack, bool), (
@@ -5951,6 +5973,7 @@ class Program:
         Program: An empty Program.
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.static as static
@@ -6181,6 +6204,7 @@ class Program:
             None.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -6343,6 +6367,7 @@ class Program:
             string: The formatted Program string.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -6351,12 +6376,8 @@ class Program:
 
                 >>> cur_program = static.Program()
                 >>> cur_block = cur_program.current_block()
-                >>> new_var = cur_block.create_var(name="X",
-                ...                                shape=[-1, 23, 48],
-                ...                                dtype='float32')
-                >>> new_op = cur_block.append_op(type="abs",
-                ...                     inputs={"X": [new_var]},
-                ...                     outputs={"Out": [new_var]})
+                >>> new_var = cur_block.create_var(name="X", shape=[-1, 23, 48], dtype='float32')
+                >>> new_op = cur_block.append_op(type="abs", inputs={"X": [new_var]}, outputs={"Out": [new_var]})
                 >>> print(cur_program._to_readable_code())
         """
         assert isinstance(skip_op_callstack, bool), (
@@ -6385,6 +6406,7 @@ class Program:
             ValueError: If any of required fields is not set and throw_on_error is True.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -6392,7 +6414,7 @@ class Program:
                 >>> paddle.enable_static()
 
                 >>> prog = static.default_main_program()
-                >>> x = static.data(name="X", shape=[2,3], dtype="float32")
+                >>> x = static.data(name="X", shape=[2, 3], dtype="float32")
                 >>> pred = static.nn.fc(x, size=3)
                 >>> prog_string = prog.to_string(throw_on_error=True, with_details=False)
                 >>> prog_string_with_details = prog.to_string(throw_on_error=False, with_details=True)
@@ -6467,6 +6489,7 @@ class Program:
           recommend you to use :code:`clone` before using :code:`Optimizer.minimize`.
 
         Examples:
+            .. code-block:: pycon
                 :name: code-example-1
 
                 >>> import paddle
@@ -6500,6 +6523,7 @@ class Program:
                 print Program Descs inorder to make sure you have same print result
                 after :code:`clone`:
 
+            .. code-block:: pycon
                 :name: code-example-2
 
                 >>> import paddle
@@ -6517,6 +6541,7 @@ class Program:
 
 
             1. To clone a test program, the sample code is:
+                .. code-block:: pycon
                     :name: code-example-3
 
                     >>> import paddle
@@ -6549,7 +6574,8 @@ class Program:
                     ...         hidden = F.dropout(hidden, p=0.5)
                     ...         loss = F.cross_entropy(
                     ...             input=static.nn.fc(x=hidden, size=10, activation='softmax'),
-                    ...             label=static.data(name='label', shape=[1], dtype='int64'))
+                    ...             label=static.data(name='label', shape=[1], dtype='int64'),
+                    ...         )
                     ...         avg_loss = paddle.mean(loss)
                     ...         test_program = train_program.clone(for_test=True)
                     >>> print_prog(test_program)
@@ -6569,6 +6595,7 @@ class Program:
 
 
             2. The clone method can be avoid if you create program for training and program for testing individually.
+                .. code-block:: pycon
                     :name: code-example-4
 
                     >>> import paddle
@@ -6595,7 +6622,8 @@ class Program:
                     ...     hidden = F.dropout(hidden, p=0.5)
                     ...     loss = F.cross_entropy(
                     ...         input=static.nn.fc(x=hidden, size=10, activation='softmax'),
-                    ...         label=static.data(name='label', shape=[1], dtype='int64'))
+                    ...         label=static.data(name='label', shape=[1], dtype='int64'),
+                    ...     )
                     ...     avg_loss = paddle.mean(loss)
                     ...     return avg_loss
 
@@ -6988,6 +7016,7 @@ class Program:
             Program: A deserialized Program.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7042,6 +7071,7 @@ class Program:
 
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7051,7 +7081,7 @@ class Program:
 
                 >>> prog = static.default_main_program()
                 >>> random_seed = prog.random_seed
-                >>> x_var = static.data(name="X", shape=[3,3], dtype="float32")
+                >>> x_var = static.data(name="X", shape=[3, 3], dtype="float32")
                 >>> print(random_seed)
                 0
                 >>> ## the default random seed is 0
@@ -7079,6 +7109,7 @@ class Program:
 
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7115,6 +7146,7 @@ class Program:
 
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7142,6 +7174,7 @@ class Program:
             :ref:`api_guide_Block_en`: The :code:`index` block
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7166,6 +7199,7 @@ class Program:
              :ref:`api_guide_Block_en`: The :code:`index`  :ref:`api_guide_Block_en`
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7336,6 +7370,7 @@ class Program:
             iterable Tensors: The Generator will yield every Tensor in this program.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> # doctest: +SKIP("This has diff in xdoctest env")
                 >>> import paddle
@@ -7344,8 +7379,8 @@ class Program:
                 >>> paddle.enable_static()
 
                 >>> prog = static.default_main_program()
-                >>> img = static.data(name='img', shape=[None, 1,28,28], dtype='float32')
-                >>> label = static.data(name='label', shape=[None,1], dtype='int64')
+                >>> img = static.data(name='img', shape=[None, 1, 28, 28], dtype='float32')
+                >>> label = static.data(name='label', shape=[None, 1], dtype='int64')
                 >>> for var in prog.list_vars():
                 ...     print(var)
 
@@ -7363,6 +7398,7 @@ class Program:
             list[ :ref:`api_guide_parameter_en` ]: The list contains all parameters in this program.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> # doctest: +SKIP("This has diff in xdoctest env")
                 >>> import paddle
@@ -7416,6 +7452,7 @@ class Program:
             dict: a dict contains the parameters and persistable buffers.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7514,6 +7551,7 @@ class Program:
             None
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import paddle.static as static
@@ -7647,11 +7685,12 @@ class Parameter(Variable, metaclass=ParameterMetaClass):
         Returns(str): The debug string.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> paddle.enable_static()
                 >>> prog = paddle.static.default_main_program()
-                >>> rlt = paddle.static.data("fake_data", shape=[-1,1,1], dtype='float32')
+                >>> rlt = paddle.static.data("fake_data", shape=[-1, 1, 1], dtype='float32')
                 >>> debug_str = prog.to_string(throw_on_error=True, with_details=False)
                 >>> print(debug_str)
         """
@@ -7857,6 +7896,7 @@ class EagerParamBase(core.eager.Tensor):
         Returns(str): A readable string.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> linear = paddle.nn.Linear(3, 3)
@@ -7875,6 +7915,7 @@ class EagerParamBase(core.eager.Tensor):
         Deep copy parameter, it will always performs Tensor copy.
 
         Examples:
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> import copy
@@ -7947,6 +7988,7 @@ def default_startup_program() -> Program:
     Returns type:
 
     Examples:
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -7977,7 +8019,7 @@ def default_main_program() -> Program:
         Program: A ``Program`` which holding the descriptions of OPs and tensors in the network.
 
     Examples:
-        ..  code-block:: python
+        ..  code-block:: pycon
 
             >>> import paddle
 
@@ -8046,6 +8088,7 @@ def program_guard(
             Default: None.
 
     Examples:
+        .. code-block:: pycon
             :name: code-example-1
 
             >>> import paddle
@@ -8061,6 +8104,7 @@ def program_guard(
     to construct either of startup program or main program.
 
     Examples:
+        .. code-block:: pycon
             :name: code-example-2
 
             >>> import paddle
@@ -8181,6 +8225,7 @@ def device_guard(device: str | None = None) -> Generator[None, None, None]:
 
     Examples:
 
+        .. code-block:: pycon
 
             >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
@@ -8189,7 +8234,7 @@ def device_guard(device: str | None = None) -> Generator[None, None, None]:
             >>> support_gpu = paddle.is_compiled_with_cuda()
             >>> place = paddle.CPUPlace()
             >>> if support_gpu:
-            ...     place = paddle.CUDAPlace(0) # type: ignore
+            ...     place = paddle.CUDAPlace(0)  # type: ignore
 
             >>> # if GPU is supported, the three OPs below will be automatically assigned to CUDAPlace(0)
             >>> data1 = paddle.full(shape=[1, 3, 8, 8], fill_value=0.5, dtype='float32')


### PR DESCRIPTION
This PR changes all remaining `code-block:: python` markers to `code-block:: pycon` in Python docstrings for better xdoctest compatibility.

This is part 3 of the code-block standardization work:
- Part 1: #77493
- Part 2: #77513
- Part 3: This PR

## Changes

- Changed 1782 occurrences of `code-block:: python` to `code-block:: pycon` across 339 files
- Affected modules include: amp, audio, autograd, base, compat, cuda, dataset, device, distributed, distribution, fft, framework, geometric, hapi, incubate, io, jit, metric, nn, onnx, optimizer, pir, profiler, quantization, random, reader, regularizer, sparse, static, sysconfig, tensor, testing, text, utils, vision