### PR TITLE
[CodeStyle][DocFormat][42] Use `pycon` for code-block language marker and format example code (`python/paddle/optimizer/adagrad.py`, `python/paddle/optimizer/adamax.py`, `python/paddle/optimizer/asgd.py`, `python/paddle/optimizer/lbfgs.py`, `python/paddle/optimizer/nadam.py`)

### DIFF
--- a/python/paddle/optimizer/adagrad.py
+++ b/python/paddle/optimizer/adagrad.py
@@ -118,8 +118,8 @@ class Adagrad(Optimizer):
             >>> loss = paddle.mean(out)
             >>> adagrad = paddle.optimizer.Adagrad(
             ...     learning_rate=0.1,
-            ...     parameters=[
-            ...         {  # type: ignore
+            ...     parameters=[  # type: ignore
+            ...         {
             ...             'params': linear_1.parameters()
             ...         },
             ...         {

--- a/python/paddle/optimizer/adagrad.py
+++ b/python/paddle/optimizer/adagrad.py
@@ -101,7 +101,7 @@ class Adagrad(Optimizer):
             >>> linear = paddle.nn.Linear(10, 10)
             >>> out = linear(inp)
             >>> loss = paddle.mean(out)
-            >>> adagrad = paddle.optimizer.Adagrad(learning_rate=0.1, parameters=linear.parameters())
+            >>> adagrad = paddle.optimizer.Adagrad(learning_rate=0.1, parameters=linear.parameters(),)
             >>> out.backward()
             >>> adagrad.step()
             >>> adagrad.clear_grad()

--- a/python/paddle/optimizer/adagrad.py
+++ b/python/paddle/optimizer/adagrad.py
@@ -93,7 +93,7 @@ class Adagrad(Optimizer):
             The default value is 0.0.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -101,8 +101,7 @@ class Adagrad(Optimizer):
             >>> linear = paddle.nn.Linear(10, 10)
             >>> out = linear(inp)
             >>> loss = paddle.mean(out)
-            >>> adagrad = paddle.optimizer.Adagrad(learning_rate=0.1,
-            ...         parameters=linear.parameters())
+            >>> adagrad = paddle.optimizer.Adagrad(learning_rate=0.1, parameters=linear.parameters())
             >>> out.backward()
             >>> adagrad.step()
             >>> adagrad.clear_grad()
@@ -116,14 +115,18 @@ class Adagrad(Optimizer):
             >>> loss = paddle.mean(out)
             >>> adagrad = paddle.optimizer.Adagrad(
             ...     learning_rate=0.1,
-            ...     parameters=[{  # type: ignore
-            ...         'params': linear_1.parameters()
-            ...     }, {
-            ...         'params': linear_2.parameters(),
-            ...         'weight_decay': 0.001,
-            ...         'learning_rate': 0.1,
-            ...     }],
-            ...     weight_decay=0.01)
+            ...     parameters=[
+            ...         {  # type: ignore
+            ...             'params': linear_1.parameters()
+            ...         },
+            ...         {
+            ...             'params': linear_2.parameters(),
+            ...             'weight_decay': 0.001,
+            ...             'learning_rate': 0.1,
+            ...         },
+            ...     ],
+            ...     weight_decay=0.01,
+            ... )
             >>> out.backward()
             >>> adagrad.step()
             >>> adagrad.clear_grad()

--- a/python/paddle/optimizer/adagrad.py
+++ b/python/paddle/optimizer/adagrad.py
@@ -120,7 +120,7 @@ class Adagrad(Optimizer):
             ...     learning_rate=0.1,
             ...     parameters=[  # type: ignore
             ...         {
-            ...             'params': linear_1.parameters()
+            ...             'params': linear_1.parameters(),
             ...         },
             ...         {
             ...             'params': linear_2.parameters(),

--- a/python/paddle/optimizer/adagrad.py
+++ b/python/paddle/optimizer/adagrad.py
@@ -101,7 +101,10 @@ class Adagrad(Optimizer):
             >>> linear = paddle.nn.Linear(10, 10)
             >>> out = linear(inp)
             >>> loss = paddle.mean(out)
-            >>> adagrad = paddle.optimizer.Adagrad(learning_rate=0.1, parameters=linear.parameters(),)
+            >>> adagrad = paddle.optimizer.Adagrad(
+            ...     learning_rate=0.1,
+            ...     parameters=linear.parameters(),
+            ... )
             >>> out.backward()
             >>> adagrad.step()
             >>> adagrad.clear_grad()
@@ -125,7 +128,7 @@ class Adagrad(Optimizer):
             ...             'learning_rate': 0.1,
             ...         },
             ...     ],
-            ...     weight_decay=0.01
+            ...     weight_decay=0.01,
             ... )
             >>> out.backward()
             >>> adagrad.step()

--- a/python/paddle/optimizer/adagrad.py
+++ b/python/paddle/optimizer/adagrad.py
@@ -125,7 +125,7 @@ class Adagrad(Optimizer):
             ...             'learning_rate': 0.1,
             ...         },
             ...     ],
-            ...     weight_decay=0.01,
+            ...     weight_decay=0.01
             ... )
             >>> out.backward()
             >>> adagrad.step()

