### PR TITLE
[CI][Docs] Move docs preview script to Paddle repo and add `--no-pager` when `git log` to avoid blocking CI

### DIFF
--- a/.github/workflows/_Auto-Parallel.yml
+++ b/.github/workflows/_Auto-Parallel.yml
@@ -103,7 +103,7 @@ jobs:
           git pull
           git checkout 6ac04028757dfbcc089916997493611f62de81b2
           git switch -c 6ac04028757dfbcc089916997493611f62de81b2
-          git cherry-pick bc08aeec91d2c992c3d8d39755bea7c6213b0e82
+          git cherry-pick bc08aeec91d2c992c3d8d39755bea7c6213b0e82
           git cherry-pick 7ab35ce94eca977bcf3b44bfb42deb0e0b5ef158
           git cherry-pick 2ac85997c2dafe3d67a4aac01d553ad76d6024bf
           git submodule update --init --recursive --force

--- a/.github/workflows/_Doc-Preview.yml
+++ b/.github/workflows/_Doc-Preview.yml
@@ -103,11 +103,10 @@ jobs:
           # Save diff to a file for the next step
           echo "$api_doc_spec_diff" > /tmp/api_doc_diff.txt
 
-          curl -sS -o /tmp/entrypoint.sh https://paddle-dev-tools-open.bj.bcebos.com/fluiddoc-preview/entrypoint-paddle-docs-review.sh
           cd /
           source ${{ github.workspace }}/../../../proxy
           pip3 install --progress-bar off -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple --force-reinstall ${work_dir}/build/pr_whl/*.whl
-          bash "/tmp/entrypoint.sh"
+          bash ${work_dir}/ci/entrypoint-paddle-docs-review.sh
           '
 
       - name: Generate Comment Body

--- a/.github/workflows/_Doc-Preview.yml
+++ b/.github/workflows/_Doc-Preview.yml
@@ -106,7 +106,7 @@ jobs:
           cd /
           source ${{ github.workspace }}/../../../proxy
           pip3 install --progress-bar off -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple --force-reinstall ${work_dir}/build/pr_whl/*.whl
-          bash ${work_dir}/ci/entrypoint-paddle-docs-review.sh
+          bash ${work_dir}/ci/run_docs_preview.sh
           '
 
       - name: Generate Comment Body

--- a/ci/entrypoint-paddle-docs-review.sh
+++ b/ci/entrypoint-paddle-docs-review.sh
@@ -77,9 +77,14 @@ if [ ! -d ${PADDLE_DIR} ] ; then
         exit 1
     fi
     git checkout -b origin_pr FETCH_HEAD
+    echo "before merge paddle branch log:"
     git log --pretty=oneline -10
+    echo "merge branch ${AGILE_COMPILE_BRANCH_REF} into PR branch"
 fi
 
+echo "after merge paddle branch log:"
 cd ${FLUIDDOCDIR}/ci_scripts
+echo "ci_scripts dir  is :"
 ls
+echo "start to run ci_start_en.sh"
 bash ci_start_en.sh

--- a/ci/entrypoint-paddle-docs-review.sh
+++ b/ci/entrypoint-paddle-docs-review.sh
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export BRANCH=${AGILE_COMPILE_BRANCH}
+export GIT_PR_ID=${AGILE_PULL_ID}
+
+# export https_proxy=http://agent.baidu.com:8118
+export no_proxy=mirrors.tuna.tsinghua.edu.cn,bcebos.com,baidu.com,mirror.baidu.com,baidu-int.com,paddlepaddle.org.cn,localhost,127.0.0.1
+git config --global user.name "PaddleCI"
+git config --global user.email "paddle_ci@example.com"
+
+set +e
+
+if [ -f '/home/data/cfs/api_doc/${AGILE_PULL_ID}/api_doc_break.flag' ];then
+  echo 'API documents no change, skip doc build.'
+  exit 0
+fi
+
+DOCS_REPO=https://github.com/PaddlePaddle/docs.git
+
+export FLUIDDOCDIR=/FluidDoc
+if [ ! -d ${FLUIDDOCDIR} ] ; then
+    DOCS_REPO_DAILY="https://github-repo-tgz.bj.bcebos.com/PaddlePaddle/docs/${BRANCH}.tgz"
+    echo "DOCS_REPO_DAILY is ${DOCS_REPO_DAILY}"
+    TMP_TGZ=/tmp/docs-repo.tgz
+    http_code=$(curl -sL -w "%{http_code}" -o ${TMP_TGZ} -X GET -k ${DOCS_REPO_DAILY})
+    if [ "${http_code}" = "200" ] ; then
+        mkdir -p ${FLUIDDOCDIR}
+        tar xzf ${TMP_TGZ} -C ${FLUIDDOCDIR}
+        cd ${FLUIDDOCDIR}
+        pwd
+        ls
+        # git remote add upstream ${DOCS_REPO}
+        git fetch upstream $BRANCH
+    else
+        echo "curl -I ${DOCS_REPO_DAILY} got http_code=${http_code}"
+        git clone --origin upstream --depth=200 --branch=${BRANCH} ${DOCS_REPO} ${FLUIDDOCDIR}
+        if [ $? -ne 0 ];then
+            exit 1
+        fi
+    fi
+    cd ${FLUIDDOCDIR}
+    pwd
+    ls
+else
+    cd ${FLUIDDOCDIR}
+    git reset --hard
+    git clean -dfx
+fi
+
+
+# clone paddle repo
+
+PADDLE_REPO=https://github.com/PaddlePaddle/Paddle.git
+
+export PADDLE_DIR=/Paddle
+
+if [ ! -d ${PADDLE_DIR} ] ; then
+    git clone --origin upstream --depth=200 --branch=${BRANCH} ${PADDLE_REPO} ${PADDLE_DIR}
+    if [ $? -ne 0 ];then
+        exit 1
+    fi
+    cd ${PADDLE_DIR}
+    git fetch upstream ${AGILE_COMPILE_BRANCH_REF}
+    if [ $? -ne 0 ];then
+        exit 1
+    fi
+    git checkout -b origin_pr FETCH_HEAD
+    git log --pretty=oneline -10
+fi
+
+cd ${FLUIDDOCDIR}/ci_scripts
+ls
+bash ci_start_en.sh

--- a/ci/entrypoint-paddle-docs-review.sh
+++ b/ci/entrypoint-paddle-docs-review.sh
@@ -78,7 +78,7 @@ if [ ! -d ${PADDLE_DIR} ] ; then
     fi
     git checkout -b origin_pr FETCH_HEAD
     echo "before merge paddle branch log:"
-    git log --pretty=oneline -10
+    git --no-pager --pretty=oneline -10
     echo "merge branch ${AGILE_COMPILE_BRANCH_REF} into PR branch"
 fi
 

--- a/ci/run_docs_preview.sh
+++ b/ci/run_docs_preview.sh
@@ -21,7 +21,7 @@ git config --global user.email "paddle_ci@example.com"
 
 set +e
 
-if [ -f '/home/data/cfs/api_doc/${AGILE_PULL_ID}/api_doc_break.flag' ];then
+if [ -f "/home/data/cfs/api_doc/${AGILE_PULL_ID}/api_doc_break.flag" ]; then
     echo 'API documents no change, skip doc build.'
     exit 0
 fi

--- a/ci/run_docs_preview.sh
+++ b/ci/run_docs_preview.sh
@@ -75,14 +75,9 @@ if [ ! -d ${PADDLE_DIR} ] ; then
         exit 1
     fi
     git checkout -b origin_pr FETCH_HEAD
-    echo "before merge paddle branch log:"
     git --no-pager log --pretty=oneline -10
-    echo "merge branch ${AGILE_COMPILE_BRANCH_REF} into PR branch"
 fi
 
-echo "after merge paddle branch log:"
 cd ${FLUIDDOCDIR}/ci_scripts
-echo "ci_scripts dir  is :"
 ls
-echo "start to run ci_start_en.sh"
 bash ci_start_en.sh

--- a/ci/run_docs_preview.sh
+++ b/ci/run_docs_preview.sh
@@ -15,7 +15,6 @@
 export BRANCH=${AGILE_COMPILE_BRANCH}
 export GIT_PR_ID=${AGILE_PULL_ID}
 
-# export https_proxy=http://agent.baidu.com:8118
 export no_proxy=mirrors.tuna.tsinghua.edu.cn,bcebos.com,baidu.com,mirror.baidu.com,baidu-int.com,paddlepaddle.org.cn,localhost,127.0.0.1
 git config --global user.name "PaddleCI"
 git config --global user.email "paddle_ci@example.com"
@@ -23,8 +22,8 @@ git config --global user.email "paddle_ci@example.com"
 set +e
 
 if [ -f '/home/data/cfs/api_doc/${AGILE_PULL_ID}/api_doc_break.flag' ];then
-  echo 'API documents no change, skip doc build.'
-  exit 0
+    echo 'API documents no change, skip doc build.'
+    exit 0
 fi
 
 DOCS_REPO=https://github.com/PaddlePaddle/docs.git
@@ -61,7 +60,6 @@ fi
 
 
 # clone paddle repo
-
 PADDLE_REPO=https://github.com/PaddlePaddle/Paddle.git
 
 export PADDLE_DIR=/Paddle
@@ -78,7 +76,7 @@ if [ ! -d ${PADDLE_DIR} ] ; then
     fi
     git checkout -b origin_pr FETCH_HEAD
     echo "before merge paddle branch log:"
-    git --no-pager --pretty=oneline -10
+    git --no-pager log --pretty=oneline -10
     echo "merge branch ${AGILE_COMPILE_BRANCH_REF} into PR branch"
 fi
 

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -1632,7 +1632,7 @@ def load(
     Returns:
         None
 
-     Examples:
+    Examples:
         .. code-block:: pycon
 
             >>> # doctest: +SKIP("paddle.static.load doesn't support PIR mode")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

将 `https://paddle-dev-tools-open.bj.bcebos.com/fluiddoc-preview/entrypoint-paddle-docs-review.sh` 的 `entrypoint.sh` 移到 Paddle repo 内，便于管理

另外通过添加 `--no-pager` 避免过长的 `git log` 阻塞 CI 运行

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否

<!-- PCard-66972 -->