### PR TITLE
fix: replace 232 bare except clauses with except Exception

### DIFF
--- a/python/paddle/base/core.py
+++ b/python/paddle/base/core.py
@@ -208,7 +208,7 @@ def load_dso(dso_absolute_path):
             from ctypes import cdll
 
             cdll.LoadLibrary(dso_absolute_path)
-        except:
+        except Exception:
             warnings.warn(f"Load {dso_absolute_path} failed")
 
 

--- a/python/paddle/base/dataset.py
+++ b/python/paddle/base/dataset.py
@@ -61,7 +61,7 @@ class DatasetFactory:
         try:
             dataset = globals()[datafeed_class]()
             return dataset
-        except:
+        except Exception:
             raise ValueError(f"datafeed class {datafeed_class} does not exist")
 
 

--- a/python/paddle/base/default_scope_funcs.py
+++ b/python/paddle/base/default_scope_funcs.py
@@ -89,7 +89,7 @@ def scoped_function(func):
     enter_local_scope()
     try:
         func()
-    except:
+    except Exception:
         raise
     finally:
         leave_local_scope()

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -2133,7 +2133,7 @@ class Variable(metaclass=VariableMetaClass):
             )
         try:
             return func(self)
-        except:
+        except Exception:
             raise ValueError(f"The PyFunc {func.__name__} could not be applied")
 
     def __str__(self):

--- a/python/paddle/base/incubate/checkpoint/checkpoint_saver.py
+++ b/python/paddle/base/incubate/checkpoint/checkpoint_saver.py
@@ -180,7 +180,7 @@ class CheckpointSaver:
             try:
                 n = int(g[1])
                 a.append(n)
-            except:
+            except Exception:
                 continue
 
         a.sort()

--- a/python/paddle/base/layers/math_op_patch.py
+++ b/python/paddle/base/layers/math_op_patch.py
@@ -126,7 +126,7 @@ def monkey_patch_variable():
     def safe_get_dtype(var):
         try:
             dtype = var.dtype
-        except:
+        except Exception:
             raise ValueError(f"Cannot get data type from {var.name}")
         return dtype
 

