### PR TITLE
[CodeStyle][DocFormat][52] Use `pycon` for code-block marker in docstring examples (`python/paddle/distribution/binomial.py`)

### DIFF
--- a/python/paddle/distribution/binomial.py
+++ b/python/paddle/distribution/binomial.py
@@ -52,7 +52,7 @@ class Binomial(distribution.Distribution):
             for each individual bernoulli trial. If the input data type is float, it will be converted to a 1-D Tensor with paddle global default dtype.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.distribution import Binomial


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

Replace docstring code-block language marker from `python` to `pycon` in `python/paddle/distribution/binomial.py` where examples use interactive prompts (`>>>`).

### 是否引起精度变化

否

This is part of a series of PRs migrating docstring code-block markers to `pycon`.

See also:

- #77856 (part 48: python/paddle/audio/datasets/tess.py)
- #77857 (part 49: python/paddle/distribution/normal.py)
- #77858 (part 50: python/paddle/distribution/transform.py)
- #77859 (part 51: python/paddle/device/custom_device.py)
