### PR TITLE
[CI] Increase Linux-DCU Build CI timeout time

### DIFF
--- a/.github/workflows/_Linux-DCU.yml
+++ b/.github/workflows/_Linux-DCU.yml
@@ -46,7 +46,7 @@ jobs:
       TASK: paddle-CI-${{ github.event.pull_request.number }}-dcu_build
     runs-on:
       group: HK-CPU
-    timeout-minutes: 120
+    timeout-minutes: 180
     steps:
       - name: Check docker image and run container
         env:


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

Linux DCU build 容易超时取消，能否延长一些限时或者check一下原因 @SigureMo 
https://github.com/PaddlePaddle/Paddle/actions/runs/21697807392
https://github.com/PaddlePaddle/Paddle/actions/runs/21671476106
https://github.com/PaddlePaddle/Paddle/actions/runs/21671238860
https://github.com/PaddlePaddle/Paddle/actions/runs/21670283077

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否