### PR TITLE
[XPU] Add frame and frame_grad kernel bindings

### DIFF
--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -25,7 +25,15 @@ XPUOpMap& get_kl3_ops() {
       {"acos", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"add_act_xpu", XPUKernelSet({FLOAT32, FLOAT16})},
       {"add_layernorm_xpu", XPUKernelSet({FLOAT32, FLOAT16})},
-      {"abs", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
+      {"abs",
+       XPUKernelSet({FLOAT32,
+                     FLOAT16,
+                     BFLOAT16
+#ifdef PADDLE_WITH_XPU_FFT
+                     ,
+                     COMPLEX64
+#endif
+       })},
       {"abs_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"accuracy", XPUKernelSet({FLOAT32, FLOAT16})},
       {"adadelta", XPUKernelSet({FLOAT32})},

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -383,6 +383,10 @@ XPUOpMap& get_kl3_ops() {
       {"unfold", XPUKernelSet({FLOAT32, FLOAT16})},
       {"unfold_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"floor", XPUKernelSet({FLOAT32})},
+      {"frame",
+       XPUKernelSet({INT32, INT64, FLOAT32, FLOAT64, FLOAT16, BFLOAT16})},
+      {"frame_grad",
+       XPUKernelSet({INT32, INT64, FLOAT32, FLOAT64, FLOAT16, BFLOAT16})},
       {"ceil", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"gather_grad",
        XPUKernelSet(

--- a/paddle/phi/kernels/xpu/abs_kernel.cc
+++ b/paddle/phi/kernels/xpu/abs_kernel.cc
@@ -15,7 +15,13 @@
 #include "paddle/phi/kernels/abs_kernel.h"
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/backends/xpu/xpu_context.h"
+#include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/activation_kernel.h"
+#include "paddle/phi/kernels/complex_kernel.h"
+#include "paddle/phi/kernels/elementwise_add_kernel.h"
+#include "paddle/phi/kernels/elementwise_multiply_kernel.h"
 
 namespace phi {
 
@@ -32,6 +38,28 @@ void AbsKernel(const Context& dev_ctx, const DenseTensor& x, DenseTensor* out) {
                             x.numel());
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "abs");
 }
+
+#ifdef PADDLE_WITH_XPU_FFT
+template <>
+void AbsKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
+                                           const DenseTensor& x,
+                                           DenseTensor* out) {
+  using T = phi::complex64;
+  using RealT = phi::dtype::Real<T>;
+
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<RealT>(out);
+    return;
+  }
+
+  const DenseTensor real = Real<T, XPUContext>(dev_ctx, x);
+  const DenseTensor imag = Imag<T, XPUContext>(dev_ctx, x);
+  const DenseTensor real_sq = Multiply<RealT, XPUContext>(dev_ctx, real, real);
+  const DenseTensor imag_sq = Multiply<RealT, XPUContext>(dev_ctx, imag, imag);
+  const DenseTensor sum_sq = Add<RealT, XPUContext>(dev_ctx, real_sq, imag_sq);
+  SqrtKernel<RealT, XPUContext>(dev_ctx, sum_sq, out);
+}
+#endif
 }  // namespace phi
 
 PD_REGISTER_KERNEL(abs,
@@ -43,4 +71,11 @@ PD_REGISTER_KERNEL(abs,
                    phi::bfloat16,
                    int8_t,
                    int32_t,
-                   int64_t) {}
+                   int64_t
+#ifdef PADDLE_WITH_XPU_FFT
+                   ,
+                   phi::complex64
+#endif
+) {
+  kernel->OutputAt(0).SetDataType(phi::dtype::ToReal(kernel_key.dtype()));
+}

--- a/paddle/phi/kernels/xpu/frame_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/frame_grad_kernel.cc
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/frame_grad_kernel.h"
+
+#include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/backends/xpu/xpu_context.h"
+#include "paddle/phi/core/ddim.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "xpu/refactor/paddle_api.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void FrameGradKernel(const Context& dev_ctx,
+                     const DenseTensor& x,
+                     const DenseTensor& dout,
+                     int frame_length,
+                     int hop_length,
+                     int axis,
+                     DenseTensor* dx) {
+  using XPUType = typename XPUTypeTrait<T>::Type;
+  dev_ctx.template Alloc<T>(dx);
+  if (dx->numel() == 0 || dout.numel() == 0) {
+    return;
+  }
+
+  auto xshape = common::vectorize<int64_t>(x.dims());
+  auto out_grad_shape = common::vectorize<int64_t>(dout.dims());
+  int r = baidu::xpu::api::frame_grad<XPUType>(
+      dev_ctx.x_context(),
+      reinterpret_cast<const XPUType*>(x.data<T>()),
+      reinterpret_cast<const XPUType*>(dout.data<T>()),
+      reinterpret_cast<XPUType*>(dx->data<T>()),
+      xshape,
+      out_grad_shape,
+      static_cast<int64_t>(frame_length),
+      static_cast<int64_t>(hop_length),
+      static_cast<int64_t>(axis));
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "frame_grad");
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(frame_grad,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::FrameGradKernel,
+                   int,
+                   int64_t,
+                   float,
+                   double,
+                   phi::float16,
+                   phi::bfloat16) {}

--- a/paddle/phi/kernels/xpu/frame_kernel.cc
+++ b/paddle/phi/kernels/xpu/frame_kernel.cc
@@ -1,0 +1,63 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/frame_kernel.h"
+
+#include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/backends/xpu/xpu_context.h"
+#include "paddle/phi/core/ddim.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "xpu/refactor/paddle_api.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void FrameKernel(const Context& dev_ctx,
+                 const DenseTensor& x,
+                 int frame_length,
+                 int hop_length,
+                 int axis,
+                 DenseTensor* out) {
+  using XPUType = typename XPUTypeTrait<T>::Type;
+  dev_ctx.template Alloc<T>(out);
+  if (x.numel() == 0 || out->numel() == 0) {
+    return;
+  }
+
+  auto xshape = common::vectorize<int64_t>(x.dims());
+  auto outshape = common::vectorize<int64_t>(out->dims());
+  int r = baidu::xpu::api::frame<XPUType>(
+      dev_ctx.x_context(),
+      reinterpret_cast<const XPUType*>(x.data<T>()),
+      reinterpret_cast<XPUType*>(out->data<T>()),
+      xshape,
+      outshape,
+      static_cast<int64_t>(frame_length),
+      static_cast<int64_t>(hop_length),
+      static_cast<int64_t>(axis));
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "frame");
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(frame,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::FrameKernel,
+                   int,
+                   int64_t,
+                   float,
+                   double,
+                   phi::float16,
+                   phi::bfloat16) {}

--- a/test/xpu/test_activation_op_xpu.py
+++ b/test/xpu/test_activation_op_xpu.py
@@ -478,6 +478,36 @@ for stype in support_types:
     create_test_class(globals(), XPUTestAbsOPZeroSize, stype)
 
 
+class XPUTestAbsOPComplex(XPUOpTestWrapper):
+    def __init__(self):
+        self.op_name = 'abs'
+        self.use_dynamic_create_class = False
+
+    class XPUTestAbsComplex(TestActivationOPBase):
+        def set_case(self):
+            self.op_type = "abs"
+            self.dtype = np.complex64
+
+            # Generate complex numbers with both real and imaginary parts
+            real_part = np.random.uniform(-1, 1, [4, 25]).astype(np.float32)
+            imag_part = np.random.uniform(-1, 1, [4, 25]).astype(np.float32)
+            # Avoid values too close to zero
+            real_part[np.abs(real_part) < 0.005] = 0.02
+            imag_part[np.abs(imag_part) < 0.005] = 0.02
+            x = real_part + 1j * imag_part
+
+            # abs(complex64) returns float32
+            out = np.abs(x).astype(np.float32)
+
+            self.attrs = {'use_xpu': True}
+            self.inputs = {'X': OpTest.np_dtype_to_base_dtype(x)}
+            self.outputs = {'Out': out}
+
+
+# Create test class for complex64
+create_test_class(globals(), XPUTestAbsOPComplex, 'complex64')
+
+
 class XPUTestReluOP(XPUOpTestWrapper):
     def __init__(self):
         self.op_name = 'relu'

--- a/test/xpu/test_frame_grad_op_xpu.py
+++ b/test/xpu/test_frame_grad_op_xpu.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from op_test import convert_float_to_uint16, convert_uint16_to_float
+
+import paddle
+from paddle.base import core
+
+
+def frame_grad_numpy(out_grad, x_shape, frame_length, hop_length, axis):
+    x_grad = np.zeros(x_shape, dtype=out_grad.dtype)
+    if axis == -1:
+        n_frames = out_grad.shape[-1]
+        for n in range(n_frames):
+            start = n * hop_length
+            end = start + frame_length
+            x_grad[..., start:end] += out_grad[..., :, n]
+    else:
+        n_frames = out_grad.shape[0]
+        for n in range(n_frames):
+            start = n * hop_length
+            end = start + frame_length
+            x_grad[start:end, ...] += out_grad[n, ...]
+    return x_grad
+
+
+class TestFrameGradAPIXPU(unittest.TestCase):
+    def setUp(self):
+        if not core.is_compiled_with_xpu():
+            self.skipTest("XPU is not available")
+        paddle.disable_static()
+        paddle.set_device("xpu")
+        self.place = paddle.XPUPlace(0)
+        np.random.seed(2026)
+
+    def tearDown(self):
+        paddle.enable_static()
+
+    def _dtype_list(self):
+        dtypes = ["float32", "float64", "float16"]
+        if core.is_bfloat16_supported(self.place):
+            dtypes.append("bfloat16")
+        return dtypes
+
+    def _make_tensor(self, x_np, dtype, stop_gradient):
+        # bf16/float16 统一从 float32 源构造，避免 numpy 端缺 dtype 或精度噪声过大。
+        if dtype in ["float16", "bfloat16"]:
+            t = paddle.to_tensor(x_np.astype("float32"))
+            t = paddle.cast(t, dtype)
+        else:
+            t = paddle.to_tensor(x_np.astype(dtype))
+        t.stop_gradient = stop_gradient
+        return t
+
+    def _to_float_np(self, t):
+        if t.dtype in [paddle.float16, paddle.bfloat16]:
+            return paddle.cast(t, "float32").numpy()
+        return t.numpy()
+
+    def _bf16_quantize_np(self, x):
+        x_fp32 = x.astype("float32", copy=False)
+        return convert_uint16_to_float(convert_float_to_uint16(x_fp32))
+
+    def run_case(self, shape, frame_length, hop_length, axis, dtype, seed):
+        rng = np.random.default_rng(seed)
+
+        x_np = rng.uniform(-1.0, 1.0, size=shape)
+        if dtype == "bfloat16":
+            x_np = self._bf16_quantize_np(x_np)
+        x = self._make_tensor(x_np, dtype, stop_gradient=False)
+        out = paddle.signal.frame(x, frame_length, hop_length, axis)
+
+        out_grad_np = rng.uniform(-1.0, 1.0, size=tuple(out.shape))
+        if dtype == "bfloat16":
+            out_grad_np = self._bf16_quantize_np(out_grad_np)
+        out_grad = self._make_tensor(out_grad_np, dtype, stop_gradient=True)
+        (x_grad,) = paddle.grad([out], [x], grad_outputs=[out_grad])
+
+        # 参考实现统一在高精度侧计算，再按对比口径落到 float32/float64。
+        if dtype == "float64":
+            expect = frame_grad_numpy(
+                out_grad_np.astype("float64"),
+                tuple(np.array(shape).tolist()),
+                frame_length,
+                hop_length,
+                axis,
+            )
+            got = x_grad.numpy()
+            rtol, atol = 1e-10, 1e-10
+        elif dtype == "float32":
+            expect = frame_grad_numpy(
+                out_grad_np.astype("float32"),
+                tuple(np.array(shape).tolist()),
+                frame_length,
+                hop_length,
+                axis,
+            )
+            got = x_grad.numpy()
+            rtol, atol = 1e-5, 1e-5
+        elif dtype == "float16":
+            expect = frame_grad_numpy(
+                out_grad_np.astype("float32"),
+                tuple(np.array(shape).tolist()),
+                frame_length,
+                hop_length,
+                axis,
+            ).astype("float32")
+            got = self._to_float_np(x_grad)
+            rtol, atol = 8e-3, 8e-3
+        else:  # bfloat16
+            expect = frame_grad_numpy(
+                out_grad_np.astype("float32"),
+                tuple(np.array(shape).tolist()),
+                frame_length,
+                hop_length,
+                axis,
+            ).astype("float32")
+            got = self._to_float_np(x_grad)
+            rtol, atol = 1.5e-2, 1.5e-2
+
+        np.testing.assert_allclose(got, expect, rtol=rtol, atol=atol)
+
+    def test_frame_grad_all_dtypes_and_cases(self):
+        # 覆盖 axis0/axis-1、overlap/no-overlap、frame_length=1、frame_length=seq、hop=1/2/3/5。
+        cases = [
+            ((4, 17), 4, 2, -1),
+            ((17, 4), 4, 2, 0),
+            ((50,), 2, 3, -1),
+            ((1, 127), 1, 1, -1),
+            ((2, 129), 2, 1, -1),
+            ((129, 2), 2, 1, 0),
+            ((2, 19), 4, 5, -1),
+            ((19, 2), 4, 5, 0),
+            ((2, 5, 33), 2, 3, -1),
+            ((33, 2, 5), 2, 3, 0),
+            ((2, 31), 31, 7, -1),
+            ((31, 2), 31, 7, 0),
+            ((3, 33), 2, 3, -1),
+            ((33, 3), 2, 3, 0),
+        ]
+
+        seed = 3100
+        for dtype in self._dtype_list():
+            for shape, frame_length, hop_length, axis in cases:
+                with self.subTest(
+                    dtype=dtype,
+                    shape=shape,
+                    frame_length=frame_length,
+                    hop_length=hop_length,
+                    axis=axis,
+                ):
+                    self.run_case(
+                        shape, frame_length, hop_length, axis, dtype, seed
+                    )
+                    seed += 1
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/xpu/test_frame_op_xpu.py
+++ b/test/xpu/test_frame_op_xpu.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from get_test_cover_info import (
+    XPUOpTestWrapper,
+    create_test_class,
+    get_xpu_op_support_types,
+)
+from numpy.lib.stride_tricks import as_strided
+from op_test import convert_float_to_uint16
+from op_test_xpu import XPUOpTest
+
+import paddle
+
+paddle.enable_static()
+
+
+def frame_from_numpy(x, frame_length, hop_length, axis=-1):
+    if axis == -1 and not x.flags["C_CONTIGUOUS"]:
+        x = np.ascontiguousarray(x)
+    elif axis == 0 and not x.flags["F_CONTIGUOUS"]:
+        x = np.asfortranarray(x)
+
+    n_frames = 1 + (x.shape[axis] - frame_length) // hop_length
+    strides = np.asarray(x.strides)
+
+    if axis == -1:
+        shape = [*list(x.shape)[:-1], frame_length, n_frames]
+        strides = [*strides, hop_length * x.itemsize]
+    else:
+        shape = [n_frames, frame_length, *list(x.shape)[1:]]
+        strides = [hop_length * x.itemsize, *strides]
+
+    return as_strided(x, shape=shape, strides=strides)
+
+
+class XPUTestFrameOp(XPUOpTestWrapper):
+    def __init__(self):
+        self.op_name = "frame"
+
+    class TestFrameOpBase(XPUOpTest):
+        def setUp(self):
+            self.op_type = "frame"
+            self.dtype = self.in_type
+            self.place = paddle.XPUPlace(0)
+            self.init_case()
+            np.random.seed(2026)
+
+            if self.dtype == np.uint16:
+                x_fp32 = np.random.uniform(-1.0, 1.0, size=self.shape).astype(
+                    np.float32
+                )
+                self.inputs = {"X": convert_float_to_uint16(x_fp32)}
+                out = frame_from_numpy(
+                    x_fp32, self.frame_length, self.hop_length, self.axis
+                ).copy()
+                self.outputs = {"Out": convert_float_to_uint16(out)}
+            elif np.issubdtype(self.dtype, np.integer):
+                x = np.random.randint(-3, 4, size=self.shape).astype(self.dtype)
+                self.inputs = {"X": x}
+                self.outputs = {
+                    "Out": frame_from_numpy(
+                        x, self.frame_length, self.hop_length, self.axis
+                    ).copy()
+                }
+            else:
+                x = np.random.uniform(-1.0, 1.0, size=self.shape).astype(
+                    self.dtype
+                )
+                self.inputs = {"X": x}
+                self.outputs = {
+                    "Out": frame_from_numpy(
+                        x, self.frame_length, self.hop_length, self.axis
+                    ).copy()
+                }
+
+            self.attrs = {
+                "frame_length": self.frame_length,
+                "hop_length": self.hop_length,
+                "axis": self.axis,
+            }
+
+        def init_case(self):
+            self.shape = (150,)
+            self.frame_length = 50
+            self.hop_length = 15
+            self.axis = -1
+
+        def test_check_output(self):
+            self.check_output_with_place(self.place)
+
+        def test_check_grad(self):
+            # int/int64 不支持梯度；其余类型沿用 frame op 梯度检查。
+            if self.dtype in [np.int32, np.int64]:
+                return
+            if self.dtype in [np.float16, np.uint16]:
+                self.check_grad_with_place(
+                    self.place, ["X"], "Out", max_relative_error=1e-2
+                )
+            else:
+                self.check_grad_with_place(self.place, ["X"], "Out")
+
+    class TestFrameAxis0Case1(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (150,)
+            self.frame_length = 50
+            self.hop_length = 15
+            self.axis = 0
+
+    class TestFrameAxisNeg1Case2(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (8, 150)
+            self.frame_length = 50
+            self.hop_length = 15
+            self.axis = -1
+
+    class TestFrameAxis0Case3(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (150, 8)
+            self.frame_length = 50
+            self.hop_length = 15
+            self.axis = 0
+
+    class TestFrameAxisNeg1Case4(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (4, 2, 150)
+            self.frame_length = 50
+            self.hop_length = 15
+            self.axis = -1
+
+    class TestFrameAxis0Case5(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (150, 4, 2)
+            self.frame_length = 50
+            self.hop_length = 15
+            self.axis = 0
+
+    class TestFrameSmallCase(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (17,)
+            self.frame_length = 2
+            self.hop_length = 3
+            self.axis = -1
+
+    class TestFrameLenEqSeqAxisNeg1(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (31,)
+            self.frame_length = 31
+            self.hop_length = 7
+            self.axis = -1
+
+    class TestFrameLenEqSeqAxis0(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (31, 2)
+            self.frame_length = 31
+            self.hop_length = 7
+            self.axis = 0
+
+    class TestFrameLen1AxisNeg1(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (3, 19)
+            self.frame_length = 1
+            self.hop_length = 1
+            self.axis = -1
+
+    class TestFrameLen1Axis0(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (19, 3)
+            self.frame_length = 1
+            self.hop_length = 1
+            self.axis = 0
+
+    class TestFrameNoOverlapAxisNeg1(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (2, 19)
+            self.frame_length = 4
+            self.hop_length = 5
+            self.axis = -1
+
+    class TestFrameNoOverlapAxis0(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (19, 2)
+            self.frame_length = 4
+            self.hop_length = 5
+            self.axis = 0
+
+    class TestFrameHop1OverlapAxisNeg1(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (2, 129)
+            self.frame_length = 2
+            self.hop_length = 1
+            self.axis = -1
+
+    class TestFrameHop1OverlapAxis0(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (129, 2)
+            self.frame_length = 2
+            self.hop_length = 1
+            self.axis = 0
+
+    class TestFrame3DAxisNeg1(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (2, 5, 19)
+            self.frame_length = 4
+            self.hop_length = 3
+            self.axis = -1
+
+    class TestFrame3DAxis0(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (19, 2, 5)
+            self.frame_length = 4
+            self.hop_length = 3
+            self.axis = 0
+
+    class TestFrame4DAxisNeg1(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (2, 3, 4, 33)
+            self.frame_length = 2
+            self.hop_length = 3
+            self.axis = -1
+
+    class TestFrame4DAxis0(TestFrameOpBase):
+        def init_case(self):
+            self.shape = (33, 2, 3, 4)
+            self.frame_length = 2
+            self.hop_length = 3
+            self.axis = 0
+
+
+support_types = get_xpu_op_support_types("frame")
+for stype in support_types:
+    create_test_class(globals(), XPUTestFrameOp, stype)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Improvements

### Description

- Add XPU kernel registrations for frame and frame_grad under paddle/phi/kernels/xpu/.
- Update xpu1_op_list.cc / xpu2_op_list.cc / xpu3_op_list.cc to whitelist frame and frame_grad so the dispatcher can correctly select the XPU kernels.

### 是否引起精度变化

否