### PR TITLE
[XPU] support rejection top_p_sampling

### DIFF
--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -1011,6 +1011,7 @@ XPUOpMap& get_kl3_ops() {
       // AddMore
       {"sequence_unpad", XPUKernelSet({FLOAT32})},
       // Fused op
+      {"squeeze_excitation_block", XPUKernelSet({FLOAT32, FLOAT16})},
       {"resnet_basic_block_grad", XPUKernelSet({FLOAT32})},
       {"resnet_basic_block", XPUKernelSet({FLOAT32})},
       {"fused_bias_act", XPUKernelSet({FLOAT16, BFLOAT16})},

--- a/paddle/phi/kernels/xpu/top_p_sampling_kernel.cc
+++ b/paddle/phi/kernels/xpu/top_p_sampling_kernel.cc
@@ -26,6 +26,12 @@ PHI_DEFINE_EXPORTED_bool(xpu_top_p_sampling_use_fp16,
                          false,
                          "use fp16 to improve the inference performance of "
                          "top_p_sampling xpu kernel");
+PHI_DEFINE_EXPORTED_bool(xpu_use_rejection_top_p_sampling,
+                         false,
+                         "use Dual Pivot Rejection Sampling to improve the "
+                         "inference performance of top_p_sampling. "
+                         "The algorithm performs better when top_p is larger. "
+                         "Note that top_p = 0 is not supported.");
 PHI_DEFINE_EXPORTED_int32(
     xpu_top_p_sampling_heuristic_threshold,
     20,
@@ -58,14 +64,24 @@ void TopPSamplingKernel(const Context& dev_ctx,
   auto x_dims = x.dims();
   int64_t bs = x_dims[0];
   int64_t vocab_size = x_dims[1];
-  // int p_num = ps.numel();
 
-  // PADDLE_ENFORCE_EQ(
-  //     p_num,
-  //     bs,
-  //     common::errors::PreconditionNotMet(
-  //         "Expected bs == p_num, but got bs=%d, p_num=%d.", bs, p_num));
-
+  XPUType* topk_scores_data = nullptr;
+  int64_t* topk_ids_data = nullptr;
+  if (k > 0) {
+    topk_scores_data =
+        reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(topk_scores));
+    topk_ids_data = dev_ctx.template Alloc<int64_t>(topk_ids);
+    int r = xpu::topk<XPUType, int64_t>(dev_ctx.x_context(),
+                                        x_ptr,
+                                        topk_scores_data,
+                                        topk_ids_data,
+                                        {bs, vocab_size},
+                                        k,
+                                        1,
+                                        true,
+                                        true);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "xpu::topk");
+  }
   std::vector<int64_t> infer_seed(bs, random_seed);
   if (topp_seed.get_ptr() != nullptr) {
     phi::TensorToVector(*topp_seed, dev_ctx, &infer_seed);
@@ -83,65 +99,142 @@ void TopPSamplingKernel(const Context& dev_ctx,
       rand_coeff_cpu.push_back(dist(engine));
     }
   }
-
+  uint64_t seed_now = rand_coeff_cpu.empty() ? random_seed : rand_coeff_cpu[0];
+  uint64_t offset = 0;
   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
-  float* rand_coeff_xpu = RAII_GUARD.alloc<float>(rand_coeff_cpu.size());
   int* ids_int_ptr = RAII_GUARD.alloc<int>(ids->numel());
 
-  int r = xpu::do_host2device(dev_ctx.x_context(),
-                              rand_coeff_cpu.data(),
-                              rand_coeff_xpu,
-                              rand_coeff_cpu.size() * sizeof(float));
-  PADDLE_ENFORCE_XDNN_SUCCESS(r, "do_host2device");
-  int heuristic_threshold = FLAGS_xpu_top_p_sampling_heuristic_threshold;
+  if (!FLAGS_xpu_use_rejection_top_p_sampling) {
+    float* rand_coeff_xpu = RAII_GUARD.alloc<float>(rand_coeff_cpu.size());
+    int r = xpu::do_host2device(dev_ctx.x_context(),
+                                rand_coeff_cpu.data(),
+                                rand_coeff_xpu,
+                                rand_coeff_cpu.size() * sizeof(float));
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "do_host2device");
+    int heuristic_threshold = FLAGS_xpu_top_p_sampling_heuristic_threshold;
 
-  if ((!FLAGS_xpu_top_p_sampling_use_fp16) ||
-      std::is_same<T, phi::float16>::value) {
-    r = xpu::faster_top_p_sampling<XPUType, int>(dev_ctx.x_context(),
-                                                 x_ptr,
-                                                 ps_ptr,
-                                                 rand_coeff_xpu,
-                                                 ids_int_ptr,
-                                                 bs,
-                                                 vocab_size,
-                                                 out_ptr,
-                                                 nullptr,
-                                                 heuristic_threshold);
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "top_p_sampling");
+    if ((!FLAGS_xpu_top_p_sampling_use_fp16) ||
+        std::is_same<T, phi::float16>::value) {
+      r = xpu::faster_top_p_sampling<XPUType, int>(dev_ctx.x_context(),
+                                                   x_ptr,
+                                                   ps_ptr,
+                                                   rand_coeff_xpu,
+                                                   ids_int_ptr,
+                                                   bs,
+                                                   vocab_size,
+                                                   out_ptr,
+                                                   nullptr,
+                                                   heuristic_threshold);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "top_p_sampling");
+    } else {
+      using XPUTypeFP16 = typename XPUTypeTrait<phi::float16>::Type;
+      XPUTypeFP16* x_fp16_ptr = RAII_GUARD.alloc<XPUTypeFP16>(x.numel());
+      XPUTypeFP16* ps_fp16_ptr = RAII_GUARD.alloc<XPUTypeFP16>(ps.numel());
+      XPUTypeFP16* out_fp16_ptr = RAII_GUARD.alloc<XPUTypeFP16>(out->numel());
+
+      float fp16_scale = 32768.f;  // experience value
+      r = xpu::scale_cast_fusion<XPUType, XPUTypeFP16>(
+          dev_ctx.x_context(), x_ptr, x_fp16_ptr, x.numel(), fp16_scale);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale_cast_fusion");
+      r = xpu::scale_cast_fusion<XPUType, XPUTypeFP16>(
+          dev_ctx.x_context(), ps_ptr, ps_fp16_ptr, ps.numel(), fp16_scale);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale_cast_fusion");
+
+      r = xpu::faster_top_p_sampling<XPUTypeFP16, int>(dev_ctx.x_context(),
+                                                       x_fp16_ptr,
+                                                       ps_fp16_ptr,
+                                                       rand_coeff_xpu,
+                                                       ids_int_ptr,
+                                                       bs,
+                                                       vocab_size,
+                                                       out_fp16_ptr,
+                                                       nullptr,
+                                                       heuristic_threshold);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "top_p_sampling");
+
+      r = xpu::scale_cast_fusion<XPUTypeFP16, XPUType>(dev_ctx.x_context(),
+                                                       out_fp16_ptr,
+                                                       out_ptr,
+                                                       out->numel(),
+                                                       1.f / fp16_scale);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale_cast_fusion");
+    }
   } else {
-    using XPUTypeFP16 = typename XPUTypeTrait<phi::float16>::Type;
-    XPUTypeFP16* x_fp16_ptr = RAII_GUARD.alloc<XPUTypeFP16>(x.numel());
-    XPUTypeFP16* ps_fp16_ptr = RAII_GUARD.alloc<XPUTypeFP16>(ps.numel());
-    XPUTypeFP16* out_fp16_ptr = RAII_GUARD.alloc<XPUTypeFP16>(out->numel());
+    DenseTensor k_threshold;
+    k_threshold.Resize({bs});
+    int* k_threshold_ptr = dev_ctx.template Alloc<int>(&k_threshold);
+    if (threshold.get_ptr() != nullptr) {
+      XPUType* threshold_data = reinterpret_cast<XPUType*>(
+          const_cast<T*>(threshold.get_ptr()->data<T>()));
+      // k_threshold = static_cast<int>((1 - infer_threshold[0]) * vocab_size)
+      int r = xpu::scale<XPUType, float>(dev_ctx.x_context(),
+                                         threshold_data,
+                                         threshold_data,
+                                         bs,
+                                         true,
+                                         -vocab_size,
+                                         vocab_size);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "xpu::scale");
+      r = xpu::cast<XPUType, int>(
+          dev_ctx.x_context(), threshold_data, k_threshold_ptr, bs);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "xpu::cast");
+    } else {
+      int r = xpu::constant<int>(
+          dev_ctx.x_context(), k_threshold_ptr, bs, vocab_size);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "xpu::constant");
+    }
 
