### PR TITLE
[API Compatibility] add decorator for paddle.amp.GradScaler -part

### DIFF
--- a/python/paddle/amp/grad_scaler.py
+++ b/python/paddle/amp/grad_scaler.py
@@ -20,6 +20,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     TypedDict,
+    overload,
 )
 
 import numpy as np
@@ -30,6 +31,7 @@ from paddle.base import core, unique_name
 from paddle.base.data_feeder import check_type
 from paddle.base.framework import Operator, _dygraph_tracer, in_pir_mode
 from paddle.framework import in_dynamic_mode
+from paddle.utils.decorator_utils import grad_scaler_decorator
 
 from .auto_cast import amp_global_state
 
@@ -672,18 +674,32 @@ class GradScaler(AmpScaler):
     Commonly, it is used together with `paddle.amp.auto_cast` to achieve Auto-Mixed-Precision in
     dynamic graph mode.
 
+    This API supports three calling conventions:
+
+    ``GradScaler(enable=True, init_loss_scaling=2.0**16, incr_ratio=2.0, decr_ratio=0.5, incr_every_n_steps=2000, decr_every_n_nan_or_inf=1, use_dynamic_loss_scaling=True)``
+
+    ``GradScaler(device, init_scale=2.0**16, growth_factor=2.0, backoff_factor=0.5, growth_interval=2000, enabled=True)``
+
+    ``GradScaler(init_scale=2.0**16, growth_factor=2.0, backoff_factor=0.5, growth_interval=2000, enabled=True)``
+
     Args:
         enable(bool, optional): Enable loss scaling or not. Default is True.
-        init_loss_scaling (float, optional): The initial loss scaling factor. Default is 65536.0.
+            **Alias**: ``enabled``
+        init_loss_scaling (float, optional): The initial loss scaling factor. Default is 2.0**16.
+            **Alias**: ``init_scale``
         incr_ratio(float, optional): The multiplier to use when increasing the loss
                         scaling. Default is 2.0.
+            **Alias**: ``growth_factor``
         decr_ratio(float, optional): The less-than-one-multiplier to use when decreasing
                         the loss scaling. Default is 0.5.
+            **Alias**: ``backoff_factor``
         incr_every_n_steps(int, optional): Increases loss scaling every n consecutive
                                 steps with finite gradients. Default is 2000.
+            **Alias**: ``growth_interval``
         decr_every_n_nan_or_inf(int, optional): Decreases loss scaling every n
                                     accumulated steps with nan or inf gradients. Default is 1.
         use_dynamic_loss_scaling(bool, optional): Whether to use dynamic loss scaling. If False, fixed loss_scaling is used. If True, the loss scaling is updated dynamically. Default is True.
+
     Returns:
         An GradScaler object.
 
@@ -711,6 +727,40 @@ class GradScaler(AmpScaler):
             >>> optimizer.clear_grad()
     """
 
+    @overload
+    def __init__(
+        self,
+        enable: bool = True,
+        init_loss_scaling: float = 2.0**16,
+        incr_ratio: float = 2.0,
+        decr_ratio: float = 0.5,
+        incr_every_n_steps: int = 2000,
+        decr_every_n_nan_or_inf: int = 1,
+        use_dynamic_loss_scaling: bool = True,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        device: str,
+        init_scale: float = 2.0**16,
+        growth_factor: float = 2.0,
+        backoff_factor: float = 0.5,
+        growth_interval: int = 2000,
+        enabled: bool = True,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        init_scale: float = 2.0**16,
+        growth_factor: float = 2.0,
+        backoff_factor: float = 0.5,
+        growth_interval: int = 2000,
+        enabled: bool = True,
+    ) -> None: ...
+
+    @grad_scaler_decorator()
     def __init__(
         self,
         enable: bool = True,
@@ -866,9 +916,14 @@ class GradScaler(AmpScaler):
         if not self._use_dynamic_loss_scaling:
             self._optimizer_states = defaultdict(_refresh_optimizer_state)
 
-    def update(self) -> None:
+    def update(self, new_scale: float | None = None) -> None:
         """
         Updates the loss_scaling.
