### PR TITLE
add _check_last_cuda_error

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3343,6 +3343,8 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("_cuda_synchronize", [](const GPUPlace &place) {
     phi::DeviceContextPool::Instance().Get(place)->Wait();
   });
+  m.def("_check_last_cuda_error",
+        []() { PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError()); });
   m.def("_set_warmup", [](bool warmup) {
 #if defined(PADDLE_WITH_CUDA)
     paddle::memory::allocation::AutoGrowthBestFitAllocatorV2State::GetInstance()

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3343,8 +3343,11 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("_cuda_synchronize", [](const GPUPlace &place) {
     phi::DeviceContextPool::Instance().Get(place)->Wait();
   });
-  m.def("_check_last_cuda_error",
-        []() { PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError()); });
+  m.def("_check_last_cuda_error", []() {
+#if defined(PADDLE_WITH_CUDA)
+    PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
+  });
   m.def("_set_warmup", [](bool warmup) {
 #if defined(PADDLE_WITH_CUDA)
     paddle::memory::allocation::AutoGrowthBestFitAllocatorV2State::GetInstance()

--- a/python/paddle/base/__init__.py
+++ b/python/paddle/base/__init__.py
@@ -72,6 +72,7 @@ from .core import (  # noqa: F401
     Scope,
     XPUPinnedPlace,
     XPUPlace,
+    _check_last_cuda_error,
     _cuda_synchronize,
     _Scope,
     _set_warmup,

--- a/python/paddle/base/core.py
+++ b/python/paddle/base/core.py
@@ -292,6 +292,7 @@ try:
         __package__,
         __unittest_throw_exception__,
         _append_python_callable_object_and_return_id,
+        _check_last_cuda_error,
         _cleanup,
         _create_loaded_parameter,
         _cuda_synchronize,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

新增paddle.base._check_last_cuda_error
底层为：PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否