### PR TITLE
[API Compatibility] fix linear_v2 small-shape transpose path

### DIFF
--- a/paddle/phi/kernels/gpu/linear_v2_kernel.cu
+++ b/paddle/phi/kernels/gpu/linear_v2_kernel.cu
@@ -116,24 +116,46 @@ void LinearV2Kernel(const Context& dev_ctx,
           transpose_weight,
           phi::funcs::MatmulFusedType::kMatmulBias);
     } else {
-      // The AddmmKernel path cannot handle transpose_weight=True when N==1,
-      // e.g. x:[1, 10], w:[1, 10] (logical weight^T:[10, 1]).
-      // Reuse MatMulFunction with transpose_weight to preserve torch-compatible
-      // linear semantics for 1D/small-output cases.
-      std::vector<std::int64_t> input_dims_vec =
-          common::vectorize(input_processed.dims());
-      std::vector<std::int64_t> weight_dims_vec =
-          common::vectorize(weight_processed.dims());
+      if (!transpose_weight) {
+        DenseTensor bias_processed = bias;
+        if (bias.numel() != (M * N)) {
+          bias_processed.Resize(make_ddim({1, bias.numel()}));
+          VLOG(10) << "bias.dim(): " << bias.dims();
+          VLOG(10) << "M*N: " << M * N;
+          VLOG(10) << "bias tiling and addmm calculating";
+          // only broadcast to 1D bias whatsoever
+          phi::TileKernel<T, Context>(
+              dev_ctx, bias_processed, {M, 1}, &bias_processed);
+          VLOG(10) << "bias_processed.dims(): " << bias_processed.dims();
+        } else {
+          bias_processed = bias;
+        }
+        phi::AddmmKernel<T>(dev_ctx,
+                            bias_processed,
+                            input_processed,
+                            weight_processed,
+                            1.0f,
+                            1.0f,
+                            out);
+      } else {
+        // AddmmKernel does not have transpose flags. For transpose_weight=True
+        // (e.g. x:[1, 10], w:[1, 10] with logical w^T:[10, 1]), use MatMul
+        // to keep torch-compatible linear semantics.
+        std::vector<std::int64_t> input_dims_vec =
+            common::vectorize(input_processed.dims());
+        std::vector<std::int64_t> weight_dims_vec =
+            common::vectorize(weight_processed.dims());
 
-      MatMulFunction<Context, T>(dev_ctx,
-                                 input_processed,
-                                 weight_processed,
-                                 input_dims_vec,
-                                 weight_dims_vec,
-                                 out,
-                                 false,
-                                 transpose_weight);
-      AddKernel<T, Context>(dev_ctx, *out, bias, out);
+        MatMulFunction<Context, T>(dev_ctx,
+                                   input_processed,
+                                   weight_processed,
+                                   input_dims_vec,
+                                   weight_dims_vec,
+                                   out,
+                                   false,
+                                   transpose_weight);
+        AddKernel<T, Context>(dev_ctx, *out, bias, out);
+      }
     }
     out->Resize(out_dim_original);
   } else  // NOLINT

--- a/paddle/phi/kernels/gpu/linear_v2_kernel.cu
+++ b/paddle/phi/kernels/gpu/linear_v2_kernel.cu
@@ -116,27 +116,24 @@ void LinearV2Kernel(const Context& dev_ctx,
           transpose_weight,
           phi::funcs::MatmulFusedType::kMatmulBias);
     } else {
-      DenseTensor bias_processed = bias;
-      auto blas = funcs::GetBlas<Context, T>(dev_ctx);
-      if (bias.numel() != (M * N)) {
-        bias_processed.Resize(make_ddim({1, bias.numel()}));
-        VLOG(10) << "bias.dim(): " << bias.dims();
-        VLOG(10) << "M*N: " << M * N;
-        VLOG(10) << "bias tiling and addmm calculating";
-        // only broadcast to 1D bias whatsoever
-        phi::TileKernel<T, Context>(
-            dev_ctx, bias_processed, {M, 1}, &bias_processed);
-        VLOG(10) << "bias_processed.dims(): " << bias_processed.dims();
-      } else {
-        bias_processed = bias;
-      }
-      phi::AddmmKernel<T>(dev_ctx,
-                          bias_processed,
-                          input_processed,
-                          weight_processed,
-                          1.0f,
-                          1.0f,
-                          out);
+      // The AddmmKernel path cannot handle transpose_weight=True when N==1,
+      // e.g. x:[1, 10], w:[1, 10] (logical weight^T:[10, 1]).
+      // Reuse MatMulFunction with transpose_weight to preserve torch-compatible
+      // linear semantics for 1D/small-output cases.
+      std::vector<std::int64_t> input_dims_vec =
+          common::vectorize(input_processed.dims());
+      std::vector<std::int64_t> weight_dims_vec =
+          common::vectorize(weight_processed.dims());
+
+      MatMulFunction<Context, T>(dev_ctx,
+                                 input_processed,
+                                 weight_processed,
+                                 input_dims_vec,
+                                 weight_dims_vec,
+                                 out,
+                                 false,
+                                 transpose_weight);
+      AddKernel<T, Context>(dev_ctx, *out, bias, out);
     }
     out->Resize(out_dim_original);
   } else  // NOLINT

