### PR TITLE
[CodeStyle][DocFormat][45] Use `pycon` for code-block language marker (`python/paddle/vision/datasets/cifar.py`)

### DIFF
--- a/python/paddle/vision/datasets/cifar.py
+++ b/python/paddle/vision/datasets/cifar.py
@@ -72,7 +72,7 @@ class Cifar10(Dataset[tuple["_ImageDataType", "npt.NDArray[Any]"]]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +TIMEOUT(60)
             >>> import itertools
@@ -225,7 +225,7 @@ class Cifar100(Cifar10):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +TIMEOUT(60)
             >>> import itertools


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

Replace docstring code-block language marker from `python` to `pycon` in `python/paddle/vision/datasets/cifar.py` where examples use interactive prompts (`>>>`).

### 是否引起精度变化

否

This is part of a series of PRs migrating docstring code-block markers to `pycon`.

See also:

- #77828 (part 43: optimizer/radam.py)
- #77826 (part 42: optimizer/adagrad.py, adamax.py, asgd.py, lbfgs.py, nadam.py)
- #77822 (part 41: optimizer/adam.py, sgd.py, momentum.py)
- #77820 (part 40: optimizer/rprop.py)
- #77817 (part 39: optimizer/lr.py)
