### PR TITLE
[CodeStyle][DocFormat][41] Use `pycon` for code-block language marker and format example code (`python/paddle/optimizer/adam.py`, `python/paddle/optimizer/sgd.py`, `python/paddle/optimizer/momentum.py`)

### DIFF
--- a/python/paddle/optimizer/adam.py
+++ b/python/paddle/optimizer/adam.py
@@ -125,7 +125,7 @@ class Adam(Optimizer):
             The default value is None.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example1
 
             >>> import paddle
@@ -142,7 +142,7 @@ class Adam(Optimizer):
             >>> adam.step()
             >>> adam.clear_grad()
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example2
 
             >>> # Adam with beta1/beta2 as Tensor and weight_decay as float
@@ -478,15 +478,14 @@ class Adam(Optimizer):
             None
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
 
-                >>> a = paddle.rand([2,13], dtype="float32")
+                >>> a = paddle.rand([2, 13], dtype="float32")
                 >>> linear = paddle.nn.Linear(13, 5)
                 >>> # This can be any optimizer supported by dygraph.
-                >>> adam = paddle.optimizer.Adam(learning_rate = 0.01,
-                ...                             parameters = linear.parameters())
+                >>> adam = paddle.optimizer.Adam(learning_rate=0.01, parameters=linear.parameters())
                 >>> out = linear(a)
                 >>> out.backward()
                 >>> adam.step()

--- a/python/paddle/optimizer/adam.py
+++ b/python/paddle/optimizer/adam.py
@@ -485,7 +485,10 @@ class Adam(Optimizer):
                 >>> a = paddle.rand([2, 13], dtype="float32")
                 >>> linear = paddle.nn.Linear(13, 5)
                 >>> # This can be any optimizer supported by dygraph.
-                >>> adam = paddle.optimizer.Adam(learning_rate=0.01, parameters=linear.parameters(),)
+                >>> adam = paddle.optimizer.Adam(
+                ...     learning_rate=0.01,
+                ...     parameters=linear.parameters(),
+                ... )
                 >>> out = linear(a)
                 >>> out.backward()
                 >>> adam.step()

--- a/python/paddle/optimizer/adam.py
+++ b/python/paddle/optimizer/adam.py
@@ -485,7 +485,7 @@ class Adam(Optimizer):
                 >>> a = paddle.rand([2, 13], dtype="float32")
                 >>> linear = paddle.nn.Linear(13, 5)
                 >>> # This can be any optimizer supported by dygraph.
-                >>> adam = paddle.optimizer.Adam(learning_rate=0.01, parameters=linear.parameters())
+                >>> adam = paddle.optimizer.Adam(learning_rate=0.01, parameters=linear.parameters(),)
                 >>> out = linear(a)
                 >>> out.backward()
                 >>> adam.step()

--- a/python/paddle/optimizer/momentum.py
+++ b/python/paddle/optimizer/momentum.py
@@ -101,7 +101,7 @@ class Momentum(Optimizer):
                 :ref:`api_guide_Name` .
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 

--- a/python/paddle/optimizer/sgd.py
+++ b/python/paddle/optimizer/sgd.py
@@ -68,7 +68,7 @@ class SGD(Optimizer):
                 :ref:`api_guide_Name` .
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

Replace docstring code-block language marker from `python` to `pycon` in `python/paddle/optimizer/adam.py`, `python/paddle/optimizer/sgd.py`, and `python/paddle/optimizer/momentum.py` where examples use interactive prompts (`>>>`).

### 是否引起精度变化

否

This is part of a series of PRs migrating docstring code-block markers to `pycon`.

See also:

- #77820 (part 40: optimizer/rprop.py)
- #77817 (part 39: optimizer/lr.py)
- #77794 (part 36: optimizer/lamb.py)
