### PR TITLE
[XPU] support more dtypes for linspace kernel

### DIFF
--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -993,7 +993,9 @@ XPUOpMap& get_kl3_ops() {
       {"sin_grad", XPUKernelSet({FLOAT32})},
       {"cos", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"cos_grad", XPUKernelSet({FLOAT32})},
-      {"linspace", XPUKernelSet({FLOAT32, INT32, INT64})},
+      {"linspace",
+       XPUKernelSet(
+           {FLOAT32, FLOAT16, BFLOAT16, INT8, UINT8, INT16, INT32, INT64})},
       {"randint", XPUKernelSet({INT32, INT64})},
       {"group_norm", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"group_norm_grad", XPUKernelSet({FLOAT32, FLOAT16})},

--- a/paddle/phi/kernels/xpu/linspace_kernel.cc
+++ b/paddle/phi/kernels/xpu/linspace_kernel.cc
@@ -39,6 +39,8 @@ T GetValueOfExpectedType(const Context& dev_ctx, const DenseTensor& x) {
       return static_cast<T>(GetValue<bool, Context>(dev_ctx, x));
     case DataType::INT16:
       return static_cast<T>(GetValue<int16_t, Context>(dev_ctx, x));
+    case DataType::INT8:
+      return static_cast<T>(GetValue<int8_t, Context>(dev_ctx, x));
     case DataType::UINT8:
       return static_cast<T>(GetValue<uint8_t, Context>(dev_ctx, x));
     default:
@@ -81,8 +83,18 @@ void LinspaceKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(
-    linspace, XPU, ALL_LAYOUT, phi::LinspaceKernel, float, int32_t, int64_t) {
+PD_REGISTER_KERNEL(linspace,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::LinspaceKernel,
+                   float,
+                   phi::float16,
+                   phi::bfloat16,
+                   int8_t,
+                   uint8_t,
+                   int16_t,
+                   int32_t,
+                   int64_t) {
   kernel->InputAt(0).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(2).SetBackend(phi::Backend::ALL_BACKEND);

--- a/test/xpu/test_linspace_op_xpu.py
+++ b/test/xpu/test_linspace_op_xpu.py
@@ -20,6 +20,7 @@ from get_test_cover_info import (
     create_test_class,
     get_xpu_op_support_types,
 )
+from op_test import convert_float_to_uint16
 from op_test_xpu import XPUOpTest
 
 import paddle
@@ -36,8 +37,6 @@ class XPUTestLinspaceOp(XPUOpTestWrapper):
         def setUp(self):
             self.op_type = "linspace"
             self.dtype = self.in_type
-            self.set_attrs()
-
             self.atol = 1e-4
             np.random.seed(10)
             self.inputs = {
@@ -53,9 +52,25 @@ class XPUTestLinspaceOp(XPUOpTestWrapper):
                     )
                 )
             }
+            self.set_attrs()
+            self._maybe_convert_bf16_io()
 
         def set_attrs(self):
             pass
+
+        def _maybe_convert_bf16_io(self):
+            if self.dtype != np.uint16:
+                return
+
+            def to_bf16_bits(x):
+                x = np.asarray(x)
+                if x.size == 0:
+                    return x.astype(np.uint16)
+                return convert_float_to_uint16(x.astype("float32"))
+
+            self.inputs["Start"] = to_bf16_bits(self.inputs["Start"])
+            self.inputs["Stop"] = to_bf16_bits(self.inputs["Stop"])
+            self.outputs["Out"] = to_bf16_bits(self.outputs["Out"])
 
         def test_check_output(self):
             self.check_output_with_place(paddle.XPUPlace(0), atol=self.atol)
@@ -77,7 +92,7 @@ class XPUTestLinspaceOp(XPUOpTestWrapper):
                 'Stop': np.array([0]).astype(self.dtype),
                 'Num': np.array([1]).astype('int32'),
             }
-            self.outputs = {'Out': np.array(10, dtype=self.dtype)}
+            self.outputs = {'Out': np.array([10], dtype=self.dtype)}
 
     class TestXPULinespace4(TestXPULinespaceOp):
         def set_attrs(self):


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Improvements

### Description

- Extend XPU linspace kernel dtype support in paddle/phi/kernels/xpu/linspace_kernel.cc.
- Add INT8 handling in GetValueOfExpectedType, so scalar start/stop/number inputs can be parsed correctly when provided as int8.
- Expand XPU kernel registration dtypes from {float, int32, int64} to:
    - float, phi::float16, phi::bfloat16, int8_t, uint8_t, int16_t, int32_t, int64_t.
- This improves dtype coverage consistency for XPU linspace without changing existing operator semantics.

### 是否引起精度变化

否