### PR TITLE
[API Compatibility] [Code Generation] Support custom args_alias, pre_process and args_mapper for inplace apis

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
@@ -521,6 +521,7 @@ class FunctionGeneratorBase:
 
         self.forward_api_name = ""
         self.python_api_info = {}
+        self.inplace_python_api_info = {}
 
         self.orig_forward_inputs_list = []  # [ [arg_name, arg_type, orig_position], ...]
         self.orig_forward_attrs_list = []  # [ [attr_name, attr_type, default_value, orig_position], ...]
@@ -537,11 +538,18 @@ class FunctionGeneratorBase:
         self.intermediate_outputs = []  # [name, ...]
         self.forward_inplace_map = {}  # {name : name, ...}
         self.args_alias_map = {}  # {arg_name: alias_vector, ...}
+        self.inplace_args_alias_map = {}  # {arg_name: alias_vector, ...}
         self.dygraph_pre_process = (
+            ""  # The pre_process function calling code for dygraph
+        )
+        self.inplace_dygraph_pre_process = (
             ""  # The pre_process function calling code for dygraph
         )
 
         self.args_mapper_func_name = None  # The custom args parser function
+        self.inplace_args_mapper_func_name = (
+            None  # The custom args parser function
+        )
         self.python_api_names = ""
 
     def ParseForwardInplaceInfo(self):
@@ -553,8 +561,11 @@ class FunctionGeneratorBase:
         self.forward_inplace_map = ParseYamlInplaceInfo(inplace_map_str)
 
     # Function for parameters parse
-    def ParsePythonAPIInfo(self):
-        python_api_info = self.python_api_info
+    def ParsePythonAPIInfo(self, inplace=False):
+        if inplace:
+            python_api_info = self.inplace_python_api_info
+        else:
+            python_api_info = self.python_api_info
         args_alias = {}
         if 'name' in python_api_info.keys():
             self.python_api_names = python_api_info['name']
@@ -571,22 +582,41 @@ class FunctionGeneratorBase:
                     "{" + ",".join(f'"{name}"' for name in alias_set) + "}"
                 )
                 args_alias.update({arg: alias_vector})
-            self.args_alias_map = args_alias
+            if inplace:
+                self.inplace_args_alias_map = args_alias
+            else:
+                self.args_alias_map = args_alias
         if 'pre_process' in python_api_info.keys():
             pre_process = python_api_info['pre_process']
             if pre_process is not None:
-                if 'dygraph_func' in pre_process.keys():
-                    self.dygraph_pre_process = pre_process['dygraph_func']
-                elif 'func' in pre_process.keys():
-                    self.dygraph_pre_process = pre_process['func']
+                if inplace:
+                    if 'dygraph_func' in pre_process.keys():
+                        self.inplace_dygraph_pre_process = pre_process[
+                            'dygraph_func'
+                        ]
+                    elif 'func' in pre_process.keys():
+                        self.inplace_dygraph_pre_process = pre_process['func']
+                else:
+                    if 'dygraph_func' in pre_process.keys():
+                        self.dygraph_pre_process = pre_process['dygraph_func']
+                    elif 'func' in pre_process.keys():
+                        self.dygraph_pre_process = pre_process['func']
 
         if 'args_mapper' in python_api_info.keys():
             args_mapper = python_api_info['args_mapper']
             if args_mapper is not None:
-                if 'dygraph_func' in args_mapper.keys():
-                    self.args_mapper_func_name = args_mapper['dygraph_func']
-                elif 'func' in args_mapper.keys():
-                    self.args_mapper_func_name = args_mapper['func']
+                if inplace:
+                    if 'dygraph_func' in args_mapper.keys():
+                        self.inplace_args_mapper_func_name = args_mapper[
+                            'dygraph_func'
+                        ]
+                    elif 'func' in args_mapper.keys():
+                        self.inplace_args_mapper_func_name = args_mapper['func']
+                else:
+                    if 'dygraph_func' in args_mapper.keys():
+                        self.args_mapper_func_name = args_mapper['dygraph_func']
+                    elif 'func' in args_mapper.keys():
+                        self.args_mapper_func_name = args_mapper['func']
 
     def ParseNoNeedBuffer(self):
         grad_api_contents = self.grad_api_contents