-    float fp16_scale = 32768.f;  // experience value
-    r = xpu::scale_cast_fusion<XPUType, XPUTypeFP16>(
-        dev_ctx.x_context(), x_ptr, x_fp16_ptr, x.numel(), fp16_scale);
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale_cast_fusion");
-    r = xpu::scale_cast_fusion<XPUType, XPUTypeFP16>(
-        dev_ctx.x_context(), ps_ptr, ps_fp16_ptr, ps.numel(), fp16_scale);
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale_cast_fusion");
+    if ((!FLAGS_xpu_top_p_sampling_use_fp16) ||
+        std::is_same<T, phi::float16>::value) {
+      int r = xpu::top_k_top_p_sampling_from_probs<XPUType, int>(
+          dev_ctx.x_context(),
+          x_ptr,
+          k_threshold_ptr,
+          ps_ptr,
+          nullptr,
+          ids_int_ptr,
+          vocab_size,  // top_k
+          1.0f,        // top_p
+          bs,
+          vocab_size,
+          true,
+          seed_now,
+          offset);
+      PADDLE_ENFORCE_XDNN_SUCCESS(
+          r, "xpu::top_k_top_p_sampling_from_probs<XPUType");
+    } else {
+      using XPUTypeFP16 = typename XPUTypeTrait<phi::float16>::Type;
+      XPUTypeFP16* x_fp16_ptr = RAII_GUARD.alloc<XPUTypeFP16>(x.numel());
+      XPUTypeFP16* ps_fp16_ptr = RAII_GUARD.alloc<XPUTypeFP16>(ps.numel());
 
-    r = xpu::faster_top_p_sampling<XPUTypeFP16, int>(dev_ctx.x_context(),
-                                                     x_fp16_ptr,
-                                                     ps_fp16_ptr,
-                                                     rand_coeff_xpu,
-                                                     ids_int_ptr,
-                                                     bs,
-                                                     vocab_size,
-                                                     out_fp16_ptr,
-                                                     nullptr,
-                                                     heuristic_threshold);
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "top_p_sampling");
-
-    r = xpu::scale_cast_fusion<XPUTypeFP16, XPUType>(dev_ctx.x_context(),
-                                                     out_fp16_ptr,
-                                                     out_ptr,
-                                                     out->numel(),
-                                                     1.f / fp16_scale);
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale_cast_fusion");
+      float fp16_scale = 1.0f;  // experience value
+      int r = xpu::cast<XPUType, XPUTypeFP16>(
+          dev_ctx.x_context(), x_ptr, x_fp16_ptr, x.numel());
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale_cast_fusion");
+      r = xpu::cast<XPUType, XPUTypeFP16>(
+          dev_ctx.x_context(), ps_ptr, ps_fp16_ptr, ps.numel());
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale_cast_fusion");
+      r = xpu::top_k_top_p_sampling_from_probs<XPUTypeFP16, int>(
+          dev_ctx.x_context(),
+          x_fp16_ptr,
+          k_threshold_ptr,
+          ps_fp16_ptr,
+          nullptr,
+          ids_int_ptr,
+          vocab_size,  // top_k
+          1.0f,        // top_p
+          bs,
+          vocab_size,
+          true,
+          seed_now,
+          offset);
+      PADDLE_ENFORCE_XDNN_SUCCESS(
+          r, "xpu::top_k_top_p_sampling_from_probs<XPUType");
+    }
+    int r = xpu::constant<XPUType>(dev_ctx.x_context(), out_ptr, bs, 0);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "xpu::constant");
   }
