### PR TITLE
Fix: prevent OOB in TransposeInferMeta by sizing count to x_rank

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -5953,7 +5953,7 @@ void TransposeInferMeta(const MetaTensor& x,
                         axis_size));
 
   std::vector<int> formatted_axis = axis;
-  std::vector<int> count(axis_size, 0);
+  std::vector<int> count(x_rank, 0);
   for (int i = 0; i < axis_size; i++) {
     PADDLE_ENFORCE_LT(axis[i],
                       x_rank,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
User Experience

### PR Types
Others

### Description
Fix potential out-of-bounds access in `phi::TransposeInferMeta` by sizing `count` to `x_rank` instead of `axis_size`. This prevents undefined behavior when `x_rank > axis_size` (e.g., after fuse squeeze2 + transpose2). Minimal change.

fixes #76948
### 是否引起精度变化
否
