### PR TITLE
[API Compatibility] [Code Generation] Move python_api parsing logic into `python_c_gen`

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
@@ -536,13 +536,6 @@ class FunctionGeneratorBase:
         self.composite_func_info = {}  # {name: func_name, args: [input_name, ...]}
         self.intermediate_outputs = []  # [name, ...]
         self.forward_inplace_map = {}  # {name : name, ...}
-        self.args_alias_map = {}  # {arg_name: alias_vector, ...}
-        self.dygraph_pre_process = (
-            ""  # The pre_process function calling code for dygraph
-        )
-
-        self.args_mapper_func_name = None  # The custom args parser function
-        self.python_api_names = ""
 
     def ParseForwardInplaceInfo(self):
         forward_api_contents = self.forward_api_contents
@@ -551,42 +544,6 @@ class FunctionGeneratorBase:
 
         inplace_map_str = forward_api_contents['inplace']
         self.forward_inplace_map = ParseYamlInplaceInfo(inplace_map_str)
-
-    # Function for parameters parse
-    def ParsePythonAPIInfo(self):
-        python_api_info = self.python_api_info
-        args_alias = {}
-        if 'name' in python_api_info.keys():
-            self.python_api_names = python_api_info['name']
-        if 'args_alias' in python_api_info.keys():
-            for arg, alias_or_mode in python_api_info['args_alias'].items():
-                if arg == 'use_default_mapping':
-                    args_alias.update({arg: alias_or_mode})
-                    continue
-                alias_set = set(alias_or_mode)
-                # Add the original argument name to the alias set
-                alias_set.add(arg)
-                # Convert to C++ vector format
-                alias_vector = (
-                    "{" + ",".join(f'"{name}"' for name in alias_set) + "}"
-                )
-                args_alias.update({arg: alias_vector})
-            self.args_alias_map = args_alias
-        if 'pre_process' in python_api_info.keys():
-            pre_process = python_api_info['pre_process']
-            if pre_process is not None:
-                if 'dygraph_func' in pre_process.keys():
-                    self.dygraph_pre_process = pre_process['dygraph_func']
-                elif 'func' in pre_process.keys():
-                    self.dygraph_pre_process = pre_process['func']
-
-        if 'args_mapper' in python_api_info.keys():
-            args_mapper = python_api_info['args_mapper']
-            if args_mapper is not None:
-                if 'dygraph_func' in args_mapper.keys():
-                    self.args_mapper_func_name = args_mapper['dygraph_func']
-                elif 'func' in args_mapper.keys():
-                    self.args_mapper_func_name = args_mapper['func']
 
     def ParseNoNeedBuffer(self):
         grad_api_contents = self.grad_api_contents

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -377,7 +377,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         FunctionGeneratorBase.__init__(self, forward_api_contents, namespace)
 
         self.is_forward_only = True
-        self.need_parse_python_api_args = False
 
         # Generated Results
         self.python_c_function_str = ""
@@ -390,7 +389,65 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             False if 'backward' in forward_api_contents.keys() else True
         )
 
-    def GeneratePythonCFunction(self, no_predefined_out_tensor=False):
+    def ParsePythonAPIInfo(self, name, no_parse_python_api_info=False):
+        python_api_info = {}
+        need_parse_python_api_args = False
+        args_alias = {}  # {arg_name: alias_vector, ...}
+        dygraph_pre_process = ""  # pre-process function name
+        args_mapper_func = None  # The custom args parser function
+
+        if no_parse_python_api_info:
+            return (
+                need_parse_python_api_args,
+                args_alias,
+                dygraph_pre_process,
+                args_mapper_func,
+            )
+
+        if name in python_api_info_from_yaml.keys():
+            python_api_info = python_api_info_from_yaml[name]
+        if len(python_api_info) > 0:
+            need_parse_python_api_args = True
+            # parse args_alias
+            if 'args_alias' in python_api_info.keys():
+                for arg, alias_or_mode in python_api_info['args_alias'].items():
+                    if arg == 'use_default_mapping':
+                        args_alias.update({arg: alias_or_mode})
+                        continue
+                    alias_set = set(alias_or_mode)
+                    # Add the original argument name to the alias set
+                    alias_set.add(arg)
+                    # Convert to C++ vector format
+                    alias_vector = (
+                        "{" + ",".join(f'"{name}"' for name in alias_set) + "}"
+                    )
+                    args_alias.update({arg: alias_vector})
+            # parse pre_process
+            if 'pre_process' in python_api_info.keys():
+                pre_process = python_api_info['pre_process']
+                if pre_process is not None:
+                    if 'dygraph_func' in pre_process.keys():
+                        dygraph_pre_process = pre_process['dygraph_func']
+                    elif 'func' in pre_process.keys():
+                        dygraph_pre_process = pre_process['func']
+            # parse args_mapper
+            if 'args_mapper' in python_api_info.keys():
+                args_mapper = python_api_info['args_mapper']
+                if args_mapper is not None:
+                    if 'dygraph_func' in args_mapper.keys():
+                        args_mapper_func = args_mapper['dygraph_func']
+                    elif 'func' in args_mapper.keys():
+                        args_mapper_func = args_mapper['func']
+        return (
+            need_parse_python_api_args,
+            args_alias,
+            dygraph_pre_process,
+            args_mapper_func,
+        )
+
+    def GeneratePythonCFunction(
+        self, no_predefined_out_tensor=False, no_parse_python_api_info=False
+    ):
         namespace = self.namespace
         forward_inplace_map = self.forward_inplace_map
         forward_api_name = self.forward_api_name
