### PR TITLE
[release/3.3] Fix log10 precision issues

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -5454,7 +5454,11 @@ struct CudaLog10Functor : public BaseActivationFunctor<T> {
   // log10(x) = log10(x)
   __device__ __forceinline__ U operator()(const T arg_x) const {
     MPType x = static_cast<MPType>(arg_x);
-    return static_cast<U>(log10_local(x));
+    // Cast to floating-point before log10_local to avoid calling
+    // host-only ::log10(int) on Windows NVCC when MPType is integral
+    using FPType =
+        std::conditional_t<std::is_integral<MPType>::value, float, MPType>;
+    return static_cast<U>(log10_local(static_cast<FPType>(x)));
   }
 };
 

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -5467,12 +5467,16 @@ template <typename T>
 struct CudaLog10GradFunctor : public BaseActivationFunctor<T> {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
 
-  // ln(10) constant matching PyTorch's M_LN10 for precise float64 backward
-  T log_ten = static_cast<T>(2.30258509299404568401);
+  // ln(10) = 2.30258509299404568402... (M_LN10)
+  // Using PyTorch's exact 16-digit literal from derivatives.yaml for bit-exact
+  // alignment
+  T log_ten = static_cast<T>(2.3025850929940456);
 
   // dx = dout / (x * log(10))
+  // Division-first order: (dout / x) / log_ten to match PyTorch's
+  // generated backward code rounding behavior (reduces 1-ULP drift).
   __device__ __forceinline__ T operator()(const T dout, const T x) const {
-    return dout / (x * log_ten);
+    return (dout / x) / log_ten;
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -5466,7 +5466,9 @@ struct CudaLog10Functor<ComplexType<T>>
 template <typename T>
 struct CudaLog10GradFunctor : public BaseActivationFunctor<T> {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  T log_ten = static_cast<T>(log(static_cast<MPType>(10.0)));
+
+  // ln(10) constant matching PyTorch's M_LN10 for precise float64 backward
+  T log_ten = static_cast<T>(2.30258509299404568401);
 
   // dx = dout / (x * log(10))
   __device__ __forceinline__ T operator()(const T dout, const T x) const {

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -5432,12 +5432,7 @@ __device__ __forceinline__
   static_assert(!std::is_same<T, double>::value,
                 "this template must be used with float or less precise type");
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
-  // use __logf fast approximation for peak bandwidth
-  return __log10f(x);
-#else
   return ::log10(x);
-#endif
 }
 
 template <>
@@ -5464,14 +5459,14 @@ struct CudaLog10Functor<ComplexType<T>>
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> arg_x) const {
     return static_cast<ComplexType<T>>(log(arg_x) /
-                                       static_cast<ComplexType<T>>(log(10.0f)));
+                                       static_cast<ComplexType<T>>(log(10.0)));
   }
 };
 
 template <typename T>
 struct CudaLog10GradFunctor : public BaseActivationFunctor<T> {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  T log_ten = static_cast<T>(log(static_cast<MPType>(10.0f)));
+  T log_ten = static_cast<T>(log(static_cast<MPType>(10.0)));
 
   // dx = dout / (x * log(10))
   __device__ __forceinline__ T operator()(const T dout, const T x) const {
@@ -5487,7 +5482,7 @@ struct CudaLog10GradFunctor<ComplexType<T>>
   // dx = dout / conj(x * log(10))
   __device__ __forceinline__ ComplexType<T> operator()(
       const ComplexType<T> dout, const ComplexType<T> x) const {
-    return dout / conj(x * static_cast<ComplexType<T>>(log(10.0f)));
+    return dout / conj(x * static_cast<ComplexType<T>>(log(10.0)));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -2715,6 +2715,7 @@ struct Log10Functor : public BaseActivationFunctor<T> {
 };
 
 // the gradient of log10(x) is 1/(x*ln(10))
+// PyTorch formula: grad / (self * 2.3025850929940456)
 template <typename T>
 struct Log10GradFunctor : public BaseActivationFunctor<T> {
   template <typename Device,
@@ -2723,7 +2724,12 @@ struct Log10GradFunctor : public BaseActivationFunctor<T> {
             typename dOut,
             typename dX>
   void operator()(Device d, X x, Out out UNUSED, dOut dout, dX dx) const {
-    dx.device(d) = dout * static_cast<T>(1) / (x * static_cast<T>(log(10)));
+    // Use PyTorch's exact constant (ln(10) to 16 significant digits) and
+    // matching evaluation order: dout / (x * ln10), i.e., multiply x by the
+    // constant first, then divide. This avoids runtime log(10) computation
+    // and aligns CPU/GPU paths with PyTorch's backward for bit-exact results.
+    T log_ten = static_cast<T>(2.3025850929940456);
+    dx.device(d) = dout / (x * log_ten);
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }
@@ -5469,14 +5475,16 @@ struct CudaLog10GradFunctor : public BaseActivationFunctor<T> {
 
   // ln(10) = 2.30258509299404568402... (M_LN10)
   // Using PyTorch's exact 16-digit literal from derivatives.yaml for bit-exact
-  // alignment
+  // alignment: grad / (self * 2.3025850929940456)
   T log_ten = static_cast<T>(2.3025850929940456);
 
-  // dx = dout / (x * log(10))
-  // Division-first order: (dout / x) / log_ten to match PyTorch's
-  // generated backward code rounding behavior (reduces 1-ULP drift).
+  // dx = dout / (x * ln(10))
+  // PyTorch computes: grad / (self * 2.3025850929940456)
+  //   i.e., multiply x by ln(10) first, then divide grad by the product.
+  // This matches PyTorch's evaluation order exactly: one multiplication
+  // followed by one division, rather than two sequential divisions.
   __device__ __forceinline__ T operator()(const T dout, const T x) const {
-    return (dout / x) / log_ten;
+    return dout / (x * log_ten);
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Bug fixes

### Description
Backport devPR:https://github.com/PaddlePaddle/Paddle/pull/77855 to branch release/3.3
This backport includes the commits from the original PR that fix log10 precision.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是
