### PR TITLE
Cherrypick linear_v2 0size issue fix

### DIFF
--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -1604,20 +1604,7 @@ void LinearV2InferMeta(const MetaTensor& input,
       common::flatten_to_2d(input_dims, input_dims.size() - 1);
 
   auto input_rank = input_dims.size();
-  int64_t K_from_input = input_mat_dims[1];
-  int64_t K_from_weight = weight_reduce_dim;
-  const bool check_dim =
-      (!config.is_runtime && K_from_input != -1) || config.is_runtime;
-  if (check_dim) {
-    PADDLE_ENFORCE_EQ(
-        K_from_input,
-        K_from_weight,
-        common::errors::InvalidArgument(
-            "The last dimension of X should be equal with Y's first dimension."
-            "But received X[-1] = [%d], Y[0] = [%d].",
-            K_from_input,
-            K_from_weight));
-  }
+
   std::vector<int64_t> out_dims;
   out_dims.reserve(input_rank);
 

--- a/paddle/phi/kernels/linear_v2_kernel.h
+++ b/paddle/phi/kernels/linear_v2_kernel.h
@@ -31,7 +31,15 @@ inline std::tuple<int64_t, int64_t, int64_t> canonicalize_dims(
   const int64_t N = weight_dims.size() < 2 ? 1 : weight_dims[!transpose_weight];
   const int64_t K =
       weight_dims.size() < 2 ? weight_dims[0] : weight_dims[transpose_weight];
-
+  const int64_t K_from_input = input_dims[input_dims.size() - 1];
+  PADDLE_ENFOECE_EQ(K_from_input,
+                    K,
+                    phi::errors::InvalidArgument(
+                        "The last dimension of input should be equal to the %d "
+                        "dimension of weight, but got %d and %d.",
+                        transpose_weight ? 1 : 0,
+                        K_from_input,
+                        K));
   int64_t M = input_dims.size() >= 2 ? input_dims[input_dims.size() - 2] : 1;
   if (input_dims.size() > 2) {
     // Accumulate the batch dims for input

--- a/paddle/phi/kernels/linear_v2_kernel.h
+++ b/paddle/phi/kernels/linear_v2_kernel.h
@@ -32,7 +32,7 @@ inline std::tuple<int64_t, int64_t, int64_t> canonicalize_dims(
   const int64_t K =
       weight_dims.size() < 2 ? weight_dims[0] : weight_dims[transpose_weight];
   const int64_t K_from_input = input_dims[input_dims.size() - 1];
-  PADDLE_ENFOECE_EQ(K_from_input,
+  PADDLE_ENFORCE_EQ(K_from_input,
                     K,
                     phi::errors::InvalidArgument(
                         "The last dimension of input should be equal to the %d "


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
Cherrypick linear_v2 0size issue fix
devPR:https://github.com/PaddlePaddle/Paddle/pull/77628
pcard-91067