--- a/python/paddle/optimizer/adamax.py
+++ b/python/paddle/optimizer/adamax.py
@@ -106,7 +106,7 @@ class Adamax(Optimizer):
         **Currently, Adamax doesn't support sparse parameter optimization.**
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -120,11 +120,7 @@ class Adamax(Optimizer):
             >>> beta2 = paddle.to_tensor([0.99], dtype="float32")
 
             >>> adamax = paddle.optimizer.Adamax(
-            ...     learning_rate=0.1,
-            ...     parameters=linear.parameters(),
-            ...     beta1=beta1,
-            ...     beta2=beta2,
-            ...     weight_decay=0.01
+            ...     learning_rate=0.1, parameters=linear.parameters(), beta1=beta1, beta2=beta2, weight_decay=0.01
             ... )
             >>> out.backward()
             >>> adamax.step()
@@ -140,16 +136,14 @@ class Adamax(Optimizer):
             >>> loss = paddle.mean(out)
             >>> adamax = paddle.optimizer.Adamax(
             ...     learning_rate=0.1,
-            ...     parameters=[{  # type: ignore
-            ...         'params': linear_1.parameters()
-            ...     }, {
-            ...         'params': linear_2.parameters(),
-            ...         'weight_decay': 0.001,
-            ...         'learning_rate': 0.1,
-            ...         'beta1': 0.8
-            ...     }],
+            ...     parameters=[
+            ...         {  # type: ignore
+            ...             'params': linear_1.parameters()
+            ...         },
+            ...         {'params': linear_2.parameters(), 'weight_decay': 0.001, 'learning_rate': 0.1, 'beta1': 0.8},
+            ...     ],
             ...     weight_decay=0.01,
-            ...     beta1=0.9
+            ...     beta1=0.9,
             ... )
             >>> out.backward()
             >>> adamax.step()

