### PR TITLE
[CodeStyle][DocFormat][46] Use `pycon` for code-block marker in docstring examples (hapi/text/vision)

### DIFF
--- a/python/paddle/hapi/dynamic_flops.py
+++ b/python/paddle/hapi/dynamic_flops.py
@@ -60,7 +60,7 @@ def flops(
         Int: A number about the FLOPs of total network.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> import paddle.nn as nn
@@ -75,13 +75,11 @@ def flops(
             ...             nn.MaxPool2D(2, 2),
             ...             nn.Conv2D(6, 16, 5, stride=1, padding=0),
             ...             nn.ReLU(),
-            ...             nn.MaxPool2D(2, 2))
+            ...             nn.MaxPool2D(2, 2),
+            ...         )
             ...
             ...         if num_classes > 0:
-            ...             self.fc = nn.Sequential(
-            ...                 nn.Linear(400, 120),
-            ...                 nn.Linear(120, 84),
-            ...                 nn.Linear(84, 10))
+            ...             self.fc = nn.Sequential(nn.Linear(400, 120), nn.Linear(120, 84), nn.Linear(84, 10))
             ...
             ...     def forward(self, inputs):
             ...         x = self.features(inputs)
@@ -90,18 +88,13 @@ def flops(
             ...             x = paddle.flatten(x, 1)
             ...             x = self.fc(x)
             ...         return x
-            ...
             >>> lenet = LeNet()
             >>> # m is the instance of nn.Layer, x is the input of layer, y is the output of layer.
             >>> def count_leaky_relu(m, x, y):
             ...     x = x[0]
             ...     nelements = x.numel()
             ...     m.total_ops += int(nelements)
-            ...
-            >>> FLOPs = paddle.flops(lenet,
-            ...                      [1, 1, 28, 28],
-            ...                      custom_ops= {nn.LeakyReLU: count_leaky_relu},
-            ...                      print_detail=True)
+            >>> FLOPs = paddle.flops(lenet, [1, 1, 28, 28], custom_ops={nn.LeakyReLU: count_leaky_relu}, print_detail=True)
             >>> # doctest: +SKIP('numpy print with different version')
             <class 'paddle.nn.layer.conv.Conv2D'>'s flops has been counted
             <class 'paddle.nn.layer.activation.ReLU'>'s flops has been counted

--- a/python/paddle/hapi/dynamic_flops.py
+++ b/python/paddle/hapi/dynamic_flops.py
@@ -79,7 +79,11 @@ def flops(
             ...         )
             ...
             ...         if num_classes > 0:
-            ...             self.fc = nn.Sequential(nn.Linear(400, 120), nn.Linear(120, 84), nn.Linear(84, 10))
+            ...             self.fc = nn.Sequential(
+            ...                 nn.Linear(400, 120),
+            ...                 nn.Linear(120, 84),
+            ...                 nn.Linear(84, 10),
+            ...             )
             ...
             ...     def forward(self, inputs):
             ...         x = self.features(inputs)
@@ -94,7 +98,12 @@ def flops(
             ...     x = x[0]
             ...     nelements = x.numel()
             ...     m.total_ops += int(nelements)
-            >>> FLOPs = paddle.flops(lenet, [1, 1, 28, 28], custom_ops={nn.LeakyReLU: count_leaky_relu}, print_detail=True)
+            >>> FLOPs = paddle.flops(
+            ...     lenet,
+            ...     [1, 1, 28, 28],
+            ...     custom_ops={nn.LeakyReLU: count_leaky_relu},
+            ...     print_detail=True,
+            ... )
             >>> # doctest: +SKIP('numpy print with different version')
             <class 'paddle.nn.layer.conv.Conv2D'>'s flops has been counted
             <class 'paddle.nn.layer.activation.ReLU'>'s flops has been counted

--- a/python/paddle/text/viterbi_decode.py
+++ b/python/paddle/text/viterbi_decode.py
@@ -56,7 +56,7 @@ def viterbi_decode(
             and the data type is int64.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> paddle.seed(2023)
@@ -131,7 +131,7 @@ class ViterbiDecoder(Layer):
             and the data type is int64.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> paddle.seed(2023)

--- a/python/paddle/vision/models/_utils.py
+++ b/python/paddle/vision/models/_utils.py
@@ -64,7 +64,13 @@ class IntermediateLayerGetter(nn.LayerDict):
             >>> m = paddle.vision.models.resnet18(pretrained=False)
 
             >>> # extract layer1 and layer3, giving as names `feat1` and feat2`
-            >>> new_m = paddle.vision.models._utils.IntermediateLayerGetter(m, {'layer1': 'feat1', 'layer3': 'feat2'})
+            >>> new_m = paddle.vision.models._utils.IntermediateLayerGetter(
+            ...     m,
+            ...     {
+            ...         'layer1': 'feat1',
+            ...         'layer3': 'feat2',
+            ...     },
+            ... )
             >>> out = new_m(paddle.rand([1, 3, 224, 224]))
             >>> print([(k, v.shape) for k, v in out.items()])
             [('feat1', [1, 64, 56, 56]), ('feat2', [1, 256, 14, 14])]

--- a/python/paddle/vision/models/_utils.py
+++ b/python/paddle/vision/models/_utils.py
@@ -58,14 +58,13 @@ class IntermediateLayerGetter(nn.LayerDict):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> m = paddle.vision.models.resnet18(pretrained=False)
 
             >>> # extract layer1 and layer3, giving as names `feat1` and feat2`
-            >>> new_m = paddle.vision.models._utils.IntermediateLayerGetter(m,
-            ...     {'layer1': 'feat1', 'layer3': 'feat2'})
+            >>> new_m = paddle.vision.models._utils.IntermediateLayerGetter(m, {'layer1': 'feat1', 'layer3': 'feat2'})
             >>> out = new_m(paddle.rand([1, 3, 224, 224]))
             >>> print([(k, v.shape) for k, v in out.items()])
             [('feat1', [1, 64, 56, 56]), ('feat2', [1, 256, 14, 14])]


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Docs

### Description
This PR continues the docstring highlight marker migration by converting 3 doc examples from `.. code-block:: python` to `.. code-block:: pycon` in:

- `python/paddle/hapi/dynamic_flops.py`
- `python/paddle/text/viterbi_decode.py`
- `python/paddle/vision/models/_utils.py`

Additionally, after switching to `pycon`, the examples were formatted by `ruff format` to keep style consistent.

@SigureMo Please review this PR when you have time. Thanks!

### 是否引起精度变化
否
