### PR TITLE
[CodeStyle][DocFormat][99] Use `pycon` marker in audio docstrings (batch)

### DIFF
--- a/python/paddle/audio/backends/backend.py
+++ b/python/paddle/audio/backends/backend.py
@@ -56,7 +56,7 @@ def info(filepath: str | BinaryIO) -> AudioInfo:
         AudioInfo: info of the given audio.
 
     Example:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import os
             >>> import paddle
@@ -100,7 +100,7 @@ def load(
         Tuple[paddle.Tensor, int]: (audio_content, sample rate)
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import os
             >>> import paddle
@@ -146,7 +146,7 @@ def save(
         None
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 

--- a/python/paddle/audio/backends/wave_backend.py
+++ b/python/paddle/audio/backends/wave_backend.py
@@ -50,7 +50,7 @@ def info(filepath: str | BinaryIO) -> AudioInfo:
         AudioInfo: info of the given audio.
 
     Example:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import os
             >>> import paddle
@@ -115,7 +115,7 @@ def load(
         Tuple[paddle.Tensor, int]: (audio_content, sample rate)
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import os
             >>> import paddle
@@ -196,7 +196,7 @@ def save(
         None
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 

--- a/python/paddle/audio/features/layers.py
+++ b/python/paddle/audio/features/layers.py
@@ -64,7 +64,7 @@ class Spectrogram(nn.Layer):
 
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.audio.features import Spectrogram
@@ -76,7 +76,7 @@ class Spectrogram(nn.Layer):
             >>> wav_data = paddle.linspace(-1.0, 1.0, int(num_frames)) * 0.1
             >>> waveform = wav_data.tile([num_channels, 1])
 
-            >>> feature_extractor = Spectrogram(n_fft=512, window = 'hann', power = 1.0)
+            >>> feature_extractor = Spectrogram(n_fft=512, window='hann', power=1.0)
             >>> feats = feature_extractor(waveform)
     """
 
@@ -152,7 +152,7 @@ class MelSpectrogram(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of MelSpectrogram.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.audio.features import MelSpectrogram
@@ -164,7 +164,7 @@ class MelSpectrogram(nn.Layer):
             >>> wav_data = paddle.linspace(-1.0, 1.0, int(num_frames)) * 0.1
             >>> waveform = wav_data.tile([num_channels, 1])
 
-            >>> feature_extractor = MelSpectrogram(sr=sample_rate, n_fft=512, window = 'hann', power = 1.0)
+            >>> feature_extractor = MelSpectrogram(sr=sample_rate, n_fft=512, window='hann', power=1.0)
             >>> feats = feature_extractor(waveform)
     """
 
@@ -262,7 +262,7 @@ class LogMelSpectrogram(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of LogMelSpectrogram.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.audio.features import LogMelSpectrogram
@@ -274,7 +274,7 @@ class LogMelSpectrogram(nn.Layer):
             >>> wav_data = paddle.linspace(-1.0, 1.0, int(num_frames)) * 0.1
             >>> waveform = wav_data.tile([num_channels, 1])
 
-            >>> feature_extractor = LogMelSpectrogram(sr=sample_rate, n_fft=512, window = 'hann', power = 1.0)
+            >>> feature_extractor = LogMelSpectrogram(sr=sample_rate, n_fft=512, window='hann', power=1.0)
             >>> feats = feature_extractor(waveform)
     """
 
@@ -370,7 +370,7 @@ class MFCC(nn.Layer):
         :ref:`api_paddle_nn_Layer`. An instance of MFCC.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> from paddle.audio.features import MFCC
@@ -382,7 +382,7 @@ class MFCC(nn.Layer):
             >>> wav_data = paddle.linspace(-1.0, 1.0, int(num_frames)) * 0.1
             >>> waveform = wav_data.tile([num_channels, 1])
 
-            >>> feature_extractor = MFCC(sr=sample_rate, n_fft=512, window = 'hann')
+            >>> feature_extractor = MFCC(sr=sample_rate, n_fft=512, window='hann')
             >>> feats = feature_extractor(waveform)
     """
 

--- a/python/paddle/audio/functional/functional.py
+++ b/python/paddle/audio/functional/functional.py
@@ -37,14 +37,13 @@ def hz_to_mel(freq: _TensorOrFloat, htk: bool = False) -> _TensorOrFloat:
         Union[Tensor, float]: Frequency in mels.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> val = 3.0
             >>> htk_flag = True
-            >>> mel_paddle_tensor = paddle.audio.functional.hz_to_mel(
-            ...     paddle.to_tensor(val), htk_flag)
+            >>> mel_paddle_tensor = paddle.audio.functional.hz_to_mel(paddle.to_tensor(val), htk_flag)
     """
 
     if htk:
@@ -91,15 +90,13 @@ def mel_to_hz(mel: _TensorOrFloat, htk: bool = False) -> _TensorOrFloat:
         Union[float, Tensor]: Frequencies in Hz.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> val = 3.0
             >>> htk_flag = True
-            >>> mel_paddle_tensor = paddle.audio.functional.mel_to_hz(
-            ...     paddle.to_tensor(val), htk_flag)
-            ...
+            >>> mel_paddle_tensor = paddle.audio.functional.mel_to_hz(paddle.to_tensor(val), htk_flag)
     """
     if htk:
         return 700.0 * (10.0 ** (mel / 2595.0) - 1.0)
@@ -143,7 +140,7 @@ def mel_frequencies(
         Tensor: Tensor of n_mels frequencies in Hz with shape `(n_mels,)`.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -152,8 +149,7 @@ def mel_frequencies(
             >>> f_max = 10000
             >>> htk_flag = True
 
-            >>> paddle_mel_freq = paddle.audio.functional.mel_frequencies(
-            ...     n_mels, f_min, f_max, htk_flag, 'float64')
+            >>> paddle_mel_freq = paddle.audio.functional.mel_frequencies(n_mels, f_min, f_max, htk_flag, 'float64')
     """
     # 'Center freqs' of mel bands - uniformly spaced between limits
     min_mel = hz_to_mel(f_min, htk=htk)
@@ -175,7 +171,7 @@ def fft_frequencies(sr: int, n_fft: int, dtype: str = 'float32') -> Tensor:
         Tensor: FFT frequencies in Hz with shape `(n_fft//2 + 1,)`.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -212,7 +208,7 @@ def compute_fbank_matrix(
         Tensor: Mel transform matrix with shape `(n_mels, n_fft//2 + 1)`.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -277,13 +273,12 @@ def power_to_db(
         Tensor: Power spectrogram in db scale.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
             >>> val = 3.0
-            >>> decibel_paddle = paddle.audio.functional.power_to_db(
-            ...     paddle.to_tensor(val))
+            >>> decibel_paddle = paddle.audio.functional.power_to_db(paddle.to_tensor(val))
     """
     if amin <= 0:
         raise Exception("amin must be strictly positive")
@@ -321,7 +316,7 @@ def create_dct(
         Tensor: The DCT matrix with shape `(n_mels, n_mfcc)`.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
             >>> n_mfcc = 23

--- a/python/paddle/audio/functional/window.py
+++ b/python/paddle/audio/functional/window.py
@@ -420,7 +420,7 @@ def get_window(
         Tensor: The window represented as a tensor.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -533,7 +533,7 @@ def hamming_window(
         Tensor: A 1-D tensor of shape `(window_length,)` containing the Hamming window.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -582,7 +582,7 @@ def hann_window(
         Tensor: A 1-D tensor of shape `(window_length,)` containing the Hann window.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -629,7 +629,7 @@ def kaiser_window(
         Tensor: A 1-D tensor of shape `(window_length,)` containing the Kaiser window.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -676,7 +676,7 @@ def blackman_window(
         Tensor: A 1-D tensor of shape `(window_length,)` containing the Blackman window.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -721,7 +721,7 @@ def bartlett_window(
         Tensor: A 1-D tensor of shape `(window_length,)` containing the Bartlett window.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

This PR migrates docstring code-block markers from `python` to `pycon` for interactive examples in the following files:

- `python/paddle/audio/backends/backend.py`
- `python/paddle/audio/backends/wave_backend.py`
- `python/paddle/audio/features/layers.py`
- `python/paddle/audio/functional/functional.py`
- `python/paddle/audio/functional/window.py`

Also ran `ruff format` on touched files.

Related PRs:
- #77960

### 是否引起精度变化

否
