### PR TITLE
[CI] Linux-IXUCA: retry pip installs once then skip on failure

### DIFF
--- a/.github/workflows/_Linux-IXUCA.yml
+++ b/.github/workflows/_Linux-IXUCA.yml
@@ -300,11 +300,24 @@ jobs:
             exit $ret
           }'\'' ERR
 
+          retry_or_skip() {
+            if "$@"; then
+              return 0
+            fi
+            echo "WARN: command failed, retrying in 20s: $*"
+            sleep 20
+            if "$@"; then
+              return 0
+            fi
+            echo "WARN: command failed again, skip install: $*"
+            return 0
+          }
+
           echo "::group::Install dependencies"
-          python -m pip install PyGithub
-          python -m pip install wheel
+          retry_or_skip python -m pip install PyGithub
+          retry_or_skip python -m pip install wheel
           echo "::endgroup::"
-          pip install -U numpy==1.26.4
+          retry_or_skip pip install -U numpy==1.26.4
           git config --global --add safe.directory ${work_dir}
           git config --global --add safe.directory ${work_dir}/Paddle
           pwd


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Not User Facing

### Description
In `.github/workflows/_Linux-IXUCA.yml`, add a helper `retry_or_skip` for dependency installation to reduce transient pip/network failures in CI.

Changes:
- wrap `python -m pip install PyGithub` with retry logic
- wrap `python -m pip install wheel` with retry logic
- wrap `pip install -U numpy==1.26.4` with retry logic

Behavior:
- first install failure: wait 20 seconds and retry once
- second failure: print warning and skip this install step instead of failing the whole CI job

### 是否引起精度变化
否
