### PR TITLE
[API Compatibility] [Code Generation] Support `python_api_info.yaml` parsing for inplace apis

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
@@ -520,7 +520,6 @@ class FunctionGeneratorBase:
         )
 
         self.forward_api_name = ""
-        self.python_api_info = {}
 
         self.orig_forward_inputs_list = []  # [ [arg_name, arg_type, orig_position], ...]
         self.orig_forward_attrs_list = []  # [ [attr_name, attr_type, default_value, orig_position], ...]

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -438,7 +438,10 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         )
 
     def GeneratePythonCFunction(
-        self, no_predefined_out_tensor=False, no_parse_python_api_info=False
+        self,
+        no_predefined_out_tensor=False,
+        no_parse_python_api_info=False,
+        inplace=False,
     ):
         namespace = self.namespace
         forward_inplace_map = self.forward_inplace_map
@@ -448,19 +451,35 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         forward_outputs_position_map = self.forward_outputs_position_map
         optional_inputs = self.optional_inputs
 
-        (
-            need_parse_python_api_args,
-            args_alias_map,
-            dygraph_pre_process,
-            args_mapper_func,
-        ) = self.ParsePythonAPIInfo(forward_api_name, no_parse_python_api_info)
+        # Get Python API Info
+        if inplace:
+            inplaced_forward_api_name = GetInplacedFunctionName(
+                forward_api_name
+            )
+            (
+                need_parse_python_api_args,
+                args_alias_map,
+                dygraph_pre_process,
+                args_mapper_func,
+            ) = self.ParsePythonAPIInfo(
+                inplaced_forward_api_name, no_parse_python_api_info
+            )
+        else:
+            (
+                need_parse_python_api_args,
+                args_alias_map,
+                dygraph_pre_process,
+                args_mapper_func,
+            ) = self.ParsePythonAPIInfo(
+                forward_api_name, no_parse_python_api_info
+            )
 
         max_args = len(orig_forward_attrs_list) + len(
             forward_inputs_position_map
         )
         inplace_args_pos_map = {}
         inplace_returns_pos_map = {}
-        get_params_nums_and_check_str = "   // NO NEED"
+        get_params_nums_and_check_str = "    // NO NEED"
         if need_parse_python_api_args:
             get_params_nums_and_check_str = (
                 PARSE_PYTHON_C_NUM_ARGS_TEMPLATE.format(max_args)
@@ -638,11 +657,18 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                     forward_api_name,
                     pos,
                 )
+
+        # Generate Remaining Params Checking Logic
         check_remaining_params_validity_str = "    // NO NEED"
-        if need_parse_python_api_args:
+        if need_parse_python_api_args and inplace:
+            check_remaining_params_validity_str = (
+                CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("true")
+            )
+        elif need_parse_python_api_args and not inplace:
             check_remaining_params_validity_str = (
                 CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("false")
             )
+
         pre_process_str = "    // NO NEED"
         if need_parse_python_api_args and len(dygraph_pre_process) > 0:
 
@@ -766,8 +792,13 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             dygraph_function_call_list[pos] = f"{name}"
         dygraph_function_call_str = ",".join(dygraph_function_call_list)
 
+        # Generate Get predefined_out Logic
         get_predefined_out_str = ""
-        if not no_predefined_out_tensor and forward_api_name != "empty_like":
+        if (
+            not inplace
+            and not no_predefined_out_tensor
+            and forward_api_name != "empty_like"
+        ):
             forward_outputs_position_list = list(
                 self.forward_outputs_position_map.values()
             )
@@ -783,69 +814,13 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                 )
 
         # Generate Python-C Function Definitions
