### PR TITLE
[CodeStyle][DocFormat][98] Use `pycon` marker in distribution docstrings (batch)

### DIFF
--- a/python/paddle/distribution/bernoulli.py
+++ b/python/paddle/distribution/bernoulli.py
@@ -78,7 +78,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.distribution import Bernoulli
@@ -324,7 +324,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Bernoulli
@@ -362,7 +362,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Bernoulli
@@ -401,7 +401,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Bernoulli
@@ -431,7 +431,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Bernoulli
@@ -464,7 +464,7 @@ class Bernoulli(exponential_family.ExponentialFamily):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Bernoulli

--- a/python/paddle/distribution/categorical.py
+++ b/python/paddle/distribution/categorical.py
@@ -65,18 +65,18 @@ class Categorical(distribution.Distribution):
         name(str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.distribution import Categorical
 
-            >>> paddle.seed(100) # on CPU device
+            >>> paddle.seed(100)  # on CPU device
             >>> x = paddle.rand([6])
             >>> print(x)
             Tensor(shape=[6], dtype=float32, place=Place(cpu), stop_gradient=True,
             [0.55355281, 0.20714243, 0.01162981, 0.51577556, 0.36369765, 0.26091650])
 
-            >>> paddle.seed(200) # on CPU device
+            >>> paddle.seed(200)  # on CPU device
             >>> y = paddle.rand([6])
             >>> print(y)
             Tensor(shape=[6], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -85,7 +85,7 @@ class Categorical(distribution.Distribution):
             >>> cat = Categorical(x)
             >>> cat2 = Categorical(y)
 
-            >>> paddle.seed(1000) # on CPU device
+            >>> paddle.seed(1000)  # on CPU device
             >>> print(cat.sample([2, 3]))
             Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
             [[0, 1, 5],
@@ -158,12 +158,12 @@ class Categorical(distribution.Distribution):
             Tensor: A tensor with prepended dimensions shape.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Categorical
 
-                >>> paddle.seed(100) # on CPU device
+                >>> paddle.seed(100)  # on CPU device
                 >>> x = paddle.rand([6])
                 >>> print(x)
                 Tensor(shape=[6], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -171,7 +171,7 @@ class Categorical(distribution.Distribution):
 
                 >>> # doctest: +SKIP('Random output')
                 >>> cat = Categorical(x)
-                >>> paddle.seed(1000) # on CPU device
+                >>> paddle.seed(1000)  # on CPU device
                 >>> print(cat.sample([2, 3]))
                 Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
                 [[0, 1, 5],
@@ -215,18 +215,18 @@ class Categorical(distribution.Distribution):
             Tensor: kl-divergence between two Categorical distributions.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Categorical
 
-                >>> paddle.seed(100) # on CPU device
+                >>> paddle.seed(100)  # on CPU device
                 >>> x = paddle.rand([6])
                 >>> print(x)
                 Tensor(shape=[6], dtype=float32, place=Place(cpu), stop_gradient=True,
                 [0.55355281, 0.20714243, 0.01162981, 0.51577556, 0.36369765, 0.26091650])
 
-                >>> paddle.seed(200) # on CPU device
+                >>> paddle.seed(200)  # on CPU device
                 >>> y = paddle.rand([6])
                 >>> print(y)
                 Tensor(shape=[6], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -269,12 +269,12 @@ class Categorical(distribution.Distribution):
             Tensor: Shannon entropy of Categorical distribution. The data type is float32.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Categorical
 
-                >>> paddle.seed(100) # on CPU device
+                >>> paddle.seed(100)  # on CPU device
                 >>> x = paddle.rand([6])
                 >>> print(x)
                 Tensor(shape=[6], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -313,12 +313,12 @@ class Categorical(distribution.Distribution):
             Tensor: probability according to the category index.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Categorical
 
-                >>> paddle.seed(100) # on CPU device
+                >>> paddle.seed(100)  # on CPU device
                 >>> x = paddle.rand([6])
                 >>> print(x)
                 Tensor(shape=[6], dtype=float32, place=Place(cpu), stop_gradient=True,
@@ -360,12 +360,12 @@ class Categorical(distribution.Distribution):
             Tensor: Log probability.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Categorical
 
-                >>> paddle.seed(100) # on CPU device
+                >>> paddle.seed(100)  # on CPU device
                 >>> x = paddle.rand([6])
                 >>> print(x)
                 Tensor(shape=[6], dtype=float32, place=Place(cpu), stop_gradient=True,

--- a/python/paddle/distribution/continuous_bernoulli.py
+++ b/python/paddle/distribution/continuous_bernoulli.py
@@ -62,7 +62,7 @@ class ContinuousBernoulli(distribution.Distribution):
             by talyor expansion. The default value is (0.499, 0.501).
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.distribution import ContinuousBernoulli

--- a/python/paddle/distribution/dirichlet.py
+++ b/python/paddle/distribution/dirichlet.py
@@ -65,15 +65,15 @@ class Dirichlet(exponential_family.ExponentialFamily):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
-            >>> dirichlet = paddle.distribution.Dirichlet(paddle.to_tensor([1., 2., 3.]))
+            >>> dirichlet = paddle.distribution.Dirichlet(paddle.to_tensor([1.0, 2.0, 3.0]))
             >>> print(dirichlet.entropy())
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             -1.24434423)
 
-            >>> print(dirichlet.prob(paddle.to_tensor([.3, .5, .6])))
+            >>> print(dirichlet.prob(paddle.to_tensor([0.3, 0.5, 0.6])))
             Tensor(shape=[], dtype=float32, place=Place(cpu), stop_gradient=True,
             10.80000019)
     """

--- a/python/paddle/distribution/exponential.py
+++ b/python/paddle/distribution/exponential.py
@@ -49,7 +49,7 @@ class Exponential(exponential_family.ExponentialFamily):
         rate (float|Tensor): Rate parameter. The value of rate must be positive.
 
     Example:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 

--- a/python/paddle/distribution/geometric.py
+++ b/python/paddle/distribution/geometric.py
@@ -55,7 +55,7 @@ class Geometric(distribution.Distribution):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.distribution import Geometric
@@ -143,7 +143,7 @@ class Geometric(distribution.Distribution):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Geometric
@@ -176,7 +176,7 @@ class Geometric(distribution.Distribution):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Geometric
@@ -206,14 +206,14 @@ class Geometric(distribution.Distribution):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Geometric
 
                 >>> paddle.seed(2023)
                 >>> geom = Geometric(0.5)
-                >>> print(geom.sample((2,2)))
+                >>> print(geom.sample((2, 2)))
                 Tensor(shape=[2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
                 [[0., 0.],
                  [1., 0.]])
@@ -232,14 +232,14 @@ class Geometric(distribution.Distribution):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Geometric
 
                 >>> paddle.seed(2023)
                 >>> geom = Geometric(0.5)
-                >>> print(geom.rsample((2,2)))
+                >>> print(geom.rsample((2, 2)))
                 Tensor(shape=[2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
                 [[0., 0.],
                  [1., 0.]])
@@ -270,7 +270,7 @@ class Geometric(distribution.Distribution):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Geometric
@@ -300,7 +300,7 @@ class Geometric(distribution.Distribution):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Geometric
@@ -334,7 +334,7 @@ class Geometric(distribution.Distribution):
 
         Examples:
 
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.distribution import Geometric

--- a/python/paddle/distribution/kl.py
+++ b/python/paddle/distribution/kl.py
@@ -66,7 +66,7 @@ def kl_divergence(p: Distribution, q: Distribution) -> Tensor:
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -97,13 +97,13 @@ def register_kl(
         cls_q (type[Distribution]): The Distribution type of Instance q. Subclass derived from ``Distribution``.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> @paddle.distribution.register_kl(paddle.distribution.Beta, paddle.distribution.Beta)
             >>> def kl_beta_beta():
-            ...     pass # insert implementation here
+            ...     pass  # insert implementation here
     """
     if not issubclass(cls_p, Distribution) or not issubclass(
         cls_q, Distribution

--- a/python/paddle/distribution/multinomial.py
+++ b/python/paddle/distribution/multinomial.py
@@ -56,7 +56,7 @@ class Multinomial(distribution.Distribution):
 
     Examples:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
         >>> import paddle
         >>> paddle.seed(2023)

--- a/python/paddle/distribution/transformed_distribution.py
+++ b/python/paddle/distribution/transformed_distribution.py
@@ -36,15 +36,15 @@ class TransformedDistribution(distribution.Distribution):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> paddle.seed(2023)
             >>> from paddle.distribution import transformed_distribution
 
             >>> d = transformed_distribution.TransformedDistribution(
-            ...     paddle.distribution.Normal(0., 1.),
-            ...     [paddle.distribution.AffineTransform(paddle.to_tensor(1.), paddle.to_tensor(2.))]
+            ...     paddle.distribution.Normal(0.0, 1.0),
+            ...     [paddle.distribution.AffineTransform(paddle.to_tensor(1.0), paddle.to_tensor(2.0))],
             ... )
 
             >>> # doctest: +SKIP('random sample')


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

This PR migrates docstring code-block markers from `python` to `pycon` for interactive examples in the following files:

- `python/paddle/distribution/bernoulli.py`
- `python/paddle/distribution/categorical.py`
- `python/paddle/distribution/continuous_bernoulli.py`
- `python/paddle/distribution/dirichlet.py`
- `python/paddle/distribution/exponential.py`
- `python/paddle/distribution/geometric.py`
- `python/paddle/distribution/kl.py`
- `python/paddle/distribution/multinomial.py`
- `python/paddle/distribution/transformed_distribution.py`

Also ran `ruff format` on touched files.

Related PRs:
- #77956
- #77958

### 是否引起精度变化

否