--- a/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
@@ -521,7 +521,6 @@ class FunctionGeneratorBase:
 
         self.forward_api_name = ""
         self.python_api_info = {}
-        self.inplace_python_api_info = {}
 
         self.orig_forward_inputs_list = []  # [ [arg_name, arg_type, orig_position], ...]
         self.orig_forward_attrs_list = []  # [ [attr_name, attr_type, default_value, orig_position], ...]
@@ -538,18 +537,11 @@ class FunctionGeneratorBase:
         self.intermediate_outputs = []  # [name, ...]
         self.forward_inplace_map = {}  # {name : name, ...}
         self.args_alias_map = {}  # {arg_name: alias_vector, ...}
-        self.inplace_args_alias_map = {}  # {arg_name: alias_vector, ...}
         self.dygraph_pre_process = (
-            ""  # The pre_process function calling code for dygraph
-        )
-        self.inplace_dygraph_pre_process = (
             ""  # The pre_process function calling code for dygraph
         )
 
         self.args_mapper_func_name = None  # The custom args parser function
-        self.inplace_args_mapper_func_name = (
-            None  # The custom args parser function
-        )
         self.python_api_names = ""
 
     def ParseForwardInplaceInfo(self):
@@ -561,11 +553,8 @@ class FunctionGeneratorBase:
         self.forward_inplace_map = ParseYamlInplaceInfo(inplace_map_str)
 
     # Function for parameters parse
-    def ParsePythonAPIInfo(self, inplace=False):
-        if inplace:
-            python_api_info = self.inplace_python_api_info
-        else:
-            python_api_info = self.python_api_info
+    def ParsePythonAPIInfo(self):
+        python_api_info = self.python_api_info
         args_alias = {}
         if 'name' in python_api_info.keys():
             self.python_api_names = python_api_info['name']
@@ -582,41 +571,22 @@ class FunctionGeneratorBase:
                     "{" + ",".join(f'"{name}"' for name in alias_set) + "}"
                 )
                 args_alias.update({arg: alias_vector})
-            if inplace:
-                self.inplace_args_alias_map = args_alias
-            else:
-                self.args_alias_map = args_alias
+            self.args_alias_map = args_alias
         if 'pre_process' in python_api_info.keys():
             pre_process = python_api_info['pre_process']
             if pre_process is not None:
-                if inplace:
-                    if 'dygraph_func' in pre_process.keys():
-                        self.inplace_dygraph_pre_process = pre_process[
-                            'dygraph_func'
-                        ]
-                    elif 'func' in pre_process.keys():
-                        self.inplace_dygraph_pre_process = pre_process['func']
-                else:
-                    if 'dygraph_func' in pre_process.keys():
-                        self.dygraph_pre_process = pre_process['dygraph_func']
-                    elif 'func' in pre_process.keys():
-                        self.dygraph_pre_process = pre_process['func']
+                if 'dygraph_func' in pre_process.keys():
+                    self.dygraph_pre_process = pre_process['dygraph_func']
+                elif 'func' in pre_process.keys():
+                    self.dygraph_pre_process = pre_process['func']
 
         if 'args_mapper' in python_api_info.keys():
             args_mapper = python_api_info['args_mapper']
             if args_mapper is not None:
-                if inplace:
-                    if 'dygraph_func' in args_mapper.keys():
-                        self.inplace_args_mapper_func_name = args_mapper[
-                            'dygraph_func'
-                        ]
-                    elif 'func' in args_mapper.keys():
-                        self.inplace_args_mapper_func_name = args_mapper['func']
-                else:
-                    if 'dygraph_func' in args_mapper.keys():
-                        self.args_mapper_func_name = args_mapper['dygraph_func']
-                    elif 'func' in args_mapper.keys():
-                        self.args_mapper_func_name = args_mapper['func']
+                if 'dygraph_func' in args_mapper.keys():
+                    self.args_mapper_func_name = args_mapper['dygraph_func']
+                elif 'func' in args_mapper.keys():
+                    self.args_mapper_func_name = args_mapper['func']
 
     def ParseNoNeedBuffer(self):
         grad_api_contents = self.grad_api_contents

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -377,8 +377,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         FunctionGeneratorBase.__init__(self, forward_api_contents, namespace)
 
         self.is_forward_only = True
