### PR TITLE
[CodeStyle][DocFormat][43] Use `pycon` for code-block language marker (`python/paddle/optimizer/radam.py`)

### DIFF
--- a/python/paddle/optimizer/radam.py
+++ b/python/paddle/optimizer/radam.py
@@ -105,7 +105,7 @@ class RAdam(Optimizer):
         Currently, RAdam doesn't support sparse parameter optimization.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

Replace docstring code-block language marker from python to pycon in python/paddle/optimizer/radam.py where examples use interactive prompts (>>>).

### 是否引起精度变化

否

This is part of a series of PRs migrating docstring code-block markers to pycon.


See also:

- #77826 (part 42: adagrad.py, adamax.py, asgd.py, lbfgs.py, nadam.py)
- #77822 (part 41: adam.py, sgd.py, momentum.py)
- #77820 (part 40: rprop.py)
- #77817 (part 39: lr.py)
