### PR TITLE
Update def spectral_norm

### DIFF
--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -3214,7 +3214,6 @@ def row_conv(input, future_context_size, param_attr=None, act=None):
     )
     return helper.append_activation(out)
 
-
 def spectral_norm(weight, dim=0, power_iters=1, eps=1e-12, name=None):
     r"""
     :api_attr: Static Graph
@@ -3276,7 +3275,7 @@ def spectral_norm(weight, dim=0, power_iters=1, eps=1e-12, name=None):
                   The data type and shape is same as input tensor.
 
     Examples:
-       .. code-block:: python
+       .. code-block:: pycon
 
             >>> import paddle
 
@@ -3284,7 +3283,7 @@ def spectral_norm(weight, dim=0, power_iters=1, eps=1e-12, name=None):
             >>> weight = paddle.static.data(name='weight', shape=[2, 8, 32, 32], dtype='float32')
             >>> x = paddle.static.nn.spectral_norm(weight=weight, dim=1, power_iters=2)
             >>> print(x.shape)
-            (2, 8, 32, 32)
+            paddle.Size([2, 8, 32, 32])
     """
     helper = LayerHelper('spectral_norm', **locals())
     check_variable_and_dtype(
@@ -3351,7 +3350,6 @@ def spectral_norm(weight, dim=0, power_iters=1, eps=1e-12, name=None):
 # For debug usage
 py_func.registered_func = PyFuncRegistry.registered_func
 py_func.registered_func_num = PyFuncRegistry.registered_func_num
-
 
 def layer_norm(
     input,

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -24,28 +24,10 @@ import numpy as np
 import paddle
 from paddle import _C_ops
 from paddle._C_ops import (  # noqa: F401
-    addmm,
-    addmm_,
     all,
     amax,
     amin,
-    angle,
     any,
-    baddbmm,
-    baddbmm_,
-    bitwise_left_shift,
-    bitwise_left_shift_,
-    bitwise_right_shift,
-    bitwise_right_shift_,
-    conj,
-    fmax,
-    fmin,
-    heaviside,
-    i0,
-    i0e,
-    i1,
-    i1e,
-    inverse,
     isfinite,
     isinf,
     isnan,
@@ -57,17 +39,17 @@ from paddle._C_ops import (  # noqa: F401
     maximum,
     minimum,
     multiply,
-    nextafter,
     sign,
     sin,
     sum,
-    tan,
     tanh,
 )
 from paddle.base.libpaddle import DataType
 from paddle.common_ops_import import VarDesc, dygraph_utils
 from paddle.pir import Value
 from paddle.utils.decorator_utils import (
+    ParamAliasDecorator,
+    floor_divide_decorator,
     param_one_alias,
     param_two_alias,
 )
@@ -88,6 +70,7 @@ from ..framework import (
     in_dynamic_or_pir_mode,
     in_pir_mode,
 )
+from .creation import _complex_to_real_dtype
 from .layer_function_generator import generate_layer_fn
 from .manipulation import cast, cast_
 from .ops import (  # noqa: F401
@@ -134,6 +117,7 @@ from .ops import (  # noqa: F401
     sqrt_,
     square,
     square_,
+    tan,
     tan_,
 )
 
@@ -245,7 +229,7 @@ def scale(
         Tensor: Output Tensor of scale operator, with shape and data type same as input.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> # scale as a float32 number
             >>> import paddle
@@ -261,7 +245,7 @@ def scale(
             [[1. , 3. , 5. ],
              [7. , 9. , 11.]])
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> # scale with parameter scale as a Tensor
             >>> import paddle
@@ -351,7 +335,7 @@ def stanh(
         A Tensor with the same shape and data type as ``x`` (integer types are autocasted into float32).
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -359,7 +343,7 @@ def stanh(
             >>> out = paddle.stanh(x, scale_a=0.67, scale_b=1.72)
             >>> print(out)
             Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [1.00616539, 1.49927628, 1.65933096, 1.70390475])
+            [1.00616539, 1.49927628, 1.65933096, 1.70390463])
 
     """
 
@@ -434,7 +418,7 @@ def multiplex(
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -508,7 +492,7 @@ def scale_(
         return _C_ops.scale_(x, scale, float(bias), bias_after_scale)
 
 
-@param_two_alias(["x", "input"], ["y", "exponent"])
+@ParamAliasDecorator({"x": ["input"], "y": ["exponent"]})
 def pow(
     x: Tensor,
     y: float | Tensor,
@@ -528,8 +512,8 @@ def pow(
         .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
 
     .. note::
-        Alias Support: The parameter name ``input`` can be used as an alias for ``x``, The parameter name ``exponent`` can be used as an alias for ``y``.
-        For example, ``pow(input=2, exponent=1.1)`` is equivalent to ``pow(x=2, y=1.1)``.
+            Alias Support: The parameter name ``input`` can be used as an alias for ``x``, The parameter name ``exponent`` can be used as an alias for ``y``.
+            For example, ``pow(input=2, exponent=1.1)`` is equivalent to ``pow(x=2, y=1.1)``.
 
     Args:
         x (Tensor): An N-D Tensor, the data type is bfloat16, float16, float32, float64, int32, int64, complex64 or complex128.
@@ -544,7 +528,7 @@ def pow(
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -757,7 +741,7 @@ def add(
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -866,7 +850,7 @@ def logaddexp(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -916,7 +900,7 @@ def subtract(
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -1043,7 +1027,7 @@ def divide(
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -1139,7 +1123,7 @@ def true_divide(
     return divide(input, other, out=out)
 
 
-@param_two_alias(['x', 'input'], ['y', 'other'])
+@floor_divide_decorator()
 def floor_divide(
     x: Tensor,
     y: Number | Tensor,
@@ -1165,7 +1149,7 @@ def floor_divide(
     Args:
         x (Tensor): the input tensor, it's data type should be uint8, int8, int32, int64, float32, float64, float16, bfloat16.
             alias: ``input``.
-        y (Tensor|Number): the input tensor or number, it's data type should be uint8, int8, int32, int64, float32, float64, float16, bfloat16.
+        y (Tensor｜Number): the input tensor or number, it's data type should be uint8, int8, int32, int64, float32, float64, float16, bfloat16.
             alias: ``other``.
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
         out (Tensor|None, optional): The output tensor. Default: None.
@@ -1175,7 +1159,7 @@ def floor_divide(
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -1188,17 +1172,10 @@ def floor_divide(
 
             >>> x = paddle.to_tensor([2, 3, 8, 7])
             >>> y = paddle.to_tensor([1, -5, -3, -3])
-            >>> z = paddle.floor_divide(x=x, y=y)
+            >>> z = paddle.floor_divide(x, y)
             >>> print(z)
             Tensor(shape=[4], dtype=int64, place=Place(cpu), stop_gradient=True,
             [2, -1, -3, -3])
-
-            >>> x = paddle.to_tensor([2, -3, 8, -7])
-            >>> y = paddle.to_tensor([1, -5, -3, 3])
-            >>> z = paddle.floor_divide(input=x, other=y)  # type: ignore[call-arg]
-            >>> print(z)
-            Tensor(shape=[4], dtype=int64, place=Place(cpu), stop_gradient=True,
-            [2, 0, -3, -3])
     """
     if in_dynamic_or_pir_mode():
         if isinstance(y, numbers.Number):
@@ -1254,7 +1231,7 @@ def remainder(
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -1341,7 +1318,7 @@ def mul(
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -1446,6 +1423,134 @@ def _divide_with_axis(x, y, axis=-1, name=None):
         return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
+def fmax(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
+    """
+    Compares the elements at the corresponding positions of the two tensors and returns a new tensor containing the maximum value of the element.
+    If one of them is a nan value, the other value is directly returned, if both are nan values, then the first nan value is returned.
+    The equation is:
+
+    .. math::
+        out = fmax(x, y)
+
+    Note:
+        ``paddle.fmax`` supports broadcasting. If you want know more about broadcasting, please refer to `Introduction to Tensor`_ .
+
+        .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
+
+    Args:
+        x (Tensor): the input tensor, it's data type should be bfloat16, float16, float32, float64, int32, int64.
+        y (Tensor): the input tensor, it's data type should be bfloat16, float16, float32, float64, int32, int64.
+        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        N-D Tensor. A location into which the result is stored. If x, y have different shapes and are "broadcastable", the resulting tensor shape is the shape of x and y after broadcasting. If x, y have the same shape,  its shape is the same as x and y.
+
+    Examples:
+
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> x = paddle.to_tensor([[1, 2], [7, 8]])
+            >>> y = paddle.to_tensor([[3, 4], [5, 6]])
+            >>> res = paddle.fmax(x, y)
+            >>> print(res)
+            Tensor(shape=[2, 2], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[3, 4],
+             [7, 8]])
+
+            >>> x = paddle.to_tensor([[1, 2, 3], [1, 2, 3]])
+            >>> y = paddle.to_tensor([3, 0, 4])
+            >>> res = paddle.fmax(x, y)
+            >>> print(res)
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[3, 2, 4],
+             [3, 2, 4]])
+
+            >>> x = paddle.to_tensor([2, 3, 5], dtype='float32')
+            >>> y = paddle.to_tensor([1, float("nan"), float("nan")], dtype='float32')
+            >>> res = paddle.fmax(x, y)
+            >>> print(res)
+            Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [2., 3., 5.])
+
+            >>> x = paddle.to_tensor([5, 3, float("inf")], dtype='float32')
+            >>> y = paddle.to_tensor([1, -float("inf"), 5], dtype='float32')
+            >>> res = paddle.fmax(x, y)
+            >>> print(res)
+            Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [5.  , 3.  , inf.])
+    """
+    if in_dynamic_or_pir_mode():
+        return _C_ops.fmax(x, y)
+    else:
+        return _elementwise_op(LayerHelper('elementwise_fmax', **locals()))
+
+
+def fmin(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
+    """
+    Compares the elements at the corresponding positions of the two tensors and returns a new tensor containing the minimum value of the element.
+    If one of them is a nan value, the other value is directly returned, if both are nan values, then the first nan value is returned.
+    The equation is:
+
+    .. math::
+        out = fmin(x, y)
+
+    Note:
+        ``paddle.fmin`` supports broadcasting. If you want know more about broadcasting, please refer to `Introduction to Tensor`_ .
+
+        .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
+
+    Args:
+        x (Tensor): the input tensor, it's data type should be bfloat16, float16, float32, float64, int32, int64.
+        y (Tensor): the input tensor, it's data type should be bfloat16, float16, float32, float64, int32, int64.
+        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        N-D Tensor. A location into which the result is stored. If x, y have different shapes and are "broadcastable", the resulting tensor shape is the shape of x and y after broadcasting. If x, y have the same shape,  its shape is the same as x and y.
+
+    Examples:
+
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> x = paddle.to_tensor([[1, 2], [7, 8]])
+            >>> y = paddle.to_tensor([[3, 4], [5, 6]])
+            >>> res = paddle.fmin(x, y)
+            >>> print(res)
+            Tensor(shape=[2, 2], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[1, 2],
+             [5, 6]])
+
+            >>> x = paddle.to_tensor([[[1, 2, 3], [1, 2, 3]]])
+            >>> y = paddle.to_tensor([3, 0, 4])
+            >>> res = paddle.fmin(x, y)
+            >>> print(res)
+            Tensor(shape=[1, 2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[[1, 0, 3],
+              [1, 0, 3]]])
+
+            >>> x = paddle.to_tensor([2, 3, 5], dtype='float32')
+            >>> y = paddle.to_tensor([1, float("nan"), float("nan")], dtype='float32')
+            >>> res = paddle.fmin(x, y)
+            >>> print(res)
+            Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [1., 3., 5.])
+
+            >>> x = paddle.to_tensor([5, 3, float("inf")], dtype='float64')
+            >>> y = paddle.to_tensor([1, -float("inf"), 5], dtype='float64')
+            >>> res = paddle.fmin(x, y)
+            >>> print(res)
+            Tensor(shape=[3], dtype=float64, place=Place(cpu), stop_gradient=True,
+            [ 1.  , -inf.,  5.  ])
+    """
+    if in_dynamic_or_pir_mode():
+        return _C_ops.fmin(x, y)
+    else:
+        return _elementwise_op(LayerHelper('elementwise_fmin', **locals()))
+
+
 def reduce_as(x: Tensor, target: Tensor, name: str | None = None) -> Tensor:
     """
     Computes the sum of tensor elements make the shape of its result equal to the shape of target.
@@ -1459,22 +1564,22 @@ def reduce_as(x: Tensor, target: Tensor, name: str | None = None) -> Tensor:
         Tensor: The sum of the input tensor x along some axis has the same shape as the shape of the input tensor target, if `x.dtype='bool'`, `x.dtype='int32'`, it's data type is `'int64'`, otherwise it's data type is the same as `x`.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
             >>> x = paddle.to_tensor([[1, 2, 3, 4], [5, 6, 7, 8]])
             >>> x
-            Tensor(shape=[2, 4], dtype=int64, place=Place(cpu), stop_gradient=True,
+            Tensor(shape=[2, 4], dtype=int64, place=Place(gpu:0), stop_gradient=True,
             [[1, 2, 3, 4],
              [5, 6, 7, 8]])
             >>> target = paddle.to_tensor([1, 2, 3, 4])
             >>> target
-            Tensor(shape=[4], dtype=int64, place=Place(cpu), stop_gradient=True,
+            Tensor(shape=[4], dtype=int64, place=Place(gpu:0), stop_gradient=True,
             [1, 2, 3, 4])
             >>> res = paddle.reduce_as(x, target)
             >>> res
-            Tensor(shape=[4], dtype=int64, place=Place(cpu), stop_gradient=True,
+            Tensor(shape=[4], dtype=int64, place=Place(gpu:0), stop_gradient=True,
             [6 , 8 , 10, 12])
     """
 
@@ -1551,7 +1656,7 @@ def nan_to_num(
         Tensor: Results of nan_to_num operation input Tensor ``x``.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -1681,7 +1786,7 @@ def nansum(
         Tensor: Results of summation operation on the specified axis of input Tensor `x`,
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -1689,7 +1794,8 @@ def nansum(
             >>> #    [[nan, 0.3, 0.5, 0.9]
             >>> #     [0.1, 0.2, -nan, 0.7]]
             >>> # Each example is followed by the corresponding output tensor.
-            >>> x = paddle.to_tensor([[float('nan'), 0.3, 0.5, 0.9], [0.1, 0.2, float('-nan'), 0.7]], dtype="float32")
+            >>> x = paddle.to_tensor([[float('nan'), 0.3, 0.5, 0.9],
+            ...                       [0.1, 0.2, float('-nan'), 0.7]],dtype="float32")
             >>> out1 = paddle.nansum(x)
             >>> out1
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -1712,12 +1818,8 @@ def nansum(
             >>> #      [[[1, nan], [3, 4]],
             >>> #       [[5, 6], [-nan, 8]]]
             >>> # Each example is followed by the corresponding output tensor.
-            >>> y = paddle.to_tensor(
-            ...     [
-            ...         [[1, float('nan')], [3, 4]],
-            ...         [[5, 6], [float('-nan'), 8]],
-            ...     ]
-            ... )
+            >>> y = paddle.to_tensor([[[1, float('nan')], [3, 4]],
+            ...                       [[5, 6], [float('-nan'), 8]]])
             >>> out5 = paddle.nansum(y, axis=[1, 2])
             >>> out5
             Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -1773,16 +1875,12 @@ def nanmean(
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> # x is a 2-D Tensor:
-            >>> x = paddle.to_tensor(
-            ...     [
-            ...         [float('nan'), 0.3, 0.5, 0.9],
-            ...         [0.1, 0.2, float('-nan'), 0.7],
-            ...     ]
-            ... )
+            >>> x = paddle.to_tensor([[float('nan'), 0.3, 0.5, 0.9],
+            ...                       [0.1, 0.2, float('-nan'), 0.7]])
             >>> out1 = paddle.nanmean(x)
             >>> out1
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -1806,12 +1904,8 @@ def nanmean(
              [0.33333334]])
 
             >>> # y is a 3-D Tensor:
-            >>> y = paddle.to_tensor(
-            ...     [
-            ...         [[1, float('nan')], [3, 4]],
-            ...         [[5, 6], [float('-nan'), 8]],
-            ...     ]
-            ... )
+            >>> y = paddle.to_tensor([[[1, float('nan')], [3, 4]],
+            ...                       [[5, 6], [float('-nan'), 8]]])
             >>> out6 = paddle.nanmean(y, axis=[1, 2])
             >>> out6
             Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -1863,17 +1957,11 @@ def count_nonzero(
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> # x is a 2-D Tensor:
-            >>> x = paddle.to_tensor(
-            ...     [
-            ...         [0.0, 1.1, 1.2],
-            ...         [0.0, 0.0, 1.3],
-            ...         [0.0, 0.0, 0.0],
-            ...     ]
-            ... )
+            >>> x = paddle.to_tensor([[0., 1.1, 1.2], [0., 0., 1.3], [0., 0., 0.]])
             >>> out1 = paddle.count_nonzero(x)
             >>> out1
             Tensor(shape=[], dtype=int64, place=Place(cpu), stop_gradient=True,
@@ -1898,12 +1986,8 @@ def count_nonzero(
              [0]])
 
             >>> # y is a 3-D Tensor:
-            >>> y = paddle.to_tensor(
-            ...     [
-            ...         [[0.0, 1.1, 1.2], [0.0, 0.0, 1.3], [0.0, 0.0, 0.0]],
-            ...         [[0.0, 2.5, 2.6], [0.0, 0.0, 2.4], [2.1, 2.2, 2.3]],
-            ...     ]
-            ... )
+            >>> y = paddle.to_tensor([[[0., 1.1, 1.2], [0., 0., 1.3], [0., 0., 0.]],
+            ...                         [[0., 2.5, 2.6], [0., 0., 2.4], [2.1, 2.2, 2.3]]])
             >>> out6 = paddle.count_nonzero(y, axis=[1, 2])
             >>> out6
             Tensor(shape=[2], dtype=int64, place=Place(cpu), stop_gradient=True,
@@ -1969,7 +2053,7 @@ def add_n(inputs: Tensor | Sequence[Tensor], name: str | None = None) -> Tensor:
         Tensor, the sum of input :math:`inputs` , its shape and data types are consistent with :math:`inputs`.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -2048,7 +2132,7 @@ def trunc(input: Tensor, name: str | None = None) -> Tensor:
         Tensor: The output Tensor of trunc.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -2143,7 +2227,7 @@ def mm(input: Tensor, mat2: Tensor, name: str | None = None) -> Tensor:
         out: [1]
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> input = paddle.arange(1, 7).reshape((3, 2)).astype('float32')
@@ -2209,6 +2293,375 @@ def mm(input: Tensor, mat2: Tensor, name: str | None = None) -> Tensor:
         return out
 
 
+def addmm(
+    input: Tensor,
+    x: Tensor,
+    y: Tensor,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+    name: str | None = None,
+) -> Tensor:
+    """
+    **addmm**
+
+    Perform matrix multiplication for input $x$ and $y$.
+    $input$ is added to the final result.
+    The equation is:
+
+    ..  math::
+        Out = alpha * x * y + beta * input
+
+    $Input$, $x$ and $y$ can carry the LoD (Level of Details) information, or not. But the output only shares the LoD information with input $input$.
+
+    Args:
+        input (Tensor): The input Tensor to be added to the final result.
+        x (Tensor): The first input Tensor for matrix multiplication.
+        y (Tensor): The second input Tensor for matrix multiplication.
+        beta (float, optional): Coefficient of $input$, default is 1.
+        alpha (float, optional): Coefficient of $x*y$, default is 1.
+        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        Tensor: The output Tensor of addmm.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> x = paddle.ones([2, 2])
+            >>> y = paddle.ones([2, 2])
+            >>> input = paddle.ones([2, 2])
+
+            >>> out = paddle.addmm(input=input, x=x, y=y, beta=0.5, alpha=5.0)
+
+            >>> print(out)
+            Tensor(shape=[2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [[10.50000000, 10.50000000],
+             [10.50000000, 10.50000000]])
+    """
+    input_shape = input.shape
+    x_shape = x.shape
+    y_shape = y.shape
+    if not len(x_shape) == len(y_shape) == 2:
+        raise ValueError(
+            f"The dimension of x, y should be 2 but receive x's shape: {x_shape}, y's shape: {y_shape}"
+        )
+    if x_shape[1] != y_shape[0]:
+        raise ValueError(
+            f"The input Variable x's width must be equal with Variable y' height. But received x's shape = {x_shape}, y's shape = {y_shape}."
+        )
+    if len(input_shape) == 2:
+        if input_shape[0] != x_shape[0]:
+            if input_shape[0] != 1:
+                raise ValueError(
+                    f"When x's dimension[0] is not equal with input's dimension[0], input's dimension[0] must be 1 but got {input_shape[0]}"
+                )
+            if input_shape[1] != y_shape[1] and input_shape[1] != 1:
+                raise ValueError(
+                    f"When y's dimension[1] is not equal with input's dimension[1], input's dimension[1] must be 1 but got {input_shape[1]}"
+                )
+        if input_shape[1] != y_shape[1]:
+            if input_shape[1] != 1:
+                raise ValueError(
+                    f"When y's dimension[1] is not equal with input's dimension[1], input's dimension[1] must be 1 but got {input_shape[1]}"
+                )
+    elif len(input_shape) == 1:
+        if input_shape[0] not in (y_shape[1], 1):
+            raise ValueError(
+                f"The input's shape: {input_shape} is not broadcastable with [x.shape[0], y.shape[1]]: [{x_shape[0]},{y_shape[1]}]"
+            )
+    else:
+        raise ValueError(
+            f"The dimension of input should be 2 or 1 but receive input's shape: {input_shape}"
+        )
+
+    if in_dynamic_or_pir_mode():
+        return _C_ops.addmm(input, x, y, beta, alpha)
+    else:
+        inputs = {'Input': input, "X": x, "Y": y}
+        attrs = {'Alpha': alpha, 'Beta': beta}
+
+        helper = LayerHelper("addmm", **locals())
+        check_variable_and_dtype(
+            input, 'Input', ['float16', 'float32', 'float64', 'uint16'], 'addmm'
+        )
+        check_variable_and_dtype(
+            x, 'X', ['float16', 'float32', 'float64', 'uint16'], 'addmm'
+        )
+        check_variable_and_dtype(
+            y, 'Y', ['float16', 'float32', 'float64', 'uint16'], 'addmm'
+        )
+        out = helper.create_variable_for_type_inference(dtype=x.dtype)
+
+        helper.append_op(
+            type="addmm", inputs=inputs, attrs=attrs, outputs={"Out": out}
+        )
+        return out
+
+
+@inplace_apis_in_dygraph_only
+def addmm_(
+    input: Tensor,
+    x: Tensor,
+    y: Tensor,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+    name: str | None = None,
+) -> Tensor:
+    """
+    Inplace version of ``addmm`` API, the output Tensor will be inplaced with input ``input``.
+    Please refer to :ref:`api_paddle_addmm`.
+    """
+    input_shape = input.shape
+    x_shape = x.shape
+    y_shape = y.shape
+    if not len(x_shape) == len(y_shape) == 2:
+        raise ValueError(
+            f"The dimension of x, y should be 2 but receive x's shape: {x_shape}, y's shape: {y_shape}"
+        )
+    if x_shape[1] != y_shape[0]:
+        raise ValueError(
+            f"The input Variable x's width must be equal with Variable y' height. But received x's shape = {x_shape}, y's shape = {y_shape}."
+        )
+    if len(input_shape) == 2:
+        if input_shape[0] != x_shape[0]:
+            if input_shape[0] != 1:
+                raise ValueError(
+                    f"When x's dimension[0] is not equal with input's dimension[0], input's dimension[0] must be 1 but got {input_shape[0]}"
+                )
+            if input_shape[1] != y_shape[1] and input_shape[1] != 1:
+                raise ValueError(
+                    f"When y's dimension[1] is not equal with input's dimension[1], input's dimension[1] must be 1 but got {input_shape[1]}"
+                )
+        if input_shape[1] != y_shape[1]:
+            if input_shape[1] != 1:
+                raise ValueError(
+                    f"When y's dimension[1] is not equal with input's dimension[1], input's dimension[1] must be 1 but got {input_shape[1]}"
+                )
+    elif len(input_shape) == 1:
+        if input_shape[0] not in (y_shape[1], 1):
+            raise ValueError(
+                f"The input's shape: {input_shape} is not broadcastable with [x.shape[0], y.shape[1]]: [{x_shape[0]},{y_shape[1]}]"
+            )
+    else:
+        raise ValueError(
+            f"The dimension of input should be 2 or 1 but receive input's shape: {input_shape}"
+        )
+
+    if in_dynamic_mode():
+        return _C_ops.addmm_(input, x, y, beta, alpha)
+
+
+def baddbmm(
+    input: Tensor,
+    x: Tensor,
+    y: Tensor,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+    name: str | None = None,
+) -> Tensor:
+    """
+    **baddbmm**
+
+    Perform batch matrix multiplication for input $x$ and $y$.
+    $input$ is added to the final result.
+    The equation is:
+
+    ..  math::
+        Out = alpha * x * y + beta * input
+
+    $Input$, $x$ and $y$ can carry the LoD (Level of Details) information, or not. But the output only shares the LoD information with input $input$.
+
+    Args:
+        input (Tensor): The input Tensor to be added to the final result.
+        x (Tensor): The first input Tensor for batch matrix multiplication.
+        y (Tensor): The second input Tensor for batch matrix multiplication.
+        beta (float, optional): Coefficient of $input$, default is 1.
+        alpha (float, optional): Coefficient of $x*y$, default is 1.
+        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        Tensor: The output Tensor of baddbmm.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> x = paddle.ones([2, 2, 2])
+            >>> y = paddle.ones([2, 2, 2])
+            >>> input = paddle.ones([2, 2, 2])
+
+            >>> out = paddle.baddbmm(input=input, x=x, y=y, beta=0.5, alpha=5.0)
+
+            >>> out
+            Tensor(shape=[2, 2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [[[10.50000000, 10.50000000],
+              [10.50000000, 10.50000000]],
+             [[10.50000000, 10.50000000],
+              [10.50000000, 10.50000000]]])
+    """
+    input_shape = input.shape
+    x_shape = x.shape
+    y_shape = y.shape
+    if not len(x_shape) == len(y_shape) == 3:
+        raise ValueError(
+            f"The dimension of x, y should be 3 but receive x's shape: {x_shape}, y's shape: {y_shape}"
+        )
+    if x_shape[2] != y_shape[1]:
+        raise ValueError(
+            f"The input Variable x's width must be equal with Variable y's height. But received x's shape = {x_shape}, y's shape = {y_shape}."
+        )
+
+    if len(input_shape) == 3:
+        if input_shape[0] != x_shape[0]:
+            if input_shape[0] != 1:
+                raise ValueError(
+                    f"If input's dimension[0] is not equal to x's dimension[0], input's dimension[0] must be 1. But received input's dimension[0] = {input_shape[0]}, x's dimension[0] = {x_shape[0]}"
+                )
+            else:
+                if not (
+                    input_shape[1] == x_shape[1] or input_shape[1] == 1
+                ) or not (input_shape[2] == y_shape[2] or input_shape[2] == 1):
+                    raise ValueError(
+                        f"If input's dimension[0] is 1, input's dimension[1] and dimension[2] must be equal to x's dimension[1] and y's dimension[2] respectively, or they must be 1. But received input's shape = {input_shape}, x's shape = {x_shape}, y's shape = {y_shape}"
+                    )
+
+        if input_shape[1] != x_shape[1]:
+            if input_shape[1] != 1:
+                raise ValueError(
+                    f"If input's dimension[1] is not equal to x's dimension[1], input's dimension[1] must be 1. But received input's dimension[1] = {input_shape[1]}, x's dimension[1] = {x_shape[1]}"
+                )
+            else:
+                if not (
+                    input_shape[0] == x_shape[0] or input_shape[0] == 1
+                ) or not (input_shape[2] == y_shape[2] or input_shape[2] == 1):
+                    raise ValueError(
+                        f"If input's dimension[1] is 1, input's dimension[0] and dimension[2] must be equal to x's dimension[0] and y's dimension[2] respectively, or they must be 1. But received input's shape = {input_shape}, x's shape = {x_shape}, y's shape = {y_shape}"
+                    )
+
+        if input_shape[2] != y_shape[2]:
+            if input_shape[2] != 1:
+                raise ValueError(
+                    f"If input's dimension[2] is not equal to y's dimension[2], input's dimension[2] must be 1. But received input's dimension[2] = {input_shape[2]}, y's dimension[2] = {y_shape[2]}"
+                )
+    elif len(input_shape) == 2:
+        if input_shape[0] != x_shape[0]:
+            raise ValueError(
+                f"The batch size of input must be equal to the batch size of x. But received input's batch size = {input_shape[0]}, x's batch size = {x_shape[0]}"
+            )
+        if input_shape[1] not in (y_shape[2], 1):
+            raise ValueError(
+                f"The input's shape: {input_shape} is not broadcastable with [x.shape[0], x.shape[1], y.shape[2]]: [{x_shape[0]},{x_shape[1]},{y_shape[2]}]"
+            )
+    else:
+        raise ValueError(
+            f"The dimension of input should be 3 or 2 but received input's shape: {input_shape}"
+        )
+
+    if in_dynamic_or_pir_mode():
+        return _C_ops.baddbmm(input, x, y, beta, alpha)
+    else:
+        inputs = {'Input': input, "X": x, "Y": y}
+        attrs = {'Alpha': alpha, 'Beta': beta}
+
+        helper = LayerHelper("baddbmm", **locals())
+        check_variable_and_dtype(
+            input,
+            'Input',
+            ['float16', 'float32', 'float64', 'uint16'],
+            'baddbmm',
+        )
+        check_variable_and_dtype(
+            x, 'X', ['float16', 'float32', 'float64', 'uint16'], 'baddbmm'
+        )
+        check_variable_and_dtype(
+            y, 'Y', ['float16', 'float32', 'float64', 'uint16'], 'baddbmm'
+        )
+        out = helper.create_variable_for_type_inference(dtype=x.dtype)
+
+        helper.append_op(
+            type="baddbmm", inputs=inputs, attrs=attrs, outputs={"Out": out}
+        )
+        return out
+
+
+@inplace_apis_in_dygraph_only
+def baddbmm_(
+    input: Tensor,
+    x: Tensor,
+    y: Tensor,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+    name: str | None = None,
+) -> Tensor:
+    """
+    Inplace version of ``baddbmm`` API, the output Tensor will be inplaced with input ``input``.
+    Please refer to :ref:`api_paddle_baddbmm`.
+    """
+    input_shape = input.shape
+    x_shape = x.shape
+    y_shape = y.shape
+    if not len(x_shape) == len(y_shape) == 3:
+        raise ValueError(
+            f"The dimension of x, y should be 3 but receive x's shape: {x_shape}, y's shape: {y_shape}"
+        )
+    if x_shape[2] != y_shape[1]:
+        raise ValueError(
+            f"The input Variable x's width must be equal with Variable y's height. But received x's shape = {x_shape}, y's shape = {y_shape}."
+        )
+
+    if len(input_shape) == 3:
+        if input_shape[0] != x_shape[0]:
+            if input_shape[0] != 1:
+                raise ValueError(
+                    f"If input's dimension[0] is not equal to x's dimension[0], input's dimension[0] must be 1. But received input's dimension[0] = {input_shape[0]}, x's dimension[0] = {x_shape[0]}"
+                )
+            else:
+                if not (
+                    input_shape[1] == x_shape[1] or input_shape[1] == 1
+                ) or not (input_shape[2] == y_shape[2] or input_shape[2] == 1):
+                    raise ValueError(
+                        f"If input's dimension[0] is 1, input's dimension[1] and dimension[2] must be equal to x's dimension[1] and y's dimension[2] respectively, or they must be 1. But received input's shape = {input_shape}, x's shape = {x_shape}, y's shape = {y_shape}"
+                    )
+
+        if input_shape[1] != x_shape[1]:
+            if input_shape[1] != 1:
+                raise ValueError(
+                    f"If input's dimension[1] is not equal to x's dimension[1], input's dimension[1] must be 1. But received input's dimension[1] = {input_shape[1]}, x's dimension[1] = {x_shape[1]}"
+                )
+            else:
+                if not (
+                    input_shape[0] == x_shape[0] or input_shape[0] == 1
+                ) or not (input_shape[2] == y_shape[2] or input_shape[2] == 1):
+                    raise ValueError(
+                        f"If input's dimension[1] is 1, input's dimension[0] and dimension[2] must be equal to x's dimension[0] and y's dimension[2] respectively, or they must be 1. But received input's shape = {input_shape}, x's shape = {x_shape}, y's shape = {y_shape}"
+                    )
+
+        if input_shape[2] != y_shape[2]:
+            if input_shape[2] != 1:
+                raise ValueError(
+                    f"If input's dimension[2] is not equal to y's dimension[2], input's dimension[2] must be 1. But received input's dimension[2] = {input_shape[2]}, y's dimension[2] = {y_shape[2]}"
+                )
+    elif len(input_shape) == 2:
+        if input_shape[0] != x_shape[0]:
+            raise ValueError(
+                f"The batch size of input must be equal to the batch size of x. But received input's batch size = {input_shape[0]}, x's batch size = {x_shape[0]}"
+            )
+        if input_shape[1] not in (y_shape[2], 1):
+            raise ValueError(
+                f"The input's shape: {input_shape} is not broadcastable with [x.shape[0], x.shape[1], y.shape[2]]: [{x_shape[0]},{x_shape[1]},{y_shape[2]}]"
+            )
+    else:
+        raise ValueError(
+            f"The dimension of input should be 3 or 2 but received input's shape: {input_shape}"
+        )
+
+    if in_dynamic_mode():
+        return _C_ops.baddbmm_(input, x, y, beta, alpha)
+
+
 def renorm(x: Tensor, p: float, axis: int, max_norm: float) -> Tensor:
     """
     **renorm**
@@ -2230,14 +2683,12 @@ def renorm(x: Tensor, p: float, axis: int, max_norm: float) -> Tensor:
         Tensor: the renorm Tensor.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
-            >>> input = [
-            ...     [[2.0, 2.0, -2.0], [3.0, 0.3, 3.0]],
-            ...     [[2.0, -8.0, 2.0], [3.1, 3.7, 3.0]],
-            ... ]
-            >>> x = paddle.to_tensor(input, dtype='float32')
+            >>> input = [[[2.0, 2.0, -2.0], [3.0, 0.3, 3.0]],
+            ...          [[2.0, -8.0, 2.0], [3.1, 3.7, 3.0]]]
+            >>> x = paddle.to_tensor(input,dtype='float32')
             >>> y = paddle.renorm(x, 1.0, 2, 2.05)
             >>> print(y)
             Tensor(shape=[2, 2, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -2313,7 +2764,7 @@ def inner(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         Tensor: The inner-product Tensor, the output shape is x.shape[:-1] + y.shape[:-1].
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> x = paddle.arange(1, 7).reshape((2, 3)).astype('float32')
@@ -2380,7 +2831,7 @@ def inner(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
             return out.reshape(dstshape)
 
 
-@param_two_alias(["x", "input"], ["y", "vec2"])
+@ParamAliasDecorator({"x": ["input"], "y": ["vec2"]})
 def outer(
     x: Tensor,
     y: Tensor,
@@ -2410,7 +2861,7 @@ def outer(
         Tensor: The outer-product Tensor.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> x = paddle.arange(1, 4).astype('float32')
@@ -2442,6 +2893,63 @@ def outer(
         out = helper.create_variable_for_type_inference(dtype=nx.dtype)
         helper.append_op(
             type='matmul_v2', inputs={'X': nx, 'Y': ny}, outputs={'Out': out}
+        )
+        return out
+
+
+def inverse(x: Tensor, name: str | None = None) -> Tensor:
+    """
+    Takes the inverse of the square matrix. A square matrix is a matrix with
+    the same number of rows and columns. The input can be a square matrix
+    (2-D Tensor) or batches of square matrices.
+
+    Args:
+        x (Tensor): The input tensor. The last two
+            dimensions should be equal. When the number of dimensions is
+            greater than 2, it is treated as batches of square matrix. The data
+            type can be float32, float64, complex64, complex128.
+        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        Tensor: A Tensor holds the inverse of x. The shape and data type
+                        is the same as x.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> mat = paddle.to_tensor([[2, 0], [0, 2]], dtype='float32')
+            >>> inv = paddle.inverse(mat)
+            >>> print(inv)
+            Tensor(shape=[2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [[0.50000000, 0.        ],
+             [0.        , 0.50000000]])
+
+    """
+    if in_dynamic_or_pir_mode():
+        return _C_ops.inverse(x)
+    else:
+
+        def _check_input(x):
+            check_variable_and_dtype(
+                x,
+                'x',
+                ['float32', 'float64', 'complex64', 'complex128'],
+                'inverse',
+            )
+            if len(x.shape) < 2:
+                raise ValueError(
+                    "The input of inverse is expected to be a Tensor whose number "
+                    f"of dimensions is no less than 2. But received: {len(x.shape)}, "
+                    f"x's shape: {x.shape}."
+                )
+
+        _check_input(x)
+        helper = LayerHelper('inverse', **locals())
+        out = helper.create_variable_for_type_inference(dtype=x.dtype)
+        helper.append_op(
+            type='inverse', inputs={'Input': [x]}, outputs={'Output': [out]}
         )
         return out
 
@@ -2486,13 +2994,15 @@ def max(
         it's data type is the same as `x`.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
             >>> # data_x is a Tensor with shape [2, 4]
             >>> # the axis is a int element
-            >>> x = paddle.to_tensor([[0.2, 0.3, 0.5, 0.9], [0.1, 0.2, 0.6, 0.7]], dtype='float64', stop_gradient=False)
+            >>> x = paddle.to_tensor([[0.2, 0.3, 0.5, 0.9],
+            ...                       [0.1, 0.2, 0.6, 0.7]],
+            ...                       dtype='float64', stop_gradient=False)
             >>> result1 = paddle.max(x)
             >>> result1.backward()
             >>> result1
@@ -2539,14 +3049,9 @@ def max(
 
             >>> # data_y is a Tensor with shape [2, 2, 2]
             >>> # the axis is list
-            >>> y = paddle.to_tensor(
-            ...     [
-            ...         [[1.0, 2.0], [3.0, 4.0]],
-            ...         [[5.0, 6.0], [7.0, 8.0]],
-            ...     ],
-            ...     dtype='float64',
-            ...     stop_gradient=False,
-            ... )
+            >>> y = paddle.to_tensor([[[1.0, 2.0], [3.0, 4.0]],
+            ...                         [[5.0, 6.0], [7.0, 8.0]]],
+            ...                         dtype='float64', stop_gradient=False)
             >>> result5 = paddle.max(y, axis=[1, 2])
             >>> result5.backward()
             >>> result5
@@ -2653,20 +3158,15 @@ def min(
         it's data type is the same as input's Tensor.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
             >>> # data_x is a Tensor with shape [2, 4]
             >>> # the axis is a int element
-            >>> x = paddle.to_tensor(
-            ...     [
-            ...         [0.2, 0.3, 0.5, 0.9],
-            ...         [0.1, 0.2, 0.6, 0.7],
-            ...     ],
-            ...     dtype='float64',
-            ...     stop_gradient=False,
-            ... )
+            >>> x = paddle.to_tensor([[0.2, 0.3, 0.5, 0.9],
+            ...                       [0.1, 0.2, 0.6, 0.7]],
+            ...                       dtype='float64', stop_gradient=False)
             >>> result1 = paddle.min(x)
             >>> result1.backward()
             >>> result1
@@ -2713,14 +3213,9 @@ def min(
 
             >>> # data_y is a Tensor with shape [2, 2, 2]
             >>> # the axis is list
-            >>> y = paddle.to_tensor(
-            ...     [
-            ...         [[1.0, 2.0], [3.0, 4.0]],
-            ...         [[5.0, 6.0], [7.0, 8.0]],
-            ...     ],
-            ...     dtype='float64',
-            ...     stop_gradient=False,
-            ... )
+            >>> y = paddle.to_tensor([[[1.0, 2.0], [3.0, 4.0]],
+            ...                       [[5.0, 6.0], [7.0, 8.0]]],
+            ...                       dtype='float64', stop_gradient=False)
             >>> result5 = paddle.min(y, axis=[1, 2])
             >>> result5.backward()
             >>> result5
@@ -2844,7 +3339,7 @@ def clip(
 
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -2971,14 +3466,14 @@ def clip_(
     Inplace version of ``clip`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_clip`.
     """
-    min_ = float(np.finfo(np.float32).min)
-    max_ = float(np.finfo(np.float32).max)
+    fmin = float(np.finfo(np.float32).min)
+    fmax = float(np.finfo(np.float32).max)
     if isinstance(min, Variable):
         min = min.item(0)
     if isinstance(max, Variable):
         max = max.item(0)
-    min = min_ if min is None else min
-    max = max_ if max is None else max
+    min = fmin if min is None else min
+    max = fmax if max is None else max
 
     if in_dynamic_mode():
         return _C_ops.clip_(x, min, max)
@@ -3118,7 +3613,7 @@ def kron(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         Tensor: The output of kron, data type: bfloat16, float16, float32, float64, int32 or int64. Its data is the same with x.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> x = paddle.to_tensor([[1, 2], [3, 4]], dtype='int64')
@@ -3189,7 +3684,7 @@ def cumsum(
         Tensor, the result of cumsum operator.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -3266,8 +3761,6 @@ def cumsum(
         return _cum_sum_(**kwargs)
 
 
-# Edit by AI Agent
-@param_one_alias(["axis", "dim"])
 @inplace_apis_in_dygraph_only
 def cumsum_(
     x: Tensor,
@@ -3278,9 +3771,6 @@ def cumsum_(
     r"""
     Inplace version of ``cumprod`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_cumprod`.
-
-    .. note::
-        Alias Support: The parameter name ``dim`` can be used as an alias for ``axis``.
     """
     if axis is None:
         flatten = True
@@ -3298,11 +3788,14 @@ def cumsum_(
         return _C_ops.cumsum_(x, axis, flatten, False, False)
 
 
+@param_two_alias(["x", "input"], ["axis", "dim"])
 def cummax(
     x: Tensor,
     axis: int | None = None,
     dtype: DTypeLike = 'int64',
     name: str | None = None,
+    *,
+    out: tuple[Tensor, Tensor] | None = None,
 ) -> tuple[Tensor, Tensor]:
     """
     The cumulative max of the elements along a given axis.
@@ -3315,6 +3808,7 @@ def cummax(
         axis (int, optional): The dimension to accumulate along. -1 means the last dimension. The default (None) is to compute the cummax over the flattened array.
         dtype (str|paddle.dtype|np.dtype, optional): The data type of the indices tensor, can be int32, int64. The default value is int64.
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+        out (tuple[Tensor, Tensor]|None, optional): The output tensors. A tuple of (values, indices). Default is None.
 
     Returns:
         out (Tensor), The result of cummax operation. The dtype of cummax result is same with input x.
@@ -3369,7 +3863,7 @@ def cummax(
         dtype = convert_np_dtype_to_dtype_(dtype)
 
     if in_dynamic_or_pir_mode():
-        return _C_ops.cummax(x, axis, dtype)
+        values, indices = _C_ops.cummax(x, axis, dtype)
     else:
         check_variable_and_dtype(
             x,
@@ -3379,15 +3873,20 @@ def cummax(
         )
         check_type(x, 'x', (Variable), 'cummax')
         helper = LayerHelper('cummax', **locals())
-        out = helper.create_variable_for_type_inference(x.dtype)
+        values = helper.create_variable_for_type_inference(x.dtype)
         indices = helper.create_variable_for_type_inference(dtype='int64')
         helper.append_op(
             type='cummax',
             inputs={'x': x},
-            outputs={'out': out, 'indices': indices},
+            outputs={'out': values, 'indices': indices},
             attrs={'axis': axis, 'dtype': dtype},
         )
-        return out, indices
+
+    if out is not None:
+        paddle.assign(values, out[0])
+        paddle.assign(indices, out[1])
+
+    return values, indices
 
 
 def cummin(
@@ -3414,7 +3913,7 @@ def cummin(
         indices (Tensor), The corresponding index results of cummin operation.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> data = paddle.to_tensor([-1, 5, 0, -2, -3, 2])
@@ -3510,7 +4009,7 @@ def logcumsumexp(
         Tensor, the result of logcumsumexp operator (integer input types are autocasted into float32).
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -3585,10 +4084,10 @@ def logcumsumexp(
 def cumprod(
     x: Tensor,
     dim: int | None = None,
-    dtype: DTypeLike | None = None,
-    name: str | None = None,
     *,
+    dtype: DTypeLike | None = None,
     out: Tensor | None = None,
+    name: str | None = None,
 ) -> Tensor:
     """
     Compute the cumulative product of the input tensor x along a given dimension dim.
@@ -3604,15 +4103,15 @@ def cumprod(
         dtype (str|core.VarDesc.VarType|core.DataType|np.dtype, optional): The data type of the output tensor, can be bfloat16, float16, float32, float64, int32, int64,
                     complex64, complex128. If specified, the input tensor is casted to dtype before the operation is performed.
                     This is useful for preventing data type overflows. The default value is None.
+        out (Tensor|None, optional): The output tensor. Default: None.
         name (str|None, optional): Name for the operation (optional, default is None). For more information,
                     please refer to :ref:`api_guide_Name`.
-        out (Tensor|None, optional): The output tensor. Default: None.
 
     Returns:
         Tensor, the result of cumprod operator.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -3750,17 +4249,13 @@ def prod(
         Tensor, result of product on the specified dim of input tensor.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
             >>> # the axis is a int element
-            >>> x = paddle.to_tensor(
-            ...     [
-            ...         [0.2, 0.3, 0.5, 0.9],
-            ...         [0.1, 0.2, 0.6, 0.7],
-            ...     ]
-            ... )
+            >>> x = paddle.to_tensor([[0.2, 0.3, 0.5, 0.9],
+            ...                       [0.1, 0.2, 0.6, 0.7]])
             >>> out1 = paddle.prod(x)
             >>> out1
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -3787,12 +4282,8 @@ def prod(
             [0, 0, 0, 0])
 
             >>> # the axis is list
-            >>> y = paddle.to_tensor(
-            ...     [
-            ...         [[1.0, 2.0], [3.0, 4.0]],
-            ...         [[5.0, 6.0], [7.0, 8.0]],
-            ...     ]
-            ... )
+            >>> y = paddle.to_tensor([[[1.0, 2.0], [3.0, 4.0]],
+            ...                         [[5.0, 6.0], [7.0, 8.0]]])
             >>> out6 = paddle.prod(y, [0, 1])
             >>> out6
             Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -3882,7 +4373,7 @@ def increment(x: Tensor, value: float = 1.0, name: str | None = None) -> Tensor:
         Tensor, the elementwise-incremented tensor with the same shape and data type as :attr:`x`.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -3930,7 +4421,7 @@ def broadcast_shapes(*shapes: Sequence[int]) -> list[int]:
         list[int], the result shape.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -3980,7 +4471,7 @@ def broadcast_shape(
         list[int], the result shape.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -3996,6 +4487,64 @@ def broadcast_shape(
     return core.broadcast_shape(x_shape, y_shape)
 
 
+def conj(x: Tensor, name: str | None = None) -> Tensor:
+    r"""
+    This function computes the conjugate of the Tensor elementwisely.
+
+    Args:
+        x (Tensor): The input Tensor which hold the complex numbers.
+            Optional data types are: bfloat16, float16, complex64, complex128, float32, float64, int32 or int64.
+        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        out (Tensor): The conjugate of input. The shape and data type is the same with input. If the elements of tensor is real type such as float32, float64, int32 or int64, the out is the same with input.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> data = paddle.to_tensor([[1+1j, 2+2j, 3+3j], [4+4j, 5+5j, 6+6j]])
+            >>> data
+            Tensor(shape=[2, 3], dtype=complex64, place=Place(cpu), stop_gradient=True,
+            [[(1+1j), (2+2j), (3+3j)],
+             [(4+4j), (5+5j), (6+6j)]])
+
+            >>> conj_data = paddle.conj(data)
+            >>> conj_data
+            Tensor(shape=[2, 3], dtype=complex64, place=Place(cpu), stop_gradient=True,
+            [[(1-1j), (2-2j), (3-3j)],
+             [(4-4j), (5-5j), (6-6j)]])
+
+    """
+    if in_dynamic_or_pir_mode():
+        return _C_ops.conj(x)
+    else:
+        check_variable_and_dtype(
+            x,
+            "x",
+            [
+                'complex64',
+                'complex128',
+                'float16',
+                'uint16',
+                'float32',
+                'float64',
+                'int32',
+                'int64',
+            ],
+            'conj',
+        )
+
+        helper = LayerHelper('conj', **locals())
+        out = helper.create_variable_for_type_inference(
+            dtype=helper.input_dtype()
+        )
+
+        helper.append_op(type='conj', inputs={'X': x}, outputs={'Out': [out]})
+        return out
+
+
 def gammaln(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     Calculates the logarithm of the absolute value of the gamma function elementwisely.
@@ -4008,7 +4557,7 @@ def gammaln(x: Tensor, name: str | None = None) -> Tensor:
         Tensor, The values of the logarithm of the absolute value of the gamma at the given tensor x.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -4016,8 +4565,8 @@ def gammaln(x: Tensor, name: str | None = None) -> Tensor:
             >>> out = paddle.gammaln(x)
             >>> print(out)
             Tensor(shape=[6], dtype=float32, place=Place(cpu), stop_gradient=True,
-                [-0.12078223,  0.        ,  0.28468287,  0.69314718,  1.20097363,
-                 1.79175949])
+                [-0.12078224,  0.        ,  0.28468287,  0.69314718,  1.20097363,
+                    1.79175949])
     """
     if in_dynamic_or_pir_mode():
         return _C_ops.gammaln(x)
@@ -4057,7 +4606,7 @@ def digamma(x: Tensor, name: str | None = None) -> Tensor:
             (integer types are autocasted into float32).
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -4066,7 +4615,7 @@ def digamma(x: Tensor, name: str | None = None) -> Tensor:
             >>> res
             Tensor(shape=[2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
             [[-0.57721591,  0.03648996],
-             [-inf.      ,  5.32286835]])
+             [ nan       ,  5.32286835]])
     """
 
     if in_dynamic_or_pir_mode():
@@ -4119,7 +4668,7 @@ def gammaincc(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         Tensor, the gammaincc of the input Tensor.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -4128,7 +4677,7 @@ def gammaincc(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
             >>> out = paddle.gammaincc(x, y)
             >>> print(out)
             Tensor(shape=[5], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [1.        , 0.15729916, 0.00000774, 0.00000000, 0.        ])
+                [1.        , 0.15729916, 0.00000774, 0.        , 0.        ])
     """
     if not isinstance(x, Value) and not paddle.all(
         paddle.greater_equal(x, paddle.zeros_like(x))
@@ -4180,7 +4729,7 @@ def gammainc(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         Tensor, the gammainc of the input Tensor.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -4189,7 +4738,7 @@ def gammainc(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
             >>> out = paddle.gammainc(x, y)
             >>> print(out)
             Tensor(shape=[5], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [0.        , 0.84270084, 0.99999225, 1.        , 1.        ])
+                [0.        , 0.84270084, 0.99999225, 1.        , 1.        ])
     """
     return 1 - paddle.gammaincc(x, y)
 
@@ -4225,7 +4774,7 @@ def lgamma(x: Tensor, name: str | None = None) -> Tensor:
             (integer types are autocasted into float32).
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -4233,7 +4782,7 @@ def lgamma(x: Tensor, name: str | None = None) -> Tensor:
             >>> out = paddle.lgamma(x)
             >>> out
             Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [1.31452465, 1.76149750, 2.25271273, 1.09579802])
+            [1.31452453, 1.76149762, 2.25271273, 1.09579790])
     """
     if in_dynamic_or_pir_mode():
         return _C_ops.lgamma(x)
@@ -4283,7 +4832,7 @@ def multigammaln(x: Tensor, p: int, name: str | None = None) -> Tensor:
         out (Tensor): The values of the log multivariate gamma at the given tensor x.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -4292,8 +4841,8 @@ def multigammaln(x: Tensor, p: int, name: str | None = None) -> Tensor:
             >>> out = paddle.multigammaln(x, p)
             >>> print(out)
             Tensor(shape=[7], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [0.85704780  , 2.46648574  , 3.56509781  , 11.02241898 , 15.84497738 ,
-             26.09257889 , 170.68318176])
+                [0.85704780  , 2.46648574  , 3.56509781  , 11.02241898 , 15.84497833 ,
+                    26.09257698 , 170.68318176])
     """
     assert p >= 1, (
         f"The p must be greater than or equal to 1, But received p is {p}.\n"
@@ -4332,7 +4881,7 @@ def neg(x: Tensor, name: str | None = None) -> Tensor:
         out (Tensor): The negative of input Tensor. The shape and data type are the same with input Tensor.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -4376,7 +4925,7 @@ def positive(x: Tensor, name: str | None = None) -> Tensor:
                 is the same.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> x = paddle.to_tensor([-1, 0, 1])
@@ -4409,7 +4958,7 @@ def negative(x: Tensor, name: str | None = None) -> Tensor:
                 is the negative.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> x = paddle.to_tensor([-1, 0, 1])
@@ -4450,19 +4999,19 @@ def atan2(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         out (Tensor): An N-D Tensor, the shape and data type is the same with input (The output data type is float64 when the input data type is int).
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
             >>> x = paddle.to_tensor([-1, +1, +1, -1]).astype('float32')
             >>> x
             Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [-1.,  1.,  1., -1.])
+            [-1,  1,  1, -1])
 
             >>> y = paddle.to_tensor([-1, -1, +1, +1]).astype('float32')
             >>> y
             Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [-1., -1.,  1.,  1.])
+            [-1,  -1,  1, 1])
 
             >>> out = paddle.atan2(x, y)
             >>> out
@@ -4537,7 +5086,7 @@ def logit(
             (integer types are autocasted into float32).
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -4615,13 +5164,13 @@ def lerp(
         out (Tensor): An N-D Tensor, the shape and data type is the same with input.
 
     Example:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
-            >>> x = paddle.arange(1.0, 5.0, dtype='float32')
+            >>> x = paddle.arange(1., 5., dtype='float32')
             >>> y = paddle.empty([4], dtype='float32')
-            >>> y.fill_(10.0)
+            >>> y.fill_(10.)
             >>> out = paddle.lerp(x, y, 0.5)
             >>> out
             Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -4629,10 +5178,7 @@ def lerp(
 
     """
     if isinstance(weight, float):
-        if x.is_cuda and in_dynamic_mode():
-            weight = paddle.full(shape=[], fill_value=weight, dtype="float64")
-        else:
-            weight = paddle.full(shape=[], fill_value=weight, dtype=x.dtype)
+        weight = paddle.full(shape=[], fill_value=weight, dtype=x.dtype)
 
     if in_dynamic_or_pir_mode():
         return _C_ops.lerp(x, y, weight)
@@ -4696,11 +5242,11 @@ def erfinv(x: Tensor, name: str | None = None) -> Tensor:
             (integer types are autocasted into float32).
 
     Example:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
-            >>> x = paddle.to_tensor([0, 0.5, -1.0], dtype="float32")
+            >>> x = paddle.to_tensor([0, 0.5, -1.], dtype="float32")
             >>> out = paddle.erfinv(x)
             >>> out
             Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -4759,7 +5305,7 @@ def rad2deg(x: Tensor, name: str | None = None) -> Tensor:
         out (Tensor): An N-D Tensor, the shape and data type is the same with input (The output data type is float32 when the input data type is int).
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> import math
@@ -4771,7 +5317,7 @@ def rad2deg(x: Tensor, name: str | None = None) -> Tensor:
             [ 180.02334595, -180.02334595,  359.98937988, -359.98937988,
               89.95437622 , -89.95437622 ])
 
-            >>> x2 = paddle.to_tensor(math.pi / 2)
+            >>> x2 = paddle.to_tensor(math.pi/2)
             >>> result2 = paddle.rad2deg(x2)
             >>> result2
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -4814,10 +5360,7 @@ def rad2deg(x: Tensor, name: str | None = None) -> Tensor:
         return out
 
 
-@param_one_alias(['x', 'input'])
-def deg2rad(
-    x: Tensor, name: str | None = None, *, out: Tensor | None = None
-) -> Tensor:
+def deg2rad(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     Convert each of the elements of input x from degrees to angles in radians.
 
@@ -4828,13 +5371,12 @@ def deg2rad(
     Args:
         x (Tensor): An N-D Tensor, the data type is float32, float64, int32, int64.
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
-        out (Tensor|None, optional): The output Tensor. If set, the result will be stored in this Tensor. Default is None.
 
     Returns:
         out (Tensor): An N-D Tensor, the shape and data type is the same with input (The output data type is float32 when the input data type is int).
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -4855,7 +5397,7 @@ def deg2rad(
     if in_dynamic_or_pir_mode():
         if convert_dtype(x.dtype) in ['int32', 'int64']:
             x = cast(x, dtype="float32")
-        return _C_ops.scale(x, deg2rad_scale, 0.0, True, out=out)
+        return _C_ops.scale(x, deg2rad_scale, 0.0, True)
     else:
         check_variable_and_dtype(
             x, 'x', ['int32', 'int64', 'float32', 'float64'], 'deg2rad'
@@ -4902,7 +5444,7 @@ def gcd(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         out (Tensor): An N-D Tensor, the data type is the same with input.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -5032,7 +5574,7 @@ def lcm(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
         out (Tensor): An N-D Tensor, the data type is the same with input.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -5093,7 +5635,7 @@ def lcm_(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     return out
 
 
-@param_two_alias(["x", "input"], ["axis", "dim"])
+@ParamAliasDecorator({"x": ["input"], "axis": ["dim"]})
 def diff(
     x: Tensor,
     n: int = 1,
@@ -5139,7 +5681,7 @@ def diff(
         Tensor: The output tensor with same dtype with x.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -5337,6 +5879,128 @@ def diff(
     return last_out
 
 
+def angle(x: Tensor, name: str | None = None) -> Tensor:
+    r"""
+    Element-wise angle of complex numbers. For non-negative real numbers, the angle is 0 while
+    for negative real numbers, the angle is :math:`\pi`, and NaNs are propagated..
+
+    Equation:
+        .. math::
+
+            angle(x)=arctan2(x.imag, x.real)
+
+    Args:
+        x (Tensor): An N-D Tensor, the data type is complex64, complex128, or float32, float64 .
+        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        Tensor: An N-D Tensor of real data type with the same precision as that of x's data type.
+
+    Examples:
+        .. code-block:: pycon
+
+            >>> import paddle
+
+            >>> x = paddle.to_tensor([-2, -1, 0, 1]).unsqueeze(-1).astype('float32')
+            >>> y = paddle.to_tensor([-2, -1, 0, 1]).astype('float32')
+            >>> z = x + 1j * y
+            >>> z
+            Tensor(shape=[4, 4], dtype=complex64, place=Place(cpu), stop_gradient=True,
+            [[(-2.00000000-2.00000000j), (-2.00000000-1.00000000j),
+              (-2.00000000+0.00000000j), (-2.00000000+1.00000000j)],
+             [(-1.00000000-2.00000000j), (-1.00000000-1.00000000j),
+              (-1.00000000+0.00000000j), (-1.00000000+1.00000000j)],
+             [(0.00000000-2.00000000j) , (0.00000000-1.00000000j) ,
+               (0.00000000+0.00000000j),  (0.00000000+1.00000000j)],
+             [ (1.00000000-2.00000000j),  (1.00000000-1.00000000j),
+               (1.00000000+0.00000000j),  (1.00000000+1.00000000j)]])
+
+            >>> theta = paddle.angle(z)
+            >>> theta
+            Tensor(shape=[4, 4], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [[-2.35619450, -2.67794514,  3.14159274,  2.67794514],
+             [-2.03444386, -2.35619450,  3.14159274,  2.35619450],
+             [-1.57079637, -1.57079637,  0.        ,  1.57079637],
+             [-1.10714877, -0.78539819,  0.        ,  0.78539819]])
+    """
+
+    if in_dynamic_or_pir_mode():
+        return _C_ops.angle(x)
+    else:
+        check_variable_and_dtype(
+            x,
+            'x',
+            [
+                'float16',
+                'float32',
+                'float64',
+                'complex64',
+                'complex128',
+                'uint16',
+            ],
+            'angle',
+        )
+        op_type = "angle"
+        helper = LayerHelper(op_type, **locals())
+        inputs = {"X": x}
+        out = helper.create_variable_for_type_inference(
+            dtype=_complex_to_real_dtype(x.dtype)
+        )
+        outputs = {"Out": out}
+        helper.append_op(type=op_type, inputs=inputs, outputs=outputs)
+        return out
+
+
+def heaviside(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
+    r"""
+    Computes the Heaviside step function determined by corresponding element in y for each element in x. The equation is
+
+    .. math::
+        heaviside(x, y)=
+            \left\{
+                \begin{array}{lcl}
+                0,& &\text{if} \ x < 0, \\
+                y,& &\text{if} \ x = 0, \\
+                1,& &\text{if} \ x > 0.
+                \end{array}
+            \right.
+
+    Note:
+        ``paddle.heaviside`` supports broadcasting. If you want know more about broadcasting, please refer to `Introduction to Tensor`_ .
+
+        .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
+
+    Args:
+        x (Tensor): The input tensor of Heaviside step function, it's data type should be bfloat16, float16, float32, float64, int32 or int64.
+        y (Tensor): The tensor that determines a Heaviside step function, it's data type should be bfloat16, float16, float32, float64, int32 or int64.
+        name (str|None, optional): Name for the operation (optional, default is None). Normally there is no need for user to set this property. For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        N-D Tensor. A location into which the result is stored. If x and y have different shapes and are broadcastable, the resulting tensor shape is the shape of x and y after broadcasting. If x, y have the same shape, its shape is the same as x and y.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+            >>> x = paddle.to_tensor([-0.5, 0, 0.5])
+            >>> y = paddle.to_tensor([0.1])
+            >>> paddle.heaviside(x, y)
+            Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [0.        , 0.10000000, 1.        ])
+            >>> x = paddle.to_tensor([[-0.5, 0, 0.5], [-0.5, 0.5, 0]])
+            >>> y = paddle.to_tensor([0.1, 0.2, 0.3])
+            >>> paddle.heaviside(x, y)
+            Tensor(shape=[2, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [[0.        , 0.20000000, 1.        ],
+             [0.        , 1.        , 0.30000001]])
+    """
+    if in_dynamic_or_pir_mode():
+        return _C_ops.heaviside(x, y)
+    else:
+        op_type = 'elementwise_heaviside'
+        return _elementwise_op(LayerHelper(op_type, **locals()))
+
+
 @param_one_alias(["x", "input"])
 def frac(
     x: Tensor, name: str | None = None, *, out: Tensor | None = None
@@ -5353,20 +6017,16 @@ def frac(
         Tensor: The output Tensor of frac.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
-            >>> input = paddle.to_tensor(
-            ...     [
-            ...         [12.22000003, -1.02999997],
-            ...         [-0.54999995, 0.66000003],
-            ...     ]
-            ... )
+            >>> input = paddle.to_tensor([[12.22000003, -1.02999997],
+            ...                           [-0.54999995, 0.66000003]])
             >>> output = paddle.frac(input)
             >>> output
             Tensor(shape=[2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [[ 0.22000027, -0.02999997],
+            [[ 0.22000003, -0.02999997],
              [-0.54999995,  0.66000003]])
     """
     if x.dtype not in [
@@ -5443,12 +6103,7 @@ def sgn(x: Tensor, name: str | None = None) -> Tensor:
 
             >>> import paddle
 
-            >>> x = paddle.to_tensor(
-            ...     [
-            ...         [3 + 4j, 7 - 24j, 0, 1 + 2j],
-            ...         [6 + 8j, 3, 0, -2],
-            ...     ]
-            ... )
+            >>> x = paddle.to_tensor([[3 + 4j, 7 - 24j, 0, 1 + 2j], [6 + 8j, 3, 0, -2]])
             >>> paddle.sgn(x)
             Tensor(shape=[2, 4], dtype=complex64, place=Place(cpu), stop_gradient=True,
             [[ (0.60000002+0.80000001j),  (0.28000000-0.95999998j),
@@ -5511,7 +6166,7 @@ def take(
         Tensor, Tensor with the same shape as index, the data type is the same with input.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -5618,7 +6273,7 @@ def frexp(x: Tensor, name: str | None = None) -> tuple[Tensor, Tensor]:
             the same as those of input.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -5770,7 +6425,7 @@ def trapezoid(
         If :attr:`y` is a 1D tensor, then the result is a float. If N is greater than 1, then the result is an (N-1)-D tensor.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -5780,7 +6435,7 @@ def trapezoid(
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             10.)
 
-            >>> paddle.trapezoid(y, dx=2.0)
+            >>> paddle.trapezoid(y, dx=2.)
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             20.)
 
@@ -5833,7 +6488,7 @@ def cumulative_trapezoid(
         The result is an N-D tensor.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -5843,7 +6498,7 @@ def cumulative_trapezoid(
             Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,
             [4.50000000, 10.       ])
 
-            >>> paddle.cumulative_trapezoid(y, dx=2.0)
+            >>> paddle.cumulative_trapezoid(y, dx=2.)
             >>> # Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,
             >>> #        [9. , 20.])
 
@@ -5899,36 +6554,36 @@ def vander(
         If increasing is True, the columns are :math:`x^0`, :math:`x^1`, ..., :math:`x^{(N-1)}`.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
-            >>> x = paddle.to_tensor([1.0, 2.0, 3.0], dtype="float32")
+            >>> x = paddle.to_tensor([1., 2., 3.], dtype="float32")
             >>> out = paddle.vander(x)
             >>> out
             Tensor(shape=[3, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
             [[1., 1., 1.],
              [4., 2., 1.],
              [9., 3., 1.]])
-            >>> out1 = paddle.vander(x, 2)
+            >>> out1 = paddle.vander(x,2)
             >>> out1
             Tensor(shape=[3, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
             [[1., 1.],
              [2., 1.],
              [3., 1.]])
-            >>> out2 = paddle.vander(x, increasing=True)
+            >>> out2 = paddle.vander(x, increasing = True)
             >>> out2
             Tensor(shape=[3, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
             [[1., 1., 1.],
              [1., 2., 4.],
              [1., 3., 9.]])
-            >>> real = paddle.to_tensor([2.0, 4.0])
-            >>> imag = paddle.to_tensor([1.0, 3.0])
+            >>> real = paddle.to_tensor([2., 4.])
+            >>> imag = paddle.to_tensor([1., 3.])
             >>> complex = paddle.complex(real, imag)
             >>> out3 = paddle.vander(complex)
             >>> out3
             Tensor(shape=[2, 2], dtype=complex64, place=Place(cpu), stop_gradient=True,
-            [[(2.00000000+1.00000000j), (1.00000000+0.00000000j)],
-             [(4.00000000+3.00000000j), (1.00000000+0.00000000j)]])
+            [[(2+1j), (1+0j)],
+             [(4+3j), (1+0j)]])
     """
     check_variable_and_dtype(
         x,
@@ -5974,6 +6629,86 @@ def vander(
     return res
 
 
+def nextafter(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
+    r"""
+    Return the next floating-point value after input towards other, elementwise.
+    The shapes of input and other must be broadcastable.
+
+    Args:
+        x (Tensor): An N-D Tensor, the data type is float32, float64.
+        y (Tensor): An N-D Tensor, the data type is float32, float64.
+        name(str, optional):Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        out (Tensor): An N-D Tensor, the shape and data type is the same with input.
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+            >>> out = paddle.nextafter(paddle.to_tensor([1.0,2.0]),paddle.to_tensor([2.0,1.0]))
+            >>> out
+            Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [1.00000012, 1.99999988])
+    """
+    if in_dynamic_or_pir_mode():
+        return _C_ops.nextafter(x, y)
+    else:
+        check_variable_and_dtype(x, 'x', ['float32', 'float64'], 'nextafter')
+        check_variable_and_dtype(y, 'y', ['float32', 'float64'], 'nextafter')
+        op_type = "nextafter"
+        helper = LayerHelper(op_type, **locals())
+        inputs = {"x": x, "y": y}
+        out = helper.create_variable_for_type_inference(dtype=paddle.float32)
+        outputs = {"out": out}
+        helper.append_op(type=op_type, inputs=inputs, outputs=outputs)
+    return out
+
+
+def i0(x: Tensor, name: str | None = None) -> Tensor:
+    r"""
+    The function used to calculate modified bessel function of order 0.
+
+    Equation:
+        ..  math::
+
+            I_0(x) = \sum^{\infty}_{k=0}\frac{(x^2/4)^k}{(k!)^2}
+
+    Args:
+        x (Tensor): The input tensor, it's data type should be float32, float64,
+            uint8, int8, int16, int32, int64.
+        name (str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
+
+    Returns:
+        - out (Tensor), A Tensor. the value of the modified bessel function of order 0 at x
+            (integer types are autocasted into float32).
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> x = paddle.to_tensor([0, 1, 2, 3, 4], dtype="float32")
+            >>> paddle.i0(x)
+            Tensor(shape=[5], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [0.99999994 , 1.26606596 , 2.27958512 , 4.88079262 , 11.30192089])
+    """
+    if in_dynamic_or_pir_mode():
+        return _C_ops.i0(x)
+    else:
+        check_variable_and_dtype(
+            x,
+            "x",
+            ["float32", "float64", "uint8", "int8", "int16", "int32", "int64"],
+            "i0",
+        )
+
+        helper = LayerHelper("i0", **locals())
+        out = helper.create_variable_for_type_inference(dtype=x.dtype)
+        helper.append_op(type='i0', inputs={'x': x}, outputs={'out': out})
+    return out
+
+
 @inplace_apis_in_dygraph_only
 def i0_(x: Tensor, name: str | None = None) -> Tensor:
     r"""
@@ -5983,6 +6718,134 @@ def i0_(x: Tensor, name: str | None = None) -> Tensor:
 
     if in_dynamic_mode():
         return _C_ops.i0_(x)
+
+
+def i0e(x: Tensor, name: str | None = None) -> Tensor:
+    r"""
+    The function used to calculate exponentially scaled modified Bessel function of order 0.
+
+    Equation:
+        ..  math::
+
+            I_0(x) = \sum^{\infty}_{k=0}\frac{(x^2/4)^k}{(k!)^2} \\
+            I_{0e}(x) = e^{-|x|}I_0(x)
+
+    Args:
+        x (Tensor): The input tensor, it's data type should be float32, float64,
+            uint8, int8, int16, int32, int64.
+        name (str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
+
+    Returns:
+        - out (Tensor), A Tensor. the value of the exponentially scaled modified Bessel function of order 0 at x
+            (integer types are autocasted into float32).
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> x = paddle.to_tensor([0, 1, 2, 3, 4], dtype="float32")
+            >>> print(paddle.i0e(x))
+            Tensor(shape=[5], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [0.99999994, 0.46575963, 0.30850831, 0.24300036, 0.20700191])
+    """
+    if in_dynamic_or_pir_mode():
+        return _C_ops.i0e(x)
+    else:
+        check_variable_and_dtype(
+            x,
+            "x",
+            ["float32", "float64", "uint8", "int8", "int16", "int32", "int64"],
+            "i0e",
+        )
+
+        helper = LayerHelper("i0e", **locals())
+        out = helper.create_variable_for_type_inference(dtype=x.dtype)
+        helper.append_op(type='i0e', inputs={'x': x}, outputs={'out': out})
+    return out
+
+
+def i1(x: Tensor, name: str | None = None) -> Tensor:
+    """
+    The function is used to calculate modified bessel function of order 1.
+
+    Args:
+        x (Tensor): The input tensor, it's data type should be float32, float64,
+            uint8, int8, int16, int32, int64.
+        name (str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
+
+    Returns:
+        - out (Tensor), A Tensor. the value of the modified bessel function of order 1 at x
+            (integer types are autocasted into float32).
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> x = paddle.to_tensor([0, 1, 2, 3, 4], dtype="float32")
+            >>> print(paddle.i1(x))
+            Tensor(shape=[5], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [0.        , 0.56515908, 1.59063685, 3.95337057, 9.75946712])
+    """
+    if in_dynamic_or_pir_mode():
+        return _C_ops.i1(x)
+    else:
+        check_variable_and_dtype(
+            x,
+            "x",
+            ["float32", "float64", "uint8", "int8", "int16", "int32", "int64"],
+            "i1",
+        )
+
+        helper = LayerHelper("i1", **locals())
+        out = helper.create_variable_for_type_inference(dtype=x.dtype)
+        helper.append_op(
+            type='i1', inputs={'x': x}, outputs={'out': out}, attrs={}
+        )
+    return out
+
+
+def i1e(x: Tensor, name: str | None = None) -> Tensor:
+    """
+    The function is used to calculate exponentially scaled modified Bessel function of order 1.
+
+    Args:
+
+        x (Tensor): The input tensor, it's data type should be float32, float64,
+            uint8, int8, int16, int32, int64.
+        name (str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
+
+    Returns:
+        - out (Tensor), A Tensor. the value of the exponentially scaled modified Bessel function of order 1 at x
+            (integer types are autocasted into float32).
+
+    Examples:
+        .. code-block:: python
+
+            >>> import paddle
+
+            >>> x = paddle.to_tensor([0, 1, 2, 3, 4], dtype="float32")
+            >>> print(paddle.i1e(x))
+            Tensor(shape=[5], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [0.        , 0.20791042, 0.21526928, 0.19682673, 0.17875087])
+    """
+    if in_dynamic_or_pir_mode():
+        return _C_ops.i1e(x)
+    else:
+        check_variable_and_dtype(
+            x,
+            "x",
+            ["float32", "float64", "uint8", "int8", "int16", "int32", "int64"],
+            "i1e",
+        )
+
+        helper = LayerHelper("i1e", **locals())
+        out = helper.create_variable_for_type_inference(dtype=x.dtype)
+        helper.append_op(
+            type='i1e', inputs={'x': x}, outputs={'out': out}, attrs={}
+        )
+    return out
 
 
 def polygamma(x: Tensor, n: int, name: str | None = None) -> Tensor:
@@ -6005,7 +6868,7 @@ def polygamma(x: Tensor, n: int, name: str | None = None) -> Tensor:
             (integer types are autocasted into float32).
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -6093,7 +6956,7 @@ def ldexp(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -6149,6 +7012,212 @@ def ldexp_(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     return paddle.multiply_(x, paddle.pow(two, y))
 
 
+def _bitwise_op(op_name, x, y, is_arithmetic, out=None, name=None):
+    check_variable_and_dtype(
+        x,
+        "x",
+        ["uint8", "int8", "int16", "int32", "int64"],
+        op_name,
+    )
+    if y is not None:
+        check_variable_and_dtype(
+            y,
+            "y",
+            ["uint8", "int8", "int16", "int32", "int64"],
+            op_name,
+        )
+
+    helper = LayerHelper(op_name, **locals())
+    assert x.dtype == y.dtype
+
+    out = helper.create_variable_for_type_inference(dtype=x.dtype)
+
+    helper.append_op(
+        type=op_name,
+        inputs={"x": x, "y": y},
+        outputs={"out": out},
+        attrs={'is_arithmetic': is_arithmetic},
+    )
+
+    return out
+
+
+def bitwise_left_shift(
+    x: Tensor,
+    y: Tensor,
+    is_arithmetic: bool = True,
+    out: Tensor | None = None,
+    name: str | None = None,
+) -> Tensor:
+    r"""
+    Apply ``bitwise_left_shift`` on Tensor ``X`` and ``Y`` .
+
+    .. math::
+
+        Out = X \ll Y
+
+    .. note::
+
+        ``paddle.bitwise_left_shift`` supports broadcasting. If you want know more about broadcasting, please refer to please refer to `Introduction to Tensor`_ .
+
+    .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
+
+    Args:
+        x (Tensor): Input Tensor of ``bitwise_left_shift`` . It is a N-D Tensor of uint8, int8, int16, int32, int64.
+        y (Tensor): Input Tensor of ``bitwise_left_shift`` . It is a N-D Tensor of uint8, int8, int16, int32, int64.
+        is_arithmetic (bool, optional): A boolean indicating whether to choose arithmetic shift, if False, means logic shift. Default True.
+        out (Tensor|None, optional): Result of ``bitwise_left_shift`` . It is a N-D Tensor with the same data type of input Tensor. Default: None.
+        name (str|None, optional): The default value is None.  Normally there is no need for
+            user to set this property.  For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        Tensor: Result of ``bitwise_left_shift`` . It is a N-D Tensor with the same data type of input Tensor.
+
+    Examples:
+        .. code-block:: python
+            :name: bitwise_left_shift_example1
+
+            >>> import paddle
+            >>> x = paddle.to_tensor([[1,2,4,8],[16,17,32,65]])
+            >>> y = paddle.to_tensor([[1,2,3,4,], [2,3,2,1]])
+            >>> paddle.bitwise_left_shift(x, y, is_arithmetic=True)
+            Tensor(shape=[2, 4], dtype=int64, place=Place(gpu:0), stop_gradient=True,
+                   [[2  , 8  , 32 , 128],
+                    [64 , 136, 128, 130]])
+
+        .. code-block:: python
+            :name: bitwise_left_shift_example2
+
+            >>> import paddle
+            >>> x = paddle.to_tensor([[1,2,4,8],[16,17,32,65]])
+            >>> y = paddle.to_tensor([[1,2,3,4,], [2,3,2,1]])
+            >>> paddle.bitwise_left_shift(x, y, is_arithmetic=False)
+            Tensor(shape=[2, 4], dtype=int64, place=Place(gpu:0), stop_gradient=True,
+                [[2  , 8  , 32 , 128],
+                    [64 , 136, 128, 130]])
+    """
+    if in_dynamic_or_pir_mode() and out is None:
+        return _C_ops.bitwise_left_shift(x, y, is_arithmetic)
+    return _bitwise_op(
+        op_name="bitwise_left_shift",
+        x=x,
+        y=y,
+        is_arithmetic=is_arithmetic,
+        name=name,
+        out=out,
+    )
+
+
+@inplace_apis_in_dygraph_only
+def bitwise_left_shift_(
+    x: Tensor,
+    y: Tensor,
+    is_arithmetic: bool = True,
+    out: Tensor | None = None,
+    name: str | None = None,
+) -> Tensor:
+    r"""
+    Inplace version of ``bitwise_left_shift`` API, the output Tensor will be inplaced with input ``x``.
+    Please refer to :ref:`api_paddle_bitwise_left_shift`.
+    """
+    out_shape = broadcast_shape(x.shape, y.shape)
+    if out_shape != x.shape:
+        raise ValueError(
+            f"The shape of broadcast output {out_shape} is different from that of inplace tensor {x.shape} in the Inplace operation."
+        )
+    if in_dynamic_or_pir_mode():
+        return _C_ops.bitwise_left_shift_(x, y, is_arithmetic)
+
+
+def bitwise_right_shift(
+    x: Tensor,
+    y: Tensor,
+    is_arithmetic: bool = True,
+    out: Tensor | None = None,
+    name: str | None = None,
+) -> Tensor:
+    r"""
+    Apply ``bitwise_right_shift`` on Tensor ``X`` and ``Y`` .
+
+    .. math::
+
+        Out = X \gg Y
+
+    .. note::
+
+        ``paddle.bitwise_right_shift`` supports broadcasting. If you want know more about broadcasting, please refer to please refer to `Introduction to Tensor`_ .
+
+    .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
+
+    Args:
+        x (Tensor): Input Tensor of ``bitwise_right_shift`` . It is a N-D Tensor of uint8, int8, int16, int32, int64.
+        y (Tensor): Input Tensor of ``bitwise_right_shift`` . It is a N-D Tensor of uint8, int8, int16, int32, int64.
+        is_arithmetic (bool, optional): A boolean indicating whether to choose arithmetic shift, if False, means logic shift. Default True.
+        out (Tensor|None, optional): Result of ``bitwise_right_shift`` . It is a N-D Tensor with the same data type of input Tensor. Default: None.
+        name (str|None, optional): The default value is None.  Normally there is no need for
+            user to set this property.  For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        Tensor: Result of ``bitwise_right_shift`` . It is a N-D Tensor with the same data type of input Tensor.
+
+    Examples:
+        .. code-block:: python
+            :name: bitwise_right_shift_example1
+
+            >>> import paddle
+            >>> x = paddle.to_tensor([[10,20,40,80],[16,17,32,65]])
+            >>> y = paddle.to_tensor([[1,2,3,4,], [2,3,2,1]])
+            >>> paddle.bitwise_right_shift(x, y, is_arithmetic=True)
+            Tensor(shape=[2, 4], dtype=int64, place=Place(gpu:0), stop_gradient=True,
+                   [[5 , 5 , 5 , 5 ],
+                    [4 , 2 , 8 , 32]])
+
+        .. code-block:: python
+            :name: bitwise_right_shift_example2
+
+            >>> import paddle
+            >>> x = paddle.to_tensor([[-10,-20,-40,-80],[-16,-17,-32,-65]], dtype=paddle.int8)
+            >>> y = paddle.to_tensor([[1,2,3,4,], [2,3,2,1]], dtype=paddle.int8)
+            >>> paddle.bitwise_right_shift(x, y, is_arithmetic=False)  # logic shift
+            Tensor(shape=[2, 4], dtype=int8, place=Place(gpu:0), stop_gradient=True,
+                [[123, 59 , 27 , 11 ],
+                    [60 , 29 , 56 , 95 ]])
+    """
+    if in_dynamic_or_pir_mode() and out is None:
+        return _C_ops.bitwise_right_shift(x, y, is_arithmetic)
+
+    return _bitwise_op(
+        op_name="bitwise_right_shift",
+        x=x,
+        y=y,
+        is_arithmetic=is_arithmetic,
+        name=name,
+        out=out,
+    )
+
+
+@inplace_apis_in_dygraph_only
+def bitwise_right_shift_(
+    x: Tensor,
+    y: Tensor,
+    is_arithmetic: bool = True,
+    out: Tensor | None = None,
+    name: str | None = None,
+) -> Tensor:
+    r"""
+    Inplace version of ``bitwise_right_shift`` API, the output Tensor will be inplaced with input ``x``.
+    Please refer to :ref:`api_paddle_bitwise_left_shift`.
+    """
+    out_shape = broadcast_shape(x.shape, y.shape)
+    if out_shape != x.shape:
+        raise ValueError(
+            f"The shape of broadcast output {out_shape} is different from that of inplace tensor {x.shape} in the Inplace operation."
+        )
+
+    if in_dynamic_or_pir_mode():
+        return _C_ops.bitwise_right_shift_(x, y, is_arithmetic)
+
+
 def __lshift__(
     x: Tensor,
     y: Tensor | int,
@@ -6160,7 +7229,7 @@ def __lshift__(
         raise TypeError(
             "unsupported operand type(s) for <<: 'Tensor' and 'float'"
         )
-    return bitwise_left_shift(x, y, is_arithmetic)
+    return bitwise_left_shift(x, y, is_arithmetic, None, None)
 
 
 def __rshift__(
@@ -6174,7 +7243,7 @@ def __rshift__(
         raise TypeError(
             "unsupported operand type(s) for <<: 'Tensor' and 'float'"
         )
-    return bitwise_right_shift(x, y, is_arithmetic)
+    return bitwise_right_shift(x, y, is_arithmetic, None, None)
 
 
 def __rlshift__(
@@ -6188,7 +7257,7 @@ def __rlshift__(
         raise TypeError(
             "unsupported operand type(s) for <<: 'float' and 'Tensor'"
         )
-    return bitwise_left_shift(y, x, is_arithmetic)
+    return bitwise_left_shift(y, x, is_arithmetic, None, None)
 
 
 def __rrshift__(
@@ -6202,7 +7271,7 @@ def __rrshift__(
         raise TypeError(
             "unsupported operand type(s) for <<: 'float' and 'Tensor'"
         )
-    return bitwise_right_shift(y, x, is_arithmetic)
+    return bitwise_right_shift(y, x, is_arithmetic, None, None)
 
 
 def copysign(x: Tensor, y: Tensor | float, name: str | None = None) -> Tensor:
@@ -6226,7 +7295,7 @@ def copysign(x: Tensor, y: Tensor | float, name: str | None = None) -> Tensor:
         out (Tensor), the output tensor. The data type is the same as the input tensor.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
             :name: example1
 
             >>> import paddle
@@ -6234,10 +7303,10 @@ def copysign(x: Tensor, y: Tensor | float, name: str | None = None) -> Tensor:
             >>> y = paddle.to_tensor([-1, 1, -1], dtype='float64')
             >>> out = paddle.copysign(x, y)
             >>> print(out)
-            Tensor(shape=[3], dtype=float64, place=Place(cpu), stop_gradient=True,
+            Tensor(shape=[3], dtype=float64, place=Place(gpu:0), stop_gradient=True,
                    [-1.,  2., -3.])
 
-        .. code-block:: pycon
+        .. code-block:: python
             :name: example2
 
             >>> import paddle
@@ -6245,10 +7314,10 @@ def copysign(x: Tensor, y: Tensor | float, name: str | None = None) -> Tensor:
             >>> y = paddle.to_tensor([-2], dtype='float64')
             >>> res = paddle.copysign(x, y)
             >>> print(res)
-            Tensor(shape=[3], dtype=float64, place=Place(cpu), stop_gradient=True,
-            [-1.,  -2.,  -3.])
+            Tensor(shape=[3], dtype=float64, place=Place(gpu:0), stop_gradient=True,
+                   [-1.,  -2.,  -3.])
 
-        .. code-block:: pycon
+        .. code-block:: python
             :name: example_zero1
 
             >>> import paddle
@@ -6256,10 +7325,10 @@ def copysign(x: Tensor, y: Tensor | float, name: str | None = None) -> Tensor:
             >>> y = paddle.to_tensor([0.0], dtype='float64')
             >>> out = paddle.copysign(x, y)
             >>> print(out)
-            Tensor(shape=[3], dtype=float64, place=Place(cpu), stop_gradient=True,
-            [1., 2., 3.])
+            Tensor(shape=[3], dtype=float64, place=Place(gpu:0), stop_gradient=True,
+                [1., 2., 3.])
 
-        .. code-block:: pycon
+        .. code-block:: python
             :name: example_zero2
 
             >>> import paddle
@@ -6267,8 +7336,8 @@ def copysign(x: Tensor, y: Tensor | float, name: str | None = None) -> Tensor:
             >>> y = paddle.to_tensor([-0.0], dtype='float64')
             >>> out = paddle.copysign(x, y)
             >>> print(out)
-            Tensor(shape=[3], dtype=float64, place=Place(cpu), stop_gradient=True,
-            [-1., -2., -3.])
+            Tensor(shape=[3], dtype=float64, place=Place(gpu:0), stop_gradient=True,
+                [-1., -2., -3.])
     """
     if isinstance(y, (float, int)):
         y = paddle.to_tensor(y, dtype=x.dtype)
@@ -6322,7 +7391,7 @@ def hypot(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
 
     Examples:
 
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
 
@@ -6379,16 +7448,16 @@ def combinations(
         out (Tensor). Tensor concatenated by combinations, same dtype with x.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> x = paddle.to_tensor([1, 2, 3], dtype='int32')
             >>> res = paddle.combinations(x)
             >>> print(res)
-            Tensor(shape=[3, 2], dtype=int32, place=Place(cpu), stop_gradient=True,
-            [[1, 2],
-             [1, 3],
-             [2, 3]])
+            Tensor(shape=[3, 2], dtype=int32, place=Place(gpu:0), stop_gradient=True,
+                   [[1, 2],
+                    [1, 3],
+                    [2, 3]])
 
     """
     if len(x.shape) != 1:
@@ -6436,18 +7505,18 @@ def signbit(x: Tensor, name: str | None = None) -> Tensor:
         out (Tensor): The output Tensor. The sign bit of the corresponding element of the input tensor, True means negative, False means positive.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
             :name: signbit-example-1
 
             >>> import paddle
             >>> paddle.set_device('cpu')
-            >>> x = paddle.to_tensor([-0.0, 1.1, -2.1, 0.0, 2.5], dtype='float32')
+            >>> x = paddle.to_tensor([-0., 1.1, -2.1, 0., 2.5], dtype='float32')
             >>> res = paddle.signbit(x)
             >>> print(res)
             Tensor(shape=[5], dtype=bool, place=Place(cpu), stop_gradient=True,
             [True, False, True, False, False])
 
-        .. code-block:: pycon
+        .. code-block:: python
             :name: signbit-example-2
 
             >>> import paddle
@@ -6497,11 +7566,11 @@ def isposinf(x: Tensor, name: str | None = None) -> Tensor:
         out (Tensor), The output Tensor. Each element of output indicates whether the input element is positive infinity or not.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> paddle.set_device('cpu')
-            >>> x = paddle.to_tensor([-0.0, float('inf'), -2.1, -float('inf'), 2.5], dtype='float32')
+            >>> x = paddle.to_tensor([-0., float('inf'), -2.1, -float('inf'), 2.5], dtype='float32')
             >>> res = paddle.isposinf(x)
             >>> print(res)
             Tensor(shape=[5], dtype=bool, place=Place(cpu), stop_gradient=True,
@@ -6544,11 +7613,11 @@ def isneginf(x: Tensor, name: str | None = None) -> Tensor:
         out (Tensor), The output Tensor. Each element of output indicates whether the input element is negative infinity or not.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> paddle.set_device('cpu')
-            >>> x = paddle.to_tensor([-0.0, float('inf'), -2.1, -float('inf'), 2.5], dtype='float32')
+            >>> x = paddle.to_tensor([-0., float('inf'), -2.1, -float('inf'), 2.5], dtype='float32')
             >>> res = paddle.isneginf(x)
             >>> print(res)
             Tensor(shape=[5], dtype=bool, place=Place(cpu), stop_gradient=True,
@@ -6591,23 +7660,23 @@ def isreal(x: Tensor, name: str | None = None) -> Tensor:
         out (Tensor), The output Tensor. Each element of output indicates whether the input element is a real number or not.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> paddle.set_device('cpu')
-            >>> x = paddle.to_tensor([-0.0, -2.1, 2.5], dtype='float32')
+            >>> x = paddle.to_tensor([-0., -2.1, 2.5], dtype='float32')
             >>> res = paddle.isreal(x)
             >>> print(res)
             Tensor(shape=[3], dtype=bool, place=Place(cpu), stop_gradient=True,
             [True, True, True])
 
-            >>> x = paddle.to_tensor([(-0.0 + 1j), (-2.1 + 0.2j), (2.5 - 3.1j)])
+            >>> x = paddle.to_tensor([(-0.+1j), (-2.1+0.2j), (2.5-3.1j)])
             >>> res = paddle.isreal(x)
             >>> print(res)
             Tensor(shape=[3], dtype=bool, place=Place(cpu), stop_gradient=True,
             [False, False, False])
 
-            >>> x = paddle.to_tensor([(-0.0 + 1j), (-2.1 + 0j), (2.5 - 0j)])
+            >>> x = paddle.to_tensor([(-0.+1j), (-2.1+0j), (2.5-0j)])
             >>> res = paddle.isreal(x)
             >>> print(res)
             Tensor(shape=[3], dtype=bool, place=Place(cpu), stop_gradient=True,
@@ -6650,7 +7719,7 @@ def sinc(x: Tensor, name: str | None = None) -> Tensor:
         out (Tensor), The Tensor of elementwise-computed normalized sinc result.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> paddle.set_device('cpu')
@@ -6738,18 +7807,18 @@ def isin(
         out (Tensor), The output Tensor with the same shape as `x`.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> paddle.set_device('cpu')
-            >>> x = paddle.to_tensor([-0.0, -2.1, 2.5, 1.0, -2.1], dtype='float32')
+            >>> x = paddle.to_tensor([-0., -2.1, 2.5, 1.0, -2.1], dtype='float32')
             >>> test_x = paddle.to_tensor([-2.1, 2.5], dtype='float32')
             >>> res = paddle.isin(x, test_x)
             >>> print(res)
             Tensor(shape=[5], dtype=bool, place=Place(cpu), stop_gradient=True,
             [False, True, True, False, True])
 
-            >>> x = paddle.to_tensor([-0.0, -2.1, 2.5, 1.0, -2.1], dtype='float32')
+            >>> x = paddle.to_tensor([-0., -2.1, 2.5, 1.0, -2.1], dtype='float32')
             >>> test_x = paddle.to_tensor([-2.1, 2.5], dtype='float32')
             >>> res = paddle.isin(x, test_x, invert=True)
             >>> print(res)
@@ -6757,8 +7826,8 @@ def isin(
             [True, False, False, True, False])
 
             >>> # Set `assume_unique` to True only when `x` and `test_x` contain unique values, otherwise the result may be incorrect.
-            >>> x = paddle.to_tensor([0.0, 1.0, 2.0] * 20).reshape([20, 3])
-            >>> test_x = paddle.to_tensor([0.0, 1.0] * 20)
+            >>> x = paddle.to_tensor([0., 1., 2.]*20).reshape([20, 3])
+            >>> test_x = paddle.to_tensor([0., 1.]*20)
             >>> correct_result = paddle.isin(x, test_x, assume_unique=False)
             >>> print(correct_result)
             Tensor(shape=[20, 3], dtype=bool, place=Place(cpu), stop_gradient=True,
@@ -6785,7 +7854,7 @@ def isin(
 
             >>> incorrect_result = paddle.isin(x, test_x, assume_unique=True)
             >>> print(incorrect_result)
-            Tensor(shape=[20, 3], dtype=bool, place=Place(cpu), stop_gradient=True,
+            Tensor(shape=[20, 3], dtype=bool, place=Place(gpu:0), stop_gradient=True,
             [[True , True , True ],
              [True , True , True ],
              [True , True , True ],
@@ -6921,7 +7990,7 @@ def cartesian_prod(x: Sequence[Tensor], name: str | None = None) -> Tensor:
         out (Tensor), cartesian product of input tensors with the same data type.
 
     Examples:
-        .. code-block:: pycon
+        .. code-block:: python
 
             >>> import paddle
             >>> a = paddle.to_tensor([1, 2, 3], dtype='int32')


### PR DESCRIPTION

### 修复任务编号
Fix #248 

### 修复说明
修复 `paddle.static.nn.spectral_norm` 的示例代码问题。
- 将代码块标记从 `python` 更新为 `pycon` 以符合新的代码规范。
- 验证了示例代码在 CPU 环境下的输出正确性。