@@ -400,13 +457,16 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         optional_inputs = self.optional_inputs
         is_forward_only = self.is_forward_only
 
-        need_parse_python_api_args = self.need_parse_python_api_args
-        args_alias_map = self.args_alias_map
+        (
+            need_parse_python_api_args,
+            args_alias_map,
+            dygraph_pre_process,
+            args_mapper_func,
+        ) = self.ParsePythonAPIInfo(forward_api_name, no_parse_python_api_info)
+
         max_args = len(orig_forward_attrs_list) + len(
             forward_inputs_position_map
         )
-        dygraph_pre_process = self.dygraph_pre_process
-        args_mapper_func = self.args_mapper_func_name
         inplace_args_pos_map = {}
         inplace_returns_pos_map = {}
         get_params_nums_and_check_str = "   // NO NEED"
@@ -888,16 +948,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                 # Generate Python-C Function Registration
                 self.python_c_function_reg_str += python_c_inplace_func_reg_str
 
-    def InitAndParsePythonAPIInfo(self):
-        global python_api_info_from_yaml
-        if self.forward_api_name in python_api_info_from_yaml.keys():
-            self.python_api_info = python_api_info_from_yaml[
-                self.forward_api_name
-            ]
-        if len(self.python_api_info) > 0:
-            self.need_parse_python_api_args = True
-            self.ParsePythonAPIInfo()
-
     def run(
         self, no_predefined_out_tensor=False, no_parse_python_api_info=False
     ):
@@ -912,8 +962,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
 
         # Initialized orig_forward_inputs_list, orig_forward_returns_list, orig_forward_attrs_list
         self.CollectOriginalForwardInfo()
-        if not no_parse_python_api_info:
-            self.InitAndParsePythonAPIInfo()
         if SkipAPIGeneration(self.forward_api_name):
             return False
 
@@ -923,7 +971,9 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         )
 
         # Code Generation
-        self.GeneratePythonCFunction(no_predefined_out_tensor)
+        self.GeneratePythonCFunction(
+            no_predefined_out_tensor, no_parse_python_api_info
+        )
 
         return True
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure

### PR Types
Performance


### Description
<!-- Describe what you’ve done -->
- Move python_api_info parsing logic from `codegen_utils.py` to `python_c_gen.py`
- Delete unused class members


### 是否引起精度变化
否

---

**Used AI Studio**

**归属任务**：支持inplace特化操作

**任务说明**：任务需要确认`python_api_info`的解析情况，针对inplace进行特化处理，因此考虑解耦，python_c_gen和monkey_patch_gen分别解析处理。本PR检查了python_c_gen的处理情况，发现存在一些对于`python_api_info`的处理放在父类，且仅进行了单次调用，返回值一次性存储于类成员内。为了简化逻辑、优化类成员，将此逻辑转移到python_c_gen.py中，同时对原先的逻辑进行整合优化

**修改说明**：`ParsePythonAPIInfo`函数的逻辑从codegen_utils.py移动到python_c_gen.py，整合了原有逻辑，删除了冗余的类成员

**修改影响**：修改后，python_c_gen.py输出的eager_op_function.cc没有任何变化