### PR TITLE
[cherry-pick]Add flags cudnn_allow_tf32 andcublas_allow_tf32 to control whether tensor cores are enabled for cudnn and cublas.

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -281,6 +281,40 @@ PHI_DEFINE_EXPORTED_int64(cudnn_exhaustive_search_times,
                           "Exhaustive search times for cuDNN convolution, "
                           "default is -1, not exhaustive search");
 
+/**
+ * CUDNN related FLAG
+ * Name: FLAGS_cudnn_allow_tf32
+ * Since Version: 3.2.0
+ * Value Range: bool, default=true
+ * Example:
+ * Note: whether to allow using TensorFloat-32 (TF32) in cudnn convolution.
+ * TF32 is only available on Ampere or newer GPUs.
+ * It provides better performance but lower precision than FP32.
+ */
+PHI_DEFINE_EXPORTED_bool(
+    cudnn_allow_tf32,
+    true,
+    "Whether to allow using TensorFloat-32 (TF32) tensor cores for "
+    "convolution operators in cuDNN on Ampere or newer GPUs. "
+    "Default is true.");
+
+/**
+ * CUBLAS related FLAG
+ * Name: FLAGS_cublas_allow_tf32
+ * Since Version: 3.2.0
+ * Value Range: bool, default=false
+ * Example:
+ * Note: whether to allow using TensorFloat-32 (TF32) in cublas matmul.
+ * TF32 is only available on Ampere or newer GPUs.
+ * It provides better performance but lower precision than FP32.
+ */
+PHI_DEFINE_EXPORTED_bool(
+    cublas_allow_tf32,
+    false,
+    "Whether to allow using TensorFloat-32 (TF32) tensor cores for "
+    "matrix multiplication operators in cuBLAS on Ampere or newer GPUs. "
+    "Default is false.");
+
 #ifdef PADDLE_WITH_HIP
 /**
  * MIOPEN related FLAG

--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -284,7 +284,7 @@ PHI_DEFINE_EXPORTED_int64(cudnn_exhaustive_search_times,
 /**
  * CUDNN related FLAG
  * Name: FLAGS_cudnn_allow_tf32
- * Since Version: 3.2.0
+ * Since Version: 3.3.0
  * Value Range: bool, default=true
  * Example:
  * Note: whether to allow using TensorFloat-32 (TF32) in cudnn convolution.
@@ -301,7 +301,7 @@ PHI_DEFINE_EXPORTED_bool(
 /**
  * CUBLAS related FLAG
  * Name: FLAGS_cublas_allow_tf32
- * Since Version: 3.2.0
+ * Since Version: 3.3.0
  * Value Range: bool, default=false
  * Example:
  * Note: whether to allow using TensorFloat-32 (TF32) in cublas matmul.

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -59,6 +59,7 @@ limitations under the License. */
 #include "paddle/phi/core/enforce.h"
 
 COMMON_DECLARE_bool(use_default_stream);
+COMMON_DECLARE_bool(cublas_allow_tf32);
 namespace phi {
 
 namespace internal {
@@ -410,8 +411,11 @@ struct GPUContext::Impl {
           blas_tf32_tensor_core_handle_ =
               blas_tf32_tensor_core_handle_creator_();
         }
+        cublasMath_t tf32_mode = FLAGS_cublas_allow_tf32
+                                     ? CUBLAS_TF32_TENSOR_OP_MATH
+                                     : CUBLAS_DEFAULT_MATH;
         PADDLE_RETRY_CUDA_SUCCESS(phi::dynload::cublasSetMathMode(
-            blas_tf32_tensor_core_handle_, CUBLAS_TF32_TENSOR_OP_MATH));
+            blas_tf32_tensor_core_handle_, tf32_mode));
       }
 #endif
     });
@@ -623,8 +627,11 @@ struct GPUContext::Impl {
           blas_tf32_tensor_core_handle_ =
               blas_tf32_tensor_core_handle_creator_();
         }