-        self.need_parse_python_api_args = False
-        self.need_parse_inplace_python_api_args = False
 
         # Generated Results
         self.python_c_function_str = ""
@@ -392,8 +390,12 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         )
 
     def GeneratePythonCFunction(
-        self, inplace=False, no_predefined_out_tensor=False
+        self,
+        inplace=False,
+        no_predefined_out_tensor=False,
+        no_parse_python_api_info=False,
     ):
+        global python_api_info_from_yaml
         namespace = self.namespace
         forward_inplace_map = self.forward_inplace_map
         forward_api_name = self.forward_api_name
@@ -404,15 +406,44 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         is_forward_only = self.is_forward_only
 
         if inplace:
-            need_parse_python_api_args = self.need_parse_inplace_python_api_args
-            args_alias_map = self.inplace_args_alias_map
-            dygraph_pre_process = self.inplace_dygraph_pre_process
-            args_mapper_func = self.inplace_args_mapper_func_name
-        else:
-            need_parse_python_api_args = self.need_parse_python_api_args
-            args_alias_map = self.args_alias_map
-            dygraph_pre_process = self.dygraph_pre_process
-            args_mapper_func = self.args_mapper_func_name
+            inplaced_forward_api_name = GetInplacedFunctionName(
+                self.forward_api_name
+            )
+            inplaced_fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
+                "::",
+                namespace,
+                GetForwardFunctionName(inplaced_forward_api_name),
+            )
+
+        # Parse python_api_info
+        need_parse_python_api_args = False
+        if not no_parse_python_api_info:
+            python_api_info = {}
+            if not inplace:
+                if forward_api_name in python_api_info_from_yaml.keys():
+                    python_api_info = python_api_info_from_yaml[
+                        forward_api_name
+                    ]
+                if len(python_api_info) > 0:
+                    self.python_api_info = python_api_info
+                    need_parse_python_api_args = True
+                    self.ParsePythonAPIInfo()
+            else:
+                if (
+                    inplaced_forward_api_name
+                    in python_api_info_from_yaml.keys()
+                ):
+                    python_api_info = python_api_info_from_yaml[
+                        inplaced_forward_api_name
+                    ]
+                if len(python_api_info) > 0:
+                    self.python_api_info = python_api_info
+                    need_parse_python_api_args = True
+                    self.ParsePythonAPIInfo()
+
+        args_alias_map = self.args_alias_map
+        dygraph_pre_process = self.dygraph_pre_process
+        args_mapper_func = self.args_mapper_func_name
 
         max_args = len(orig_forward_attrs_list) + len(
             forward_inputs_position_map
@@ -446,16 +477,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                         "{" + ",".join(f'"{name}"' for name in alias_set) + "}"
                     )
             return keywords
-
-        if inplace:
-            inplaced_forward_api_name = GetInplacedFunctionName(
-                self.forward_api_name
-            )
-            inplaced_fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
-                "::",
-                namespace,
-                GetForwardFunctionName(inplaced_forward_api_name),
-            )
 
         for name, (ttype, pos) in forward_inputs_position_map.items():
             input_names = input_names + ", " + name
@@ -903,25 +924,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                 # Generate Python-C Function Registration
                 self.python_c_function_reg_str += python_c_inplace_func_reg_str
 
