### PR TITLE
[CI] Set timeout for all jobs and download steps

### DIFF
--- a/.github/workflows/Approval.yml
+++ b/.github/workflows/Approval.yml
@@ -15,6 +15,7 @@ jobs:
   check-approvers:
     name: Check approval
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -10,6 +10,7 @@ jobs:
     name: Check
     runs-on:
       group: Template
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -9,6 +9,7 @@ jobs:
     name: Pre Commit
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       PR_ID: ${{ github.event.pull_request.number }}
       BRANCH: develop

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -50,6 +50,7 @@ jobs:
     if: needs.clone.outputs.can-skip != 'true'
     runs-on:
       group: GZ_BD-CPU
+    timeout-minutes: 120
     outputs:
       can-skip: ${{ steps.check-bypass.outputs.can-skip }}
 
@@ -135,6 +136,7 @@ jobs:
             -w /paddle --network host ${docker_image}
 
       - name: Download paddle.tar.gz and update test branch
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }}  /bin/bash -c '
           rm -rf * .[^.]*
@@ -258,6 +260,7 @@ jobs:
     if: needs.build.outputs.can-skip != 'true'
     runs-on:
       group: BD_BJ-V100
+    timeout-minutes: 240
     steps:
       - name: Check docker image and run container
         env:
@@ -331,6 +334,7 @@ jobs:
             -w /paddle --network host ${docker_image}
 
       - name: Download paddle.tar.gz and update test branch
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*

--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -42,6 +42,7 @@ jobs:
     if: needs.clone.outputs.can-skip != 'true'
     runs-on:
       group: GZ_BD-CPU
+    timeout-minutes: 120
     outputs:
       can-skip: ${{ steps.check-bypass.outputs.can-skip }}
 
@@ -111,6 +112,7 @@ jobs:
             -w /paddle --network host ${docker_image}
 
       - name: Download paddle.tar.gz and update test branch
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }}  /bin/bash -c '
           rm -rf * .[^.]*
@@ -226,6 +228,7 @@ jobs:
     if: needs.build.outputs.can-skip != 'true'
     runs-on:
       group: H-Coverage
+    timeout-minutes: 120
     steps:
       - name: Determine the runner
         run: |
@@ -307,6 +310,7 @@ jobs:
             -w /paddle --network host ${docker_image}
 
       - name: Download paddle.tar.gz and update test branch
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*
@@ -352,6 +356,7 @@ jobs:
     if: needs.build.outputs.can-skip != 'true'
     runs-on:
       group: GZ_BD-CPU
+    timeout-minutes: 60
     env:
       TASK: fleet-ci-paddle-build-whl-${{ github.event.pull_request.number }}
       docker_image: "ccr-2vdh3abv-pub.cnc.bj.baidubce.com/paddlepaddle/paddle:cuda129-coverage-test"
@@ -435,13 +440,13 @@ jobs:
           docker exec -t ${{ env.container_name }} /bin/bash -c 'bash ci/clean_uv_cache.sh; rm -rf * .[^.]*'
           docker rm -f ${{ env.container_name }}
 
-
   fleet_single_card_test:
     name: Fleet Unit test (single card)
     needs: [build, fleet-build]
     if: needs.build.outputs.can-skip != 'true'
     runs-on:
       group: Fleet-H-single-card
+    timeout-minutes: 60
     env:
       PIP_CACHE_DIR: /root/.cache/pip
       CACHE_DIR: /root/.cache
@@ -500,6 +505,7 @@ jobs:
           '
 
       - name: Download paddle.tar.gz and install paddle whl
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           set -e
@@ -545,6 +551,7 @@ jobs:
     if: needs.build.outputs.can-skip != 'true'
     runs-on:
       group: Fleet-H-multi-card
+    timeout-minutes: 60
     env:
       PIP_CACHE_DIR: /root/.cache/pip
       TASK: paddle-fleet-CI-${{ github.event.pull_request.number }}-multi-card_test
@@ -596,6 +603,7 @@ jobs:
           '
 
       - name: Download paddle.tar.gz and install paddle whl
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           set -e

