### PR TITLE
[release/3.3] Fix fast_ln_v2 kernel dispatch condition

### DIFF
--- a/paddle/phi/kernels/funcs/fast_ln_v2_bwd_kernel.cu
+++ b/paddle/phi/kernels/funcs/fast_ln_v2_bwd_kernel.cu
@@ -217,8 +217,8 @@ __global__ __launch_bounds__(Ktraits::THREADS_PER_CTA) void ln_bwd_kernel(
         (params.dscale_part != nullptr)
             ? static_cast<compute_t *>(params.dscale_part) + bidm * COLS + tidx
             : nullptr;
-    for (int jt = 0; jt < NUM_RES; jt++) {
-      if (dgamma_part != nullptr) {
+    if (dgamma_part != nullptr) {
+      for (int jt = 0; jt < NUM_RES; jt++) {
         *dgamma_part = cta_dzy_sum[jt];
         dgamma_part += Ktraits::THREADS_PER_CTA;
       }

--- a/paddle/phi/kernels/gpu/layer_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_grad_kernel.cu
@@ -32,10 +32,12 @@ static inline LayerNormGadKernelVariant LayerNormGradKernelDispatch(
     const paddle::DataType compute_type,
     const uint32_t hidden_size,
     const int64_t x_numel,
-    const DenseTensor* scale) {
+    const DenseTensor* scale,
+    const DenseTensor* bias) {
 #if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
-  if (scale != nullptr && input_type != paddle::DataType::FLOAT32 &&
-      hidden_size != 4096 && hidden_size > 1024 && hidden_size <= 10240 &&
+  if (scale != nullptr && bias != nullptr &&
+      input_type != paddle::DataType::FLOAT32 && hidden_size != 4096 &&
+      hidden_size > 1024 && hidden_size <= 10240 &&
       x_numel <= std::numeric_limits<uint32_t>::max()) {
     // using fast_ln_v2 only sm > 70 and x_numel <= uint32_max
     auto prop = funcs::fast_ln_v2::GetDeviceProp();
@@ -193,7 +195,8 @@ void LayerNormGradKernel(const Context& dev_ctx,
                                                     compute_dtype,
                                                     feature_size,
                                                     x.numel(),
-                                                    scale);
+                                                    scale,
+                                                    bias);
   switch (kernel_variant) {
 #if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
     case LayerNormGadKernelVariant::FAST_LN_V2:


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
- Fix the fast_ln_v2 kernel dispatch condition to only activate when both scale and bias are present, avoiding potential incorrect computations
- Optimize the loop order in fast_ln_v2 backward kernel to reduce unnecessary iterations
- These changes ensure numerical correctness and improve performance for LayerNorm gradient computation

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

---

Cherry-pick of #77709 (authored by @zrr1999) to `release/3.3`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/77709 <!-- For pass CI -->