### PR TITLE
[CodeStyle][DocFormat][97] Use `pycon` for code-block marker in docstring examples (`python/paddle/distribution/{independent,lognormal,multivariate_normal}.py`)

### DIFF
--- a/python/paddle/distribution/independent.py
+++ b/python/paddle/distribution/independent.py
@@ -38,7 +38,7 @@ class Independent(distribution.Distribution):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.distribution import independent
@@ -52,7 +52,7 @@ class Independent(distribution.Distribution):
             >>> reinterpreted_beta = independent.Independent(beta, 1)
             >>> print(reinterpreted_beta.batch_shape, reinterpreted_beta.event_shape)
             () (2,)
-            >>> print(reinterpreted_beta.log_prob(paddle.to_tensor([0.2,  0.2])))
+            >>> print(reinterpreted_beta.log_prob(paddle.to_tensor([0.2, 0.2])))
             Tensor(shape=[], dtype=float32, place=Place(gpu:0), stop_gradient=True,
                     -0.45687842)
     """

--- a/python/paddle/distribution/lognormal.py
+++ b/python/paddle/distribution/lognormal.py
@@ -80,29 +80,29 @@ class LogNormal(TransformedDistribution):
         scale(int|float|list|tuple|numpy.ndarray|Tensor): The stddevs of the underlying Normal distribution.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.distribution import LogNormal
 
             >>> # Define a single scalar LogNormal distribution.
-            >>> dist = LogNormal(loc=0., scale=3.)
+            >>> dist = LogNormal(loc=0.0, scale=3.0)
             >>> # Define a batch of two scalar valued LogNormals.
             >>> # The underlying Normal of first has mean 1 and standard deviation 11, the underlying Normal of second 2 and 22.
-            >>> dist = LogNormal(loc=[1., 2.], scale=[11., 22.])
+            >>> dist = LogNormal(loc=[1.0, 2.0], scale=[11.0, 22.0])
             >>> # Get 3 samples, returning a 3 x 2 tensor.
-            >>> dist.sample((3, ))
+            >>> dist.sample((3,))
 
             >>> # Define a batch of two scalar valued LogNormals.
             >>> # Their underlying Normal have mean 1, but different standard deviations.
-            >>> dist = LogNormal(loc=1., scale=[11., 22.])
+            >>> dist = LogNormal(loc=1.0, scale=[11.0, 22.0])
 
             >>> # Complete example
             >>> value_tensor = paddle.to_tensor([0.8], dtype="float32")
 
-            >>> lognormal_a = LogNormal([0.], [1.])
-            >>> lognormal_b = LogNormal([0.5], [2.])
-            >>> sample = lognormal_a.sample((2, ))
+            >>> lognormal_a = LogNormal([0.0], [1.0])
+            >>> lognormal_b = LogNormal([0.5], [2.0])
+            >>> sample = lognormal_a.sample((2,))
             >>> # a random tensor created by lognormal distribution with shape: [2, 1]
             >>> entropy = lognormal_a.entropy()
             >>> print(entropy)

--- a/python/paddle/distribution/multivariate_normal.py
+++ b/python/paddle/distribution/multivariate_normal.py
@@ -55,14 +55,14 @@ class MultivariateNormal(distribution.Distribution):
             convert to be the same as the type of loc.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.distribution import MultivariateNormal
             >>> paddle.set_device("cpu")
             >>> paddle.seed(100)
 
-            >>> rv = MultivariateNormal(loc=paddle.to_tensor([2.,5.]), covariance_matrix=paddle.to_tensor([[2.,1.],[1.,2.]]))
+            >>> rv = MultivariateNormal(loc=paddle.to_tensor([2.0, 5.0]), covariance_matrix=paddle.to_tensor([[2.0, 1.0], [1.0, 2.0]]))
 
             >>> print(rv.sample([3, 2]))
             Tensor(shape=[3, 2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -85,8 +85,10 @@ class MultivariateNormal(distribution.Distribution):
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             3.38718319)
 
-            >>> rv1 = MultivariateNormal(loc=paddle.to_tensor([2.,5.]), covariance_matrix=paddle.to_tensor([[2.,1.],[1.,2.]]))
-            >>> rv2 = MultivariateNormal(loc=paddle.to_tensor([-1.,3.]), covariance_matrix=paddle.to_tensor([[3.,2.],[2.,3.]]))
+            >>> rv1 = MultivariateNormal(loc=paddle.to_tensor([2.0, 5.0]), covariance_matrix=paddle.to_tensor([[2.0, 1.0], [1.0, 2.0]]))
+            >>> rv2 = MultivariateNormal(
+            ...     loc=paddle.to_tensor([-1.0, 3.0]), covariance_matrix=paddle.to_tensor([[3.0, 2.0], [2.0, 3.0]])
+            ... )
             >>> print(rv1.kl_divergence(rv2))
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             1.55541301)

--- a/python/paddle/distribution/multivariate_normal.py
+++ b/python/paddle/distribution/multivariate_normal.py
@@ -62,7 +62,10 @@ class MultivariateNormal(distribution.Distribution):
             >>> paddle.set_device("cpu")
             >>> paddle.seed(100)
 
-            >>> rv = MultivariateNormal(loc=paddle.to_tensor([2.0, 5.0]), covariance_matrix=paddle.to_tensor([[2.0, 1.0], [1.0, 2.0]]))
+            >>> rv = MultivariateNormal(
+            ...     loc=paddle.to_tensor([2.0, 5.0]),
+            ...     covariance_matrix=paddle.to_tensor([[2.0, 1.0], [1.0, 2.0]]),
+            ... )
 
             >>> print(rv.sample([3, 2]))
             Tensor(shape=[3, 2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -85,7 +88,10 @@ class MultivariateNormal(distribution.Distribution):
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             3.38718319)
 
-            >>> rv1 = MultivariateNormal(loc=paddle.to_tensor([2.0, 5.0]), covariance_matrix=paddle.to_tensor([[2.0, 1.0], [1.0, 2.0]]))
+            >>> rv1 = MultivariateNormal(
+            ...     loc=paddle.to_tensor([2.0, 5.0]),
+            ...     covariance_matrix=paddle.to_tensor([[2.0, 1.0], [1.0, 2.0]]),
+            ... )
             >>> rv2 = MultivariateNormal(
             ...     loc=paddle.to_tensor([-1.0, 3.0]), covariance_matrix=paddle.to_tensor([[3.0, 2.0], [2.0, 3.0]])
             ... )


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

This PR migrates docstring marker from `code-block:: python` to `code-block:: pycon` for interactive examples in the following files:

- `python/paddle/distribution/independent.py`
- `python/paddle/distribution/lognormal.py`
- `python/paddle/distribution/multivariate_normal.py`

Also ran `ruff format` after migration.

Part of the ongoing docstring marker migration series.
See also: #77955

### 是否引起精度变化

否