-    def InitAndParsePythonAPIInfo(self):
-        global python_api_info_from_yaml
-        if self.forward_api_name in python_api_info_from_yaml.keys():
-            self.python_api_info = python_api_info_from_yaml[
-                self.forward_api_name
-            ]
-        if len(self.python_api_info) > 0:
-            self.need_parse_python_api_args = True
-            self.ParsePythonAPIInfo()
-        if self.forward_inplace_map:
-            inplace_api_name = GetInplacedFunctionName(self.forward_api_name)
-            if inplace_api_name in python_api_info_from_yaml.keys():
-                self.inplace_python_api_info = python_api_info_from_yaml[
-                    inplace_api_name
-                ]
-            if len(self.inplace_python_api_info) > 0:
-                self.need_parse_inplace_python_api_args = True
-                self.ParsePythonAPIInfo(True)
-
     def run(
         self, no_predefined_out_tensor=False, no_parse_python_api_info=False
     ):
@@ -936,8 +938,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
 
         # Initialized orig_forward_inputs_list, orig_forward_returns_list, orig_forward_attrs_list
         self.CollectOriginalForwardInfo()
-        if not no_parse_python_api_info:
-            self.InitAndParsePythonAPIInfo()
         if SkipAPIGeneration(self.forward_api_name):
             return False
 
@@ -947,9 +947,13 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         )
 
         # Code Generation
-        self.GeneratePythonCFunction(False, no_predefined_out_tensor)
+        self.GeneratePythonCFunction(
+            False, no_predefined_out_tensor, no_parse_python_api_info
+        )
         if self.forward_inplace_map:
-            self.GeneratePythonCFunction(True, no_predefined_out_tensor)
+            self.GeneratePythonCFunction(
+                True, no_predefined_out_tensor, no_parse_python_api_info
+            )
 
         return True
 

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -378,6 +378,7 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
 
         self.is_forward_only = True
         self.need_parse_python_api_args = False
+        self.need_parse_inplace_python_api_args = False
 
         # Generated Results
         self.python_c_function_str = ""
@@ -390,7 +391,9 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             False if 'backward' in forward_api_contents.keys() else True
         )
 
-    def GeneratePythonCFunction(self, no_predefined_out_tensor=False):
+    def GeneratePythonCFunction(
+        self, inplace=False, no_predefined_out_tensor=False
+    ):
         namespace = self.namespace
         forward_inplace_map = self.forward_inplace_map
         forward_api_name = self.forward_api_name
@@ -400,13 +403,20 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         optional_inputs = self.optional_inputs
         is_forward_only = self.is_forward_only
 
-        need_parse_python_api_args = self.need_parse_python_api_args
-        args_alias_map = self.args_alias_map
+        if inplace:
+            need_parse_python_api_args = self.need_parse_inplace_python_api_args
+            args_alias_map = self.inplace_args_alias_map
+            dygraph_pre_process = self.inplace_dygraph_pre_process
+            args_mapper_func = self.inplace_args_mapper_func_name
+        else:
+            need_parse_python_api_args = self.need_parse_python_api_args
+            args_alias_map = self.args_alias_map
+            dygraph_pre_process = self.dygraph_pre_process
+            args_mapper_func = self.args_mapper_func_name
+
         max_args = len(orig_forward_attrs_list) + len(
             forward_inputs_position_map
         )
-        dygraph_pre_process = self.dygraph_pre_process
-        args_mapper_func = self.args_mapper_func_name
         inplace_args_pos_map = {}
         inplace_returns_pos_map = {}
         get_params_nums_and_check_str = "   // NO NEED"
@@ -436,6 +446,16 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                         "{" + ",".join(f'"{name}"' for name in alias_set) + "}"
                     )
             return keywords
+
+        if inplace:
+            inplaced_forward_api_name = GetInplacedFunctionName(
+                self.forward_api_name
+            )
+            inplaced_fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
+                "::",
+                namespace,
+                GetForwardFunctionName(inplaced_forward_api_name),
+            )
 
         for name, (ttype, pos) in forward_inputs_position_map.items():
             input_names = input_names + ", " + name
@@ -589,9 +609,14 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                 )
         check_remaining_params_validity_str = "    // NO NEED"
         if need_parse_python_api_args:
