### PR TITLE
[CodeStyle][DocFormat][109] Use `pycon` marker in dataloader/amp docs

### DIFF
--- a/python/paddle/io/dataloader/batch_sampler.py
+++ b/python/paddle/io/dataloader/batch_sampler.py
@@ -59,7 +59,7 @@ class BatchSampler(Sampler[Sequence[int]]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import numpy as np
             >>> from paddle.io import RandomSampler, BatchSampler, Dataset
@@ -72,17 +72,12 @@ class BatchSampler(Sampler[Sequence[int]]):
             ...
             ...     def __getitem__(self, idx):
             ...         image = np.random.random([784]).astype('float32')
-            ...         label = np.random.randint(0, 9, (1, )).astype('int64')
+            ...         label = np.random.randint(0, 9, (1,)).astype('int64')
             ...         return image, label
             ...
             ...     def __len__(self):
             ...         return self.num_samples
-            ...
-            >>> bs = BatchSampler(dataset=RandomDataset(100),
-            ...                     shuffle=False,
-            ...                     batch_size=16,
-            ...                     drop_last=False)
-            ...
+            >>> bs = BatchSampler(dataset=RandomDataset(100), shuffle=False, batch_size=16, drop_last=False)
             >>> for batch_indices in bs:
             ...     print(batch_indices)
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
@@ -90,10 +85,7 @@ class BatchSampler(Sampler[Sequence[int]]):
             [96, 97, 98, 99]
             >>> # init with sampler
             >>> sampler = RandomSampler(RandomDataset(100))
-            >>> bs = BatchSampler(sampler=sampler,
-            ...                     batch_size=8,
-            ...                     drop_last=True)
-            ...
+            >>> bs = BatchSampler(sampler=sampler, batch_size=8, drop_last=True)
             >>> for batch_indices in bs:
             ...     print(batch_indices)
             [56, 12, 68, 0, 82, 66, 91, 44]
@@ -215,7 +207,7 @@ class DistributedBatchSampler(BatchSampler):
         DistributedBatchSampler, return an iterable object for indices iterating.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import numpy as np
 
@@ -228,12 +220,11 @@ class DistributedBatchSampler(BatchSampler):
             ...
             ...     def __getitem__(self, idx):
             ...         image = np.random.random([784]).astype('float32')
-            ...         label = np.random.randint(0, 9, (1, )).astype('int64')
+            ...         label = np.random.randint(0, 9, (1,)).astype('int64')
             ...         return image, label
             ...
             ...     def __len__(self):
             ...         return self.num_samples
-            ...
             >>> dataset = RandomDataset(100)
             >>> sampler = DistributedBatchSampler(dataset, batch_size=64)
 
@@ -376,7 +367,7 @@ class DistributedBatchSampler(BatchSampler):
             epoch (int): Epoch number.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import numpy as np
 
@@ -389,12 +380,11 @@ class DistributedBatchSampler(BatchSampler):
                 ...
                 ...     def __getitem__(self, idx):
                 ...         image = np.random.random([784]).astype('float32')
-                ...         label = np.random.randint(0, 9, (1, )).astype('int64')
+                ...         label = np.random.randint(0, 9, (1,)).astype('int64')
                 ...         return image, label
                 ...
                 ...     def __len__(self):
                 ...         return self.num_samples
-                ...
                 >>> dataset = RandomDataset(100)
                 >>> sampler = DistributedBatchSampler(dataset, batch_size=64)
 

--- a/python/paddle/io/dataloader/dataset.py
+++ b/python/paddle/io/dataloader/dataset.py
@@ -58,7 +58,7 @@ class Dataset(Generic[_T]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import numpy as np
             >>> from paddle.io import Dataset
@@ -70,12 +70,11 @@ class Dataset(Generic[_T]):
             ...
             ...     def __getitem__(self, idx):
             ...         image = np.random.random([784]).astype('float32')
-            ...         label = np.random.randint(0, 9, (1, )).astype('int64')
+            ...         label = np.random.randint(0, 9, (1,)).astype('int64')
             ...         return image, label
             ...
             ...     def __len__(self):
             ...         return self.num_samples
-            ...
             >>> dataset = RandomDataset(10)
             >>> for i in range(len(dataset)):
             ...     image, label = dataset[i]
@@ -121,23 +120,22 @@ class IterableDataset(Dataset[_T]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example1
 
             >>> import numpy as np
             >>> from paddle.io import IterableDataset
 
             >>> # define a random dataset
-            >>> class RandomDataset(IterableDataset): # type: ignore[type-arg]
+            >>> class RandomDataset(IterableDataset):  # type: ignore[type-arg]
             ...     def __init__(self, num_samples):
             ...         self.num_samples = num_samples
             ...
             ...     def __iter__(self):
             ...         for i in range(self.num_samples):
             ...             image = np.random.random([784]).astype('float32')
-            ...             label = np.random.randint(0, 9, (1, )).astype('int64')
+            ...             label = np.random.randint(0, 9, (1,)).astype('int64')
             ...             yield image, label
-            ...
             >>> dataset = RandomDataset(10)
             >>> for img, label in dataset:
             ...     # do something
@@ -152,7 +150,7 @@ class IterableDataset(Dataset[_T]):
 
     splitting data copy in each worker in :code:`__iter__`
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example2
 
             >>> import math
@@ -160,7 +158,7 @@ class IterableDataset(Dataset[_T]):
             >>> import numpy as np
             >>> from paddle.io import IterableDataset, DataLoader, get_worker_info
 
-            >>> class SplitedIterableDataset(IterableDataset): # type: ignore[type-arg]
+            >>> class SplitedIterableDataset(IterableDataset):  # type: ignore[type-arg]
             ...     def __init__(self, start, end):
             ...         self.start = start
             ...         self.end = end
@@ -171,25 +169,17 @@ class IterableDataset(Dataset[_T]):
             ...             iter_start = self.start
             ...             iter_end = self.end
             ...         else:
-            ...             per_worker = int(
-            ...                 math.ceil((self.end - self.start) / float(
-            ...                     worker_info.num_workers)))
+            ...             per_worker = int(math.ceil((self.end - self.start) / float(worker_info.num_workers)))
             ...             worker_id = worker_info.id
             ...             iter_start = self.start + worker_id * per_worker
             ...             iter_end = min(iter_start + per_worker, self.end)
             ...
             ...         for i in range(iter_start, iter_end):
             ...             yield np.array([i])
-            ...
             >>> dataset = SplitedIterableDataset(start=2, end=9)
-            >>> dataloader = DataLoader(
-            ...     dataset,
-            ...     num_workers=2,
-            ...     batch_size=1,
-            ...     drop_last=True)
-            ...
+            >>> dataloader = DataLoader(dataset, num_workers=2, batch_size=1, drop_last=True)
             >>> for data in dataloader:
-            ...     print(data) # doctest: +SKIP("The output depends on the environment.")
+            ...     print(data)  # doctest: +SKIP("The output depends on the environment.")
             Tensor(shape=[1, 1], dtype=int64, place=Place(cpu), stop_gradient=True,
                 [[2]])
             Tensor(shape=[1, 1], dtype=int64, place=Place(cpu), stop_gradient=True,
@@ -207,7 +197,7 @@ class IterableDataset(Dataset[_T]):
 
     splitting data copy in each worker by :code:`worker_init_fn`
 
-        .. code-block:: python
+        .. code-block:: pycon
             :name: code-example3
 
             >>> import math
@@ -215,7 +205,7 @@ class IterableDataset(Dataset[_T]):
             >>> import numpy as np
             >>> from paddle.io import IterableDataset, DataLoader, get_worker_info
 
-            >>> class RangeIterableDataset(IterableDataset): # type: ignore[type-arg]
+            >>> class RangeIterableDataset(IterableDataset):  # type: ignore[type-arg]
             ...     def __init__(self, start, end):
             ...         self.start = start
             ...         self.end = end
@@ -223,31 +213,22 @@ class IterableDataset(Dataset[_T]):
             ...     def __iter__(self):
             ...         for i in range(self.start, self.end):
             ...             yield np.array([i])
-            ...
             >>> dataset = RangeIterableDataset(start=2, end=9)
 
             >>> def worker_init_fn(worker_id):
             ...     worker_info = get_worker_info()
             ...
-            ...     dataset: RangeIterableDataset = worker_info.dataset # type: ignore[assignment]
+            ...     dataset: RangeIterableDataset = worker_info.dataset  # type: ignore[assignment]
             ...     start = dataset.start
             ...     end = dataset.end
-            ...     num_per_worker = int(
-            ...         math.ceil((end - start) / float(worker_info.num_workers)))
+            ...     num_per_worker = int(math.ceil((end - start) / float(worker_info.num_workers)))
             ...
             ...     worker_id = worker_info.id
             ...     dataset.start = start + worker_id * num_per_worker
             ...     dataset.end = min(dataset.start + num_per_worker, end)
-            ...
-            >>> dataloader = DataLoader(
-            ...     dataset,
-            ...     num_workers=2,
-            ...     batch_size=1,
-            ...     drop_last=True,
-            ...     worker_init_fn=worker_init_fn)
-            ...
+            >>> dataloader = DataLoader(dataset, num_workers=2, batch_size=1, drop_last=True, worker_init_fn=worker_init_fn)
             >>> for data in dataloader:
-            ...     print(data) # doctest: +SKIP("The output depends on the environment.")
+            ...     print(data)  # doctest: +SKIP("The output depends on the environment.")
             Tensor(shape=[1, 1], dtype=int64, place=Place(cpu), stop_gradient=True,
                 [[2]])
             Tensor(shape=[1, 1], dtype=int64, place=Place(cpu), stop_gradient=True,
@@ -306,7 +287,7 @@ class TensorDataset(Dataset["Tensor"]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import numpy as np
             >>> import paddle
@@ -367,7 +348,7 @@ class ComposeDataset(Dataset[tuple[Unpack[_Ts]]]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import numpy as np
             >>> import paddle
@@ -380,12 +361,11 @@ class ComposeDataset(Dataset[tuple[Unpack[_Ts]]]):
             ...
             ...     def __getitem__(self, idx):
             ...         image = np.random.random([32]).astype('float32')
-            ...         label = np.random.randint(0, 9, (1, )).astype('int64')
+            ...         label = np.random.randint(0, 9, (1,)).astype('int64')
             ...         return image, label
             ...
             ...     def __len__(self):
             ...         return self.num_samples
-            ...
             >>> dataset = ComposeDataset([RandomDataset(10), RandomDataset(10)])  # type: ignore[var-annotated]
             >>> for i in range(len(dataset)):
             ...     image1, label1, image2, label2 = dataset[i]
@@ -434,7 +414,7 @@ class ChainDataset(IterableDataset[Any]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import numpy as np
             >>> import paddle
@@ -449,9 +429,8 @@ class ChainDataset(IterableDataset[Any]):
             ...     def __iter__(self):
             ...         for i in range(10):
             ...             image = np.random.random([32]).astype('float32')
-            ...             label = np.random.randint(0, 9, (1, )).astype('int64')
+            ...             label = np.random.randint(0, 9, (1,)).astype('int64')
             ...             yield image, label
-            ...
             >>> dataset = ChainDataset([RandomDataset(10), RandomDataset(10)])
             >>> for image, label in iter(dataset):
             ...     # do something
@@ -485,7 +464,7 @@ class Subset(Dataset[_T]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -544,7 +523,7 @@ def random_split(
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import paddle
 
@@ -555,14 +534,14 @@ def random_split(
 
             >>> # output of the first subset
             >>> for idx, v in enumerate(a_list[0]):
-            ...     print(idx, v) # doctest: +SKIP("The output depends on the environment.")
+            ...     print(idx, v)  # doctest: +SKIP("The output depends on the environment.")
             0 7
             1 6
             2 5
 
             >>> # output of the second subset
             >>> for idx, v in enumerate(a_list[1]):
-            ...     print(idx, v) # doctest: +SKIP("The output depends on the environment.")
+            ...     print(idx, v)  # doctest: +SKIP("The output depends on the environment.")
             0 1
             1 9
             2 4
@@ -623,7 +602,7 @@ def _accumulate(
 
     Example code:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> list(_accumulate([1, 2, 3, 4, 5]))
             [1, 3, 6, 10, 15]
@@ -658,7 +637,7 @@ class ConcatDataset(Dataset[_T]):
 
     Examples:
 
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import numpy as np
             >>> import paddle
@@ -671,12 +650,11 @@ class ConcatDataset(Dataset[_T]):
             ...
             ...     def __getitem__(self, idx):
             ...         image = np.random.random([32]).astype('float32')
-            ...         label = np.random.randint(0, 9, (1, )).astype('int64')
+            ...         label = np.random.randint(0, 9, (1,)).astype('int64')
             ...         return image, label
             ...
             ...     def __len__(self):
             ...         return self.num_samples
-            ...
             >>> dataset = ConcatDataset([RandomDataset(10), RandomDataset(10)])  # type: ignore[var-annotated]
             >>> for i in range(len(dataset)):
             ...     image, label = dataset[i]

--- a/python/paddle/static/amp/fp16_utils.py
+++ b/python/paddle/static/amp/fp16_utils.py
@@ -382,7 +382,7 @@ def fp16_guard():
     transformed as float16 type.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> import numpy as np
             >>> import paddle


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

This PR migrates docstring code-block markers from `python` to `pycon` for interactive examples in the following files:

- `python/paddle/io/dataloader/dataset.py`
- `python/paddle/io/dataloader/batch_sampler.py`
- `python/paddle/static/amp/fp16_utils.py`

Also ran `ruff format` on touched files.

Related PRs:
- #77970

### 是否引起精度变化

否
