### PR TITLE
[API] Add PyTorch-style alias support for paddle.rot90 (input/dims)

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1872,17 +1872,24 @@ def flip(
         return out
 
 
+@param_two_alias(["x", "input"], ["axes", "dims"])
 def rot90(
     x: Tensor, k: int = 1, axes: Sequence[int] = [0, 1], name: str | None = None
 ) -> Tensor:
     """
     Rotate a n-D tensor by 90 degrees. The rotation direction and times are specified by axes and the absolute value of k. Rotation direction is from axes[0] towards axes[1] if k > 0, and from axes[1] towards axes[0] for k < 0.
 
+    .. note::
+        Alias Support: The parameter name ``input`` can be used as an alias for ``x``, and ``dims`` can be used as an alias for ``axes``.
+        For example, ``rot90(input=tensor_x, k=1, dims=[0, 1])`` is equivalent to ``rot90(x=tensor_x, k=1, axes=[0, 1])``.
+
     Args:
         x (Tensor): The input Tensor. The data type of the input Tensor x
             should be float16, float32, float64, int32, int64, bool. float16 is only supported on gpu.
+            alias: ``input``.
         k (int, optional): Direction and number of times to rotate, default value: 1.
         axes (list|tuple, optional): Axes to rotate, dimension must be 2. default value: [0, 1].
+            alias: ``dims``.
         name (str|None, optional): The default value is None.  Normally there is no need for user to set this property.
             For more information, please refer to :ref:`api_guide_Name` .
 

--- a/test/legacy_test/test_rot90_op.py
+++ b/test/legacy_test/test_rot90_op.py
@@ -354,5 +354,61 @@ def create_test_zero_size_class(op_type, dtype, shape, axis):
 create_test_zero_size_class("rot90", "float32", [3, 4, 0], (0, 1))
 create_test_zero_size_class("rot90", "int32", [3, 4, 0, 3, 4], (0, 1))
 
+
+class TestRot90Alias(unittest.TestCase):
+    """Test rot90 PyTorch-style alias arguments (input, dims)."""
+
+    def test_dygraph_alias_input_dims(self):
+        paddle.disable_static()
+        data = paddle.to_tensor([[1, 2, 3], [4, 5, 6]], dtype='float32')
+        out1 = paddle.rot90(x=data, k=1, axes=[0, 1])
+        out2 = paddle.rot90(input=data, k=1, dims=[0, 1])
+        np.testing.assert_allclose(out1.numpy(), out2.numpy())
+        paddle.enable_static()
+
+    def test_dygraph_alias_dims_tuple(self):
+        paddle.disable_static()
+        data = paddle.to_tensor([[1, 2, 3], [4, 5, 6]], dtype='float32')
+        out1 = paddle.rot90(x=data, k=1, axes=[0, 1])
+        out2 = paddle.rot90(input=data, k=1, dims=(0, 1))
+        np.testing.assert_allclose(out1.numpy(), out2.numpy())
+        paddle.enable_static()
+
+    def test_dygraph_alias_3d(self):
+        paddle.disable_static()
+        data = paddle.to_tensor(
+            [[[0, 1], [2, 3]], [[4, 5], [6, 7]]], dtype='float32'
+        )
+        out1 = paddle.rot90(x=data, k=1, axes=[1, 2])
+        out2 = paddle.rot90(input=data, k=1, dims=[1, 2])
+        np.testing.assert_allclose(out1.numpy(), out2.numpy())
+        paddle.enable_static()
+
+    def test_static_graph_alias(self):
+        paddle.enable_static()
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
+            input_var = paddle.static.data(
+                name='input_alias', dtype='float32', shape=[2, 3]
+            )
+            out1 = paddle.rot90(x=input_var, k=1, axes=[0, 1])
+            out2 = paddle.rot90(input=input_var, k=1, dims=[0, 1])
+            place = base.CPUPlace()
+            if base.core.is_compiled_with_cuda() or is_custom_device():
+                place = get_device_place()
+            exe = base.Executor(place)
+            exe.run(startup_program)
+
+            img = np.array([[1, 2, 3], [4, 5, 6]]).astype(np.float32)
+            res1, res2 = exe.run(
+                train_program,
+                feed={'input_alias': img},
+                fetch_list=[out1, out2],
+            )
+
+            np.testing.assert_allclose(res1, res2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `@param_two_alias` decorator to `rot90` function to support PyTorch-style keyword arguments
- `input` as alias for `x`
- `dims` as alias for `axes`

## Details
This PR implements issue #76301 No.214 to improve PyTorch compatibility for `paddle.rot90`.

### Changes:
1. **python/paddle/tensor/manipulation.py**:
   - Added `@param_two_alias(["x", "input"], ["axes", "dims"])` decorator
   - Updated docstring with alias information

2. **test/legacy_test/test_rot90_op.py**:
   - Added `TestRot90Alias` test class with 4 test cases:
     - Dynamic graph test with `input`/`dims` aliases
     - Dynamic graph test with `dims` as tuple
     - 3D tensor test with aliases
     - Static graph test with aliases

### Usage:
```python
# Both are equivalent:
paddle.rot90(x=tensor, k=1, axes=[0, 1])
paddle.rot90(input=tensor, k=1, dims=[0, 1])
```

Close #76301 No.214