-            check_remaining_params_validity_str = (
-                CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("false")
-            )
+            if not inplace:
+                check_remaining_params_validity_str = (
+                    CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("false")
+                )
+            else:
+                check_remaining_params_validity_str = (
+                    CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("true")
+                )
         pre_process_str = "    // NO NEED"
         if need_parse_python_api_args and len(dygraph_pre_process) > 0:
 
@@ -715,100 +740,34 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             dygraph_function_call_list[pos] = f"{name}"
         dygraph_function_call_str = ",".join(dygraph_function_call_list)
 
-        get_predefined_out_str = ""
-        if not no_predefined_out_tensor and forward_api_name != "empty_like":
-            forward_outputs_position_list = list(
-                self.forward_outputs_position_map.values()
-            )
-            if IsUsePredefinedOut(forward_outputs_position_list):
-                length = len(forward_outputs_position_list)
-                if length == 1:
-                    get_predefined_out_str = "    auto predefined_out = GetInputOutTensorFromKwargs(kwargs);"
-                else:
-                    get_predefined_out_str = f"    auto predefined_out = GetPredefinedOutTupleTensorFromKwargs_{length}(kwargs);"
-
-                dygraph_function_call_str = (
-                    dygraph_function_call_str + ", predefined_out"
+        if not inplace:
+            get_predefined_out_str = ""
+            if (
+                not no_predefined_out_tensor
+                and forward_api_name != "empty_like"
+            ):
+                forward_outputs_position_list = list(
+                    self.forward_outputs_position_map.values()
                 )
+                if IsUsePredefinedOut(forward_outputs_position_list):
+                    length = len(forward_outputs_position_list)
+                    if length == 1:
+                        get_predefined_out_str = "    auto predefined_out = GetInputOutTensorFromKwargs(kwargs);"
+                    else:
+                        get_predefined_out_str = f"    auto predefined_out = GetPredefinedOutTupleTensorFromKwargs_{length}(kwargs);"
+
+                    dygraph_function_call_str = (
+                        dygraph_function_call_str + ", predefined_out"
+                    )
 
         # Generate Python-C Function Definitions
         fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
             "::", namespace, GetForwardFunctionName(forward_api_name)
         )
 
-        return_str = "    return ToPyObject(ad_func_out);"
-
-        # Generate Record Event for performance profiling
-        pythonc_record_event_str = RECORD_EVENT_TEMPLATE.format(
-            "pythonc_record_event", forward_api_name, "pybind_imperative_func"
-        )
-
-        noamp_dygraph_function_str = NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
-            fwd_function_name,
-            dygraph_function_call_str,
-            fwd_function_name,
-            dygraph_function_call_str,
-        )
-
-        # Generate Python-C Function Definition
-        self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
-            forward_api_name,
-            pythonc_record_event_str,
-            forward_api_name,
-            get_params_nums_and_check_str,
-            get_eager_tensor_str,
-            parse_attributes_str,
-            check_remaining_params_validity_str,
-            args_mapper_str,
-            convert_to_dist_str,
-            pre_process_str,
-            get_predefined_out_str,
-            set_device_str,
-            noamp_dygraph_function_str,
-            return_str,
-        )
-        self.python_c_function_declare_str = (
-            PYTHON_C_FUNCTION_DECLARE_TEMPLATE.format(name=forward_api_name)
-        )
-
-        # Set prefix of forward_api_name to avoid conflicts
-        prefix = self.namespace.removeprefix("::").removesuffix("::")
-        forward_api_name_prefix = "" if prefix == "" else prefix + "_"
-
-        # Generate Python-C Function Registration
-        self.python_c_function_reg_str = PYTHON_C_FUNCTION_REG_TEMPLATE.format(
-            forward_api_name_prefix,
-            forward_api_name,
-            namespace,
-            forward_api_name,
-            forward_api_name,
-        )
-
-        if forward_inplace_map:
-            inplaced_forward_api_name = GetInplacedFunctionName(
-                self.forward_api_name
-            )
-            inplaced_fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
-                "::",
-                namespace,
-                GetForwardFunctionName(inplaced_forward_api_name),
-            )
-            dygraph_function_call_str = ",".join(dygraph_function_call_list)
-
-            inplace_noamp_dygraph_function_str = (
-                NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
-                    inplaced_fwd_function_name,
-                    dygraph_function_call_str,
-                    inplaced_fwd_function_name,
-                    dygraph_function_call_str,
-                )
-            )
-
-            if need_parse_python_api_args and args_mapper_func is None:
-                check_remaining_params_validity_str = (
-                    CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("true")
-                )
-
+        if not inplace:
+            return_str = "    return ToPyObject(ad_func_out);"
+        else:
             # map of output position and input position
             return_str = "    std::map<ssize_t, ssize_t> inplace_var_idx_map;"
             for inplace_input, inplace_output in forward_inplace_map.items():
