### PR TITLE
[LargeTensor] Fix int32 overflow in fused_weighted_swiglu_act_quant, fused_multi_transformer, moe_fuse_bwd

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_kernel.cu
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
+
 #include "paddle/phi/api/include/tensor.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
@@ -70,10 +72,10 @@ void FusedMultiTransformerOpKernel(
   // 0. input
   auto *input_x = &x;
   const auto input_x_dims = input_x->dims();
-  int bsz = input_x_dims[0];
-  int seq_len = input_x_dims[1];
-  int dim_embed = input_x_dims[2];
-  int bsz_seq = bsz * seq_len;
+  int64_t bsz = input_x_dims[0];
+  int64_t seq_len = input_x_dims[1];
+  int64_t dim_embed = input_x_dims[2];
+  int64_t bsz_seq = bsz * seq_len;
 
   // Optional Bias input for LayerNorm / RMSNorm
   std::vector<const DenseTensor *> ln_biases;
@@ -108,7 +110,7 @@ void FusedMultiTransformerOpKernel(
   }
 
   auto *beam_cache_offset = beam_offset.get_ptr();
-  int beam_size = 1;
+  int64_t beam_size = 1;
   if (beam_cache_offset) {
     beam_size = beam_cache_offset->dims()[1];
   }
@@ -120,7 +122,7 @@ void FusedMultiTransformerOpKernel(
   // cumulative seqlens [batch_size+1]
   DenseTensor cu_seqlens_q, cu_seqlens_k;
   bool encoder_remove_padding = (remove_padding && !time_step);
-  int token_num = 0;
+  int64_t token_num = 0;
 
   auto *from_data = dev_ctx.template Alloc<T>(out, out->numel() * sizeof(T));
 
@@ -146,16 +148,18 @@ void FusedMultiTransformerOpKernel(
     dev_ctx.template Alloc<int32_t>(&cu_seqlens_q,
                                     cu_seqlens_q.numel() * sizeof(int32_t));
 
+    int token_num_int = 0;
     phi::fusion::InvokeGetPaddingOffset(
         dev_ctx,
-        &token_num,
+        &token_num_int,
         d_token_num,
         padding_offset_tensor.data<int>(),
         cu_seqlens_q.data<int>(),
         sequence_lengths ? sequence_lengths->data<int>()
                          : sequence_lengths_backup.data<int>(),
-        bsz,
-        seq_len);
+        static_cast<int>(bsz),
+        static_cast<int>(seq_len));
+    token_num = token_num_int;
     if (token_num == 0) return;
     padding_offset_tensor.Resize({{token_num}});
     x_remove_padding.Resize({{token_num, dim_embed}});
@@ -197,7 +201,7 @@ void FusedMultiTransformerOpKernel(
   }
 
   const auto qkv_w_dims = qkv_weights[0]->dims();
-  int num_head, dim_head;
+  int64_t num_head, dim_head;
   if (gqa_group_size > 0) {
     num_head = trans_qkvw ? (qkv_w_dims[0] - 2 * gqa_group_size)
                           : (qkv_w_dims[1] - 2 * gqa_group_size);
@@ -206,15 +210,33 @@ void FusedMultiTransformerOpKernel(
     num_head = trans_qkvw ? qkv_w_dims[1] : qkv_w_dims[2];
     dim_head = trans_qkvw ? qkv_w_dims[2] : qkv_w_dims[3];
   }
-  int hidden_size = num_head * dim_head;
-  int output_size = gqa_group_size <= 0
-                        ? 3 * hidden_size
-                        : (num_head + 2 * gqa_group_size) * dim_head;
-  int input_size = dim_embed;
+  int64_t hidden_size = num_head * dim_head;
+  int64_t output_size = gqa_group_size <= 0
+                            ? 3 * hidden_size
+                            : (num_head + 2 * gqa_group_size) * dim_head;
+  int64_t input_size = dim_embed;
 
   // Set a flag whether need to add Matmul / Layernorm bias.
   bool compute_bias = qkv_biases.size() > 0;
   bool compute_ln_bias = ln_biases.size() > 0;
+
+  // TODO(large-tensor): GEMMHelper/NormHelper/FFNHelper and downstream functors
+  // still use int internally. Guard until they are fully upgraded to int64_t.
+  PADDLE_ENFORCE_LE(
+      token_num,
+      static_cast<int64_t>(std::numeric_limits<int>::max()),
+      common::errors::InvalidArgument(
+          "token_num (%lld) exceeds INT_MAX. Large tensor support for "
+          "fused_multi_transformer helper classes is not yet implemented.",
+          token_num));
+  PADDLE_ENFORCE_LE(dim_embed,
+                    static_cast<int64_t>(std::numeric_limits<int>::max()),
+                    common::errors::InvalidArgument(
+                        "dim_embed (%lld) exceeds INT_MAX.", dim_embed));
+  PADDLE_ENFORCE_LE(output_size,
+                    static_cast<int64_t>(std::numeric_limits<int>::max()),
+                    common::errors::InvalidArgument(
+                        "output_size (%lld) exceeds INT_MAX.", output_size));
 
   auto qkv_compute = phi::fusion::GEMMHelper<T>(
       dev_ctx, token_num, output_size, input_size, "None", trans_qkvw);
@@ -249,7 +271,7 @@ void FusedMultiTransformerOpKernel(
     pre_caches = *pre_caches_ptr;
   }
 
-  int cache_offset = 0;
+  int64_t cache_offset = 0;
   if (pre_caches.size() > 0) {
     cache_offset = pre_caches[0]->dims()[3];
   }
@@ -402,7 +424,7 @@ void FusedMultiTransformerOpKernel(
   auto ffn1_weight_dim = ffn1_weights[0]->dims();
   // if quant weight,
   // matmul weight is transposed
-  int dim_ffn = ffn1_weight_dim[1];
+  int64_t dim_ffn = ffn1_weight_dim[1];
   phi::fusion::FFNHelper<T> ffn1_helper(
       dev_ctx, act_method, token_num, dim_ffn, dim_embed, "None");
 
@@ -421,7 +443,7 @@ void FusedMultiTransformerOpKernel(
   phi::fusion::FusedDropoutHelper<T, int8_t> fused_act_dropout_helper(
       dev_ctx, token_num, dim_ffn, ffn1_dropout_param);
   DenseTensor ffn1_dropout_out, ffn1_dropout_mask;
-  int tmp_dim_ffn = dim_ffn;
+  int64_t tmp_dim_ffn = dim_ffn;
   if (use_glu) tmp_dim_ffn /= 2;
   int8_t *ffn1_dropout_mask_data = nullptr;
   ffn1_dropout_out.Resize({{token_num, tmp_dim_ffn}});
@@ -550,7 +572,7 @@ void FusedMultiTransformerOpKernel(
     // step3. fmha
     const DenseTensor *cache_kv = cache_kvs.size() > 0 ? cache_kvs[i] : nullptr;
     DenseTensor *cache_kv_out = cache_kv ? cache_kv_outs[i] : nullptr;
-    int cache_bsz = 0;
+    int64_t cache_bsz = 0;
     if (cache_kv) {
       cache_bsz = cache_kv->dims()[1];
     }

--- a/paddle/phi/kernels/fusion/gpu/fused_weighted_swiglu_act_quant_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_weighted_swiglu_act_quant_kernel.cu
@@ -198,8 +198,8 @@ __global__ void FusedSPAQKernel(const phi::bfloat16 *__restrict__ Xin,
                                 const float *__restrict__ prob,
                                 phi::float8_e4m3fn *__restrict__ out,
                                 float *__restrict__ scales,
-                                const int rows,
-                                const int cols) {
+                                const int64_t rows,
+                                const int64_t cols) {
   // Configure shared memory
   __shared__ float smem_tile[256];  // Shared memory for activation values
   __shared__ float warp_max[2][4];  // Shared memory for warp maxima (2 quant
@@ -211,86 +211,89 @@ __global__ void FusedSPAQKernel(const phi::bfloat16 *__restrict__ Xin,
   const int x_offset = threadIdx.x;
   const int quant_block_idx =
       threadIdx.x / 128;  // 0 or 1, two quant blocks per block
-  const int in_y_idx = blockIdx.y;
-  const int in_x_idx = blockIdx.x * blockDim.x + x_offset;
-  const int src_idx = in_y_idx * cols + in_x_idx;
+  const int64_t in_x_idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + x_offset;
+  const int64_t scale_stride = (cols / 2 + 127) / 128;
 
-  // Load data and compute swiGLU activation
-  if (in_x_idx < cols / 2) [[likely]] {        // NOLINT
-    __nv_bfloat16 x1 = X[src_idx];             // First half of the input
-    __nv_bfloat16 x2 = X[src_idx + cols / 2];  // Second half of the input
+  for (int64_t in_y_idx = blockIdx.y; in_y_idx < rows; in_y_idx += gridDim.y) {
+    const int64_t src_idx = in_y_idx * cols + in_x_idx;
 
-    if constexpr (with_prob) {
-      float row_prob = prob[in_y_idx];
-      smem_tile[x_offset] = fast_swiglu(x1, x2) * row_prob;
-    } else {
-      smem_tile[x_offset] = fast_swiglu(x1, x2);
-    }
-  }
+    // Load data and compute swiGLU activation
+    if (in_x_idx < cols / 2) [[likely]] {        // NOLINT
+      __nv_bfloat16 x1 = X[src_idx];             // First half of the input
+      __nv_bfloat16 x2 = X[src_idx + cols / 2];  // Second half of the input
 
-  __syncthreads();  // Ensure all threads have loaded their data
-
-  // Phase 2: Block Reduction to find per-quant block absolute maximums
-  float local_max = (in_x_idx < (cols / 2)) ? fabsf(smem_tile[x_offset]) : 0.0f;
-
-  // Warp-level reduction
-  unsigned int mask = 0xffffffff;
-  int lane = threadIdx.x % 32;
-  int warp_id =
-      (threadIdx.x % 128) / 32;  // Warp ID within the quant block (0-3)
-
-  // Reduce within the warp
-  for (int offset = 16; offset > 0; offset /= 2) {
-    float val = __shfl_down_sync(mask, local_max, offset);
-    local_max = fmaxf(local_max, val);
-  }
-
-  // Store warp maxima
-  if (lane == 0) {
-    warp_max[quant_block_idx][warp_id] = local_max;
-  }
-
-  __syncthreads();
-
-  // Reduce warp maxima to get quant block maxima
-  if (warp_id == 0 && lane < 4) {
-    if (threadIdx.x < 256) {  // Ensure only valid threads participate
-      float block_max = warp_max[quant_block_idx][lane];
-      // Reduce over the 4 warp maxima
-      if (lane == 0) {
-        block_max = fmaxf(block_max, warp_max[quant_block_idx][1]);
-        block_max = fmaxf(block_max, warp_max[quant_block_idx][2]);
-        block_max = fmaxf(block_max, warp_max[quant_block_idx][3]);
-        quant_block_amax[quant_block_idx] = __float2bfloat16(block_max);
+      if constexpr (with_prob) {
+        float row_prob = prob[in_y_idx];
+        smem_tile[x_offset] = fast_swiglu(x1, x2) * row_prob;
+      } else {
+        smem_tile[x_offset] = fast_swiglu(x1, x2);
       }
     }
-  }
 
-  __syncthreads();
+    __syncthreads();  // Ensure all threads have loaded their data
 
-  // Phase 3: Compute scales and quantize the outputs
-  const float block_max_float =
-      static_cast<float>(quant_block_amax[quant_block_idx]);
-  const int scale_stride = (cols / 2 + 127) / 128;
+    // Phase 2: Block Reduction to find per-quant block absolute maximums
+    float local_max =
+        (in_x_idx < (cols / 2)) ? fabsf(smem_tile[x_offset]) : 0.0f;
 
-  float scale = ComputeScale<float, __nv_fp8_e4m3, using_pow2_scaling>(
-      block_max_float, 0.0f);
-  float inv_scale = __frcp_rn(scale);
+    // Warp-level reduction
+    unsigned int mask = 0xffffffff;
+    int lane = threadIdx.x % 32;
+    int warp_id =
+        (threadIdx.x % 128) / 32;  // Warp ID within the quant block (0-3)
 
-  // Quantize
-  float output_scaled_fp32 = smem_tile[x_offset] * scale;
-
-  const int g_output_y_offset = in_y_idx;
-  const int g_output_x_offset = in_x_idx;
-
-  // Write output and scales
-  if (g_output_y_offset < rows && g_output_x_offset < cols / 2) {
-    out[g_output_y_offset * (cols / 2) + g_output_x_offset] =
-        static_cast<phi::float8_e4m3fn>(output_scaled_fp32);
-    if (x_offset % 128 == 0) {
-      // Only one thread per quant block writes the scale
-      scales[g_output_y_offset * scale_stride + in_x_idx / 128] = inv_scale;
+    // Reduce within the warp
+    for (int offset = 16; offset > 0; offset /= 2) {
+      float val = __shfl_down_sync(mask, local_max, offset);
+      local_max = fmaxf(local_max, val);
     }
+
+    // Store warp maxima
+    if (lane == 0) {
+      warp_max[quant_block_idx][warp_id] = local_max;
+    }
+
+    __syncthreads();
+
+    // Reduce warp maxima to get quant block maxima
+    if (warp_id == 0 && lane < 4) {
+      if (threadIdx.x < 256) {  // Ensure only valid threads participate
+        float block_max = warp_max[quant_block_idx][lane];
+        // Reduce over the 4 warp maxima
+        if (lane == 0) {
+          block_max = fmaxf(block_max, warp_max[quant_block_idx][1]);
+          block_max = fmaxf(block_max, warp_max[quant_block_idx][2]);
+          block_max = fmaxf(block_max, warp_max[quant_block_idx][3]);
+          quant_block_amax[quant_block_idx] = __float2bfloat16(block_max);
+        }
+      }
+    }
+
+    __syncthreads();
+
+    // Phase 3: Compute scales and quantize the outputs
+    const float block_max_float =
+        static_cast<float>(quant_block_amax[quant_block_idx]);
+
+    float scale = ComputeScale<float, __nv_fp8_e4m3, using_pow2_scaling>(
+        block_max_float, 0.0f);
+    float inv_scale = __frcp_rn(scale);
+
+    // Quantize
+    float output_scaled_fp32 = smem_tile[x_offset] * scale;
+
+    // Write output and scales
+    if (in_y_idx < rows && in_x_idx < cols / 2) {
+      out[in_y_idx * (cols / 2) + in_x_idx] =
+          static_cast<phi::float8_e4m3fn>(output_scaled_fp32);
+      if (x_offset % 128 == 0) {
+        // Only one thread per quant block writes the scale
+        scales[in_y_idx * scale_stride + in_x_idx / 128] = inv_scale;
+      }
+    }
+
+    __syncthreads();  // Ensure all writes complete before next iteration
   }
 }
 
@@ -299,8 +302,8 @@ void dispatch_fused_spaq(const phi::bfloat16 *x_data,
                          phi::float8_e4m3fn *out_data,
                          float *scale_data,
                          cudaStream_t stream,
-                         const int rows,
-                         const int cols,
+                         const int64_t rows,
+                         const int64_t cols,
                          const bool &using_pow2_scaling,
                          const bool &with_prob) {
   constexpr int thread_per_block = 256;

--- a/paddle/phi/kernels/legacy/gpu/moe_fuse_bwd_op.h
+++ b/paddle/phi/kernels/legacy/gpu/moe_fuse_bwd_op.h
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #pragma once
+#include <limits>
+
 #include "paddle/common/exception.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
 #include "paddle/phi/kernels/legacy/gpu/moe_kernel_impl.h"
@@ -195,7 +197,7 @@ void gather_with_mask_launcher(const T* dy,                   // [s*k, d]
                                int64_t world_size = -1,
                                int64_t num_local_experts = -1,
                                int64_t capacity = -1) {
-  int numel = num_rows * dim;
+  int64_t numel = num_rows * dim;
 
   int64_t threads = 512;
   if (dim % 4 == 0) {
@@ -284,14 +286,14 @@ __global__ void topk_grad_with_mask(const T* dy,               // [s, k]
                                     int64_t num_experts        // e
 ) {
   // init dx to zero
-  for (int i = blockIdx.x; i < num_rows; i += gridDim.x) {
-    int base_grad = i * num_experts;
-    for (int j = threadIdx.x; j < num_experts; j += blockDim.x) {
+  for (int64_t i = blockIdx.x; i < num_rows; i += gridDim.x) {
+    int64_t base_grad = i * num_experts;
+    for (int64_t j = threadIdx.x; j < num_experts; j += blockDim.x) {
       dx[base_grad + j] = static_cast<T>(0);
     }
     __syncthreads();
-    int base_index = i * k;
-    for (int j = threadIdx.x; j < k; j += blockDim.x) {
+    int64_t base_index = i * k;
+    for (int64_t j = threadIdx.x; j < k; j += blockDim.x) {
       int64_t idx = topk_idx[base_index + j];
       if (combine_weights[base_index + j] > static_cast<T>(0)) {
         dx[base_grad + idx] = dy[base_index + j];
@@ -313,7 +315,8 @@ void topk_grad_with_mask_launcher(const T* dy,               // [s, k]
                                   int64_t k,                 // k
                                   int64_t num_experts,       // e
                                   cudaStream_t stream) {
-  int blocks = num_rows;
+  int64_t blocks =
+      std::min(num_rows, static_cast<int64_t>(std::numeric_limits<int>::max()));
   int threads = 1024;
 
   topk_grad_with_mask<T><<<blocks, threads, 0, stream>>>(


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

修复三个 P0 级别的大 Tensor（int32 溢出）GPU kernel bug：

**1. `fused_weighted_swiglu_act_quant_kernel.cu` — 正确性 bug（静默丢数据）**
- 非 vec4 路径的 `FusedSPAQKernel` 将 `gridDim.y` 钳位到 65535，但**缺少行循环**，导致 rows > 65535 时多余的行被静默跳过。
- vec4 路径（`FusedSPAQKernelVec4`）已有正确的 stride-loop 模式。
- 修复：补齐 `for (int64_t in_y_idx = blockIdx.y; in_y_idx < rows; in_y_idx += gridDim.y)` 行循环（与 vec4 路径对齐），参数从 `int` 改为 `int64_t`，循环末尾增加 `__syncthreads()` 保证 shared memory 安全。

**2. `fused_multi_transformer_kernel.cu` — 静默 int32 溢出**
- 所有维度变量（`bsz`、`seq_len`、`dim_embed`、`token_num` 等）均声明为 `int`，在大 batch 推理场景下 `bsz * seq_len` 会溢出 int32。
- 修复：将维度变量改为 `int64_t`；在向仍接受 `int` 参数的下游 helper 类传值前，增加 `PADDLE_ENFORCE_LE` 守卫防止静默截断。

**3. `moe_fuse_bwd_op.h` — int64_t→int 截断**
- `int numel = num_rows * dim` 将 `int64_t * int64_t` 的乘积静默截断为 `int`，导致大 MOE 模型下 grid 维度计算错误和潜在的非法内存访问。
- `int blocks = num_rows` 在 rows > INT32_MAX 时同样溢出。
- 修复：`numel` 改为 `int64_t`，`blocks` 使用 `std::numeric_limits<int>::max()` 钳位，`topk_grad_with_mask` kernel 内部循环变量拓宽为 `int64_t`。

三个文件均已通过 CUDA 12.9（sm_80/sm_86，`-Werror`）编译验证。

### 是否引起精度变化
否