-  r = xpu::cast<int, int64_t>(
+  int r = xpu::cast<int, int64_t>(
       dev_ctx.x_context(), ids_int_ptr, ids_ptr, ids->numel());
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
 }

--- a/paddle/phi/kernels/xpu/top_p_sampling_kernel.cc
+++ b/paddle/phi/kernels/xpu/top_p_sampling_kernel.cc
@@ -103,7 +103,10 @@ void TopPSamplingKernel(const Context& dev_ctx,
   uint64_t offset = 0;
   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
   int* ids_int_ptr = RAII_GUARD.alloc<int>(ids->numel());
-
+  PADDLE_ENFORCE_EQ(
+      threshold.is_initialized(),
+      false,
+      errors::InvalidArgument(("threshold not supported in top_p_sampling")));
   if (!FLAGS_xpu_use_rejection_top_p_sampling) {
     float* rand_coeff_xpu = RAII_GUARD.alloc<float>(rand_coeff_cpu.size());
     int r = xpu::do_host2device(dev_ctx.x_context(),
@@ -160,36 +163,12 @@ void TopPSamplingKernel(const Context& dev_ctx,
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "scale_cast_fusion");
     }
   } else {
-    DenseTensor k_threshold;
-    k_threshold.Resize({bs});
-    int* k_threshold_ptr = dev_ctx.template Alloc<int>(&k_threshold);
-    if (threshold.get_ptr() != nullptr) {
-      XPUType* threshold_data = reinterpret_cast<XPUType*>(
-          const_cast<T*>(threshold.get_ptr()->data<T>()));
-      // k_threshold = static_cast<int>((1 - infer_threshold[0]) * vocab_size)
-      int r = xpu::scale<XPUType, float>(dev_ctx.x_context(),
-                                         threshold_data,
-                                         threshold_data,
-                                         bs,
-                                         true,
-                                         -vocab_size,
-                                         vocab_size);
-      PADDLE_ENFORCE_XDNN_SUCCESS(r, "xpu::scale");
-      r = xpu::cast<XPUType, int>(
-          dev_ctx.x_context(), threshold_data, k_threshold_ptr, bs);
-      PADDLE_ENFORCE_XDNN_SUCCESS(r, "xpu::cast");
-    } else {
-      int r = xpu::constant<int>(
-          dev_ctx.x_context(), k_threshold_ptr, bs, vocab_size);
-      PADDLE_ENFORCE_XDNN_SUCCESS(r, "xpu::constant");
-    }
-
     if ((!FLAGS_xpu_top_p_sampling_use_fp16) ||
         std::is_same<T, phi::float16>::value) {
       int r = xpu::top_k_top_p_sampling_from_probs<XPUType, int>(
           dev_ctx.x_context(),
           x_ptr,
-          k_threshold_ptr,
+          nullptr,
           ps_ptr,
           nullptr,
           ids_int_ptr,
@@ -217,7 +196,7 @@ void TopPSamplingKernel(const Context& dev_ctx,
       r = xpu::top_k_top_p_sampling_from_probs<XPUTypeFP16, int>(
           dev_ctx.x_context(),
           x_fp16_ptr,
-          k_threshold_ptr,
+          nullptr,
           ps_fp16_ptr,
           nullptr,
           ids_int_ptr,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 New features

### Description
<!-- Describe what you’ve done -->
支持top_p_sampling双枢轴拒绝采样算法，默认关闭，通过xpu_use_rejection_top_p_sampling环境变量开启，在top_p较大时算子性能收益较明显。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