@@ -838,6 +797,64 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                     )
             return_str += "    return ToPyObject(ad_func_out, args, kwargs, inplace_var_idx_map, inplace_var_name_map);"
 
+        # Generate Record Event for performance profiling
+        pythonc_record_event_str = RECORD_EVENT_TEMPLATE.format(
+            "pythonc_record_event", forward_api_name, "pybind_imperative_func"
+        )
+
+        if not inplace:
+            noamp_dygraph_function_str = NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
+                fwd_function_name,
+                dygraph_function_call_str,
+                fwd_function_name,
+                dygraph_function_call_str,
+            )
+        else:
+            inplace_noamp_dygraph_function_str = (
+                NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
+                    inplaced_fwd_function_name,
+                    dygraph_function_call_str,
+                    inplaced_fwd_function_name,
+                    dygraph_function_call_str,
+                )
+            )
+
+        # Set prefix of forward_api_name to avoid conflicts
+        prefix = self.namespace.removeprefix("::").removesuffix("::")
+        forward_api_name_prefix = "" if prefix == "" else prefix + "_"
+
+        if not inplace:
+            # Generate Python-C Function Definition
+            self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
+                forward_api_name,
+                pythonc_record_event_str,
+                forward_api_name,
+                get_params_nums_and_check_str,
+                get_eager_tensor_str,
+                parse_attributes_str,
+                check_remaining_params_validity_str,
+                args_mapper_str,
+                convert_to_dist_str,
+                pre_process_str,
+                get_predefined_out_str,
+                set_device_str,
+                noamp_dygraph_function_str,
+                return_str,
+            )
+            self.python_c_function_declare_str = (
+                PYTHON_C_FUNCTION_DECLARE_TEMPLATE.format(name=forward_api_name)
+            )
+            # Generate Python-C Function Registration
+            self.python_c_function_reg_str = (
+                PYTHON_C_FUNCTION_REG_TEMPLATE.format(
+                    forward_api_name_prefix,
+                    forward_api_name,
+                    namespace,
+                    forward_api_name,
+                    forward_api_name,
+                )
+            )
+        else:
             # Generate Python-C Function Definition
             python_c_inplace_func_str = PYTHON_C_FUNCTION_TEMPLATE.format(
                 inplaced_forward_api_name,
@@ -855,13 +872,11 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                 inplace_noamp_dygraph_function_str,
                 return_str,
             )
-
             python_c_function_declare_str = (
                 PYTHON_C_FUNCTION_DECLARE_TEMPLATE.format(
                     name=inplaced_forward_api_name
                 )
             )
-
             python_c_inplace_func_reg_str = (
                 PYTHON_C_FUNCTION_REG_TEMPLATE.format(
                     forward_api_name_prefix,
@@ -897,6 +912,15 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         if len(self.python_api_info) > 0:
             self.need_parse_python_api_args = True
             self.ParsePythonAPIInfo()
+        if self.forward_inplace_map:
+            inplace_api_name = GetInplacedFunctionName(self.forward_api_name)
+            if inplace_api_name in python_api_info_from_yaml.keys():
+                self.inplace_python_api_info = python_api_info_from_yaml[
+                    inplace_api_name
+                ]
+            if len(self.inplace_python_api_info) > 0:
+                self.need_parse_inplace_python_api_args = True
+                self.ParsePythonAPIInfo(True)
 
     def run(
         self, no_predefined_out_tensor=False, no_parse_python_api_info=False
@@ -923,7 +947,9 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         )
 
         # Code Generation
-        self.GeneratePythonCFunction(no_predefined_out_tensor)
+        self.GeneratePythonCFunction(False, no_predefined_out_tensor)
+        if self.forward_inplace_map:
+            self.GeneratePythonCFunction(True, no_predefined_out_tensor)
 
         return True
 

--- a/paddle/fluid/pybind/arg_pre_process.cc
+++ b/paddle/fluid/pybind/arg_pre_process.cc
@@ -556,6 +556,41 @@ void BaddbmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y) {
   }
 }
 