+        cublasMath_t tf32_mode = FLAGS_cublas_allow_tf32
+                                     ? CUBLAS_TF32_TENSOR_OP_MATH
+                                     : CUBLAS_DEFAULT_MATH;
         PADDLE_RETRY_CUDA_SUCCESS(phi::dynload::cublasSetMathMode(
-            blas_tf32_tensor_core_handle_, CUBLAS_TF32_TENSOR_OP_MATH));
+            blas_tf32_tensor_core_handle_, tf32_mode));
       }
 #endif
     });
@@ -664,8 +671,11 @@ struct GPUContext::Impl {
           blas_tf32_tensor_core_handle_ =
               blas_tf32_tensor_core_handle_creator_();
         }
+        cublasMath_t tf32_mode = FLAGS_cublas_allow_tf32
+                                     ? CUBLAS_TF32_TENSOR_OP_MATH
+                                     : CUBLAS_DEFAULT_MATH;
         PADDLE_RETRY_CUDA_SUCCESS(phi::dynload::cublasSetMathMode(
-            blas_tf32_tensor_core_handle_, CUBLAS_TF32_TENSOR_OP_MATH));
+            blas_tf32_tensor_core_handle_, tf32_mode));
       }
 #endif
     });

--- a/paddle/phi/kernels/gpudnn/conv_cudnn_frontend.h
+++ b/paddle/phi/kernels/gpudnn/conv_cudnn_frontend.h
@@ -30,6 +30,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/gpudnn/conv_gpudnn_base.h"
 
 COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
