### PR TITLE
[IXUCA CI] Add k8s runner fallback when test2 is busy

### DIFF
--- a/.github/workflows/_Linux-IXUCA.yml
+++ b/.github/workflows/_Linux-IXUCA.yml
@@ -29,10 +29,43 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  test:
-    name: Build and Test
+  check-runner:
+    name: Check runner availability
     needs: check-bypass
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      use_fallback: ${{ steps.check.outputs.use_fallback }}
+    steps:
+      - name: Check if test2 runners are busy
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // _Linux-IXUCA.yml is a reusable workflow called via workflow_call,
+            // so workflow runs are tracked under the caller workflow.
+            // We check if there are other in_progress runs of the same caller workflow.
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: context.workflow,
+              status: 'in_progress',
+            });
+            const otherActive = runs.data.workflow_runs.filter(
+              r => r.id !== context.runId
+            );
+            const useFallback = otherActive.length > 0;
+            console.log(`Current run ID: ${context.runId}`);
+            console.log(`Total in_progress runs: ${runs.data.total_count}`);
+            console.log(`Other active runs (excluding current): ${otherActive.length}`);
+            console.log(`Use fallback (iluvatar-gpu-2): ${useFallback}`);
+            core.setOutput('use_fallback', useFallback ? 'true' : 'false');
+
+  test:
+    name: Build and Test
+    needs: [check-bypass, check-runner]
+    if: ${{ needs.check-bypass.outputs.can-skip != 'true' && needs.check-runner.outputs.use_fallback != 'true' }}
     runs-on:
       group: test2
     timeout-minutes: 120
@@ -341,3 +374,236 @@ jobs:
           docker exec -t ${{ env.container_name }} /bin/bash -c 'rm -rf * .[^.]*'
           docker stop ${{ env.container_name }}
           docker rm ${{ env.container_name }}
