### PR TITLE
[CodeStyle][Xdoctest][232] Fix example code(`paddle.static.create_global_var`)

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -131,7 +131,7 @@ def create_global_var(
     Examples:
         .. code-block:: pycon
 
-            >>> # doctest: +SKIP("static mode has dtype mismatch issue")
+            >>> # doctest: +SKIP("paddle.static.create_global_var doesn't support PIR mode")
             >>> import paddle
             >>> paddle.enable_static()
             >>> main_program = paddle.static.Program()

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -129,26 +129,23 @@ def create_global_var(
         Variable: The created Variable
 
     Examples:
-    .. code-block:: pycon
+        .. code-block:: pycon
 
-        >>> # doctest: +SKIP('Cannot be executed reliably due to dtype mismatch in constant initializer')
-        >>> import paddle
-        >>> paddle.device.set_device("cpu")
-        >>> paddle.enable_static()
-        >>> main_program = paddle.static.Program()
-        >>> startup_program = paddle.static.Program()
-        >>> with paddle.static.program_guard(main_program, startup_program):
-        ...     var = paddle.static.create_global_var(
-        ...         shape=[2, 3],
-        ...         value=1.0,
-        ...         dtype="float32",
-        ...         persistable=True,
-        ...         force_cpu=True,
-        ...     )
-        >>> var.shape
-        (2, 3)
-        >>> paddle.disable_static()
-
+            >>> # doctest: +SKIP("static mode has dtype mismatch issue")
+            >>> import paddle
+            >>> paddle.enable_static()
+            >>> main_program = paddle.static.Program()
+            >>> startup_program = paddle.static.Program()
+            >>> with paddle.static.program_guard(main_program, startup_program):
+            ...     var = paddle.static.create_global_var(
+            ...         shape=[2, 3],
+            ...         value=1.0,
+            ...         dtype="float32",
+            ...         persistable=True,
+            ...         force_cpu=True,
+            ...     )
+            >>> var.shape
+            (2, 3)
     """
     check_type(shape, 'shape', (list, tuple, np.ndarray), 'create_global_var')
     for item in shape:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -129,12 +129,26 @@ def create_global_var(
         Variable: The created Variable
 
     Examples:
-        .. code-block:: python
+    .. code-block:: pycon
 
-            >>> import paddle
-            >>> paddle.enable_static()
-            >>> var = paddle.static.create_global_var(shape=[2,3], value=1.0, dtype='float32',
-            ...                                persistable=True, force_cpu=True, name='new_var')
+        >>> # doctest: +SKIP('Cannot be executed reliably due to dtype mismatch in constant initializer')
+        >>> import paddle
+        >>> paddle.device.set_device("cpu")
+        >>> paddle.enable_static()
+        >>> main_program = paddle.static.Program()
+        >>> startup_program = paddle.static.Program()
+        >>> with paddle.static.program_guard(main_program, startup_program):
+        ...     var = paddle.static.create_global_var(
+        ...         shape=[2, 3],
+        ...         value=1.0,
+        ...         dtype="float32",
+        ...         persistable=True,
+        ...         force_cpu=True,
+        ...     )
+        >>> var.shape
+        (2, 3)
+        >>> paddle.disable_static()
+
     """
     check_type(shape, 'shape', (list, tuple, np.ndarray), 'create_global_var')
     for item in shape:


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Docs

### Description
<!-- Describe what you've done -->
This PR updates the docstring example for paddle.static.create_global_var (task 232).

Changes made in this PR:
- Change the example code block type from python to pycon.
- Rewrite the example in a clearer interactive (pycon) style using Program and program_guard.
- Mark the example with doctest SKIP because the example cannot be executed reliably
  in the current nightly CPU implementation due to a dtype mismatch in the Constant
  initializer path.

This PR only modifies the docstring example and does not change any runtime behavior.

@ooooo-create

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否