### PR TITLE
Fix CUDA error(9) in one_hot kernel when input numel is 0

### DIFF
--- a/paddle/phi/kernels/gpu/one_hot_kernel.cu
+++ b/paddle/phi/kernels/gpu/one_hot_kernel.cu
@@ -55,9 +55,10 @@ void OneHotKernel(const Context& dev_ctx,
   auto* p_in_data = x.data<T>();
   auto numel = x.numel();
   auto* p_out_data = dev_ctx.template Alloc<float>(out);
+  if (numel == 0) return;
+
   auto stream = dev_ctx.stream();
   funcs::set_constant(dev_ctx, out, static_cast<float>(0.0));
-  if (numel == 0) return;
 
   auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
 

--- a/paddle/phi/kernels/legacy/gpu/one_hot_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/one_hot_kernel.cu
@@ -58,6 +58,8 @@ struct OneHotV2OpCUDAFunctor {
     auto* p_in_data = in_->data<InT>();
     auto numel = in_->numel();
     auto* p_out_data = dev_ctx_.template Alloc<OutT>(out_);
+    if (numel == 0) return;
+
     auto stream = dev_ctx_.stream();
     funcs::set_constant(dev_ctx_, out_, 0.0);
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

#### 问题描述
在运行 `test_one_hot_v2_op.py` 测试时，使用调试 FLAGS `FLAGS_check_cuda_error=1 FLAGS_use_system_allocator=1` 会触发 CUDA error(9) (cudaErrorInvalidConfiguration)。

复现命令：
```bash
cd test/legacy_test
FLAGS_check_cuda_error=1 FLAGS_use_system_allocator=1 python test_one_hot_v2_op.py
```

#### 根因分析
问题出在 `one_hot_kernel.cu` 的 GPU 实现中。当 `TestOneHotOp_ZeroSize` 测试用例输入 tensor 的 shape 为 `[0, 10, 7, 3]`（即 `numel == 0`）时，kernel 在检查 `numel == 0` 之前就调用了 `funcs::set_constant()`，导致启动了无效的 CUDA kernel 配置。

原始代码：
```cpp
funcs::set_constant(dev_ctx, out, 0.0);  // 问题：numel=0 时调用
if (numel == 0) return;                   // 检查太晚
```

#### 修复方案
将 `numel == 0` 检查移到 `set_constant` 调用之前：
```cpp
if (numel == 0) return;                   // 提前检查
funcs::set_constant(dev_ctx, out, 0.0);
```

#### 修改文件
- `paddle/phi/kernels/gpu/one_hot_kernel.cu`
- `paddle/phi/kernels/legacy/gpu/one_hot_kernel.cu`

### 是否引起精度变化
否