### PR TITLE
Align CUBLAS workspace size, with optimization of CUBLASLt workspace, and linear_v2 CPU overhead

### DIFF
--- a/paddle/phi/backends/context_pool.cc
+++ b/paddle/phi/backends/context_pool.cc
@@ -26,7 +26,7 @@ namespace phi {
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
     defined(PADDLE_WITH_CUSTOM_DEVICE)
-bool allow_tf32_cublas = true;
+bool allow_tf32_cublas = false;
 void SetAllowTF32Cublas(bool active) { allow_tf32_cublas = active; }
 bool AllowTF32Cublas() { return allow_tf32_cublas; }
 bool allow_tf32_cudnn = true;

--- a/paddle/phi/backends/dynload/cublas.h
+++ b/paddle/phi/backends/dynload/cublas.h
@@ -129,8 +129,18 @@ extern void *cublas_dso_handle;
 
 CUBLAS_BLAS_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUBLAS_WRAP)
 
+// NVIDIA's cublas_v2.h defines: #define cublasSetWorkspace
+// cublasSetWorkspace_v2 The actual exported symbol in NVIDIA's libcublas.so is
+// cublasSetWorkspace_v2, so dlsym must look up "cublasSetWorkspace_v2" (the _v2
+// name). Non-NVIDIA toolchains (e.g. Iluvatar/COREX) do NOT define this macro
+// and export only "cublasSetWorkspace" in their shared library. We use #ifdef
+// to detect which symbol name dlsym should look up.
 #if !defined(_WIN32)
+#ifdef cublasSetWorkspace  // NVIDIA: macro maps to cublasSetWorkspace_v2
 #define CUBLAS_WORKSPACE_ROUTINE(__macro) __macro(cublasSetWorkspace_v2);
+#else  // Iluvatar/COREX: only cublasSetWorkspace exists
+#define CUBLAS_WORKSPACE_ROUTINE(__macro) __macro(cublasSetWorkspace);
+#endif
 CUBLAS_WORKSPACE_ROUTINE(DECLARE_DYNAMIC_LOAD_CUBLAS_WRAP)
 #endif
 

--- a/paddle/phi/backends/dynload/cublas.h
+++ b/paddle/phi/backends/dynload/cublas.h
@@ -130,7 +130,7 @@ extern void *cublas_dso_handle;
 CUBLAS_BLAS_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUBLAS_WRAP)
 
 #if !defined(_WIN32)
-#define CUBLAS_WORKSPACE_ROUTINE(__macro) __macro(cublasSetWorkspace);
+#define CUBLAS_WORKSPACE_ROUTINE(__macro) __macro(cublasSetWorkspace_v2);
 CUBLAS_WORKSPACE_ROUTINE(DECLARE_DYNAMIC_LOAD_CUBLAS_WRAP)
 #endif
 

--- a/paddle/phi/backends/dynload/cublas.h
+++ b/paddle/phi/backends/dynload/cublas.h
@@ -129,6 +129,11 @@ extern void *cublas_dso_handle;
 
 CUBLAS_BLAS_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUBLAS_WRAP)
 