-        fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
-            "::", namespace, GetForwardFunctionName(forward_api_name)
-        )
-
-        return_str = "    return ToPyObject(ad_func_out);"
-
-        # Generate Record Event for performance profiling
-        pythonc_record_event_str = RECORD_EVENT_TEMPLATE.format(
-            "pythonc_record_event", forward_api_name, "pybind_imperative_func"
-        )
-
-        noamp_dygraph_function_str = NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
-            fwd_function_name,
-            dygraph_function_call_str,
-            fwd_function_name,
-            dygraph_function_call_str,
-        )
-
-        # Generate Python-C Function Definition
-        self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
-            forward_api_name,
-            pythonc_record_event_str,
-            forward_api_name,
-            get_params_nums_and_check_str,
-            get_eager_tensor_str,
-            parse_attributes_str,
-            check_remaining_params_validity_str,
-            args_mapper_str,
-            convert_to_dist_str,
-            pre_process_str,
-            get_predefined_out_str,
-            set_device_str,
-            noamp_dygraph_function_str,
-            return_str,
-        )
-        self.python_c_function_declare_str = (
-            PYTHON_C_FUNCTION_DECLARE_TEMPLATE.format(name=forward_api_name)
-        )
-
-        # Set prefix of forward_api_name to avoid conflicts
-        prefix = self.namespace.removeprefix("::").removesuffix("::")
-        forward_api_name_prefix = "" if prefix == "" else prefix + "_"
-
-        # Generate Python-C Function Registration
-        self.python_c_function_reg_str = PYTHON_C_FUNCTION_REG_TEMPLATE.format(
-            forward_api_name_prefix,
-            forward_api_name,
-            namespace,
-            forward_api_name,
-            forward_api_name,
-        )
-
-        if forward_inplace_map:
-            inplaced_forward_api_name = GetInplacedFunctionName(
-                self.forward_api_name
-            )
+        # Generate ad_func Call
+        if inplace:
             inplaced_fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
                 "::",
                 namespace,
                 GetForwardFunctionName(inplaced_forward_api_name),
             )
-            dygraph_function_call_str = ",".join(dygraph_function_call_list)
-
             inplace_noamp_dygraph_function_str = (
                 NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
                     inplaced_fwd_function_name,
@@ -854,12 +829,19 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                     dygraph_function_call_str,
                 )
             )
+        else:
+            fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
+                "::", namespace, GetForwardFunctionName(forward_api_name)
+            )
+            noamp_dygraph_function_str = NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
+                fwd_function_name,
+                dygraph_function_call_str,
+                fwd_function_name,
+                dygraph_function_call_str,
+            )
 
-            if need_parse_python_api_args and args_mapper_func is None:
-                check_remaining_params_validity_str = (
-                    CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("true")
-                )
-
+        # Generate Return
+        if inplace:
             # map of output position and input position
             return_str = "    std::map<ssize_t, ssize_t> inplace_var_idx_map;"
             for inplace_input, inplace_output in forward_inplace_map.items():
@@ -888,7 +870,19 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                         _get_keywords(inplace_input, args_alias_map),
                     )
             return_str += "    return ToPyObject(ad_func_out, args, kwargs, inplace_var_idx_map, inplace_var_name_map);"
+        else:
+            return_str = "    return ToPyObject(ad_func_out);"
 
+        # Generate Record Event for performance profiling
+        pythonc_record_event_str = RECORD_EVENT_TEMPLATE.format(
+            "pythonc_record_event", forward_api_name, "pybind_imperative_func"
+        )
+
+        # Set prefix of forward_api_name to avoid conflicts
+        prefix = self.namespace.removeprefix("::").removesuffix("::")
+        forward_api_name_prefix = "" if prefix == "" else prefix + "_"
+
+        if inplace:
             # Generate Python-C Function Definition
             python_c_inplace_func_str = PYTHON_C_FUNCTION_TEMPLATE.format(
                 inplaced_forward_api_name,
@@ -906,13 +900,12 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                 inplace_noamp_dygraph_function_str,
                 return_str,
             )
-
             python_c_function_declare_str = (
                 PYTHON_C_FUNCTION_DECLARE_TEMPLATE.format(
                     name=inplaced_forward_api_name
                 )
             )
