### PR TITLE
[CodeStyle][DocFormat][98] Use `pycon` for code-block marker in docstring examples (`paddle/fluid/pybind/compiled_program.cc`)

### DIFF
--- a/paddle/fluid/pybind/compiled_program.cc
+++ b/paddle/fluid/pybind/compiled_program.cc
@@ -229,7 +229,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 Default is 'AllReduce'.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -255,7 +255,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 It is useful for debugging. Default is empty string, that is, ""
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -333,7 +333,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                       Default False.
 
                       Examples:
-                            .. code-block:: python
+                            .. code-block:: pycon
 
                                 >>> import paddle
                                 >>> import paddle.static as static
@@ -359,7 +359,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 it may make the execution faster. Default is False.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -385,7 +385,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 it may make the execution faster. Default is False.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -413,15 +413,15 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 it would make the execution faster. Default is False.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
-                        import paddle
-                        import paddle.static as static
+                        >>> import paddle
+                        >>> import paddle.static as static
 
-                        paddle.enable_static()
+                        >>> paddle.enable_static()
 
-                        build_strategy = static.BuildStrategy()
-                        build_strategy.fuse_dot_product_attention = True
+                        >>> build_strategy = static.BuildStrategy()
+                        >>> build_strategy.fuse_dot_product_attention = True
                      )DOC")
       .def_property(
           "fuse_adamw",
@@ -438,7 +438,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 to fuse all adamw optimizers with multi_tensor_adam,
                 it may make the execution faster. Default is False.
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -462,7 +462,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 it may make the execution faster. Default is False.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -488,7 +488,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 it may make the execution faster. Default is False.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -513,7 +513,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
           order of `ProgramDesc`. Default is False.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -543,15 +543,15 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
           R"DOC((bool, optional): fuse_resunit Default is False.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
-                        import paddle
-                        import paddle.static as static
+                        >>> import paddle
+                        >>> import paddle.static as static
 
-                        paddle.enable_static()
+                        >>> paddle.enable_static()
 
-                        build_strategy = static.BuildStrategy()
-                        build_strategy.fuse_resunit = True
+                        >>> build_strategy = static.BuildStrategy()
+                        >>> build_strategy.fuse_resunit = True
                      )DOC")
       .def_property(
           "fuse_bn_act_ops",
@@ -569,7 +569,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 it may make the execution faster. Default is False.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -595,7 +595,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 it may make the execution faster. Default is True
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -622,7 +622,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 without broadcast and activations.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -652,7 +652,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 Default is False.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -684,7 +684,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                       for NCCLReduce operations for a period of time. Default False.
 
                       Examples:
-                            .. code-block:: python
+                            .. code-block:: pycon
 
                                 >>> import paddle
                                 >>> import paddle.static as static
@@ -726,7 +726,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 Default is False.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static
@@ -766,7 +766,7 @@ void BindCompiledProgram(pybind11::module &m) {  // NOLINT
                 True means enabling and False means disabling. Default is None.
 
                 Examples:
-                    .. code-block:: python
+                    .. code-block:: pycon
 
                         >>> import paddle
                         >>> import paddle.static as static


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

Replace docstring code-block marker from `python` to `pycon` in `paddle/fluid/pybind/compiled_program.cc` where examples use interactive prompts (`>>>`).

Also fix two example blocks that were missing `>>>` prompts so they match `pycon` style.

### 是否引起精度变化

否

This is part of a series of PRs migrating docstring code-block markers to `pycon`.