+// BitwiseAnd broadcast validation for dygraph
+void BitwiseInplacePreProcess(Tensor* x, Tensor* y) {
+  auto x_shape = x->dims();
+  auto y_shape = y->dims();
+
+  auto out_shape = phi::funcs::BroadcastTwoDims(x_shape, y_shape);
+
+  PADDLE_ENFORCE_EQ(
+      out_shape,
+      x_shape,
+      phi::errors::InvalidArgument(
+          "The shape of broadcast output %s is different from that of inplace "
+          "tensor %s in the Inplace operation.",
+          out_shape,
+          x_shape));
+}
+
+// BitwiseAnd broadcast validation for static graph
+void BitwiseInplacePreProcess(pir::Value* x, pir::Value* y) {
+  auto x_shape = pir::GetShapeFromValue(*x);
+  auto y_shape = pir::GetShapeFromValue(*y);
+
+  auto out_shape = phi::funcs::BroadcastTwoDims(common::make_ddim(x_shape),
+                                                common::make_ddim(y_shape));
+
+  PADDLE_ENFORCE_EQ(
+      out_shape,
+      common::make_ddim(x_shape),
+      phi::errors::InvalidArgument(
+          "The shape of broadcast output %s is different from that of inplace "
+          "tensor %s in the Inplace operation.",
+          out_shape,
+          common::make_ddim(x_shape)));
+}
+
 }  // namespace pybind
 
 }  // namespace paddle

--- a/paddle/fluid/pybind/arg_pre_process.cc
+++ b/paddle/fluid/pybind/arg_pre_process.cc
@@ -557,7 +557,7 @@ void BaddbmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y) {
 }
 
 // BitwiseAnd broadcast validation for dygraph
-void BitwiseInplacePreProcess(Tensor* x, Tensor* y) {
+void InplaceShapePreProcess(Tensor* x, Tensor* y) {
   auto x_shape = x->dims();
   auto y_shape = y->dims();
 
@@ -574,7 +574,7 @@ void BitwiseInplacePreProcess(Tensor* x, Tensor* y) {
 }
 
 // BitwiseAnd broadcast validation for static graph
-void BitwiseInplacePreProcess(pir::Value* x, pir::Value* y) {
+void InplaceShapePreProcess(pir::Value* x, pir::Value* y) {
   auto x_shape = pir::GetShapeFromValue(*x);
   auto y_shape = pir::GetShapeFromValue(*y);
 

--- a/paddle/fluid/pybind/arg_pre_process.h
+++ b/paddle/fluid/pybind/arg_pre_process.h
@@ -76,6 +76,12 @@ void BaddbmmPreProcess(Tensor* input, Tensor* x, Tensor* y);
 // Baddbmm broadcast validation for static graph
 void BaddbmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y);
 
+// BitwiseAnd broadcast validation for dygraph
+void BitwiseInplacePreProcess(Tensor* x, Tensor* y);
+
+// BitwiseAnd broadcast validation for static graph
+void BitwiseInplacePreProcess(pir::Value* x, pir::Value* y);
+
 }  // namespace pybind
 
 }  // namespace paddle

--- a/paddle/fluid/pybind/arg_pre_process.h
+++ b/paddle/fluid/pybind/arg_pre_process.h
@@ -77,10 +77,10 @@ void BaddbmmPreProcess(Tensor* input, Tensor* x, Tensor* y);
 void BaddbmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y);
 
 // BitwiseAnd broadcast validation for dygraph
