### PR TITLE
[API Compatibility No.214] Add PyTorch-style alias support for paddle.rot90 -part

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1809,17 +1809,24 @@ def broadcast_tensors(
         return out
 
 
+@param_two_alias(["x", "input"], ["axes", "dims"])
 def rot90(
     x: Tensor, k: int = 1, axes: Sequence[int] = [0, 1], name: str | None = None
 ) -> Tensor:
     """
     Rotate a n-D tensor by 90 degrees. The rotation direction and times are specified by axes and the absolute value of k. Rotation direction is from axes[0] towards axes[1] if k > 0, and from axes[1] towards axes[0] for k < 0.
 
+    .. note::
+        Alias Support: The parameter name ``input`` can be used as an alias for ``x``, and ``dims`` can be used as an alias for ``axes``.
+        For example, ``rot90(input=tensor_x, k=1, dims=[0, 1])`` is equivalent to ``rot90(x=tensor_x, k=1, axes=[0, 1])``.
+
     Args:
         x (Tensor): The input Tensor. The data type of the input Tensor x
             should be float16, float32, float64, int32, int64, bool. float16 is only supported on gpu.
+            alias: ``input``.
         k (int, optional): Direction and number of times to rotate, default value: 1.
         axes (list|tuple, optional): Axes to rotate, dimension must be 2. default value: [0, 1].
+            alias: ``dims``.
         name (str|None, optional): The default value is None.  Normally there is no need for user to set this property.
             For more information, please refer to :ref:`api_guide_Name` .
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1816,10 +1816,6 @@ def rot90(
     """
     Rotate a n-D tensor by 90 degrees. The rotation direction and times are specified by axes and the absolute value of k. Rotation direction is from axes[0] towards axes[1] if k > 0, and from axes[1] towards axes[0] for k < 0.
 
-    .. note::
-        Alias Support: The parameter name ``input`` can be used as an alias for ``x``, and ``dims`` can be used as an alias for ``axes``.
-        For example, ``rot90(input=tensor_x, k=1, dims=[0, 1])`` is equivalent to ``rot90(x=tensor_x, k=1, axes=[0, 1])``.
-
     Args:
         x (Tensor): The input Tensor. The data type of the input Tensor x
             should be float16, float32, float64, int32, int64, bool. float16 is only supported on gpu.

--- a/test/legacy_test/test_rot90_op.py
+++ b/test/legacy_test/test_rot90_op.py
@@ -356,58 +356,51 @@ create_test_zero_size_class("rot90", "int32", [3, 4, 0, 3, 4], (0, 1))
 
 
 class TestRot90Alias(unittest.TestCase):
-    """Test rot90 PyTorch-style alias arguments (input, dims)."""
+    """Test rot90 alias arguments (input, dims)."""
 
-    def test_dygraph_alias_input_dims(self):
+    def setUp(self):
+        self.shape = [2, 3]
+        self.x_np = np.array([[1, 2, 3], [4, 5, 6]]).astype(np.float32)
+
+    def test_alias_dygraph(self):
         paddle.disable_static()
-        data = paddle.to_tensor([[1, 2, 3], [4, 5, 6]], dtype='float32')
-        out1 = paddle.rot90(x=data, k=1, axes=[0, 1])
-        out2 = paddle.rot90(input=data, k=1, dims=[0, 1])
-        np.testing.assert_allclose(out1.numpy(), out2.numpy())
+        try:
+            data = paddle.to_tensor(self.x_np)
+            out1 = paddle.rot90(x=data, k=1, axes=[0, 1])
+            out2 = paddle.rot90(input=data, k=1, dims=[0, 1])
+            np.testing.assert_allclose(out1.numpy(), out2.numpy())
+        finally:
+            paddle.enable_static()
+
+    def test_alias_static(self):
         paddle.enable_static()
-
-    def test_dygraph_alias_dims_tuple(self):
-        paddle.disable_static()
-        data = paddle.to_tensor([[1, 2, 3], [4, 5, 6]], dtype='float32')
-        out1 = paddle.rot90(x=data, k=1, axes=[0, 1])
-        out2 = paddle.rot90(input=data, k=1, dims=(0, 1))
-        np.testing.assert_allclose(out1.numpy(), out2.numpy())
-        paddle.enable_static()
-
-    def test_dygraph_alias_3d(self):
-        paddle.disable_static()
-        data = paddle.to_tensor(
-            [[[0, 1], [2, 3]], [[4, 5], [6, 7]]], dtype='float32'
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            x = paddle.static.data('X', self.shape, dtype='float32')
+            out1 = paddle.rot90(x=x, k=1, axes=[0, 1])
+            out2 = paddle.rot90(input=x, k=1, dims=[0, 1])
+        exe = paddle.static.Executor(paddle.CPUPlace())
+        exe.run(startup_program)
+        res1, res2 = exe.run(
+            main_program,
+            feed={'X': self.x_np},
+            fetch_list=[out1, out2],
         )
-        out1 = paddle.rot90(x=data, k=1, axes=[1, 2])
-        out2 = paddle.rot90(input=data, k=1, dims=[1, 2])
-        np.testing.assert_allclose(out1.numpy(), out2.numpy())
-        paddle.enable_static()
+        np.testing.assert_allclose(res1, res2)
 
-    def test_static_graph_alias(self):
-        paddle.enable_static()
-        startup_program = base.Program()
-        train_program = base.Program()
-        with base.program_guard(train_program, startup_program):
-            input_var = paddle.static.data(
-                name='input_alias', dtype='float32', shape=[2, 3]
+    def test_alias_conflict(self):
+        paddle.disable_static()
+        try:
+            data = paddle.to_tensor(self.x_np)
+            with self.assertRaises(ValueError) as context:
+                paddle.rot90(x=data, input=data, k=1, axes=[0, 1])
+            self.assertIn(
+                "Cannot specify both 'x' and its alias 'input'",
+                str(context.exception),
             )
-            out1 = paddle.rot90(x=input_var, k=1, axes=[0, 1])
-            out2 = paddle.rot90(input=input_var, k=1, dims=[0, 1])
-            place = base.CPUPlace()
-            if base.core.is_compiled_with_cuda() or is_custom_device():
-                place = get_device_place()
-            exe = base.Executor(place)
-            exe.run(startup_program)
-
-            img = np.array([[1, 2, 3], [4, 5, 6]]).astype(np.float32)
-            res1, res2 = exe.run(
-                train_program,
-                feed={'input_alias': img},
-                fetch_list=[out1, out2],
-            )
-
-            np.testing.assert_allclose(res1, res2)
+        finally:
+            paddle.enable_static()
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_rot90_op.py
+++ b/test/legacy_test/test_rot90_op.py
@@ -354,5 +354,61 @@ def create_test_zero_size_class(op_type, dtype, shape, axis):
 create_test_zero_size_class("rot90", "float32", [3, 4, 0], (0, 1))
 create_test_zero_size_class("rot90", "int32", [3, 4, 0, 3, 4], (0, 1))
 
+
+class TestRot90Alias(unittest.TestCase):
+    """Test rot90 PyTorch-style alias arguments (input, dims)."""
+
+    def test_dygraph_alias_input_dims(self):
+        paddle.disable_static()
+        data = paddle.to_tensor([[1, 2, 3], [4, 5, 6]], dtype='float32')
+        out1 = paddle.rot90(x=data, k=1, axes=[0, 1])
+        out2 = paddle.rot90(input=data, k=1, dims=[0, 1])
+        np.testing.assert_allclose(out1.numpy(), out2.numpy())
+        paddle.enable_static()
+
+    def test_dygraph_alias_dims_tuple(self):
+        paddle.disable_static()
+        data = paddle.to_tensor([[1, 2, 3], [4, 5, 6]], dtype='float32')
+        out1 = paddle.rot90(x=data, k=1, axes=[0, 1])
+        out2 = paddle.rot90(input=data, k=1, dims=(0, 1))
+        np.testing.assert_allclose(out1.numpy(), out2.numpy())
+        paddle.enable_static()
+
+    def test_dygraph_alias_3d(self):
+        paddle.disable_static()
+        data = paddle.to_tensor(
+            [[[0, 1], [2, 3]], [[4, 5], [6, 7]]], dtype='float32'
+        )
+        out1 = paddle.rot90(x=data, k=1, axes=[1, 2])
+        out2 = paddle.rot90(input=data, k=1, dims=[1, 2])
+        np.testing.assert_allclose(out1.numpy(), out2.numpy())
+        paddle.enable_static()
+
+    def test_static_graph_alias(self):
+        paddle.enable_static()
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(train_program, startup_program):
+            input_var = paddle.static.data(
+                name='input_alias', dtype='float32', shape=[2, 3]
+            )
+            out1 = paddle.rot90(x=input_var, k=1, axes=[0, 1])
+            out2 = paddle.rot90(input=input_var, k=1, dims=[0, 1])
+            place = base.CPUPlace()
+            if base.core.is_compiled_with_cuda() or is_custom_device():
+                place = get_device_place()
+            exe = base.Executor(place)
+            exe.run(startup_program)
+
+            img = np.array([[1, 2, 3], [4, 5, 6]]).astype(np.float32)
+            res1, res2 = exe.run(
+                train_program,
+                feed={'input_alias': img},
+                fetch_list=[out1, out2],
+            )
+
+            np.testing.assert_allclose(res1, res2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New Features

### Description
[任务](https://github.com/PaddlePaddle/Paddle/issues/76301#issue-3599435252)：No.214 torch.rot90 -> paddle.rot90

### 修改内容
1. 在 `python/paddle/tensor/manipulation.py` 的 `rot90` 函数上添加 `@param_two_alias` 装饰器：
   - `input` 作为 `x` 的别名
   - `dims` 作为 `axes` 的别名
2. 更新 docstring，添加 alias 说明
3. 在 `test/legacy_test/test_rot90_op.py` 中添加 `TestRot90Alias` 测试类，覆盖动态图和静态图的 alias 功能测试

### 是否引起精度变化
否