--- a/.github/workflows/_Api-Benchmark.yml
+++ b/.github/workflows/_Api-Benchmark.yml
@@ -45,7 +45,7 @@ jobs:
     if: ${{ inputs.can-skip != 'true' }}
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'api-benchmark'
+      workflow-name: "api-benchmark"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -56,6 +56,7 @@ jobs:
     runs-on:
       group: Api-bm
       labels: [self-hosted, "${{ inputs.run-labels }}"]
+    timeout-minutes: 60
     steps:
       - name: Determine the runner
         run: |
@@ -108,6 +109,7 @@ jobs:
       - name: Download PaddleTest.tar.gz
         env:
           work_dir: ${{ github.workspace }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           ldconfig

--- a/.github/workflows/_Auto-Parallel.yml
+++ b/.github/workflows/_Auto-Parallel.yml
@@ -31,7 +31,7 @@ jobs:
     if: ${{ inputs.can-skip != 'true' }}
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'auto-parallel'
+      workflow-name: "auto-parallel"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -41,6 +41,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: Auto-Parallel
+    timeout-minutes: 120
     steps:
       - name: Check docker image and run container
         env:
@@ -74,6 +75,7 @@ jobs:
       - name: Download Paddle
         env:
           work_dir: ${{ github.workspace }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*
@@ -88,6 +90,7 @@ jobs:
       - name: Download PaddleTest
         env:
           work_dir: ${{ github.workspace }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           echo "Download and extract PaddleNLP.tar.gz"

--- a/.github/workflows/_CE-CINN-Framework.yml
+++ b/.github/workflows/_CE-CINN-Framework.yml
@@ -32,6 +32,7 @@ jobs:
     if: ${{ inputs.can-skip != 'true' }}
     runs-on:
       group: BD_BJ-V100
+    timeout-minutes: 120
     steps:
       - name: Check docker image and run container
         env:
@@ -67,6 +68,7 @@ jobs:
       - name: Download Paddle and PaddleTest
         env:
           work_dir: ${{ github.workspace }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*

--- a/.github/workflows/_CE-Framework.yml
+++ b/.github/workflows/_CE-Framework.yml
@@ -32,6 +32,7 @@ jobs:
     if: ${{ inputs.can-skip != 'true' }}
     runs-on:
       group: GZ_BD-CPU
+    timeout-minutes: 120
     env:
       TASK: paddle-CI-${{ github.event.pull_request.number }}-CE-Framework-whl
     steps:
@@ -63,6 +64,7 @@ jobs:
       - name: Download Paddle and PaddleTest
         env:
           work_dir: ${{ github.workspace }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*
@@ -104,6 +106,7 @@ jobs:
     if: ${{ inputs.can-skip != 'true' }}
     runs-on:
       group: BD_BJ-V100
+    timeout-minutes: 120
     env:
       TASK: paddle-CI-${{ github.event.pull_request.number }}-CE-Framework-infer
     steps:
@@ -138,6 +141,7 @@ jobs:
       - name: Download Paddle and PaddleTest
         env:
           work_dir: ${{ github.workspace }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*
@@ -203,6 +207,7 @@ jobs:
     if: ${{ inputs.can-skip != 'true' }}
     runs-on:
       group: BD_BJ-V100
+    timeout-minutes: 120
     env:
       TASK: paddle-CI-${{ github.event.pull_request.number }}-CE-Framework-test
     steps:
@@ -237,6 +242,7 @@ jobs:
       - name: Download Paddle and PaddleTest
         env:
           work_dir: ${{ github.workspace }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*

--- a/.github/workflows/_Clone-linux.yml
+++ b/.github/workflows/_Clone-linux.yml
@@ -9,11 +9,11 @@ on:
       clone_dir:
         type: string
         required: false
-        default: 'Paddle'
+        default: "Paddle"
       is_pr:
         type: string
         required: false
-        default: 'true'
+        default: "true"
     outputs:
       can-skip:
         value: ${{ jobs.clone.outputs.can-skip }}
@@ -41,13 +41,14 @@ jobs:
       slice-check: ${{ steps.check-execution.outputs.slice-check }}
     runs-on:
       group: HK-Clone
+    timeout-minutes: 30
 
     steps:
       - name: Clone paddle
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
-          submodules: 'recursive'
+          submodules: "recursive"
           fetch-depth: 1000
 
       - name: Merge PR to test branch

--- a/.github/workflows/_Clone-windows.yml
+++ b/.github/workflows/_Clone-windows.yml
@@ -21,6 +21,7 @@ jobs:
     name: Clone Paddle
     runs-on:
       group: win-clone
+    timeout-minutes: 30
     steps:
       - name: Git config
         run: |

--- a/.github/workflows/_Deepmd-pd-test.yml
+++ b/.github/workflows/_Deepmd-pd-test.yml
@@ -47,6 +47,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: BD_BJ-V100
+    timeout-minutes: 20
     steps:
       - name: Check docker image and run container
         env:

--- a/.github/workflows/_Distribute-stable-Formers.yml
+++ b/.github/workflows/_Distribute-stable-Formers.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ inputs.clone-can-skip != 'true' }}
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'formers'
+      workflow-name: "formers"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -43,6 +43,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: Distribute
+    timeout-minutes: 120
     steps:
       - name: Check docker image and run container
         env:
@@ -127,6 +128,7 @@ jobs:
           -e no_proxy \
           -w /workspace --network host ${formers_docker}
       - name: Download paddle.tar.gz and merge target branch
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*

--- a/.github/workflows/_Distribute-stable-Test.yml
+++ b/.github/workflows/_Distribute-stable-Test.yml
@@ -43,6 +43,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: Distribute
+    timeout-minutes: 120
     steps:
       - name: Check docker image and run container
         env:
@@ -121,6 +122,7 @@ jobs:
           -w /paddle --network host ${docker_image}
 
       - name: Download paddle.tar.gz and merge target branch
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*

--- a/.github/workflows/_Distribute-stable.yml
+++ b/.github/workflows/_Distribute-stable.yml
@@ -34,6 +34,7 @@ jobs:
       can-skip: ${{ steps.check-bypass.outputs.can-skip }}
     runs-on:
       group: GZ_BD-CPU
+    timeout-minutes: 120
 
     steps:
       - name: Check docker image and run container
@@ -119,6 +120,7 @@ jobs:
       - name: Download paddle.tar.gz and merge target branch
         env:
           work_dir: ${{ github.workspace }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           mkdir -p /root/.cache/build

--- a/.github/workflows/_Doc-Preview.yml
+++ b/.github/workflows/_Doc-Preview.yml
@@ -31,7 +31,7 @@ jobs:
     if: ${{ inputs.can-skip != 'true' }}
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'Doc-Preview'
+      workflow-name: "Doc-Preview"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -41,6 +41,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: BD_BJ-V100
+    timeout-minutes: 120
     steps:
       - name: Check docker image and run container
         env:

--- a/.github/workflows/_Inference.yml
+++ b/.github/workflows/_Inference.yml
@@ -44,6 +44,7 @@ jobs:
       TASK: paddle-CI-${{ github.event.pull_request.number }}-inference_build
     runs-on:
       group: GZ_BD-CPU
+    timeout-minutes: 120
 
     steps:
       - name: Check docker image and run container
@@ -116,6 +117,7 @@ jobs:
           -w /paddle --network host ${docker_image} /bin/bash
 
       - name: Download paddle.tar.gz and update test branch
+        timeout-minutes: 30
         run: |
           docker exec -t ${container_name} /bin/bash -c '
           rm -rf * .[^.]*
@@ -192,6 +194,7 @@ jobs:
       TASK: paddle-CI-${{ github.event.pull_request.number }}-inference_test
     runs-on:
       group: Inference-P4
+    timeout-minutes: 120
 
     steps:
       - name: Check docker image and run container
@@ -266,6 +269,7 @@ jobs:
           -w /paddle --network host ${docker_image} /bin/bash
 
       - name: Download paddle.tar.gz
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           set -e

--- a/.github/workflows/_Linux-CPU.yml
+++ b/.github/workflows/_Linux-CPU.yml
@@ -33,6 +33,7 @@ jobs:
       can-skip: ${{ steps.check-bypass.outputs.can-skip }}
     runs-on:
       group: GZ_BD-CPU
+    timeout-minutes: 120
 
     steps:
       - name: Check docker image  and run container
@@ -104,6 +105,7 @@ jobs:
       - name: Download paddle.tar.gz and merge target branch
         env:
           work_dir: ${{ github.workspace }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf  * .[^.]*

--- a/.github/workflows/_Linux-DCU.yml
+++ b/.github/workflows/_Linux-DCU.yml
@@ -34,7 +34,7 @@ jobs:
     if: ${{ inputs.clone-can-skip != 'true' }}
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'dcu'
+      workflow-name: "dcu"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -46,6 +46,7 @@ jobs:
       TASK: paddle-CI-${{ github.event.pull_request.number }}-dcu_build
     runs-on:
       group: HK-CPU
+    timeout-minutes: 120
     steps:
       - name: Check docker image and run container
         env:
@@ -122,6 +123,7 @@ jobs:
             -w /paddle --network host ${docker_image} /bin/bash
 
       - name: Download paddle.tar.gz and update test branch
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           ulimit -n 102400
@@ -197,6 +199,7 @@ jobs:
       TASK: paddle-CI-${{ github.event.pull_request.number }}-dcu_test
     runs-on:
       group: dcu-z100
+    timeout-minutes: 120
 
     steps:
       - name: Determine the runner

--- a/.github/workflows/_Linux-IXUCA.yml
+++ b/.github/workflows/_Linux-IXUCA.yml
@@ -25,7 +25,7 @@ jobs:
     if: ${{ inputs.can-skip != 'true' }}
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'ixuca'
+      workflow-name: "ixuca"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -35,6 +35,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: test2
+    timeout-minutes: 120
 
     steps:
       - name: Check approval
@@ -126,6 +127,7 @@ jobs:
 
       - name: Download paddle.tar.gz and update test branch
         if: steps.check-approval.outputs.can-skip != 'true'
+        timeout-minutes: 30
         run: |
           docker run -i --rm \
           --network host \

--- a/.github/workflows/_Linux-NPU.yml
+++ b/.github/workflows/_Linux-NPU.yml
@@ -28,7 +28,7 @@ jobs:
     if: ${{ inputs.can-skip != 'true' }}
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'npu'
+      workflow-name: "npu"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -38,9 +38,11 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: NPU
+    timeout-minutes: 120
 
     steps:
       - name: Download paddle.tar.gz and update test branch
+        timeout-minutes: 30
         run: |
           docker run -i --rm \
           -v ${{ github.workspace }}:/paddle \

--- a/.github/workflows/_Linux-XPU.yml
+++ b/.github/workflows/_Linux-XPU.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ inputs.clone-can-skip != 'true' }}
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'xpu'
+      workflow-name: "xpu"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -45,6 +45,7 @@ jobs:
       TASK: paddle-CI-${{ github.event.pull_request.number }}-xpu_build
     runs-on:
       group: XPU-build
+    timeout-minutes: 120
     steps:
       - name: Check docker image and run  container
         env:
@@ -107,6 +108,7 @@ jobs:
             -w /paddle --network host ${docker_image} /bin/bash
 
       - name: Download paddle.tar.gz and update test branch
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           ulimit -n 102400
@@ -184,6 +186,7 @@ jobs:
       TASK: paddle-CI-${{ github.event.pull_request.number }}-xpu_test
     runs-on:
       group: Kunlun
+    timeout-minutes: 120
 
     steps:
       - name: Determine the runner

--- a/.github/workflows/_Linux-build.yml
+++ b/.github/workflows/_Linux-build.yml
@@ -39,6 +39,7 @@ jobs:
       can-skip: ${{ steps.check-bypass.outputs.can-skip }}
     runs-on:
       group: GZ_BD-CPU
+    timeout-minutes: 120
 
     steps:
       - name: Check docker image and run container
@@ -127,6 +128,7 @@ jobs:
       - name: Download paddle.tar.gz
         env:
           work_dir: ${{ github.workspace }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*

--- a/.github/workflows/_Mac.yml
+++ b/.github/workflows/_Mac.yml
@@ -50,6 +50,7 @@ jobs:
     if: ${{ inputs.clone-can-skip != 'true' }}
     runs-on:
       group: Mac-CI
+    timeout-minutes: 60
 
     steps:
       - name: Check environment

--- a/.github/workflows/_Model-Benchmark.yml
+++ b/.github/workflows/_Model-Benchmark.yml
@@ -29,7 +29,7 @@ jobs:
     if: ${{ inputs.can-skip != 'true' }}
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'model-benchmark'
+      workflow-name: "model-benchmark"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -39,6 +39,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: model-benchmark
+    timeout-minutes: 120
     steps:
       - name: Check docker image and run container
         env:
@@ -87,6 +88,7 @@ jobs:
             -w /workspace --network host ${docker_image}
 
       - name: Prepare environment and download paddle
+        timeout-minutes: 30
         run: |
           docker exec ${container_name} bash -c '
           rm -rf * .[^.]*
@@ -115,6 +117,7 @@ jobs:
           '
 
       - name: Download paddlescope
+        timeout-minutes: 30
         if: ${{ env.can-skip != 'true' }}
         run: |
           docker exec ${container_name} bash -c '

--- a/.github/workflows/_SOT.yml
+++ b/.github/workflows/_SOT.yml
@@ -39,6 +39,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: GZ_BD-CPU
+    timeout-minutes: 120
 
     steps:
       - name: run container
@@ -108,6 +109,7 @@ jobs:
             -w /paddle --network host ${docker_image}
 
       - name: Download paddle.tar.gz and merge target branch
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*
@@ -162,6 +164,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         if: ${{ env.determine_excode == 0 }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           export PY_VERSION=3.9
@@ -176,6 +179,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         if: ${{ env.determine_excode == 0 }}
+        timeout-minutes: 10
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           source ${{ github.workspace }}/../../../proxy
@@ -190,6 +194,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         if: ${{ env.determine_excode == 0 }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           export PY_VERSION=3.10
@@ -204,6 +209,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         if: ${{ env.determine_excode == 0 }}
+        timeout-minutes: 10
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           source ${{ github.workspace }}/../../../proxy
@@ -218,6 +224,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         if: ${{ env.determine_excode == 0 }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           export PY_VERSION=3.11
@@ -232,6 +239,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         if: ${{ env.determine_excode == 0 }}
+        timeout-minutes: 10
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           source ${{ github.workspace }}/../../../proxy
@@ -246,6 +254,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         if: ${{ env.determine_excode == 0 }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           export PY_VERSION=3.12
@@ -260,6 +269,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         if: ${{ env.determine_excode == 0 }}
+        timeout-minutes: 10
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           source ${{ github.workspace }}/../../../proxy
@@ -274,6 +284,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         if: ${{ env.determine_excode == 0 }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           export PY_VERSION=3.13
@@ -288,6 +299,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         if: ${{ env.determine_excode == 0 }}
+        timeout-minutes: 10
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           source ${{ github.workspace }}/../../../proxy
@@ -302,6 +314,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         if: ${{ env.determine_excode == 0 }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           export PY_VERSION=3.14
@@ -317,6 +330,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         if: ${{ env.determine_excode == 0 }}
+        timeout-minutes: 10
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           source ${{ github.workspace }}/../../../proxy

--- a/.github/workflows/_Slice.yml
+++ b/.github/workflows/_Slice.yml
@@ -15,11 +15,11 @@ on:
       SLICE_TEST_MODE:
         type: string
         required: false
-        default: 'test_ci'
+        default: "test_ci"
       SLICE_BENCHMARK_FRAMEWORKS:
         type: string
         required: false
-        default: 'paddle'
+        default: "paddle"
       MANUALLY_PR_ID:
         type: string
         required: false
@@ -58,6 +58,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: slice
+    timeout-minutes: 20
     steps:
       - name: Check docker image and run container
         env:
@@ -91,6 +92,7 @@ jobs:
       - name: Download PaddleTest
         env:
           work_dir: ${{ github.workspace }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*

--- a/.github/workflows/_Static-Check.yml
+++ b/.github/workflows/_Static-Check.yml
@@ -32,6 +32,7 @@ jobs:
     if: ${{ inputs.can-skip != 'true' }}
     runs-on:
       group: BD_BJ-V100
+    timeout-minutes: 30
 
     steps:
       - name: Check docker image and run container
@@ -93,6 +94,7 @@ jobs:
       - name: Download paddle.tar.gz and merge target branch
         env:
           work_dir: ${{ github.workspace }}
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           rm -rf  * .[^.]*

--- a/.github/workflows/_Windows-GPU.yml
+++ b/.github/workflows/_Windows-GPU.yml
@@ -24,7 +24,7 @@ jobs:
     name: Check bypass
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'win-gpu'
+      workflow-name: "win-gpu"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -34,6 +34,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: win-gpu
+    timeout-minutes: 120
     env:
       PADDLE_VERSION: 0.0.0
       NIGHTLY_MODE: "OFF"
@@ -63,6 +64,7 @@ jobs:
     steps:
       - name: Download Paddle and clean env
         working-directory: ..
+        timeout-minutes: 30
         run: |
           whoami
           cd

--- a/.github/workflows/_Windows-Inference.yml
+++ b/.github/workflows/_Windows-Inference.yml
@@ -24,7 +24,7 @@ jobs:
     name: Check bypass
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'win-inference'
+      workflow-name: "win-inference"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -34,6 +34,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: win-infer
+    timeout-minutes: 120
     env:
       PADDLE_VERSION: 0.0.0
       NIGHTLY_MODE: "OFF"
@@ -64,6 +65,7 @@ jobs:
     steps:
       - name: Download Paddle and clean env
         working-directory: ..
+        timeout-minutes: 30
         run: |
           whoami
           cd

--- a/.github/workflows/_Windows-OPENBLAS.yml
+++ b/.github/workflows/_Windows-OPENBLAS.yml
@@ -25,7 +25,7 @@ jobs:
     name: Check bypass
     uses: ./.github/workflows/check-bypass.yml
     with:
-      workflow-name: 'win-openblas'
+      workflow-name: "win-openblas"
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -35,6 +35,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: win-openblas
+    timeout-minutes: 120
     env:
       PADDLE_VERSION: 0.0.0
       NIGHTLY_MODE: "OFF"
@@ -61,6 +62,7 @@ jobs:
     steps:
       - name: Download Paddle and clean env
         working-directory: ..
+        timeout-minutes: 30
         run: |
           whoami
           cd

--- a/.github/workflows/check-bypass.yml
+++ b/.github/workflows/check-bypass.yml
@@ -22,6 +22,7 @@ jobs:
       CI_TEAM_MEMBERS: '["swgu98", "risemeup1" , "XieYunshen", "luotao1", "ooooo-create"]'
     outputs:
       can-skip: ${{ steps.check-bypass.outputs.can-skip }}
+    timeout-minutes: 3
     steps:
       - id: check-bypass
         name: Check Bypass

--- a/.github/workflows/cleanup-ccache.yml
+++ b/.github/workflows/cleanup-ccache.yml
@@ -55,7 +55,7 @@ jobs:
             -e no_proxy \
             -w /paddle --network host ${docker_image}
 
-      - name: Cleanup L2 ccache inside container
+      - name: Cleanup L2 ccache in CFS
         run: |
           docker exec -t ${container_name} bash -c '
             CFS_CCACHE_DIR="${CCACHE_SECONDARY_STORAGE#file://}"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

添加 CI 超时时间，避免偶发问题占用大量 CI 机器时间，阻塞其它 PR 推进

- 所有流水线 job 都添加 timeout，一般最大 120min，部分较快流水线设置较小阈值，coverage test 设置 240min
- 所有下载 tar 包的 step 都添加 timeout，最大 30min
- SOT 流水线所有 step 都添加 timeout

<!-- PCard-66972 -->

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否