### PR TITLE
Add _new_shared_tensor method for tensor

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -34,6 +34,7 @@ typedef SSIZE_T ssize_t;
 #include "paddle/fluid/pybind/eager.h"
 #include "paddle/fluid/pybind/eager_utils.h"
 #include "paddle/fluid/pybind/exception.h"
+#include "paddle/fluid/pybind/op_function_common.h"
 #include "paddle/fluid/pybind/slice_utils.h"
 #include "paddle/fluid/pybind/uva_utils.h"
 #include "paddle/phi/api/include/api.h"
@@ -765,6 +766,101 @@ static PyObject* tensor_method_copy_(TensorObject* self,
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }
 
+PyDoc_STRVAR(tensor_method__new_shared_tensor__doc__,  // NOLINT
+             R"DOC(_new_shared_tensor($self, retain_holder=True, /)
+--
+
+Returns a new Tensor that shares data with the original Tensor.
+
+This method creates a new Tensor object that shares the underlying data storage
+with the original Tensor. The behavior depends on the `retain_holder` parameter.
+
+Notes:
+- The original Tensor's autograd metadata (including gradients and backward
+  propagation information) is also shared between the two Tensors.
+
+Args:
+    retain_holder (bool, optional): Controls whether to share the data holder.
+        - If True (default): The new Tensor shares the exact same underlying
+          data allocation with the original Tensor. Changes to one will affect
+          the other. Additionally, both Tensors share the same autograd metadata.
+        - If False: Creates a new Tensor with the same metadata but with an
+          empty data allocation. The autograd metadata is still shared.
+
+Returns:
+    Tensor: A new Tensor object that shares data and autograd metadata with
+            the original Tensor.
+
+Raises:
+    ValueError: If the original Tensor has not been initialized.
+
+Examples:
+    >>> # doctest: +REQUIRES(env:GPU)
+    >>> import paddle
+    >>> x = paddle.to_tensor([1, 2, 3], stop_gradient=False)
+    >>> y = x._new_shared_tensor()  # Shares data and autograd metadata with x
+    >>> y[0] = 10
+    >>> print(x)  # x is also modified
+    Tensor(shape=[3], dtype=int64, place=Place(gpu:0), stop_gradient=True,
+          [10, 2 , 3 ])
+    >>> z = x._new_shared_tensor(retain_holder=False)  # Creates a new Tensor
+    >>> print(z)  # z is an empty Tensor with the same metadata as x
+    Tensor(Not initialized)
+    >> x.stop_gradient = False
+    >> w = paddle.to_tensor([1,2,3])
+    >> w.stop_gradient = False
+    >> (x + w).sum().backward()
+    >> x.grad
+    Tensor(shape=[3], dtype=int64, place=Place(gpu:0), stop_gradient=False,
+       [1, 1, 1])
+    >> z.grad
+    Tensor(shape=[3], dtype=int64, place=Place(gpu:0), stop_gradient=False,
+       [1, 1, 1])
+
+)DOC");
+
+static PyObject* tensor_method__new_shared_tensor(TensorObject* self,
+                                                  PyObject* args,
+                                                  PyObject* kwargs) {
+  EAGER_TRY
+  PADDLE_ENFORCE_EQ(
+      self->tensor.defined(),
+      true,
+      common::errors::InvalidArgument("Tensor %s has not been initialized!",
+                                      self->tensor.name()));
+  bool retain_holder = true;
+  int nargs = args ? static_cast<int>(PyTuple_Size(args)) : 0;
+  int remaining_kwargs = kwargs ? static_cast<int>(PyDict_Size(kwargs)) : 0;
+  PyObject* retain_holder_obj = GetItemFromArgsOrKWArgs(
+      args, 0, kwargs, {"retain_holder"}, nargs, &remaining_kwargs);
+  retain_holder =
+      CastPyArg2Boolean(retain_holder_obj, "_new_shared_tensor", 0, true);
+  PyObject* obj = p_tensor_type->tp_alloc(p_tensor_type, 0);
+  if (obj) {
+    auto v = reinterpret_cast<TensorObject*>(obj);
+    new (&(v->tensor)) Tensor();
+    if (retain_holder) {
+      v->tensor.set_impl(self->tensor.impl());
+    } else {
+      auto* dense_tensor =
+          dynamic_cast<phi::DenseTensor*>(self->tensor.impl().get());
+      if (dense_tensor != nullptr && dense_tensor->Holder() != nullptr) {
+        auto tmp = std::make_shared<DenseTensor>(
+            std::make_shared<phi::Allocation>(
+                nullptr, 0, dense_tensor->Holder()->place()),
+            dense_tensor->meta());
+        v->tensor.set_impl(tmp);
+      }
+    }
+    v->tensor.set_name(self->tensor.name());
+    v->tensor.set_autograd_meta(self->tensor.mutable_autograd_meta());
+  } else {
+    PADDLE_THROW(
+        common::errors::Fatal("tp_alloc return null, can not new a PyObject."));
+  }
+  return obj;
+  EAGER_CATCH_AND_THROW_RETURN_NULL
+}
 PyDoc_STRVAR(tensor_method_clone__doc__,  // NOLINT
              R"DOC(clone($self, /)
 --
@@ -3800,6 +3896,10 @@ PyMethodDef variable_methods[] = {  // NOLINT
      (PyCFunction)(void (*)())tensor_method_clone,
      METH_VARARGS | METH_KEYWORDS,
      tensor_method_clone__doc__},
+    {"_new_shared_tensor",
+     (PyCFunction)(void (*)())tensor_method__new_shared_tensor,
+     METH_VARARGS | METH_KEYWORDS,
+     tensor_method__new_shared_tensor__doc__},
     {"reconstruct_from_",
      (PyCFunction)(void (*)())tensor_method_reconstruct_from_,
      METH_VARARGS | METH_KEYWORDS,

--- a/test/legacy_test/test_tensor.py
+++ b/test/legacy_test/test_tensor.py
@@ -634,5 +634,78 @@ class TestTensorDataSetter(unittest.TestCase):
         assert x.grad.place == x.place
 
 
+class TestTensorNewSharedTensor(unittest.TestCase):
+    def test_shared_data(self):
+        x = paddle.to_tensor([1.0, 2.0, 3.0])
+        y = x._new_shared_tensor()
+        x[0] = 88.88
+        # Test that they share the same data
+        self.assertEqual(y.shape, x.shape)
+        self.assertEqual(y.dtype, x.dtype)
+        self.assertEqual(y.place, x.place)
+        np.testing.assert_allclose(y.numpy(), x.numpy())
+
+    def test_new_shared_tensor_retain_holder_true(self):
+        """Test _new_shared_tensor with retain_holder=True (default)"""
+        x = paddle.to_tensor([1.0, 2.0, 3.0], stop_gradient=False)
+        y = x._new_shared_tensor(retain_holder=True)
+
+        # Test that they share the same data
+        self.assertEqual(y.shape, x.shape)
+        self.assertEqual(y.dtype, x.dtype)
+        self.assertEqual(y.place, x.place)
+        np.testing.assert_allclose(y.numpy(), x.numpy())
+
+        # Test autograd metadata sharing
+        self.assertEqual(y.stop_gradient, x.stop_gradient)
+
+        # Test gradient sharing after backward
+        loss = x.sum() + y.sum()
+        loss.backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(y.grad)
+        np.testing.assert_allclose(x.grad.numpy(), y.grad.numpy())
+
+        self.assertEqual(id(x.grad), id(y.grad))
+        # Test data sharing - modification affects both
+
+    def test_new_shared_tensor_retain_holder_false(self):
+        """Test _new_shared_tensor with retain_holder=False"""
+        x = paddle.to_tensor([1.0, 2.0, 3.0], stop_gradient=False)
+        z = x._new_shared_tensor(retain_holder=False)
+
+        # Test metadata is the same
+        self.assertEqual(z.shape, x.shape)
+        self.assertEqual(z.dtype, x.dtype)
+        self.assertEqual(z.place, x.place)
+
+        # Test that new tensor has empty data allocation
+        # It should be uninitialized or have default values
+        self.assertEqual(z.stop_gradient, x.stop_gradient)
+
+        # Test autograd metadata is still shared
+        loss = x.sum()
+        loss.backward()
+        self.assertIsNotNone(z.grad)
+
+    def test_new_shared_tensor_default_behavior(self):
+        """Test _new_shared_tensor with default parameters"""
+        x = paddle.to_tensor([[1.0, 2.0], [3.0, 4.0]], stop_gradient=False)
+        y = x._new_shared_tensor()  # default retain_holder=True
+
+        # Test gradient calculation
+        loss = (x + y).sum()
+        loss.backward()
+
+        np.testing.assert_allclose(x.grad.numpy(), y.grad.numpy())
+
+    def test_new_shared_tensor_uninitialized_error(self):
+        """Test error when original tensor is not initialized"""
+        x = paddle.Tensor()
+        x._clear_dataptr()  # Ensure Tensor is uninitialized tensor
+        with self.assertRaises(ValueError):
+            x._new_shared_tensor()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
新增Tensor._new_shared_tensor() 方法用于浅拷贝Pyobject Tensor
### API功能描述：
返回一个与原始 Tensor 共享数据的新 Tensor。

此方法创建一个新的 Tensor 对象，该对象与原始 Tensor 共享底层数据存储。行为取决于 retain_holder 参数。

**注意事项：**

原始 Tensor 的autograd meta（包括梯度和反向传播信息）也会在两个 Tensor 之间共享。

**参数：**

retain_holder（bool，可选）：控制是否共享数据持有者（data holder）。
如果为 True（默认值）：新 Tensor 与原始 Tensor 共享完全相同的底层数据分配（共享DenseTensor）。对其中一个 Tensor 的修改会影响另一个。此外，两个 Tensor 共享相同的autograd meta。
如果为 False：创建一个具有相同元数据但数据分配为空的新 Tensor（根据复制一份DenseTensorMeta相同的DenseTensor，但是不持有内存分配的holder）。autograd meta仍然共享。

**返回值：**

Tensor：一个与原始 Tensor 共享数据和自动求导元数据的新 Tensor 对象。
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否