### PR TITLE
[CI] Disable windows workflow third party cache

### DIFF
--- a/.github/workflows/_Clone-windows.yml
+++ b/.github/workflows/_Clone-windows.yml
@@ -49,6 +49,8 @@ jobs:
           git merge --no-ff pr
           git branch -d pr
           REM call %ci_scripts%\third_party_tag.bat
+          git config -f .gitmodules submodule.third_party/openvino.update none && git submodule sync third_party/openvino
+          git submodule update --init --recursive
 
       - name: Upload paddle to bos
         working-directory: ..
@@ -74,4 +76,6 @@ jobs:
           cd ${{ github.workspace }}
           git switch %BRANCH%
           git branch -D test
+          git config -f .gitmodules submodule.third_party/openvino.update none && git submodule sync third_party/openvino
+          git submodule update --init --recursive
           git gc

--- a/.github/workflows/_Windows-GPU.yml
+++ b/.github/workflows/_Windows-GPU.yml
@@ -39,7 +39,7 @@ jobs:
       PADDLE_VERSION: 0.0.0
       NIGHTLY_MODE: "OFF"
       WITH_UNITY_BUILD: "ON"
-      WITH_TPCACHE: "ON"
+      WITH_TPCACHE: "OFF"
       WITH_SCCACHE: "ON"
       WITH_SHARED_PHI: "ON"
       GIT_PR_ID: ${{ github.event.pull_request.number }}

--- a/.github/workflows/_Windows-Inference.yml
+++ b/.github/workflows/_Windows-Inference.yml
@@ -39,7 +39,7 @@ jobs:
       PADDLE_VERSION: 0.0.0
       NIGHTLY_MODE: "OFF"
       WITH_UNITY_BUILD: "ON"
-      WITH_TPCACHE: "ON"
+      WITH_TPCACHE: "OFF"
       WITH_SCCACHE: "ON"
       WITH_SHARED_PHI: "ON"
       GIT_PR_ID: ${{ github.event.pull_request.number }}

--- a/.github/workflows/_Windows-OPENBLAS.yml
+++ b/.github/workflows/_Windows-OPENBLAS.yml
@@ -41,7 +41,7 @@ jobs:
       NIGHTLY_MODE: "OFF"
       WITH_UNITY_BUILD: "ON"
       WITH_CACHE: "OFF"
-      WITH_TPCACHE: "ON"
+      WITH_TPCACHE: "OFF"
       WITH_SCCACHE: "ON"
       WITH_SHARED_PHI: "ON"
       FLAGS_enable_eager_mode: 1


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
取消原始windows CI的第三方库缓存逻辑，改为缓存在clone机器上

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否