### PR TITLE
[BugFix] Fix OOB memory access in IndexEleGetGradAccKernel for sub-4-byte types

### DIFF
--- a/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
@@ -407,7 +407,17 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                                    const bool accumulate,
                                    const bool is_combined,
                                    DenseTensor* x_grad) {
-  dev_ctx.template Alloc<T>(x_grad);
+  // CudaAtomicAdd for sub-4-byte types (bool, int8_t, uint8_t, int16_t) uses
+  // atomicCAS on uint32_t, which reads 4 bytes at a 4-byte-aligned address.
+  // If the total allocation size is not a multiple of 4, the last few elements
+  // may cause out-of-bounds reads. Pad the allocation to prevent this.
+  if (sizeof(T) < 4 && accumulate) {
+    size_t alloc_bytes = static_cast<size_t>(x_grad->numel()) * sizeof(T);
+    size_t padded_bytes = (alloc_bytes + 3) & ~static_cast<size_t>(3);
+    dev_ctx.template Alloc<T>(x_grad, padded_bytes);
+  } else {
+    dev_ctx.template Alloc<T>(x_grad);
+  }
   funcs::set_constant(dev_ctx, x_grad, static_cast<float>(0));
   if (out_grad.numel() == 0) return;
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

`CudaAtomicAdd` for sub-4-byte types (`bool`, `int8_t`, `uint8_t`, `int16_t`) uses `atomicCAS` on `uint32_t`, which reads 4 bytes at a 4-byte-aligned address. In `IndexEleGetGradAccKernel` (the accumulate path of `index_elementwise_get_grad`), when the gradient tensor's total byte size is not a multiple of 4, the last few elements trigger out-of-bounds memory reads.

For example, a `[3,3]` bool tensor has 9 bytes of allocation. The last element at byte offset 8 causes a 4-byte read spanning offsets 8–11, but only offsets 0–8 are allocated.

This is detected by `compute-sanitizer --tool memcheck` as:
```
Invalid __global__ read of size 4 bytes
    Access at 0x7fe9eca00a08 is out of bounds
    and is inside the nearest allocation at 0x7fe9eca00a00 of size 9 bytes
```
which then triggers CUDA error 719 (unspecified launch failure).

**Fix**: Pad the `x_grad` allocation to a multiple of 4 bytes when `sizeof(T) < 4` and `accumulate` is true, by using the `requested_size` parameter of `Alloc<T>()`.

**Verification**: After applying the fix, running the same test case with compute-sanitizer reports `ERROR SUMMARY: 0 errors`.

### 是否引起精度变化
否