### PR TITLE
[API Compatibility No.14, 22, 23] Sink fill_diagonal_/squeeze_/unsqueeze_ to C++ with alias compatibility -part

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/monkey_patch_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/monkey_patch_gen.py
@@ -83,6 +83,13 @@ SET_UNIFIED_FUNCTION_TEMPLATE = """
 
 # Unified map: list of (module_path, method_name, func) for all module paths
 unified_func_map = []
+# APIs that keep Python wrappers for richer argument normalization/signatures.
+_SKIP_MONKEY_PATCH_APIS = {
+    ("paddle", "unsqueeze"),
+    ("paddle.Tensor", "unsqueeze"),
+    ("paddle", "squeeze"),
+    ("paddle.Tensor", "squeeze"),
+}
 # The python api info which not in ops.yaml
 python_api_info_from_yaml = {}
 
@@ -132,6 +139,9 @@ def ClassifyAPIByPrefix(python_api_info, op_name):
 
         # Remove trailing dot to get module_path
         module_path = prefix.rstrip('.')
+        if (module_path, method_name) in _SKIP_MONKEY_PATCH_APIS:
+            continue
+
         unified_mapping = UNIFIED_NAME_METHOD_MAPPING_TEMPLATE.format(
             module_path=module_path,
             method_name=method_name,

--- a/paddle/fluid/pybind/args_mapper.cc
+++ b/paddle/fluid/pybind/args_mapper.cc
@@ -454,8 +454,8 @@ void FillDiagonalMapper(PyObject* args,
   const int max_args = 4;
   CheckParamsCount(nargs, remaining_kwargs, max_args);
 
-  PyObject* x_obj = GetItemFromArgsOrKWArgs(
-      args, 0, kwargs, {"x"}, nargs, &remaining_kwargs);
+  PyObject* x_obj =
+      GetItemFromArgsOrKWArgs(args, 0, kwargs, {"x"}, nargs, &remaining_kwargs);
   *x = CastPyArg2Value(x_obj, "fill_diagonal_", 0, false);
 
   PyObject* value_obj = GetItemFromArgsOrKWArgs(args,

--- a/paddle/fluid/pybind/args_mapper.cc
+++ b/paddle/fluid/pybind/args_mapper.cc
@@ -21,6 +21,7 @@
 #include "paddle/fluid/pybind/args_mapper.h"
 #include "paddle/fluid/eager/utils.h"
 #include "paddle/fluid/pir/dialect/operator/ir/pd_api.h"
+#include "paddle/fluid/pir/utils/general_functions.h"
 #include "paddle/fluid/pybind/eager_utils.h"
 #include "paddle/fluid/pybind/op_function_common.h"
 #include "paddle/phi/common/data_type.h"
@@ -366,6 +367,148 @@ void GeluMapper(PyObject* args,
 
   // Check Remaining Params validity if needed
   CheckRemainingParamsValidity(args, kwargs, remaining_kwargs, nargs);
+}
+
+void FillDiagonalMapper(PyObject* args,
+                        PyObject* kwargs,
+                        Tensor** x_ptr_ptr,
+                        float* value,
+                        int* offset,
+                        bool* wrap) {
+  int nargs = args ? static_cast<int>(PyTuple_Size(args)) : 0;
+  int remaining_kwargs = kwargs ? static_cast<int>(PyDict_Size(kwargs)) : 0;
+  const int max_args = 4;
+  CheckParamsCount(nargs, remaining_kwargs, max_args);
+
+  auto& x = GetTensorFromArgsOrKWArgs("fill_diagonal_",
+                                      "x",
+                                      args,
+                                      0,
+                                      kwargs,
+                                      {"x"},
+                                      nargs,
+                                      &remaining_kwargs,
+                                      false);
+  *x_ptr_ptr = &x;
+
+  PyObject* value_obj = GetItemFromArgsOrKWArgs(args,
+                                                1,
+                                                kwargs,
+                                                {"value", "fill_value"},
+                                                nargs,
+                                                &remaining_kwargs,
+                                                false);
+  *value = CastPyArg2Float(value_obj, "fill_diagonal_", 1);
+
+  PyObject* wrap_obj = nullptr;
+  bool wrap_provided = false;
+  if (nargs > 3) {
+    wrap_obj = PyTuple_GetItem(args, 3);
+    wrap_provided = true;
+  } else if (kwargs) {
+    wrap_obj = PyDict_GetItemString(kwargs, "wrap");
+    if (wrap_obj) {
+      wrap_provided = true;
+      remaining_kwargs--;
+    }
+  }
+
+  PyObject* offset_obj = nullptr;
+  if (nargs > 2) {
+    offset_obj = PyTuple_GetItem(args, 2);
+  } else if (kwargs) {
+    offset_obj = PyDict_GetItemString(kwargs, "offset");
+    if (offset_obj) {
+      remaining_kwargs--;
+    }
+  }
+
+  if (offset_obj && CheckBool(offset_obj) && !wrap_provided) {
+    wrap_obj = offset_obj;
+    wrap_provided = true;
+    offset_obj = nullptr;
+  }
+
+  if (offset_obj) {
+    *offset = CastPyArg2Int(offset_obj, "fill_diagonal_", 2);
+  } else {
+    *offset = 0;
+  }
+  *wrap = CastPyArg2Boolean(wrap_obj, "fill_diagonal_", 3, false);
+
+  if (x.dims().size() != 2) {
+    *wrap = true;
+  }
+
+  CheckRemainingParamsValidity(args, kwargs, remaining_kwargs, nargs, true);
+}
+
+void FillDiagonalMapper(PyObject* args,
+                        PyObject* kwargs,
+                        pir::Value* x,
+                        float* value,
+                        int* offset,
+                        bool* wrap) {
+  int nargs = args ? static_cast<int>(PyTuple_Size(args)) : 0;
+  int remaining_kwargs = kwargs ? static_cast<int>(PyDict_Size(kwargs)) : 0;
+  const int max_args = 4;
+  CheckParamsCount(nargs, remaining_kwargs, max_args);
+
+  PyObject* x_obj = GetItemFromArgsOrKWArgs(
+      args, 0, kwargs, {"x"}, nargs, &remaining_kwargs);
+  *x = CastPyArg2Value(x_obj, "fill_diagonal_", 0, false);
+
+  PyObject* value_obj = GetItemFromArgsOrKWArgs(args,
+                                                1,
+                                                kwargs,
+                                                {"value", "fill_value"},
+                                                nargs,
+                                                &remaining_kwargs,
+                                                false);
+  *value = CastPyArg2Float(value_obj, "fill_diagonal_", 1);
+
+  PyObject* wrap_obj = nullptr;
+  bool wrap_provided = false;
+  if (nargs > 3) {
+    wrap_obj = PyTuple_GetItem(args, 3);
+    wrap_provided = true;
+  } else if (kwargs) {
+    wrap_obj = PyDict_GetItemString(kwargs, "wrap");
+    if (wrap_obj) {
+      wrap_provided = true;
+      remaining_kwargs--;
+    }
+  }
+
+  PyObject* offset_obj = nullptr;
+  if (nargs > 2) {
+    offset_obj = PyTuple_GetItem(args, 2);
+  } else if (kwargs) {
+    offset_obj = PyDict_GetItemString(kwargs, "offset");
+    if (offset_obj) {
+      remaining_kwargs--;
+    }
+  }
+
+  if (offset_obj && CheckBool(offset_obj) && !wrap_provided) {
+    wrap_obj = offset_obj;
+    wrap_provided = true;
+    offset_obj = nullptr;
+  }
+
+  if (offset_obj) {
+    *offset = CastPyArg2Int(offset_obj, "fill_diagonal_", 2);
+  } else {
+    *offset = 0;
+  }
+  *wrap = CastPyArg2Boolean(wrap_obj, "fill_diagonal_", 3, false);
+
+  auto x_shape = pir::GetShapeFromValue(*x);
+  if (x_shape.size() != 2) {
+    *wrap = true;
+  }
+
+  CheckRemainingParamsValidity(args, kwargs, remaining_kwargs, nargs, true);
 }
 
 }  // namespace pybind

--- a/paddle/fluid/pybind/args_mapper.h
+++ b/paddle/fluid/pybind/args_mapper.h
@@ -59,6 +59,19 @@ void ArgSumMapper(PyObject* args,
                   pir::Value* axis,
                   phi::DataType* dtype,
                   bool* keepdim);
+
+void FillDiagonalMapper(PyObject* args,
+                        PyObject* kwargs,
+                        Tensor** x_ptr_ptr,
+                        float* value,
+                        int* offset,
+                        bool* wrap);
+void FillDiagonalMapper(PyObject* args,
+                        PyObject* kwargs,
+                        pir::Value* x,
+                        float* value,
+                        int* offset,
+                        bool* wrap);
 }  // namespace pybind
 
 }  // namespace paddle

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -246,6 +246,11 @@
   pre_process :
     func : ExpandAsPreProcess(x, y, target_shape)
 
+- op : fill_diagonal
+  name : [paddle.fill_diagonal_, paddle.Tensor.fill_diagonal_]
+  args_mapper :
+    func : FillDiagonalMapper
+
 - op : floor
   name : [paddle.floor, paddle.Tensor.floor]
   args_alias :
@@ -472,6 +477,11 @@
 
 - op : square
   name : [paddle.square, paddle.Tensor.square]
+  args_alias :
+    use_default_mapping : True
+
+- op : squeeze_
+  name : [paddle.squeeze_, paddle.Tensor.squeeze_]
   args_alias :
     use_default_mapping : True
 

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -246,7 +246,7 @@
   pre_process :
     func : ExpandAsPreProcess(x, y, target_shape)
 
-- op : fill_diagonal
+- op : fill_diagonal_
   name : [paddle.fill_diagonal_, paddle.Tensor.fill_diagonal_]
   args_mapper :
     func : FillDiagonalMapper

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -480,6 +480,11 @@
   args_alias :
     use_default_mapping : True
 
+- op : squeeze
+  name : [paddle.squeeze, paddle.Tensor.squeeze]
+  args_alias :
+    use_default_mapping : True
+
 - op : squeeze_
   name : [paddle.squeeze_, paddle.Tensor.squeeze_]
   args_alias :
@@ -511,5 +516,15 @@
 
 - op : triu
   name : [paddle.triu, paddle.Tensor.triu]
+  args_alias :
+    use_default_mapping : True
+
+- op : unsqueeze_
+  name : [paddle.unsqueeze_, paddle.Tensor.unsqueeze_]
+  args_alias :
+    use_default_mapping : True
+
+- op : unsqueeze
+  name : [paddle.unsqueeze, paddle.Tensor.unsqueeze]
   args_alias :
     use_default_mapping : True

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -2121,6 +2121,45 @@ def squeeze_(
 """,
 )
 
