### PR TITLE
[PyLayer] Optimize input processing in PyLayer.apply before forward call

### DIFF
--- a/paddle/fluid/eager/pylayer/py_layer_node.h
+++ b/paddle/fluid/eager/pylayer/py_layer_node.h
@@ -68,7 +68,8 @@ class GradNodePyLayer : public GradNodeBase {
   std::string name() override { return name_; }
 
   void SaveForwardOutputsMeta(
-      const std::vector<std::vector<paddle::Tensor*>>& outputs_tensor) {
+      const paddle::small_vector<std::vector<paddle::Tensor*>>&
+          outputs_tensor) {
     forward_outputs_meta_.resize(outputs_tensor.size());
     forward_outputs_place_.resize(outputs_tensor.size());
     forward_outputs_dist_attr_.resize(outputs_tensor.size());

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -1828,6 +1828,15 @@ void CheckGradNodeAccumulation(
   }
 }
 
+void CheckGradNodeAccumulation(
+    const paddle::small_vector<std::vector<paddle::Tensor*>>& tensors) {
+  for (const auto& sub_tensors : tensors) {
+    for (const auto& tensor : sub_tensors) {
+      CheckGradNodeAccumulation(*tensor);
+    }
+  }
+}
+
 LogLevelGuardBackward::LogLevelGuardBackward(bool need_backward_vlog_guard,
                                              GradNodeBase* node) {
   //

--- a/paddle/fluid/eager/utils.h
+++ b/paddle/fluid/eager/utils.h
@@ -508,6 +508,8 @@ void CheckGradNodeAccumulation(
 void CheckGradNodeAccumulation(const std::vector<paddle::Tensor>& tensors);
 void CheckGradNodeAccumulation(
     const std::vector<std::vector<paddle::Tensor*>>& tensors);
+void CheckGradNodeAccumulation(
+    const paddle::small_vector<std::vector<paddle::Tensor*>>& tensors);
 
 class LogLevelGuardBackward {
  public:

--- a/paddle/fluid/pybind/eager_py_layer.cc
+++ b/paddle/fluid/pybind/eager_py_layer.cc
@@ -258,131 +258,129 @@ PyObject* pylayer_method_apply(PyObject* cls,
   std::set<phi::TensorBase*> input_tensorbases;
 
   const phi::distributed::ProcessMesh* mesh = nullptr;
-  for (size_t i = 0; i < inputs_size; i++) {
+  auto TrySetMeshFromTensor = [&mesh](PyObject* obj) {
+    if (!PyCheckTensor(obj)) return false;
+    paddle::Tensor& tensor = reinterpret_cast<TensorObject*>(obj)->tensor;
+    if (!tensor.defined() || !tensor.is_dist_tensor()) return false;
+    mesh =
+        &(std::dynamic_pointer_cast<phi::distributed::DistTensor>(tensor.impl())
+              ->dist_attr()
+              .process_mesh());
+    return true;
+  };
+
+  for (int64_t i = inputs_size - 1; i >= 0; --i) {
     PyObject* obj = nullptr;
     if (i >= args_size) {
       obj = PyList_GetItem(kwargs_value_list, i - args_size);  // NOLINT
     } else {
       obj = PyTuple_GET_ITEM(args, i);
     }
-    if (PyCheckTensor(obj)) {
-      Tensor& tensor = reinterpret_cast<TensorObject*>(obj)->tensor;
-      if (tensor.defined() && tensor.is_dist_tensor()) {
-        mesh = &(std::dynamic_pointer_cast<phi::distributed::DistTensor>(
-                     tensor.impl())
-                     ->dist_attr()
-                     .process_mesh());
-      }
-    } else if (PyList_Check(obj)) {
-      Py_ssize_t len = PyList_Size(obj);
-      for (Py_ssize_t j = 0; j < len; j++) {
+    bool mesh_found = false;
+    if (PyList_Check(obj)) {
+      int64_t len = PyList_Size(obj);
+      for (int64_t j = len - 1; j >= 0; --j) {
         PyObject* o = PyList_GetItem(obj, j);
-        if (PyCheckTensor(o)) {
-          Tensor& tensor = reinterpret_cast<TensorObject*>(o)->tensor;
-          if (tensor.defined() && tensor.is_dist_tensor()) {
-            mesh = &(std::dynamic_pointer_cast<phi::distributed::DistTensor>(
-                         tensor.impl())
-                         ->dist_attr()
-                         .process_mesh());
-          }
-        }
+        mesh_found = TrySetMeshFromTensor(o);
       }
     } else if (PyTuple_Check(obj)) {
-      Py_ssize_t len = PyTuple_Size(obj);
-      for (Py_ssize_t j = 0; j < len; j++) {
+      int64_t len = PyTuple_Size(obj);
+      for (int64_t j = len - 1; j >= 0; --j) {
         PyObject* o = PyTuple_GetItem(obj, j);
-        if (PyCheckTensor(o)) {
-          Tensor& tensor = reinterpret_cast<TensorObject*>(o)->tensor;
-          if (tensor.defined() && tensor.is_dist_tensor()) {
-            mesh = &(std::dynamic_pointer_cast<phi::distributed::DistTensor>(
-                         tensor.impl())
-                         ->dist_attr()
-                         .process_mesh());
-          }
-        }
+        mesh_found = TrySetMeshFromTensor(o);
       }
+    } else {
+      mesh_found = TrySetMeshFromTensor(obj);
     }
+    if (mesh_found) break;
   }
 
-  for (size_t i = 0; i < inputs_size; i++) {
-    PyObject* obj = nullptr;
-    if (i >= args_size) {
-      obj = PyList_GetItem(kwargs_value_list, i - args_size);  // NOLINT
-    } else {
-      obj = PyTuple_GET_ITEM(args, i);
+  auto HandleSingleTensorObj = [&mesh,
+                                &input_tensorbases,
+                                &inputs_autograd_meta,
+                                &inputs_tensor,
+                                &require_any_grad,
+                                &ctx](TensorObject* t_obj) {
+    auto& t = t_obj->tensor;
+    if (mesh) {
+      ConvertToDistTensor(&t, mesh);
     }
-    if (PyCheckTensor(obj)) {
-      if (mesh) {
-        ConvertToDistTensor(&(reinterpret_cast<TensorObject*>(obj)->tensor),
-                            mesh);
-      }
-      input_tensorbases.insert(
-          reinterpret_cast<TensorObject*>(obj)->tensor.impl().get());
-      auto autograd_meta = egr::EagerUtils::nullable_autograd_meta(
-          reinterpret_cast<TensorObject*>(obj)->tensor);
-      inputs_autograd_meta.push_back({autograd_meta});
-      inputs_tensor.push_back(
-          {&(reinterpret_cast<TensorObject*>(obj)->tensor)});  // NOLINT
-      bool stop_gradient =
-          autograd_meta == nullptr ? true : autograd_meta->StopGradient();
+    input_tensorbases.insert(t.impl().get());
+    auto* autograd_meta = egr::EagerUtils::nullable_autograd_meta(t);
+    inputs_autograd_meta.push_back({autograd_meta});
+
+    inputs_tensor.push_back({&t});  // NOLINT
+
+    bool stop_gradient =
+        autograd_meta == nullptr ? true : autograd_meta->StopGradient();
+    if (!stop_gradient) {
+      require_any_grad = true;
+    }
+    ctx->forward_input_tensor_is_duplicable.push_back(false);
+  };
+
+  auto CollectOneTensor = [&mesh, &input_tensorbases](
+                              TensorObject* t_obj,
+                              std::vector<paddle::Tensor*>* tensors) {
+    auto& t = t_obj->tensor;
+
+    if (mesh) {
+      ConvertToDistTensor(&t, mesh);
+    }
+
+    input_tensorbases.insert(t.impl().get());
+    tensors->push_back(&t);
+  };
+
+  auto FinalizeTensorList = [&require_any_grad,
+                             &inputs_autograd_meta,
+                             &inputs_tensor,
+                             &ctx](std::vector<paddle::Tensor*>& tensors) {
+    if (tensors.empty()) return;
+
+    auto autograd_meta = egr::EagerUtils::nullable_autograd_meta(tensors);
+    for (auto* m : autograd_meta) {
+      bool stop_gradient = (m == nullptr) ? true : m->StopGradient();
       if (!stop_gradient) {
         require_any_grad = true;
       }
-      ctx->forward_input_tensor_is_duplicable.push_back(false);
+    }
+
+    inputs_autograd_meta.push_back(autograd_meta);
+    inputs_tensor.push_back(tensors);
+    ctx->forward_input_tensor_is_duplicable.push_back(true);
+  };
+
+  for (size_t i = 0; i < inputs_size; ++i) {
+    PyObject* obj = nullptr;
+    if (i >= args_size) {
+      obj = PyList_GetItem(kwargs_value_list, i - args_size);  // NOLINT
+    } else {
+      obj = PyTuple_GET_ITEM(args, i);
+    }
+
+    if (PyCheckTensor(obj)) {
+      HandleSingleTensorObj(reinterpret_cast<TensorObject*>(obj));
     } else if (PyList_Check(obj)) {
       std::vector<Tensor*> tensors;
       Py_ssize_t len = PyList_Size(obj);
-      for (Py_ssize_t j = 0; j < len; j++) {
-        PyObject* o = PyList_GetItem(obj, j);
+      for (Py_ssize_t j = 0; j < len; ++j) {
+        PyObject* o = PyList_GetItem(obj, j);  // borrowed
         if (PyCheckTensor(o)) {
-          if (mesh) {
-            ConvertToDistTensor(&(reinterpret_cast<TensorObject*>(o)->tensor),
-                                mesh);
-          }
-          input_tensorbases.insert(
-              reinterpret_cast<TensorObject*>(o)->tensor.impl().get());
-          tensors.push_back(&(reinterpret_cast<TensorObject*>(o)->tensor));
+          CollectOneTensor(reinterpret_cast<TensorObject*>(o), &tensors);
         }
       }
-      if (!tensors.empty()) {
-        auto autograd_meta = egr::EagerUtils::nullable_autograd_meta(tensors);
-        for (auto iter : autograd_meta) {
-          bool stop_gradient = iter == nullptr ? true : iter->StopGradient();
-          if (!stop_gradient) {
-            require_any_grad = true;
-          }
-        }
-        inputs_autograd_meta.push_back(autograd_meta);
-        inputs_tensor.push_back(tensors);
-        ctx->forward_input_tensor_is_duplicable.push_back(true);
-      }
+      FinalizeTensorList(tensors);
     } else if (PyTuple_Check(obj)) {
       std::vector<Tensor*> tensors;
       Py_ssize_t len = PyTuple_Size(obj);
-      for (Py_ssize_t j = 0; j < len; j++) {
-        PyObject* o = PyTuple_GetItem(obj, j);
+      for (Py_ssize_t j = 0; j < len; ++j) {
+        PyObject* o = PyTuple_GetItem(obj, j);  // borrowed
         if (PyCheckTensor(o)) {
-          if (mesh) {
-            ConvertToDistTensor(&(reinterpret_cast<TensorObject*>(o)->tensor),
-                                mesh);
-          }
-          input_tensorbases.insert(
-              reinterpret_cast<TensorObject*>(o)->tensor.impl().get());
-          tensors.push_back(&(reinterpret_cast<TensorObject*>(o)->tensor));
+          CollectOneTensor(reinterpret_cast<TensorObject*>(o), &tensors);
         }
       }
-      if (!tensors.empty()) {
-        auto autograd_meta = egr::EagerUtils::nullable_autograd_meta(tensors);
-        for (auto iter : autograd_meta) {
-          bool stop_gradient = iter == nullptr ? true : iter->StopGradient();
-          if (!stop_gradient) {
-            require_any_grad = true;
-          }
-        }
-        inputs_autograd_meta.push_back(autograd_meta);
-        inputs_tensor.push_back(tensors);
-        ctx->forward_input_tensor_is_duplicable.push_back(true);
-      }
+      FinalizeTensorList(tensors);
     }
 
     if (i < args_size) {

--- a/paddle/fluid/pybind/eager_py_layer.cc
+++ b/paddle/fluid/pybind/eager_py_layer.cc
@@ -210,8 +210,9 @@ PyObject* pylayer_method_apply(PyObject* cls,
   }
   VLOG(4) << classname << ":"
           << "Construct PyLayerContext";
-  PyObject* backward_function =
-      PyObject_GetAttrString(cls, "_backward_function");
+  static PyObject* kBackwardFunctionAttr =
+      PyUnicode_InternFromString("_backward_function");
+  PyObject* backward_function = PyObject_GetAttr(cls, kBackwardFunctionAttr);
   if (!backward_function) {
     PADDLE_THROW(
         common::errors::InvalidArgument("Get _backward_function failed."));
@@ -263,7 +264,7 @@ PyObject* pylayer_method_apply(PyObject* cls,
     paddle::Tensor& tensor = reinterpret_cast<TensorObject*>(obj)->tensor;
     if (!tensor.defined() || !tensor.is_dist_tensor()) return false;
     mesh =
-        &(std::dynamic_pointer_cast<phi::distributed::DistTensor>(tensor.impl())
+        &(std::static_pointer_cast<phi::distributed::DistTensor>(tensor.impl())
               ->dist_attr()
               .process_mesh());
     return true;
@@ -281,16 +282,16 @@ PyObject* pylayer_method_apply(PyObject* cls,
       int64_t len = PyList_Size(obj);
       for (int64_t j = len - 1; j >= 0; --j) {
         PyObject* o = PyList_GetItem(obj, j);
-        mesh_found = TrySetMeshFromTensor(o);
+        mesh_found |= TrySetMeshFromTensor(o);
       }
     } else if (PyTuple_Check(obj)) {
       int64_t len = PyTuple_Size(obj);
       for (int64_t j = len - 1; j >= 0; --j) {
         PyObject* o = PyTuple_GetItem(obj, j);
-        mesh_found = TrySetMeshFromTensor(o);
+        mesh_found |= TrySetMeshFromTensor(o);
       }
     } else {
-      mesh_found = TrySetMeshFromTensor(obj);
+      mesh_found |= TrySetMeshFromTensor(obj);
     }
     if (mesh_found) break;
   }
@@ -397,7 +398,8 @@ PyObject* pylayer_method_apply(PyObject* cls,
       << classname << ":"
       << "PyLayer forward args is ready, begin call user's forward function...";
   // call forward
-  auto forward_fn = PyObject_GetAttrString(cls, "forward");
+  static PyObject* kForwardAttr = PyUnicode_InternFromString("forward");
+  auto forward_fn = PyObject_GetAttr(cls, kForwardAttr);
   if (!forward_fn) {
     PADDLE_THROW(
         common::errors::InvalidArgument("Get forward function failed."));
@@ -471,10 +473,10 @@ PyObject* pylayer_method_apply(PyObject* cls,
                   reinterpret_cast<TensorObject*>(o)->tensor.impl().get())) {
             if (not_inplace_tensorbases.count(
                     reinterpret_cast<TensorObject*>(o)->tensor.impl().get())) {
-              PyTuple_SetItem(obj,
-                              j,
-                              new_tensor_with_impl(&(
-                                  reinterpret_cast<TensorObject*>(o)->tensor)));
+              PyList_SetItem(obj,
+                             j,
+                             new_tensor_with_impl(&(
+                                 reinterpret_cast<TensorObject*>(o)->tensor)));
             } else {
               inplace_tensors.insert(
                   &(reinterpret_cast<TensorObject*>(o)->tensor));

--- a/paddle/fluid/pybind/eager_py_layer.cc
+++ b/paddle/fluid/pybind/eager_py_layer.cc
@@ -213,16 +213,15 @@ PyObject* pylayer_method_apply(PyObject* cls,
   static PyObject* kBackwardFunctionAttr =
       PyUnicode_InternFromString("_backward_function");
   PyObject* backward_function = PyObject_GetAttr(cls, kBackwardFunctionAttr);
-  if (!backward_function) {
+  if (!backward_function) [[unlikely]] {
     PADDLE_THROW(
         common::errors::InvalidArgument("Get _backward_function failed."));
   }
   PyLayerObject* ctx = reinterpret_cast<PyLayerObject*>(
       PyObject_CallFunctionObjArgs(backward_function, nullptr));
-  if (!ctx) {
+  if (!ctx) [[unlikely]] {
     PADDLE_THROW(
         common::errors::External(pybind11::detail::error_string().c_str()));
-    return nullptr;
   }
   VLOG(6) << "PyLayer construct PyLayerContext finish...";
   if (FLAGS_check_cuda_error) [[unlikely]] {
@@ -250,9 +249,9 @@ PyObject* pylayer_method_apply(PyObject* cls,
   PyTuple_SET_ITEM(forward_args, 0, reinterpret_cast<PyObject*>(ctx));
   VLOG(6) << classname << ":Prepare Pylayer forward args ";
   VLOG(6) << classname << ":Input size is " << inputs_size;
-  std::vector<std::vector<egr::AutogradMeta*>> inputs_autograd_meta;
+  paddle::small_vector<std::vector<egr::AutogradMeta*>> inputs_autograd_meta;
   inputs_autograd_meta.reserve(inputs_size);
-  std::vector<std::vector<Tensor*>> inputs_tensor;
+  paddle::small_vector<std::vector<Tensor*>> inputs_tensor;
   inputs_tensor.reserve(inputs_size);
   ctx->forward_input_tensor_is_duplicable.clear();
   ctx->forward_input_tensor_is_duplicable.reserve(inputs_size);
@@ -400,7 +399,7 @@ PyObject* pylayer_method_apply(PyObject* cls,
   // call forward
   static PyObject* kForwardAttr = PyUnicode_InternFromString("forward");
   auto forward_fn = PyObject_GetAttr(cls, kForwardAttr);
-  if (!forward_fn) {
+  if (!forward_fn) [[unlikely]] {
     PADDLE_THROW(
         common::errors::InvalidArgument("Get forward function failed."));
   }
@@ -435,9 +434,9 @@ PyObject* pylayer_method_apply(PyObject* cls,
   }
 
   auto outputs_size = PyTuple_GET_SIZE(outputs_tuple);
-  std::vector<std::vector<Tensor*>> outputs_tensor;
+  paddle::small_vector<std::vector<Tensor*>> outputs_tensor;
   outputs_tensor.reserve(outputs_size);
-  std::vector<std::vector<egr::AutogradMeta*>> outputs_autograd_meta;
+  paddle::small_vector<std::vector<egr::AutogradMeta*>> outputs_autograd_meta;
   outputs_autograd_meta.reserve(outputs_size);
   ctx->forward_output_tensor_is_duplicable.clear();
   ctx->forward_output_tensor_is_duplicable.reserve(outputs_size);
@@ -520,7 +519,7 @@ PyObject* pylayer_method_apply(PyObject* cls,
       }
     }
   }
-  if (outputs_tensor.empty()) {
+  if (outputs_tensor.empty()) [[unlikely]] {
     PADDLE_THROW(common::errors::InvalidArgument(
         "%s : At least one output of `PyLayer.forward` is a `Tensor`.",
         classname));

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -684,7 +684,16 @@ def recompute(function, *args, **kwargs):
 
     if use_reentrant:
         offload_indices = kwargs.pop('offload_indices', [])
-        input_args = []
+        if not kwargs:  # fast path
+            return RecomputeFunction.apply(
+                function,
+                preserve,
+                offload_indices,
+                custom_get_state_func,
+                custom_set_state_func,
+                *args,
+            )
+
         # rearrange `position-args + keyword-args` into `position-args`
         target = (
             function.forward
@@ -693,11 +702,17 @@ def recompute(function, *args, **kwargs):
         )
         if isinstance(target, StaticFunction):
             target = target.dygraph_function
-        dyfunc_sig = inspect.signature(target)
+
+        # Use getattr to get the cached signature. If it doesn't exist, parse and mount it to the target.
+        # This avoids the heavy overhead of inspect.signature during repeated executions.
+        dyfunc_sig = getattr(target, "_cached_signature", None)
+        if dyfunc_sig is None:
+            dyfunc_sig = inspect.signature(target)
+            target._cached_signature = dyfunc_sig
 
         bound_args = dyfunc_sig.bind(*args, **kwargs)
         bound_args.apply_defaults()
-
+        input_args = []
         for arg, param in zip(
             bound_args.arguments.values(), dyfunc_sig.parameters.values()
         ):

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 
 
 __all__ = []
+_SIGNATURE_CACHE = {}
 
 
 def _varbase_help(param):
@@ -705,10 +706,11 @@ def recompute(function, *args, **kwargs):
 
         # Use getattr to get the cached signature. If it doesn't exist, parse and mount it to the target.
         # This avoids the heavy overhead of inspect.signature during repeated executions.
-        dyfunc_sig = getattr(target, "_cached_signature", None)
+        cache_key = getattr(target, "__func__", target)
+        dyfunc_sig = _SIGNATURE_CACHE.get(cache_key)
         if dyfunc_sig is None:
             dyfunc_sig = inspect.signature(target)
-            target._cached_signature = dyfunc_sig
+            _SIGNATURE_CACHE[cache_key] = dyfunc_sig
 
         bound_args = dyfunc_sig.bind(*args, **kwargs)
         bound_args.apply_defaults()

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -160,8 +160,11 @@ def switch_rng_state_tracker(
 
     orig_numpy_state = np.random.get_state()
     orig_random_state = random.getstate()
-    np.random.set_state(numpy_state)
-    random.setstate(random_state)
+
+    if numpy_state is not None:
+        np.random.set_state(numpy_state)
+    if random_state is not None:
+        random.setstate(random_state)
 
     if custom_state is not None:
         assert custom_get_state_func is not None
@@ -186,6 +189,7 @@ class RecomputeFunction(PyLayer):
         ctx,
         run_function,
         preserve_rng_state,
+        preserve_external_rng_state,
         offload_indices,
         custom_get_state_func,
         custom_set_state_func,
@@ -195,6 +199,7 @@ class RecomputeFunction(PyLayer):
         # store for recomputing
         ctx.run_function = run_function
         ctx.preserve_rng_state = preserve_rng_state
+        ctx.preserve_external_rng_state = preserve_external_rng_state
         ctx.offload_indices = offload_indices
         ctx.kwargs = kwargs
 
@@ -209,8 +214,12 @@ class RecomputeFunction(PyLayer):
             ctx.fwd_rng_state_tracker = (
                 get_rng_state_tracker().get_states_tracker()
             )
-            ctx.fwd_numpy_state = np.random.get_state()
-            ctx.fwd_random_state = random.getstate()
+            if ctx.preserve_external_rng_state:
+                ctx.fwd_numpy_state = np.random.get_state()
+                ctx.fwd_random_state = random.getstate()
+            else:
+                ctx.fwd_numpy_state = None
+                ctx.fwd_random_state = None
             ctx.fwd_custom_state = custom_get_state_func()
             ctx.custom_get_state_func = custom_get_state_func
             ctx.custom_set_state_func = custom_set_state_func
@@ -404,6 +413,7 @@ def _recompute_without_reentrant(
     custom_get_state_func,
     custom_set_state_func,
     preserve_rng_state=True,
+    preserve_external_rng_state=True,
     *args,
     **kwargs,
 ):
@@ -431,8 +441,12 @@ def _recompute_without_reentrant(
         fwd_cuda_rng_state_tracker = (
             get_rng_state_tracker().get_states_tracker()
         )
-        fwd_numpy_state = np.random.get_state()
-        fwd_random_state = random.getstate()
+        if preserve_external_rng_state:
+            fwd_numpy_state = np.random.get_state()
+            fwd_random_state = random.getstate()
+        else:
+            fwd_numpy_state = None
+            fwd_random_state = None
         fwd_custom_state = custom_get_state_func()
 
     tracer = framework._dygraph_tracer()
@@ -552,16 +566,20 @@ def recompute(function, *args, **kwargs):
 
     Parameters:
         function(paddle.nn.Layer): layer of sequence of layers that describes part of forward pass of the model
-              whose intermediate activations will be released to save memory in forward stage and will be recomputed
-              in backward stage for gradient calculation.
+            whose intermediate activations will be released to save memory in forward stage and will be recomputed
+            in backward stage for gradient calculation.
         *args(Tensor): inputs to the function.
         **kwargs(Dict): Kwargs should only contain two kinds of key-value params, the one is part of function's key-value params,
-                        and the other contains 'preserve_rng_state' and 'use_reentrant'. the key-value pair of preserve_rng_state,
-                        which is used to indicate whether to save the forward rng. If it is True, then the last forward rng value
-                        will be restored when the forward recalculation of backpropagation is performed, its default value is True.
-                        the key-value pair of use_reentrant is used to indicate which implementation of recompute you will be used.
-                        'use_reentrant=True' means to use the PyLayer implementation of recompute, 'use_reentrant=False' means to
-                        use the Hook implementation of recompute, its default value is True.
+            and the other contains 'preserve_rng_state', 'preserve_external_rng_state' and 'use_reentrant'.
+            The key-value pair of preserve_rng_state is used to indicate whether to save the forward rng. If it is True,
+            then the last forward rng value will be restored when the forward recalculation of backpropagation is performed,
+            its default value is True.
+            The key-value pair of preserve_external_rng_state is used to indicate whether to save and restore the external
+            random number generator states (numpy.random and python random). If your forward function does not use numpy.random
+            or python random, you can set this to False to improve performance. Its default value is True.
+            The key-value pair of use_reentrant is used to indicate which implementation of recompute you will be used.
+            'use_reentrant=True' means to use the PyLayer implementation of recompute, 'use_reentrant=False' means to
+            use the Hook implementation of recompute, its default value is True.
     Returns:
         Output of function on args.
 
@@ -659,6 +677,9 @@ def recompute(function, *args, **kwargs):
     """
     # Hack to mix *args with **kwargs in a python 2.7-compliant way
     preserve = kwargs.pop('preserve_rng_state', True)
+    preserve_external_rng_state = kwargs.pop(
+        'preserve_external_rng_state', True
+    )
 
     # whether to use reentrant method to implement recompute
     use_reentrant = kwargs.pop('use_reentrant', True)
@@ -689,6 +710,7 @@ def recompute(function, *args, **kwargs):
             return RecomputeFunction.apply(
                 function,
                 preserve,
+                preserve_external_rng_state,
                 offload_indices,
                 custom_get_state_func,
                 custom_set_state_func,
@@ -737,6 +759,7 @@ def recompute(function, *args, **kwargs):
         return RecomputeFunction.apply(
             function,
             preserve,
+            preserve_external_rng_state,
             offload_indices,
             custom_get_state_func,
             custom_set_state_func,
@@ -748,6 +771,7 @@ def recompute(function, *args, **kwargs):
             custom_get_state_func,
             custom_set_state_func,
             preserve,
+            preserve_external_rng_state,
             *args,
             **kwargs,
         )

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 
 
 __all__ = []
-_SIGNATURE_CACHE = {}
+_SIGNATURE_CACHE = weakref.WeakKeyDictionary()
 
 
 def _varbase_help(param):
@@ -158,12 +158,14 @@ def switch_rng_state_tracker(
     paddle.set_rng_state(rng_state)
     get_rng_state_tracker().set_states_tracker(tracker)
 
-    orig_numpy_state = np.random.get_state()
-    orig_random_state = random.getstate()
+    orig_numpy_state = None
+    orig_random_state = None
 
     if numpy_state is not None:
+        orig_numpy_state = np.random.get_state()
         np.random.set_state(numpy_state)
     if random_state is not None:
+        orig_random_state = random.getstate()
         random.setstate(random_state)
 
     if custom_state is not None:
@@ -176,8 +178,10 @@ def switch_rng_state_tracker(
     finally:
         paddle.set_rng_state(orig_rng_state)
         get_rng_state_tracker().set_states_tracker(orig_rng_tracker)
-        np.random.set_state(orig_numpy_state)
-        random.setstate(orig_random_state)
+        if orig_numpy_state is not None:
+            np.random.set_state(orig_numpy_state)
+        if orig_random_state is not None:
+            random.setstate(orig_random_state)
 
         if custom_state is not None:
             custom_set_state_func(orig_custom_state)

--- a/test/collective/fleet/test_dygraph_recompute_for_eager.py
+++ b/test/collective/fleet/test_dygraph_recompute_for_eager.py
@@ -413,6 +413,25 @@ class TestRecompute(unittest.TestCase):
                 self.assertEqual(grad_ref, grad)
 
 
+class TestPreserveExternalRngState(unittest.TestCase):
+    def test_preserve_external_rng_state(self):
+        loss_ref, param_ref, grad_ref = run_model(recompute_block=[])
+
+        for flag in [True, False]:
+            for preserve_ext in [True, False]:
+                loss, param, grad = run_model(
+                    recompute_block=[1, 3],
+                    recompute_kwargs={
+                        "preserve_rng_state": True,
+                        "preserve_external_rng_state": preserve_ext,
+                        "use_reentrant": flag,
+                    },
+                )
+                self.assertEqual(loss_ref, loss)
+                self.assertEqual(param_ref, param)
+                self.assertEqual(grad_ref, grad)
+
+
 class RandomManager:
     def __init__(self):
         self.global_random = random.Random(11)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->


尝试优化 PyLayer 中 forward 函数执行前的空泡，最简复现demo中，单 recompute step 约降低 120μs，约30%

优化前：
<img width="1587" height="432" alt="image" src="https://github.com/user-attachments/assets/0a8f3d57-022f-459a-9a8e-57314760d6a2" />

优化后：

<!--- 
这个是没优化 `PyObject_Call` 里面的结果
<img width="1608" height="422" alt="image" src="https://github.com/user-attachments/assets/248fa1c9-ccf0-46e0-84f3-226a308d40ed" /> 
--->
<img width="1329" height="533" alt="image" src="https://github.com/user-attachments/assets/8351026a-4d93-4a2a-ba3f-9187b6302e08" />


本PR包含两部分：

  1. **PyLayer.apply 侧性能优化**
  - 调整 `process_mesh` 的探测顺序：将输入扫描由正序改为**逆序遍历**（从最后一个输入向前），优先从更靠后的输入中定位分布式 Tensor；在当前输入位命中后提前结束外层扫描，从而减少平均探测开销
  - 抽取并复用公共逻辑，降低重复代码，包括 `TrySetMeshFromTensor`、`HandleSingleTensorObj`、`CollectOneTensor` 和 `FinalizeTensorList`
  - 将 `_backward_function` / `forward` 的属性名改为 interned string，减少重复字符串构造与查找开销。
  - 将 `inputs_tensor/outputs_tensor` 及对应 autograd meta 容器从 `std::vector` 调整为 `paddle::small_vector`，降低小规模场景下的分配成本。
  - 增加 `[[unlikely]]` 分支提示（异常/慢路径）。
  - 补充 `CheckGradNodeAccumulation` 对 `small_vector<std::vector<Tensor*>>` 的重载，并同步 `GradNodePyLayer::SaveForwardOutputsMeta` 入参类型。

  3. **recompute 路径优化**
  - 增加 `kwargs` 为空时的 fast path，避免不必要的参数重排。
  - 为 `inspect.signature` 引入缓存，降低重复执行时的签名解析开销。
  - 在 `recompute` 函数 `**kwargs` 参数中添加了 `preserve_external_rng_state`，该参数用于控制是否保存和恢复外部随机数生成器状态（numpy.random 和 python random），当 forward 函数不使用 numpy.random 或 python random 时，可以设置为 False 以提升性能

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否