### PR TITLE
[Doc] Add C++ examples for py_func_op.h (task 247)

### DIFF
--- a/paddle/fluid/operators/py_func_op.h
+++ b/paddle/fluid/operators/py_func_op.h
@@ -22,3 +22,14 @@ size_t AppendPythonCallableObjectAndReturnId(const ::pybind11::object &py_obj);
 
 }  // namespace operators
 }  // namespace paddle
+// C++示例：使用AppendPythonCallableObjectAndReturnId
+// 功能：注册Python可调用对象并获取ID
+#include <pybind11/pybind11.h>
+namespace py = pybind11;
+
+// 示例1：注册简单Python函数
+py::object py_add_func = py::module::import("__main__").attr("add");
+size_t add_func_id = paddle::operators::AppendPythonCallableObjectAndReturnId(py_add_func);
+// 示例2：注册带参数的Python函数
+py::object py_multiply_func = py::module::import("__main__").attr("multiply");
+size_t multiply_func_id = paddle::operators::AppendPythonCallableObjectAndReturnId(py_multiply_func);


### PR DESCRIPTION
Add C++ usage examples for paddle.static.nn.py_func, complete task 247.

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->


### Description
<!-- Describe what you’ve done -->


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