-void BitwiseInplacePreProcess(Tensor* x, Tensor* y);
+void InplaceShapePreProcess(Tensor* x, Tensor* y);
 
 // BitwiseAnd broadcast validation for static graph
-void BitwiseInplacePreProcess(pir::Value* x, pir::Value* y);
+void InplaceShapePreProcess(pir::Value* x, pir::Value* y);
 
 }  // namespace pybind
 

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -140,7 +140,7 @@
   args_alias :
     use_default_mapping : True
   pre_process :
-    func : BitwiseInplacePreProcess(x, y)
+    func : InplaceShapePreProcess(x, y)
 
 - op : bitwise_left_shift
   name : [paddle.bitwise_left_shift, paddle.Tensor.bitwise_left_shift]
@@ -172,7 +172,7 @@
   args_alias :
     use_default_mapping : True
   pre_process :
-    func : BitwiseInplacePreProcess(x, y)
+    func : InplaceShapePreProcess(x, y)
 
 - op : bitwise_right_shift
   name : [paddle.bitwise_right_shift, paddle.Tensor.bitwise_right_shift]
@@ -194,7 +194,7 @@
   args_alias :
     use_default_mapping : True
   pre_process :
-    func : BitwiseInplacePreProcess(x, y)
+    func : InplaceShapePreProcess(x, y)
 
 - op : ceil
   name : [paddle.ceil, paddle.Tensor.ceil]

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -139,6 +139,8 @@
   name : [paddle.bitwise_and_, paddle.Tensor.bitwise_and_]
   args_alias :
     use_default_mapping : True
+  pre_process :
+    func : BitwiseInplacePreProcess(x, y)
 
 - op : bitwise_left_shift
   name : [paddle.bitwise_left_shift, paddle.Tensor.bitwise_left_shift]
@@ -169,6 +171,8 @@
   name : [paddle.bitwise_or_, paddle.Tensor.bitwise_or_]
   args_alias :
     use_default_mapping : True
+  pre_process :
+    func : BitwiseInplacePreProcess(x, y)
 
 - op : bitwise_right_shift
   name : [paddle.bitwise_right_shift, paddle.Tensor.bitwise_right_shift]
@@ -189,6 +193,8 @@
   name : [paddle.bitwise_xor_, paddle.Tensor.bitwise_xor_]
   args_alias :
     use_default_mapping : True
+  pre_process :
+    func : BitwiseInplacePreProcess(x, y)
 
 - op : ceil
   name : [paddle.ceil, paddle.Tensor.ceil]

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -1601,7 +1601,7 @@ class TestDygraphInplacBitwiseAnd(TestDygraphInplaceLogicAnd):
         )
 
     # will fix it by add inplace pre_process
-    def _test_broadcast_error(self):
+    def test_broadcast_error(self):
         broadcast_input = paddle.randint(
             low=0, high=10, shape=[3, 1, 4], dtype="int32"
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism

### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Add inplace api info processing from `python_api_info.yaml`
- Refactor `python_c_gen.py` to support inplace api config in `python_api_info.yaml`
- Add pre-process for `bitwise_and_`, `bitwise_or_`, `bitwise_xor_`
- Activate corresponding tests


### 是否引起精度变化
否

**Used AI Studio**

---

修改详细说明：

`paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py`
- 追加了读取inplace api信息，保存在新的类成员内的逻辑

`paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py`
- 追加了对于inplace api信息的读取和解析（R915）
- 将inplace api的生成调用移到外面，通过传入参数来区分（R950）
- 将inplace api生成逻辑和原有逻辑整合（其它部分）

`paddle/fluid/pybind/arg_pre_process.cc`
`paddle/fluid/pybind/arg_pre_process.h`
- 追加 @zhwesky2010 写的预处理逻辑

`paddle/phi/ops/yaml/python_api_info.yaml`
- 为三个inplace api配置pre-process

`test/legacy_test/test_inplace.py`
- 打开测试