### PR TITLE
Add shallow copy in recompute

### DIFF
--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -717,7 +717,10 @@ def recompute(function, *args, **kwargs):
                 )
             else:
                 raise ValueError("Unknown parameter kind.")
-
+        # Make a shallow copy of each Tensor to prevent the release of some Tensors reserved for backward in some special scenarios (such as scheduling logic of parallel pipelines)
+        for idx, arg in enumerate(input_args):
+            if isinstance(arg, core.eager.Tensor):
+                input_args[idx] = arg._new_shared_tensor()
         return RecomputeFunction.apply(
             function,
             preserve,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
在paddle recompute的实现中使用浅copy来将Pyobject类型的Tensor拷贝一份，避免recompute反向要用到的前向的Tensor有可能被释放的情况。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否