### PR TITLE
[API Compatibility] add param alias for parameters in paddle.nn.ParameterDict -part

### DIFF
--- a/python/paddle/nn/layer/container.py
+++ b/python/paddle/nn/layer/container.py
@@ -335,6 +335,7 @@ class ParameterDict(Layer):
 
     Parameters:
         parameters (iterable, optional): a mapping (dictionary) of (string : Any) or an iterable of key-value pairs of type (string, Any)
+            alias: values
 
     Examples:
         .. code-block:: pycon
@@ -375,6 +376,7 @@ class ParameterDict(Layer):
             paddle.Size([5, 4])
     """
 
+    @param_one_alias(["parameters", "values"])
     def __init__(
         self,
         parameters: (
@@ -418,7 +420,10 @@ class ParameterDict(Layer):
             + type(parameters).__name__
         )
 
-        if isinstance(parameters, (OrderedDict, ParameterDict, Mapping)):
+        if isinstance(parameters, ParameterDict):
+            for key, parameter in parameters._parameters.items():
+                self.add_parameter(key, parameter)
+        elif isinstance(parameters, (OrderedDict, Mapping)):
             for key, parameter in parameters.items():
                 self.add_parameter(key, parameter)
         else:

--- a/test/legacy_test/test_imperative_container_parameterdict.py
+++ b/test/legacy_test/test_imperative_container_parameterdict.py
@@ -22,6 +22,10 @@ import paddle
 from paddle import base
 
 
+def _make_param(shape, dtype='float32'):
+    return paddle.create_parameter(shape=shape, dtype=dtype)
+
+
 class MyLayer(paddle.nn.Layer):
     def __init__(self, num_stacked_param):
         super().__init__()
@@ -46,6 +50,8 @@ class MyLayer(paddle.nn.Layer):
 
 
 class TestImperativeContainerParameterDict(unittest.TestCase):
+    """Original test: basic forward/backward with list-of-tuples init and update."""
+
     def parameter_dict(self):
         self.place = get_device_place()
         data_np = np.random.uniform(-1, 1, [5, 2]).astype('float32')
@@ -81,6 +87,197 @@ class TestImperativeContainerParameterDict(unittest.TestCase):
 
     def test_parameter_dict(self):
         self.parameter_dict()
+
+
+class TestParameterDictInit(unittest.TestCase):
+    def test_init_types(self):
+        # None, plain dict, OrderedDict, list of tuples
+        self.assertEqual(len(paddle.nn.ParameterDict()), 0)
+        self.assertEqual(
+            len(paddle.nn.ParameterDict({'w': _make_param([2, 3])})), 1
+        )
+        self.assertEqual(
+            len(
+                paddle.nn.ParameterDict(
+                    OrderedDict([('w', _make_param([2, 3]))])
+                )
+            ),
+            1,
+        )
+        self.assertEqual(
+            len(paddle.nn.ParameterDict([('w', _make_param([2, 3]))])), 1
+        )
+
+    def test_init_with_parameter_dict(self):
+        # ParameterDict as input — exercises the update() fix
+        pd1 = paddle.nn.ParameterDict({'w': _make_param([2, 3])})
+        pd2 = paddle.nn.ParameterDict(pd1)
+        self.assertEqual(len(pd2), 1)
+
+    def test_init_with_values_alias(self):
+        # @param_one_alias: 'values' maps to 'parameters'
+        pd = paddle.nn.ParameterDict(values={'w': _make_param([2, 3])})
+        self.assertEqual(len(pd), 1)
+
+    def test_init_preserves_order(self):
+        keys_in = ['c', 'a', 'b']
+        pd = paddle.nn.ParameterDict(
+            OrderedDict([(k, _make_param([1, 2])) for k in keys_in])
+        )
+        self.assertEqual(list(pd), keys_in)
+
+    def test_init_errors(self):
+        with self.assertRaises((ValueError, TypeError)):
+            paddle.nn.ParameterDict([('w', _make_param([2, 3]), 'extra')])
+        with self.assertRaises((AssertionError, TypeError)):
+            paddle.nn.ParameterDict(42)
+
+
+class TestParameterDictAccess(unittest.TestCase):
+    def setUp(self):
+        self.pd = paddle.nn.ParameterDict(
+            {'w1': _make_param([2, 3]), 'w2': _make_param([3, 4])}
+        )
+
+    def test_getitem(self):
+        self.assertEqual(list(self.pd['w1'].shape), [2, 3])
+        self.assertEqual(list(self.pd['w2'].shape), [3, 4])
+
+    def test_setitem(self):
+        self.pd['w1'] = _make_param([2, 5])  # replace
+        self.assertEqual(list(self.pd['w1'].shape), [2, 5])
+        self.pd['w3'] = _make_param([4, 5])  # add new
+        self.assertEqual(len(self.pd), 3)
+
+    def test_setitem_non_parameter_raises(self):
+        with self.assertRaises((AssertionError, TypeError)):
+            self.pd['bad'] = paddle.to_tensor([1.0, 2.0])
+
+    def test_len_iter_contains(self):
+        self.assertEqual(len(self.pd), 2)
+        self.assertEqual(sorted(self.pd), ['w1', 'w2'])
+        self.assertIn('w1', self.pd)
+        self.assertNotIn('missing', self.pd)
+
+
+class TestParameterDictUpdate(unittest.TestCase):
+    def setUp(self):
+        self.pd = paddle.nn.ParameterDict({'w1': _make_param([2, 3])})
+
+    def test_update_input_types(self):
+        # plain dict, OrderedDict, list of tuples
+        self.pd.update({'w2': _make_param([3, 4])})
+        self.assertEqual(len(self.pd), 2)
+        self.pd.update(OrderedDict([('w3', _make_param([4, 5]))]))
+        self.assertEqual(len(self.pd), 3)
+        self.pd.update([('w4', _make_param([5, 6]))])
+        self.assertEqual(len(self.pd), 4)
+
+    def test_update_from_parameter_dict(self):
+        # ParameterDict as input — exercises the update() fix
+        other = paddle.nn.ParameterDict({'w2': _make_param([3, 4])})
+        self.pd.update(other)
+        self.assertEqual(len(self.pd), 2)
+
+    def test_update_overwrites(self):
+        self.pd.update({'w1': _make_param([2, 5])})
+        self.assertEqual(list(self.pd['w1'].shape), [2, 5])
+
+    def test_update_errors(self):
+        with self.assertRaises((ValueError, TypeError)):
+            self.pd.update([('w2', _make_param([3, 4]), 'extra')])
+        with self.assertRaises((AssertionError, TypeError)):
+            self.pd.update(42)
+
+
+class TestParameterDictRegistration(unittest.TestCase):
+    def _make_model(self):
+        class M(paddle.nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.pd = paddle.nn.ParameterDict(
+                    {'w1': _make_param([2, 3]), 'w2': _make_param([3, 4])}
+                )
+
+            def forward(self, x):
+                return paddle.matmul(
+                    paddle.matmul(x, self.pd['w1']), self.pd['w2']
+                )
+
+        return M()
+
+    def test_registered_in_parameters_named_state_dict(self):
+        model = self._make_model()
+        self.assertEqual(len(list(model.parameters())), 2)
+        named = dict(model.named_parameters())
+        self.assertIn('pd.w1', named)
+        self.assertIn('pd.w2', named)
+        state = model.state_dict()
+        self.assertIn('pd.w1', state)
+        self.assertIn('pd.w2', state)
+
+    def test_gradient_flows(self):
+        model = self._make_model()
+        paddle.matmul(paddle.uniform([2, 2]), model.pd['w1']).sum().backward()
+        self.assertIsNotNone(model.pd['w1'].grad)
+
+    def test_dynamic_setitem_and_update_registered(self):
+        class M(paddle.nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.pd = paddle.nn.ParameterDict()
+
+            def forward(self, x):
+                return x
+
+        model = M()
+        model.pd['w'] = _make_param([2, 2])
+        model.pd.update({'v': _make_param([2, 2])})
+        self.assertEqual(len(list(model.parameters())), 2)
+        named = dict(model.named_parameters())
+        self.assertIn('pd.w', named)
+        self.assertIn('pd.v', named)
+
+
+class TestParameterDictForwardBackward(unittest.TestCase):
+    def _chain_model(self, n):
+        class M(paddle.nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.pd = paddle.nn.ParameterDict(
+                    {f't{i}': _make_param([2, 2]) for i in range(n)}
+                )
+
+            def forward(self, x):
+                for key in self.pd:
+                    x = paddle.matmul(x, self.pd[key])
+                return x
+
+        return M()
+
+    def test_forward_and_backward(self):
+        model = self._chain_model(3)
+        x = paddle.uniform([5, 2])
+        out = model(x)
+        self.assertEqual(list(out.shape), [5, 2])
+        paddle.mean(out).backward()
+        for key in model.pd:
+            self.assertIsNotNone(model.pd[key].grad)
+
+    def test_replace_param_changes_output_shape(self):
+        model = self._chain_model(2)
+        x = paddle.uniform([3, 2])
+        self.assertEqual(list(model(x).shape), [3, 2])
+        model.pd['t1'] = _make_param([2, 5])
+        self.assertEqual(list(model(x).shape), [3, 5])
+
+    def test_float64_params(self):
+        pd = paddle.nn.ParameterDict(
+            {'w': paddle.create_parameter(shape=[2, 3], dtype='float64')}
+        )
+        out = paddle.matmul(paddle.uniform([1, 2], dtype='float64'), pd['w'])
+        self.assertEqual(list(out.shape), [1, 3])
+        self.assertEqual(out.dtype, paddle.float64)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### PR Category
User Experience


### PR Types
New features


### Description
  1. Add values as an alias for the parameters argument in ParameterDict.__init__ via @param_one_alias
  2. Fix update() when passed another ParameterDict: the original code called .items() on a ParameterDict, but ParameterDict has no items() method, causing AttributeError. Fixed by routing ParameterDict inputs through ._parameters.items() directly.


### 是否引起精度变化
否
