### PR TITLE
[API compatibility] Add `MaxPool*D`/`FractionalMaxPool*D` param alias -part

### DIFF
--- a/python/paddle/nn/__init__.py
+++ b/python/paddle/nn/__init__.py
@@ -235,6 +235,11 @@ AdaptiveMaxPool2d = AdaptiveMaxPool2D
 AdaptiveMaxPool3d = AdaptiveMaxPool3D
 LPPool2d = LPPool2D
 LPPool1d = LPPool1D
+MaxPool1d = MaxPool1D
+MaxPool2d = MaxPool2D
+MaxPool3d = MaxPool3D
+FractionalMaxPool2d = FractionalMaxPool2D
+FractionalMaxPool3d = FractionalMaxPool3D
 
 __all__ = [
     'BatchNorm',
@@ -416,4 +421,9 @@ __all__ = [
     'Module',
     'ModuleDict',
     'ModuleList',
+    'MaxPool1d',
+    'MaxPool2d',
+    'MaxPool3d',
+    'FractionalMaxPool2d',
+    'FractionalMaxPool3d',
 ]

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -573,6 +573,7 @@ def avg_pool3d(
         )
 
 
+@param_two_alias(["x", "input"], ["return_mask", "return_indices"])
 def max_pool1d(
     x: Tensor,
     kernel_size: Size1,
@@ -590,6 +591,7 @@ def max_pool1d(
         x (Tensor): The input tensor of pooling operator which is a 3-D tensor with
                           shape [N, C, L], where `N` is batch size, `C` is the number of channels,
                           `L` is the length of the feature. The data type if float32 or float64.
+            Alias: ``input``.
         kernel_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list,
             it must contain an integer.
         stride (int|list|tuple): The pool stride size. If pool stride size is a tuple or list,
@@ -602,6 +604,7 @@ def max_pool1d(
             5. A list or tuple of pairs of integers. It has the form [[pad_before, pad_after], [pad_before, pad_after], ...]. Note that, the batch dimension and channel dimension should be [0,0] or (0,0).
             The default value is 0.
         return_mask (bool): Whether return the max indices along with the outputs. default is `False`.
+            Alias: ``return_indices``.
         ceil_mode (bool): Whether to use the ceil function to calculate output height and width. False is the default.
             If it is set to False, the floor function will be used. Default False.
         name(str|None, optional): For detailed information, please refer
@@ -1143,6 +1146,7 @@ def max_unpool3d(
     return unpool_out
 
 
+@param_two_alias(["x", "input"], ["return_mask", "return_indices"])
 def max_pool2d(
     x: Tensor,
     kernel_size: Size2,
@@ -1163,6 +1167,7 @@ def max_pool2d(
                           `"NHWC"`, where `N` is batch size, `C` is the number of channels,
                           `H` is the height of the feature, and `W` is the width of the
                           feature. The data type if float32 or float64.
+            Alias: ``input``.
         kernel_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list,
             it must contain two integers, (kernel_size_Height, kernel_size_Width).
             Otherwise, the pool kernel size will be a square of an int.
@@ -1178,6 +1183,7 @@ def max_pool2d(
             The default value is 0.
         ceil_mode (bool): when True, will use `ceil` instead of `floor` to compute the output shape
         return_mask (bool): Whether to return the max indices along with the outputs. Default False, only support `"NCHW"` data format
+            Alias: ``return_indices``.
         data_format (string): The data format of the input and output data. An optional string from: `"NCHW"`, `"NHWC"`.
                         The default is `"NCHW"`. When it is `"NCHW"`, the data is stored in the order of:
                         `[batch_size, input_channels, input_height, input_width]`.
@@ -1305,6 +1311,7 @@ def max_pool2d(
             return pool_out
 
 
+@param_two_alias(["x", "input"], ["return_mask", "return_indices"])
 def max_pool3d(
     x: Tensor,
     kernel_size: Size3,
@@ -1322,6 +1329,7 @@ def max_pool3d(
     Args:
         x (Tensor): The input tensor of pooling operator, which is a 5-D tensor with
                           shape [N, C, D, H, W]. The format of input tensor is `"NCDHW"` or `"NDHWC"`, where N represents batch size, C represents the number of channels, D, H and W represent the depth, height and width of the feature respectively.
+            Alias: ``input``.
         kernel_size (int|list|tuple): The pool kernel size. If the kernel size
             is a tuple or list, it must contain three integers,
             (kernel_size_Depth, kernel_size_Height, kernel_size_Width).
@@ -1338,6 +1346,7 @@ def max_pool3d(
             The default value is 0.
         ceil_mode (bool): ${ceil_mode_comment}
         return_mask (bool): Whether to return the max indices along with the outputs. Default False. Only support "NDCHW" data_format.
+            Alias: ``return_indices``.
         data_format (string): The data format of the input and output data. An optional string from: `"NCDHW"`, `"NDHWC"`.
                         The default is `"NCDHW"`. When it is `"NCDHW"`, the data is stored in the order of:
                         `[batch_size, input_channels, input_depth, input_height, input_width]`.
@@ -1818,9 +1827,11 @@ def adaptive_max_pool1d(
                               with shape [N, C, L].  The format of input tensor is NCL,
                               where N is batch size, C is the number of channels, L is the
                               length of the feature. The data type is float32 or float64.
+            Alias: ``input``.
         output_size (int|list|tuple): The pool kernel size. It can be an integer, or a list or tuple containing a single integer.
         return_mask (bool): If true, the index of max pooling point will be returned along
                 with outputs. It cannot be set in average pooling type. Default False.
+            Alias: ``return_indices``.
         name(str|None, optional): For detailed information, please refer
                                  to :ref:`api_guide_Name`. Usually name is no need to set and
                                  None by default.
@@ -1918,8 +1929,10 @@ def adaptive_max_pool2d(
 
     Args:
         x (Tensor): The input tensor of adaptive max pool2d operator, which is a 4-D tensor. The data type can be float16, float32, float64, int32 or int64.
+            Alias: ``input``.
         output_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list, it must contain two elements, (H, W). H and W can be either a int, or None which means the size will be the same as that of the input.
         return_mask (bool): If true, the index of max pooling point will be returned along with outputs. Default False.
+            Alias: ``return_indices``.
         name(str|None, optional): For detailed information, please refer to :ref:`api_guide_Name`. Usually name is no need to set and None by default.
 
     Returns:
@@ -2009,8 +2022,10 @@ def adaptive_max_pool3d(
 
     Args:
         x (Tensor): The input tensor of adaptive max pool3d operator, which is a 5-D tensor. The data type can be float32, float64.
+            Alias: ``input``.
         output_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list, it must contain three elements, (D, H, W). D, H and W can be either a int, or None which means the size will be the same as that of the input.
         return_mask (bool): If true, the index of max pooling point will be returned along with outputs. Default False.
+            Alias: ``return_indices``.
         name(str|None, optional): For detailed information, please refer to :ref:`api_guide_Name`. Usually name is no need to set and None by default.
 
     Returns:
@@ -2095,6 +2110,7 @@ def adaptive_max_pool3d(
         return (pool_out, mask) if return_mask else pool_out
 
 
+@param_two_alias(["x", "input"], ["return_mask", "return_indices"])
 def fractional_max_pool2d(
     x: Tensor,
     output_size: Size2,
@@ -2137,12 +2153,14 @@ def fractional_max_pool2d(
         output_size(int|list|tuple): The output size. If output size is a tuple or list, it must contain
             two element, (H, W). H and W can be either a int, or None which means the size will be the same as that of
             the input.
+            Alias: ``input``.
         kernel_size (int|list|tuple, optional): The pool kernel size. If the kernel size
             is a tuple or list, it must contain two integers, (kernel_size_Height, kernel_size_Width).
             Otherwise, the pool kernel size will be the square of an int. Default is None, means using the non-overlapping mode.
         random_u(float): A random float number in range (0, 1) for the fractional pooling.
             Default None, means randomly generated by framework which can be fixed by ``paddle.seed``.
         return_mask(bool, optional): If true, the index of max pooling point will be returned along with outputs. Default False.
+            Alias: ``return_indices``.
         name(str|None, optional): For detailed information, please refer to :ref:`api_guide_Name`.
             Usually name is no need to set and None by default.
 
@@ -2250,6 +2268,7 @@ def fractional_max_pool2d(
         return (pool_out, mask) if return_mask else pool_out
 
 
+@param_two_alias(["x", "input"], ["return_mask", "return_indices"])
 def fractional_max_pool3d(
     x: Tensor,
     output_size: Size2,
@@ -2289,6 +2308,7 @@ def fractional_max_pool3d(
 
     Parameters:
         x (Tensor): The input tensor of fractional max pool3d operator, which is a 5-D tensor. The data type can be float16, bfloat16, float32, float64.
+            Alias: ``input``.
         output_size(int|list|tuple): The output size. If output size is a tuple or list, it must contain
             three element, (D, H, W). D, H and W can be either a int, or None which means the size will be the same as that of
             the input.
@@ -2298,6 +2318,7 @@ def fractional_max_pool3d(
         random_u(float): A random float number in range (0, 1) for the fractional pooling.
             Default None, means randomly generated by framework which can be fixed by ``paddle.seed``.
         return_mask(bool, optional): If true, the index of max pooling point will be returned along with outputs. Default False.
+            Alias: ``return_indices``.
         name(str|None, optional): For detailed information, please refer to :ref:`api_guide_Name`.
             Usually name is no need to set and None by default.
 

--- a/python/paddle/nn/layer/pooling.py
+++ b/python/paddle/nn/layer/pooling.py
@@ -672,6 +672,7 @@ class MaxPool1D(Layer):
     ceil_mode: bool
     name: str | None
 
+    @param_one_alias(["return_mask", "return_indices"])
     def __init__(
         self,
         kernel_size: Size1,
@@ -790,6 +791,7 @@ class MaxPool2D(Layer):
     data_format: DataLayout2D
     name: str | None
 
+    @param_one_alias(["return_mask", "return_indices"])
     def __init__(
         self,
         kernel_size: Size2,
@@ -809,6 +811,7 @@ class MaxPool2D(Layer):
         self.data_format = data_format
         self.name = name
 
+    @param_one_alias(["x", "input"])
     def forward(self, x: Tensor) -> Tensor:
         return F.max_pool2d(
             x,
@@ -898,6 +901,7 @@ class MaxPool3D(Layer):
     data_format: DataLayout3D
     name: str | None
 
+    @param_one_alias(["return_mask", "return_indices"])
     def __init__(
         self,
         kernel_size: Size3,
@@ -917,6 +921,7 @@ class MaxPool3D(Layer):
         self.data_format = data_format
         self.name = name
 
+    @param_one_alias(["x", "input"])
     def forward(self, x: Tensor) -> Tensor:
         return F.max_pool3d(
             x,
@@ -1952,6 +1957,7 @@ class FractionalMaxPool2D(Layer):
             paddle.Size([2, 3, 2, 3])
     """
 
+    @param_one_alias(["return_mask", "return_indices"])
     def __init__(
         self,
         output_size: Size2,
@@ -1967,6 +1973,7 @@ class FractionalMaxPool2D(Layer):
         self._return_mask = return_mask
         self._name = name
 
+    @param_one_alias(["x", "input"])
     def forward(self, x: Tensor) -> Tensor:
         return F.fractional_max_pool2d(
             x,
@@ -2068,6 +2075,7 @@ class FractionalMaxPool3D(Layer):
             paddle.Size([2, 3, 2, 3, 3])
     """
 
+    @param_one_alias(["return_mask", "return_indices"])
     def __init__(
         self,
         output_size: Size2,
@@ -2083,6 +2091,7 @@ class FractionalMaxPool3D(Layer):
         self._return_mask = return_mask
         self._name = name
 
+    @param_one_alias(["x", "input"])
     def forward(self, x: Tensor) -> Tensor:
         return F.fractional_max_pool3d(
             x,

--- a/test/legacy_test/test_fractional_max_pool2d_api.py
+++ b/test/legacy_test/test_fractional_max_pool2d_api.py
@@ -358,7 +358,7 @@ class TestFractionalMaxPool2DAPI(unittest.TestCase):
             np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
             np.testing.assert_allclose(out_6.numpy(), self.res_6_np)
             np.testing.assert_allclose(out_7.numpy(), self.res_7_np)
-            np.testing.assert_allclose(out_8.numpy(), self.res_8_np)
+            np.testing.assert_allclose(out_8.numpy(), self.res_7_np)
 
 
 class TestFractionalMaxPool2DClassAPI(unittest.TestCase):

--- a/test/legacy_test/test_fractional_max_pool2d_api.py
+++ b/test/legacy_test/test_fractional_max_pool2d_api.py
@@ -343,6 +343,14 @@ class TestFractionalMaxPool2DAPI(unittest.TestCase):
                 x=x, output_size=[3, None], random_u=0.6
             )
 
+            # test param_two_alias(["x", "input"], ["return_mask", "return_indices"])
+            out_8 = paddle.nn.functional.fractional_max_pool2d(
+                input=x,
+                output_size=[3, None],
+                random_u=0.6,
+                return_indices=False,
+            )
+
             np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
             np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
             np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
@@ -350,6 +358,7 @@ class TestFractionalMaxPool2DAPI(unittest.TestCase):
             np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
             np.testing.assert_allclose(out_6.numpy(), self.res_6_np)
             np.testing.assert_allclose(out_7.numpy(), self.res_7_np)
+            np.testing.assert_allclose(out_8.numpy(), self.res_8_np)
 
 
 class TestFractionalMaxPool2DClassAPI(unittest.TestCase):
@@ -467,11 +476,28 @@ class TestFractionalMaxPool2DClassAPI(unittest.TestCase):
             )
             out_5 = fractional_max_pool(x=x)
 
+            # test param_one_alias(["x", "input"])
+            fractional_max_pool = paddle.nn.FractionalMaxPool2D(
+                kernel_size=[2, 2], output_size=[3, 3], random_u=0.6
+            )
+            out_6 = fractional_max_pool(input=x)
+
+            # test param_one_alias(["return_mask", "return_indices"])
+            fractional_max_pool = paddle.nn.FractionalMaxPool2D(
+                kernel_size=[2, 2],
+                output_size=[3, 3],
+                random_u=0.6,
+                return_indices=False,
+            )
+            out_7 = fractional_max_pool(x=x)
+
             np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
             np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
             np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
             np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
             np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
+            np.testing.assert_allclose(out_6.numpy(), self.res_5_np)
+            np.testing.assert_allclose(out_7.numpy(), self.res_5_np)
 
 
 class TestOutDtype(unittest.TestCase):

--- a/test/legacy_test/test_fractional_max_pool3d_api.py
+++ b/test/legacy_test/test_fractional_max_pool3d_api.py
@@ -422,6 +422,14 @@ class TestFractionalMaxPool3DAPI(unittest.TestCase):
                 x=x, output_size=[3, 3, None], random_u=0.6
             )
 
+            # test param_two_alias(["x", "input"], ["return_mask", "return_indices"])
+            out_9 = paddle.nn.functional.fractional_max_pool3d(
+                input=x,
+                output_size=[3, 3, None],
+                random_u=0.6,
+                return_indices=False,
+            )
+
             np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
             np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
             np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
@@ -430,6 +438,7 @@ class TestFractionalMaxPool3DAPI(unittest.TestCase):
             np.testing.assert_allclose(out_6.numpy(), self.res_6_np)
             np.testing.assert_allclose(out_7.numpy(), self.res_7_np)
             np.testing.assert_allclose(out_8.numpy(), self.res_8_np)
+            np.testing.assert_allclose(out_9.numpy(), self.res_8_np)
 
 
 class TestFractionalMaxPool3DClassAPI(unittest.TestCase):
@@ -550,11 +559,28 @@ class TestFractionalMaxPool3DClassAPI(unittest.TestCase):
             )
             out_5 = fractional_max_pool(x=x)
 
+            # test param_one_alias(["x", "input"])
+            fractional_max_pool = paddle.nn.FractionalMaxPool3D(
+                kernel_size=[2, 2, 2], output_size=[3, 3, 3], random_u=0.6
+            )
+            out_6 = fractional_max_pool(input=x)
+
+            # test param_one_alias(["return_mask", "return_indices"])
+            fractional_max_pool = paddle.nn.FractionalMaxPool3D(
+                kernel_size=[2, 2, 2],
+                output_size=[3, 3, 3],
+                random_u=0.6,
+                return_indices=False,
+            )
+            out_7 = fractional_max_pool(x=x)
+
             np.testing.assert_allclose(out_1.numpy(), self.res_1_np)
             np.testing.assert_allclose(out_2.numpy(), self.res_2_np)
             np.testing.assert_allclose(out_3.numpy(), self.res_3_np)
             np.testing.assert_allclose(out_4.numpy(), self.res_4_np)
             np.testing.assert_allclose(out_5.numpy(), self.res_5_np)
+            np.testing.assert_allclose(out_6.numpy(), self.res_5_np)
+            np.testing.assert_allclose(out_7.numpy(), self.res_5_np)
 
 
 class TestOutDtype(unittest.TestCase):

--- a/test/legacy_test/test_pool1d_api.py
+++ b/test/legacy_test/test_pool1d_api.py
@@ -297,8 +297,25 @@ class TestPool1D_API(unittest.TestCase):
 
             np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)
 
+            # test param_two_alias(["x", "input"], ["return_mask", "return_indices"])
+            result = F.max_pool1d(
+                input=input,
+                kernel_size=2,
+                stride=2,
+                padding=0,
+                return_indices=False,
+            )
+            np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)
+
             max_pool1d_dg = paddle.nn.layer.MaxPool1D(
                 kernel_size=2, stride=None, padding=0
+            )
+            result = max_pool1d_dg(input)
+            np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)
+
+            # test param_one_alias(["return_mask", "return_indices"])
+            max_pool1d_dg = paddle.nn.layer.MaxPool1D(
+                kernel_size=2, stride=None, padding=0, return_indices=False
             )
             result = max_pool1d_dg(input)
             np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)

--- a/test/legacy_test/test_pool2d_api.py
+++ b/test/legacy_test/test_pool2d_api.py
@@ -167,8 +167,29 @@ class TestPool2D_API(unittest.TestCase):
             )
             np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)
 
+            # test param_two_alias(["x", "input"], ["return_mask", "return_indices"])
+            result = max_pool2d(
+                input=input,
+                kernel_size=2,
+                stride=2,
+                padding=0,
+                return_indices=False,
+            )
+            np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)
+
             max_pool2d_dg = paddle.nn.layer.MaxPool2D(
                 kernel_size=2, stride=2, padding=0
+            )
+            result = max_pool2d_dg(input)
+            np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)
+
+            # test param_one_alias(["x", "input"])
+            result = max_pool2d_dg(input=input)
+            np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)
+
+            # test param_one_alias(["return_mask", "return_indices"])
+            max_pool2d_dg = paddle.nn.layer.MaxPool2D(
+                kernel_size=2, stride=2, padding=0, return_indices=False
             )
             result = max_pool2d_dg(input)
             np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)

--- a/test/legacy_test/test_pool3d_api.py
+++ b/test/legacy_test/test_pool3d_api.py
@@ -176,10 +176,31 @@ class TestPool3D_API(unittest.TestCase):
                 paddings=[0, 0, 0],
                 pool_type='max',
             )
-
             np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)
+
+            # test param_two_alias(["x", "input"], ["return_mask", "return_indices"])
+            result = max_pool3d(
+                input=input,
+                kernel_size=2,
+                stride=2,
+                padding=0,
+                return_indices=False,
+            )
+            np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)
+
             max_pool3d_dg = paddle.nn.layer.MaxPool3D(
                 kernel_size=2, stride=None, padding=0
+            )
+            result = max_pool3d_dg(input)
+            np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)
+
+            # test param_one_alias(["x", "input"])
+            result = max_pool3d_dg(input=input)
+            np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)
+
+            # test param_one_alias(["return_mask", "return_indices"])
+            max_pool3d_dg = paddle.nn.layer.MaxPool3D(
+                kernel_size=2, stride=None, padding=0, return_indices=False
             )
             result = max_pool3d_dg(input)
             np.testing.assert_allclose(result.numpy(), result_np, rtol=1e-05)


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

New features

### Description
<!-- Describe what you’ve done -->
`MaxPool*D` / `FractionalMaxPool*D` params alias
* x -> input
* return_mask -> return_indices

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否