+add_doc_and_signature(
+    "unsqueeze_",
+    r"""
+    Note:
+        This API is ONLY available in Dygraph mode.
+
+    Inplace version of ``unsqueeze``. It inserts dimensions of size 1 to the input tensor.
+
+    Args:
+        x (Tensor): The input Tensor. Alias: ``input``.
+        axis (int|list|tuple|Tensor): The dimensions to be inserted. Alias: ``dim``.
+        name (str|None, optional): Name for the operation (optional, default is None).
+
+    Returns:
+        Tensor: The input Tensor after unsqueeze.
+
+    Examples:
+        .. code-block:: pycon
+
+            >>> import paddle
+            >>> x = paddle.rand([5, 10])
+            >>> x.unsqueeze_(axis=0)
+            >>> print(x.shape)
+            [1, 5, 10]
+
+            >>> x = paddle.rand([5, 10])
+            >>> x.unsqueeze_(dim=1)  # type: ignore
+            >>> print(x.shape)
+            [5, 1, 10]
+""",
+    """
+def unsqueeze_(
+    x: Tensor,
+    axis: int | Sequence[int] | Tensor,
+    name: str | None = None,
+) -> Tensor
+""",
+)
+
 # shenwei
 add_doc_and_signature(
     "grid_sample",

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -2039,6 +2039,88 @@ def expand_as(
 """,
 )
 
+add_doc_and_signature(
+    "fill_diagonal_",
+    r"""
+    Note:
+        This API is ONLY available in Dygraph mode.
+
+    This function fills the value into the input Tensor's diagonal inplace.
+
+    Args:
+        x (Tensor): The input Tensor.
+        value (int|float): The value to fill in x's diagonal. Alias: ``fill_value``.
+        offset (int, optional): The offset to the main diagonal. Default: 0 (main diagonal).
+        wrap (bool, optional): The diagonal 'wrapped' after N columns for tall matrices. Default: False.
+        name (str|None, optional): Name for the operation (optional, default is None).
+
+    Returns:
+        Tensor: The input Tensor with diagonal filled with ``value``.
+
+    Examples:
+        .. code-block:: pycon
+
+            >>> import paddle
+            >>> x = paddle.ones((4, 3)) * 2
+            >>> x.fill_diagonal_(1.0)
+            >>> print(x.tolist())
+            [[1.0, 2.0, 2.0], [2.0, 1.0, 2.0], [2.0, 2.0, 1.0], [2.0, 2.0, 2.0]]
+
+            >>> # Use 'fill_value' alias (PyTorch compatible)
+            >>> x.fill_diagonal_(fill_value=0.0)  # type: ignore
+            >>> print(x.tolist())
+            [[0.0, 2.0, 2.0], [2.0, 0.0, 2.0], [2.0, 2.0, 0.0], [2.0, 2.0, 2.0]]
+""",
+    """
+def fill_diagonal_(
+    x: Tensor,
+    value: float,
+    offset: int = 0,
+    wrap: bool = False,
+    name: str | None = None,
+) -> Tensor
+""",
+)
+
+add_doc_and_signature(
+    "squeeze_",
+    r"""
+    Note:
+        This API is ONLY available in Dygraph mode.
+
+    Inplace version of ``squeeze``. It removes the dimensions of size 1 from the input tensor.
+
+    Args:
+        x (Tensor): The input Tensor. Alias: ``input``.
+        axis (int|list|tuple|None, optional): The dimensions to be squeezed. If None, all dimensions of size 1 will be removed. Alias: ``dim``.
+        name (str|None, optional): Name for the operation (optional, default is None).
+
+    Returns:
+        Tensor: The input Tensor after squeeze.
+
+    Examples:
+        .. code-block:: pycon
+
+            >>> import paddle
+            >>> x = paddle.rand([1, 3, 1, 5])
+            >>> x.squeeze_(axis=0)
+            >>> print(x.shape)
+            [3, 1, 5]
+
+            >>> x = paddle.rand([1, 3, 1, 5])
+            >>> x.squeeze_(dim=2)  # type: ignore
+            >>> print(x.shape)
+            [1, 3, 5]
+""",
+    """
+def squeeze_(
+    x: Tensor,
+    axis: int | Sequence[int] | None = None,
+    name: str | None = None,
+) -> Tensor
+""",
+)
+
 # shenwei
 add_doc_and_signature(
     "grid_sample",

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -30,6 +30,7 @@ from paddle._C_ops import (  # noqa: F401
     index_put_,
     roll,
     squeeze_,
+    unsqueeze_,
 )
 from paddle.tensor import fill_constant
 from paddle.utils.decorator_utils import (
@@ -4054,28 +4055,6 @@ def unsqueeze(
         )
 
         return out
-
-
-@inplace_apis_in_dygraph_only
-def unsqueeze_(
-    x: Tensor, axis: int | Sequence[int] | Tensor, name: str | None = None
-) -> Tensor:
-    """
-    Inplace version of ``unsqueeze`` API, the output Tensor will be inplaced with input ``x``.
-    Please refer to :ref:`api_paddle_tensor_unsqueeze`.
-    """
-    input = x
-    axes = axis
-    if isinstance(axes, int):
-        axes = [axes]
-    elif isinstance(axes, Variable):
-        axes = axes.tolist()
-    elif isinstance(axes, (list, tuple)):
-        axes = [
-            item.item(0) if isinstance(item, Variable) else item
-            for item in axes
-        ]
-    return _C_ops.unsqueeze_(input, axes)
 
 
 def _take_along_axis_wrapper(

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -24,7 +24,13 @@ from typing_extensions import overload
 
 import paddle
 from paddle import _C_ops
-from paddle._C_ops import index_put, index_put_, roll  # noqa: F401
+from paddle._C_ops import (  # noqa: F401
+    fill_diagonal_,
+    index_put,
+    index_put_,
+    roll,
+    squeeze_,
+)
 from paddle.tensor import fill_constant
 from paddle.utils.decorator_utils import (
     ParamAliasDecorator,
@@ -1192,52 +1198,6 @@ def zero_(x: Tensor) -> Tensor:
 
     """
     return _C_ops.fill_(x, 0.0)
-
-
-@dygraph_only
-@param_one_alias(["value", "fill_value"])
-def fill_diagonal_(
-    x: Tensor,
-    value: float,
-    offset: int = 0,
-    wrap: bool = False,
-    name: str | None = None,
-) -> Tensor:
-    """
-    Note:
-        This API is ONLY available in Dygraph mode.
-
-    This function fill the value into the x Tensor's diagonal inplace.
-
-    Args:
-        x(Tensor): ``x`` is the original Tensor
-        value(int|float): ``value`` is the value to filled in x.
-            alias: ``fill_value``.
-        offset(int,optional): the offset to the main diagonal. Default: 0 (main diagonal).
-        wrap(bool,optional): the diagonal 'wrapped' after N columns for tall matrices.
-        name(str|None,optional): Name for the operation (optional, default is None)
-
-    Returns:
-        Tensor, Tensor with diagonal filled with value.
-
-    Examples:
-        .. code-block:: pycon
-
-            >>> import paddle
-            >>> x = paddle.ones((4, 3)) * 2
-            >>> x.fill_diagonal_(1.0)
-            >>> print(x.tolist())
-            [[1.0, 2.0, 2.0], [2.0, 1.0, 2.0], [2.0, 2.0, 1.0], [2.0, 2.0, 2.0]]
-
-            >>> # Use 'fill_value' alias (PyTorch compatible)
-            >>> x.fill_diagonal_(fill_value=0.0)  # type: ignore
-            >>> print(x.tolist())
-            [[0.0, 2.0, 2.0], [2.0, 0.0, 2.0], [2.0, 2.0, 0.0], [2.0, 2.0, 2.0]]
-    """
-    if in_dynamic_mode():
-        if len(x.shape) == 2:
-            return _C_ops.fill_diagonal_(x, value, offset, wrap)
-        return _C_ops.fill_diagonal_(x, value, offset, True)
 
 
 def _fill_diagonal_tensor_impl(
@@ -3487,27 +3447,6 @@ def squeeze(
         )
 
         return out
-
-
-@inplace_apis_in_dygraph_only
-def squeeze_(
-    x: Tensor, axis: int | Sequence[int] | None = None, name: str | None = None
-) -> Tensor:
-    """
-    Inplace version of ``squeeze`` API, the output Tensor will be inplaced with input ``x``.
-    Please refer to :ref:`api_paddle_tensor_squeeze`.
-    """
-    if axis is None:
-        axis = []
-    elif isinstance(axis, int):
-        axis = [axis]
-    elif isinstance(axis, tuple):
-        axis = list(axis)
-
-    input = x
-    axes = axis
-    if in_dynamic_mode():
-        return _C_ops.squeeze_(input, axes)
 
 
 @param_two_alias(["x", "input"], ["axis", "dim"])

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -1765,5 +1765,78 @@ class TestTensorCumsumInplace(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestSqueezeInplaceCompatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2025)
+        self.shape = [2, 1, 3]
+        self.dtype = 'float32'
+        self.np_x = np.random.rand(*self.shape).astype(self.dtype)
+
+    def test_dygraph_inplace_Compatibility(self):
+        paddle.disable_static()
+        ref_out = np.squeeze(self.np_x, axis=1)
+
+        # Test 1: Paddle positional arguments
+        x1 = paddle.to_tensor(self.np_x)
+        out1 = paddle.squeeze_(x1, 1)
+
+        # Test 2: Paddle keyword arguments
+        x2 = paddle.to_tensor(self.np_x)
+        out2 = paddle.squeeze_(x=x2, axis=1)
+
+        # Test 3: PyTorch keyword arguments (alias)
+        x3 = paddle.to_tensor(self.np_x)
+        out3 = paddle.squeeze_(input=x3, dim=1)
+
+        # Test 4: Mixed arguments
+        x4 = paddle.to_tensor(self.np_x)
+        out4 = paddle.squeeze_(x4, axis=1)
+
+        # Test 5: Tensor method positional arguments
+        x5 = paddle.to_tensor(self.np_x)
+        out5 = x5.squeeze_(1)
+
+        # Test 6: Tensor method keyword arguments
+        x6 = paddle.to_tensor(self.np_x)
+        out6 = x6.squeeze_(axis=1)
+
+        # Test 7: Tensor method keyword arguments (alias)
+        x7 = paddle.to_tensor(self.np_x)
+        out7 = x7.squeeze_(dim=1)
+
+        for out in [out1, out2, out3, out4, out5, out6, out7]:
+            np.testing.assert_allclose(ref_out, out.numpy())
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
+            x = paddle.static.data(
+                name="x", shape=self.shape, dtype=self.dtype
+            )
+            out1 = paddle.squeeze_(x, 1)
+            out2 = paddle.squeeze_(input=x, dim=1)
+            out3 = x.squeeze_(axis=1)
+            out4 = x.squeeze_(dim=1)
+            exe = paddle.static.Executor()
+            fetches = exe.run(
+                main,
+                feed={"x": self.np_x},
+                fetch_list=[out1, out2, out3, out4],
+            )
+            ref_out = np.squeeze(self.np_x, axis=1)
+            for out in fetches:
+                np.testing.assert_allclose(out, ref_out)
+
+    def test_error(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        with self.assertRaises(TypeError):
+            paddle.squeeze_(x, axis=1.2)
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -1838,5 +1838,72 @@ class TestSqueezeInplaceCompatibility(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestUnsqueezeInplaceCompatibility(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2025)
+        self.shape = [2, 3]
+        self.dtype = 'float32'
+        self.np_x = np.random.rand(*self.shape).astype(self.dtype)
+
+    def test_dygraph_inplace_Compatibility(self):
+        paddle.disable_static()
+        ref_out = np.expand_dims(self.np_x, axis=1)
+
+        # Test 1: Paddle positional arguments
+        x1 = paddle.to_tensor(self.np_x)
+        out1 = paddle.unsqueeze_(x1, 1)
+
+        # Test 2: Paddle keyword arguments
+        x2 = paddle.to_tensor(self.np_x)
+        out2 = paddle.unsqueeze_(x=x2, axis=1)
+
+        # Test 3: PyTorch keyword arguments (alias)
+        x3 = paddle.to_tensor(self.np_x)
+        out3 = paddle.unsqueeze_(input=x3, dim=1)
+
+        # Test 4: Mixed arguments
+        x4 = paddle.to_tensor(self.np_x)
+        out4 = paddle.unsqueeze_(x4, axis=1)
+
+        # Test 5: Tensor method positional arguments
+        x5 = paddle.to_tensor(self.np_x)
+        out5 = x5.unsqueeze_(1)
+
+        # Test 6: Tensor method keyword arguments
+        x6 = paddle.to_tensor(self.np_x)
+        out6 = x6.unsqueeze_(axis=1)
+
+        # Test 7: Tensor method keyword arguments (alias)
+        x7 = paddle.to_tensor(self.np_x)
+        out7 = x7.unsqueeze_(dim=1)
+
+        for out in [out1, out2, out3, out4, out5, out6, out7]:
+            np.testing.assert_allclose(ref_out, out.numpy())
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
+            x = paddle.static.data(
+                name="x", shape=self.shape, dtype=self.dtype
+            )
+            out1 = paddle.unsqueeze_(x, 1)
+            out2 = paddle.unsqueeze_(input=x, dim=1)
+            out3 = x.unsqueeze_(axis=1)
+            out4 = x.unsqueeze_(dim=1)
+            exe = paddle.static.Executor()
+            fetches = exe.run(
+                main,
+                feed={"x": self.np_x},
+                fetch_list=[out1, out2, out3, out4],
+            )
+            ref_out = np.expand_dims(self.np_x, axis=1)
+            for out in fetches:
+                np.testing.assert_allclose(ref_out, out)
+        paddle.disable_static()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -1813,9 +1813,7 @@ class TestSqueezeInplaceCompatibility(unittest.TestCase):
         main = paddle.static.Program()
         startup = paddle.static.Program()
         with paddle.static.program_guard(main, startup):
-            x = paddle.static.data(
-                name="x", shape=self.shape, dtype=self.dtype
-            )
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
             out1 = paddle.squeeze_(x, 1)
             out2 = paddle.squeeze_(input=x, dim=1)
             out3 = x.squeeze_(axis=1)
@@ -1886,9 +1884,7 @@ class TestUnsqueezeInplaceCompatibility(unittest.TestCase):
         main = paddle.static.Program()
         startup = paddle.static.Program()
         with paddle.static.program_guard(main, startup):
-            x = paddle.static.data(
-                name="x", shape=self.shape, dtype=self.dtype
-            )
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
             out1 = paddle.unsqueeze_(x, 1)
             out2 = paddle.unsqueeze_(input=x, dim=1)
             out3 = x.unsqueeze_(axis=1)

--- a/test/legacy_test/test_tensor_fill_diagonal_.py
+++ b/test/legacy_test/test_tensor_fill_diagonal_.py
@@ -311,6 +311,23 @@ class TestFillDiagonalAlias(unittest.TestCase):
         with self.assertRaises((ValueError, TypeError)):
             x.fill_diagonal_(value=1.0, fill_value=2.0)
 
+    def test_positional_wrap_bool(self):
+        expected_np = np.array(
+            [
+                [1, 2, 2],
+                [2, 1, 2],
+                [2, 2, 1],
+                [2, 2, 2],
+                [1, 2, 2],
+                [2, 1, 2],
+                [2, 2, 1],
+            ]
+        ).astype('float32')
+        x = paddle.ones((7, 3), dtype='float32')
+        y = x * 2
+        y.fill_diagonal_(1, True)
+        self.assertTrue((y.numpy() == expected_np).all())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/gen_pybind11_stub.py
+++ b/tools/gen_pybind11_stub.py
@@ -730,9 +730,8 @@ class OpsYamlBaseAPI:
         python_api_info: dict[str, list[str]],
     ):
         if name in python_api_info:
-            return self.make_python_api_function(
-                name, python_api_info[raw_name]
-            )
+            api_names = python_api_info.get(raw_name, python_api_info[name])
+            return self.make_python_api_function(name, api_names)
         else:
             return self.make_op_function(
                 raw_name, inputs, attrs, output_type_list


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category

User Experience


### PR Types

New features

### Description

 - Sink paddle.fill_diagonal_, paddle.squeeze_, and paddle.unsqueeze_ to C++ path.
  - Add/align alias compatibility for PyTorch-style kwargs (input/x, dim/axis) through YAML-based API mapping.
  - Introduce FillDiagonalMapper in C++ args mapper to support positional wrap behavior and alias parsing
    consistently in dygraph/PIR paths.
  - Remove Python-side unsqueeze_ wrapper logic so inplace calls use generated _C_ops bindings directly.
  - Update API docs/signatures and stub generation handling for inplace-only API entries.
  - Add compatibility test coverage for squeeze_ and unsqueeze_ (dygraph + static) and extend fill_diagonal_
    tests for positional wrap usage.

### 是否引起精度变化

否