--- a/python/paddle/optimizer/adamax.py
+++ b/python/paddle/optimizer/adamax.py
@@ -140,8 +140,8 @@ class Adamax(Optimizer):
             >>> loss = paddle.mean(out)
             >>> adamax = paddle.optimizer.Adamax(
             ...     learning_rate=0.1,
-            ...     parameters=[
-            ...         {  # type: ignore
+            ...     parameters=[  # type: ignore
+            ...         {
             ...             'params': linear_1.parameters()
             ...         },
             ...         {

--- a/python/paddle/optimizer/adamax.py
+++ b/python/paddle/optimizer/adamax.py
@@ -120,7 +120,7 @@ class Adamax(Optimizer):
             >>> beta2 = paddle.to_tensor([0.99], dtype="float32")
 
             >>> adamax = paddle.optimizer.Adamax(
-            ...     learning_rate=0.1, parameters=linear.parameters(), beta1=beta1, beta2=beta2, weight_decay=0.01
+            ...     learning_rate=0.1, parameters=linear.parameters(), beta1=beta1, beta2=beta2, weight_decay=0.01,
             ... )
             >>> out.backward()
             >>> adamax.step()
@@ -140,7 +140,7 @@ class Adamax(Optimizer):
             ...         {  # type: ignore
             ...             'params': linear_1.parameters()
             ...         },
-            ...         {'params': linear_2.parameters(), 'weight_decay': 0.001, 'learning_rate': 0.1, 'beta1': 0.8},
+            ...         {'params': linear_2.parameters(), 'weight_decay': 0.001, 'learning_rate': 0.1, 'beta1': 0.8,},
             ...     ],
             ...     weight_decay=0.01,
             ...     beta1=0.9

--- a/python/paddle/optimizer/adamax.py
+++ b/python/paddle/optimizer/adamax.py
@@ -142,7 +142,7 @@ class Adamax(Optimizer):
             ...     learning_rate=0.1,
             ...     parameters=[  # type: ignore
             ...         {
-            ...             'params': linear_1.parameters()
+            ...             'params': linear_1.parameters(),
             ...         },
             ...         {
             ...             'params': linear_2.parameters(),

--- a/python/paddle/optimizer/adamax.py
+++ b/python/paddle/optimizer/adamax.py
@@ -143,7 +143,7 @@ class Adamax(Optimizer):
             ...         {'params': linear_2.parameters(), 'weight_decay': 0.001, 'learning_rate': 0.1, 'beta1': 0.8},
             ...     ],
             ...     weight_decay=0.01,
-            ...     beta1=0.9,
+            ...     beta1=0.9
             ... )
             >>> out.backward()
             >>> adamax.step()

--- a/python/paddle/optimizer/adamax.py
+++ b/python/paddle/optimizer/adamax.py
@@ -120,7 +120,11 @@ class Adamax(Optimizer):
             >>> beta2 = paddle.to_tensor([0.99], dtype="float32")
 
             >>> adamax = paddle.optimizer.Adamax(
-            ...     learning_rate=0.1, parameters=linear.parameters(), beta1=beta1, beta2=beta2, weight_decay=0.01,
+            ...     learning_rate=0.1,
+            ...     parameters=linear.parameters(),
+            ...     beta1=beta1,
+            ...     beta2=beta2,
+            ...     weight_decay=0.01,
             ... )
             >>> out.backward()
             >>> adamax.step()
@@ -140,10 +144,15 @@ class Adamax(Optimizer):
             ...         {  # type: ignore
             ...             'params': linear_1.parameters()
             ...         },
-            ...         {'params': linear_2.parameters(), 'weight_decay': 0.001, 'learning_rate': 0.1, 'beta1': 0.8,},
+            ...         {
+            ...             'params': linear_2.parameters(),
+            ...             'weight_decay': 0.001,
+            ...             'learning_rate': 0.1,
+            ...             'beta1': 0.8,
+            ...         },
             ...     ],
             ...     weight_decay=0.01,
-            ...     beta1=0.9
+            ...     beta1=0.9,
             ... )
             >>> out.backward()
             >>> adamax.step()

--- a/python/paddle/optimizer/asgd.py
+++ b/python/paddle/optimizer/asgd.py
@@ -87,7 +87,7 @@ class ASGD(Optimizer):
             For more information, please refer to :ref:`api_guide_Name` .
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 

--- a/python/paddle/optimizer/lbfgs.py
+++ b/python/paddle/optimizer/lbfgs.py
@@ -404,7 +404,7 @@ class LBFGS(Optimizer):
         loss (Tensor): the final loss of closure.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import numpy as np
@@ -504,7 +504,7 @@ class LBFGS(Optimizer):
             differs between optimizer classes.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
 
@@ -531,7 +531,6 @@ class LBFGS(Optimizer):
                 ...         return loss
                 ...
                 ...     opt.step(closure)
-                ...
                 >>> inputs = paddle.rand([10, 10], dtype="float32")
                 >>> targets = paddle.to_tensor([2 * x for x in inputs])
 
@@ -604,7 +603,7 @@ class LBFGS(Optimizer):
             and returns the loss.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
 
@@ -632,7 +631,6 @@ class LBFGS(Optimizer):
                 ...     opt.clear_grad()
                 ...     loss.backward()
                 ...     return loss
-                ...
                 >>> opt.step(closure)
         """
 

--- a/python/paddle/optimizer/nadam.py
+++ b/python/paddle/optimizer/nadam.py
@@ -102,7 +102,7 @@ class NAdam(Optimizer):
         Currently, NAdam doesn't support sparse parameter optimization.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

Replace docstring code-block language marker from `python` to `pycon` in `python/paddle/optimizer/adagrad.py`, `python/paddle/optimizer/adamax.py`, `python/paddle/optimizer/asgd.py`, `python/paddle/optimizer/lbfgs.py`, and `python/paddle/optimizer/nadam.py` where examples use interactive prompts (`>>>`).

### 是否引起精度变化

否

This is part of a series of PRs migrating docstring code-block markers to `pycon`.

See also:

- #77799 (part 38: sysconfig.py)
- #77798 (part 37: mnist.py)
- #77794 (part 36: lamb.py)
- #77791 (part 35: image.py)
- #77822 (part 41: adam.py, sgd.py, momentum.py)
- #77820 (part 40: rprop.py)
- #77817 (part 39: lr.py)