-
+            # Generate Python-C Function Registration
             python_c_inplace_func_reg_str = (
                 PYTHON_C_FUNCTION_REG_TEMPLATE.format(
                     forward_api_name_prefix,
@@ -938,6 +931,37 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                 )
                 # Generate Python-C Function Registration
                 self.python_c_function_reg_str += python_c_inplace_func_reg_str
+        else:
+            # Generate Python-C Function Definition
+            self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
+                forward_api_name,
+                pythonc_record_event_str,
+                forward_api_name,
+                get_params_nums_and_check_str,
+                get_eager_tensor_str,
+                parse_attributes_str,
+                check_remaining_params_validity_str,
+                args_mapper_str,
+                convert_to_dist_str,
+                pre_process_str,
+                get_predefined_out_str,
+                set_device_str,
+                noamp_dygraph_function_str,
+                return_str,
+            )
+            self.python_c_function_declare_str = (
+                PYTHON_C_FUNCTION_DECLARE_TEMPLATE.format(name=forward_api_name)
+            )
+            # Generate Python-C Function Registration
+            self.python_c_function_reg_str = (
+                PYTHON_C_FUNCTION_REG_TEMPLATE.format(
+                    forward_api_name_prefix,
+                    forward_api_name,
+                    namespace,
+                    forward_api_name,
+                    forward_api_name,
+                )
+            )
 
     def run(
         self, no_predefined_out_tensor=False, no_parse_python_api_info=False
@@ -962,6 +986,10 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         self.GeneratePythonCFunction(
             no_predefined_out_tensor, no_parse_python_api_info
         )
+        if self.forward_inplace_map:
+            self.GeneratePythonCFunction(
+                no_predefined_out_tensor, no_parse_python_api_info, True
+            )
 
         return True
 

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -376,18 +376,10 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         # self.forward_inplace_map
         FunctionGeneratorBase.__init__(self, forward_api_contents, namespace)
 
-        self.is_forward_only = True
-
         # Generated Results
         self.python_c_function_str = ""
         self.python_c_function_reg_str = ""
         self.python_c_function_declare_str = ""
-
-    def CollectIsForwardOnly(self):
-        forward_api_contents = self.forward_api_contents
-        self.is_forward_only = (
-            False if 'backward' in forward_api_contents.keys() else True
-        )
 
     def ParsePythonAPIInfo(self, name, no_parse_python_api_info=False):
         python_api_info = {}
@@ -455,7 +447,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         forward_inputs_position_map = self.forward_inputs_position_map
         forward_outputs_position_map = self.forward_outputs_position_map
         optional_inputs = self.optional_inputs
-        is_forward_only = self.is_forward_only
 
         (
             need_parse_python_api_args,
@@ -951,9 +942,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
     def run(
         self, no_predefined_out_tensor=False, no_parse_python_api_info=False
     ):
-        # Initialized is_forward_only
-        self.CollectIsForwardOnly()
-
         # Initialized optional_inputs
         self.ParseDispensable()
 

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -660,14 +660,15 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
 
         # Generate Remaining Params Checking Logic
         check_remaining_params_validity_str = "    // NO NEED"
-        if need_parse_python_api_args and inplace:
-            check_remaining_params_validity_str = (
-                CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("true")
-            )
-        elif need_parse_python_api_args and not inplace:
-            check_remaining_params_validity_str = (
-                CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("false")
-            )
+        if need_parse_python_api_args:
+            if inplace:
+                check_remaining_params_validity_str = (
+                    CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("true")
+                )
+            else:
+                check_remaining_params_validity_str = (
+                    CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("false")
+                )
 
         pre_process_str = "    // NO NEED"
         if need_parse_python_api_args and len(dygraph_pre_process) > 0:

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -451,28 +451,17 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         forward_outputs_position_map = self.forward_outputs_position_map
         optional_inputs = self.optional_inputs
 
-        # Get Python API Info
         if inplace:
-            inplaced_forward_api_name = GetInplacedFunctionName(
-                forward_api_name
-            )
-            (
-                need_parse_python_api_args,
-                args_alias_map,
-                dygraph_pre_process,
-                args_mapper_func,
-            ) = self.ParsePythonAPIInfo(
-                inplaced_forward_api_name, no_parse_python_api_info
-            )
+            function_name = GetInplacedFunctionName(forward_api_name)
         else:
-            (
-                need_parse_python_api_args,
-                args_alias_map,
-                dygraph_pre_process,
-                args_mapper_func,
-            ) = self.ParsePythonAPIInfo(
-                forward_api_name, no_parse_python_api_info
-            )
+            function_name = forward_api_name
+        # Get Python API Info
+        (
+            need_parse_python_api_args,
+            args_alias_map,
+            dygraph_pre_process,
+            args_mapper_func,
+        ) = self.ParsePythonAPIInfo(function_name, no_parse_python_api_info)
 
         max_args = len(orig_forward_attrs_list) + len(
             forward_inputs_position_map
@@ -670,6 +659,7 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                     CHECK_REMAINING_ARGS_VALID_TEMPLATE.format("false")
                 )
 
+        # Generate Call Pre-Process Logic
         pre_process_str = "    // NO NEED"
         if need_parse_python_api_args and len(dygraph_pre_process) > 0:
 
@@ -679,6 +669,8 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             pre_process_str = CALL_PRE_PROCESS_TEMPLATE.format(
                 pre_process_add_ampersand(dygraph_pre_process)
             )
+
+        # Generate Call Args Mapper Logic
         args_mapper_str = "    // NO NEED"
         if args_mapper_func is not None:
             all_params_list = []
@@ -815,31 +807,19 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                 )
 
         # Generate Python-C Function Definitions
+        fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
+            "::",
+            namespace,
+            GetForwardFunctionName(function_name),
+        )
+
         # Generate ad_func Call
