### PR TITLE
[API Compatibility No.190] Support 'input' argument alias for paddle.nn.functional.pixel_unshuffle -part

### DIFF
--- a/python/paddle/nn/functional/vision.py
+++ b/python/paddle/nn/functional/vision.py
@@ -23,6 +23,7 @@ from paddle.base.framework import (
     in_dynamic_or_pir_mode,
     in_pir_mode,
 )
+from paddle.utils.decorator_utils import param_one_alias
 
 from ...base.data_feeder import check_variable_and_dtype
 from ...base.layer_helper import LayerHelper
@@ -211,6 +212,7 @@ def pixel_shuffle(
         return out
 
 
+@param_one_alias(["x", "input"])
 def pixel_unshuffle(
     x: Tensor,
     downscale_factor: int,
@@ -223,6 +225,7 @@ def pixel_unshuffle(
 
     Parameters:
         x (Tensor): 4-D tensor, the data type should be float32 or float64.
+            Alias: ``input``.
         downscale_factor (int): Factor to decrease spatial resolution.
         data_format (str, optional): The data format of the input and output data. An optional string of ``'NCHW'`` or ``'NHWC'``. When it is ``'NCHW'``, the data is stored in the order of [batch_size, input_channels, input_height, input_width]. Default: ``'NCHW'``.
         name (str|None, optional): Name for the operation (optional, default is None). Normally there is no need for user to set this property. For more information, please refer to :ref:`api_guide_Name`.

--- a/test/legacy_test/test_pixel_unshuffle.py
+++ b/test/legacy_test/test_pixel_unshuffle.py
@@ -246,6 +246,28 @@ class TestPixelUnshuffleAPI(unittest.TestCase):
             np.testing.assert_allclose(res_1, self.out_1_np, rtol=1e-05, atol=1)
             np.testing.assert_allclose(res_2, self.out_2_np, rtol=1e-05, atol=1)
 
+    def test_static_param_alias(self):
+        '''test_static_param_alias'''
+
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with base.program_guard(main, startup):
+            x_1 = paddle.static.data(
+                name="x", shape=[2, 1, 12, 12], dtype="float64"
+            )
+            out_1 = F.pixel_unshuffle(x=x_1, downscale_factor=3)
+            out_1_alias = F.pixel_unshuffle(input=x_1, downscale_factor=3)
+
+        exe = paddle.static.Executor()
+        res_1, res_1_alias = exe.run(
+            main,
+            feed={"x": self.x_1_np},
+            fetch_list=[out_1, out_1_alias],
+        )
+
+        np.testing.assert_allclose(res_1, res_1_alias)
+
     # same test between layer and functional in this op.
     def test_static_graph_layer(self):
         '''test_static_graph_layer'''
@@ -334,6 +356,17 @@ class TestPixelUnshuffleAPI(unittest.TestCase):
         '''test_dygraph2'''
 
         self.run_dygraph(3, "NHWC")
+
+    def test_dygraph_param_alias(self):
+        '''test_dygraph_param_alias'''
+
+        paddle.disable_static()
+
+        x = paddle.to_tensor(self.x_1_np)
+        out_1 = F.pixel_unshuffle(x=x, downscale_factor=3)
+        out_1_alias = F.pixel_unshuffle(input=x, downscale_factor=3)
+
+        np.testing.assert_allclose(out_1.numpy(), out_1_alias.numpy())
 
 
 class TestPixelUnshuffleError(unittest.TestCase):


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
1. **API**: Applied `@param_one_alias(["x", "input"])` to `paddle.nn.functional.pixel_unshuffle` in `python/paddle/nn/functional/vision.py` to map `input` to `x`.
2. **Test**: Added `test_static_graph_functional_input_alias` and `test_dygraph_input_alias` in `test/legacy_test/test_pixel_unshuffle.py` to verify the correctness of the new argument alias for both NCHW and NHWC formats.
3. **Doc**: Updated the docstring of `pixel_unshuffle` to explicitly document the `input` alias support.

### 是否引起精度变化
否