--- a/python/paddle/base/reader.py
+++ b/python/paddle/base/reader.py
@@ -125,7 +125,7 @@ def _reader_process_loop(
     except KeyboardInterrupt:
         # NOTE: Main process will raise KeyboardInterrupt anyways, ignore it in child process
         pass
-    except:
+    except Exception:
         raise
 
 

--- a/python/paddle/decomposition/decomp.py
+++ b/python/paddle/decomposition/decomp.py
@@ -1018,7 +1018,7 @@ def auto_recompute_pir_program(pir_program, is_forward_op_func=None):
             fwd_op_end_idx = max(
                 get_forward_op_idxs(pir_program, is_forward_op_func)
             )
-        except:
+        except Exception:
             logger.info("No Forward Ops Found!")
 
     if fwd_op_end_idx == -1:

--- a/python/paddle/decomposition/recompute.py
+++ b/python/paddle/decomposition/recompute.py
@@ -1003,14 +1003,14 @@ def get_real_define_op_name(value_node):
 def is_dynamic_value_node(value_node):
     try:
         return -1 in value_node.shape
-    except:
+    except Exception:
         raise ValueError(f"value node not found in program: {value_node} ")
 
 
 def is_vector_value_node(value_node):
     try:
         return value_node.type().as_vec_type() is not None
-    except:
+    except Exception:
         raise ValueError(f"value node illegal: {value_node} ")
 
 

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -590,7 +590,7 @@ def is_bf16_supported(including_emulation: bool = True) -> bool:
     try:
         paddle.tensor([1.0], dtype=paddle.bfloat16, device=device)
         return True
-    except:
+    except Exception:
         return False
 
 

--- a/python/paddle/distributed/auto_parallel/static/cluster.py
+++ b/python/paddle/distributed/auto_parallel/static/cluster.py
@@ -544,7 +544,7 @@ class AlphaLatency:
         if self._switch is not None:
             try:
                 self._switch = float(self._switch)
-            except:
+            except Exception:
                 raise TypeError("The switch latency must be float")
         self._base_ring = (
             self._base.get("ring", None) if self._base is not None else None
@@ -558,12 +558,12 @@ class AlphaLatency:
         if self._base_ring is not None:
             try:
                 self._base_ring = float(self._base_ring)
-            except:
+            except Exception:
                 raise TypeError("The base ring latency must be float.")
         if self._base_tree is not None:
             try:
                 self._base_tree = float(self._base_tree)
-            except:
+            except Exception:
                 raise TypeError("The base ring latency must be float.")
 
         self._inter_ring = self._inter.get("ring", None)
@@ -578,7 +578,7 @@ class AlphaLatency:
             else:
                 try:
                     self._inter_ring = float(self._inter_ring)
-                except:
+                except Exception:
                     raise TypeError("The inter ring latency must be float.")
 
         if self._inter_tree is not None:
@@ -588,7 +588,7 @@ class AlphaLatency:
             else:
                 try:
                     self._inter_tree = float(self._inter_tree)
-                except:
+                except Exception:
                     raise TypeError("The inter tree latency must be float.")
 
         if self._intra_ring is not None:
@@ -598,7 +598,7 @@ class AlphaLatency:
             else:
                 try:
                     self._intra_ring = float(self._intra_ring)
-                except:
+                except Exception:
                     raise TypeError("The intra ring latency must be float.")
 
         if self._intra_tree is not None:
@@ -608,7 +608,7 @@ class AlphaLatency:
             else:
                 try:
                     self._intra_tree = float(self._intra_tree)
-                except:
+                except Exception:
                     raise TypeError("The intra tree latency must be float.")
 
     @property
@@ -1399,7 +1399,7 @@ def get_default_cluster(json_config=None, auto_config=None):
                 re_result = re.split(r'[ , -]', gpu_name)
                 gpu_model = re_result[1]
                 memory = int(re_result[-1][:-2])
-            except:
+            except Exception:
                 memory = int(gpu_info.total_memory) // (1000**3)
                 gpu_model = gpu_name
 

--- a/python/paddle/distributed/auto_parallel/static/cost/base_cost.py
+++ b/python/paddle/distributed/auto_parallel/static/cost/base_cost.py
@@ -788,7 +788,7 @@ class CommOpCost(OpCost):
                 # NOTE: The tensor communicated input_name is "X" in default. Otherwise, this function should be overridden
                 try:
                     var_name = self.op.input("X")[0]
-                except:
+                except Exception:
                     var_name = self.op.output("Out")[0]
                 var = get_var_with_recursion(
                     var_name, self.op.block, self.op.block.program

--- a/python/paddle/distributed/auto_parallel/static/cost/comm_op_cost.py
+++ b/python/paddle/distributed/auto_parallel/static/cost/comm_op_cost.py
@@ -155,7 +155,7 @@ class AllReduceOpCost(CommOpCost):
                 vars = self.op.block.vars
                 try:
                     var_name = self.op.input("x")[0]
-                except:
+                except Exception:
                     var_name = self.op.output("out")[0]
                 var = get_var_with_recursion(
                     var_name, self.op.block, self.op.block.program
@@ -214,7 +214,7 @@ class AllgatherOpCost(CommOpCost):
                 vars = self.op.block.vars
                 try:
                     var_name = self.op.input("x")[0]
-                except:
+                except Exception:
                     var_name = self.op.output("out")[0]
                 var = get_var_with_recursion(
                     var_name, self.op.block, self.op.block.program

--- a/python/paddle/distributed/auto_parallel/static/cost_model.py
+++ b/python/paddle/distributed/auto_parallel/static/cost_model.py
@@ -291,7 +291,7 @@ class CostModel:
                     graph[op_id][PRED].append(var_node.id)
                     graph[var_id][SUCC].append(op_node.id)
                     comm_input_shape = var_node.shape
-                except:
+                except Exception:
                     continue
 
             for i in range(len(op.output_names)):
@@ -301,7 +301,7 @@ class CostModel:
                     graph[op_id][SUCC].append(var_node.id)
                     graph[var_id][PRED].append(op_node.id)
                     comm_output_shape = var_node.shape
-                except:
+                except Exception:
                     continue
             if op_node.type == CostNodeType.COMMUNICATION:
                 op_node.set_shapes(comm_input_shape, comm_output_shape)
@@ -523,36 +523,36 @@ class CostModel:
                     runtime_graph[merged_node_id][PRED] = runtime_graph[
                         pred_id
                     ][PRED]
-                except:
+                except Exception:
                     pass
                 try:
                     for i in runtime_graph[pred_id][PRED]:
                         try:
                             runtime_graph[i][SUCC].remove(pred_id)
-                        except:
+                        except Exception:
                             continue
                         runtime_graph[i][SUCC].append(merged_node_id)
-                except:
+                except Exception:
                     pass
 
                 try:
                     for i in edges[SUCC]:
                         runtime_graph[i][PRED].remove(node_id)
                         runtime_graph[i][PRED].append(merged_node_id)
-                except:
+                except Exception:
                     pass
                 if succ is not None:
                     for i in succ:
                         try:
                             runtime_graph[i][PRED].remove(pred_id)
-                        except:
+                        except Exception:
                             continue
                         runtime_graph[i][PRED].append(merged_node_id)
 
                 runtime_graph.pop(node_id)
                 try:
                     runtime_graph.pop(pred_id)
-                except:
+                except Exception:
                     continue
                 reduct_cnt += 1
                 self.eliminate_multi_edges(runtime_graph)
@@ -576,7 +576,7 @@ class CostModel:
                     for succ_2_id in succ_nodes_id:
                         try:
                             tmp = runtime_graph[succ_2_id][SUCC]
-                        except:
+                        except Exception:
                             continue
                         if succ_id in tmp:
                             succ_to_elim.append(succ_id)
@@ -593,7 +593,7 @@ class CostModel:
                         or len(runtime_graph[edges[SUCC][0]][SUCC]) < 1
                     ):
                         continue
-                except:
+                except Exception:
                     continue
                 end_node_id = runtime_graph[edges[SUCC][0]][SUCC][0]
                 for i in succ_nodes_id:
@@ -604,7 +604,7 @@ class CostModel:
                         ):
                             to_merge = False  # if branches has different end node, we don't merge them
                             break
-                    except:
+                    except Exception:
                         continue
                 if to_merge and len(succ_nodes_id) > 1:
                     to_merge_node_list = [nodes[i] for i in succ_nodes_id]
@@ -626,7 +626,7 @@ class CostModel:
                             runtime_graph.pop(i)
                         reduct_cnt += len(to_merge_node_list) - 1
                         break
-                    except:
+                    except Exception:
                         pass
         return reduct_cnt
 

--- a/python/paddle/distributed/auto_parallel/static/dist_loader.py
+++ b/python/paddle/distributed/auto_parallel/static/dist_loader.py
@@ -144,7 +144,7 @@ class DistributedDataLoaderFromGenerator(DistributedDataLoaderBase):
                 steps_per_epoch = (
                     len(self.dataset) // self.batch_size // self.acc_steps
                 )
-        except:
+        except Exception:
             raise ValueError(
                 "Please set `steps_per_epoch` or implement `__len__` method in dataset class."
             )

--- a/python/paddle/distributed/auto_parallel/static/planner_v2.py
+++ b/python/paddle/distributed/auto_parallel/static/planner_v2.py
@@ -78,7 +78,7 @@ class Planner:
         if self._dist_context._json_config:
             try:
                 path = self._dist_context._json_config["tuner_load_path"]
-            except:
+            except Exception:
                 path = None
         if path and os.path.exists(path):
             try:
@@ -115,7 +115,7 @@ class Planner:
                     need_set_dist_attr = False
                 else:
                     need_set_dist_attr = True
-            except:
+            except Exception:
                 need_set_dist_attr = False
 
             if need_set_dist_attr:

--- a/python/paddle/distributed/auto_parallel/static/tuner/rule_based_tuner.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/rule_based_tuner.py
@@ -1118,7 +1118,7 @@ class RuleBasedTuner:
                 self._strategy_path = self._dist_context._json_config[
                     "tuner_save_path"
                 ]
-            except:
+            except Exception:
                 self._strategy_path = None
 
     @property

--- a/python/paddle/distributed/auto_parallel/static/utils.py
+++ b/python/paddle/distributed/auto_parallel/static/utils.py
@@ -1651,7 +1651,7 @@ def get_standalone_cost_data(distributed_programs):
         runtime = 0
         try:
             runtime = float(op_cost["op_time"])
-        except:
+        except Exception:
             return runtime
         op_config = op_cost["config"]
         total_static_input_size = 0

--- a/python/paddle/distributed/auto_tuner/prune.py
+++ b/python/paddle/distributed/auto_tuner/prune.py
@@ -52,7 +52,7 @@ def log_pruned_info(cur_cfg, pruned_reason, tuner_cfg):
         ctx.logger.info(
             f"Strategy {pruned_strategy} has been pruned that {pruned_reason}"
         )
-    except:
+    except Exception:
         pass
     logger.info(
         f"Strategy {pruned_strategy} has been pruned that {pruned_reason}"

--- a/python/paddle/distributed/auto_tuner/utils.py
+++ b/python/paddle/distributed/auto_tuner/utils.py
@@ -846,7 +846,7 @@ def gen_sharding_overlap_args_of_grid_search(res_args, cfg, tuner_cfg):
             try:
                 with open(file_path, "r") as f:
                     cmd_cfg = json.load(f)
-            except:
+            except Exception:
                 raise ValueError(
                     "Please check your auto tuner json whether valid."
                 )
@@ -870,7 +870,7 @@ def gen_sharding_overlap_args_of_grid_search(res_args, cfg, tuner_cfg):
             try:
                 with open(file_path, "r") as f:
                     cmd_cfg = yaml.safe_load(f)
-            except:
+            except Exception:
                 raise ValueError(
                     "Please check your auto tuner json whether valid."
                 )
@@ -934,7 +934,7 @@ def gen_sharding_overlap_args(res_args, cfg, tuner_cfg):
                 try:
                     with open(file_path, "r") as f:
                         cmd_cfg = json.load(f)
-                except:
+                except Exception:
                     raise ValueError(
                         "Please check your auto tuner json whether valid."
                     )
@@ -957,7 +957,7 @@ def gen_sharding_overlap_args(res_args, cfg, tuner_cfg):
                 try:
                     with open(file_path, "r") as f:
                         cmd_cfg = yaml.safe_load(f)
-                except:
+                except Exception:
                     raise ValueError(
                         "Please check your auto tuner json whether valid."
                     )
@@ -1009,14 +1009,14 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
                     // cfg["micro_batch_size"]
                 )
                 cfg["gradient_accumulation_steps"] = gradient_accumulation_steps
-            except:
+            except Exception:
                 return
 
         if arg == "sequence_parallel" and arg in cmd:
             try:
                 sequence_parallel = 1 if cfg["mp_degree"] > 1 else 0
                 cfg["sequence_parallel"] = sequence_parallel
-            except:
+            except Exception:
                 return
 
         if arg == "global_batch_size" and arg in cmd:
@@ -1027,7 +1027,7 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
                     else tuner_cfg["model_cfg"]["global_batch_size"]
                 )
                 cfg["global_batch_size"] = global_batch_size
-            except:
+            except Exception:
                 return
 
     def _gen_new_arg(arg, cmd, cfg, res_args, tuner_cfg):
@@ -1048,7 +1048,7 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
                 try:
                     with open(file_path, "r") as f:
                         cmd_cfg = json.load(f)
-                except:
+                except Exception:
                     raise ValueError(
                         "Please check your auto tuner json whether valid."
                     )
@@ -1090,7 +1090,7 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
                 try:
                     with open(file_path, "r") as f:
                         cmd_cfg = yaml.safe_load(f)
-                except:
+                except Exception:
                     raise ValueError(
                         "Please check your auto tuner json whether valid."
                     )
@@ -1141,7 +1141,7 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
                 try:
                     with open(file_path, "r") as f:
                         cmd_cfg = json.load(f)
-                except:
+                except Exception:
                     raise ValueError(
                         "Please check your auto tuner json whether valid."
                     )
@@ -1185,7 +1185,7 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
                 try:
                     with open(file_path, "r") as f:
                         cmd_cfg = yaml.safe_load(f)
-                except:
+                except Exception:
                     raise ValueError(
                         "Please check your auto tuner json whether valid."
                     )
@@ -1261,7 +1261,7 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
                 try:
                     with open(file_path, "r") as f:
                         cmd_cfg = json.load(f)
-                except:
+                except Exception:
                     raise ValueError(
                         "Please check your auto tuner json whether valid."
                     )
@@ -1284,7 +1284,7 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
                 try:
                     with open(file_path, "r") as f:
                         cmd_cfg = yaml.safe_load(f)
-                except:
+                except Exception:
                     raise ValueError(
                         "Please check your auto tuner json whether valid."
                     )
@@ -1315,7 +1315,7 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
                 try:
                     with open(file_path, "r") as f:
                         cmd_cfg = json.load(f)
-                except:
+                except Exception:
                     raise ValueError(
                         "Please check your auto tuner json whether valid."
                     )
@@ -1338,7 +1338,7 @@ def gen_new_args(raw_args, cfg, tuner_cfg, run_best=False):
                 try:
                     with open(file_path, "r") as f:
                         cmd_cfg = yaml.safe_load(f)
-                except:
+                except Exception:
                     raise ValueError(
                         "Please check your auto tuner json whether valid."
                     )
@@ -1442,7 +1442,7 @@ def read_metric_log(
                         value = float(item)
                         metric_list.append(value)
                         break
-                    except:
+                    except Exception:
                         continue
                 assert value is not None
 
@@ -1489,7 +1489,7 @@ def read_step_time_log(
                         value = float(item)
                         metric_list.append(value)
                         break
-                    except:
+                    except Exception:
                         continue
                 assert value is not None
         if not metric_list:
@@ -1529,7 +1529,7 @@ def read_allocated_memory_log(
                         value = int(float(item))
                         metric_list.append(value)
                         break
-                    except:
+                    except Exception:
                         continue
                 assert value is not None
         if not metric_list:
@@ -1624,7 +1624,7 @@ def read_log(
     try:
         res_memory, memory_flag = read_memory_log(path, memory_file)
         err_code = (memory_flag << 2) | err_code
-    except:
+    except Exception:
         res_memory = 0.0
         err_code = (1 << 2) | err_code
     return res_metric, res_memory, err_code

--- a/python/paddle/distributed/fleet/base/role_maker.py
+++ b/python/paddle/distributed/fleet/base/role_maker.py
@@ -940,7 +940,7 @@ class PaddleCloudRoleMaker(RoleMakerBase):
                     self._previous_heter_trainer_endpoints = (
                         previous_heter_trainer_eplist.split(",")
                     )
-                except:
+                except Exception:
                     raise ValueError(
                         "Can not Find PADDLE_PREVIOUS_HETER_TRAINER_IP_PORT_LIST in env or its format doesn't match the requirement: 'IP:PORT,IP:PORT' ."
                     )
@@ -955,7 +955,7 @@ class PaddleCloudRoleMaker(RoleMakerBase):
                     self._next_heter_trainer_endpoints = (
                         next_heter_trainer_eplist.split(",")
                     )
-                except:
+                except Exception:
                     raise ValueError(
                         "Can not Find PADDLE_NEXT_HETER_TRAINER_IP_PORT_LIST in env or its format doesn't match the requirement: 'IP:PORT,IP:PORT' ."
                     )

--- a/python/paddle/distributed/fleet/elastic/manager.py
+++ b/python/paddle/distributed/fleet/elastic/manager.py
@@ -398,7 +398,7 @@ class ElasticManager:
     def _get_host(self):
         try:
             return socket.gethostbyname(socket.getfqdn(socket.gethostname()))
-        except:
+        except Exception:
             return '127.0.0.1'
 
     def _completed(self):

--- a/python/paddle/distributed/fleet/launch.py
+++ b/python/paddle/distributed/fleet/launch.py
@@ -439,7 +439,7 @@ def launch_collective(args):
 
             time.sleep(3)
 
-        except:
+        except Exception:
             logger.warning("Terminating... exit")
             terminate_local_procs(procs)
             sys.exit(1)

--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -345,7 +345,7 @@ def get_host_name_ip():
         host_name = socket.gethostname()
         host_ip = socket.gethostbyname(host_name)
         return host_name, host_ip
-    except:
+    except Exception:
         return None
 
 
@@ -650,7 +650,7 @@ def watch_local_trainers(procs, nranks):
         )
         terminate_local_procs(procs)
         raise
-    except:
+    except Exception:
         logger.error(
             f"ABORT!!! Out of all {nranks} trainers, the trainer process with rank={error_rank} was aborted. Please check its log."
         )

--- a/python/paddle/distributed/fleet/runtime/the_one_ps.py
+++ b/python/paddle/distributed/fleet/runtime/the_one_ps.py
@@ -1286,7 +1286,7 @@ class TheOnePSRuntime(RuntimeBase):
                 # only save sparse param to local
                 try:
                     self._worker.recv_and_save_model(id, model_path)
-                except:
+                except Exception:
                     pass
             # save sparse & distributed param on server
             self._worker.save_one_model(id, dirname, mode)

--- a/python/paddle/distributed/fleet/utils/http_server.py
+++ b/python/paddle/distributed/fleet/utils/http_server.py
@@ -81,7 +81,7 @@ class KVHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         content_length = int(self.headers['Content-Length'])
         try:
             value = self.rfile.read(content_length)
-        except:
+        except Exception:
             print("receive error invalid request")
             self.send_status_code(404)
             return

--- a/python/paddle/distributed/fleet/utils/tensor_fusion_helper.py
+++ b/python/paddle/distributed/fleet/utils/tensor_fusion_helper.py
@@ -76,7 +76,7 @@ def get_current_device_type():
             current_device = _current_expected_place_()
             try:
                 device_type = current_device.get_device_type()
-            except:
+            except Exception:
                 device_type = "unknown"
         assert device_type in alignment.keys(), (
             f"tensor fusion helper now only support {alignment.keys()}, but got device {device_type} instead."

--- a/python/paddle/distributed/flex_checkpoint/dcp/utils.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/utils.py
@@ -363,7 +363,7 @@ def is_list_string(s):
     try:
         result = ast.literal_eval(s)
         return (True, result) if isinstance(result, list) else (False, None)
-    except:
+    except Exception:
         return False, None
 
 

--- a/python/paddle/distributed/launch/context/node.py
+++ b/python/paddle/distributed/launch/context/node.py
@@ -40,7 +40,7 @@ class Node:
             self.hostname = socket.gethostname()
             self.ip = socket.gethostbyname(socket.getfqdn(self.hostname))
             return self.ip
-        except:
+        except Exception:
             return '127.0.0.1'
 
     def get_free_ports(self, n=1, rank=0):
@@ -66,7 +66,7 @@ class Node:
             try:
                 s.bind(('', port))
                 return s.getsockname()[1]
-            except:
+            except Exception:
                 return -1
 
     def _update_port_cur(self):

--- a/python/paddle/distributed/launch/job/container.py
+++ b/python/paddle/distributed/launch/job/container.py
@@ -107,7 +107,7 @@ class Container:
             if not os.path.isdir(d):
                 os.makedirs(d, exist_ok=True)
             return open(pth, self.log_mode)
-        except:
+        except Exception:
             return None
 
     def start(self):
@@ -192,7 +192,7 @@ class Container:
                     return False
                 fn.write(line)
             return True
-        except:
+        except Exception:
             return
 
     def tail(self, length=3000):
@@ -202,7 +202,7 @@ class Container:
         try:
             self._log_handler.seek(0, 2)
             ed = self._log_handler.tell()
-        except:
+        except Exception:
             pass
 
         if ed > length:

--- a/python/paddle/distributed/launch/main.py
+++ b/python/paddle/distributed/launch/main.py
@@ -326,7 +326,7 @@ def launch() -> None:
         try:
             with open(ctx.args.auto_tuner_json, "r") as f:
                 tuner_cfg = json.load(f)
-        except:
+        except Exception:
             raise ValueError("Please check your auto tuner json whether valid.")
 
         logger = logging.getLogger('auto_tuner')
@@ -402,7 +402,7 @@ def launch() -> None:
             try:
                 hostname = socket.gethostname()
                 ip = socket.gethostbyname(socket.getfqdn(hostname))
-            except:
+            except Exception:
                 ip = '127.0.0.1'
             assert ip != '127.0.0.1'
             if tuner_cfg["search_algo"].get("estimated_num_gpus", None):

--- a/python/paddle/distributed/launch/utils/kv_client.py
+++ b/python/paddle/distributed/launch/utils/kv_client.py
@@ -32,7 +32,7 @@ class KVClient:
                 return True
             else:
                 return False
-        except:
+        except Exception:
             return False
 
     def get(self, key):
@@ -45,7 +45,7 @@ class KVClient:
                 return ret.get(key, '')
             else:
                 return "error"
-        except:
+        except Exception:
             return ""
 
     def get_prefix(self, key):
@@ -55,7 +55,7 @@ class KVClient:
             r = httpx.get(u, timeout=None, follow_redirects=True)
             if r.status_code == 200:
                 return r.json()
-        except:
+        except Exception:
             return ""
 
     def delete(self, key):
@@ -67,7 +67,7 @@ class KVClient:
                 return True
             else:
                 return False
-        except:
+        except Exception:
             return False
 
     def wait_server_ready(self, timeout=3):

--- a/python/paddle/distributed/launch/utils/kv_server.py
+++ b/python/paddle/distributed/launch/utils/kv_server.py
@@ -44,7 +44,7 @@ class KVHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 self.server.kv[self.path] = value
                 self.output(200)
                 return
-        except:
+        except Exception:
             self.output(500)
 
     def do_DELETE(self):

--- a/python/paddle/distributed/launch/utils/process_context.py
+++ b/python/paddle/distributed/launch/utils/process_context.py
@@ -82,7 +82,7 @@ class ProcessContext:
 
             if not self._stderr.isatty():
                 self._stderr.close()
-        except:
+        except Exception:
             pass
 
     def alive(self):

--- a/python/paddle/distributed/passes/auto_parallel_quantization.py
+++ b/python/paddle/distributed/passes/auto_parallel_quantization.py
@@ -162,7 +162,7 @@ class QuantizationPass(PassBase):
                 )
                 # for sub_graph in main_graph.all_sub_graphs():
                 #     out_scale_infer_pass.apply(sub_graph)
-            except:
+            except Exception:
                 logging.warning(
                     "Unable to convert quant model with onnx_format=True, please update PaddlePaddle >= 2.4.0"
                 )

--- a/python/paddle/distributed/ps/the_one_ps.py
+++ b/python/paddle/distributed/ps/the_one_ps.py
@@ -1469,7 +1469,7 @@ class TheOnePSRuntime(RuntimeBase):
                 # only save sparse param to local
                 try:
                     self._worker.recv_and_save_model(id, model_path)
-                except:
+                except Exception:
                     pass
             # save sparse & distributed param on server
             self._worker.save_one_model(id, dirname, mode)

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -335,7 +335,7 @@ def get_host_name_ip():
         host_name = socket.gethostname()
         host_ip = socket.gethostbyname(host_name)
         return host_name, host_ip
-    except:
+    except Exception:
         return None
 
 
@@ -537,7 +537,7 @@ def watch_local_trainers(procs, nranks):
         )
         terminate_local_procs(procs)
         raise
-    except:
+    except Exception:
         logger.error(
             f"ABORT!!! Out of all {nranks} trainers, the trainer process with rank={error_rank} was aborted. Please check its log."
         )

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -1306,7 +1306,7 @@ def load(path: str | BytesIO, **configs: Unpack[_LoadOptions]) -> Any:
             try:
                 tensor, _ = _load_selected_rows(path)
                 return tensor
-            except:
+            except Exception:
                 try:
                     tensor, _ = _load_dense_tensor(path)
                     if config.return_numpy:
@@ -1322,7 +1322,7 @@ def load(path: str | BytesIO, **configs: Unpack[_LoadOptions]) -> Any:
                         if in_dygraph_mode():
                             return _lod_tensor2varbase(tensor)
                         return tensor
-                except:
+                except Exception:
                     try:
                         if in_pir_mode():
                             program = paddle.static.Program()
@@ -1360,7 +1360,7 @@ def load(path: str | BytesIO, **configs: Unpack[_LoadOptions]) -> Any:
                                     for op in remove_op_list:
                                         block.remove_op(op)
                             return program
-                    except:
+                    except Exception:
                         raise ValueError(
                             f"`paddle.load` can not parse the file:{path}."
                         )

--- a/python/paddle/hapi/model_summary.py
+++ b/python/paddle/hapi/model_summary.py
@@ -452,7 +452,7 @@ def summary_string(model, input_size=None, dtypes=None, input=None):
 
             try:
                 layer_idx = int(layer._full_name.split('_')[-1])
-            except:
+            except Exception:
                 layer_idx = len(summary)
 
             m_key = f"{class_name}-{layer_idx + 1}"
@@ -460,13 +460,13 @@ def summary_string(model, input_size=None, dtypes=None, input=None):
 
             try:
                 summary[m_key]["input_shape"] = _get_shape_from_tensor(input)
-            except:
+            except Exception:
                 warnings.warn('Get layer {} input shape failed!')
                 summary[m_key]["input_shape"] = []
 
             try:
                 summary[m_key]["output_shape"] = _get_output_shape(output)
-            except:
+            except Exception:
                 warnings.warn('Get layer {} output shape failed!')
                 summary[m_key]["output_shape"]
 
@@ -493,7 +493,7 @@ def summary_string(model, input_size=None, dtypes=None, input=None):
                         trainable_flag = True
                     elif not trainable_flag:
                         summary[m_key]["trainable"] = False
-                except:
+                except Exception:
                     summary[m_key]["trainable"] = True
 
             summary[m_key]["nb_params"] = params
@@ -618,7 +618,7 @@ def summary_string(model, input_size=None, dtypes=None, input=None):
             total_output += int(
                 np.sum(np.prod(summary[layer]["output_shape"], axis=-1))
             )
-        except:
+        except Exception:
             for output_shape in summary[layer]["output_shape"]:
                 total_output += int(np.sum(np.prod(output_shape, axis=-1)))
 

--- a/python/paddle/incubate/distributed/fleet/parameter_server/ir/public.py
+++ b/python/paddle/incubate/distributed/fleet/parameter_server/ir/public.py
@@ -149,7 +149,7 @@ class CompileTimeStrategy:
         self.use_ps_gpu = False
         try:
             self.is_heter_ps_mode = role_maker._is_heter_parameter_server_mode
-        except:
+        except Exception:
             warnings.warn(
                 "Using paddle.distributed.fleet instead of paddle.base.incubate.fleet"
             )

--- a/python/paddle/incubate/distributed/fleet/parameter_server/pslib/__init__.py
+++ b/python/paddle/incubate/distributed/fleet/parameter_server/pslib/__init__.py
@@ -1273,7 +1273,7 @@ class DownpourOptimizer(DistributedOptimizer):
             try:
                 if op.output("Out")[0] in table_name:
                     need_remove_op_index.append(ids)
-            except:
+            except Exception:
                 pass
 
         need_remove_op_index.sort(reverse=True)

--- a/python/paddle/incubate/distributed/utils/io/dist_save.py
+++ b/python/paddle/incubate/distributed/utils/io/dist_save.py
@@ -186,7 +186,7 @@ def save(
         if dist.get_rank() in gather_to:
             configs = _remove_not_supported_conf(configs)
             paddle.save(gathered_state_dict, path, **configs)
-    except:
+    except Exception:
         raise RuntimeError(
             f'''Saving failed. Following are some suggestions:
     1) pass the param max_grouped_size to turn the grouped size smaller (current value of max_grouped_size is {max_size})
@@ -350,7 +350,7 @@ def _grouped_gather_data_dict(state_data_dict, dst, group, max_size):
     for k, v in state_data_dict.items():
         try:
             numpy_dict[k] = v.numpy()
-        except:
+        except Exception:
             raise TypeError(
                 f"the object (type of {type(v)}) of '{k}' is neither tensor nor parameter"
             )

--- a/python/paddle/io/dataloader/dataloader_iter.py
+++ b/python/paddle/io/dataloader/dataloader_iter.py
@@ -71,7 +71,7 @@ def _clear_loader():
         try:
             _loader.__del__()
             del _loader
-        except:
+        except Exception:
             pass
 
 
@@ -283,7 +283,7 @@ class _DataLoaderIterSingleProcess(_DataLoaderIterBase):
 
                 try:
                     self._blocking_queue.push(array)
-                except:
+                except Exception:
                     self._exit_thread_expectedly()
 
             except Exception as e:
@@ -421,7 +421,7 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
         ]:
             try:
                 self._worker_shm_buffer_size = (2 + 1) * len(self._dataset[0])
-            except:
+            except Exception:
                 self._worker_shm_buffer_size = 0
                 warnings.warn(
                     "Setting the shm cache buffer size to 0, equivalent to not using the shm cache policy."
@@ -497,7 +497,7 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
             while True:
                 try:
                     self._data_queue.get_nowait()
-                except:
+                except Exception:
                     self._data_queue.cancel_join_thread()
                     self._data_queue.close()
                     break

--- a/python/paddle/io/dataloader/worker.py
+++ b/python/paddle/io/dataloader/worker.py
@@ -331,7 +331,7 @@ def _worker_loop(
             fetcher = _DatasetKind.create_fetcher(
                 dataset_kind, dataset, auto_collate_batch, collate_fn, drop_last
             )
-        except:
+        except Exception:
             init_exception = _WorkerException(worker_id)
 
         iterator_drained = False
@@ -409,7 +409,7 @@ def _worker_loop(
     except KeyboardInterrupt:
         # NOTE: Main process will raise KeyboardInterrupt anyways, ignore it in child process
         pass
-    except:
+    except Exception:
         raise
     finally:
         if use_shared_memory:

--- a/python/paddle/jit/dy2static/error.py
+++ b/python/paddle/jit/dy2static/error.py
@@ -256,7 +256,7 @@ class ErrorData:
                     )
                 ):
                     self._simplify_error_value()
-            except:
+            except Exception:
                 pass
             else:
                 message_lines.append(str(self.error_value))

--- a/python/paddle/jit/dy2static/origin_info.py
+++ b/python/paddle/jit/dy2static/origin_info.py
@@ -322,6 +322,6 @@ def update_op_callstack_with_origin_info(program):
                         # (@xiongkun) In 2-order derivative for paddle science, there may exists `pow_grad`
                         # which has op_proto == nullptr and causes _set_attr failed. so we add a try...except.
                         op._set_attr(callstack_var_name, callstack)
-                    except:
+                    except Exception:
                         pass
     return program

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -595,7 +595,7 @@ def ast_to_func(ast_root, dyfunc, delete_on_exit=True):
         if hasattr(func, '__self__'):
             try:
                 prefix = f"{func.__self__.__class__.__name__}_{func.__name__}"
-            except:
+            except Exception:
                 pass
         return prefix
 
@@ -789,7 +789,7 @@ def _compatible_non_tensor_spec(src_spec, desired_spec):
     def hash_value(spec):
         try:
             hash_val = make_hashable(spec)
-        except:
+        except Exception:
             hash_val = None
         return hash_val
 

--- a/python/paddle/jit/sot/infer_meta.py
+++ b/python/paddle/jit/sot/infer_meta.py
@@ -586,7 +586,7 @@ class SpecialInferMeta(metaclass=Singleton):
         try:
             funcname = fn.__name__
             return getattr(self, f"infermeta_{funcname}")
-        except:
+        except Exception:
             pass
         return None
 

--- a/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/basic.py
@@ -2562,7 +2562,7 @@ class DataClassInstanceVariable(VariableBase):
             )
             try:
                 data_dict = dataclass_as_dict(value)
-            except:
+            except Exception:
                 data_dict = {}
             var = DataClassInstanceVariable(
                 data_dict,

--- a/python/paddle/jit/sot/utils/utils.py
+++ b/python/paddle/jit/sot/utils/utils.py
@@ -178,7 +178,7 @@ def no_eval_frame(func):
         old_cb = paddle.framework.core.set_eval_frame(None)
         try:
             retval = func(*args, **kwargs)
-        except:
+        except Exception:
             raise
         finally:
             paddle.framework.core.set_eval_frame(old_cb)

--- a/python/paddle/optimizer/fusion_utils.py
+++ b/python/paddle/optimizer/fusion_utils.py
@@ -62,7 +62,7 @@ def get_current_device_type():
             current_device = _current_expected_place_()
             try:
                 device_type = current_device.get_device_type()
-            except:
+            except Exception:
                 device_type = "unknown"
         assert device_type in alignment.keys(), (
             f"tensor fusion helper now only support {alignment.keys()}, but got device {device_type} instead."

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -148,7 +148,7 @@ def monkey_patch_value():
     def safe_get_dtype(var):
         try:
             dtype = var.dtype
-        except:
+        except Exception:
             raise ValueError("Cannot get data type from var")
         return dtype
 

--- a/python/paddle/profiler/profiler.py
+++ b/python/paddle/profiler/profiler.py
@@ -975,7 +975,7 @@ def get_profiler(config_path):
                     translated_config_dict['targets'].append(ProfilerTarget.CPU)
                 elif target.lower() == 'gpu':
                     translated_config_dict['targets'].append(ProfilerTarget.GPU)
-        except:
+        except Exception:
             print('Set targets parameter error, use default parameter instead.')
             translated_config_dict['targets'] = None
     if "scheduler" in config_dict:
@@ -998,7 +998,7 @@ def get_profiler(config_path):
                     config_dict['scheduler'][1],
                 ]
 
-        except:
+        except Exception:
             print(
                 'Set scheduler parameter error, use default parameter instead.'
             )
@@ -1017,7 +1017,7 @@ def get_profiler(config_path):
                         )
                     else:
                         translated_config_dict['on_trace_ready'] = method
-        except:
+        except Exception:
             print(
                 'Set on_trace_ready parameter error, use default parameter instead.'
             )

--- a/python/paddle/static/amp/debugging.py
+++ b/python/paddle/static/amp/debugging.py
@@ -81,7 +81,7 @@ def _get_var_dtype_from_block(block, op, arg_name, is_input):
     try:
         var = block._var_recursive(var_name)
         return var.dtype
-    except:
+    except Exception:
         _logger.warning(
             "Operator < {} > gets {} < {} : {} > error!".format(
                 op.type, "input" if is_input else "output", arg_name, var_name

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -1751,7 +1751,7 @@ def load(
             except RuntimeError as e:
                 _logger.error(e)
                 raise e
-            except:
+            except Exception:
                 raise RuntimeError(
                     "Failed to load model file, please make sure model file is saved with the "
                     "following APIs: save_params, save_persistables, save_vars"
@@ -1784,7 +1784,7 @@ def load(
             except RuntimeError as e:
                 _logger.error(e)
                 raise e
-            except:
+            except Exception:
                 raise RuntimeError(
                     "Failed to load model file , please make sure model file is saved with the "
                     "the following APIs: [ save_params, save_persistables, save_vars ]. "
@@ -2081,7 +2081,7 @@ def load_program_state(
                         filename=filename,
                     )
                     return True
-                except:
+                except Exception:
                     error_str = (
                         "Failed to load model/variables `%s`, please make sure "
                         "model/variables file is saved with the following APIs: "

--- a/python/paddle/static/quantization/post_training_quantization.py
+++ b/python/paddle/static/quantization/post_training_quantization.py
@@ -20,7 +20,7 @@ import numpy as np
 
 try:
     from tqdm import tqdm
-except:
+except Exception:
     from .utils import tqdm
 
 from paddle.base.framework import IrGraph, _get_var

--- a/python/paddle/static/quantization/quantization_pass.py
+++ b/python/paddle/static/quantization/quantization_pass.py
@@ -19,7 +19,7 @@ import numpy as np
 
 try:
     from tqdm import tqdm
-except:
+except Exception:
     from .utils import tqdm
 
 import paddle
@@ -525,7 +525,7 @@ class QuantizationTransformPass:
             scale_value = np.array(
                 self._scope.find_var(scale_name).get_tensor()
             )
-        except:
+        except Exception:
             scale_value = np.zeros([1], dtype=data_type)
         scale_var_node = graph.create_persistable_node(
             name=scale_name,
@@ -572,7 +572,7 @@ class QuantizationTransformPass:
             scale_value = np.array(
                 self._scope.find_var(scale_name).get_tensor()
             )
-        except:
+        except Exception:
             scale_value = np.array([_SCALE_DEFAULT_VALUE], dtype=data_type)
         scale_in_node = graph.create_persistable_node(
             name=scale_name,
@@ -654,7 +654,7 @@ class QuantizationTransformPass:
             scale_value = np.array(
                 self._scope.find_var(scale_name).get_tensor()
             )
-        except:
+        except Exception:
             scale_value = np.array([_SCALE_DEFAULT_VALUE], dtype=data_type)
         scale_in_node = graph.create_persistable_node(
             name=scale_name,
@@ -762,7 +762,7 @@ class QuantizationTransformPass:
             scale_value = np.array(
                 self._scope.find_var(scale_name).get_tensor()
             )
-        except:
+        except Exception:
             scale_value = np.zeros(
                 [var_node.shape()[quant_axis]], dtype=data_type
             )
@@ -1653,7 +1653,7 @@ class OutScaleForTrainingPass:
                             self._scale_name(in_node.name()),
                         )
                         continue
-                    except:
+                    except Exception:
                         scale_node = graph.create_persistable_node(
                             name=self._scale_name(in_node.name()),
                             var_type=core.VarDesc.VarType.DENSE_TENSOR,
@@ -1665,7 +1665,7 @@ class OutScaleForTrainingPass:
                                 scale_value = np.array(
                                     [self._scale_dict[in_node.name()]]
                                 )
-                            except:
+                            except Exception:
                                 scale_value = np.ones([1], dtype=data_type)
                         else:
                             scale_value = np.ones([1], dtype=data_type)
@@ -2013,7 +2013,7 @@ class AddQuantDequantPass:
                     self._scope.find_var(scale_name).get_tensor(),
                     dtype=data_type,
                 )
-        except:
+        except Exception:
             scale_value = np.array([_SCALE_DEFAULT_VALUE], dtype=data_type)
 
         scale_in_node = graph.create_persistable_node(
@@ -3408,7 +3408,7 @@ class AddQuantDequantForInferencePass:
             scale_var_node = graph._find_node_by_name(
                 graph.all_persistable_nodes(), self._scale_name(var_name)
             )
-        except:
+        except Exception:
             if (
                 self._calibration_range_dict
                 and var_name in self._calibration_range_dict
@@ -3441,7 +3441,7 @@ class AddQuantDequantForInferencePass:
                 graph.all_persistable_nodes(),
                 f"{quant_var_node.name()}@zero_point",
             )
-        except:
+        except Exception:
             zero_point_node = graph.create_persistable_node(
                 name=f"{quant_var_node.name()}@zero_point",
                 var_type=core.VarDesc.VarType.DENSE_TENSOR,

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -938,7 +938,7 @@ def _to_tensor_static(
 
                     data = array_data
 
-                except:
+                except Exception:
                     to_stack_list = [None] * len(data)
                     for idx, d in enumerate(data):
                         to_stack_list[idx] = _to_tensor_static(

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -779,7 +779,7 @@ def find_ccache_home():
             ccache_path = (
                 subprocess.check_output([which_cmd, 'ccache']).decode().strip()
             )
-        except:
+        except Exception:
             ccache_path = None
 
     if ccache_path is None:
@@ -811,7 +811,7 @@ def find_cuda_home():
 
                 # for example: /usr/local/cuda/bin/nvcc
                 cuda_home = os.path.dirname(os.path.dirname(nvcc_path))
-        except:
+        except Exception:
             if IS_WINDOWS:
                 # search from default NVIDIA GPU path
                 candidate_paths = glob.glob(
@@ -852,7 +852,7 @@ def find_rocm_home():
 
                 # for example: /opt/rocm/bin/hipcc
                 rocm_home = os.path.dirname(os.path.dirname(hipcc_path))
-        except:
+        except Exception:
             rocm_home = "/opt/rocm"
     # step 3. check whether path is valid
     if (

--- a/python/paddle/utils/download.py
+++ b/python/paddle/utils/download.py
@@ -29,7 +29,7 @@ import httpx
 
 try:
     from tqdm import tqdm
-except:
+except Exception:
 
     class tqdm:
         def __init__(self, total=None):

--- a/python/paddle/utils/layers_utils.py
+++ b/python/paddle/utils/layers_utils.py
@@ -547,7 +547,7 @@ def try_get_constant_shape_from_tensor(shape_tensor):
                         generate_op.input_arg_names[0]
                     ]
                     return var.shape
-        except:
+        except Exception:
             return None
 
         return None

--- a/python/paddle/vision/transforms/functional_pil.py
+++ b/python/paddle/vision/transforms/functional_pil.py
@@ -30,7 +30,7 @@ try:
         'lanczos': Image.Resampling.LANCZOS,
         'hamming': Image.Resampling.HAMMING,
     }
-except:
+except Exception:
     _pil_interp_from_str = {
         'nearest': Image.NEAREST,
         'bilinear': Image.BILINEAR,

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ def parse_input_command(input_parameters):
     )
     try:
         dist.parse_command_line()
-    except:
+    except Exception:
         print(
             f"An error occurred while parsing the parameters, {dist.script_args}"
         )
@@ -305,7 +305,7 @@ def git_commit() -> str:
             .communicate()[0]
             .strip()
         )
-    except:
+    except Exception:
         git_commit = 'Unknown'
     git_commit = git_commit.decode('utf-8')
     return str(git_commit)
@@ -434,7 +434,7 @@ def is_tagged() -> bool:
             .strip()
         )
         git_tag = git_tag.decode()
-    except:
+    except Exception:
         return False
     if str(git_tag).replace('v', '') == env_dict.get("PADDLE_VERSION"):
         return True
@@ -1373,7 +1373,7 @@ def build_cutlass3_src_code():
             .communicate()[0]
             .strip()
         )
-    except:
+    except Exception:
         git_commit = 'Unknown'
         raise Exception("obtain commit id of third_party cutlass failed")
     commit_id = str(git_commit.decode())

--- a/test/auto_parallel/hybrid_strategy/semi_auto_parallel_llama_model.py
+++ b/test/auto_parallel/hybrid_strategy/semi_auto_parallel_llama_model.py
@@ -26,7 +26,7 @@ from paddle.distributed.fleet.utils import recompute
 
 try:
     from paddle.nn.functional.flash_attention import flash_attention
-except:
+except Exception:
     flash_attention = None
 
 

--- a/test/auto_parallel/test_tunable_space.py
+++ b/test/auto_parallel/test_tunable_space.py
@@ -140,7 +140,7 @@ class TestTunableSpace(unittest.TestCase):
         try:
             val = space.get_value("test")
             flag = False
-        except:
+        except Exception:
             pass
         self.assertTrue(flag)
 

--- a/test/collective/fleet/dygraph_dist_save_load.py
+++ b/test/collective/fleet/dygraph_dist_save_load.py
@@ -124,7 +124,7 @@ def train_mlp(
     if test_minimize:
         try:
             optimizer.minimize()
-        except:
+        except Exception:
             print(
                 "====== Find sharding_stage2_optimizer.minimize() error ======"
             )

--- a/test/collective/fleet/dygraph_group_sharded_stage2.py
+++ b/test/collective/fleet/dygraph_group_sharded_stage2.py
@@ -136,7 +136,7 @@ def train_mlp(
     if test_minimize:
         try:
             optimizer.minimize()
-        except:
+        except Exception:
             print(
                 "====== Find sharding_stage2_optimizer.minimize() error ======"
             )

--- a/test/collective/fleet/dygraph_group_sharded_stage2_comm_overlap.py
+++ b/test/collective/fleet/dygraph_group_sharded_stage2_comm_overlap.py
@@ -127,7 +127,7 @@ def train_mlp(
     if test_minimize:
         try:
             optimizer.minimize()
-        except:
+        except Exception:
             print(
                 "====== Find sharding_stage2_optimizer.minimize() error ======"
             )

--- a/test/collective/fleet/dygraph_group_sharded_stage3.py
+++ b/test/collective/fleet/dygraph_group_sharded_stage3.py
@@ -186,7 +186,7 @@ def train_mlp(
     if test_minimize:
         try:
             optimizer.minimize()
-        except:
+        except Exception:
             print(
                 "====== Find sharding_stage3_optimizer.minimize() error ======"
             )

--- a/test/collective/fleet/hybrid_parallel_pp_transformer_save.py
+++ b/test/collective/fleet/hybrid_parallel_pp_transformer_save.py
@@ -71,7 +71,7 @@ class TestDistPPSaveTraining(unittest.TestCase):
         )
         try:
             os.makedirs(output_dir)
-        except:
+        except Exception:
             # dir is already created, do nothing
             pass
         for step_id in range(2):

--- a/test/collective/fleet/hybrid_parallel_pp_transformer_save_with_virtual_stage.py
+++ b/test/collective/fleet/hybrid_parallel_pp_transformer_save_with_virtual_stage.py
@@ -76,7 +76,7 @@ class TestDistPPSaveTraining(unittest.TestCase):
         )
         try:
             os.makedirs(output_dir)
-        except:
+        except Exception:
             # dir is already created, do nothing
             pass
         for step_id in range(2):

--- a/test/collective/fleet/hybrid_parallel_sharding_state_dict.py
+++ b/test/collective/fleet/hybrid_parallel_sharding_state_dict.py
@@ -268,7 +268,7 @@ class TestDistShardingTraining(unittest.TestCase):
         try:
             sharding_opt._set_inner_opt_attr(123, 123)
             self.assertTrue(False)
-        except:
+        except Exception:
             pass
 
 

--- a/test/collective/fleet/test_fleet_checkpoint.py
+++ b/test/collective/fleet/test_fleet_checkpoint.py
@@ -106,7 +106,7 @@ class FleetTest(unittest.TestCase):
                 cache_path=cache_path,
             )
             self.assertFalse(True)
-        except:
+        except Exception:
             pass
 
         # can't load under a file
@@ -120,7 +120,7 @@ class FleetTest(unittest.TestCase):
                 cache_path=cache_path,
             )
             self.assertFalse(True)
-        except:
+        except Exception:
             pass
         fs.delete(cache_path)
 

--- a/test/collective/multinode/mn_dygraph_group_sharded_stage3.py
+++ b/test/collective/multinode/mn_dygraph_group_sharded_stage3.py
@@ -140,7 +140,7 @@ def train_mlp(
     if test_minimize:
         try:
             optimizer.minimize()
-        except:
+        except Exception:
             print(
                 "====== Find sharding_stage3_optimizer.minimize() error ======"
             )

--- a/test/collective/test_collective_cpu_barrier_with_gloo.py
+++ b/test/collective/test_collective_cpu_barrier_with_gloo.py
@@ -59,7 +59,7 @@ class CollectiveCPUBarrierWithGlooTest(unittest.TestCase):
             out_dict[id] = end - start
             # Release
             paddle.distributed.gloo_release()
-        except:
+        except Exception:
             out_dict[id] = 0
 
     def barrier_op(self, id, rank_num, server_endpoint, out_dict, sleep_time):
@@ -85,7 +85,7 @@ class CollectiveCPUBarrierWithGlooTest(unittest.TestCase):
             out_dict[id] = end - start
             # Release
             paddle.distributed.gloo_release()
-        except:
+        except Exception:
             out_dict[id] = 0
 
     def test_barrier_func_with_multiprocess(self):

--- a/test/dygraph_to_static/test_gradname_parse.py
+++ b/test/dygraph_to_static/test_gradname_parse.py
@@ -91,7 +91,7 @@ class TestTanhHighOrderGrad(Dy2StTestBase):
         try:
             dy_out = self.func(*self.dy_input)
             dy_grad = paddle.grad(dy_out, self.dy_grad_input, allow_unused=True)
-        except:
+        except Exception:
             dy_grad = [None for i in self.dy_grad_input]
         dy_grad = [
             t.numpy() if isinstance(t, paddle.Tensor) else t for t in dy_grad

--- a/test/dygraph_to_static/tsm_config_utils.py
+++ b/test/dygraph_to_static/tsm_config_utils.py
@@ -71,7 +71,7 @@ def merge_configs(cfg, sec, args_dict):
         try:
             if hasattr(sec_dict, k):
                 setattr(sec_dict, k, v)
-        except:
+        except Exception:
             pass
     return cfg
 

--- a/test/ipu/test_ipu_strategy_ipu.py
+++ b/test/ipu/test_ipu_strategy_ipu.py
@@ -51,7 +51,7 @@ class TestIpuStrategy(unittest.TestCase):
                 assert new_value == set_value, (
                     f"set {option_name} to {set_value} failed"
                 )
-            except:
+            except Exception:
                 raise Exception(f"set {option_name} to {set_value} failed")
 
     def test_set_string_options(self):

--- a/test/ir/inference/dist_llama_inference_model.py
+++ b/test/ir/inference/dist_llama_inference_model.py
@@ -785,7 +785,7 @@ class LlamaInferenceModel(nn.Layer):
             hcg = fleet.get_hybrid_communicate_group()
             model_parallel_group = hcg.get_model_parallel_group()
             ring_id = model_parallel_group.id
-        except:
+        except Exception:
             pass
         linear_shift_attrs = None
         linear_smooth_attrs = None

--- a/test/legacy_test/ernie_utils/moe_layer.py
+++ b/test/legacy_test/ernie_utils/moe_layer.py
@@ -43,7 +43,7 @@ except ImportError:
     moe_router_loss_ops = None
 try:
     from paddle.distributed import in_auto_parallel_align_mode
-except:
+except Exception:
 
     def in_auto_parallel_align_mode():
         """

--- a/test/legacy_test/test_batch_fc_op.py
+++ b/test/legacy_test/test_batch_fc_op.py
@@ -101,7 +101,7 @@ class TestBatchFCOp1(OpTest):
     def test_check_output_cpu(self):
         try:
             self.check_output_with_place(place=core.CPUPlace())
-        except:
+        except Exception:
             print("do not support cpu test, skip")
 
     def test_check_grad_cpu(self):
@@ -109,7 +109,7 @@ class TestBatchFCOp1(OpTest):
             self.check_grad_with_place(
                 core.CPUPlace(), ["Bias", "W", "Input"], "Out"
             )
-        except:
+        except Exception:
             print("do not support cpu test, skip")
 
 

--- a/test/legacy_test/test_broadcast_error.py
+++ b/test/legacy_test/test_broadcast_error.py
@@ -37,7 +37,7 @@ class TestBroadcastOpCpu(OpTest):
     def test_check_output_cpu(self):
         try:
             self.check_output_with_place(place=core.CPUPlace())
-        except:
+        except Exception:
             print("do not support cpu test, skip")
 
     def init_dtype(self):

--- a/test/legacy_test/test_diff_op.py
+++ b/test/legacy_test/test_diff_op.py
@@ -134,7 +134,7 @@ class TestDiffOp(unittest.TestCase):
             try:
                 out.backward()
                 x_grad = x.grad
-            except:
+            except Exception:
                 raise RuntimeError("Check Diff Gradient Failed")
 
     def test_grad(self):

--- a/test/legacy_test/test_directory_migration.py
+++ b/test/legacy_test/test_directory_migration.py
@@ -201,7 +201,7 @@ err_module = ""
                 cmd_context_loop_template = """
 try:
     {run_cmd}
-except:
+except Exception:
     count += 1
 else:
     err_module = "{module}"

--- a/test/legacy_test/test_elementwise_tensor_split.py
+++ b/test/legacy_test/test_elementwise_tensor_split.py
@@ -38,7 +38,7 @@ class TestElementwiseOp(unittest.TestCase):
         try:
             re_result = re.split(r'[ , -]', gpu_name)
             memory = int(re_result[-1][:-2])
-        except:
+        except Exception:
             memory = int(gpu_info.total_memory) // (1000**3)
         if memory < 37:  # 37GB
             return

--- a/test/legacy_test/test_fleet_rolemaker.py
+++ b/test/legacy_test/test_fleet_rolemaker.py
@@ -100,7 +100,7 @@ class TestCloudRoleMaker(unittest.TestCase):
             adam = fleet.distributed_optimizer(adam)
             adam.minimize([cost], [scope])
             fleet.run_server()
-        except:
+        except Exception:
             print("do not support pslib test, skip")
             return
         fleet.clear_one_table(0)
@@ -111,22 +111,22 @@ class TestCloudRoleMaker(unittest.TestCase):
         try:
             role = MPISymmetricRoleMaker()
             role._all_reduce([1], [2])
-        except:
+        except Exception:
             print("catch expected error of not inited")
         try:
             role = MPISymmetricRoleMaker()
             role._all_reduce([1], [2], "min")
-        except:
+        except Exception:
             print("catch expected error of not inited")
         try:
             role = MPISymmetricRoleMaker()
             role._all_reduce([1], [2], "max")
-        except:
+        except Exception:
             print("catch expected error of not inited")
         try:
             role = MPISymmetricRoleMaker()
             role._all_reduce([1], [2], "unknown")
-        except:
+        except Exception:
             print("catch expected error of unknown type")
 
 

--- a/test/legacy_test/test_fleet_rolemaker_2.py
+++ b/test/legacy_test/test_fleet_rolemaker_2.py
@@ -56,7 +56,7 @@ class TestCloudRoleMaker2(unittest.TestCase):
         exe = base.Executor(place)
         try:
             fleet.init(None)
-        except:
+        except Exception:
             print("no mpi4py, skip test_pslib_2")
             return
         train_program = base.Program()
@@ -77,14 +77,14 @@ class TestCloudRoleMaker2(unittest.TestCase):
             adam = fleet.distributed_optimizer(adam)
             adam.minimize([cost], [scope])
             fleet.run_server()
-        except:
+        except Exception:
             print("do not support pslib test, skip")
             return
         os.environ["TRAINING_ROLE"] = "wrong"
         try:
             role1 = GeneralRoleMaker(path="./test_gloo_1")
             role1.generate_role()
-        except:
+        except Exception:
             print("catch expected error of wrong TRAINING_ROLE")
         os.environ["TRAINING_ROLE"] = "PSERVER"
         os.environ["PADDLE_PSERVERS_IP_PORT_LIST"] = "127.0.0.1:36001"

--- a/test/legacy_test/test_fleet_rolemaker_3.py
+++ b/test/legacy_test/test_fleet_rolemaker_3.py
@@ -78,7 +78,7 @@ class TestCloudRoleMaker(unittest.TestCase):
             http_server_d["running"] = False
             size_d = {}
             role_maker._GeneralRoleMaker__start_kv_server(http_server_d, size_d)
-        except:
+        except Exception:
             print("do not support pslib test, skip")
             return
 

--- a/test/legacy_test/test_fleet_rolemaker_4.py
+++ b/test/legacy_test/test_fleet_rolemaker_4.py
@@ -39,7 +39,7 @@ class TestCloudRoleMaker(unittest.TestCase):
                 KVHTTPServer,
                 KVServer,
             )
-        except:
+        except Exception:
             print("warning: no fleet, skip test_pslib_4")
             return
 
@@ -118,7 +118,7 @@ class TestCloudRoleMaker(unittest.TestCase):
                     """
                     pass
 
-        except:
+        except Exception:
             print("warning: no KVHandler, skip test_pslib_4")
             return
 
@@ -136,7 +136,7 @@ class TestCloudRoleMaker(unittest.TestCase):
                     self.kv_lock = threading.Lock()
                     self.kv = {}
 
-        except:
+        except Exception:
             print("warning: no KVHTTPServer, skip test_pslib_4")
             return
 
@@ -154,7 +154,7 @@ class TestCloudRoleMaker(unittest.TestCase):
                     self.size = {}
                     self.size["a"] = 999
 
-        except:
+        except Exception:
             print("warning: no KVServer, skip test_pslib_4")
             return
 

--- a/test/legacy_test/test_global_var_getter_setter.py
+++ b/test/legacy_test/test_global_var_getter_setter.py
@@ -48,7 +48,7 @@ class TestGlobalVarGetterSetter(unittest.TestCase):
                 try:
                     g[var.name] = False
                     self.assertTrue(False)
-                except:
+                except Exception:
                     self.assertTrue(True)
 
         name = "__any_non_exist_name__"

--- a/test/legacy_test/test_linalg_pinv_op.py
+++ b/test/legacy_test/test_linalg_pinv_op.py
@@ -96,7 +96,7 @@ class LinalgPinvTestCase(unittest.TestCase):
                 out.backward()
                 x_grad = x.grad
                 # print(x_grad)
-            except:
+            except Exception:
                 raise RuntimeError("Check PINV Grad Failed")
 
 

--- a/test/legacy_test/test_naive_best_fit_gpu_memory_limit.py
+++ b/test/legacy_test/test_naive_best_fit_gpu_memory_limit.py
@@ -49,7 +49,7 @@ class TestBase(unittest.TestCase):
         try:
             t.set(large_np, place)
             self.assertTrue(False)
-        except:
+        except Exception:
             self.assertTrue(True)
 
 

--- a/test/legacy_test/test_newprofiler.py
+++ b/test/legacy_test/test_newprofiler.py
@@ -264,7 +264,7 @@ class TestGetProfiler(unittest.TestCase):
 
         try:
             profiler = profiler.get_profiler(filehandle.name)
-        except:
+        except Exception:
             pass
 
         # test scheduler

--- a/test/legacy_test/test_rank_attention_op.py
+++ b/test/legacy_test/test_rank_attention_op.py
@@ -247,13 +247,13 @@ class TestRankAttentionOpCpu(OpTest):
     def test_check_output_cpu(self):
         try:
             self.check_output_with_place(place=core.CPUPlace())
-        except:
+        except Exception:
             print("do not support cpu test, skip")
 
     def test_check_grad_cpu(self):
         try:
             self.check_grad_with_place(core.CPUPlace(), ["RankParam"], "Out")
-        except:
+        except Exception:
             print("do not support cpu test, skip")
 
 

--- a/test/legacy_test/test_renorm_op.py
+++ b/test/legacy_test/test_renorm_op.py
@@ -97,13 +97,13 @@ class TestRenormAPI(unittest.TestCase):
             exp = False
             try:
                 paddle.renorm(x, 1.0, 8, 2.05)
-            except:
+            except Exception:
                 exp = True
             self.assertTrue(exp)
             exp = False
             try:
                 paddle.renorm(x, 1.0, -4, 2.05)
-            except:
+            except Exception:
                 exp = True
             self.assertTrue(exp)
             y = paddle.renorm(x, 1.0, -1, 2.05)

--- a/test/legacy_test/test_sdpa_kernel.py
+++ b/test/legacy_test/test_sdpa_kernel.py
@@ -42,7 +42,7 @@ def is_flashattn_supported():
         major, minor = capability[0], capability[1]
         # Support sm8x or sm90
         return (major == 8 and minor >= 0) or (major == 9 and minor == 0)
-    except:
+    except Exception:
         return False
 
 

--- a/test/legacy_test/test_slice_scatter.py
+++ b/test/legacy_test/test_slice_scatter.py
@@ -28,7 +28,7 @@ def numpy_ref(_x, value, axes, starts, ends, strides):
 
     try:
         value = np.broadcast_to(value, x.shape)
-    except:
+    except Exception:
         pass
 
     indices_x = []

--- a/test/legacy_test/test_variable.py
+++ b/test/legacy_test/test_variable.py
@@ -564,7 +564,7 @@ class TestListIndex(unittest.TestCase):
             try:
                 getitem_np = array[np.array(index_mod)]
 
-            except:
+            except Exception:
                 with self.assertRaises(ValueError):
                     getitem_pp = pt[index_mod]
                 array = array[0]
@@ -689,7 +689,7 @@ class TestListIndex(unittest.TestCase):
 
         try:
             value_np = array2[index]
-        except:
+        except Exception:
             with self.assertRaises(ValueError):
                 getitem_pp = exe.run(
                     prog, feed={x.name: array}, fetch_list=fetch_list
@@ -751,7 +751,7 @@ class TestListIndex(unittest.TestCase):
                 else index
             )
             array2[index] = value_np
-        except:
+        except Exception:
             with self.assertRaises(ValueError):
                 setitem_pp = exe.run(
                     prog,

--- a/test/sot/test_24_exceptions.py
+++ b/test/sot/test_24_exceptions.py
@@ -58,7 +58,7 @@ class TestRaiseVarargs(TestCaseBase):
             except ZeroDivisionError:
                 x += 3
                 raise  # RAISE_VARARGS(0)
-        except:
+        except Exception:
             x += 4
         return x + 5
 
@@ -73,7 +73,7 @@ class TestRaiseVarargs(TestCaseBase):
             except ZeroDivisionError:
                 x += 3
                 raise  # RAISE_VARARGS(0)
-        except:
+        except Exception:
             x += 4
         return x + 5
 
@@ -84,13 +84,13 @@ class TestRaiseVarargs(TestCaseBase):
         try:
             try:
                 x += 2
-            except:
+            except Exception:
                 x += 3
             else:
                 x += 4
                 raise NotImplementedError  # RAISE_VARARGS(1)
                 x += 5
-        except:
+        except Exception:
             x += 6
         return x + 7
 
@@ -121,7 +121,7 @@ class TestRaiseVarargs(TestCaseBase):
             except NameError as e:
                 x -= 4
                 raise TimeoutError("TESTING") from e  # RAISE_VARARGS(2)
-        except:
+        except Exception:
             x /= 5
         return x + 6
 
@@ -237,7 +237,7 @@ class TestTryExcept(TestCaseBase):
     def try_except_wo_error(x):
         try:
             x = x + 1
-        except:
+        except Exception:
             x = x * 2
         return x
 
@@ -268,7 +268,7 @@ class TestTryExcept(TestCaseBase):
             x = x + 1
             raise ValueError(f"{__class__.__name__}")
             x = x * 3
-        except:
+        except Exception:
             y = x * 2
         return y
 
@@ -280,7 +280,7 @@ class TestTryExcept(TestCaseBase):
             x = x + 1
             raise ValueError
             x = x * 3
-        except:
+        except Exception:
             y = x * 2
         return y
 
@@ -472,7 +472,7 @@ class TestTryExceptElse(TestCaseBase):
     def try_except_else(x):
         try:
             x += 1
-        except:
+        except Exception:
             x += 2
         else:
             x += 3
@@ -559,7 +559,7 @@ class TestTryExceptFinally(TestCaseBase):
     def try_except_finally(x):
         try:
             x -= 1
-        except:
+        except Exception:
             x -= 2
         finally:
             x -= 3
@@ -571,7 +571,7 @@ class TestTryExceptFinally(TestCaseBase):
         try:
             x -= 1
             raise ValueError
-        except:
+        except Exception:
             x -= 2
         finally:
             x -= 3
@@ -649,7 +649,7 @@ class TestTryExceptElseFinally(TestCaseBase):
     def try_except_else_finally(x):
         try:
             x -= 1
-        except:
+        except Exception:
             x -= 2
         else:
             x -= 3
@@ -777,7 +777,7 @@ class TestNestingCase(TestCaseBase):
                             raise TimeoutError(
                                 "TESTING"
                             ) from e  # RAISE_VARARGS(2)
-                    except:
+                    except Exception:
                         x /= 8
                         raise AssertionError
                 except IndentationError as e:
@@ -836,7 +836,7 @@ class TestNestingCase(TestCaseBase):
                     x -= 3
                 except ValueError:
                     x *= 4
-            except:
+            except Exception:
                 x += 5
             return x  # / 6
 
@@ -866,10 +866,10 @@ class TestAssertException(TestCaseBase):
             try:
                 x /= 2
                 raise TimeoutError("TESTING")
-            except:
+            except Exception:
                 x -= 3
                 assert condition
-        except:
+        except Exception:
             x *= 4
         return x / 5
 
@@ -910,7 +910,7 @@ class TestAssertException(TestCaseBase):
                 x += 2
                 assert y > -10000
                 x += 3
-            except:
+            except Exception:
                 x += 4
 
         self.assert_results(try_assert_except, paddle.to_tensor(10), 10)

--- a/test/xpu/amp/test_amp_api_xpu.py
+++ b/test/xpu/amp/test_amp_api_xpu.py
@@ -1,1 +1,460 @@
-../../amp/test_amp_api.py
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from contextlib import contextmanager
+
+import numpy as np
+from amp_base_models import AmpTestBase
+
+import paddle
+from paddle import nn
+from paddle.base import core
+from paddle.static import amp
+
+paddle.set_flags({"FLAGS_use_legacy_linear": True})
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
+    "Bugs on XPU3, disable temporarily",
+)
+class TestAutoCast(AmpTestBase):
+    def init_net(self):
+        self._conv = paddle.nn.Conv2D(
+            in_channels=1, out_channels=6, kernel_size=3, bias_attr=False
+        )
+        self._linear = paddle.nn.Linear(in_features=4, out_features=4)
+
+    def test_amp_OD_level(self):
+        self.init_net()
+        with paddle.amp.auto_cast(level='OD'):
+            out1 = self._conv(paddle.rand(shape=[1, 1, 6, 6], dtype='float32'))
+            out2 = out1 + paddle.rand(shape=out1.shape, dtype='float16')
+            out3 = self._linear(out2)
+
+        self.assertEqual(out1.dtype, paddle.float16)
+        self.assertEqual(out2.dtype, paddle.float32)
+        self.assertEqual(out3.dtype, paddle.float32)
+
+    def test_pir_amp_OD_level(self):
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ),
+        ):
+            self.init_net()
+            with paddle.amp.auto_cast(level='OD'):
+                out1 = self._conv(
+                    paddle.rand(shape=[1, 1, 6, 6], dtype='float32')
+                )
+                out2 = out1 + paddle.rand(shape=out1.shape, dtype='float16')
+                out3 = self._linear(out2)
+
+            self.assertEqual(out1.dtype, core.DataType.FLOAT16)
+            self.assertEqual(out2.dtype, core.DataType.FLOAT32)
+            self.assertEqual(out3.dtype, core.DataType.FLOAT32)
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
+    "Bugs on XPU3, disable temporarily",
+)
+class TestCudaAutoCast(unittest.TestCase):
+    def setUp(self):
+        self._conv = paddle.nn.Conv2D(1, 1, 3, bias_attr=False)
+        self._linear = paddle.nn.Linear(4, 4)
+
+    def _run_autocast_test(self, ctx):
+        with ctx:
+            out1 = self._conv(paddle.rand(shape=[1, 1, 6, 6], dtype='float32'))
+            out2 = out1 + paddle.rand(shape=out1.shape, dtype='float16')
+            out3 = self._linear(out2)
+
+        self.assertEqual(out1.dtype, paddle.float16)
+        self.assertEqual(out2.dtype, paddle.float16)
+        self.assertEqual(out3.dtype, paddle.float32)
+
+    def test_amp_autocast(self):
+        self._run_autocast_test(paddle.amp.autocast(device_type='cuda'))
+
+    def test_amp_autocast2(self):
+        self._run_autocast_test(
+            paddle.amp.autocast(
+                device_type='cuda',
+                enabled=True,
+                dtype=paddle.float16,
+                cache_enabled=True,
+            )
+        )
+
+    def test_autocast(self):
+        self._run_autocast_test(
+            paddle.autocast(
+                device_type='cuda',
+                enabled=True,
+                dtype=paddle.float16,
+                cache_enabled=True,
+            )
+        )
+
+    def test_cuda_amp_autocast(self):
+        self._run_autocast_test(paddle.cuda.amp.autocast())
+
+    def test_device_amp_autocast(self):
+        self._run_autocast_test(paddle.device.amp.autocast())
+
+    def test_cuda_amp_autocast_mode_autocast(self):
+        self._run_autocast_test(paddle.cuda.amp.autocast_mode.autocast())
+
+
+class SimpleConvNet(nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self._conv = paddle.nn.Conv2D(
+            in_channels=1, out_channels=6, kernel_size=3, bias_attr=False
+        )
+        self._linear = paddle.nn.Linear(in_features=4, out_features=4)
+
+    def forward(self, x):
+        out1 = self._conv(paddle.rand(shape=[1, 1, 6, 6], dtype='float32'))
+        out2 = out1 + paddle.rand(shape=out1.shape, dtype='float16')
+        out3 = self._linear(out2)
+        return out3
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
+    "Bugs on XPU3, disable temporarily",
+)
+class TestStaticDecorate(AmpTestBase):
+    def check_results(
+        self, use_amp, dtype, level, use_promote, expected_op_calls
+    ):
+        main_program = paddle.static.Program()
+        startup_program = paddle.static.Program()
+        with (
+            paddle.utils.unique_name.guard(),
+            paddle.static.program_guard(main_program, startup_program),
+        ):
+            model = SimpleConvNet()
+            x = paddle.static.data(
+                name='input', shape=[None, 1, 6, 6], dtype='float32'
+            )
+            out = model(x)
+            loss = paddle.mean(out)
+            optimizer = paddle.optimizer.Adadelta(learning_rate=0.001)
+            optimizer = paddle.static.amp.decorate(
+                optimizer,
+                init_loss_scaling=128.0,
+                use_dynamic_loss_scaling=True,
+                level=level,
+            )
+            optimizer.minimize(loss)
+
+        feed_vars = [x]
+        fetch_vars = [loss]
+        self.assertEqual(main_program.num_blocks, 1)
+
+        amp.debugging.collect_operator_stats(main_program)
+        op_stats_list = amp.debugging._get_op_stats_list(main_program)
+
+        self._check_op_calls(
+            op_stats_list[0], expected_fp16_calls=expected_op_calls
+        )
+
+        if paddle.is_compiled_with_cuda():
+            place = paddle.CUDAPlace(0)
+        elif paddle.device.is_compiled_with_xpu():
+            place = paddle.device.XPUPlace(0)
+        else:
+            raise ValueError("Only support CUDA or XPU Place.")
+        exe = paddle.static.Executor(place)
+
+        max_iters = 2
+        x_fp32 = np.random.random(size=[1, 1, 6, 6]).astype("float32")
+        losses_o1 = self.run_program(
+            main_program,
+            startup_program,
+            optimizer,
+            feed_vars,
+            fetch_vars,
+            place,
+            exe,
+            x_fp32,
+            max_iters,
+            dtype,
+            level,
+        )
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
+    "Bugs on XPU3, disable temporarily",
+)
+class TestGradScaler(AmpTestBase):
+    def test_amp_grad_scaler(self):
+        model = paddle.nn.Conv2D(3, 2, 3)
+        optimizer = paddle.optimizer.SGD(
+            learning_rate=0.01, parameters=model.parameters()
+        )
+        scaler = paddle.amp.GradScaler()
+        data = paddle.rand([1, 3, 8, 8], dtype='float32')
+        paddle.amp.debugging.enable_operator_stats_collection()
+        with paddle.amp.auto_cast(
+            custom_black_list=['conv2d'], dtype='bfloat16'
+        ):
+            out = model(data)
+            loss = out.mean()
+        scaled = scaler.scale(loss)
+        scaled.backward()
+        scaler.minimize(optimizer, scaled)
+        optimizer.clear_grad()
+        paddle.amp.debugging.disable_operator_stats_collection()
+        op_list = paddle.base.core.get_low_precision_op_list()
+
+        self.assertEqual(scaler._enable, False)
+        self.assertEqual(scaler._use_dynamic_loss_scaling, False)
+        self.assertTrue('scale' not in op_list)
+        self.assertTrue('check_finite_and_unscale' not in op_list)
+
+    def test_pir_amp_grad_scaler(self):
+        with paddle.pir_utils.IrGuard():
+            startup = paddle.static.Program()
+            main = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                model = paddle.nn.Conv2D(3, 2, 3)
+                optimizer = paddle.optimizer.SGD(
+                    learning_rate=0.01, parameters=model.parameters()
+                )
+                model, optimizer = paddle.amp.decorate(
+                    models=model,
+                    optimizers=optimizer,
+                )
+                scaler = paddle.amp.GradScaler()
+                data = paddle.static.data('data', [1, 3, 8, 8], dtype='float32')
+
+                with paddle.amp.auto_cast(
+                    custom_black_list=['conv2d'], dtype='bfloat16'
+                ):
+                    out = model(data)
+                    loss = out.mean()
+                scaled = scaler.scale(loss)
+                scaler.minimize(optimizer, scaled)
+
+                if paddle.is_compiled_with_cuda():
+                    place = paddle.CUDAPlace(0)
+                elif paddle.device.is_compiled_with_xpu():
+                    place = paddle.device.XPUPlace(0)
+                else:
+                    raise ValueError("Only support CUDA or XPU Place.")
+                exe = paddle.static.Executor(place)
+                exe.run(startup)
+                paddle.amp.debugging.enable_operator_stats_collection()
+                exe.run(
+                    main,
+                    feed={'data': np.random.rand(1, 3, 8, 8).astype('float32')},
+                    fetch_list=[loss],
+                )
+                paddle.amp.debugging.disable_operator_stats_collection()
+                op_list = paddle.base.core.get_low_precision_op_list()
+
+                self.assertEqual(scaler._enable, False)
+                self.assertEqual(scaler._use_dynamic_loss_scaling, False)
+                self.assertTrue('pd_op.scale' not in op_list)
+                self.assertTrue(
+                    'pd_op.check_finite_and_unscale_' not in op_list
+                )
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
+    "Bugs on XPU3, disable temporarily",
+)
+class SimpleModelIncludeSetValue(nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.norm = nn.LayerNorm(3)
+
+    def forward(self, x):
+        x = x + 1
+        tmp = x * 1
+        y = self.norm(tmp)
+        x[:] = y
+
+        z = x * 1
+        return z
+
+
+# Copy from ../dygraph_to_static/dygraph_to_static_utils.py
+@contextmanager
+def pir_dygraph_guard():
+    in_dygraph_mode = paddle.in_dynamic_mode()
+    with paddle.pir_utils.IrGuard():
+        if in_dygraph_mode:
+            paddle.disable_static()
+        yield
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
+    "Bugs on XPU3, disable temporarily",
+)
+class TestDy2STWithSetValue(AmpTestBase):
+    def test_op_called_as_expected(self):
+        if paddle.framework.use_pir_api():
+            return
+        expected_fp16_calls = {
+            "cast": 1,
+            "layer_norm": 1,
+            "scale": 3,
+            "set_value": 1,
+        }
+
+        func = SimpleModelIncludeSetValue()
+        func = paddle.amp.decorate(func, level='O2')
+        func = paddle.jit.to_static(func, full_graph=True, backend=None)
+        input = paddle.randn((2, 3))
+
+        with paddle.amp.auto_cast(level='O2', use_promote=False):
+            res = func(input)
+            loss = res.sum()
+            prog = func.forward.get_concrete_program(input)[1].forward_program
+            amp.debugging.collect_operator_stats(prog)
+            op_stats_list = amp.debugging._get_op_stats_list(prog)
+        loss.backward()
+        self._check_op_calls(
+            op_stats_list[0], expected_fp16_calls=expected_fp16_calls
+        )
+
+    def test_pir_op_called_as_expected(self):
+        expected_fp16_calls = {
+            "pd_op.layer_norm": 1,
+            "pd_op.scale": 1,
+            "pd_op.scale_": 2,
+            "pd_op.set_value_with_tensor_": 1,
+        }
+
+        with pir_dygraph_guard():
+            func = SimpleModelIncludeSetValue()
+            func = paddle.amp.decorate(func, level='O2')
+            func = paddle.jit.to_static(func, full_graph=True, backend=None)
+            input = paddle.randn((2, 3))
+
+            paddle.amp.debugging.enable_operator_stats_collection()
+            with paddle.amp.auto_cast(level='O2', use_promote=False):
+                res = func(input)
+                loss = res.sum()
+                paddle.amp.debugging.disable_operator_stats_collection()
+                op_stats = paddle.base.core.get_low_precision_op_list()
+
+            loss.backward()
+            self._check_op_calls(
+                op_stats, expected_fp16_calls=expected_fp16_calls
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/xpu/amp/test_amp_decorate_xpu.py
+++ b/test/xpu/amp/test_amp_decorate_xpu.py
@@ -1,1 +1,248 @@
-../../amp/test_amp_decorate.py
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.nn.functional as F
+from paddle.base import core
+
+
+class ConvBNLayer(paddle.nn.Layer):
+    def __init__(
+        self,
+        num_channels,
+        num_filters,
+        filter_size,
+        stride=1,
+        groups=1,
+        act=None,
+    ):
+        super().__init__()
+
+        self._conv = paddle.nn.Conv2D(
+            in_channels=num_channels,
+            out_channels=num_filters,
+            kernel_size=filter_size,
+            stride=stride,
+            padding=(filter_size - 1) // 2,
+            groups=groups,
+            bias_attr=None,
+        )
+
+        self._batch_norm = paddle.nn.BatchNorm(num_filters, act=act)
+
+    def forward(self, inputs):
+        y = self._conv(inputs)
+        y = self._batch_norm(y)
+
+        return y
+
+
+class Model(paddle.nn.Layer):
+    def __init__(
+        self, input_channel, hidden_size, fp16_conv=True, fp16_linear=True
+    ):
+        super().__init__()
+        self.conv = ConvBNLayer(input_channel, 8, 3)
+        self.linear = paddle.nn.Linear(8, hidden_size)
+        self.layernorm = paddle.nn.Sequential(
+            paddle.nn.LayerNorm(hidden_size),
+            paddle.nn.LayerNorm(hidden_size),
+        )
+        self.fp16_conv = fp16_conv
+        self.fp16_linear = fp16_linear
+
+    def forward(self, inputs):
+        with paddle.amp.auto_cast(enable=self.fp16_conv):
+            if not self.fp16_conv:
+                inputs = inputs.astype('float32')
+            x = self.conv(inputs)
+        with paddle.amp.auto_cast(enable=self.fp16_linear):
+            if not self.fp16_linear:
+                x = x.astype('float32')
+            x = self.linear(x)
+        x = F.relu(x)
+        x = self.layernorm(x)
+        return x
+
+
+class LayerNorm2D(paddle.nn.LayerNorm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def forward(self, x):
+        x = x.transpose([0, 2, 3, 1])
+        x = super().forward(x)
+        return x.transpose([0, 3, 1, 2])
+
+
+class CustomLayer(paddle.nn.Layer):
+    def __init__(
+        self, input_channel, hidden_size, fp16_conv=True, fp16_linear=True
+    ):
+        super().__init__()
+        self.conv = ConvBNLayer(input_channel, 8, 3)
+        self.linear = paddle.nn.Linear(8, hidden_size)
+        self.layernorm = paddle.nn.Sequential(
+            LayerNorm2D(hidden_size),
+            LayerNorm2D(hidden_size),
+        )
+        self.fp16_conv = fp16_conv
+        self.fp16_linear = fp16_linear
+
+    def forward(self, inputs):
+        with paddle.amp.auto_cast(enable=self.fp16_conv):
+            if not self.fp16_conv:
+                inputs = inputs.astype('float32')
+            x = self.conv(inputs)
+        with paddle.amp.auto_cast(enable=self.fp16_linear):
+            if not self.fp16_linear:
+                x = x.astype('float32')
+            x = self.linear(x)
+        x = F.relu(x)
+        x = self.layernorm(x)
+        return x
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+class TestAMPDecorate(unittest.TestCase):
+    def check_results(self, fp32_layers=[], fp16_layers=[]):
+        for idx in range(len(fp32_layers)):
+            for layer in fp32_layers[idx].sublayers(include_self=False):
+                self.assertTrue(
+                    layer.weight.dtype
+                    in (paddle.float32, core.DataType.FLOAT32)
+                )
+                self.assertTrue(
+                    layer.bias.dtype in (paddle.float32, core.DataType.FLOAT32)
+                )
+
+        for idx in range(len(fp16_layers)):
+            for layer in fp16_layers[idx].sublayers(include_self=False):
+                self.assertTrue(
+                    layer.weight.dtype
+                    in (paddle.float16, core.DataType.FLOAT16)
+                )
+                self.assertTrue(
+                    layer.bias.dtype in (paddle.float16, core.DataType.FLOAT16)
+                )
+
+    def test_excluded_layers(self):
+        model = Model(4, 8, fp16_conv=False)
+        model = paddle.amp.decorate(
+            models=model,
+            level='O2',
+            dtype='float16',
+            excluded_layers=model.conv,
+        )
+        with paddle.amp.auto_cast(level='O2'):
+            out = model(paddle.rand(shape=[2, 4, 8, 8], dtype='float32'))
+        self.check_results(
+            fp32_layers=[model.conv, model.layernorm],
+            fp16_layers=[model.linear],
+        )
+
+    def test_excluded_layers_attr_list(self):
+        model = Model(4, 8, fp16_conv=False, fp16_linear=False)
+        model = paddle.amp.decorate(
+            models=model,
+            level='O2',
+            dtype='float16',
+            excluded_layers=[model.conv, model.linear],
+        )
+
+        with paddle.amp.auto_cast(level='O2'):
+            out = model(paddle.rand(shape=[2, 4, 8, 8], dtype='float32'))
+
+        self.check_results(
+            fp32_layers=[model.conv, model.linear, model.layernorm]
+        )
+
+    def test_excluded_layers_attr_types(self):
+        model = Model(4, 8)
+        model = paddle.amp.decorate(
+            models=model,
+            level='O2',
+            dtype='float16',
+            excluded_layers=[paddle.nn.Conv2D, model.linear],
+        )
+
+        with paddle.amp.auto_cast(level='O2'):
+            out = model(paddle.rand(shape=[2, 4, 8, 8], dtype='float16'))
+
+        self.check_results(
+            fp32_layers=[model.conv, model.linear, model.layernorm]
+        )
+
+    def test_excluded_layers_attr_none(self):
+        model = Model(4, 8)
+        model = paddle.amp.decorate(
+            models=model,
+            level='O2',
+            dtype='float16',
+            excluded_layers=None,
+        )
+
+        with paddle.amp.auto_cast(level='O2'):
+            out = model(paddle.rand(shape=[2, 4, 8, 8], dtype='float16'))
+
+        self.check_results(
+            fp32_layers=[model.layernorm, model.conv._batch_norm],
+            fp16_layers=[model.conv._conv, model.linear],
+        )
+
+    def test_excluded_layers_custom_layer(self):
+        model = CustomLayer(4, 8)
+        model = paddle.amp.decorate(
+            models=model,
+            level='O2',
+            dtype='bfloat16',
+            excluded_layers=[paddle.nn.LayerNorm, paddle.nn.BatchNorm],
+        )
+        with paddle.amp.auto_cast(level='O2'):
+            out = model(paddle.rand(shape=[2, 4, 8, 8], dtype='float32'))
+        self.check_results(
+            fp32_layers=[model.layernorm, model.conv._batch_norm],
+        )
+
+    def test_pir(self):
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ),
+        ):
+            self.test_excluded_layers()
+            self.test_excluded_layers_attr_list()
+            self.test_excluded_layers_attr_types()
+            self.test_excluded_layers_attr_none()
+            self.test_excluded_layers_custom_layer()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/xpu/amp/test_amp_list_xpu.py
+++ b/test/xpu/amp/test_amp_list_xpu.py
@@ -1,1 +1,170 @@
-../../amp/test_amp_list.py
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+from paddle.base import core
+from paddle.static.amp import AutoMixedPrecisionLists, fp16_lists
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+class TestAMPList(unittest.TestCase):
+    def setUp(self):
+        self.default_black_list = [
+            'linear_interp_v2',
+            'nearest_interp_v2',
+            'bilinear_interp_v2',
+            'bicubic_interp_v2',
+            'trilinear_interp_v2',
+        ]
+        self.custom_white_list = [
+            'lookup_table',
+            'lookup_table_v2',
+        ]
+
+    def check_if_op_in_list(self, op_list, amp_list):
+        for op in op_list:
+            self.assertTrue(op in amp_list)
+
+    def check_if_op_not_in_list(self, op_list, amp_list):
+        for op in op_list:
+            self.assertTrue(op not in amp_list)
+
+    def test_static(self):
+        amp_list = AutoMixedPrecisionLists(
+            custom_white_list=self.custom_white_list
+        )
+        self.check_if_op_in_list(self.default_black_list, amp_list.black_list)
+        self.check_if_op_in_list(self.custom_white_list, amp_list.white_list)
+        self.check_if_op_not_in_list(
+            self.custom_white_list, amp_list.black_list
+        )
+        if paddle.amp.is_float16_supported():
+            self.check_if_op_not_in_list(
+                self.custom_white_list, amp_list.black_list
+            )
+
+    def test_eager(self):
+        if not paddle.amp.is_float16_supported():
+            return
+        white_list = paddle.amp.white_list()
+        black_list = paddle.amp.black_list()
+        self.check_if_op_in_list(
+            self.default_black_list, black_list["float16"]["O2"]
+        )
+        self.check_if_op_not_in_list(['log', 'elementwise_add'], white_list)
+        with paddle.amp.auto_cast(custom_white_list={'elementwise_add'}):
+            out1 = paddle.rand([2, 3]) + paddle.rand([2, 3])
+            out2 = out1.mean()
+            out3 = paddle.log(out2)
+        self.check_if_op_not_in_list(['log', 'elementwise_add'], white_list)
+        self.assertEqual(out1.dtype, paddle.float16)
+        self.assertEqual(out2.dtype, paddle.float32)
+        self.assertEqual(out3.dtype, paddle.float32)
+
+    def test_pir(self):
+        with (
+            paddle.pir_utils.IrGuard(),
+            paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ),
+        ):
+            white_list = paddle.amp.white_list()
+            black_list = paddle.amp.black_list()
+            self.check_if_op_in_list(
+                self.default_black_list, black_list["float16"]["O2"]
+            )
+            self.check_if_op_not_in_list(['log', 'elementwise_add'], white_list)
+            with paddle.amp.auto_cast(custom_white_list={'elementwise_add'}):
+                out1 = paddle.rand([2, 3]) + paddle.rand([2, 3])
+                out2 = out1.mean()
+                out3 = paddle.log(out2)
+            self.check_if_op_not_in_list(['log', 'elementwise_add'], white_list)
+            self.assertEqual(out1.dtype, core.DataType.FLOAT16)
+            self.assertEqual(out2.dtype, core.DataType.FLOAT32)
+            self.assertEqual(out3.dtype, core.DataType.FLOAT32)
+
+    def test_apis(self):
+        def _run_check_dtype():
+            fp16_lists.check_amp_dtype(dtype="int64")
+
+        self.assertRaises(ValueError, _run_check_dtype)
+
+        for vartype in [core.VarDesc.VarType.FP16, core.VarDesc.VarType.BF16]:
+            self.assertEqual(
+                fp16_lists.get_low_precision_vartype(vartype), vartype
+            )
+        self.assertEqual(
+            fp16_lists.get_low_precision_vartype("float16"),
+            core.VarDesc.VarType.FP16,
+        )
+        self.assertEqual(
+            fp16_lists.get_low_precision_vartype("bfloat16"),
+            core.VarDesc.VarType.BF16,
+        )
+
+        def _run_get_vartype():
+            fp16_lists.get_low_precision_vartype(dtype="int64")
+
+        self.assertRaises(ValueError, _run_get_vartype)
+
+        for dtype in ["float16", "bfloat16"]:
+            self.assertEqual(
+                fp16_lists.get_low_precision_dtypestr(dtype), dtype
+            )
+        if paddle.framework.use_pir_api():
+            self.assertEqual(
+                fp16_lists.get_low_precision_dtypestr(core.DataType.FLOAT16),
+                "float16",
+            )
+            self.assertEqual(
+                fp16_lists.get_low_precision_dtypestr(core.DataType.BFLOAT16),
+                "bfloat16",
+            )
+        else:
+            self.assertEqual(
+                fp16_lists.get_low_precision_dtypestr(
+                    core.VarDesc.VarType.FP16
+                ),
+                "float16",
+            )
+            self.assertEqual(
+                fp16_lists.get_low_precision_dtypestr(
+                    core.VarDesc.VarType.BF16
+                ),
+                "bfloat16",
+            )
+
+        def _run_get_dtypestr():
+            fp16_lists.get_low_precision_dtypestr(dtype="int64")
+
+        self.assertRaises(ValueError, _run_get_dtypestr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/xpu/amp/test_amp_master_grad_xpu.py
+++ b/test/xpu/amp/test_amp_master_grad_xpu.py
@@ -1,1 +1,222 @@
-../../amp/test_amp_master_grad.py
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.base import core
+
+paddle.set_flags({"FLAGS_use_legacy_linear": True})
+
+
+class SimpleNet(paddle.nn.Layer):
+    def __init__(self, input_size, output_size):
+        super().__init__()
+        self.linear = paddle.nn.Linear(input_size, output_size)
+
+    def forward(self, x):
+        x = self.linear(x)
+        return x
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and not core.is_float16_supported(core.CUDAPlace(0)),
+    "core is not compiled with CUDA and not support the float16",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) == core.XPUVersion.XPU3,
+    "Bugs on XPU3, disable temporarily",
+)
+class TestMasterGrad(unittest.TestCase):
+    def check_results(
+        self, fp32_grads, op_list, total_steps, accumulate_batches_num
+    ):
+        for grad in fp32_grads:
+            self.assertEqual(grad.dtype, paddle.float32)
+        # fp16 calls
+        self.assertEqual(int(op_list['matmul_v2'].split(',')[0]), total_steps)
+        self.assertEqual(
+            int(op_list['adam_'].split(',')[0]),
+            2 * (total_steps / accumulate_batches_num),
+        )
+        # Since two additional casts are called when constructing master grad,
+        # the number of operators of this type +2
+        self.assertEqual(
+            int(op_list['cast'].split(',')[0]),
+            total_steps * 2 + 2,
+        )
+
+    def run_dygraph(
+        self, total_steps, accumulate_batches_num, model, optimizer
+    ):
+        model, opt = paddle.amp.decorate(
+            model, optimizers=optimizer, level='O2', master_grad=True
+        )
+        scaler = paddle.amp.GradScaler()
+        paddle.amp.debugging.enable_operator_stats_collection()
+        for i in range(total_steps):
+            x = np.random.random((2, 2)).astype('float32')
+            label = np.random.random((2, 4)).astype('float32')
+
+            with paddle.amp.auto_cast(level='O2'):
+                out = model(paddle.to_tensor(x))
+                loss = paddle.nn.functional.l1_loss(
+                    out, paddle.to_tensor(label)
+                )
+            scaled = scaler.scale(loss)
+            scaled.backward()
+            fp32_grads = [model.linear.weight.grad, model.linear.bias.grad]
+            if (i + 1) % accumulate_batches_num == 0:
+                scaler.step(opt)
+                scaler.update()
+                opt.clear_grad()
+        paddle.amp.debugging.disable_operator_stats_collection()
+        op_list = paddle.base.core.get_low_precision_op_list()
+        return fp32_grads, op_list
+
+    def test_adam_master_grad(self):
+        total_steps = 4
+        accumulate_batches_num = 2
+        model = SimpleNet(2, 4)
+        opt = paddle.optimizer.Adam(parameters=model.parameters())
+        fp32_grads, op_list = self.run_dygraph(
+            total_steps, accumulate_batches_num, model, opt
+        )
+        self.check_results(
+            fp32_grads, op_list, total_steps, accumulate_batches_num
+        )
+
+    def test_momentum_master_grad(self):
+        total_steps = 4
+        accumulate_batches_num = 1
+        model = SimpleNet(2, 4)
+        L1Decay = paddle.regularizer.L1Decay(0.0001)
+        opt = paddle.optimizer.Momentum(
+            parameters=model.parameters(), weight_decay=L1Decay
+        )
+        fp32_grads, op_list = self.run_dygraph(
+            total_steps, accumulate_batches_num, model, opt
+        )
+        for grad in fp32_grads:
+            self.assertEqual(grad.dtype, paddle.float32)
+
+    def run_pir(self, total_steps, accumulate_batches_num, model, optimizer):
+        model, opt = paddle.amp.decorate(
+            model, optimizers=optimizer, level='O2', master_grad=True
+        )
+        scaler = paddle.amp.GradScaler()
+        x = paddle.static.data('x', (2, 2), 'float32')
+        label = paddle.static.data('label', (2, 4), 'float32')
+        with paddle.amp.auto_cast(level='O2'):
+            out = model(paddle.to_tensor(x))
+            loss = paddle.nn.functional.l1_loss(out, paddle.to_tensor(label))
+        scaled = scaler.scale(loss)
+        scaler.minimize(opt, scaled)
+
+        fp32_grads = list(opt._optimizer._master_grads.values())
+        if paddle.is_compiled_with_cuda():
+            place = paddle.CUDAPlace(0)
+        elif paddle.device.is_compiled_with_xpu():
+            place = paddle.device.XPUPlace(0)
+        else:
+            raise ValueError("Only support CUDA or XPU Place.")
+        exe = paddle.static.Executor(place)
+        exe.run(paddle.static.default_startup_program())
+        paddle.amp.debugging.enable_operator_stats_collection()
+        for i in range(total_steps):
+            exe.run(
+                paddle.static.default_main_program(),
+                feed={
+                    'x': np.random.random((2, 2)).astype('float32'),
+                    'label': np.random.random((2, 4)).astype('float32'),
+                },
+                fetch_list=[loss],
+            )
+        paddle.amp.debugging.disable_operator_stats_collection()
+        op_list = paddle.base.core.get_low_precision_op_list()
+        return fp32_grads, op_list
+
+    def check_pir_results(
+        self, fp32_grads, op_list, total_steps, accumulate_batches_num
+    ):
+        for grad in fp32_grads:
+            self.assertEqual(grad.dtype, core.DataType.FLOAT32)
+        # fp16 calls
+        self.assertEqual(
+            int(op_list['pd_op.matmul'].split(',')[0]), total_steps
+        )
+        self.assertEqual(
+            int(op_list['pd_op.adam_'].split(',')[0]),
+            2 * total_steps,
+        )
+        self.assertEqual(
+            int(op_list['pd_op.cast'].split(',')[0]),
+            total_steps * 3,
+        )
+
+    def test_pir_adam_master_grad(self):
+        with paddle.pir_utils.IrGuard():
+            startup = paddle.static.Program()
+            main = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                total_steps = 4
+                accumulate_batches_num = 2
+                model = SimpleNet(2, 4)
+                opt = paddle.optimizer.Adam(parameters=model.parameters())
+                fp32_grads, op_list = self.run_pir(
+                    total_steps, accumulate_batches_num, model, opt
+                )
+                self.check_pir_results(
+                    fp32_grads, op_list, total_steps, accumulate_batches_num
+                )
+
+    def test_pir_momentum_master_grad(self):
+        with paddle.pir_utils.IrGuard():
+            startup = paddle.static.Program()
+            main = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                total_steps = 4
+                accumulate_batches_num = 1
+                model = SimpleNet(2, 4)
+                L1Decay = paddle.regularizer.L1Decay(0.0001)
+                opt = paddle.optimizer.Momentum(
+                    parameters=model.parameters(), weight_decay=L1Decay
+                )
+                fp32_grads, op_list = self.run_pir(
+                    total_steps, accumulate_batches_num, model, opt
+                )
+                for grad in fp32_grads:
+                    self.assertEqual(grad.dtype, core.DataType.FLOAT32)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/xpu/amp/test_amp_master_weight_xpu.py
+++ b/test/xpu/amp/test_amp_master_weight_xpu.py
@@ -1,1 +1,213 @@
-../../amp/test_amp_master_weight.py
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from amp_base_models import AmpTestBase
+
+import paddle
+from paddle.base import core
+
+
+class SimpleNet(paddle.nn.Layer):
+    def __init__(self, input_size, output_size):
+        super().__init__()
+        weight_attr = paddle.ParamAttr(
+            name="weight", initializer=paddle.nn.initializer.Constant(value=0.5)
+        )
+        bias_attr = paddle.ParamAttr(
+            name="bias", initializer=paddle.nn.initializer.Constant(value=1.0)
+        )
+        self.linear = paddle.nn.Linear(
+            input_size, output_size, weight_attr, bias_attr
+        )
+
+    def forward(self, x):
+        x = self.linear(x)
+        return x
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+class TestMasterWeight(AmpTestBase):
+    def run_dygraph(self, dtype, level, use_promote, max_iters, x_data):
+        losses = []
+        model = SimpleNet(100, 100)
+        optimizer = paddle.optimizer.AdamW(
+            learning_rate=0.01,
+            parameters=model.parameters(),
+        )
+        scaler = paddle.amp.GradScaler()
+        model, optimizer = paddle.amp.decorate(
+            models=model,
+            optimizers=optimizer,
+            level=level,
+            dtype=dtype,
+        )
+
+        for i in range(max_iters):
+            with paddle.amp.auto_cast(
+                enable=True,
+                dtype=dtype,
+                level=level,
+                use_promote=use_promote,
+            ):
+                x = paddle.to_tensor(x_data, dtype='float16')
+                out = model(x)
+                loss = paddle.mean(out)
+                losses.append(loss)
+            scaled = scaler.scale(loss)
+            scaled.backward()
+            scaler.minimize(optimizer, scaled)
+            optimizer.clear_grad()
+        return losses
+
+    def run_pir(self, dtype, level, use_promote, max_iters, x_data):
+        with paddle.pir_utils.IrGuard():
+            losses = []
+            startup = paddle.static.Program()
+            main = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                model = SimpleNet(100, 100)
+                optimizer = paddle.optimizer.AdamW(
+                    learning_rate=0.01,
+                    parameters=model.parameters(),
+                )
+                scaler = paddle.amp.GradScaler(enable=True)
+                model, optimizer = paddle.amp.decorate(
+                    models=model,
+                    optimizers=optimizer,
+                    level=level,
+                    dtype=dtype,
+                )
+                with paddle.amp.auto_cast(
+                    enable=True,
+                    dtype=dtype,
+                    level=level,
+                    use_promote=use_promote,
+                ):
+                    x = paddle.static.data('x', x_data.shape, 'float16')
+                    out = model(x)
+                    loss = paddle.mean(out)
+                scaled = scaler.scale(loss)
+                scaler.minimize(optimizer, scaled)
+            if paddle.is_compiled_with_cuda():
+                place = paddle.CUDAPlace(0)
+            elif paddle.device.is_compiled_with_xpu():
+                place = paddle.device.XPUPlace(0)
+            else:
+                raise ValueError("Only support CUDA or XPU Place.")
+            exe = paddle.static.Executor(place)
+            exe.run(startup)
+            for iter_id in range(max_iters):
+                results = exe.run(
+                    main,
+                    feed={'x': x_data},
+                    fetch_list=[loss],
+                )
+
+                losses.append(results[0])
+
+            return losses
+
+    def run_static(self, dtype, level, use_promote, max_iters, x_data):
+        paddle.enable_static()
+        with paddle.pir_utils.OldIrGuard():
+            main_program = paddle.static.Program()
+            startup_program = paddle.static.Program()
+            losses = []
+            with (
+                paddle.utils.unique_name.guard(),
+                paddle.static.program_guard(main_program, startup_program),
+            ):
+                model = SimpleNet(100, 100)
+                optimizer = paddle.optimizer.AdamW(learning_rate=0.01)
+                optimizer = paddle.static.amp.decorate(
+                    optimizer,
+                    level=level,
+                    dtype=dtype,
+                    use_promote=use_promote,
+                    master_weight=True,
+                )
+                x = paddle.static.data(
+                    name='input', shape=[100, 100], dtype='float16'
+                )
+                out = model(x)
+                loss = paddle.mean(out)
+                optimizer.minimize(loss)
+
+            if paddle.is_compiled_with_cuda():
+                place = paddle.CUDAPlace(0)
+            elif paddle.device.is_compiled_with_xpu():
+                place = paddle.device.XPUPlace(0)
+            else:
+                raise ValueError("Only support CUDA or XPU Place.")
+            exe = paddle.static.Executor(place)
+            exe.run(startup_program)
+            optimizer.amp_init(
+                place,
+                scope=paddle.static.global_scope(),
+                rewrite_master_weight=True,
+            )
+            for iter_id in range(max_iters):
+                results = exe.run(
+                    program=main_program,
+                    feed={x.name: x_data},
+                    fetch_list=[loss],
+                )
+                print(
+                    f"-- [AMP {dtype} {level}] iter={iter_id}, loss={results[0]}"
+                )
+                losses.append(results[0])
+
+        paddle.disable_static()
+        return losses
+
+    def test_master_weight(self):
+        np.random.seed(1)
+        paddle.seed(1)
+        dtype = 'float16'
+        level = 'O2'
+        use_promote = True
+        total_steps = 4
+        x_data = np.random.random(size=[100, 100]).astype("float16")
+
+        loss_dygraph = self.run_dygraph(
+            dtype, level, use_promote, total_steps, x_data
+        )
+        loss_static = self.run_static(
+            dtype, level, use_promote, total_steps, x_data
+        )
+        loss_pir = self.run_pir(dtype, level, use_promote, total_steps, x_data)
+
+        for i in range(total_steps):
+            self.assertEqual(loss_dygraph[i], loss_static[i])
+            self.assertEqual(loss_dygraph[i], loss_pir[i])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/xpu/amp/test_amp_promote_xpu.py
+++ b/test/xpu/amp/test_amp_promote_xpu.py
@@ -1,1 +1,424 @@
-../../amp/test_amp_promote.py
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from amp_base_models import AmpTestBase, build_conv_model
+
+import paddle
+from paddle.base import core
+from paddle.static import amp
+
+paddle.set_flags({"FLAGS_use_legacy_linear": True})
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+class TestStaticAmpPromoteStats(AmpTestBase):
+    def check_promote_results(
+        self, use_amp, dtype, level, use_promote, expected_op_calls, debug_info
+    ):
+        paddle.enable_static()
+        (
+            main_program,
+            startup_program,
+            optimizer,
+            feed_vars,
+            fetch_vars,
+        ) = build_conv_model(use_amp, dtype, level, use_promote)
+        self.assertEqual(main_program.num_blocks, 1)
+
+        amp.debugging.collect_operator_stats(main_program)
+        op_stats_list = amp.debugging._get_op_stats_list(main_program)
+
+        self._check_op_calls(
+            op_stats_list[0],
+            expected_fp16_calls=expected_op_calls,
+            debug_info=debug_info,
+        )
+
+        if paddle.is_compiled_with_cuda():
+            place = paddle.CUDAPlace(0)
+        elif paddle.device.is_compiled_with_xpu():
+            place = paddle.device.XPUPlace(0)
+        else:
+            raise ValueError("Only support CUDA or XPU Place.")
+        exe = paddle.static.Executor(place)
+
+        max_iters = 2
+        x_fp32 = np.random.random(size=[1, 1, 6, 6]).astype("float32")
+        losses_o1 = self.run_program(
+            main_program,
+            startup_program,
+            optimizer,
+            feed_vars,
+            fetch_vars,
+            place,
+            exe,
+            x_fp32,
+            max_iters,
+            dtype,
+            level,
+        )
+        paddle.disable_static()
+
+    def test_static_amp_o1(self):
+        expected_fp16_calls = {
+            "conv2d": 1,
+            "elementwise_add": 0,
+            "relu": 0,
+            "matmul_v2": 1,
+            "softmax": 0,
+            "reduce_mean": 0,
+            "adamw": 0,
+        }
+        with paddle.pir_utils.OldIrGuard():
+            self.check_promote_results(
+                True,
+                'float16',
+                'O1',
+                use_promote=True,
+                expected_op_calls=expected_fp16_calls,
+                debug_info="TestStaticAmpPromoteStats/test_static_amp_o1",
+            )
+
+    def test_static_amp_o2(self):
+        expected_fp16_calls = {
+            "conv2d": 1,
+            "elementwise_add": 2,
+            "relu": 0,
+            "matmul_v2": 1,
+            "softmax": 1,
+            "reduce_mean": 1,
+            "adamw": 4,
+        }
+        with paddle.pir_utils.OldIrGuard():
+            self.check_promote_results(
+                True,
+                'float16',
+                'O2',
+                use_promote=True,
+                expected_op_calls=expected_fp16_calls,
+                debug_info="TestStaticAmpPromoteStats/test_static_amp_o2",
+            )
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+class TestEagerAmpPromoteStats(AmpTestBase):
+    def check_promote_results(
+        self, dtype, level, use_promote, expected_op_calls, debug_info
+    ):
+        model, optimizer, scaler = build_conv_model(
+            use_amp=True,
+            amp_dtype=dtype,
+            amp_level=level,
+            use_promote=use_promote,
+        )
+        model.train()
+
+        paddle.amp.debugging.enable_operator_stats_collection()
+        with paddle.amp.auto_cast(
+            enable=True, dtype=dtype, level=level, use_promote=use_promote
+        ):
+            x = paddle.rand(shape=[1, 1, 6, 6], dtype='float32')
+            out = model(x)
+            loss = paddle.mean(out)
+        scaled = scaler.scale(loss)
+        scaled.backward()
+        scaler.minimize(optimizer, scaled)
+        optimizer.clear_grad()
+        paddle.amp.debugging.disable_operator_stats_collection()
+        op_stats = paddle.base.core.get_low_precision_op_list()
+
+        self._check_op_calls(
+            op_stats,
+            expected_fp16_calls=expected_op_calls,
+            debug_info=debug_info,
+        )
+
+    def test_o2_promote_on(self):
+        expected_fp16_calls = {
+            "conv2d": 1,
+            "elementwise_add": 2,
+            "relu": 0,
+            "matmul_v2": 1,
+            "softmax": 1,
+            "reduce_mean": 1,
+            "adamw_": 4,
+        }
+        self.check_promote_results(
+            'float16',
+            'O2',
+            use_promote=True,
+            expected_op_calls=expected_fp16_calls,
+            debug_info="TestEagerAmpPromoteStats/test_o2_promote_on",
+        )
+
+    def test_o2_promote_off(self):
+        expected_fp16_calls = {
+            "conv2d": 1,
+            "elementwise_add": 2,
+            "relu": 1,
+            "matmul_v2": 1,
+            "softmax": 1,
+            "reduce_mean": 1,
+            "adamw_": 4,
+        }
+        self.check_promote_results(
+            'float16',
+            'O2',
+            use_promote=False,
+            expected_op_calls=expected_fp16_calls,
+            debug_info="TestEagerAmpPromoteStats/test_o2_promote_off",
+        )
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+class TestPirAmpPromoteStats(AmpTestBase):
+    def check_promote_results(
+        self, dtype, level, use_promote, expected_op_calls, debug_info
+    ):
+        with paddle.pir_utils.IrGuard():
+            startup = paddle.static.Program()
+            main = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                model, optimizer, scaler = build_conv_model(
+                    use_amp=True,
+                    amp_dtype=dtype,
+                    amp_level=level,
+                    use_promote=use_promote,
+                )
+                model.train()
+
+                with paddle.amp.auto_cast(
+                    enable=True,
+                    dtype=dtype,
+                    level=level,
+                    use_promote=use_promote,
+                ):
+                    x = paddle.static.data(
+                        'x', shape=[1, 1, 6, 6], dtype='float32'
+                    )
+                    out = model(x)
+                    loss = paddle.mean(out)
+                scaled = scaler.scale(loss)
+                scaler.minimize(optimizer, scaled)
+
+                if paddle.is_compiled_with_cuda():
+                    place = paddle.CUDAPlace(0)
+                elif paddle.device.is_compiled_with_xpu():
+                    place = paddle.device.XPUPlace(0)
+                else:
+                    raise ValueError("Only support CUDA or XPU Place.")
+                exe = paddle.static.Executor(place)
+                exe.run(startup)
+                paddle.amp.debugging.enable_operator_stats_collection()
+                exe.run(
+                    main,
+                    feed={
+                        'x': np.random.random([1, 1, 6, 6]).astype('float32'),
+                    },
+                    fetch_list=[loss],
+                )
+                paddle.amp.debugging.disable_operator_stats_collection()
+                op_stats = paddle.base.core.get_low_precision_op_list()
+
+                self._check_op_calls(
+                    op_stats,
+                    expected_fp16_calls=expected_op_calls,
+                    debug_info=debug_info,
+                )
+
+    def test_o2_promote_on(self):
+        paddle.set_flags({"FLAGS_pir_apply_inplace_pass": 0})
+        expected_fp16_calls = {
+            "pd_op.conv2d": 1,
+            "pd_op.add": 2,
+            "pd_op.relu": 0,
+            "pd_op.matmul": 1,
+            "pd_op.softmax": 1,
+            "pd_op.mean": 1,
+            "pd_op.adamw_": 4,
+        }
+        self.check_promote_results(
+            'float16',
+            'O2',
+            use_promote=True,
+            expected_op_calls=expected_fp16_calls,
+            debug_info="TestEagerAmpPromoteStats/test_o2_promote_on",
+        )
+
+    def test_o2_promote_off(self):
+        paddle.set_flags({"FLAGS_pir_apply_inplace_pass": 0})
+        expected_fp16_calls = {
+            "pd_op.conv2d": 1,
+            "pd_op.add": 2,
+            "pd_op.relu": 1,
+            "pd_op.matmul": 1,
+            "pd_op.softmax": 1,
+            "pd_op.mean": 1,
+            "pd_op.adamw_": 4,
+        }
+        self.check_promote_results(
+            'float16',
+            'O2',
+            use_promote=False,
+            expected_op_calls=expected_fp16_calls,
+            debug_info="TestEagerAmpPromoteStats/test_o2_promote_off",
+        )
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+class TestEagerAmpPromoteSimple(AmpTestBase):
+    def setUp(self):
+        self._conv = paddle.nn.Conv2D(
+            in_channels=1, out_channels=6, kernel_size=3, bias_attr=False
+        )
+        self._linear = paddle.nn.Linear(in_features=4, out_features=4)
+
+    def test_o2_use_promote_on(self):
+        with paddle.amp.auto_cast(level='O2'):
+            x = paddle.rand(shape=[1, 1, 6, 6], dtype='float32')
+            conv_out = self._conv(x)
+            y = paddle.rand(shape=conv_out.shape, dtype='float16')
+            add_out = conv_out + y
+            linear_out = self._linear(add_out)
+
+        self.assertEqual(conv_out.dtype, paddle.float16)
+        self.assertEqual(add_out.dtype, paddle.float16)
+        self.assertEqual(linear_out.dtype, paddle.float32)
+
+    def test_o2_use_promote_off(self):
+        with paddle.amp.auto_cast(level='O2', use_promote=False):
+            x = paddle.rand(shape=[1, 1, 6, 6], dtype='float32')
+            conv_out = self._conv(x)
+            y = paddle.rand(shape=conv_out.shape, dtype='float16')
+            add_out = conv_out + y
+            linear_out = self._linear(add_out)
+
+        self.assertEqual(conv_out.dtype, paddle.float16)
+        self.assertEqual(add_out.dtype, paddle.float16)
+        self.assertEqual(linear_out.dtype, paddle.float16)
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_cuda()
+    and paddle.device.cuda.get_device_capability()[0] < 7.0,
+    "run test when gpu's compute capability is at least 7.0.",
+)
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+class TestPirAmpPromoteSimple(AmpTestBase):
+    def init_net(self):
+        self._conv = paddle.nn.Conv2D(
+            in_channels=1, out_channels=6, kernel_size=3, bias_attr=False
+        )
+        self._linear = paddle.nn.Linear(in_features=4, out_features=4)
+
+    def test_o2_use_promote_on(self):
+        with paddle.pir_utils.IrGuard():
+            startup = paddle.static.Program()
+            main = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                self.init_net()
+                with paddle.amp.auto_cast(level='O2'):
+                    x = paddle.rand(shape=[1, 1, 6, 6], dtype='float32')
+                    conv_out = self._conv(x)
+                    y = paddle.rand(shape=conv_out.shape, dtype='float16')
+                    add_out = conv_out + y
+                    linear_out = self._linear(add_out)
+
+            self.assertEqual(conv_out.dtype, paddle.float16)
+            self.assertEqual(add_out.dtype, paddle.float16)
+            self.assertEqual(linear_out.dtype, paddle.float32)
+
+    def test_o2_use_promote_off(self):
+        with paddle.pir_utils.IrGuard():
+            startup = paddle.static.Program()
+            main = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                self.init_net()
+                with paddle.amp.auto_cast(level='O2', use_promote=False):
+                    x = paddle.rand(shape=[1, 1, 6, 6], dtype='float32')
+                    conv_out = self._conv(x)
+                    y = paddle.rand(shape=conv_out.shape, dtype='float16')
+                    add_out = conv_out + y
+                    linear_out = self._linear(add_out)
+
+            self.assertEqual(conv_out.dtype, paddle.float16)
+            self.assertEqual(add_out.dtype, paddle.float16)
+            self.assertEqual(linear_out.dtype, paddle.float16)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/xpu/amp/test_layer_convert_dtype_xpu.py
+++ b/test/xpu/amp/test_layer_convert_dtype_xpu.py
@@ -1,1 +1,226 @@
-../../amp/test_layer_convert_dtype.py
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.nn.functional as F
+from paddle import nn
+from paddle.base import core
+
+
+class MyModel(paddle.nn.Layer):
+    def __init__(self, input_size, hidden_size):
+        super().__init__()
+        self.linear1 = paddle.nn.Linear(input_size, hidden_size)
+        self.linear2 = paddle.nn.Linear(hidden_size, hidden_size)
+        self.linear3 = paddle.nn.Linear(hidden_size, 1)
+        self.batchnorm = paddle.nn.Sequential(paddle.nn.BatchNorm(hidden_size))
+        register_buffer_in_temp = paddle.ones([4, 6])
+        self.register_buffer('register_buffer_in', register_buffer_in_temp)
+
+    def forward(self, inputs):
+        x = self.linear1(inputs)
+        x = F.relu(x)
+        x = self.batchnorm(x)
+        x = self.linear3(x)
+        return x
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+    "Require compiled with CUDA or XPU.",
+)
+class TestDtypeConvert(unittest.TestCase):
+    def setUp(self):
+        self.batch_size, self.input_size, self.hidden_size = 128, 128, 256
+
+    def verify_trans_dtype(
+        self, test_type=None, excluded_layers=None, corrected_dtype=None
+    ):
+        model = MyModel(self.input_size, self.hidden_size)
+        if test_type == 'float16':
+            model.float16(excluded_layers=excluded_layers)
+        elif test_type == 'bfloat16':
+            model.bfloat16(excluded_layers=excluded_layers)
+        else:
+            model.float(excluded_layers=excluded_layers)
+
+        for name, para in model.named_parameters():
+            if 'linear' in name:
+                self.assertEqual(para.dtype, corrected_dtype)
+            elif 'batchnorm' in name:
+                if excluded_layers is None:
+                    self.assertEqual(para.dtype, paddle.float32)
+                else:
+                    self.assertEqual(para.dtype, paddle.float16)
+
+    def test_excluded_layers(self):
+        self.verify_trans_dtype(
+            test_type='float16',
+            excluded_layers=[nn.Linear],
+            corrected_dtype=paddle.float32,
+        )
+        self.verify_trans_dtype(
+            test_type='float16',
+            excluded_layers=nn.Linear,
+            corrected_dtype=paddle.float32,
+        )
+
+    def test_float16(self):
+        self.verify_trans_dtype(
+            test_type='float16',
+            corrected_dtype=paddle.float16,
+        )
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+        "Require compiled with CUDA or XPU.",
+    )
+    @unittest.skipIf(
+        core.is_compiled_with_cuda()
+        and paddle.device.cuda.get_device_capability()[0] >= 8.0,
+        "run test when maximum gpu's compute capability is 8.0.",
+    )
+    @unittest.skipIf(
+        core.is_compiled_with_xpu()
+        and core.get_xpu_device_version(0) >= core.XPUVersion.XPU3,
+        "run test when xpu's compute capability < xpu3.",
+    )
+    def test_unsupported_bfloat16(self):
+        self.verify_trans_dtype(
+            test_type='bfloat16',
+            corrected_dtype=paddle.float32,
+        )
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda() and not core.is_compiled_with_xpu(),
+        "Require compiled with CUDA or XPU.",
+    )
+    @unittest.skipIf(
+        core.is_compiled_with_cuda()
+        and paddle.device.cuda.get_device_capability()[0] < 8.0,
+        "run test when gpu's compute capability is at least 8.0.",
+    )
+    @unittest.skipIf(
+        core.is_compiled_with_xpu()
+        and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+        "run test when xpu's compute capability >= xpu3.",
+    )
+    def test_supported_bfloat16(self):
+        self.verify_trans_dtype(
+            test_type='bfloat16',
+            corrected_dtype=paddle.bfloat16,
+        )
+
+    def test_float32(self):
+        paddle.set_default_dtype('float16')
+        self.verify_trans_dtype(
+            test_type='float32',
+            corrected_dtype=paddle.float32,
+        )
+        paddle.set_default_dtype('float32')
+
+    def test_excluded_layers_type_error(self):
+        self.assertRaises(
+            TypeError, self.verify_trans_dtype, excluded_layers=111
+        )
+
+
+class TestSupportedTypeInfo(unittest.TestCase):
+    def test_cpu(self):
+        res = paddle.amp.is_float16_supported('cpu')
+        self.assertEqual(res, False)
+        res = paddle.amp.is_bfloat16_supported('cpu')
+        self.assertEqual(res, core.supports_bfloat16())
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda(), "Require compiled with CUDA."
+    )
+    def test_gpu_fp16_supported(self):
+        res = paddle.amp.is_float16_supported()
+        self.assertEqual(res, True)
+        res = paddle.amp.is_float16_supported('gpu')
+        self.assertEqual(res, True)
+        res = paddle.amp.is_float16_supported('gpu:0')
+        self.assertEqual(res, True)
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda()
+        or paddle.device.cuda.get_device_capability()[0] >= 8.0,
+        "run test when maximum gpu's compute capability is 8.0.",
+    )
+    def test_gpu_bf16_unsupported(self):
+        res = paddle.amp.is_bfloat16_supported()
+        self.assertEqual(res, False)
+        res = paddle.amp.is_bfloat16_supported('gpu')
+        self.assertEqual(res, False)
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda()
+        or paddle.device.cuda.get_device_capability()[0] < 8.0,
+        "run test when gpu's compute capability is at least 8.0.",
+    )
+    def test_gpu_bf16_supported(self):
+        res = paddle.amp.is_bfloat16_supported()
+        self.assertEqual(res, True)
+        res = paddle.amp.is_bfloat16_supported('gpu')
+        self.assertEqual(res, True)
+
+    def test_device_value_error(self):
+        self.assertRaises(
+            ValueError, paddle.amp.is_float16_supported, device='xxx'
+        )
+        self.assertRaises(
+            ValueError, paddle.amp.is_float16_supported, device=111
+        )
+
+    @unittest.skipIf(
+        not core.is_compiled_with_xpu()
+        or not core.get_xpu_device_version(0) >= core.XPUVersion.XPU2,
+        "run test when xpu's compute capability >= xpu2.",
+    )
+    def test_xpu_fp16_supported(self):
+        res = paddle.amp.is_float16_supported()
+        self.assertEqual(res, True)
+        res = paddle.amp.is_float16_supported('xpu')
+        self.assertEqual(res, True)
+        res = paddle.amp.is_float16_supported('xpu:0')
+        self.assertEqual(res, True)
+
+    @unittest.skipIf(
+        not core.is_compiled_with_xpu()
+        or core.get_xpu_device_version(0) >= core.XPUVersion.XPU3,
+        "run test when xpu's compute capability < xpu3.",
+    )
+    def test_xpu_bf16_unsupported(self):
+        res = paddle.amp.is_bfloat16_supported()
+        self.assertEqual(res, False)
+        res = paddle.amp.is_bfloat16_supported('xpu')
+        self.assertEqual(res, False)
+
+    @unittest.skipIf(
+        not core.is_compiled_with_xpu()
+        or not core.get_xpu_device_version(0) >= core.XPUVersion.XPU3,
+        "run test when xpu's compute capability >= xpu3.",
+    )
+    def test_xpu_bf16_supported(self):
+        res = paddle.amp.is_bfloat16_supported()
+        self.assertEqual(res, True)
+        res = paddle.amp.is_bfloat16_supported('xpu')
+        self.assertEqual(res, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/xpu/test_incubate_build_src_rank_and_local_expert_id_xpu.py
+++ b/test/xpu/test_incubate_build_src_rank_and_local_expert_id_xpu.py
@@ -1,1 +1,68 @@
-../legacy_test/test_incubate_build_src_rank_and_local_expert_id.py
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.incubate.nn.functional import build_src_rank_and_local_expert_id
+
+logger = logging.getLogger(__name__)
+
+
+class TestFusedCalculateAuxLoss(unittest.TestCase):
+    def test_build_src_rank_and_local_expert_id(self):
+        def orig_func(expert_num_global_list, num_local_experts):
+            send_rank_cpu = np.concatenate(  # TOO SLOW!!! break every thing
+                [
+                    np.full([j], i // num_local_experts, dtype="int32")
+                    for i, j in enumerate(expert_num_global_list)
+                ],
+                0,
+            )
+            local_expert_id_cpu = np.concatenate(
+                [
+                    np.full([j], i % num_local_experts, dtype="int32")
+                    for i, j in enumerate(expert_num_global_list)
+                ],
+                0,
+            )
+            send_rank = paddle.to_tensor(send_rank_cpu)
+            local_expert_id = paddle.to_tensor(local_expert_id_cpu)
+            return send_rank, local_expert_id
+
+        def fused_func(
+            expert_num_global_tensor, expert_num_global, num_local_experts
+        ):
+            return build_src_rank_and_local_expert_id(
+                expert_num_global_tensor, expert_num_global, num_local_experts
+            )
+
+        expert_num_global = np.random.randint(
+            0, 512, size=[12 * 8], dtype="int32"
+        )
+        expert_num_global_tensor = paddle.to_tensor(
+            expert_num_global, dtype="int64"
+        )
+
+        s1, l1 = orig_func(expert_num_global, 12)
+        s2, l2 = fused_func(expert_num_global_tensor, expert_num_global, 12)
+        assert ((s1 - s2) == 0).all(), (s1, s2)
+        assert ((l1 - l2) == 0).all(), (l1, l2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/xpu/test_incubate_expand_modality_expert_id_xpu.py
+++ b/test/xpu/test_incubate_expand_modality_expert_id_xpu.py
@@ -1,1 +1,179 @@
-../legacy_test/test_incubate_expand_modality_expert_id.py
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from collections import namedtuple
+from functools import partial
+
+from ernie_utils.moe_all_gather_layer import MOEAllGatherLayerV2
+
+import paddle
+import paddle.nn.functional as F
+from paddle.incubate.nn.functional import expand_modality_expert_id
+
+
+def fused_gate_logits_process_ref(
+    self, gate_logits_lm, gate_logits_mm, token_type_ids
+):
+    """process gatelogits"""
+    top_k = self.k
+    num_expert_per_rank_per_modality = (
+        gate_logits_lm.shape[-1] // self.config.moe_world_size
+    )
+
+    @paddle.no_grad()
+    def shift_ids(ids, modality_offset):
+        # 现在认为所以模态的 expert 数都一样
+        rank = ids // num_expert_per_rank_per_modality
+        expert_id_in_rank = ids % num_expert_per_rank_per_modality
+        return (
+            rank * (num_expert_per_rank_per_modality * 2)
+            + expert_id_in_rank
+            + modality_offset * num_expert_per_rank_per_modality
+        )
+
+    if self.group_experts:
+        gate_logits_lm = gate_logits_lm.reshape(
+            [gate_logits_lm.shape[0], top_k, -1]
+        )
+        prob_lm = self.gate.act(gate_logits_lm)
+        weight_lm, expert_id_lm = prob_lm.topk(k=1, axis=-1)
+        weight_lm = weight_lm.reshape([gate_logits_lm.shape[0], -1])
+        expert_id_lm = expert_id_lm.reshape([gate_logits_lm.shape[0], -1])
+        group_size = gate_logits_lm.shape[-1]
+        scale = paddle.arange(0, top_k * group_size, group_size).unsqueeze(0)
+        expert_id_lm = expert_id_lm + scale
+    else:
+        prob_lm = self.gate.act(gate_logits_lm)
+        weight_lm, expert_id_lm = prob_lm.topk(k=top_k, axis=-1)
+    if token_type_ids is not None:
+        expert_id_lm = shift_ids(expert_id_lm, 0)
+    expert_id_lm.stop_gradient = True
+    lm_weight_and_expert_id = paddle.concat(
+        [weight_lm, expert_id_lm.astype("float32")], -1
+    )
+    if token_type_ids is None:
+        return (
+            lm_weight_and_expert_id,
+            prob_lm.reshape([prob_lm.shape[0], -1]),
+            None,
+        )
+
+    prob_mm = self.gate.act(gate_logits_mm)
+    weight_mm, expert_id_mm = prob_mm.topk(k=top_k, axis=-1)
+
+    expert_id_mm = shift_ids(expert_id_mm, 1)
+    expert_id_mm.stop_gradient = True
+
+    mm_weight_and_expert_id = paddle.concat(
+        [weight_mm, expert_id_mm.astype("float32")], -1
+    )
+
+    token_type_ids_float = token_type_ids[:, None].astype("float32")
+    weight_and_expert = (
+        1 - token_type_ids_float
+    ) * lm_weight_and_expert_id + token_type_ids_float * mm_weight_and_expert_id
+    return weight_and_expert, prob_lm.reshape([prob_lm.shape[0], -1]), prob_mm
+
+
+def test_expand_modality_expert_id():
+    def expand_id_one(
+        expert_id,
+        num_expert_per_modality,
+        k,
+        group_size,
+        modality_offset,
+        is_group_expert,
+    ):
+        orig_shape = expert_id.shape
+        expert_id = expert_id.reshape([-1])
+        xid = paddle.arange(len(expert_id))
+        if is_group_expert:
+            eid = xid % k
+            expert_id += eid * group_size
+
+        rank = expert_id // num_expert_per_modality
+        expert_id_in_rank = expert_id % num_expert_per_modality
+        ret = (
+            rank * (num_expert_per_modality * 2)
+            + expert_id_in_rank
+            + modality_offset * num_expert_per_modality
+        )
+        return ret.reshape(orig_shape)
+
+    S, E, k = 100, 24, 3
+    expert_id_mm = paddle.randint(0, 12, shape=[S, k])
+    num_expert_per_rank_per_modality = E // 2 // 4
+    group_size = E // 2 // k
+    print(
+        f"num_expert_per_rank_per_modality: {num_expert_per_rank_per_modality}"
+    )
+    fused = expand_modality_expert_id(
+        expert_id_mm, num_expert_per_rank_per_modality, group_size, 1, True
+    )
+
+    nonfused = expand_id_one(
+        expert_id_mm, num_expert_per_rank_per_modality, k, group_size, 1, True
+    )
+    # num_expert_per_rank_per_modality, group_size
+    assert (fused == nonfused).all().item()
+
+    Config = namedtuple("Config", ["moe_world_size"])
+    Self = namedtuple(
+        "Self",
+        [
+            "config",
+            "k",
+            "gate",
+            "group_experts",
+            "moe_statics",
+            "use_correction_bias",
+        ],
+    )
+    Gate = namedtuple("Gate", ["act"])
+    fake_gate = Gate(act=partial(F.softmax, axis=-1))
+    fake_self = Self(
+        config=Config(
+            moe_world_size=8,
+        ),
+        k=k,
+        gate=fake_gate,
+        moe_statics=None,
+        use_correction_bias=False,
+        group_experts=True,
+    )
+
+    fake_logits = paddle.randn([S, E])
+    fake_logits_mm = paddle.randn([S, E])
+    token_type_ids = paddle.randint(0, 2, shape=[S])
+    w_and_e, prob_lm, prob_mm = (
+        MOEAllGatherLayerV2.fused_gate_logits_process_fused(
+            fake_self, fake_logits, fake_logits_mm, None
+        )
+    )
+    w_and_e_ref, prob_lm_ref, prob_mm_ref = fused_gate_logits_process_ref(
+        fake_self, fake_logits, fake_logits_mm, None
+    )
+    assert (prob_lm == prob_lm_ref).all().item()
+    assert (w_and_e == w_and_e_ref).all().item()
+    w, e = w_and_e_ref.chunk(2, axis=-1)
+
+
+class Test_expand_modality_expert_id_API(unittest.TestCase):
+    def test_dygraph(self):
+        test_expand_modality_expert_id()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/codestyle/clang-tidy.py
+++ b/tools/codestyle/clang-tidy.py
@@ -208,7 +208,7 @@ def check_clang_apply_replacements_binary(args):
         subprocess.check_call(
             [args.clang_apply_replacements_binary, '--version']
         )
-    except:
+    except Exception:
         print(
             'Unable to run clang-apply-replacements. Is clang-apply-replacements '
             'binary correctly specified?',
@@ -388,7 +388,7 @@ def main():
                 subprocess.check_call(invocation, stdout=dev_null)
         else:
             subprocess.check_call(invocation)
-    except:
+    except Exception:
         print("Unable to run clang-tidy.", file=sys.stderr)
         sys.exit(0)
 
@@ -448,7 +448,7 @@ def main():
         print('Writing fixes to ' + args.export_fixes + ' ...')
         try:
             merge_replacement_files(tmpdir, args.export_fixes)
-        except:
+        except Exception:
             print('Error exporting fixes.\n', file=sys.stderr)
             traceback.print_exc()
             return_code = 1
@@ -457,7 +457,7 @@ def main():
         print('Applying fixes ...')
         try:
             apply_fixes(args, tmpdir)
-        except:
+        except Exception:
             print('Error applying fixes.\n', file=sys.stderr)
             traceback.print_exc()
             return_code = 1
@@ -495,7 +495,7 @@ if __name__ == '__main__':
                 'pip install --no-cache clang-tidy=="15.0.2.1"',
                 shell=True,
             )
-    except:
+    except Exception:
         print(
             "clang-tidy not found, attempting auto-install...", file=sys.stderr
         )

--- a/tools/count_api_without_core_ops.py
+++ b/tools/count_api_without_core_ops.py
@@ -70,7 +70,7 @@ def split_with_and_without_core_ops(member, cur_name):
                     api_with_ops.append(cur_name)
                 else:
                     api_without_ops.append(cur_name)
-        except:
+        except Exception:
             # If getsource failed (pybind API or function inherit from father class), just skip
             pass
 
@@ -87,7 +87,7 @@ def get_md5_of_func(member, cur_name):
         try:
             source = inspect.getsource(member)
             func_dict[cur_name] = md5(source)
-        except:
+        except Exception:
             # If getsource failed (pybind API or function inherit from father class), just skip
             pass
 
@@ -162,7 +162,7 @@ def visit_all_module(mod, func):
                     continue
                 IdSet.add(instance_id)
                 visit_member(mod.__name__, instance, func)
-        except:
+        except Exception:
             if cur_name not in ErrorSet:
                 ErrorSet.add(cur_name)
 

--- a/tools/coverage/coverage_diff_list.py
+++ b/tools/coverage/coverage_diff_list.py
@@ -49,7 +49,7 @@ def filter_by(list_file, max_rate):
 
                 if rate >= max_rate:
                     continue
-            except:
+            except Exception:
                 pass
 
             print(name, rate)

--- a/tools/diff_unittest.py
+++ b/tools/diff_unittest.py
@@ -20,7 +20,7 @@ try:
     f1 = open(sys.argv[1], 'r')
     origin = f1.read()
     origin = origin.splitlines()
-except:
+except Exception:
     sys.exit(0)
 else:
     f1.close()
@@ -29,7 +29,7 @@ try:
     f2 = open(sys.argv[2], 'r')
     new = f2.read()
     new = new.splitlines()
-except:
+except Exception:
     sys.exit(0)
 else:
     f2.close()

--- a/tools/gen_pybind11_stub.py
+++ b/tools/gen_pybind11_stub.py
@@ -712,7 +712,7 @@ class OpsYamlBaseAPI:
         else:
             try:
                 eval(info_value)
-            except:
+            except Exception:
                 info_value = f'"{info_value}"'
 
         return info_name + ' = ' + info_value
@@ -853,7 +853,7 @@ class OpsYamlBaseAPI:
                                     python_api_info,
                                 )
                             )
-                        except:
+                        except Exception:
                             print(
                                 op_name, op_inputs, op_attrs, output_type_list
                             )

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -119,7 +119,7 @@ def visit_all_module(mod):
                         f"Found alias API, alias name is: {member_name}, original name is: {instance.__name__}",
                         file=sys.stderr,
                     )
-        except:
+        except Exception:
             if cur_name not in ErrorSet and cur_name not in skiplist:
                 ErrorSet.add(cur_name)
 

--- a/tools/summary_env.py
+++ b/tools/summary_env.py
@@ -43,7 +43,7 @@ def get_paddle_info():
 
         envs['paddle_version'] = paddle.__version__
         envs['paddle_with_cuda'] = paddle.base.core.is_compiled_with_cuda()
-    except:
+    except Exception:
         envs['paddle_version'] = 'N/A'
         envs['paddle_with_cuda'] = 'N/A'
 
@@ -69,7 +69,7 @@ def get_gcc_version():
         envs['gcc_version'] = (
             run_shell_command("gcc --version").split('\n')[0].split("gcc ")[1]
         )
-    except:
+    except Exception:
         envs['gcc_version'] = 'N/A'
 
 
@@ -80,7 +80,7 @@ def get_clang_version():
             .split('\n')[0]
             .split("clang version ")[1]
         )
-    except:
+    except Exception:
         envs['clang_version'] = 'N/A'
 
 
@@ -91,7 +91,7 @@ def get_cmake_version():
             .split('\n')[0]
             .split("cmake ")[1]
         )
-    except:
+    except Exception:
         envs['cmake_version'] = 'N/A'
 
 
@@ -191,7 +191,7 @@ def get_nvidia_gpu_driver():
         for gpu_info in gpu_list.split("\n"):
             result += gpu_info.split(" (UUID:")[0] + "\n"
         envs['nvidia_gpu_driver'] = result
-    except:
+    except Exception:
         envs['nvidia_gpu_driver'] = 'N/A'
 
 


### PR DESCRIPTION
## What
Replace 232 bare `except:` clauses with `except Exception:` across the codebase.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.