-        if inplace:
-            inplaced_fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
-                "::",
-                namespace,
-                GetForwardFunctionName(inplaced_forward_api_name),
-            )
-            inplace_noamp_dygraph_function_str = (
-                NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
-                    inplaced_fwd_function_name,
-                    dygraph_function_call_str,
-                    inplaced_fwd_function_name,
-                    dygraph_function_call_str,
-                )
-            )
-        else:
-            fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
-                "::", namespace, GetForwardFunctionName(forward_api_name)
-            )
-            noamp_dygraph_function_str = NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
-                fwd_function_name,
-                dygraph_function_call_str,
-                fwd_function_name,
-                dygraph_function_call_str,
-            )
+        noamp_dygraph_function_str = NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
+            fwd_function_name,
+            dygraph_function_call_str,
+            fwd_function_name,
+            dygraph_function_call_str,
+        )
 
         # Generate Return
         if inplace:
@@ -883,86 +863,45 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         prefix = self.namespace.removeprefix("::").removesuffix("::")
         forward_api_name_prefix = "" if prefix == "" else prefix + "_"
 
-        if inplace:
-            # Generate Python-C Function Definition
-            python_c_inplace_func_str = PYTHON_C_FUNCTION_TEMPLATE.format(
-                inplaced_forward_api_name,
-                pythonc_record_event_str,
-                inplaced_forward_api_name,
-                get_params_nums_and_check_str,
-                get_eager_tensor_str,
-                parse_attributes_str,
-                check_remaining_params_validity_str,
-                args_mapper_str,
-                convert_to_dist_str,
-                pre_process_str,
-                "",
-                set_device_str,
-                inplace_noamp_dygraph_function_str,
-                return_str,
-            )
-            python_c_function_declare_str = (
-                PYTHON_C_FUNCTION_DECLARE_TEMPLATE.format(
-                    name=inplaced_forward_api_name
-                )
-            )
-            # Generate Python-C Function Registration
-            python_c_inplace_func_reg_str = (
-                PYTHON_C_FUNCTION_REG_TEMPLATE.format(
-                    forward_api_name_prefix,
-                    inplaced_forward_api_name,
-                    namespace,
-                    inplaced_forward_api_name,
-                    inplaced_forward_api_name,
-                )
-            )
+        # Generate Python-C Function Definition
+        python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
+            function_name,
+            pythonc_record_event_str,
+            function_name,
+            get_params_nums_and_check_str,
+            get_eager_tensor_str,
+            parse_attributes_str,
+            check_remaining_params_validity_str,
+            args_mapper_str,
+            convert_to_dist_str,
+            pre_process_str,
+            get_predefined_out_str,
+            set_device_str,
+            noamp_dygraph_function_str,
+            return_str,
+        )
+        python_c_function_declare_str = (
+            PYTHON_C_FUNCTION_DECLARE_TEMPLATE.format(name=function_name)
+        )
+        # Generate Python-C Function Registration
+        python_c_function_reg_str = PYTHON_C_FUNCTION_REG_TEMPLATE.format(
+            forward_api_name_prefix,
+            function_name,
+            namespace,
+            function_name,
+            function_name,
+        )
 
