### PR TITLE
[CodeStyle][DocFormat][95] Use `pycon` for code-block marker in docstring examples (`python/paddle/nn/functional/flash_attention.py`)

### DIFF
--- a/python/paddle/nn/functional/flash_attention.py
+++ b/python/paddle/nn/functional/flash_attention.py
@@ -585,7 +585,7 @@ def flash_attn_qkvpacked(
         - softmax(Tensor). The softmax tensor. None if return_softmax is False.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('flash_attn need A100 compile')
             >>> import paddle
@@ -819,7 +819,7 @@ def flash_attn_unpadded(
         softmax(Tensor): The softmax tensor. None if return_softmax is False.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> paddle.seed(2023)
@@ -1178,7 +1178,7 @@ def flash_attn_varlen_qkvpacked(
         - softmax(Tensor). The softmax tensor. None if return_softmax is False.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('flash_attn need A100 compile')
             >>> import paddle
@@ -1356,15 +1356,15 @@ def flashmask_attention(
         This API supports GQA.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('flash_attn need A100 compile')
             >>> import paddle
             >>> paddle.seed(2023)
-            >>> q = paddle.rand((1, 10, 2, 32),dtype="bfloat16") # shape: [batch_size, seq_len, num_heads, head_dim]
-            >>> k = paddle.rand((1, 10, 2, 32),dtype="bfloat16") # shape: [batch_size, seq_len, num_heads, head_dim]
-            >>> v = paddle.rand((1, 10, 2, 32),dtype="bfloat16") # shape: [batch_size, seq_len, num_heads, head_dim]
-            >>> startend_row_indices = paddle.to_tensor([8]*10 + [5]*10, dtype="int32").reshape([1, 2, 10, 1])
+            >>> q = paddle.rand((1, 10, 2, 32), dtype="bfloat16")  # shape: [batch_size, seq_len, num_heads, head_dim]
+            >>> k = paddle.rand((1, 10, 2, 32), dtype="bfloat16")  # shape: [batch_size, seq_len, num_heads, head_dim]
+            >>> v = paddle.rand((1, 10, 2, 32), dtype="bfloat16")  # shape: [batch_size, seq_len, num_heads, head_dim]
+            >>> startend_row_indices = paddle.to_tensor([8] * 10 + [5] * 10, dtype="int32").reshape([1, 2, 10, 1])
             >>> output = paddle.nn.functional.flashmask_attention(q, k, v, startend_row_indices, causal=True)
             >>> print(output)
             Tensor(shape=[1, 10, 2, 32], dtype=bfloat16, place=Place(gpu:0), stop_gradient=True,
@@ -1522,7 +1522,7 @@ def flashmask_attention(
 
     To convert FlashMask's `startend_row_indices` to `dense_mask`, use the code below:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
         >>> import paddle
         >>> import numpy as np
@@ -1555,7 +1555,7 @@ def flashmask_attention(
 
     For `Causal Mask`, where `causal=True`, the values of `startend_row_indices` are as follows:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
        [[[[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -1570,7 +1570,7 @@ def flashmask_attention(
 
         >>> # doctest: +SKIP('Only example')
         >>> import paddle
-        >>> startend_row_indices = paddle.to_tensor([8]*10, dtype="int32").reshape([1, 1, 10, 1])
+        >>> startend_row_indices = paddle.to_tensor([8] * 10, dtype="int32").reshape([1, 1, 10, 1])
         >>> print(startend_row_indices)
         Tensor(shape=[1, 1, 10, 1], dtype=int32, place=Place(gpu:0), stop_gradient=True,
             [[[[8],
@@ -1588,7 +1588,7 @@ def flashmask_attention(
 
     For `Sliding Window Mask`, where `causal=True`, the values of `startend_row_indices` are as follows:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
        [[[[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -1620,7 +1620,7 @@ def flashmask_attention(
 
     For `Causal Document Mask`, where `causal=True`, the values of `startend_row_indices` are as follows:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
        [[[[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -1652,7 +1652,7 @@ def flashmask_attention(
 
     For `Document Mask`, where `causal=False`, the values of `startend_row_indices` are as follows:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
        [[[[1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
           [1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
@@ -1686,7 +1686,7 @@ def flashmask_attention(
 
     For `Share Question Mask`, where `causal=True`, the values of `startend_row_indices` are as follows:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
        [[[[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -1718,7 +1718,7 @@ def flashmask_attention(
 
     For `Global + Sliding Window Mask`, where `causal=False`, the values of `startend_row_indices` are as follows:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
         >>> # doctest: +SKIP('Only example')
 
@@ -1755,7 +1755,7 @@ def flashmask_attention(
 
     For `Causal Blockwise Mask`, where `causal=True`, the values of `startend_row_indices` are as follows:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
        [[[[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -1789,7 +1789,7 @@ def flashmask_attention(
 
     For `Prefix LM Document Mask`, where `causal=False`, the values of `startend_row_indices` are as follows:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
        [[[[1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
           [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -1823,7 +1823,7 @@ def flashmask_attention(
 
     For `Prefix LM Causal Mask`, where `causal=False`, the values of `startend_row_indices` are as follows:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
        [[[[1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
           [1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
@@ -1856,7 +1856,7 @@ def flashmask_attention(
 
     For `QK-sparse Mask`, where `causal=True`, the values of `startend_row_indices` are as follows:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
        [[[[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -2144,7 +2144,7 @@ def calc_reduced_attention_scores(
         reduced_attention_scores(Tensor), The reduce sum of attention scores across seqlen_q.
         4-D tensor with shape: [batch_size, num_heads, 1, seqlen_k]. The dtype is float32.
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # doctest: +SKIP('reduce_attn_scores need A100 compile')
             >>> import paddle
@@ -2154,8 +2154,8 @@ def calc_reduced_attention_scores(
             >>>     calc_reduced_attention_scores
             >>> )
             >>> np.random.seed(2024)
-            >>> q_shape = (5,1024,16,128)
-            >>> k_shape = (5,2048,16,128)
+            >>> q_shape = (5, 1024, 16, 128)
+            >>> k_shape = (5, 2048, 16, 128)
             >>> dtype = 'float16'
             >>> query = np.random.random(q_shape)
             >>> key = np.random.random(k_shape)


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

Replace docstring code-block language marker from `python` to `pycon` in `python/paddle/nn/functional/flash_attention.py` where examples use interactive prompts (`>>>`).

### 是否引起精度变化

否

This is part of a series of PRs migrating docstring code-block markers to `pycon`.

See also:

- #77952 (part 93: python/paddle/static/pir_io.py)
- #77953 (part 94: python/paddle/framework/io_utils.py)
