### PR TITLE
[Doc Link Fix No.4-5] 文档链接修复

### DIFF
--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -264,8 +264,8 @@ class SliceOpMaker : public framework::OpProtoAndCheckerMaker {
     AddComment(R"DOC(
 Slice Operator.
 
-Produces a slice of the input tensor along multiple axes. Similar to numpy:
-https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
+ Produces a slice of the input tensor along multiple axes. Similar to numpy:
+https://numpy.org/doc/stable/user/basics.indexing.html
 Slice uses `axes`, `starts` and `ends` attributes to specify the start and
 end dimension for each axis in the list of axes, it uses this information
 to slice the input data tensor. If a negative value is passed for any of

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -323,7 +323,7 @@ def slice(
 ) -> Tensor:
     """
     This operator produces a slice of ``input`` along multiple axes. Similar to numpy:
-    https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
+    https://numpy.org/doc/stable/user/basics.indexing.html
     Slice uses ``axes``, ``starts`` and ``ends`` attributes to specify the start and
     end dimension for each axis in the list of axes and Slice uses this information
     to slice the input data tensor. If a negative value is passed to
@@ -6102,8 +6102,8 @@ def strided_slice(
     name: str | None = None,
 ) -> Tensor:
     """
-    This operator produces a slice of ``x`` along multiple axes. Similar to numpy:
-    https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
+     This operator produces a slice of ``x`` along multiple axes. Similar to numpy:
+    https://numpy.org/doc/stable/user/basics.indexing.html
     Slice uses ``axes``, ``starts`` and ``ends`` attributes to specify the start and
     end dimension for each axis in the list of axes and Slice uses this information
     to slice the input data tensor. If a negative value is passed to

--- a/python/paddle/text/datasets/conll05.py
+++ b/python/paddle/text/datasets/conll05.py
@@ -45,8 +45,7 @@ UNK_IDX = 0
 
 class Conll05st(Dataset):
     """
-    Implementation of `Conll05st <https://www.cs.upc.edu/~srlconll/soft.html>`_
-    test dataset.
+    This class implements the Conll05st test dataset. For details, please refer to the relevant documentation:https://aclanthology.org/W05-0620.pdf
 
     Note: only support download test dataset automatically for that
           only test dataset of Conll05st is public.

--- a/python/paddle/text/datasets/imdb.py
+++ b/python/paddle/text/datasets/imdb.py
@@ -38,7 +38,7 @@ MD5 = '7c2ac02c03563afcf9b574c7e56c153a'
 
 class Imdb(Dataset):
     """
-    Implementation of `IMDB <https://www.imdb.com/interfaces/>`_ dataset.
+    Implementation of `IMDB <https://datasets.imdbws.com/>`_ dataset.
 
     Args:
         data_file(str|None): path to data tar file, can be set None if


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Docs
### Description
<!-- Describe what you’ve done -->

Fixed two links errors in Conll05st_cn.rst and Imdb_cn.rst, referring to https://github.com/PaddlePaddle/docs/pull/7767
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否