+COMMON_DECLARE_bool(cudnn_allow_tf32);
 
 namespace phi {
 
@@ -191,14 +192,37 @@ class CudnnFrontendConvHelper {
       std::vector<void*>* data_ptrs,
       std::vector<int64_t>* uids,
       cudnnHandle_t handle,
-      phi::DnnWorkspaceHandle* workspace_handle) {
+      phi::DnnWorkspaceHandle* workspace_handle,
+      phi::DataType data_type) {
+    auto filter_fn = [=](cudnnBackendDescriptor_t c) {
+      if (deterministic) {
+        if (cudnn_frontend::hasNumericalNote<
+                CUDNN_NUMERICAL_NOTE_NONDETERMINISTIC>(c)) {
+          return true;
+        }
+      }
+
+      if (cudnn_frontend::hasNumericalNote<
+              CUDNN_NUMERICAL_NOTE_DOWN_CONVERT_INPUTS>(c)) {
+        return true;
+      }
+      if (data_type == phi::DataType::FLOAT32) {
+        if (!FLAGS_cudnn_allow_tf32 &&
+            cudnn_frontend::hasNumericalNote<CUDNN_NUMERICAL_NOTE_TENSOR_CORE>(
+                c)) {
+          return true;
+        }
+      }
+      return false;
+    };
+
     auto heurgen_method = [=](cudnn_frontend::OperationGraph& op_graph_)
         -> cudnn_frontend::EngineConfigList {
       cudnn_frontend::EngineConfigList filtered_configs;
       auto statuses = cudnn_frontend::get_heuristics_list<2>(
           {"heuristics_instant", "heuristics_fallback"},
           op_graph_,
-          deterministic ? IsNonDeterministic : AllowAll,
+          filter_fn,
           filtered_configs,
           true);
       VLOG(6) << "Filter config list has " << filtered_configs.size()
@@ -262,11 +286,52 @@ class CudnnFrontendConvHelper {
       cudnn_frontend::OperationGraph* op_graph_pointer,
       bool exhaustive_search,
       bool deterministic,
+      std::vector<void*>* data_ptrs,
+      std::vector<int64_t>* uids,
+      cudnnHandle_t handle,
+      phi::DnnWorkspaceHandle* workspace_handle) {
+    return FindExecutionPlans(op_graph_pointer,
+                              exhaustive_search,
+                              deterministic,
+                              data_ptrs,
+                              uids,
+                              handle,
+                              workspace_handle,
+                              phi::DataType::UNDEFINED);
+  }
+
+  static cudnn_frontend::executionPlans_t FindExecutionPlans(
+      cudnn_frontend::OperationGraph* op_graph_pointer,
+      bool exhaustive_search,
+      bool deterministic,
       void* x_data,
       void* y_data,
       void* w_data,
       cudnnHandle_t handle,
       phi::DnnWorkspaceHandle* workspace_handle) {
+    std::vector<void*> data_ptrs({x_data, y_data, w_data});
+    std::vector<int64_t> uids({'x', 'y', 'w'});
+
+    return FindExecutionPlans(op_graph_pointer,
+                              exhaustive_search,
+                              deterministic,
+                              &data_ptrs,
+                              &uids,
+                              handle,
+                              workspace_handle,
+                              phi::DataType::UNDEFINED);
+  }
+
+  static cudnn_frontend::executionPlans_t FindExecutionPlans(
+      cudnn_frontend::OperationGraph* op_graph_pointer,
+      bool exhaustive_search,
+      bool deterministic,
+      void* x_data,
+      void* y_data,
+      void* w_data,
+      cudnnHandle_t handle,
+      phi::DnnWorkspaceHandle* workspace_handle,
+      phi::DataType data_type) {
     std::vector<void*> data_ptrs({x_data, y_data, w_data});
     std::vector<int64_t> uids({'x', 'y', 'w'});
     return FindExecutionPlans(op_graph_pointer,
@@ -275,7 +340,8 @@ class CudnnFrontendConvHelper {
                               &data_ptrs,
                               &uids,
                               handle,
-                              workspace_handle);
+                              workspace_handle,
+                              data_type);
   }
 
   static void ExecutePlan(cudnnHandle_t handle_,
@@ -502,7 +568,8 @@ void CudnnConvBwdDataV8(const DenseTensor* dy_tensor,
                                           dy_tensor_data,
                                           w_tensor_data,
                                           handle,
-                                          workspace_handle);
+                                          workspace_handle,
+                                          dy_tensor->dtype());
 
   helper::ExecutePlansAndCache(handle,
                                workspace_handle,
@@ -576,7 +643,8 @@ void CudnnConvBwdFilterV8(const DenseTensor* x_tensor,
                                           dy_tensor_data,
                                           dw_tensor_data,
                                           handle,
-                                          workspace_handle);
+                                          workspace_handle,
+                                          x_tensor->dtype());
 
   helper::ExecutePlansAndCache(handle,
                                workspace_handle,

--- a/paddle/phi/kernels/gpudnn/conv_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_kernel.cu
@@ -280,7 +280,8 @@ void ConvCudnnKernelImplV8(const DenseTensor* input_tensor,
                                           output_data,
                                           filter_data,
                                           handle,
-                                          &workspace_handle);
+                                          &workspace_handle,
+                                          input_tensor->dtype());
 
   helper::ExecutePlansAndCache(handle,
                                &workspace_handle,

--- a/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
@@ -225,7 +225,8 @@ void ConvTransposeCudnnKernelImplV8(const DenseTensor* transformed_x,
                                           input_data,
                                           filter_data,
                                           handle,
-                                          &workspace_handle);
+                                          &workspace_handle,
+                                          transformed_x->dtype());
 
   helper::ExecutePlansAndCache(handle,
                                &workspace_handle,

--- a/python/paddle/base/__init__.py
+++ b/python/paddle/base/__init__.py
@@ -165,9 +165,6 @@ def __bootstrap__():
 
     os.environ['OMP_NUM_THREADS'] = str(num_threads)
 
-    if os.getenv('NVIDIA_TF32_OVERRIDE', None) is None:
-        os.environ['NVIDIA_TF32_OVERRIDE'] = '0'
-
     flag_prefix = "FLAGS_"
     read_env_flags = [
         key[len(flag_prefix) :]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
Cherry-pick from develop：
devPR:https://github.com/PaddlePaddle/Paddle/pull/77781
pcard-91067