--- a/python/paddle/nn/layer/pooling.py
+++ b/python/paddle/nn/layer/pooling.py
@@ -98,7 +98,7 @@ class AvgPool1D(Layer):
 
             >>> data = paddle.uniform([1, 3, 32], dtype="float32", min=-1, max=1)
             >>> avg_pool1d = nn.AvgPool1D(kernel_size=2, stride=2, padding=0)
-            >>> pool_out = avg_pool1D(data)
+            >>> pool_out = avg_pool1d(data)
             >>> print(pool_out.shape)
             paddle.Size([1, 3, 16])
 

--- a/test/legacy_test/test_compat_functional_linear.py
+++ b/test/legacy_test/test_compat_functional_linear.py
@@ -145,6 +145,16 @@ class TestCompatLinear(unittest.TestCase):
         self._compare_forward(x_np, weight_np, bias_np)
         self._compare_backward(x_np, weight_np, bias_np)
 
+
+    def test_1d_input_single_output_with_bias(self):
+        """Test 1D input with out_features=1 to cover addmm fallback path"""
+        x_np = np.random.randn(10).astype(np.float32)
+        weight_np = np.random.randn(1, 10).astype(np.float32)
+        bias_np = np.random.randn(1).astype(np.float32)
+
+        self._compare_forward(x_np, weight_np, bias_np)
+        self._compare_backward(x_np, weight_np, bias_np)
+
     def test_3d_input_with_bias(self):
         """Test 3D input with bias"""
         x_np = np.random.randn(2, 4, 3).astype(np.float32)

--- a/test/legacy_test/test_compat_functional_linear.py
+++ b/test/legacy_test/test_compat_functional_linear.py
@@ -145,7 +145,6 @@ class TestCompatLinear(unittest.TestCase):
         self._compare_forward(x_np, weight_np, bias_np)
         self._compare_backward(x_np, weight_np, bias_np)
 
-
     def test_1d_input_single_output_with_bias(self):
         """Test 1D input with out_features=1 to cover addmm fallback path"""
         x_np = np.random.randn(10).astype(np.float32)

--- a/test/legacy_test/test_compat_nn_linear.py
+++ b/test/legacy_test/test_compat_nn_linear.py
@@ -183,6 +183,16 @@ class TestCompatLinearLayer(unittest.TestCase):
         self._compare_forward(x_np, weight_np, bias_np)
         self._compare_backward(x_np, weight_np, bias_np)
 
+
+    def test_1d_input_single_output_with_bias(self):
+        """Test 1D input with out_features=1 to cover addmm fallback path"""
+        x_np = np.random.randn(10).astype(np.float32)
+        weight_np = np.random.randn(1, 10).astype(np.float32)
+        bias_np = np.random.randn(1).astype(np.float32)
+
+        self._compare_forward(x_np, weight_np, bias_np)
+        self._compare_backward(x_np, weight_np, bias_np)
+
     def test_3d_input_with_bias(self):
         """Test 3D input with bias"""
         x_np = np.random.randn(2, 4, 3).astype(np.float32)

--- a/test/legacy_test/test_compat_nn_linear.py
+++ b/test/legacy_test/test_compat_nn_linear.py
@@ -183,7 +183,6 @@ class TestCompatLinearLayer(unittest.TestCase):
         self._compare_forward(x_np, weight_np, bias_np)
         self._compare_backward(x_np, weight_np, bias_np)
 
-
     def test_1d_input_single_output_with_bias(self):
         """Test 1D input with out_features=1 to cover addmm fallback path"""
         x_np = np.random.randn(10).astype(np.float32)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category

User Experience

### PR Types

Bug fixes

### Description

  - Fix a GPU linear_v2 compatibility issue in the small-shape fallback path when transpose_weight=True (e.g., 1D input + out_features=1).
  - Replace the AddmmKernel branch in linear_v2 small-shape path with MatMulFunction(..., transpose_weight) + AddKernel to preserve torch-compatible
    linear semantics.
  - Add regression tests for compat linear with 1D input and single output:
      - test_compat_functional_linear.py::test_1d_input_single_output_with_bias
      - test_compat_nn_linear.py::test_1d_input_single_output_with_bias
  - This resolves the shape-mismatch error observed in PaConvert GPU CI (X shape [10] vs Y shape [1]) for converted torch.nn.Linear(10, 1) cases.

### 是否引起精度变化
否
