### PR TITLE
[CodeStyle][DocFormat][49] Use `pycon` for code-block marker in docstring examples (`python/paddle/distribution/normal.py`)

### DIFF
--- a/python/paddle/distribution/normal.py
+++ b/python/paddle/distribution/normal.py
@@ -92,28 +92,28 @@ class Normal(distribution.Distribution):
         name(str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.distribution import Normal
 
             >>> # Define a single scalar Normal distribution.
-            >>> dist = Normal(loc=0., scale=3.)
+            >>> dist = Normal(loc=0.0, scale=3.0)
             >>> # Define a batch of two scalar valued Normals.
             >>> # The first has mean 1 and standard deviation 11, the second 2 and 22.
-            >>> dist = Normal(loc=[1., 2.], scale=[11., 22.])
+            >>> dist = Normal(loc=[1.0, 2.0], scale=[11.0, 22.0])
             >>> # Get 3 samples, returning a 3 x 2 tensor.
             >>> dist.sample([3])
 
             >>> # Define a batch of two scalar valued Normals.
             >>> # Both have mean 1, but different standard deviations.
-            >>> dist = Normal(loc=1., scale=[11., 22.])
+            >>> dist = Normal(loc=1.0, scale=[11.0, 22.0])
 
             >>> # Complete example
             >>> value_tensor = paddle.to_tensor([0.8], dtype="float32")
 
-            >>> normal_a = Normal([0.], [1.])
-            >>> normal_b = Normal([0.5], [2.])
+            >>> normal_a = Normal([0.0], [1.0])
+            >>> normal_b = Normal([0.5], [2.0])
             >>> sample = normal_a.sample([2])
             >>> # a random tensor created by normal distribution with shape: [2, 1]
             >>> entropy = normal_a.entropy()


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

Replace docstring code-block language marker from `python` to `pycon` in `python/paddle/distribution/normal.py` where examples use interactive prompts (`>>>`).

### 是否引起精度变化

否

This is part of a series of PRs migrating docstring code-block markers to `pycon`.

See also:

- #77850 (part 46)
- #77853 (part 47)
- #77856 (part 48)
