### PR TITLE
【Hackathon 10th Spring No.46】[Windows] Add phi.lib into python package -part

### DIFF
--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -312,6 +312,12 @@ set(PHI_LIB
     "${CMAKE_CURRENT_BINARY_DIR}/${PHI_NAME}"
     CACHE FILEPATH "PHI Dummy Library" FORCE)
 
+if(WIN32)
+  set(PHI_LINK
+      "${CMAKE_CURRENT_BINARY_DIR}/phi.lib"
+      CACHE FILEPATH "PHI Import Library" FORCE)
+endif()
+
 string(REPLACE "phi" "phi_core" PHI_CORE_NAME ${PHI_NAME})
 set(PHI_CORE_NAME
     ${PHI_CORE_NAME}

--- a/python/env_dict.py.in
+++ b/python/env_dict.py.in
@@ -13,6 +13,7 @@ env_dict={
     'WITH_PSLI':'@WITH_PSLI@',
     'FLUID_CORE_NAME':'@FLUID_CORE_NAME@',
     'PHI_LIB':'@PHI_LIB@',
+    'PHI_LINK':'@PHI_LINK@',
     'PHI_NAME':'@PHI_NAME@',
     'PHI_CORE_LIB':'@PHI_CORE_LIB@',
     'PHI_CORE_NAME':'@PHI_CORE_NAME@',

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1178,6 +1178,9 @@ if('${WITH_SHARED_PHI}' == 'ON'):
         if('${WITH_GPU}' == 'ON' or '${WITH_ROCM}' == 'ON'):
             package_data['paddle.libs'] += [('libphi_gpu' if os.name != 'nt' else 'phi_gpu') + ext_name]
             shutil.copy('${PHI_GPU_LIB}', libs_path)
+    if os.name == 'nt':
+        package_data['paddle.libs'] += ['phi.lib']
+        shutil.copy('${PHI_LINK}', libs_path)
 
 if('${WITH_SHARED_IR}' == 'ON'):
     package_data['paddle.libs'] += [('libpir' if os.name != 'nt' else 'pir') + ext_name]

--- a/setup.py
+++ b/setup.py
@@ -1540,6 +1540,9 @@ def get_package_data_and_package_dir():
                     + ext_suffix
                 ]
                 shutil.copy(env_dict.get("PHI_GPU_LIB"), libs_path)
+        if os.name == 'nt':
+            package_data['paddle.libs'] += ['phi.lib']
+            shutil.copy(env_dict.get("PHI_LINK"), libs_path)
 
     if env_dict.get("WITH_SHARED_IR") == "ON":
         package_data['paddle.libs'] += [


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
按照自定义算子文档，在Windows下编译自定义算子报错：
<img width="2528" height="724" alt="image" src="https://github.com/user-attachments/assets/dc68a976-6555-412d-aa6c-8baae4a77851" />
需要显示链接phi.lib，才能正常完成编译。
```
from paddle.utils.cpp_extension import CppExtension, setup

setup(
    name='custom_setup_ops',
    ext_modules=CppExtension(
        sources=['relu_cpu.cc'],
        extra_link_args=['phi.lib']
    )
)
```

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否