-            # self.forward_api_name ending with '_' means it only has inplace api
-            if self.forward_api_name[-1] == '_':
-                self.python_c_function_str = python_c_inplace_func_str
-                self.python_c_function_declare_str = (
-                    python_c_function_declare_str
-                )
-                # Generate Python-C Function Registration
-                self.python_c_function_reg_str = python_c_inplace_func_reg_str
-            else:
-                self.python_c_function_str += python_c_inplace_func_str
-                self.python_c_function_declare_str += (
-                    python_c_function_declare_str
-                )
-                # Generate Python-C Function Registration
-                self.python_c_function_reg_str += python_c_inplace_func_reg_str
+        # self.forward_api_name ending with '_' means it only has inplace api
+        if inplace and self.forward_api_name[-1] != '_':
+            # Add Inplace Function Code After Non-Inplace Function Code
+            self.python_c_function_str += python_c_function_str
+            self.python_c_function_declare_str += python_c_function_declare_str
+            self.python_c_function_reg_str += python_c_function_reg_str
         else:
-            # Generate Python-C Function Definition
-            self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
-                forward_api_name,
-                pythonc_record_event_str,
-                forward_api_name,
-                get_params_nums_and_check_str,
-                get_eager_tensor_str,
-                parse_attributes_str,
-                check_remaining_params_validity_str,
-                args_mapper_str,
-                convert_to_dist_str,
-                pre_process_str,
-                get_predefined_out_str,
-                set_device_str,
-                noamp_dygraph_function_str,
-                return_str,
-            )
-            self.python_c_function_declare_str = (
-                PYTHON_C_FUNCTION_DECLARE_TEMPLATE.format(name=forward_api_name)
-            )
-            # Generate Python-C Function Registration
-            self.python_c_function_reg_str = (
-                PYTHON_C_FUNCTION_REG_TEMPLATE.format(
-                    forward_api_name_prefix,
-                    forward_api_name,
-                    namespace,
-                    forward_api_name,
-                    forward_api_name,
-                )
-            )
+            self.python_c_function_str = python_c_function_str
+            self.python_c_function_declare_str = python_c_function_declare_str
+            self.python_c_function_reg_str = python_c_function_reg_str
 
     def run(
         self, no_predefined_out_tensor=False, no_parse_python_api_info=False

--- a/paddle/fluid/pybind/arg_pre_process.cc
+++ b/paddle/fluid/pybind/arg_pre_process.cc
@@ -554,6 +554,41 @@ void BaddbmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y) {
   }
 }
 
