### PR TITLE
[large tensor] Add large-tensor safety checks for primitive entry points

### DIFF
--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -828,6 +828,10 @@ void BroadcastKernel(const KPDevice &dev_ctx,
   if ((*outs)[0]->numel() == 0) {
     return;
   }
+  PADDLE_ENFORCE_LE_INT_MAX((*outs)[0]->numel(), "out->numel()");
+  for (int i = 0; i < (*outs)[0]->dims().size(); ++i) {
+    PADDLE_ENFORCE_LE_INT_MAX((*outs)[0]->dims()[i], "out.dim(i)");
+  }
   int max_rank = 0;
   int min_rank = DDim::kMaxRank;
   for (auto *in : ins) {

--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -829,9 +829,6 @@ void BroadcastKernel(const KPDevice &dev_ctx,
     return;
   }
   PADDLE_ENFORCE_LE_INT_MAX((*outs)[0]->numel(), "out->numel()");
-  for (int i = 0; i < (*outs)[0]->dims().size(); ++i) {
-    PADDLE_ENFORCE_LE_INT_MAX((*outs)[0]->dims()[i], "out.dim(i)");
-  }
   int max_rank = 0;
   int min_rank = DDim::kMaxRank;
   for (auto *in : ins) {

--- a/paddle/phi/kernels/funcs/index_impl.cu.h
+++ b/paddle/phi/kernels/funcs/index_impl.cu.h
@@ -21,6 +21,7 @@ limitations under the License. */
 #include "paddle/common/hostdevice.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/enforce.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
 #include "paddle/phi/kernels/primitive/kernel_primitives.h"
 
@@ -57,6 +58,7 @@ void IndexKernel(const KPDevice &dev_ctx, DenseTensor *out, Functor func) {
   int64_t numel = out->numel();
   T *out_data = dev_ctx.template Alloc<T>(out);
   if (numel <= 0) return;
+  PADDLE_ENFORCE_LE_INT_MAX(numel, "numel");
   size_t vec_size = std::min(4, phi::GetVectorizedSize(out_data));
 #ifdef PADDLE_WITH_XPU_KP
   size_t block = 64;

--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -1083,6 +1083,7 @@ void ReduceKernel(const KPDevice& dev_ctx,
     dev_ctx.Alloc<Ty>(y);
     return;
   }
+  PADDLE_ENFORCE_LE_INT_MAX(x.numel(), "x.numel()");
 #ifdef PADDLE_WITH_XPU_KP
   auto stream = dev_ctx.x_context()->xpu_stream;
 #else
@@ -1102,6 +1103,9 @@ void ReduceKernel(const KPDevice& dev_ctx,
   using MPType = typename phi::dtype::MPTypeTrait<Ty>::Type;
   auto config = ReduceConfig<Ty, MPType>(origin_reduce_dims, x_dim);
   config.Run(dev_ctx);
+
+  PADDLE_ENFORCE_LE_INT_MAX(config.reduce_num, "reduce_num");
+  PADDLE_ENFORCE_LE_INT_MAX(config.left_num, "left_num");
 
   int64_t numel = x.numel();
   // after config.run()

--- a/paddle/phi/kernels/primitive/datamover_primitives.h
+++ b/paddle/phi/kernels/primitive/datamover_primitives.h
@@ -21,6 +21,7 @@
 #include <hip/hip_fp16.h>
 #endif
 #include "paddle/common/ddim.h"
+#include "paddle/phi/core/enforce.h"
 #include "paddle/phi/kernels/funcs/fast_divmod.h"
 
 namespace phi {
@@ -51,7 +52,8 @@ struct BroadcastConfig {
                   const std::vector<int64_t>& in_dims,
                   int dim_size) {
     for (int i = 0; i < dim_size; ++i) {
-      divmoders[i] = funcs::FastDivMod<int>(out_dims[i]);
+      PADDLE_ENFORCE_LE_INT_MAX(out_dims[i], "out_dims[i]");
+      divmoders[i] = funcs::FastDivMod<int>(static_cast<int>(out_dims[i]));
     }
 
     for (int i = 0; i < dim_size; ++i) {

--- a/paddle/phi/kernels/primitive/datamover_primitives_xpu2.h
+++ b/paddle/phi/kernels/primitive/datamover_primitives_xpu2.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include "paddle/phi/core/enforce.h"
 #include "xpu/kernel/cluster_header.h"
 #include "xpu/kernel/debug.h"
 #include "xpu/kernel/math.h"
@@ -104,15 +105,18 @@ struct BroadcastConfig {
     strides_out_tmp.resize(dim_size, 1);
     dim_tmp.resize(dim_size, 1);
     for (int i = 1; i < dim_size; i++) {
+      PADDLE_ENFORCE_LE_INT_MAX(out_dims[i], "out_dims[i]");
+      PADDLE_ENFORCE_LE_INT_MAX(in_dims[i], "in_dims[i]");
       strides_in_tmp[i] = strides_in_tmp[i - 1] * in_dims[i - 1];
       strides_out_tmp[i] = strides_out_tmp[i - 1] * out_dims[i - 1];
     }
 
-    int numel_out = 1;
+    int64_t numel_out = 1;
     for (int i = 0; i < dim_size; i++) {
       dim_tmp[i] = in_dims[i];
       numel_out = out_dims[i] * numel_out;
     }
+    PADDLE_ENFORCE_LE_INT_MAX(numel_out, "numel_out");
     kDims = dim_size;
     memcpy(strides_in, strides_in_tmp.data(), kDims * sizeof(int));
     memcpy(strides_out, strides_out_tmp.data(), kDims * sizeof(int));
@@ -120,15 +124,17 @@ struct BroadcastConfig {
 
     cmp_res = get_mnk_for_broadcast_ops(in_dims, y_in_dims);
     get_opt_type();
-    buf_len = get_buf_len(numel_out);
-    int numel_x = 1;
-    int numel_y = 1;
+    buf_len = get_buf_len(static_cast<int>(numel_out));
+    int64_t numel_x = 1;
+    int64_t numel_y = 1;
     for (int i = 0; i < dim_size; i++) {
       numel_x = in_dims[i] * numel_x;
       numel_y = y_in_dims[i] * numel_y;
     }
+    PADDLE_ENFORCE_LE_INT_MAX(numel_x, "numel_x");
+    PADDLE_ENFORCE_LE_INT_MAX(numel_y, "numel_y");
     if (numel_out == numel_x && numel_out == numel_y) {
-      buf_len = GetXpuReadLens(numel_out, 8, 64);
+      buf_len = GetXpuReadLens(static_cast<int>(numel_out), 8, 64);
     }
   }
 


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Improvements

### Description
Add large-tensor safety checks for primitive entry points to prevent narrowing conversion issues with large tensors by validating size constraints. This ensures that tensor dimensions are properly validated before performing operations that could lead to data loss or incorrect results with large tensor sizes.

### 是否引起精度变化
否