### PR TITLE
[API compatibility] FractionalMaxPool return_mask dtyp set to int64 -part

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2035,7 +2035,7 @@ void FractionalMaxPoolInferMeta(const MetaTensor& x,
   out->set_dtype(x.dtype());
 
   mask->set_dims(make_ddim(output_shape));
-  mask->set_dtype(phi::CppTypeToDataType<int>::Type());
+  mask->set_dtype(phi::CppTypeToDataType<int64_t>::Type());
 }
 
 void FrameInferMeta(const MetaTensor& x,

--- a/paddle/phi/kernels/cpu/pool_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/pool_grad_kernel.cc
@@ -64,7 +64,7 @@ PD_REGISTER_KERNEL(fractional_max_pool2d_grad,
                    float,
                    double,
                    phi::float16) {
-  kernel->InputAt(1).SetDataType(phi::CppTypeToDataType<int>::Type());
+  kernel->InputAt(1).SetDataType(phi::CppTypeToDataType<int64_t>::Type());
 }
 
 PD_REGISTER_KERNEL(fractional_max_pool3d_grad,
@@ -74,5 +74,5 @@ PD_REGISTER_KERNEL(fractional_max_pool3d_grad,
                    float,
                    double,
                    phi::float16) {
-  kernel->InputAt(1).SetDataType(phi::CppTypeToDataType<int>::Type());
+  kernel->InputAt(1).SetDataType(phi::CppTypeToDataType<int64_t>::Type());
 }

--- a/paddle/phi/kernels/cpu/pool_kernel.cc
+++ b/paddle/phi/kernels/cpu/pool_kernel.cc
@@ -48,7 +48,7 @@ PD_REGISTER_KERNEL(fractional_max_pool2d,
                    float,
                    double,
                    phi::float16) {
-  kernel->OutputAt(1).SetDataType(phi::CppTypeToDataType<int>::Type());
+  kernel->OutputAt(1).SetDataType(phi::CppTypeToDataType<int64_t>::Type());
 }
 
 PD_REGISTER_KERNEL(fractional_max_pool3d,
@@ -58,5 +58,5 @@ PD_REGISTER_KERNEL(fractional_max_pool3d,
                    float,
                    double,
                    phi::float16) {
-  kernel->OutputAt(1).SetDataType(phi::CppTypeToDataType<int>::Type());
+  kernel->OutputAt(1).SetDataType(phi::CppTypeToDataType<int64_t>::Type());
 }

--- a/paddle/phi/kernels/funcs/pooling.cc
+++ b/paddle/phi/kernels/funcs/pooling.cc
@@ -1554,7 +1554,9 @@ template class FractionalMaxPool2dGradFunctor<CPUContext, float, int64_t>;
 template class FractionalMaxPool2dFunctor<CPUContext, double, int64_t>;
 template class FractionalMaxPool2dGradFunctor<CPUContext, double, int64_t>;
 template class FractionalMaxPool2dFunctor<CPUContext, dtype::float16, int64_t>;
-template class FractionalMaxPool2dGradFunctor<CPUContext, dtype::float16, int64_t>;
+template class FractionalMaxPool2dGradFunctor<CPUContext,
+                                              dtype::float16,
+                                              int64_t>;
 
 /*
  * All tensors are in NCDHW format.
@@ -1746,6 +1748,8 @@ template class FractionalMaxPool3dGradFunctor<CPUContext, float, int64_t>;
 template class FractionalMaxPool3dFunctor<CPUContext, double, int64_t>;
 template class FractionalMaxPool3dGradFunctor<CPUContext, double, int64_t>;
 template class FractionalMaxPool3dFunctor<CPUContext, dtype::float16, int64_t>;
-template class FractionalMaxPool3dGradFunctor<CPUContext, dtype::float16, int64_t>;
+template class FractionalMaxPool3dGradFunctor<CPUContext,
+                                              dtype::float16,
+                                              int64_t>;
 
 }  // namespace phi::funcs

--- a/paddle/phi/kernels/funcs/pooling.cc
+++ b/paddle/phi/kernels/funcs/pooling.cc
@@ -1549,12 +1549,12 @@ class FractionalMaxPool2dGradFunctor<CPUContext, T1, T2> {
   }
 };
 
-template class FractionalMaxPool2dFunctor<CPUContext, float, int>;
-template class FractionalMaxPool2dGradFunctor<CPUContext, float, int>;
-template class FractionalMaxPool2dFunctor<CPUContext, double, int>;
-template class FractionalMaxPool2dGradFunctor<CPUContext, double, int>;
-template class FractionalMaxPool2dFunctor<CPUContext, dtype::float16, int>;
-template class FractionalMaxPool2dGradFunctor<CPUContext, dtype::float16, int>;
+template class FractionalMaxPool2dFunctor<CPUContext, float, int64_t>;
+template class FractionalMaxPool2dGradFunctor<CPUContext, float, int64_t>;
+template class FractionalMaxPool2dFunctor<CPUContext, double, int64_t>;
+template class FractionalMaxPool2dGradFunctor<CPUContext, double, int64_t>;
+template class FractionalMaxPool2dFunctor<CPUContext, dtype::float16, int64_t>;
+template class FractionalMaxPool2dGradFunctor<CPUContext, dtype::float16, int64_t>;
 
 /*
  * All tensors are in NCDHW format.
@@ -1741,11 +1741,11 @@ class FractionalMaxPool3dGradFunctor<CPUContext, T1, T2> {
   }
 };
 
-template class FractionalMaxPool3dFunctor<CPUContext, float, int>;
-template class FractionalMaxPool3dGradFunctor<CPUContext, float, int>;
-template class FractionalMaxPool3dFunctor<CPUContext, double, int>;
-template class FractionalMaxPool3dGradFunctor<CPUContext, double, int>;
-template class FractionalMaxPool3dFunctor<CPUContext, dtype::float16, int>;
-template class FractionalMaxPool3dGradFunctor<CPUContext, dtype::float16, int>;
+template class FractionalMaxPool3dFunctor<CPUContext, float, int64_t>;
+template class FractionalMaxPool3dGradFunctor<CPUContext, float, int64_t>;
+template class FractionalMaxPool3dFunctor<CPUContext, double, int64_t>;
+template class FractionalMaxPool3dGradFunctor<CPUContext, double, int64_t>;
+template class FractionalMaxPool3dFunctor<CPUContext, dtype::float16, int64_t>;
+template class FractionalMaxPool3dGradFunctor<CPUContext, dtype::float16, int64_t>;
 
 }  // namespace phi::funcs

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -3136,20 +3136,22 @@ class FractionalMaxPool2dGradFunctor<phi::GPUContext, T1, T2> {
   }
 };
 
-template class FractionalMaxPool2dFunctor<phi::GPUContext, float, int>;
-template class FractionalMaxPool2dGradFunctor<phi::GPUContext, float, int>;
-template class FractionalMaxPool2dFunctor<phi::GPUContext, double, int>;
-template class FractionalMaxPool2dGradFunctor<phi::GPUContext, double, int>;
-template class FractionalMaxPool2dFunctor<phi::GPUContext, dtype::float16, int>;
+template class FractionalMaxPool2dFunctor<phi::GPUContext, float, int64_t>;
+template class FractionalMaxPool2dGradFunctor<phi::GPUContext, float, int64_t>;
+template class FractionalMaxPool2dFunctor<phi::GPUContext, double, int64_t>;
+template class FractionalMaxPool2dGradFunctor<phi::GPUContext, double, int64_t>;
+template class FractionalMaxPool2dFunctor<phi::GPUContext,
+                                          dtype::float16,
+                                          int64_t>;
 template class FractionalMaxPool2dGradFunctor<phi::GPUContext,
                                               dtype::float16,
-                                              int>;
+                                              int64_t>;
 template class FractionalMaxPool2dFunctor<phi::GPUContext,
                                           dtype::bfloat16,
-                                          int>;
+                                          int64_t>;
 template class FractionalMaxPool2dGradFunctor<phi::GPUContext,
                                               dtype::bfloat16,
-                                              int>;
+                                              int64_t>;
 
 template <typename T1, typename T2, typename IndexT>
 __global__ void FractionalKernelMaxPool3d(
@@ -3534,20 +3536,22 @@ class FractionalMaxPool3dGradFunctor<phi::GPUContext, T1, T2> {
   }
 };
 
-template class FractionalMaxPool3dFunctor<phi::GPUContext, float, int>;
-template class FractionalMaxPool3dGradFunctor<phi::GPUContext, float, int>;
-template class FractionalMaxPool3dFunctor<phi::GPUContext, double, int>;
-template class FractionalMaxPool3dGradFunctor<phi::GPUContext, double, int>;
-template class FractionalMaxPool3dFunctor<phi::GPUContext, dtype::float16, int>;
+template class FractionalMaxPool3dFunctor<phi::GPUContext, float, int64_t>;
+template class FractionalMaxPool3dGradFunctor<phi::GPUContext, float, int64_t>;
+template class FractionalMaxPool3dFunctor<phi::GPUContext, double, int64_t>;
+template class FractionalMaxPool3dGradFunctor<phi::GPUContext, double, int64_t>;
+template class FractionalMaxPool3dFunctor<phi::GPUContext,
+                                          dtype::float16,
+                                          int64_t>;
 template class FractionalMaxPool3dGradFunctor<phi::GPUContext,
                                               dtype::float16,
-                                              int>;
+                                              int64_t>;
 template class FractionalMaxPool3dFunctor<phi::GPUContext,
                                           dtype::bfloat16,
-                                          int>;
+                                          int64_t>;
 template class FractionalMaxPool3dGradFunctor<phi::GPUContext,
                                               dtype::bfloat16,
-                                              int>;
+                                              int64_t>;
 
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/pool_grad_kernel.cu
@@ -77,7 +77,7 @@ PD_REGISTER_KERNEL(fractional_max_pool2d_grad,
                    double,
                    phi::float16,
                    phi::bfloat16) {
-  kernel->InputAt(1).SetDataType(phi::CppTypeToDataType<int>::Type());
+  kernel->InputAt(1).SetDataType(phi::CppTypeToDataType<int64_t>::Type());
 }
 
 PD_REGISTER_KERNEL(fractional_max_pool3d_grad,
@@ -88,5 +88,5 @@ PD_REGISTER_KERNEL(fractional_max_pool3d_grad,
                    double,
                    phi::float16,
                    phi::bfloat16) {
-  kernel->InputAt(1).SetDataType(phi::CppTypeToDataType<int>::Type());
+  kernel->InputAt(1).SetDataType(phi::CppTypeToDataType<int64_t>::Type());
 }

--- a/paddle/phi/kernels/gpu/pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/pool_kernel.cu
@@ -71,7 +71,7 @@ PD_REGISTER_KERNEL(fractional_max_pool2d,
                    double,
                    phi::float16,
                    phi::bfloat16) {
-  kernel->OutputAt(1).SetDataType(phi::CppTypeToDataType<int>::Type());
+  kernel->OutputAt(1).SetDataType(phi::CppTypeToDataType<int64_t>::Type());
 }
 
 PD_REGISTER_KERNEL(fractional_max_pool3d,
@@ -82,5 +82,5 @@ PD_REGISTER_KERNEL(fractional_max_pool3d,
                    double,
                    phi::float16,
                    phi::bfloat16) {
-  kernel->OutputAt(1).SetDataType(phi::CppTypeToDataType<int>::Type());
+  kernel->OutputAt(1).SetDataType(phi::CppTypeToDataType<int64_t>::Type());
 }

--- a/paddle/phi/kernels/impl/pool_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pool_grad_kernel_impl.h
@@ -412,7 +412,7 @@ void MaxPool3dWithIndexGradKernel(const Context& dev_ctx,
                                             dx);
 }
 
-template <typename Context, typename T1, typename T2 = int>
+template <typename Context, typename T1, typename T2 = int64_t>
 void FractionalMaxPoolGradRawKernel(const Context& dev_ctx,
                                     const DenseTensor& x UNUSED,
                                     const DenseTensor& mask,

--- a/paddle/phi/kernels/impl/pool_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pool_kernel_impl.h
@@ -427,7 +427,7 @@ void MaxPool3dWithIndexKernel(const Context& dev_ctx,
                                         mask);
 }
 
-template <typename Context, typename T1, typename T2 = int>
+template <typename Context, typename T1, typename T2 = int64_t>
 void FractionalMaxPoolRawKernel(const Context& dev_ctx,
                                 const DenseTensor& x,
                                 const std::vector<int>& output_size,

--- a/test/legacy_test/test_fractional_max_pool2d_op.py
+++ b/test/legacy_test/test_fractional_max_pool2d_op.py
@@ -149,7 +149,7 @@ class TestMaxPoolWithIndex_Op(OpTest):
             self.random_u,
             self.return_mask,
         )
-        mask = mask.astype("int32")
+        mask = mask.astype("int64")
         if self.is_bfloat16_op():
             output = output.astype(np.float32)
         else:

--- a/test/legacy_test/test_fractional_max_pool3d_op.py
+++ b/test/legacy_test/test_fractional_max_pool3d_op.py
@@ -166,7 +166,7 @@ class TestMaxPoolWithIndex_Op(OpTest):
             self.random_u,
             self.return_mask,
         )
-        mask = mask.astype("int32")
+        mask = mask.astype("int64")
         if self.is_bfloat16_op():
             output = output.astype(np.float32)
         else:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->

当 FractionalMaxPool*D 参数 **return_mask=True** 时，第二个返回值 **mask** 的 Tensor **dtype 从 INT32 改为 INT64** 与pytorch对齐

涉及 API：
paddle.nn.functional.fractional_max_pool2d(x, output_size, kernel_size=None, random_u=None, **return_mask=False**, name=None)
paddle.nn.functional.fractional_max_pool3d(x, output_size, kernel_size=None, random_u=None, **return_mask=False**, name=None)
paddle.nn.FractionalMaxPool2D(output_size, kernel_size=None, random_u=None, **return_mask=False**, name=None)
paddle.nn.FractionalMaxPool2D(output_size, kernel_size=None, random_u=None, **return_mask=False**, name=None)

例子：
```python
>>> import paddle
>>> x = paddle.rand([2, 3, 32, 32])

>>> fractional_max_pool = paddle.nn.FractionalMaxPool2D(output_size=[2, 3], return_mask=True)
>>> pool_out, indices = fractional_max_pool(x=x)
>>> print(indices.dtype)
paddle.int64 # 原为paddle.int32
```

 **XPU 暂时不修改**  （需要修改xpu sdk kernel）

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否