+
+        Args:
+            new_scale(float, optional): New loss scaling factor. If provided, the loss scaling factor
+                is directly set to ``new_scale`` and the internal step counts are reset.
+                Default is None.
 
         Examples:
 
@@ -895,7 +950,12 @@ class GradScaler(AmpScaler):
         """
         if not self._enable:
             return
-        if self._use_dynamic_loss_scaling:
+        if new_scale is not None:
+            self._scale = paddle.to_tensor([new_scale], dtype='float32')
+            self._incr_count = 0
+            self._decr_count = 0
+            self._optimizer_states = defaultdict(_refresh_optimizer_state)
+        elif self._use_dynamic_loss_scaling:
             self._update()
             self._optimizer_states = defaultdict(_refresh_optimizer_state)
         return
@@ -1278,6 +1338,38 @@ class GradScaler(AmpScaler):
                 3
         """
         super().set_decr_every_n_nan_or_inf(new_decr_every_n_nan_or_inf)
+
+    is_enabled = is_enable
+
+    def get_scale(self) -> float:
+        """
+        Return the current scale factor as a Python float.
+
+        If loss scaling is not enabled, returns 0.0.
+
+        Returns:
+            float: The current loss scaling factor, or 0.0 if disabled.
+
+        Examples:
+
+            .. code-block:: pycon
+
+                >>> # doctest: +REQUIRES(env:GPU, env:XPU)
+                >>> import paddle
+                >>> scaler = paddle.amp.GradScaler(init_loss_scaling=1024)
+                >>> print(scaler.get_scale())
+                1024.0
+        """
+        if self._enable and self._scale is not None:
+            return float(self._scale)
+        return 0.0
+
+    get_growth_factor = get_incr_ratio
+    set_growth_factor = set_incr_ratio
+    get_backoff_factor = get_decr_ratio
+    set_backoff_factor = set_decr_ratio
+    get_growth_interval = get_incr_every_n_steps
+    set_growth_interval = set_incr_every_n_steps
 
     def state_dict(self) -> _ScaleStateDict:
         """

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -25,7 +25,7 @@ from paddle.device import (
     Stream,
     StreamContext,
     _device_to_paddle as _device_to_paddle,
-    amp,  # noqa: F401
+    amp,
     current_device,
     device,
     ipc_collect,
@@ -889,4 +889,5 @@ __all__ = [
     "Event",
     "ipc_collect",
     "StreamContext",
+    "amp",
 ]

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -27,6 +27,7 @@ from typing_extensions import TypeAlias
 
 import paddle
 from paddle.amp import autocast as _autocast
+from paddle.amp.grad_scaler import GradScaler as _GradScaler
 from paddle.base import core, framework
 from paddle.base.framework import (
     is_compiled_with_cinn,
@@ -1976,14 +1977,14 @@ class _AutocastMode:
                 >>> conv2d = paddle.nn.Conv2D(3, 2, 3, bias_attr=False)
                 >>> data = paddle.rand([10, 3, 32, 32])
 
-                >>> with paddle.device.amp.auto_cast():
+                >>> with paddle.device.amp.autocast():
                 ...     conv = conv2d(data)
                 ...     print(conv.dtype)
                 >>> # doctest: +SKIP("This has diff in xdoctest env")
                 paddle.float16
                 >>> # doctest: -SKIP
 
-                >>> with paddle.device.amp.auto_cast(enable=False):
+                >>> with paddle.device.amp.autocast(enabled=False):
                 ...     conv = conv2d(data)
                 ...     print(conv.dtype)
                 >>> # doctest: +SKIP("This has diff in xdoctest env")
@@ -1999,6 +2000,7 @@ class amp:
 
     autocast = staticmethod(_AutocastMode.autocast)
     autocast_mode = _AutocastMode()
+    GradScaler = _GradScaler
 
 
 class nvtx:

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -954,6 +954,83 @@ def variadic_tensor_decorator(
     return decorator
 
 
+def grad_scaler_decorator() -> Callable[
+    [Callable[_InputT, _RetT]], Callable[_InputT, _RetT]
+]:
+    """Decorator for GradScaler.__init__ to support three calling conventions:
+
+    GradScaler(enable, init_loss_scaling, incr_ratio, decr_ratio, incr_every_n_steps, decr_every_n_nan_or_inf, use_dynamic_loss_scaling)
+    GradScaler(device, init_scale, growth_factor, backoff_factor, growth_interval, enabled)
+    GradScaler(init_scale, growth_factor, backoff_factor, growth_interval, enabled)
+    """
+
+    _ALIAS_MAP = {
+        'enabled': 'enable',
+        'init_scale': 'init_loss_scaling',
+        'growth_factor': 'incr_ratio',
+        'backoff_factor': 'decr_ratio',
+        'growth_interval': 'incr_every_n_steps',
+    }
+    # PyTorch positional order (device already stripped): init_scale, growth_factor, backoff_factor, growth_interval, enabled
+    _TORCH_POS_NAMES = [
+        'init_loss_scaling',
+        'incr_ratio',
+        'decr_ratio',
+        'incr_every_n_steps',
+        'enable',
+    ]
+
+    def _remap_kwargs(kwargs: dict[str, Any]) -> None:
+        for torch_key, paddle_key in _ALIAS_MAP.items():
+            if torch_key in kwargs:
+                if paddle_key not in kwargs:
+                    kwargs[paddle_key] = kwargs.pop(torch_key)
+                else:
+                    raise ValueError(
+                        f"Cannot specify both '{paddle_key}' and its alias '{torch_key}'"
+                    )
+
+    def decorator(func: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> _RetT:
+            # args[0] is always `self` for a bound __init__ call
+            real_args = args[1:]
+
+            # Drop PyTorch-only 'device' kwarg (no Paddle equivalent)
+            kwargs.pop('device', None)
+
+            # Remap PyTorch keyword aliases to Paddle names unconditionally
+            _remap_kwargs(kwargs)
+
+            if real_args and isinstance(real_args[0], str):
+                # PyTorch with device prefix: GradScaler('cuda', init_scale=1024, ...)
+                # Strip device; remaining positional follow torch order
+                torch_pos = real_args[1:]
+                args = args[:1]  # keep only self
+                for i, val in enumerate(torch_pos):
+                    if i < len(_TORCH_POS_NAMES):
+                        name = _TORCH_POS_NAMES[i]
+                        if name not in kwargs:
+                            kwargs[name] = val
+            elif real_args and not isinstance(real_args[0], bool):
+                # PyTorch positional without device: GradScaler(1024, 2.0, 0.5, ...)
+                # int/float but not bool: first arg is init_scale (PyTorch), not enable (Paddle)
+                args = args[:1]  # keep only self
+                for i, val in enumerate(real_args):
+                    if i < len(_TORCH_POS_NAMES):
+                        name = _TORCH_POS_NAMES[i]
+                        if name not in kwargs:
+                            kwargs[name] = val
+            # else: Paddle call — pass through unchanged
+
+            return func(*args, **kwargs)
+
+        wrapper.__signature__ = inspect.signature(func)
+        return wrapper
+
+    return decorator
+
+
 def index_fill_decorator() -> Callable[
     [Callable[_InputT, _RetT]], Callable[_InputT, _RetT]
 ]:

--- a/test/amp/CMakeLists.txt
+++ b/test/amp/CMakeLists.txt
@@ -4,6 +4,10 @@ file(
   "test_*.py")
 string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 
+if(NOT WITH_GPU AND NOT WITH_XPU)
+  list(REMOVE_ITEM TEST_OPS test_grad_scaler_out)
+endif()
+
 function(py_test_modules TARGET_NAME)
   if(WITH_TESTING)
     set(options SERIAL)

--- a/test/amp/test_grad_scaler_out.py
+++ b/test/amp/test_grad_scaler_out.py
@@ -1,0 +1,314 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+from paddle.amp import AmpScaler, GradScaler
+
+
+class TestGradScalerParamAlias(unittest.TestCase):
+    """Test ParamAliasDecorator: PyTorch aliases, Paddle names, mixed,
+    positional args, single alias, conflict detection, and non-aliased params."""
+
+    def _assert_scaler(self, scaler, **expected):
+        """Helper to check multiple scaler attributes at once."""
+        attr_map = {
+            'enable': '_enable',
+            'init_loss_scaling': '_init_loss_scaling',
+            'incr_ratio': '_incr_ratio',
+            'decr_ratio': '_decr_ratio',
+            'incr_every_n_steps': '_incr_every_n_steps',
+            'decr_every_n_nan_or_inf': '_decr_every_n_nan_or_inf',
+            'use_dynamic_loss_scaling': '_use_dynamic_loss_scaling',
+        }
+        for key, val in expected.items():
+            self.assertEqual(getattr(scaler, attr_map[key]), val, msg=key)
+
+    def test_default_values(self):
+        self._assert_scaler(
+            GradScaler(),
+            enable=True,
+            init_loss_scaling=2.0**16,
+            incr_ratio=2.0,
+            decr_ratio=0.5,
+            incr_every_n_steps=2000,
+            decr_every_n_nan_or_inf=1,
+            use_dynamic_loss_scaling=True,
+        )
+
+    def test_pytorch_style_kwargs(self):
+        self._assert_scaler(
+            GradScaler(
+                enabled=True,
+                init_scale=1024.0,
+                growth_factor=3.0,
+                backoff_factor=0.25,
+                growth_interval=500,
+            ),
+            enable=True,
+            init_loss_scaling=1024.0,
+            incr_ratio=3.0,
+            decr_ratio=0.25,
+            incr_every_n_steps=500,
+        )
+
+    def test_mixed_kwargs(self):
+        self._assert_scaler(
+            GradScaler(
+                enable=True,
+                init_loss_scaling=1024.0,
+                growth_factor=3.0,
+                decr_ratio=0.25,
+                growth_interval=500,
+            ),
+            init_loss_scaling=1024.0,
+            incr_ratio=3.0,
+            decr_ratio=0.25,
+            incr_every_n_steps=500,
+        )
+
+    def test_single_alias_each(self):
+        self.assertFalse(GradScaler(enabled=False)._enable)
+        self.assertEqual(GradScaler(init_scale=512.0)._init_loss_scaling, 512.0)
+        self.assertEqual(GradScaler(growth_factor=5.0)._incr_ratio, 5.0)
+        self.assertEqual(GradScaler(backoff_factor=0.1)._decr_ratio, 0.1)
+        self.assertEqual(
+            GradScaler(growth_interval=100)._incr_every_n_steps, 100
+        )
+
+    def test_positional_args(self):
+        self._assert_scaler(
+            GradScaler(True, 1024.0, 3.0, 0.25, 500, 2, True),
+            enable=True,
+            init_loss_scaling=1024.0,
+            incr_ratio=3.0,
+            decr_ratio=0.25,
+            incr_every_n_steps=500,
+            decr_every_n_nan_or_inf=2,
+        )
+
+    def test_positional_with_alias_kwarg(self):
+        self._assert_scaler(
+            GradScaler(True, 1024.0, growth_factor=5.0),
+            enable=True,
+            init_loss_scaling=1024.0,
+            incr_ratio=5.0,
+        )
+
+    def test_non_aliased_with_aliases(self):
+        self._assert_scaler(
+            GradScaler(
+                enabled=True,
+                init_scale=2048.0,
+                decr_every_n_nan_or_inf=3,
+                use_dynamic_loss_scaling=False,
+            ),
+            enable=True,
+            init_loss_scaling=2048.0,
+            decr_every_n_nan_or_inf=3,
+            use_dynamic_loss_scaling=False,
+        )
+
+    def test_pytorch_vs_paddle_equivalence(self):
+        pt = GradScaler(
+            enabled=True,
+            init_scale=1024.0,
+            growth_factor=3.0,
+            backoff_factor=0.25,
+            growth_interval=500,
+        )
+        pd = GradScaler(
+            enable=True,
+            init_loss_scaling=1024.0,
+            incr_ratio=3.0,
+            decr_ratio=0.25,
+            incr_every_n_steps=500,
+        )
+        for attr in (
+            '_enable',
+            '_init_loss_scaling',
+            '_incr_ratio',
+            '_decr_ratio',
+            '_incr_every_n_steps',
+        ):
+            self.assertEqual(getattr(pt, attr), getattr(pd, attr), msg=attr)
+
+    def test_conflict_raises_error(self):
+        conflicts = [
+            {"enable": True, "enabled": False},
+            {"init_loss_scaling": 1024.0, "init_scale": 2048.0},
+            {"incr_ratio": 2.0, "growth_factor": 3.0},
+            {"decr_ratio": 0.5, "backoff_factor": 0.25},
+            {"incr_every_n_steps": 1000, "growth_interval": 2000},
+        ]
+        for kwargs in conflicts:
+            with self.assertRaises(ValueError, msg=str(kwargs)):
+                GradScaler(**kwargs)
+
+    def test_torch_positional_no_device(self):
+        # PyTorch older API: init_scale first (float -> detected as torch positional)
+        self._assert_scaler(
+            GradScaler(1024.0, 3.0, 0.25, 500, True),
+            enable=True,
+            init_loss_scaling=1024.0,
+            incr_ratio=3.0,
+            decr_ratio=0.25,
+            incr_every_n_steps=500,
+        )
+
+    def test_torch_positional_no_device_disabled(self):
+        # PyTorch: GradScaler(init_scale, ..., enabled=False)
+        scaler = GradScaler(1024.0, 2.0, 0.5, 2000, False)
+        self.assertFalse(scaler._enable)
+        self.assertEqual(scaler._init_loss_scaling, 1.0)
+
+    def test_torch_positional_with_device(self):
+        # PyTorch newer API: device string first
+        self._assert_scaler(
+            GradScaler('cuda', 1024.0, 3.0, 0.25, 500, True),
+            enable=True,
+            init_loss_scaling=1024.0,
+            incr_ratio=3.0,
+            decr_ratio=0.25,
+            incr_every_n_steps=500,
+        )
+
+    def test_torch_device_kwarg_dropped(self):
+        # device kwarg is silently ignored (no Paddle equivalent)
+        self._assert_scaler(
+            GradScaler(device='cuda', init_scale=2048.0, growth_factor=3.0),
+            init_loss_scaling=2048.0,
+            incr_ratio=3.0,
+        )
+
+    def test_torch_device_string_with_kwargs(self):
+        # device as positional string combined with torch keyword aliases
+        self._assert_scaler(
+            GradScaler('cuda', init_scale=512.0, enabled=True),
+            enable=True,
+            init_loss_scaling=512.0,
+        )
+
+    def test_torch_positional_partial(self):
+        # Only init_scale positionally, rest default
+        self._assert_scaler(
+            GradScaler(4096.0),
+            init_loss_scaling=4096.0,
+            incr_ratio=2.0,
+            decr_ratio=0.5,
+            incr_every_n_steps=2000,
+        )
+
+    def test_torch_device_string_only(self):
+        # GradScaler('cuda') — device only, all remaining params default
+        self._assert_scaler(
+            GradScaler('cuda'),
+            enable=True,
+            init_loss_scaling=2.0**16,
+            incr_ratio=2.0,
+            decr_ratio=0.5,
+            incr_every_n_steps=2000,
+        )
+
+    def test_torch_device_string_partial_positional(self):
+        # GradScaler('cuda', init_scale) — device + only first positional param
+        self._assert_scaler(
+            GradScaler('cuda', 1024.0),
+            enable=True,
+            init_loss_scaling=1024.0,
+            incr_ratio=2.0,
+            decr_ratio=0.5,
+            incr_every_n_steps=2000,
+        )
+
+    def test_torch_positional_with_kwarg_disabled(self):
+        # GradScaler(init_scale, enabled=False) — positional float + torch kwarg
+        scaler = GradScaler(1024.0, enabled=False)
+        self.assertFalse(scaler._enable)
+        self.assertEqual(scaler._init_loss_scaling, 1.0)
+
+    def test_disabled_scaler(self):
+        scaler = GradScaler(enabled=False)
+        self.assertFalse(scaler._enable)
+        self.assertEqual(scaler._init_loss_scaling, 1.0)
+
+
+class TestGradScalerPytorchCompatMethods(unittest.TestCase):
+    """Test PyTorch-compatible getter/setter methods."""
+
+    def test_is_enabled(self):
+        self.assertTrue(GradScaler(enabled=True).is_enabled())
+        self.assertFalse(GradScaler(enabled=False).is_enabled())
+
+    def test_get_scale(self):
+        self.assertEqual(GradScaler(init_scale=2048.0).get_scale(), 2048.0)
+        self.assertEqual(GradScaler(enabled=False).get_scale(), 0.0)
+
+    def test_growth_factor_get_set(self):
+        s = GradScaler(growth_factor=3.0)
+        self.assertEqual(s.get_growth_factor(), 3.0)
+        s.set_growth_factor(5.0)
+        self.assertEqual(s.get_growth_factor(), 5.0)
+        self.assertEqual(s.get_incr_ratio(), 5.0)
+
+    def test_backoff_factor_get_set(self):
+        s = GradScaler(backoff_factor=0.25)
+        self.assertEqual(s.get_backoff_factor(), 0.25)
+        s.set_backoff_factor(0.1)
+        self.assertEqual(s.get_backoff_factor(), 0.1)
+        self.assertEqual(s.get_decr_ratio(), 0.1)
+
+    def test_growth_interval_get_set(self):
+        s = GradScaler(growth_interval=500)
+        self.assertEqual(s.get_growth_interval(), 500)
+        s.set_growth_interval(100)
+        self.assertEqual(s.get_growth_interval(), 100)
+        self.assertEqual(s.get_incr_every_n_steps(), 100)
+
+
+class TestGradScalerCallPathsAndInheritance(unittest.TestCase):
+    """Test all public call paths and AmpScaler vs GradScaler defaults."""
+
+    def test_all_paths_same_class(self):
+        self.assertIs(paddle.device.amp.GradScaler, GradScaler)
+        self.assertIs(paddle.cuda.amp.GradScaler, GradScaler)
+
+    def test_gradscaler_is_subclass_of_ampscaler(self):
+        self.assertTrue(issubclass(GradScaler, AmpScaler))
+
+    def test_alias_via_device_and_cuda(self):
+        s1 = paddle.device.amp.GradScaler(init_scale=512.0, growth_factor=4.0)
+        self.assertEqual(s1._init_loss_scaling, 512.0)
+        self.assertEqual(s1._incr_ratio, 4.0)
+
+        s2 = paddle.cuda.amp.GradScaler(backoff_factor=0.3, growth_interval=800)
+        self.assertEqual(s2._decr_ratio, 0.3)
+        self.assertEqual(s2._incr_every_n_steps, 800)
+
+    def test_defaults_differ_from_ampscaler(self):
+        a, g = AmpScaler(), GradScaler()
+        # Intentionally different: GradScaler aligns with PyTorch
+        self.assertEqual(a._init_loss_scaling, 2.0**15)
+        self.assertEqual(g._init_loss_scaling, 2.0**16)
+        self.assertEqual(a._incr_every_n_steps, 1000)
+        self.assertEqual(g._incr_every_n_steps, 2000)
+        # Shared defaults stay the same
+        self.assertEqual(a._incr_ratio, g._incr_ratio)
+        self.assertEqual(a._decr_ratio, g._decr_ratio)
+        self.assertEqual(a._decr_every_n_nan_or_inf, g._decr_every_n_nan_or_inf)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
User Experience


### PR Types
New features


### Description


```
GradScaler(enable=True, init_loss_scaling=2.0**16, incr_ratio=2.0, decr_ratio=0.5, incr_every_n_steps=2000, decr_every_n_nan_or_inf=1, use_dynamic_loss_scaling=True)

GradScaler(device, init_scale=2.0**16, growth_factor=2.0, backoff_factor=0.5, growth_interval=2000, enabled=True)

GradScaler(init_scale=2.0**16, growth_factor=2.0, backoff_factor=0.5, growth_interval=2000, enabled=True)
```

### 是否引起精度变化
否
