### PR TITLE
[API Compatibility No.21、213] Add parameter alias support for `renorm` and `renorm_` - part

### DIFF
--- a/paddle/fluid/pybind/arg_pre_process.cc
+++ b/paddle/fluid/pybind/arg_pre_process.cc
@@ -171,15 +171,6 @@ void LogsumexpPreProcess(pir::Value* x,
 }
 
 void RenormPreProcess(Tensor* x, int* axis) {
-  // Python原逻辑：
-  // if not axis < len(input_shape):
-  //     raise ValueError(f"the axis:{axis} should be less then the shape's size
-  //     {len(input_shape)}:{input_shape}")
-  // if not axis >= 0:
-  //     if not axis >= -1 * len(input_shape):
-  //         raise ValueError(f"the axis:{axis} should not be less than -1 *
-  //         length of input_shape:{-1 * len(input_shape)}")
-  //     axis = axis + len(input_shape)
   int input_shape_size = x->dims().size();
   PADDLE_ENFORCE_LT(*axis,
                     input_shape_size,

--- a/paddle/fluid/pybind/arg_pre_process.cc
+++ b/paddle/fluid/pybind/arg_pre_process.cc
@@ -169,6 +169,57 @@ void LogsumexpPreProcess(pir::Value* x,
   }
   return;
 }
+
+void RenormPreProcess(Tensor* x, int* axis) {
+  // Python原逻辑：
+  // if not axis < len(input_shape):
+  //     raise ValueError(f"the axis:{axis} should be less then the shape's size
+  //     {len(input_shape)}:{input_shape}")
+  // if not axis >= 0:
+  //     if not axis >= -1 * len(input_shape):
+  //         raise ValueError(f"the axis:{axis} should not be less than -1 *
+  //         length of input_shape:{-1 * len(input_shape)}")
+  //     axis = axis + len(input_shape)
+  int input_shape_size = x->dims().size();
+  PADDLE_ENFORCE_LT(*axis,
+                    input_shape_size,
+                    phi::errors::InvalidArgument(
+                        "the axis:%d should be less then the shape's size %d",
+                        *axis,
+                        input_shape_size));
+  if (*axis < 0) {
+    PADDLE_ENFORCE_GE(
+        *axis,
+        -input_shape_size,
+        phi::errors::InvalidArgument(
+            "the axis:%d should not be less than -1 * length of input_shape:%d",
+            *axis,
+            -input_shape_size));
+    *axis = *axis + input_shape_size;
+  }
+}
+
+void RenormPreProcess(pir::Value* x, int* axis) {
+  std::vector<int64_t> x_shape = pir::GetShapeFromValue(*x);
+  int input_shape_size = x_shape.size();
+  PADDLE_ENFORCE_LT(*axis,
+                    input_shape_size,
+                    phi::errors::InvalidArgument(
+                        "the axis:%d should be less then the shape's size %d",
+                        *axis,
+                        input_shape_size));
+  if (*axis < 0) {
+    PADDLE_ENFORCE_GE(
+        *axis,
+        -input_shape_size,
+        phi::errors::InvalidArgument(
+            "the axis:%d should not be less than -1 * length of input_shape:%d",
+            *axis,
+            -input_shape_size));
+    *axis = *axis + input_shape_size;
+  }
+}
+
 void SumPreProcess(Value* x, Value* axis) {
   paddle::dialect::SetStopGradient(axis);
 }

--- a/paddle/fluid/pybind/arg_pre_process.h
+++ b/paddle/fluid/pybind/arg_pre_process.h
@@ -49,6 +49,9 @@ void BinCountPreProcess(Value* x,
 void LogsumexpPreProcess(Tensor* x, std::vector<int>* axis, bool* reduce_all);
 void LogsumexpPreProcess(Value* x, std::vector<int>* axis, bool* reduce_all);
 
+void RenormPreProcess(Tensor* x, int* axis);
+void RenormPreProcess(Value* x, int* axis);
+
 void SumPreProcess(Value* x, Value* axis);
 void IsClosePreProcess(Value* x, Value* y, Value* rtol, Value* atol);
 void AllClosePreProcess(Value* x, Value* y, Value* rtol, Value* atol);

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -427,7 +427,6 @@
   args_alias :
     axis : [dim]
     max_norm : [maxnorm]
-    use_default_mapping : True
   pre_process:
     func : RenormPreProcess(x, axis)
 
@@ -436,7 +435,6 @@
   args_alias :
     axis : [dim]
     max_norm : [maxnorm]
-    use_default_mapping : True
   pre_process:
     func : RenormPreProcess(x, axis)
 

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -425,6 +425,7 @@
 - op : renorm
   name : [paddle.renorm, paddle.Tensor.renorm]
   args_alias :
+    x : [input]
     axis : [dim]
     max_norm : [maxnorm]
   pre_process:
@@ -433,6 +434,7 @@
 - op : renorm_
   name : [paddle.renorm_, paddle.Tensor.renorm]
   args_alias :
+    x : [input]
     axis : [dim]
     max_norm : [maxnorm]
   pre_process:

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -422,6 +422,20 @@
   args_alias :
     use_default_mapping : True
 
+- op : renorm
+  name : [paddle.renorm, paddle.Tensor.renorm]
+  args_alias :
+    use_default_mapping : True
+  pre_process:
+    func : RenormPreProcess(x, axis)
+
+- op : renorm_
+  name : [paddle.renorm_, paddle.Tensor.renorm]
+  args_alias :
+    use_default_mapping : True
+  pre_process:
+    func : RenormPreProcess(x, axis)
+
 - op : roll
   name : [paddle.roll, paddle.Tensor.roll]
   args_alias:

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -425,6 +425,8 @@
 - op : renorm
   name : [paddle.renorm, paddle.Tensor.renorm]
   args_alias :
+    axis : [dim]
+    max_norm : [maxnorm]
     use_default_mapping : True
   pre_process:
     func : RenormPreProcess(x, axis)
@@ -432,6 +434,8 @@
 - op : renorm_
   name : [paddle.renorm_, paddle.Tensor.renorm]
   args_alias :
+    axis : [dim]
+    max_norm : [maxnorm]
     use_default_mapping : True
   pre_process:
     func : RenormPreProcess(x, axis)

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -432,7 +432,7 @@
     func : RenormPreProcess(x, axis)
 
 - op : renorm_
-  name : [paddle.renorm_, paddle.Tensor.renorm]
+  name : [paddle.renorm_, paddle.Tensor.renorm_]
   args_alias :
     x : [input]
     axis : [dim]

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -4743,3 +4743,67 @@ def baddbmm_(
 ) -> Tensor
 """,
 )
+
+add_doc_and_signature(
+    "renorm",
+    r"""
+    This operator is used to calculate the p-norm along the axis,
+    suppose the input-shape on axis dimension has the value of T, then
+    the tensor is split into T parts, the p-norm should be calculated for each
+    part, if the p-norm for part i is larger than max-norm, then each element
+    in part i should be re-normalized at the same scale so that part-i' p-norm equals
+    max-norm exactly, otherwise part-i stays unchanged.
+
+    Args:
+        x (Tensor): The input Tensor
+        p (float): The power of the norm operation.
+        axis (int): the dimension to slice the tensor.
+        max_norm (float): the maximal norm limit.
+
+    Returns:
+        Tensor: the renorm Tensor.
+
+    Examples:
+        .. code-block:: pycon
+
+            >>> import paddle
+            >>> input = [
+            ...     [[2.0, 2.0, -2.0], [3.0, 0.3, 3.0]],
+            ...     [[2.0, -8.0, 2.0], [3.1, 3.7, 3.0]],
+            ... ]
+            >>> x = paddle.to_tensor(input, dtype='float32')
+            >>> y = paddle.renorm(x, 1.0, 2, 2.05)
+            >>> print(y)
+            Tensor(shape=[2, 2, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [[[ 0.40594056,  0.29285714, -0.41000000],
+              [ 0.60891086,  0.04392857,  0.61500001]],
+             [[ 0.40594056, -1.17142856,  0.41000000],
+              [ 0.62920785,  0.54178572,  0.61500001]]])
+""",
+    """
+def renorm(
+    x: Tensor,
+    p: float,
+    axis: int,
+    max_norm: float,
+    *,
+    out: Tensor | None = None,
+) -> Tensor
+""",
+)
+
+add_doc_and_signature(
+    "renorm_",
+    r"""
+    Inplace version of ``renorm`` API, the output Tensor will be inplaced with input ``x``.
+    Please refer to :ref:`api_paddle_renorm`.
+""",
+    """
+def renorm_(
+    x: Tensor,
+    p: float,
+    axis: int,
+    max_norm: float,
+) -> Tensor
+""",
+)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -58,6 +58,8 @@ from paddle._C_ops import (  # noqa: F401
     minimum,
     multiply,
     nextafter,
+    renorm,
+    renorm_,
     sign,
     sin,
     sum,
@@ -2206,94 +2208,6 @@ def mm(input: Tensor, mat2: Tensor, name: str | None = None) -> Tensor:
             inputs={'X': input, 'Y': mat2},
             outputs={'Out': out},
         )
-        return out
-
-
-def renorm(x: Tensor, p: float, axis: int, max_norm: float) -> Tensor:
-    """
-    **renorm**
-
-    This operator is used to calculate the p-norm along the axis,
-    suppose the input-shape on axis dimension has the value of T, then
-    the tensor is split into T parts, the p-norm should be calculated for each
-    part, if the p-norm for part i is larger than max-norm, then each element
-    in part i should be re-normalized at the same scale so that part-i' p-norm equals
-    max-norm exactly, otherwise part-i stays unchanged.
-
-    Args:
-        x (Tensor): The input Tensor
-        p (float): The power of the norm operation.
-        axis (int): the dimension to slice the tensor.
-        max-norm (float): the maximal norm limit.
-
-    Returns:
-        Tensor: the renorm Tensor.
-
-    Examples:
-        .. code-block:: pycon
-
-            >>> import paddle
-            >>> input = [
-            ...     [[2.0, 2.0, -2.0], [3.0, 0.3, 3.0]],
-            ...     [[2.0, -8.0, 2.0], [3.1, 3.7, 3.0]],
-            ... ]
-            >>> x = paddle.to_tensor(input, dtype='float32')
-            >>> y = paddle.renorm(x, 1.0, 2, 2.05)
-            >>> print(y)
-            Tensor(shape=[2, 2, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [[[ 0.40594056,  0.29285714, -0.41000000],
-              [ 0.60891086,  0.04392857,  0.61500001]],
-             [[ 0.40594056, -1.17142856,  0.41000000],
-              [ 0.62920785,  0.54178572,  0.61500001]]])
-
-    """
-    input_shape = x.shape
-    if not axis < len(input_shape):
-        raise ValueError(
-            f"the axis:{axis} should be less then the shape's size {len(input_shape)}:{input_shape}"
-        )
-    if not axis >= 0:
-        if not axis >= -1 * len(input_shape):
-            raise ValueError(
-                f"the axis:{axis} should not be less than -1 * length of input_shape:{-1 * len(input_shape)}"
-            )
-        axis = axis + len(input_shape)
-    if in_dynamic_or_pir_mode():
-        out = _C_ops.renorm(x, p, axis, max_norm)
-        return out
-    else:
-        check_variable_and_dtype(x, 'x', ['float32', 'float64'], 'renorm')
-        inputs = {'X': x}
-        attrs = {'p': p, 'axis': axis, 'max_norm': max_norm}
-
-        helper = LayerHelper("renorm", **locals())
-        out = helper.create_variable_for_type_inference(dtype=x.dtype)
-
-        helper.append_op(
-            type="renorm", inputs=inputs, attrs=attrs, outputs={"Out": out}
-        )
-        return out
-
-
-@inplace_apis_in_dygraph_only
-def renorm_(x: Tensor, p: float, axis: int, max_norm: float) -> Tensor:
-    """
-    Inplace version of ``renorm`` API, the output Tensor will be inplaced with input ``x``.
-    Please refer to :ref:`api_paddle_renorm`.
-    """
-    input_shape = x.shape
-    if not axis < len(input_shape):
-        raise ValueError(
-            f"the axis:{axis} should be less then the shape's size {len(input_shape)}:{input_shape}"
-        )
-    if not axis >= 0:
-        if not axis >= -1 * len(input_shape):
-            raise ValueError(
-                f"the axis:{axis} should not be less than -1 * length of input_shape:{-1 * len(input_shape)}"
-            )
-        axis = axis + len(input_shape)
-    if in_dynamic_mode():
-        out = _C_ops.renorm_(x, p, axis, max_norm)
         return out
 
 

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -1765,5 +1765,72 @@ class TestTensorCumsumInplace(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestRenormAPI_Compatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+        paddle.enable_static()
+        self.shape = [2, 2, 3]
+        self.dtype = 'float32'
+        self.init_data()
+
+    def init_data(self):
+        self.np_input = np.random.rand(*self.shape).astype(self.dtype)
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_input)
+        paddle_dygraph_out = []
+
+        # 位置参数 (args)
+        out1 = paddle.renorm(x, 1.0, 2, 2.05)
+        paddle_dygraph_out.append(out1)
+
+        # Paddle关键字参数 (kwargs)
+        out2 = paddle.renorm(x=x, p=1.0, axis=2, max_norm=2.05)
+        paddle_dygraph_out.append(out2)
+
+        # Torch关键字参数
+        out3 = paddle.renorm(input=x, p=1.0, dim=2, max_norm=2.05)
+        paddle_dygraph_out.append(out3)
+
+        # Tensor方法 - kwargs
+        out4 = x.renorm(p=1.0, axis=2, max_norm=2.05)
+        paddle_dygraph_out.append(out4)
+
+        # Tensor方法 - dim别名
+        out5 = x.renorm(p=1.0, dim=2, max_norm=2.05)
+        paddle_dygraph_out.append(out5)
+
+        # 验证所有输出
+        for out in paddle_dygraph_out:
+            self.assertEqual(out.shape, self.shape)
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
+
+            # 位置参数
+            out1 = paddle.renorm(x, 1.0, 2, 2.05)
+            # Paddle关键字参数
+            out2 = paddle.renorm(x=x, p=1.0, axis=2, max_norm=2.05)
+            # Torch关键字参数
+            out3 = paddle.renorm(input=x, p=1.0, dim=2, max_norm=2.05)
+            # Tensor方法
+            out4 = x.renorm(p=1.0, axis=2, max_norm=2.05)
+
+            exe = paddle.static.Executor(paddle.CPUPlace())
+            fetches = exe.run(
+                main,
+                feed={"x": self.np_input},
+                fetch_list=[out1, out2, out3, out4],
+            )
+            for out in fetches:
+                self.assertEqual(out.shape, self.shape)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -1781,27 +1781,17 @@ class TestRenormAPI_Compatibility(unittest.TestCase):
         x = paddle.to_tensor(self.np_input)
         paddle_dygraph_out = []
 
-        # 位置参数 (args)
         out1 = paddle.renorm(x, 1.0, 2, 2.05)
         paddle_dygraph_out.append(out1)
-
-        # Paddle关键字参数 (kwargs)
         out2 = paddle.renorm(x=x, p=1.0, axis=2, max_norm=2.05)
         paddle_dygraph_out.append(out2)
-
-        # Torch关键字参数
         out3 = paddle.renorm(input=x, p=1.0, dim=2, max_norm=2.05)
         paddle_dygraph_out.append(out3)
-
-        # Tensor方法 - kwargs
         out4 = x.renorm(p=1.0, axis=2, max_norm=2.05)
         paddle_dygraph_out.append(out4)
-
-        # Tensor方法 - dim别名
         out5 = x.renorm(p=1.0, dim=2, max_norm=2.05)
         paddle_dygraph_out.append(out5)
 
-        # 验证所有输出
         for out in paddle_dygraph_out:
             self.assertEqual(out.shape, self.shape)
         paddle.enable_static()
@@ -1813,15 +1803,10 @@ class TestRenormAPI_Compatibility(unittest.TestCase):
         with paddle.static.program_guard(main, startup):
             x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
 
-            # 位置参数
             out1 = paddle.renorm(x, 1.0, 2, 2.05)
-            # Paddle关键字参数
             out2 = paddle.renorm(x=x, p=1.0, axis=2, max_norm=2.05)
-            # Torch关键字参数
             out3 = paddle.renorm(input=x, p=1.0, dim=2, max_norm=2.05)
-            # Tensor方法
             out4 = x.renorm(p=1.0, axis=2, max_norm=2.05)
-
             exe = paddle.static.Executor(paddle.CPUPlace())
             fetches = exe.run(
                 main,

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -1769,7 +1769,7 @@ class TestRenormAPI_Compatibility(unittest.TestCase):
     def setUp(self):
         np.random.seed(123)
         paddle.enable_static()
-        self.shape = [2, 2, 3]
+        self.shape = (2, 2, 3)
         self.dtype = 'float32'
         self.init_data()
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Add parameter alias support for `renorm` and `renorm_`
- https://github.com/PaddlePaddle/Paddle/issues/76301#issuecomment-3502554429 No21 and No213
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否