+// Inplace API broadcast validation for dygraph
+void InplaceShapePreProcess(Tensor* x, Tensor* y) {
+  auto x_shape = x->dims();
+  auto y_shape = y->dims();
+
+  auto out_shape = phi::funcs::BroadcastTwoDims(x_shape, y_shape);
+
+  PADDLE_ENFORCE_EQ(
+      out_shape,
+      x_shape,
+      phi::errors::InvalidArgument(
+          "The shape of broadcast output %s is different from that of inplace "
+          "tensor %s in the Inplace operation.",
+          out_shape,
+          x_shape));
+}
+
+// Inplace API broadcast validation for static graph
+void InplaceShapePreProcess(pir::Value* x, pir::Value* y) {
+  auto x_shape = pir::GetShapeFromValue(*x);
+  auto y_shape = pir::GetShapeFromValue(*y);
+
+  auto out_shape = phi::funcs::BroadcastTwoDims(common::make_ddim(x_shape),
+                                                common::make_ddim(y_shape));
+
+  PADDLE_ENFORCE_EQ(
+      out_shape,
+      common::make_ddim(x_shape),
+      phi::errors::InvalidArgument(
+          "The shape of broadcast output %s is different from that of inplace "
+          "tensor %s in the Inplace operation.",
+          out_shape,
+          common::make_ddim(x_shape)));
+}
+
 }  // namespace pybind
 
 }  // namespace paddle

--- a/paddle/fluid/pybind/arg_pre_process.h
+++ b/paddle/fluid/pybind/arg_pre_process.h
@@ -76,6 +76,12 @@ void BaddbmmPreProcess(Tensor* input, Tensor* x, Tensor* y);
 // Baddbmm broadcast validation for static graph
 void BaddbmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y);
 
+// Inplace API broadcast validation for dygraph
+void InplaceShapePreProcess(Tensor* x, Tensor* y);
+
+// Inplace API broadcast validation for static graph
+void InplaceShapePreProcess(pir::Value* x, pir::Value* y);
+
 }  // namespace pybind
 
 }  // namespace paddle

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -144,6 +144,8 @@
   name : [paddle.bitwise_and_, paddle.Tensor.bitwise_and_]
   args_alias :
     use_default_mapping : True
+  pre_process :
+    func : InplaceShapePreProcess(x, y)
 
 - op : bitwise_left_shift
   name : [paddle.bitwise_left_shift, paddle.Tensor.bitwise_left_shift]
@@ -174,6 +176,8 @@
   name : [paddle.bitwise_or_, paddle.Tensor.bitwise_or_]
   args_alias :
     use_default_mapping : True
+  pre_process :
+    func : InplaceShapePreProcess(x, y)
 
 - op : bitwise_right_shift
   name : [paddle.bitwise_right_shift, paddle.Tensor.bitwise_right_shift]
@@ -194,6 +198,8 @@
   name : [paddle.bitwise_xor_, paddle.Tensor.bitwise_xor_]
   args_alias :
     use_default_mapping : True
+  pre_process :
+    func : InplaceShapePreProcess(x, y)
 
 - op : ceil
   name : [paddle.ceil, paddle.Tensor.ceil]

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -1600,8 +1600,7 @@ class TestDygraphInplacBitwiseAnd(TestDygraphInplaceLogicAnd):
             no_inplace_var.numpy(), inplace_var.numpy()
         )
 
-    # will fix it by add inplace pre_process
-    def _test_broadcast_error(self):
+    def test_broadcast_error(self):
         broadcast_input = paddle.randint(
             low=0, high=10, shape=[3, 1, 4], dtype="int32"
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure


### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Remove unused logic
- Merge logics of inplace api generation and non-inplace api generation
- Add pre-process for `bitwise_and_`, `bitwise_or_`, `bitwise_xor_`
- Activate corresponding tests

由于 Check PR Template 的影响，PR说明移动到[这里](https://github.com/PaddlePaddle/Paddle/pull/77824#issuecomment-3877751570)

### 是否引起精度变化
否