+
+  test-k8s:
+    name: Build and Test (k8s-fallback)
+    needs: [check-bypass, check-runner]
+    if: ${{ needs.check-bypass.outputs.can-skip != 'true' && needs.check-runner.outputs.use_fallback == 'true' }}
+    runs-on: iluvatar-gpu-2
+    timeout-minutes: 120
+    container:
+      image: ccr-2vdh3abv-pub.cnc.bj.baidubce.com/device/paddle-ixuca:3.3.0
+      env:
+        LD_LIBRARY_PATH: /usr/local/corex/lib
+        LIBRARY_PATH: /usr/local/corex/lib
+
+    steps:
+      - name: Check approval
+        id: check-approval
+        run: |
+          set -euo pipefail
+
+          AUTHORIZED_REVIEWERS=("YqGe585" "yongqiangma")
+
+          echo "Authorized reviewers: ${AUTHORIZED_REVIEWERS[*]}"
+          echo "Repository: ${{ github.repository }}"
+          echo "PR number: ${{ github.event.pull_request.number }}"
+
+          response=$(curl -s \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews")
+
+          echo "Response length: ${#response}"
+
+          can_skip=$(python3 -c '
+          import json, sys
+
+          def debug(msg):
+              print(msg, file=sys.stderr)
+
+          debug("=== Review Check Debug Info ===")
+          debug(f"Authorized reviewers: {sys.argv[1:]}")
+          AUTHORIZED = set(sys.argv[1:])
+
+          try:
+              input_data = sys.stdin.read()
+              debug(f"Raw input data length: {len(input_data)}")
+              data = json.loads(input_data)
+              debug(f"Parsed {len(data)} reviews")
+          except Exception as e:
+              debug(f"JSON parse error: {str(e)}")
+              print("false")
+              sys.exit(0)
+
+          latest_state = {}
+          debug("\n=== Review States ===")
+          for r in data:
+              user = r.get("user", {}).get("login")
+              if not user:
+                  continue
+              state = r.get("state")
+              latest_state[user] = state
+              commit_id = r.get("commit_id") or ""
+              debug(f"- {user}: {state} (commit: {commit_id[:8]})")
+
+          debug("\n=== Final Check ===")
+          for user, state in latest_state.items():
+              if user in AUTHORIZED and state == "APPROVED":
+                  debug(f"Found APPROVED review from authorized user: {user}")
+                  print("true")
+                  sys.exit(0)
+
+          debug("No APPROVED review found from authorized users")
+          print("false")
+          ' "${AUTHORIZED_REVIEWERS[@]}" <<< "$response")
+
+          echo "can-skip=$can_skip" >> "$GITHUB_OUTPUT"
+
+          if [ "$can_skip" = "true" ]; then
+            echo "Found valid approval from authorized reviewer, skipping IXUCA CI"
+          else
+            echo "No valid approval found, running full CI"
+          fi
+
+      - name: Download paddle.tar.gz and update test branch
+        if: steps.check-approval.outputs.can-skip != 'true'
+        timeout-minutes: 30
+        run: |
+          set -e
+          echo "Downloading Paddle.tar.gz"
+          wget -q --tries=5 --no-proxy https://paddle-github-action.bj.bcebos.com/PR/Paddle/${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/Paddle.tar.gz --no-check-certificate
+          echo "Extracting Paddle.tar.gz"
+          tar -xf Paddle.tar.gz
+          rm Paddle.tar.gz
+          git config --global --add safe.directory $(pwd)/Paddle
+          cd Paddle
+          git remote add upstream https://github.com/PaddlePaddle/Paddle.git
+          git config pull.rebase false
+          git checkout test
+          echo "Fetching upstream develop branch"
+          git fetch upstream develop
+          echo "Rebasing test branch onto upstream/develop"
+          git rebase upstream/develop || {
+            echo "Rebase failed, attempting to continue with current state"
+            git rebase --abort || true
+          }
+          echo "Latest 5 commits after rebase:"
+          git log --oneline -5
+
+      - name: Determine the runner
+        if: steps.check-approval.outputs.can-skip != 'true'
+        run: |
+          echo "Running on k8s fallback runner: iluvatar-gpu-2"
+          echo "Workspace: $(pwd)"
+
+      - name: Get PaddleCustomDevice PR number from Paddle PR description
+        if: steps.check-approval.outputs.can-skip != 'true'
+        id: get-pcd-pr
+        run: |
+          # Get Paddle PR description
+          PR_BODY=$(curl -s \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
+            | python3 -c "import json,sys; data=json.load(sys.stdin); print(data.get('body', ''))")
+
+          # Extract [PaddleCustomDevice PR] XXXX from description
+          PCD_PR_NUM=$(echo "$PR_BODY" | grep -oP '\[PaddleCustomDevice PR\]\s*\K\d+' || echo "")
+
+          if [ -n "$PCD_PR_NUM" ]; then
+            echo "Found PaddleCustomDevice PR: $PCD_PR_NUM"
+            echo "pcd_pr_num=$PCD_PR_NUM" >> "$GITHUB_OUTPUT"
+          else
+            echo "No PaddleCustomDevice PR found in PR description"
+            echo "pcd_pr_num=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Clone PaddleCustomDevice repository
+        if: steps.check-approval.outputs.can-skip != 'true'
+        run: |
+          # Clone PaddleCustomDevice
+          git clone https://github.com/PaddlePaddle/PaddleCustomDevice.git
+          cd PaddleCustomDevice
+
+          # If PaddleCustomDevice PR number exists, fetch and merge it
+          PCD_PR_NUM="${{ steps.get-pcd-pr.outputs.pcd_pr_num }}"
+          if [ -n "$PCD_PR_NUM" ]; then
+            echo "Fetching and merging PaddleCustomDevice PR #$PCD_PR_NUM"
+            git fetch origin pull/$PCD_PR_NUM/head:pr-$PCD_PR_NUM
+            git merge pr-$PCD_PR_NUM --no-edit
+            echo "Successfully merged PaddleCustomDevice PR #$PCD_PR_NUM"
+          fi
+
+          cp -r ../Paddle .
+          git add Paddle
+          git commit -m "add Paddle submodule"
+
+      - name: Install Paddle-CPU
+        if: steps.check-approval.outputs.can-skip != 'true'
+        run: |
+          set -x
+          pip uninstall -y paddlepaddle || true
+          # Install nightly paddlepaddle CPU with retry
+          retry_count=0
+          max_retries=3
+          while [ $retry_count -lt $max_retries ]; do
+            if python -m pip install --pre paddlepaddle -i https://www.paddlepaddle.org.cn/packages/nightly/cpu/; then
+              echo "PaddlePaddle installation successful"
+              break
+            else
+              retry_count=$((retry_count + 1))
+              if [ $retry_count -lt $max_retries ]; then
+                echo "PaddlePaddle installation failed, retrying in 60 seconds... (Attempt $retry_count/$max_retries)"
+                sleep 60
+              else
+                echo "PaddlePaddle installation failed after $max_retries attempts, Please try rerun this job."
+                exit 1
+              fi
+            fi
+          done
+          echo "::group::Verify Paddle Installation"
+          python -c "import paddle; print(paddle.__version__)"
+          python -c "import paddle; print(paddle.version.commit)"
+          echo "::endgroup::"
+
+      - name: Build and test
+        if: steps.check-approval.outputs.can-skip != 'true'
+        run: |
+          set -x
+          set -euo pipefail
+
+          trap '{
+            ret=$?
+            echo "============================================================"
+            echo "IXUCA CI TEST FAILED (k8s-fallback)"
+            echo "Please contact the following maintainers for help:"
+            echo "  - YqGe585"
+            echo "  - yongqiangma"
+            echo "============================================================"
+            exit $ret
+          }' ERR
+
+          retry_or_skip() {
+            if "$@"; then
+              return 0
+            fi
+            echo "WARN: command failed, retrying in 20s: $*"
+            sleep 20
+            if "$@"; then
+              return 0
+            fi
+            echo "WARN: command failed again, skip install: $*"
+            return 0
+          }
+
+          echo "::group::Install dependencies"
+          retry_or_skip python -m pip install PyGithub
+          retry_or_skip python -m pip install wheel
+          echo "::endgroup::"
+          retry_or_skip pip install -U numpy==1.26.4
+          git config --global --add safe.directory "*"
+          cd PaddleCustomDevice
+          pwd
+          ls
+          cd backends/iluvatar_gpu/
+          bash build_paddle.sh
+          pip install build_pip/paddle_iluvatar_gpu*.whl
+          cd tests/
+          export FLAG_SKIP_FLOAT64=1
+          bash run_test.sh
+
+      - name: Cleanup workspace
+        if: always()
+        run: |
+          rm -rf * .[^.]*


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you've done -->
- 当 test2 runner group 已有 IXUCA CI 任务在运行时，新任务自动路由到 iluvatar-gpu-2（K8s runner），减少排队等待
- 新增 check-runner job：通过 GitHub API 检测是否有其他 in_progress 的 workflow run，决定路由到 test2 或 iluvatar-gpu-2
- 新增 test-k8s job：适配 iluvatar-gpu-2 执行环境（container 指令、无代理、nightly paddlepaddle 安装、无 conda）
- 原有 test job 增加条件判断，仅在 test2 空闲时执行，其余逻辑不变

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否