### PR TITLE
Fix tensor multiplication with string to return NotImplemented

### DIFF
--- a/paddle/fluid/pybind/eager_math_op_patch.cc
+++ b/paddle/fluid/pybind/eager_math_op_patch.cc
@@ -636,6 +636,18 @@ static PyObject* tensor__mul__method(TensorObject* self,
       other_tensor = paddle::empty({}, phi::DataType::FLOAT32, place);
       InitTensorWithNumpyValue(numpy_value, place, &other_tensor);
     } else {
+      // NOTE: For string types, return NotImplemented to allow Python to try to
+      // reflected method. This is the expected behavior per Python's data
+      // model: when the left operand doesn't support the operation with the
+      // right operand type, it should return NotImplemented so that the right
+      // operand's reflected method can be attempted. This avoids unintended
+      // string-to-number conversions (e.g., "a" -> 0) in the Scalar
+      // constructor.
+      if (PyObject_CheckString(other_obj)) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+      }
+
       paddle::experimental::Scalar value;
 
       // NOTE: call reflected method of other_obj if cast failed


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes a bug where tensor multiplication with string objects incorrectly returned a result instead of raising a TypeError.

Previously, when performing `paddle.to_tensor(2) * "a"`, the string "a" was converted to a scalar value (0) through the `Scalar` constructor's string-to-number conversion, leading to an incorrect result of `Tensor(0)` instead of raising a `TypeError`.

According to Python's data model, when the left operand doesn't support the operation with the right operand type, it should return `NotImplemented` so that Python can attempt the right operand's reflected method. This allows strings to properly handle operations like `"a" * 3` while rejecting unsupported operations like `"a" * tensor`.

**Changes:**
- Added string type check in `tensor__mul__method` before attempting scalar conversion
- Return `Py_NotImplemented` for string operands to let Python handle the operation properly
- Added detailed comments explaining the rationale following Python's data model

### 是否引起精度变化
否