### PR TITLE
[API Compatibility No.15] support torch-style kwarg values for Tensor.index_put_ via cpp sink -part

### DIFF
--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -315,7 +315,8 @@
 - op : index_put_
   name : [paddle.index_put_, paddle.Tensor.index_put_]
   args_alias :
-    value : [values]
+    value :
+      - values
     use_default_mapping : True
 
 - op : isclose

--- a/test/legacy_test/test_index_put_op.py
+++ b/test/legacy_test/test_index_put_op.py
@@ -1310,6 +1310,52 @@ class TestIndexPutAPI_Compatibility(unittest.TestCase):
 
         paddle.enable_static()
 
+    def test_dygraph_tensor_index_put_values_alias_Compatibility(self):
+        paddle.disable_static()
+        try:
+            x = paddle.to_tensor(self.np_input, dtype=self.dtype)
+            idx0_t = paddle.to_tensor(self.idx0, dtype='int64')
+            idx1_t = paddle.to_tensor(self.idx1, dtype='int64')
+            indices_t = (idx0_t, idx1_t)
+            values_t = paddle.to_tensor(self.value, dtype=self.dtype)
+
+            ref = x.clone()
+            ref.index_put_(indices_t, value=values_t, accumulate=False)
+
+            out = x.clone()
+            out.index_put_(indices_t, values=values_t, accumulate=False)
+
+            expected = compute_index_put_ref(
+                copy.deepcopy(self.np_input),
+                (self.idx0, self.idx1),
+                self.value,
+                accumulate=False,
+            )
+
+            np.testing.assert_allclose(ref.numpy(), out.numpy())
+            np.testing.assert_allclose(expected, out.numpy())
+        finally:
+            paddle.enable_static()
+
+    def test_dygraph_tensor_index_put_conflict_value_values_Compatibility(self):
+        paddle.disable_static()
+        try:
+            x = paddle.to_tensor(self.np_input, dtype=self.dtype)
+            idx0_t = paddle.to_tensor(self.idx0, dtype='int64')
+            idx1_t = paddle.to_tensor(self.idx1, dtype='int64')
+            indices_t = (idx0_t, idx1_t)
+            values_t = paddle.to_tensor(self.value, dtype=self.dtype)
+
+            with self.assertRaises(ValueError):
+                x.index_put_(
+                    indices_t,
+                    value=values_t,
+                    values=values_t,
+                    accumulate=False,
+                )
+        finally:
+            paddle.enable_static()
+
     def test_static_Compatibility(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
This PR completes API Compatibility No.15 for `paddle.Tensor.index_put_`.

- Keep the C++ sink alias mapping path (`python_api_info.yaml` + `args_alias` + `use_default_mapping`) and make the `values -> value` alias explicit in the `index_put_` entry.
- Add dygraph compatibility tests in `test/legacy_test/test_index_put_op.py` to verify:
  - `x.index_put_(indices, value=v)` and `x.index_put_(indices, values=v)` are equivalent.
  - passing both `value` and `values` raises an error.

Validation:
- `PYTHONPATH=test/legacy_test python -m pytest test/legacy_test/test_index_put_op.py -k "TestIndexPutAPI_Compatibility and index_put_" -q`
- `PYTHONPATH=test/legacy_test python -m pytest test/legacy_test/test_index_put_op.py -k "TestIndexPutAPI_Compatibility" -q`

Issue:
- https://github.com/PaddlePaddle/Paddle/issues/76301

### 是否引起精度变化
否