### PR TITLE
[CodeStyle][DocFormat][134] Use pycon marker in quantization docs examples

### DIFF
--- a/python/paddle/quantization/config.py
+++ b/python/paddle/quantization/config.py
@@ -75,7 +75,7 @@ class QuantConfig:
         weight(QuanterFactory | None): The global quantizer used to quantize the weights.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> from paddle.quantization import QuantConfig
             >>> from paddle.quantization.quanters import FakeQuanterWithAbsMaxObserver
@@ -121,7 +121,7 @@ class QuantConfig:
             weight(QuanterFactory | None): Quanter used for weights. Default is None.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.nn import Linear
@@ -129,9 +129,9 @@ class QuantConfig:
                 >>> from paddle.quantization.quanters import FakeQuanterWithAbsMaxObserver
 
                 >>> class Model(paddle.nn.Layer):
-                ...    def __init__(self):
-                ...        super().__init__()
-                ...        self.fc = Linear(576, 120)
+                ...     def __init__(self):
+                ...         super().__init__()
+                ...         self.fc = Linear(576, 120)
                 >>> model = Model()
                 >>> quanter = FakeQuanterWithAbsMaxObserver(moving_rate=0.9)
                 >>> q_config = QuantConfig(activation=None, weight=None)
@@ -170,7 +170,7 @@ class QuantConfig:
             weight(QuanterFactory | None): Quanter used for weights. Default is None.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.nn import Linear
@@ -308,7 +308,7 @@ class QuantConfig:
             layer_type(type[Layer]): The type of layer to be declared as leaf.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> from paddle.nn import Sequential
                 >>> from paddle.quantization import QuantConfig
@@ -415,7 +415,7 @@ class QuantConfig:
             model(Layer): The model to be specified by the config.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> import paddle
                 >>> from paddle.nn import Linear, Sequential
@@ -425,7 +425,7 @@ class QuantConfig:
                 >>> class Model(paddle.nn.Layer):
                 ...     def __init__(self):
                 ...         super().__init__()
-                ...         self.fc = Sequential(Linear(576, 120),Linear(576, 120))
+                ...         self.fc = Sequential(Linear(576, 120), Linear(576, 120))
                 >>> model = Model()
                 >>> quanter = FakeQuanterWithAbsMaxObserver(moving_rate=0.9)
                 >>> q_config = QuantConfig(activation=None, weight=None)

--- a/python/paddle/quantization/factory.py
+++ b/python/paddle/quantization/factory.py
@@ -85,7 +85,7 @@ def quanter(
         class_name (str): The name of factory class to be declared.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> # type: ignore
             >>> # doctest: +SKIP('need 2 file to run example')

--- a/python/paddle/quantization/observers/abs_max.py
+++ b/python/paddle/quantization/observers/abs_max.py
@@ -30,7 +30,7 @@ class AbsmaxObserver(ObserverFactory):
             For details, please refer to :ref:`api_guide_Name`. Default is None.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> from paddle.quantization import QuantConfig
             >>> from paddle.quantization.quanters import FakeQuanterWithAbsMaxObserver

--- a/python/paddle/quantization/qat.py
+++ b/python/paddle/quantization/qat.py
@@ -31,7 +31,7 @@ class QAT(Quantization):
         config(QuantConfig): Quantization configuration
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> from paddle.quantization import QAT, QuantConfig
             >>> from paddle.quantization.quanters import FakeQuanterWithAbsMaxObserver
@@ -57,7 +57,7 @@ class QAT(Quantization):
         Return: The prepared model for quantization-aware training.
 
         Examples:
-            .. code-block:: python
+            .. code-block:: pycon
 
                 >>> from paddle.quantization import QAT, QuantConfig
                 >>> from paddle.quantization.quanters import FakeQuanterWithAbsMaxObserver

--- a/python/paddle/quantization/quanters/abs_max.py
+++ b/python/paddle/quantization/quanters/abs_max.py
@@ -67,7 +67,7 @@ class FakeQuanterWithAbsMaxObserver(QuanterFactory):
             For details, please refer to :ref:`api_guide_Name`. Default is None.
 
     Examples:
-        .. code-block:: python
+        .. code-block:: pycon
 
             >>> from paddle.quantization import QuantConfig
             >>> from paddle.quantization.quanters import FakeQuanterWithAbsMaxObserver


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Docs

### Description

Migrate docstring code-block markers from `python` to `pycon` in quantization docs where examples use interactive prompts (`>>>`).

Updated files:

- `python/paddle/quantization/qat.py`
- `python/paddle/quantization/config.py`
- `python/paddle/quantization/factory.py`
- `python/paddle/quantization/quanters/abs_max.py`
- `python/paddle/quantization/observers/abs_max.py`

### 是否引起精度变化

否

This is part of the docstring highlight marker migration series.
