### PR TITLE
[API Compatibility No.191] torch.nn.functional.poisson_nll_loss -> paddle.nn.functional.poisson_nll_loss -part

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1607,6 +1607,7 @@ def nll_loss(
         return out
 
 
+@param_two_alias(["label", "target"], ["epsilon", "eps"])
 def poisson_nll_loss(
     input: Tensor,
     label: Tensor,
@@ -1628,6 +1629,7 @@ def poisson_nll_loss(
             Label tensor, random sampled from Poisson distribution :math:`label \sim \text{Poisson}(input)`.
             The shape of input tensor should be `(N, *)` or `(*)`, same shape as the input tensor.
             It's data type should be float16, bfloat16, float32, float64.
+            Alias: ``target``.
          log_input (bool, optional):
             Whether to the treat input tensor as log input.
             If ``True`` the loss is computed as, :math:`\exp(\text{input}) - \text{label} * \text{input}` .
@@ -1641,6 +1643,7 @@ def poisson_nll_loss(
          epsilon (float, optional):
             A small value to avoid evaluation of :math:`\log(0)` when `log_input`\ =\ ``False``. ``epsilon > 0``.
             Default: 1e-8.
+            Alias: ``eps``.
          reduction (str, optional):
             Indicate how to reduce the loss, the candidates are ``'none'`` | ``'mean'`` | ``'sum'``.
             If `reduction` is ``'mean'``, the reduced mean loss is returned;

--- a/test/legacy_test/test_poisson_nll_loss.py
+++ b/test/legacy_test/test_poisson_nll_loss.py
@@ -298,5 +298,88 @@ class TestPoissonNLLLossCase_ZeroSize2(TestPoissonNLLLossCase_ZeroSize):
         self.shape = [0, 0]
 
 
+class TestPoissonNLLLossAliasCase(unittest.TestCase):
+    def setUp(self):
+        self.shape = [10, 2]
+        self.input_np = np.random.random(self.shape).astype("float32")
+        self.label_np = np.random.random(self.shape).astype("float32")
+        self.place = get_device_place()
+
+    def test_alias_dynamic_case(self):
+        paddle.disable_static(self.place)
+        self.addCleanup(paddle.enable_static)
+
+        input_x = paddle.to_tensor(self.input_np)
+        label = paddle.to_tensor(self.label_np)
+        for reduction in ["mean", "none"]:
+            with self.subTest(reduction=reduction):
+                out_normal = F.poisson_nll_loss(
+                    input_x,
+                    label=label,
+                    log_input=False,
+                    epsilon=1e-6,
+                    reduction=reduction,
+                )
+                out_alias = F.poisson_nll_loss(
+                    input=input_x,
+                    target=label,
+                    log_input=False,
+                    eps=1e-6,
+                    reduction=reduction,
+                )
+                np.testing.assert_allclose(
+                    out_normal.numpy(), out_alias.numpy(), rtol=1e-5
+                )
+
+    def test_alias_static_case(self):
+        paddle.enable_static()
+        for reduction in ["mean", "none"]:
+            with self.subTest(reduction=reduction):
+                prog = paddle.static.Program()
+                startup_prog = paddle.static.Program()
+                with paddle.static.program_guard(prog, startup_prog):
+                    input = paddle.static.data("input", self.shape, "float32")
+                    label = paddle.static.data("label", self.shape, "float32")
+                    out_normal = F.poisson_nll_loss(
+                        input,
+                        label=label,
+                        log_input=False,
+                        epsilon=1e-6,
+                        reduction=reduction,
+                    )
+                    out_alias = F.poisson_nll_loss(
+                        input=input,
+                        target=label,
+                        log_input=False,
+                        eps=1e-6,
+                        reduction=reduction,
+                    )
+                exe = paddle.static.Executor(self.place)
+                exe.run(startup_prog)
+                res = exe.run(
+                    prog,
+                    feed={"input": self.input_np, "label": self.label_np},
+                    fetch_list=[out_normal, out_alias],
+                )
+                np.testing.assert_allclose(res[0], res[1], rtol=1e-5)
+
+    def test_alias_conflict_error(self):
+        paddle.disable_static(self.place)
+        self.addCleanup(paddle.enable_static)
+
+        input_x = paddle.to_tensor(self.input_np)
+        label = paddle.to_tensor(self.label_np)
+        with self.assertRaises((TypeError, ValueError)):
+            F.poisson_nll_loss(input_x, label=label, target=label)
+        with self.assertRaises((TypeError, ValueError)):
+            F.poisson_nll_loss(
+                input_x,
+                label,
+                log_input=False,
+                epsilon=1e-6,
+                eps=1e-6,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
1. 为 `paddle.nn.functional.poisson_nll_loss` 添加 PyTorch 风格的参数别名支持
2. `target` 作为 `label` 的别名，`eps` 作为 `epsilon` 的别名
3. 新增参数别名单测（动态图、静态图、冲突错误测试）

### 是否引起精度变化
否