### PR TITLE
[PyTorch API Compatible] Add input alias for paddle.nn.functional.mish

### DIFF
--- a/python/paddle/nn/functional/activation.py
+++ b/python/paddle/nn/functional/activation.py
@@ -1516,6 +1516,7 @@ def swish(x: Tensor, inplace: bool = False, name: str | None = None) -> Tensor:
         return out
 
 
+@param_one_alias(["x", "input"])
 def mish(x: Tensor, inplace: bool = False, name: str | None = None) -> Tensor:
     r"""
     mish activation.
@@ -1531,6 +1532,7 @@ def mish(x: Tensor, inplace: bool = False, name: str | None = None) -> Tensor:
 
     Parameters:
         x (Tensor): The input Tensor with data type float32, float64.
+            Alias: ``input``.
         inplace (bool, optional): Whether to use inplace operation. Default: False.
         name (str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
 

--- a/test/legacy_test/test_mish_op.py
+++ b/test/legacy_test/test_mish_op.py
@@ -109,5 +109,33 @@ class TestMishAPI(unittest.TestCase):
             run(place, False)
 
 
+class TestMishInputAlias(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(0)
+        self.shape = [10, 12]
+        self.x_np = np.random.uniform(-1, 1, self.shape).astype(np.float32)
+
+    def test_input_alias_dygraph(self):
+        paddle.disable_static()
+        x_tensor = paddle.to_tensor(self.x_np)
+        out_x = F.mish(x_tensor)
+        out_input = F.mish(input=x_tensor)
+        np.testing.assert_allclose(out_x.numpy(), out_input.numpy(), rtol=1e-5)
+
+    def test_input_alias_static(self):
+        paddle.enable_static()
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.static.data('X', self.shape)
+            out_x = F.mish(x)
+            out_input = F.mish(input=x)
+        paddle.disable_static()
+
+    def test_input_alias_conflict(self):
+        paddle.disable_static()
+        x_tensor = paddle.to_tensor(self.x_np)
+        with self.assertRaises(TypeError):
+            F.mish(x_tensor, input=x_tensor)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Add PyTorch-style keyword argument `input` as an alias for `x` in `paddle.nn.functional.mish`
- Related to issue #76301 (No.185)

## Changes
- Add `@param_one_alias(["x", "input"])` decorator to `mish` function in `python/paddle/nn/functional/activation.py`
- Update docstring to document the `input` alias
- Add unit tests in `test/legacy_test/test_mish_op.py`:
  - `test_input_alias_dygraph`: verify `F.mish(x)` equals `F.mish(input=x)` in dynamic graph
  - `test_input_alias_static`: verify alias works in static graph
  - `test_input_alias_conflict`: verify TypeError when both `x` and `input` are passed

## Test Plan
Run: `python -m pytest test/legacy_test/test_mish_op.py::TestMishInputAlias -v`