### PR TITLE
[API Compatibility No.13、75] Add param alias for hypot and hypot_ -part

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6251,7 +6251,14 @@ def copysign_(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     return _C_ops.copysign_(x, y)
 
 
-def hypot(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
+@param_two_alias(["x", "input"], ["y", "other"])
+def hypot(
+    x: Tensor,
+    y: Tensor,
+    name: str | None = None,
+    *,
+    out: Tensor | None = None,
+) -> Tensor:
     """
     Calculate the length of the hypotenuse of a right-angle triangle. The equation is:
 
@@ -6260,8 +6267,13 @@ def hypot(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
 
     Args:
         x (Tensor): The input Tensor, the data type is float32, float64, int32 or int64.
+            Alias: ``input``.
         y (Tensor): The input Tensor, the data type is float32, float64, int32 or int64.
+            Alias: ``other``.
         name (str|None, optional): Name for the operation (optional, default is None).For more information, please refer to :ref:`api_guide_Name`.
+
+    Keyword args:
+        out (Tensor|None, optional): The output tensor. Default: None.
 
     Returns:
         out (Tensor): An N-D Tensor. If x, y have different shapes and are "broadcastable", the resulting tensor shape is the shape of x and y after broadcasting. If x, y have the same shape, its shape is the same as x and y. And the data type is float32 or float64.
@@ -6285,14 +6297,21 @@ def hypot(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     if not isinstance(y, (paddle.Tensor, Variable, paddle.pir.Value)):
         raise TypeError(f"y must be tensor type, but got {type(y)}")
 
-    out = (paddle.pow(x, 2) + paddle.pow(y, 2)).sqrt()
-    return out
+    ret = (paddle.pow(x, 2) + paddle.pow(y, 2)).sqrt()
+    if out is not None:
+        paddle.assign(ret, out)
+        return out
+    return ret
 
 
+@param_two_alias(["x", "input"], ["y", "other"])
 @inplace_apis_in_dygraph_only
 def hypot_(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     r"""
     Inplace version of ``hypot`` API, the output Tensor will be inplaced with input ``x``.
+    Alias Support:
+    The parameter name ``input`` can be used as an alias for ``x``,
+    and ``other`` can be used as an alias for ``y``.
     Please refer to :ref:`api_paddle_hypot`.
     """
     if not isinstance(x, (paddle.Tensor, Variable)):

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -382,22 +382,6 @@ class TestHypotAPI(unittest.TestCase):
             for out in fetches:
                 np.testing.assert_allclose(out, ref_out, rtol=1e-6, atol=1e-6)
 
-    def test_invalid_args(self):
-        paddle.disable_static()
-        x = paddle.to_tensor(self.np_x)
-        y = paddle.to_tensor(self.np_y)
-
-        with self.assertRaises(TypeError):
-            paddle.hypot(x)
-
-        with self.assertRaises(TypeError):
-            paddle.hypot(x, y, foo=1)
-
-        with self.assertRaises(TypeError):
-            paddle.hypot(x=x, y=y, other=y)
-
-        paddle.enable_static()
-
 
 class TestHypotInplaceAPI(unittest.TestCase):
     def setUp(self):
@@ -427,19 +411,6 @@ class TestHypotInplaceAPI(unittest.TestCase):
             np.testing.assert_allclose(
                 ref_out, out.numpy(), rtol=1e-6, atol=1e-6
             )
-
-    def test_invalid_args(self):
-        x = paddle.to_tensor(self.np_x)
-        y = paddle.to_tensor(self.np_y)
-
-        with self.assertRaises(TypeError):
-            paddle.hypot_(x)
-
-        with self.assertRaises(TypeError):
-            paddle.hypot_(x, y, foo=1)
-
-        with self.assertRaises(TypeError):
-            paddle.hypot_(x=x, y=y, other=y)
 
 
 # Edit by AI Agent

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -308,6 +308,138 @@ class TestAtan2API_Compatibility(unittest.TestCase):
                 np.testing.assert_allclose(out, ref_out, rtol=1e-6)
 
 
+class TestHypotAPI(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+        paddle.enable_static()
+        self.shape = [5, 6]
+        self.dtype = 'float32'
+        self.init_data()
+
+    def init_data(self):
+        self.np_x = np.random.randn(*self.shape).astype(self.dtype)
+        self.np_y = np.random.randn(*self.shape).astype(self.dtype)
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        y = paddle.to_tensor(self.np_y)
+        paddle_dygraph_out = []
+
+        # Paddle positional args
+        out1 = paddle.hypot(x, y)
+        paddle_dygraph_out.append(out1)
+
+        # Paddle keyword args
+        out2 = paddle.hypot(x=x, y=y)
+        paddle_dygraph_out.append(out2)
+
+        # PyTorch keyword args
+        out3 = paddle.hypot(input=x, other=y)
+        paddle_dygraph_out.append(out3)
+
+        # Mixed args
+        out4 = paddle.hypot(x, y=y)
+        paddle_dygraph_out.append(out4)
+
+        # Test out parameter
+        out5 = paddle.empty_like(x)
+        out6 = paddle.hypot(x, y, out=out5)
+        paddle_dygraph_out.append(out5)
+        paddle_dygraph_out.append(out6)
+
+        ref_out = np.hypot(self.np_x, self.np_y)
+        for out in paddle_dygraph_out:
+            np.testing.assert_allclose(ref_out, out.numpy(), rtol=1e-6, atol=1e-6)
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.base.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
+            y = paddle.static.data(name="y", shape=self.shape, dtype=self.dtype)
+
+            # Paddle positional args
+            out1 = paddle.hypot(x, y)
+            # Paddle keyword args
+            out2 = paddle.hypot(x=x, y=y)
+            # PyTorch keyword args
+            out3 = paddle.hypot(input=x, other=y)
+            # Mixed args
+            out4 = paddle.hypot(x, y=y)
+
+            exe = paddle.base.Executor(paddle.CPUPlace())
+            fetches = exe.run(
+                main,
+                feed={"x": self.np_x, "y": self.np_y},
+                fetch_list=[out1, out2, out3, out4],
+            )
+            ref_out = np.hypot(self.np_x, self.np_y)
+            for out in fetches:
+                np.testing.assert_allclose(out, ref_out, rtol=1e-6, atol=1e-6)
+
+    def test_invalid_args(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        y = paddle.to_tensor(self.np_y)
+
+        with self.assertRaises(TypeError):
+            paddle.hypot(x)
+
+        with self.assertRaises(TypeError):
+            paddle.hypot(x, y, foo=1)
+
+        with self.assertRaises(TypeError):
+            paddle.hypot(x=x, y=y, other=y)
+
+        paddle.enable_static()
+
+
+class TestHypotInplaceAPI(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+        paddle.disable_static()
+        self.shape = [5, 6]
+        self.dtype = 'float32'
+        self.init_data()
+
+    def init_data(self):
+        self.np_x = np.random.randn(*self.shape).astype(self.dtype)
+        self.np_y = np.random.randn(*self.shape).astype(self.dtype)
+
+    def test_dygraph_InplaceCompatibility(self):
+        x = paddle.to_tensor(self.np_x)
+        y = paddle.to_tensor(self.np_y)
+        ref_out = np.hypot(self.np_x, self.np_y)
+
+        for out in [
+            x.clone().hypot_(y),
+            x.clone().hypot_(y=y),
+            x.clone().hypot_(other=y),
+            paddle.hypot_(x.clone(), y),
+            paddle.hypot_(x=x.clone(), y=y),
+            paddle.hypot_(input=x.clone(), other=y),
+        ]:
+            np.testing.assert_allclose(
+                ref_out, out.numpy(), rtol=1e-6, atol=1e-6
+            )
+
+    def test_invalid_args(self):
+        x = paddle.to_tensor(self.np_x)
+        y = paddle.to_tensor(self.np_y)
+
+        with self.assertRaises(TypeError):
+            paddle.hypot_(x)
+
+        with self.assertRaises(TypeError):
+            paddle.hypot_(x, y, foo=1)
+
+        with self.assertRaises(TypeError):
+            paddle.hypot_(x=x, y=y, other=y)
+
+
 # Edit by AI Agent
 # Test fmax compatibility
 class TestFmaxAPI(unittest.TestCase):

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -350,7 +350,9 @@ class TestHypotAPI(unittest.TestCase):
 
         ref_out = np.hypot(self.np_x, self.np_y)
         for out in paddle_dygraph_out:
-            np.testing.assert_allclose(ref_out, out.numpy(), rtol=1e-6, atol=1e-6)
+            np.testing.assert_allclose(
+                ref_out, out.numpy(), rtol=1e-6, atol=1e-6
+            )
         paddle.enable_static()
 
     def test_static_Compatibility(self):


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
* 为 `paddle.hypot`、`paddle.hypot_` 添加参数别名
* `paddle.hypot` 新增 `out` 参数
* 为新增参数增加单测


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否