### PR TITLE
[SOT] Handle SymbolicStaticFunction signature check for @unified decorated class

### DIFF
--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -777,6 +777,16 @@ class SymbolicStaticFunction(StaticFunction):
 
         build_strategy = self._kwargs.get("build_strategy", None)
         backend = self._kwargs.get("backend", None)
+
+        if (
+            self.class_instance is not None
+            and not TransformOptions.check_fn_need_transform(
+                self.class_instance, TransformOptions.ToStaticMode.SOT
+            )
+        ):
+            args = (self.class_instance, *args)
+            return self._dygraph_function(*args, **kwargs)
+
         traced_fun = symbolic_translate(
             self._dygraph_function,
             build_strategy=build_strategy,

--- a/test/dygraph_to_static/test_convert_call.py
+++ b/test/dygraph_to_static/test_convert_call.py
@@ -505,6 +505,37 @@ class TestMarkerUnified(Dy2StTestBase):
             )
         )
 
+    def test_unified_layer_to_static_in_init(self):
+        """Test that @unified decorated layer can be to_static in __init__."""
+
+        @paddle.jit.marker.unified
+        class UnifiedLayer(paddle.nn.Layer):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                # Currently, not support SETUP_WITH
+                with paddle.amp.auto_cast(False):
+                    return x * 2
+
+        class Model(paddle.nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.unified_layer = UnifiedLayer()
+                # to_static in __init__ should work for @unified layer
+                self.unified_layer = paddle.jit.to_static(self.unified_layer)
+
+            def forward(self, x):
+                return self.unified_layer(x)
+
+        inp = paddle.rand([2, 10])
+        inp.stop_gradient = False
+        model = Model()
+        out = model(inp)
+        out.sum().backward()
+        np.testing.assert_allclose(out.numpy(), (inp * 2).numpy())
+        np.testing.assert_allclose(inp.grad.numpy(), np.full_like(inp, 2))
+
 
 class TestCaptureControlFlow(Dy2StTestBase):
     def test_decorator(self):


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

当使用 `@paddle.jit.marker.unified` 装饰器标记一个 `nn.Layer` 子类时，如果在 `__init__` 中调用 `paddle.jit.to_static()`，会触发 SOT trace 。但如果在 `if __main__` 块中调用则正常工作。

`SymbolicStaticFunction._perform_call()` 在调用 `symbolic_translate()` 之前，没有检查 `class_instance`（即 Layer 实例）上是否有 `@unified` 标记。

由于 `@unified` 装饰器是加在类上，SOT 通过 `skip_files.py` 跳过 paddle 路径下的代码（如 `nn.Linear`），但用户定义的 `@unified` 类不在 paddle 路径下，仍会被 SOT trace，导致遇到不支持的字节码（如 `SETUP_WITH`）时报错。

在 `_perform_call()` 方法中增加对 `self.class_instance` 的检查，如果 Layer 实例被标记为不需要 SOT 转换，则直接调用动态图函数，跳过 SOT 追踪。

添加了 `test_unified_layer_to_static_in_init` 测试用例，验证 `@unified` 装饰的 Layer 在 `__init__` 中调用 `to_static` 时能正常工作。

cc @SigureMo，是否有更好的方法喵


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否