### PR TITLE
[API Compatibility] revert record stream compat API

### DIFF
--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -441,29 +441,14 @@ class Tensor : public TensorBase {
                                        /*decrease_axis=*/{0});
   }
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-  void record_stream(const gpuStream_t& stream) const {
+#if defined(PADDLE_WITH_CUDA)
+  void record_stream(const cudaStream_t& stream) const {
     paddle::memory::RecordStream(
         std::dynamic_pointer_cast<phi::DenseTensor>(tensor_.impl())->Holder(),
-        stream);
+        reinterpret_cast<gpuStream_t>(stream));
   }
 #endif
 
-#ifdef PADDLE_WITH_XPU
-  void record_stream(const XPUStream& stream) const {
-    paddle::memory::RecordStream(
-        std::dynamic_pointer_cast<phi::DenseTensor>(tensor_.impl())->Holder(),
-        stream);
-  }
-#endif
-
-#ifdef PADDLE_WITH_CUSTOM_DEVICE
-  void record_stream(const phi::stream::stream_t& stream) const {
-    paddle::memory::RecordStream(
-        std::dynamic_pointer_cast<phi::DenseTensor>(tensor_.impl())->Holder(),
-        stream);
-  }
-#endif
 
   Tensor var(int dim) const { return var(at::IntArrayRef{dim}, true, false); }
 

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -449,7 +449,6 @@ class Tensor : public TensorBase {
   }
 #endif
 
-
   Tensor var(int dim) const { return var(at::IntArrayRef{dim}, true, false); }
 
   Tensor var(bool unbiased = true) const {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure


### PR Types
Bug fixes


### Description
1. record_stream接口的多硬件支持部分存在bug导致了沐曦CI失败（https://github.com/PaddlePaddle/PaddleCustomDevice/actions/runs/21966371693/job/63457921233?pr=2415#step:4:14186）
2. record_stream接口没有完全跟torch对齐，先将这个接口revert，后续增加at::stream实现（和torch对齐）再上线


### 是否引起精度变化
否
