### PR TITLE
[CodeStyle][DocFormat][96] Use `pycon` for code-block marker in docstring examples (`python/paddle/distribution/{beta,gamma,uniform}.py`)

### DIFF
--- a/python/paddle/distribution/beta.py
+++ b/python/paddle/distribution/beta.py
@@ -61,7 +61,7 @@ class Beta(exponential_family.ExponentialFamily):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 

--- a/python/paddle/distribution/gamma.py
+++ b/python/paddle/distribution/gamma.py
@@ -52,7 +52,7 @@ class Gamma(exponential_family.ExponentialFamily):
             a batch_shape(refer to :ref:`api_paddle_distribution_Distribution`).
 
     Example:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 

--- a/python/paddle/distribution/uniform.py
+++ b/python/paddle/distribution/uniform.py
@@ -92,7 +92,10 @@ class Uniform(distribution.Distribution):
             >>> # 2 distributions [1, 3], [2, 4]
             >>> u2 = Uniform(low=[1.0, 2.0], high=[3.0, 4.0])
             >>> # 4 distributions
-            >>> u3 = Uniform(low=[[1.0, 2.0], [3.0, 4.0]], high=[[1.5, 2.5], [3.5, 4.5]])
+            >>> u3 = Uniform(
+            ...     low=[[1.0, 2.0], [3.0, 4.0]],
+            ...     high=[[1.5, 2.5], [3.5, 4.5]],
+            ... )
             >>> # With broadcasting:
             >>> u4 = Uniform(low=3.0, high=[5.0, 6.0, 7.0])
 

--- a/python/paddle/distribution/uniform.py
+++ b/python/paddle/distribution/uniform.py
@@ -81,7 +81,7 @@ class Uniform(distribution.Distribution):
         name (str, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.distribution import Uniform
@@ -92,16 +92,14 @@ class Uniform(distribution.Distribution):
             >>> # 2 distributions [1, 3], [2, 4]
             >>> u2 = Uniform(low=[1.0, 2.0], high=[3.0, 4.0])
             >>> # 4 distributions
-            >>> u3 = Uniform(low=[[1.0, 2.0], [3.0, 4.0]],
-            ...             high=[[1.5, 2.5], [3.5, 4.5]])
-            ...
+            >>> u3 = Uniform(low=[[1.0, 2.0], [3.0, 4.0]], high=[[1.5, 2.5], [3.5, 4.5]])
             >>> # With broadcasting:
             >>> u4 = Uniform(low=3.0, high=[5.0, 6.0, 7.0])
 
             >>> # Complete example
             >>> value_tensor = paddle.to_tensor([0.8], dtype="float32")
 
-            >>> uniform = Uniform([0.], [2.])
+            >>> uniform = Uniform([0.0], [2.0])
 
             >>> sample = uniform.sample([2])
             >>> # a random tensor created by uniform distribution with shape: [2, 1]


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

This PR migrates docstring code-block markers from `python` to `pycon` for interactive examples (`>>>`) in the following files:

- `python/paddle/distribution/beta.py`
- `python/paddle/distribution/gamma.py`
- `python/paddle/distribution/uniform.py`

Also ran `ruff format` on touched files after migration.

Part of the ongoing docstring marker migration series.
See also: #77954

### 是否引起精度变化

否