+#if !defined(_WIN32)
+#define CUBLAS_WORKSPACE_ROUTINE(__macro) __macro(cublasSetWorkspace);
+CUBLAS_WORKSPACE_ROUTINE(DECLARE_DYNAMIC_LOAD_CUBLAS_WRAP)
+#endif
+
 #if CUDA_VERSION >= 12030 && defined(__linux__)
 #define CUBLAS_BLAS_ROUTINE_EACH_R5(__macro) \
   __macro(cublasGemmStridedBatchedEx_64);    \

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -248,6 +248,16 @@ struct GPUContext::Impl {
   ~Impl() {
     backends::gpu::GPUDeviceGuard guard(place_.device);
     if (owned_) {
+#ifdef PADDLE_WITH_CUDA
+      if (cublas_workspace_) {
+        cudaFree(cublas_workspace_);
+        cublas_workspace_ = nullptr;
+      }
+      if (cublaslt_workspace_) {
+        cudaFree(cublaslt_workspace_);
+        cublaslt_workspace_ = nullptr;
+      }
+#endif
       DestroyInternalWorkspace();
       DestroyInternalEigenDevice();
       phi::DestroySparseHandle(sparse_handle_);
@@ -278,6 +288,58 @@ struct GPUContext::Impl {
 
   bool IsTensorCoreAvailable() const {
     return blas_tensor_core_handle_ != nullptr;
+  }
+
+  // Returns the cublas workspace size matching PyTorch's behavior
+  // for different GPU architectures.
+  // Hopper (SM 9.0): 32 MiB, others: ~8.125 MiB
+  static size_t GetCublasWorkspaceSize(int compute_capability) {
+    if (compute_capability == 90) {
+      return 4096 * 8 * 1024;  // 32 MiB
+    }
+    return 4096 * 1024 * 2 + 16 * 1024 * 8;  // ~8.125 MiB
+  }
+
+  void InitCublasWorkspace() {
+#if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
+    std::call_once(flag_cublas_workspace_, [&]() {
+      size_t workspace_size = GetCublasWorkspaceSize(compute_capability_);
+      PADDLE_ENFORCE_GPU_SUCCESS(
+          cudaMalloc(&cublas_workspace_, workspace_size));
+      cublas_workspace_size_ = workspace_size;
+    });
+#endif
+  }
+
+  void SetCublasWorkspace(blasHandle_t handle) {
+#if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
+    InitCublasWorkspace();
+    PADDLE_RETRY_CUDA_SUCCESS(phi::dynload::cublasSetWorkspace(
+        handle, cublas_workspace_, cublas_workspace_size_));
+#endif
+  }
+
+  // Persistent cublasLt workspace: grow-only, freed in destructor.
+  // Returns {ptr, size}. Thread-safe via mutex for grow path.
+  std::pair<void*, size_t> GetCublasLtWorkspace(size_t required_size) {
+#ifdef PADDLE_WITH_CUDA
+    if (cublaslt_workspace_size_ >= required_size && cublaslt_workspace_) {
+      return {cublaslt_workspace_, cublaslt_workspace_size_};
+    }
+    std::lock_guard<std::mutex> guard(cublaslt_workspace_mtx_);
+    // Double-check after acquiring lock
+    if (cublaslt_workspace_size_ >= required_size && cublaslt_workspace_) {
+      return {cublaslt_workspace_, cublaslt_workspace_size_};
+    }
+    if (cublaslt_workspace_) {
+      cudaFree(cublaslt_workspace_);
+    }
+    PADDLE_ENFORCE_GPU_SUCCESS(cudaMalloc(&cublaslt_workspace_, required_size));
+    cublaslt_workspace_size_ = required_size;
+    return {cublaslt_workspace_, cublaslt_workspace_size_};
+#else
+    return {nullptr, 0};
+#endif
   }
 
   void InitDnnWorkspace() {
@@ -784,6 +846,11 @@ struct GPUContext::Impl {
   std::function<blasHandle_t()> blas_tf32_tensor_core_handle_creator_{nullptr};
   blasLtHandle_t blaslt_handle_{nullptr};
   std::function<blasLtHandle_t()> blaslt_handle_creator_{nullptr};
+  void* cublas_workspace_{nullptr};
+  size_t cublas_workspace_size_{0};
+  void* cublaslt_workspace_{nullptr};
+  size_t cublaslt_workspace_size_{0};
+  mutable std::mutex cublaslt_workspace_mtx_;
   dnnHandle_t dnn_handle_{nullptr};
   std::function<dnnHandle_t()> dnn_handle_creator_{nullptr};
   solverHandle_t solver_handle_{nullptr};
@@ -800,6 +867,7 @@ struct GPUContext::Impl {
   std::once_flag flag_cublas_;
   std::once_flag flag_tensorcore_cublas_;
   std::once_flag flag_eigen_device_;
+  std::once_flag flag_cublas_workspace_;
 
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
   // NCCL communicator (single process version) for NCCL collective operations.
@@ -859,6 +927,11 @@ blasHandle_t GPUContext::cublas_handle() const {
 
 blasLtHandle_t GPUContext::cublaslt_handle() const {
   return impl_->GetBlasLtHandle();
+}
+
+std::pair<void*, size_t> GPUContext::cublaslt_workspace(
+    size_t required_size) const {
+  return impl_->GetCublasLtWorkspace(required_size);
 }
 
 solverHandle_t GPUContext::cusolver_dn_handle() const {

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -319,7 +319,7 @@ struct GPUContext::Impl {
     // the symbol exists before calling to avoid a null-function-pointer
     // segfault on older CUDA versions.
     InitCublasWorkspace();
-    PADDLE_RETRY_CUDA_SUCCESS(phi::dynload::cublasSetWorkspace_v2(
+    PADDLE_RETRY_CUDA_SUCCESS(phi::dynload::cublasSetWorkspace(
         handle, cublas_workspace_, cublas_workspace_size_));
 #endif
   }

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -59,6 +59,7 @@ limitations under the License. */
 #include "paddle/phi/core/enforce.h"
 
 COMMON_DECLARE_bool(use_default_stream);
+COMMON_DECLARE_bool(use_legacy_gemm);
 namespace phi {
 
 namespace internal {
@@ -304,18 +305,33 @@ struct GPUContext::Impl {
 #if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
     std::call_once(flag_cublas_workspace_, [&]() {
       size_t workspace_size = GetCublasWorkspaceSize(compute_capability_);
+      LOG(INFO) << "[SetCublasWorkspace] InitCublasWorkspace: "
+                << "compute_capability=" << compute_capability_
+                << ", workspace_size=" << workspace_size;
       PADDLE_ENFORCE_GPU_SUCCESS(
           cudaMalloc(&cublas_workspace_, workspace_size));
       cublas_workspace_size_ = workspace_size;
+      LOG(INFO) << "[SetCublasWorkspace] InitCublasWorkspace done: "
+                << "cublas_workspace_=" << cublas_workspace_
+                << ", cublas_workspace_size_=" << cublas_workspace_size_;
     });
 #endif
   }
 
   void SetCublasWorkspace(blasHandle_t handle) {
 #if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
+    LOG(INFO) << "[SetCublasWorkspace] begin: handle=" << handle;
+    // cublasSetWorkspace requires cuBLAS >= 11.4 (CUDA >= 11.4).
+    // The dynload wrapper does not check for null, so we must verify
+    // the symbol exists before calling to avoid a null-function-pointer
+    // segfault on older CUDA versions.
     InitCublasWorkspace();
-    PADDLE_RETRY_CUDA_SUCCESS(phi::dynload::cublasSetWorkspace(
+    LOG(INFO) << "[SetCublasWorkspace] calling cublasSetWorkspace: "
+              << "handle=" << handle << ", workspace=" << cublas_workspace_
+              << ", size=" << cublas_workspace_size_;
+    PADDLE_RETRY_CUDA_SUCCESS(phi::dynload::cublasSetWorkspace_v2(
         handle, cublas_workspace_, cublas_workspace_size_));
+    LOG(INFO) << "[SetCublasWorkspace] done for handle=" << handle;
 #endif
   }
 
@@ -474,6 +490,21 @@ struct GPUContext::Impl {
         }
         PADDLE_RETRY_CUDA_SUCCESS(phi::dynload::cublasSetMathMode(
             blas_tf32_tensor_core_handle_, CUBLAS_TF32_TENSOR_OP_MATH));
+      }
+#endif
+#if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
+      if (!FLAGS_use_legacy_gemm) {
+        LOG(INFO) << "[SetCublasWorkspace] GetBlasHandle: "
+                  << "blas_handle_=" << blas_handle_
+                  << ", blas_tensor_core_handle_=" << blas_tensor_core_handle_
+                  << ", blas_tf32_tensor_core_handle_="
+                  << blas_tf32_tensor_core_handle_;
+        if (blas_handle_) SetCublasWorkspace(blas_handle_);
+        if (blas_tensor_core_handle_)
+          SetCublasWorkspace(blas_tensor_core_handle_);
+        if (blas_tf32_tensor_core_handle_)
+          SetCublasWorkspace(blas_tf32_tensor_core_handle_);
+        LOG(INFO) << "[SetCublasWorkspace] GetBlasHandle done";
       }
 #endif
     });
@@ -689,6 +720,21 @@ struct GPUContext::Impl {
             blas_tf32_tensor_core_handle_, CUBLAS_TF32_TENSOR_OP_MATH));
       }
 #endif
+#if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
+      if (!FLAGS_use_legacy_gemm) {
+        LOG(INFO) << "[SetCublasWorkspace] CublasCall: "
+                  << "blas_handle_=" << blas_handle_
+                  << ", blas_tensor_core_handle_=" << blas_tensor_core_handle_
+                  << ", blas_tf32_tensor_core_handle_="
+                  << blas_tf32_tensor_core_handle_;
+        if (blas_handle_) SetCublasWorkspace(blas_handle_);
+        if (blas_tensor_core_handle_)
+          SetCublasWorkspace(blas_tensor_core_handle_);
+        if (blas_tf32_tensor_core_handle_)
+          SetCublasWorkspace(blas_tf32_tensor_core_handle_);
+        LOG(INFO) << "[SetCublasWorkspace] CublasCall done";
+      }
+#endif
     });
     if (blas_tf32_tensor_core_handle_ && phi::AllowTF32Cublas()) {
       std::lock_guard<std::mutex> guard(blas_tf32_mtx_);
@@ -728,6 +774,22 @@ struct GPUContext::Impl {
         }
         PADDLE_RETRY_CUDA_SUCCESS(phi::dynload::cublasSetMathMode(
             blas_tf32_tensor_core_handle_, CUBLAS_TF32_TENSOR_OP_MATH));
+      }
+#endif
+#if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
+      if (!FLAGS_use_legacy_gemm) {
+        LOG(INFO) << "[SetCublasWorkspace] TensorCoreCublasCallIfAvailable: "
+                  << "blas_handle_=" << blas_handle_
+                  << ", blas_tensor_core_handle_=" << blas_tensor_core_handle_
+                  << ", blas_tf32_tensor_core_handle_="
+                  << blas_tf32_tensor_core_handle_;
+        if (blas_handle_) SetCublasWorkspace(blas_handle_);
+        if (blas_tensor_core_handle_)
+          SetCublasWorkspace(blas_tensor_core_handle_);
+        if (blas_tf32_tensor_core_handle_)
+          SetCublasWorkspace(blas_tf32_tensor_core_handle_);
+        LOG(INFO)
+            << "[SetCublasWorkspace] TensorCoreCublasCallIfAvailable done";
       }
 #endif
     });

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -305,33 +305,22 @@ struct GPUContext::Impl {
 #if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
     std::call_once(flag_cublas_workspace_, [&]() {
       size_t workspace_size = GetCublasWorkspaceSize(compute_capability_);
-      LOG(INFO) << "[SetCublasWorkspace] InitCublasWorkspace: "
-                << "compute_capability=" << compute_capability_
-                << ", workspace_size=" << workspace_size;
       PADDLE_ENFORCE_GPU_SUCCESS(
           cudaMalloc(&cublas_workspace_, workspace_size));
       cublas_workspace_size_ = workspace_size;
-      LOG(INFO) << "[SetCublasWorkspace] InitCublasWorkspace done: "
-                << "cublas_workspace_=" << cublas_workspace_
-                << ", cublas_workspace_size_=" << cublas_workspace_size_;
     });
 #endif
   }
 
   void SetCublasWorkspace(blasHandle_t handle) {
 #if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
-    LOG(INFO) << "[SetCublasWorkspace] begin: handle=" << handle;
     // cublasSetWorkspace requires cuBLAS >= 11.4 (CUDA >= 11.4).
     // The dynload wrapper does not check for null, so we must verify
     // the symbol exists before calling to avoid a null-function-pointer
     // segfault on older CUDA versions.
     InitCublasWorkspace();
-    LOG(INFO) << "[SetCublasWorkspace] calling cublasSetWorkspace: "
-              << "handle=" << handle << ", workspace=" << cublas_workspace_
-              << ", size=" << cublas_workspace_size_;
     PADDLE_RETRY_CUDA_SUCCESS(phi::dynload::cublasSetWorkspace_v2(
         handle, cublas_workspace_, cublas_workspace_size_));
-    LOG(INFO) << "[SetCublasWorkspace] done for handle=" << handle;
 #endif
   }
 
@@ -494,17 +483,11 @@ struct GPUContext::Impl {
 #endif
 #if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
       if (!FLAGS_use_legacy_gemm) {
-        LOG(INFO) << "[SetCublasWorkspace] GetBlasHandle: "
-                  << "blas_handle_=" << blas_handle_
-                  << ", blas_tensor_core_handle_=" << blas_tensor_core_handle_
-                  << ", blas_tf32_tensor_core_handle_="
-                  << blas_tf32_tensor_core_handle_;
         if (blas_handle_) SetCublasWorkspace(blas_handle_);
         if (blas_tensor_core_handle_)
           SetCublasWorkspace(blas_tensor_core_handle_);
         if (blas_tf32_tensor_core_handle_)
           SetCublasWorkspace(blas_tf32_tensor_core_handle_);
-        LOG(INFO) << "[SetCublasWorkspace] GetBlasHandle done";
       }
 #endif
     });
@@ -722,17 +705,11 @@ struct GPUContext::Impl {
 #endif
 #if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
       if (!FLAGS_use_legacy_gemm) {
-        LOG(INFO) << "[SetCublasWorkspace] CublasCall: "
-                  << "blas_handle_=" << blas_handle_
-                  << ", blas_tensor_core_handle_=" << blas_tensor_core_handle_
-                  << ", blas_tf32_tensor_core_handle_="
-                  << blas_tf32_tensor_core_handle_;
         if (blas_handle_) SetCublasWorkspace(blas_handle_);
         if (blas_tensor_core_handle_)
           SetCublasWorkspace(blas_tensor_core_handle_);
         if (blas_tf32_tensor_core_handle_)
           SetCublasWorkspace(blas_tf32_tensor_core_handle_);
-        LOG(INFO) << "[SetCublasWorkspace] CublasCall done";
       }
 #endif
     });
@@ -778,18 +755,11 @@ struct GPUContext::Impl {
 #endif
 #if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
       if (!FLAGS_use_legacy_gemm) {
-        LOG(INFO) << "[SetCublasWorkspace] TensorCoreCublasCallIfAvailable: "
-                  << "blas_handle_=" << blas_handle_
-                  << ", blas_tensor_core_handle_=" << blas_tensor_core_handle_
-                  << ", blas_tf32_tensor_core_handle_="
-                  << blas_tf32_tensor_core_handle_;
         if (blas_handle_) SetCublasWorkspace(blas_handle_);
         if (blas_tensor_core_handle_)
           SetCublasWorkspace(blas_tensor_core_handle_);
         if (blas_tf32_tensor_core_handle_)
           SetCublasWorkspace(blas_tf32_tensor_core_handle_);
-        LOG(INFO)
-            << "[SetCublasWorkspace] TensorCoreCublasCallIfAvailable done";
       }
 #endif
     });

--- a/paddle/phi/backends/gpu/gpu_context.h
+++ b/paddle/phi/backends/gpu/gpu_context.h
@@ -26,6 +26,7 @@ limitations under the License. */
 #include <array>
 #include <functional>
 #include <mutex>
+#include <utility>
 
 #include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/forwards.h"
@@ -116,6 +117,10 @@ class PADDLE_API GPUContext : public DeviceContext,
 
   /*! \brief  Return cublasLt handle in the device context. */
   blasLtHandle_t cublaslt_handle() const;
+
+  /*! \brief  Return persistent cublasLt workspace (grow-only, multi-stream
+   * safe). */
+  std::pair<void*, size_t> cublaslt_workspace(size_t required_size) const;
 
   /*! \brief  Return cusolver handle in the device context. */
   solverHandle_t cusolver_dn_handle() const;

--- a/paddle/phi/kernels/gpu/linear_v2_kernel.cu
+++ b/paddle/phi/kernels/gpu/linear_v2_kernel.cu
@@ -43,7 +43,6 @@
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/enforce.h"
-#include "paddle/phi/core/scope_guard.h"
 #include "paddle/utils/optional.h"
 #if defined(PADDLE_WITH_CUDA)
 #include "paddle/phi/backends/dynload/cublasLt.h"
@@ -60,6 +59,110 @@ COMMON_DECLARE_bool(use_legacy_linear);
 
 namespace phi {
 
+#if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && \
+    !defined(_WIN32) && CUDA_VERSION >= 11060
+
+// Direct cublasLt matmul+bias, bypassing MatmulPlanner/DescriptorSetter/
+// CublasLtBase. Uses persistent workspace from GPUContext.
+template <typename T>
+static void CublasLtMatmulBias(const phi::GPUContext& ctx,
+                               const T* x,
+                               const T* w,
+                               const T* bias,
+                               T* out,
+                               int64_t M,
+                               int64_t N,
+                               int64_t K,
+                               bool trans_w) {
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+  constexpr auto compute =
+      std::is_same<T, double>::value ? CUBLAS_COMPUTE_64F : CUBLAS_COMPUTE_32F;
+  const auto dtype = phi::backends::gpu::ToCudaDataType<T>();
+  const auto stype = phi::backends::gpu::ToCudaDataType<MT>();
+
+  MT alpha = static_cast<MT>(1), beta = static_cast<MT>(0);
+  auto lt = ctx.cublaslt_handle();
+
+  // op desc
+  cublasLtMatmulDesc_t op = nullptr;
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      dynload::cublasLtMatmulDescCreate(&op, compute, stype));
+
+  // col-major: C(N,M) = A(weight) * B(input)
+  cublasOperation_t ta = trans_w ? CUBLAS_OP_T : CUBLAS_OP_N;
+  cublasOperation_t tb = CUBLAS_OP_N;
+  PADDLE_ENFORCE_GPU_SUCCESS(dynload::cublasLtMatmulDescSetAttribute(
+      op, CUBLASLT_MATMUL_DESC_TRANSA, &ta, sizeof(ta)));
+  PADDLE_ENFORCE_GPU_SUCCESS(dynload::cublasLtMatmulDescSetAttribute(
+      op, CUBLASLT_MATMUL_DESC_TRANSB, &tb, sizeof(tb)));
+
+  cublasLtEpilogue_t epi = CUBLASLT_EPILOGUE_BIAS;
+  PADDLE_ENFORCE_GPU_SUCCESS(dynload::cublasLtMatmulDescSetAttribute(
+      op, CUBLASLT_MATMUL_DESC_EPILOGUE, &epi, sizeof(epi)));
+  PADDLE_ENFORCE_GPU_SUCCESS(dynload::cublasLtMatmulDescSetAttribute(
+      op, CUBLASLT_MATMUL_DESC_BIAS_POINTER, &bias, sizeof(bias)));
+
+  // matrix layouts (col-major)
+  cublasLtMatrixLayout_t la = nullptr, lb = nullptr, lc = nullptr;
+  if (trans_w) {
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        dynload::cublasLtMatrixLayoutCreate(&la, dtype, K, N, K));
+  } else {
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        dynload::cublasLtMatrixLayoutCreate(&la, dtype, N, K, N));
+  }
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      dynload::cublasLtMatrixLayoutCreate(&lb, dtype, K, M, K));
+  PADDLE_ENFORCE_GPU_SUCCESS(
+      dynload::cublasLtMatrixLayoutCreate(&lc, dtype, N, M, N));
+
+  // persistent workspace from context
+  constexpr size_t kWsSize = 1024 * 1024;
+  auto [ws, ws_sz] = ctx.cublaslt_workspace(kWsSize);
+
+  // heuristic
+  cublasLtMatmulPreference_t pref = nullptr;
+  PADDLE_ENFORCE_GPU_SUCCESS(dynload::cublasLtMatmulPreferenceCreate(&pref));
+  PADDLE_ENFORCE_GPU_SUCCESS(dynload::cublasLtMatmulPreferenceSetAttribute(
+      pref, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &ws_sz, sizeof(ws_sz)));
+
+  cublasLtMatmulHeuristicResult_t heur = {};
+  int n_res = 0;
+  PADDLE_ENFORCE_GPU_SUCCESS(dynload::cublasLtMatmulAlgoGetHeuristic(
+      lt, op, la, lb, lc, lc, pref, 1, &heur, &n_res));
+  PADDLE_ENFORCE_GT(
+      n_res,
+      0,
+      common::errors::Unavailable("No cublasLt GEMM algorithm available."));
+  dynload::cublasLtMatmulPreferenceDestroy(pref);
+
+  // execute
+  PADDLE_ENFORCE_GPU_SUCCESS(dynload::cublasLtMatmul(lt,
+                                                     op,
+                                                     &alpha,
+                                                     w,
+                                                     la,
+                                                     x,
+                                                     lb,
+                                                     &beta,
+                                                     out,
+                                                     lc,
+                                                     out,
+                                                     lc,
+                                                     &heur.algo,
+                                                     ws,
+                                                     ws_sz,
+                                                     ctx.stream()));
+
+  // cleanup
+  dynload::cublasLtMatmulDescDestroy(op);
+  dynload::cublasLtMatrixLayoutDestroy(la);
+  dynload::cublasLtMatrixLayoutDestroy(lb);
+  dynload::cublasLtMatrixLayoutDestroy(lc);
+}
+
+#endif
+
 template <typename T, typename Context>
 void LinearV2Kernel(const Context& dev_ctx,
                     const DenseTensor& input,
@@ -72,13 +175,12 @@ void LinearV2Kernel(const Context& dev_ctx,
     return;
   }
 
-// broadcast bias, reshape input,  run_fuse, reshape output
-#if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
+#if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && \
+    !defined(_WIN32) && CUDA_VERSION >= 11060
   if (!FLAGS_use_legacy_linear) {
-    VLOG(10) << "Use LinearV2Kernel with cublaslt";
     const auto out_dim_original = out->dims();
     const auto [M, N, K] = canonicalize_dims(input, weight, transpose_weight);
-    VLOG(10) << "M: " << M << ", N: " << N << ", K: " << K;
+
     DenseTensor input_processed = input;
     DenseTensor weight_processed = weight;
     input_processed.Resize(common::make_ddim({M, K}));
@@ -88,47 +190,32 @@ void LinearV2Kernel(const Context& dev_ctx,
       weight_processed.Resize(common::make_ddim({K, N}));
     }
     out->Resize(common::make_ddim({M, N}));
-    VLOG(10) << "input_processed: " << input_processed.dims()
-             << ", weight_processed: " << weight_processed.dims()
-             << ", output_processed: " << out->dims();
 
     if (N > 1 && K > 1) {
       DenseTensor bias_processed;
       if (bias.numel() != N) {
-        // only broadcast to 1D bias whatsoever
-        // pass1: scalar to 1D
         phi::TileKernel<T, Context>(dev_ctx, bias, {N}, &bias_processed);
       } else {
         bias_processed = bias;
       }
-      // CublasLt path with bias add epilogue
-      phi::funcs::LinearWithCublasLt<T>::Run(
-          dev_ctx,
-          &input_processed,
-          &weight_processed,
-          out,
-          static_cast<const void*>(bias_processed.data<T>()),
-          nullptr,
-          M,
-          N,
-          K,
-          false,
-          transpose_weight,
-          phi::funcs::MatmulFusedType::kMatmulBias);
+      CublasLtMatmulBias<T>(dev_ctx,
+                            input_processed.data<T>(),
+                            weight_processed.data<T>(),
+                            bias_processed.data<T>(),
+                            out->data<T>(),
+                            M,
+                            N,
+                            K,
+                            transpose_weight);
     } else {
+      // When N=1 or K=1, {N,K} and {K,N} have identical memory layout,
+      // so just reshape to {K,N} which is what AddmmKernel expects.
+      weight_processed.Resize(common::make_ddim({K, N}));
       DenseTensor bias_processed = bias;
-      auto blas = funcs::GetBlas<Context, T>(dev_ctx);
       if (bias.numel() != (M * N)) {
         bias_processed.Resize(make_ddim({1, bias.numel()}));
-        VLOG(10) << "bias.dim(): " << bias.dims();
-        VLOG(10) << "M*N: " << M * N;
-        VLOG(10) << "bias tiling and addmm calculating";
-        // only broadcast to 1D bias whatsoever
         phi::TileKernel<T, Context>(
             dev_ctx, bias_processed, {M, 1}, &bias_processed);
-        VLOG(10) << "bias_processed.dims(): " << bias_processed.dims();
-      } else {
-        bias_processed = bias;
       }
       phi::AddmmKernel<T>(dev_ctx,
                           bias_processed,
@@ -141,10 +228,7 @@ void LinearV2Kernel(const Context& dev_ctx,
     out->Resize(out_dim_original);
   } else  // NOLINT
 #endif
-  // Fallback logic for legacy CUDA version or other hardware.
-  // Or specified by user to use a legacy behaviour.
   {  // NOLINT
-    // NOTE(Pan Zhaowu): Fallback logic for legacy CUDA version or DCU.
     std::vector<std::int64_t> input_dims_vec = common::vectorize(input.dims());
     std::vector<std::int64_t> weight_dims_vec =
         common::vectorize(weight.dims());

--- a/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
@@ -384,26 +384,77 @@ void MatmulGradKernel(const Context& dev_ctx,
     }
 
     if (transpose_x && transpose_y) {
-      CalcInputGrad<T>(dev_ctx,
-                       y_conj,
-                       true,
-                       true,
-                       out_grad_help,
-                       true,
-                       false,
-                       dx,
-                       false,
-                       true);
-      CalcInputGrad<T>(dev_ctx,
-                       out_grad_help,
-                       true,
-                       true,
-                       x_conj,
-                       true,
-                       false,
-                       dy,
-                       false,
-                       true);
+#if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
+      if (!FLAGS_use_legacy_gemm && x_help.dims().size() == 3 &&
+          y_help.dims().size() == 3) {
+        // For batched case only (both x and y are 3D after reshape): match
+        // PyTorch's backward cublas call pattern (OP_N/OP_N instead of
+        // OP_T/OP_T), compute without transposes and transpose the results.
+        // dX = (dOut @ Y_conj)^T, dY = (X_conj @ dOut)^T
+        if (dx) {
+          auto dx_dims_orig = dx->dims();
+          DenseTensor dx_tmp = EmptyLike<T, Context>(dev_ctx, *dx);
+          dx_tmp.Resize({dx_tmp.dims()[0], dx_tmp.dims()[2], dx_tmp.dims()[1]});
+          CalcInputGrad<T>(dev_ctx,
+                           out_grad_help,
+                           false,
+                           true,
+                           y_conj,
+                           false,
+                           false,
+                           &dx_tmp,
+                           false,
+                           true);
+          dev_ctx.template Alloc<T>(dx);
+          std::vector<int> axis = {0, 2, 1};
+          funcs::Transpose<Context, T, 3> trans;
+          trans(dev_ctx, dx_tmp, dx, axis);
+          dx->Resize(dx_dims_orig);
+        }
+        if (dy) {
+          auto dy_dims_orig = dy->dims();
+          DenseTensor dy_tmp = EmptyLike<T, Context>(dev_ctx, *dy);
+          dy_tmp.Resize({dy_tmp.dims()[0], dy_tmp.dims()[2], dy_tmp.dims()[1]});
+          CalcInputGrad<T>(dev_ctx,
+                           x_conj,
+                           false,
+                           true,
+                           out_grad_help,
+                           false,
+                           false,
+                           &dy_tmp,
+                           false,
+                           true);
+          dev_ctx.template Alloc<T>(dy);
+          std::vector<int> axis = {0, 2, 1};
+          funcs::Transpose<Context, T, 3> trans;
+          trans(dev_ctx, dy_tmp, dy, axis);
+          dy->Resize(dy_dims_orig);
+        }
+      } else  // NOLINT
+#endif
+      {  // NOLINT
+        CalcInputGrad<T>(dev_ctx,
+                         y_conj,
+                         true,
+                         true,
+                         out_grad_help,
+                         true,
+                         false,
+                         dx,
+                         false,
+                         true);
+        CalcInputGrad<T>(dev_ctx,
+                         out_grad_help,
+                         true,
+                         true,
+                         x_conj,
+                         true,
+                         false,
+                         dy,
+                         false,
+                         true);
+      }
     } else if (transpose_x) {
       CalcInputGrad<T>(dev_ctx,
                        y_conj,
@@ -436,16 +487,48 @@ void MatmulGradKernel(const Context& dev_ctx,
                        dx,
                        false,
                        true);
-      CalcInputGrad<T>(dev_ctx,
-                       out_grad_help,
-                       true,
-                       true,
-                       x_conj,
-                       false,
-                       true,
-                       dy,
-                       false,
-                       true);
+#if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
+      if (!FLAGS_use_legacy_gemm && x_help.dims().size() == 3 &&
+          y_help.dims().size() == 3) {
+        // For batched case only (both x and y are 3D after reshape): match
+        // PyTorch's backward cublas call pattern for dY. Compute X_conj^T @
+        // dOut into a temp buffer with transposed shape, then transpose the
+        // result. This produces the same cublas descriptor layout as PyTorch,
+        // ensuring identical algorithm selection and bitwise alignment.
+        if (dy) {
+          auto dy_dims_orig = dy->dims();
+          DenseTensor dy_tmp = EmptyLike<T, Context>(dev_ctx, *dy);
+          dy_tmp.Resize({dy_tmp.dims()[0], dy_tmp.dims()[2], dy_tmp.dims()[1]});
+          CalcInputGrad<T>(dev_ctx,
+                           x_conj,
+                           true,
+                           true,
+                           out_grad_help,
+                           false,
+                           false,
+                           &dy_tmp,
+                           false,
+                           true);
+          dev_ctx.template Alloc<T>(dy);
+          std::vector<int> axis = {0, 2, 1};
+          funcs::Transpose<Context, T, 3> trans;
+          trans(dev_ctx, dy_tmp, dy, axis);
+          dy->Resize(dy_dims_orig);
+        }
+      } else  // NOLINT
+#endif
+      {  // NOLINT
+        CalcInputGrad<T>(dev_ctx,
+                         out_grad_help,
+                         true,
+                         true,
+                         x_conj,
+                         false,
+                         true,
+                         dy,
+                         false,
+                         true);
+      }
     } else {
       CalcInputGrad<T>(dev_ctx,
                        out_grad_help,

--- a/test/legacy_test/test_tf32_cublas.py
+++ b/test/legacy_test/test_tf32_cublas.py
@@ -25,7 +25,7 @@ class TestTF32Switch(unittest.TestCase):
     def test_on_off(self):
         if core.is_compiled_with_cuda() or is_custom_device():
             place = get_device_place()
-            self.assertTrue(core.get_cublas_switch())  # default
+            self.assertFalse(core.get_cublas_switch())  # default
             core.set_cublas_switch(False)
             self.assertFalse(core.get_cublas_switch())  # turn off
             core.set_cublas_switch(True)
@@ -40,7 +40,6 @@ class TestTF32OnMatmul(unittest.TestCase):
     def test_dygraph_without_out(self):
         if core.is_compiled_with_cuda() or is_custom_device():
             place = get_device_place()
-            core.set_cublas_switch(False)  # turn off
             with base.dygraph.guard(place):
                 input_array1 = np.random.rand(4, 12, 64, 88).astype("float32")
                 input_array2 = np.random.rand(4, 12, 88, 512).astype("float32")
@@ -49,7 +48,6 @@ class TestTF32OnMatmul(unittest.TestCase):
                 out = paddle.matmul(data1, data2)
                 expected_result = np.matmul(input_array1, input_array2)
             np.testing.assert_allclose(expected_result, out.numpy(), rtol=0.001)
-            core.set_cublas_switch(True)  # restore the switch
         else:
             pass
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
Align CUBLAS workspace size, with optimization of cublaslt workspace, and linear_v2 CPU overhead
对PR:https://github.com/PaddlePaddle/Paddle/pull/77039 的Ampere架构善后和调度性能优化

L、N、T分别代表Legacy linear、 New linear和torch
- old bf16
<img width="1876" height="524" alt="image" src="https://github.com/user-attachments/assets/9c0838de-a197-47e5-b66a-eb4092822b31" />

- new bf16
<img width="1976" height="518" alt="image" src="https://github.com/user-attachments/assets/37e7146e-0d9c-4dad-95ca-3ce25f2828bb" />

- Blackwell bf16 
<img width="1962" height="530" alt="image" src="https://github.com/user-attachments/assets/ab1c5639-407f-4f9c-a76e-dda758b8f056" />

### 精度结论如下：
经回测A卡下已知的32k+个case，paddle的matmul + linear前反向逐位对齐torch
H、B卡精度未发生变化，仍旧对齐

### 性能结论如下：

1. bf16下，H、B卡框架linear_v2调度性能基本追平torch，部分反超。
2. 调整cublas workspace后，Hopper普通GEMM碎算子的基线有较大提升。
3. 融合算子仍然能展现出较大的性能优势，且在B卡上比H卡优势更为明显


pcard-91067

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是