### PR TITLE
[CodeStyle][DocFormat][48] Use `pycon` for code-block marker in docstring examples (`python/paddle/audio/datasets/tess.py`)

### DIFF
--- a/python/paddle/audio/datasets/tess.py
+++ b/python/paddle/audio/datasets/tess.py
@@ -51,23 +51,27 @@ class TESS(AudioClassificationDataset):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +TIMEOUT(60)
             >>> import paddle
 
             >>> mode = 'dev'
-            >>> tess_dataset = paddle.audio.datasets.TESS(mode=mode,  # type: ignore[arg-type]
-            ...                                         feat_type='raw')
+            >>> tess_dataset = paddle.audio.datasets.TESS(
+            ...     mode=mode,  # type: ignore[arg-type]
+            ...     feat_type='raw',
+            ... )
             >>> for idx in range(5):
             ...     audio, label = tess_dataset[idx]
             ...     # do something with audio, label
             ...     print(audio.shape, label)
             ...     # [audio_data_length] , label_id
 
-            >>> tess_dataset = paddle.audio.datasets.TESS(mode=mode,  # type: ignore[arg-type]
-            ...                                         feat_type='mfcc',
-            ...                                         n_mfcc=40)
+            >>> tess_dataset = paddle.audio.datasets.TESS(
+            ...     mode=mode,  # type: ignore[arg-type]
+            ...     feat_type='mfcc',
+            ...     n_mfcc=40,
+            ... )
             >>> for idx in range(5):
             ...     audio, label = tess_dataset[idx]
             ...     # do something with mfcc feature, label


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

Replace docstring code-block language marker from `python` to `pycon` in `python/paddle/audio/datasets/tess.py` where examples use interactive prompts (`>>>`). Also apply `ruff-format` to keep examples readable.

### 是否引起精度变化

否

This is part of a series of PRs migrating docstring code-block markers to `pycon`.

See also:

- #77850 (part 46: hapi/text/vision)
- #77853 (part 47: unique_name.py)

@SigureMo Please review this PR when you have time. Thanks!
