### PR TITLE
[CI] Increase windows CI timeout time

### DIFF
--- a/.github/workflows/_Windows-GPU.yml
+++ b/.github/workflows/_Windows-GPU.yml
@@ -34,7 +34,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: win-gpu
-    timeout-minutes: 120
+    timeout-minutes: 180
     env:
       PADDLE_VERSION: 0.0.0
       NIGHTLY_MODE: "OFF"

--- a/.github/workflows/_Windows-Inference.yml
+++ b/.github/workflows/_Windows-Inference.yml
@@ -34,7 +34,7 @@ jobs:
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: win-infer
-    timeout-minutes: 120
+    timeout-minutes: 180
     env:
       PADDLE_VERSION: 0.0.0
       NIGHTLY_MODE: "OFF"


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

上调 windows-inference 和 windows-gpu CI timeout 时间到 180min，部分情况 120min 还是会超时

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否

<!-- PCard-66972 -->