### PR TITLE
[Eager] Use native Python object hash for `DataType` enum to improve hashing performance

### DIFF
--- a/paddle/fluid/pybind/data_type_caster.h
+++ b/paddle/fluid/pybind/data_type_caster.h
@@ -1,0 +1,171 @@
+/* Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+// This header provides a singleton cache for phi::DataType Python objects and
+// a custom pybind11 type_caster specialization that ensures ALL C++ → Python
+// conversions of DataType return the same cached Python object (singleton).
+//
+// This guarantees `paddle.float32 is value.dtype` for all code paths,
+// including PIR ops (which go through pybind11 auto-cast) and eager ops
+// (which go through ToPyObject).
+//
+// Include this header BEFORE any pybind11 binding code that involves DataType.
+// It must be included in every translation unit that might cast DataType to
+// Python (pybind.cc, pir.cc, native_meta_tensor.cc, etc.).
+
+#pragma once
+
+#include <Python.h>
+
+#include "paddle/phi/common/data_type.h"
+#include "pybind11/pybind11.h"
+
+// Enumerate all phi::DataType enum names (excluding NUM_DATA_TYPES and
+// ALL_DTYPE).  The order MUST match the enum definition in
+// paddle/phi/common/data_type.h.
+//
+// NOTE: Do NOT name this PD_FOR_EACH_DATA_TYPE — that macro already exists in
+// paddle/phi/common/data_type.h with a different callback signature
+// (cpp_type, DataType).  This one takes a single NAME argument.
+// clang-format off
+#define PD_FOR_EACH_DATA_TYPE_ENUM(CB) \
+  CB(UNDEFINED)                  \
+  CB(BOOL)                       \
+  CB(UINT8)                      \
+  CB(INT8)                       \
+  CB(UINT16)                     \
+  CB(INT16)                      \
+  CB(UINT32)                     \
+  CB(INT32)                      \
+  CB(UINT64)                     \
+  CB(INT64)                      \
+  CB(FLOAT32)                    \
+  CB(FLOAT64)                    \
+  CB(COMPLEX64)                  \
+  CB(COMPLEX128)                 \
+  CB(PSTRING)                    \
+  CB(FLOAT16)                    \
+  CB(BFLOAT16)                   \
+  CB(FLOAT8_E4M3FN)             \
+  CB(FLOAT8_E5M2)
+// clang-format on
+
+namespace paddle {
+namespace pybind {
+
+/// Global singleton cache for DataType Python objects.
+/// Initialized once after py::enum_<DataType> registration, stores a
+/// reference to each enum value's class attribute (e.g., DataType.FLOAT32).
+class DataTypeSingletonCache {
+ public:
+  static constexpr size_t kCacheSize =
+      static_cast<size_t>(phi::DataType::NUM_DATA_TYPES);
+
+  static DataTypeSingletonCache& Instance() {
+    static DataTypeSingletonCache instance;
+    return instance;
+  }
+
+  /// Initialize the cache by fetching enum attributes from the registered
+  /// py::enum_<DataType> type object. Must be called once after enum
+  /// registration in PYBIND11_MODULE.
+  void Init(PyTypeObject* data_type_pytype) {
+#define PD_DATA_TYPE_NAME_(NAME) #NAME,
+    static const char* kNames[] = {
+        PD_FOR_EACH_DATA_TYPE_ENUM(PD_DATA_TYPE_NAME_)};
+#undef PD_DATA_TYPE_NAME_
+    static_assert(sizeof(kNames) / sizeof(kNames[0]) == kCacheSize,
+                  "PD_FOR_EACH_DATA_TYPE_ENUM must match DataType enum size");
+
+    auto* type_obj = reinterpret_cast<PyObject*>(data_type_pytype);
+    for (size_t i = 0; i < kCacheSize; ++i) {
+      // PyObject_GetAttrString returns a new reference; we hold it forever.
+      cache_[i] = PyObject_GetAttrString(type_obj, kNames[i]);
+    }
+    initialized_ = true;
+  }
+
+  bool IsInitialized() const { return initialized_; }
+
+  /// Get the cached singleton PyObject* for the given DataType.
+  /// Returns nullptr if cache is not initialized or index is out of range.
+  /// The returned reference is borrowed (caller must Py_INCREF if needed).
+  PyObject* Get(phi::DataType dtype) const {
+    if (!initialized_) return nullptr;
+    auto idx = static_cast<size_t>(dtype);
+    if (idx >= kCacheSize) return nullptr;
+    return cache_[idx];
+  }
+
+ private:
+  DataTypeSingletonCache() = default;
+
+  bool initialized_ = false;
+  PyObject* cache_[kCacheSize] = {};
+};
+
+}  // namespace pybind
+}  // namespace paddle
+
+// Custom pybind11 type_caster specialization for phi::DataType.
+// This MUST be defined before any pybind11 code that casts DataType,
+// and it must be inside the pybind11::detail namespace.
+//
+// The key insight: pybind11's default type_caster_base creates a new Python
+// object on every C++ → Python cast via make_new_instance(). By specializing
+// the type_caster, we intercept the cast and return the cached singleton
+// instead, ensuring identity (`is`) comparison works.
+//
+// Note: pybind11's enum __init__ (e.g., `core.DataType(10)`) bypasses this
+// caster, so those objects are NOT singletons. The value-based `tp_hash`
+// (DataTypeEnumHash) ensures hash consistency for such edge cases.
+//
+// During enum registration (before cache init), we fall back to the default
+// pybind11 behavior so that the enum values are created normally.
+namespace pybind11 {
+namespace detail {
+
+template <>
+struct type_caster<phi::DataType> : public type_caster_base<phi::DataType> {
+  using base = type_caster_base<phi::DataType>;
+
+ public:
+  // Python → C++ direction: reuse default behavior
+  using base::load;
+
+  // C++ → Python direction: return cached singleton if available
+  static handle cast(const phi::DataType& src,
+                     return_value_policy policy,
+                     handle parent) {
+    auto& cache = paddle::pybind::DataTypeSingletonCache::Instance();
+    if (cache.IsInitialized()) {
+      PyObject* cached = cache.Get(src);
+      if (cached) {
+        Py_INCREF(cached);
+        return handle(cached);
+      }
+    }
+    // Fallback: during enum registration or for unknown values
+    return base::cast(src, policy, parent);
+  }
+
+  static handle cast(phi::DataType&& src,
+                     return_value_policy policy,
+                     handle parent) {
+    return cast(src, policy, parent);
+  }
+};
+
+}  // namespace detail
+}  // namespace pybind11

--- a/paddle/fluid/pybind/data_type_caster.h
+++ b/paddle/fluid/pybind/data_type_caster.h
@@ -31,36 +31,6 @@ limitations under the License. */
 #include "paddle/phi/common/data_type.h"
 #include "pybind11/pybind11.h"
 
-// Enumerate all phi::DataType enum names (excluding NUM_DATA_TYPES and
-// ALL_DTYPE).  The order MUST match the enum definition in
-// paddle/phi/common/data_type.h.
-//
-// NOTE: Do NOT name this PD_FOR_EACH_DATA_TYPE — that macro already exists in
-// paddle/phi/common/data_type.h with a different callback signature
-// (cpp_type, DataType).  This one takes a single NAME argument.
-// clang-format off
-#define PD_FOR_EACH_DATA_TYPE_ENUM(CB) \
-  CB(UNDEFINED)                  \
-  CB(BOOL)                       \
-  CB(UINT8)                      \
-  CB(INT8)                       \
-  CB(UINT16)                     \
-  CB(INT16)                      \
-  CB(UINT32)                     \
-  CB(INT32)                      \
-  CB(UINT64)                     \
-  CB(INT64)                      \
-  CB(FLOAT32)                    \
-  CB(FLOAT64)                    \
-  CB(COMPLEX64)                  \
-  CB(COMPLEX128)                 \
-  CB(PSTRING)                    \
-  CB(FLOAT16)                    \
-  CB(BFLOAT16)                   \
-  CB(FLOAT8_E4M3FN)             \
-  CB(FLOAT8_E5M2)
-// clang-format on
-
 namespace paddle {
 namespace pybind {
 
@@ -81,12 +51,16 @@ class DataTypeSingletonCache {
   /// py::enum_<DataType> type object. Must be called once after enum
   /// registration in PYBIND11_MODULE.
   void Init(PyTypeObject* data_type_pytype) {
-#define PD_DATA_TYPE_NAME_(NAME) #NAME,
+    // The order MUST match the enum definition in
+    // paddle/phi/common/data_type.h (excluding NUM_DATA_TYPES / ALL_DTYPE).
     static const char* kNames[] = {
-        PD_FOR_EACH_DATA_TYPE_ENUM(PD_DATA_TYPE_NAME_)};
-#undef PD_DATA_TYPE_NAME_
+        "UNDEFINED", "BOOL",     "UINT8",         "INT8",        "UINT16",
+        "INT16",     "UINT32",   "INT32",         "UINT64",      "INT64",
+        "FLOAT32",   "FLOAT64",  "COMPLEX64",     "COMPLEX128",  "PSTRING",
+        "FLOAT16",   "BFLOAT16", "FLOAT8_E4M3FN", "FLOAT8_E5M2",
+    };
     static_assert(sizeof(kNames) / sizeof(kNames[0]) == kCacheSize,
-                  "PD_FOR_EACH_DATA_TYPE_ENUM must match DataType enum size");
+                  "kNames must match DataType enum size");
 
     auto* type_obj = reinterpret_cast<PyObject*>(data_type_pytype);
     for (size_t i = 0; i < kCacheSize; ++i) {

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -34,6 +34,7 @@ limitations under the License. */
 #include "paddle/fluid/pir/utils/general_functions.h"
 #include "paddle/fluid/pir/utils/name_analysis.h"
 #include "paddle/fluid/platform/enforce.h"
+#include "paddle/fluid/pybind/data_type_caster.h"
 #include "paddle/fluid/pybind/eager.h"
 #include "paddle/fluid/pybind/op_function_common.h"
 #include "paddle/fluid/pybind/pir.h"
@@ -1253,14 +1254,15 @@ PyObject* ToPyObject(const phi::DenseTensor* value) {
 }
 
 PyObject* ToPyObject(const DataType& dtype) {
-  static const std::vector<std::string> dtype_names = {
-      "UNDEFINED", "BOOL",     "UINT8",         "INT8",        "UINT16",
-      "INT16",     "UINT32",   "INT32",         "UINT64",      "INT64",
-      "FLOAT32",   "FLOAT64",  "COMPLEX64",     "COMPLEX128",  "PSTRING",
-      "FLOAT16",   "BFLOAT16", "FLOAT8_E4M3FN", "FLOAT8_E5M2",
-  };
-  return PyObject_GetAttrString(reinterpret_cast<PyObject*>(g_data_type_pytype),
-                                dtype_names[static_cast<int>(dtype)].c_str());
+  auto& cache = paddle::pybind::DataTypeSingletonCache::Instance();
+  PyObject* cached = cache.Get(dtype);
+  if (cached) {
+    Py_INCREF(cached);
+    return cached;
+  }
+  // Fallback: cache not initialized yet (should not happen in normal flow)
+  PADDLE_THROW(common::errors::Fatal(
+      "DataTypeSingletonCache is not initialized when ToPyObject is called."));
 }
 
 PyObject* ToPyObject(const std::vector<DataType>& dtypes) {

--- a/paddle/fluid/pybind/native_meta_tensor.cc
+++ b/paddle/fluid/pybind/native_meta_tensor.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/api/ext/native_meta_tensor.h"
+#include "paddle/fluid/pybind/data_type_caster.h"
 #include "paddle/fluid/pybind/native_meta_tensor.h"
 #include "paddle/utils/pybind.h"
 #include "pybind11/functional.h"

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -4366,10 +4366,26 @@ All parameter, weight, gradient are variables in Paddle.
 
   py::enum_<DataType> data_type(m, "DataType");
   g_data_type_pytype = (PyTypeObject *)data_type.ptr();  // NOLINT
-#define PD_REGISTER_DATA_TYPE_(NAME) data_type.value(#NAME, DataType::NAME);
-  PD_FOR_EACH_DATA_TYPE_ENUM(PD_REGISTER_DATA_TYPE_)
-#undef PD_REGISTER_DATA_TYPE_
-  data_type.value("ALL_DTYPE", DataType::ALL_DTYPE)
+  data_type.value("UNDEFINED", DataType::UNDEFINED)
+      .value("BOOL", DataType::BOOL)
+      .value("UINT8", DataType::UINT8)
+      .value("INT8", DataType::INT8)
+      .value("UINT16", DataType::UINT16)
+      .value("INT16", DataType::INT16)
+      .value("UINT32", DataType::UINT32)
+      .value("INT32", DataType::INT32)
+      .value("UINT64", DataType::UINT64)
+      .value("INT64", DataType::INT64)
+      .value("FLOAT32", DataType::FLOAT32)
+      .value("FLOAT64", DataType::FLOAT64)
+      .value("COMPLEX64", DataType::COMPLEX64)
+      .value("COMPLEX128", DataType::COMPLEX128)
+      .value("PSTRING", DataType::PSTRING)
+      .value("FLOAT16", DataType::FLOAT16)
+      .value("BFLOAT16", DataType::BFLOAT16)
+      .value("FLOAT8_E4M3FN", DataType::FLOAT8_E4M3FN)
+      .value("FLOAT8_E5M2", DataType::FLOAT8_E5M2)
+      .value("ALL_DTYPE", DataType::ALL_DTYPE)
       .export_values()
       .def("__dlpack_data_type__", [](const DataType &self) {
         ::DLDataType dl_dtype =

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -4382,8 +4382,8 @@ All parameter, weight, gradient are variables in Paddle.
         return py::make_tuple(dl_dtype.code, dl_dtype.bits, dl_dtype.lanes);
       });
   // Make sure the hash function of DataType is consistent with Python's default
-  // behavior. This is fast than pybind11's default hash implementation for
-  // enum.
+  // behavior by using identity hashing (object.__hash__) for the enum type.
+  // This is faster than pybind11's default hash implementation for enums.
   g_data_type_pytype->tp_hash = PyBaseObject_Type.tp_hash;
   PyType_Modified(g_data_type_pytype);
 

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -279,6 +279,17 @@ PyTypeObject *g_custom_op_kernel_ctx_pytype = nullptr;
 PyTypeObject *g_data_type_pytype = nullptr;
 PyTypeObject *g_tensorrt_engine_params_pytype = nullptr;
 
+// Custom hash function for DataType enum that extracts the underlying integer
+// value directly from pybind11's instance layout. This is much faster than
+// pybind11's default Python-level `__hash__ = lambda self: int(self)` which
+// involves method dispatch and temporary Python int object creation.
+// The hash is value-based, consistent with pybind11's value-based `__eq__`.
+static Py_hash_t DataTypeEnumHash(PyObject *self) {
+  auto *inst = reinterpret_cast<pybind11::detail::instance *>(self);
+  return static_cast<Py_hash_t>(
+      *reinterpret_cast<DataType *>(inst->simple_value_holder[0]));
+}
+
 bool IsCompiledWithAVX() {
 #ifndef PADDLE_WITH_AVX
   return false;
@@ -4355,36 +4366,28 @@ All parameter, weight, gradient are variables in Paddle.
 
   py::enum_<DataType> data_type(m, "DataType");
   g_data_type_pytype = (PyTypeObject *)data_type.ptr();  // NOLINT
-  data_type.value("UNDEFINED", DataType::UNDEFINED)
-      .value("BOOL", DataType::BOOL)
-      .value("UINT8", DataType::UINT8)
-      .value("INT8", DataType::INT8)
-      .value("UINT16", DataType::UINT16)
-      .value("INT16", DataType::INT16)
-      .value("UINT32", DataType::UINT32)
-      .value("INT32", DataType::INT32)
-      .value("UINT64", DataType::UINT64)
-      .value("INT64", DataType::INT64)
-      .value("FLOAT32", DataType::FLOAT32)
-      .value("FLOAT64", DataType::FLOAT64)
-      .value("COMPLEX64", DataType::COMPLEX64)
-      .value("COMPLEX128", DataType::COMPLEX128)
-      .value("FLOAT16", DataType::FLOAT16)
-      .value("BFLOAT16", DataType::BFLOAT16)
-      .value("FLOAT8_E4M3FN", DataType::FLOAT8_E4M3FN)
-      .value("FLOAT8_E5M2", DataType::FLOAT8_E5M2)
-      .value("PSTRING", DataType::PSTRING)
-      .value("ALL_DTYPE", DataType::ALL_DTYPE)
+#define PD_REGISTER_DATA_TYPE_(NAME) data_type.value(#NAME, DataType::NAME);
+  PD_FOR_EACH_DATA_TYPE_ENUM(PD_REGISTER_DATA_TYPE_)
+#undef PD_REGISTER_DATA_TYPE_
+  data_type.value("ALL_DTYPE", DataType::ALL_DTYPE)
       .export_values()
       .def("__dlpack_data_type__", [](const DataType &self) {
         ::DLDataType dl_dtype =
             paddle::framework::PhiDataTypeToDLDataType(self);
         return py::make_tuple(dl_dtype.code, dl_dtype.bits, dl_dtype.lanes);
       });
-  // Make sure the hash function of DataType is consistent with Python's default
-  // behavior by using identity hashing (object.__hash__) for the enum type.
-  // This is faster than pybind11's default hash implementation for enums.
-  g_data_type_pytype->tp_hash = PyBaseObject_Type.tp_hash;
+  // Initialize the DataType singleton cache from the registered enum
+  // attributes. After this, all C++ → Python conversions of DataType (via
+  // pybind11 auto-cast or ToPyObject) will return cached singletons,
+  // guaranteeing `paddle.float32 is value.dtype` for all code paths.
+  DataTypeSingletonCache::Instance().Init(g_data_type_pytype);
+
+  // Override the hash function with a fast C-level implementation that hashes
+  // based on the underlying enum integer value. This is faster than pybind11's
+  // default hash (which goes through Python method dispatch).
+  // With singleton caching, identity-based hash would also work, but we keep
+  // value-based hash as a safety net for any edge cases.
+  g_data_type_pytype->tp_hash = DataTypeEnumHash;
   PyType_Modified(g_data_type_pytype);
 
   py::class_<paddle::platform::EngineParams> engine_params(m,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -4381,6 +4381,11 @@ All parameter, weight, gradient are variables in Paddle.
             paddle::framework::PhiDataTypeToDLDataType(self);
         return py::make_tuple(dl_dtype.code, dl_dtype.bits, dl_dtype.lanes);
       });
+  // Make sure the hash function of DataType is consistent with Python's default
+  // behavior. This is fast than pybind11's default hash implementation for
+  // enum.
+  g_data_type_pytype->tp_hash = PyBaseObject_Type.tp_hash;
+  PyType_Modified(g_data_type_pytype);
 
   py::class_<paddle::platform::EngineParams> engine_params(m,
                                                            "TRTEngineParams");

--- a/paddle/fluid/pybind/pybind_variant_caster.h
+++ b/paddle/fluid/pybind/pybind_variant_caster.h
@@ -19,6 +19,7 @@ limitations under the License. */
 
 #include "glog/logging.h"
 #include "paddle/fluid/pir/drr/include/drr_pattern_base.h"
+#include "paddle/fluid/pybind/data_type_caster.h"
 #include "paddle/utils/variant.h"
 #include "pybind11/numpy.h"
 #include "pybind11/pybind11.h"

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -1457,8 +1457,8 @@ class TestEagerTensor(unittest.TestCase):
             paddle.bool,
         ]
 
-        # Check no hash collision among all dtypes
-        self.assertEqual(len(set(all_types)), len(all_types))
+        # Check that all dtypes have distinct hash values
+        self.assertEqual(len({hash(t) for t in all_types}), len(all_types))
 
     def test___cuda_array_interface__(self):
         """test Tensor.__cuda_array_interface__"""

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -1427,6 +1427,39 @@ class TestEagerTensor(unittest.TestCase):
         self.assertTrue(a.dtype is not paddle.float64)
         self.assertTrue(a.dtype is not c.dtype)
 
+    def test_tensor_dtype_hash(self):
+        a = paddle.randn([2], dtype="float32")
+        b = paddle.randn([2], dtype="float32")
+        c = paddle.randn([2], dtype="float64")
+
+        self.assertEqual(hash(a.dtype), hash(paddle.float32))
+        self.assertEqual(hash(a.dtype), hash(b.dtype))
+        self.assertNotEqual(hash(a.dtype), hash(paddle.float64))
+        self.assertNotEqual(hash(a.dtype), hash(c.dtype))
+
+        all_types = [
+            paddle.complex64,
+            paddle.complex128,
+            paddle.float8_e4m3fn,
+            paddle.float8_e5m2,
+            paddle.bfloat16,
+            paddle.float16,
+            paddle.float32,
+            paddle.float64,
+            paddle.uint8,
+            paddle.uint16,
+            paddle.uint32,
+            paddle.uint64,
+            paddle.int8,
+            paddle.int16,
+            paddle.int32,
+            paddle.int64,
+            paddle.bool,
+        ]
+
+        # Check no hash collision among all dtypes
+        self.assertEqual(len(set(all_types)), len(all_types))
+
     def test___cuda_array_interface__(self):
         """test Tensor.__cuda_array_interface__"""
         with dygraph_guard():

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -18,7 +18,7 @@ import warnings
 
 import numpy as np
 from op_test import get_device, get_device_place, is_custom_device
-from utils import dygraph_guard
+from utils import dygraph_guard, static_guard
 
 import paddle
 import paddle.nn.functional as F
@@ -1459,6 +1459,27 @@ class TestEagerTensor(unittest.TestCase):
 
         # Check that all dtypes have distinct hash values
         self.assertEqual(len({hash(t) for t in all_types}), len(all_types))
+
+        # Verify dict lookup works with dtype as key
+        dtype_map = {paddle.float32: "fp32", paddle.float64: "fp64"}
+        self.assertEqual(dtype_map[a.dtype], "fp32")
+        self.assertEqual(dtype_map[c.dtype], "fp64")
+
+    @static_guard()
+    def test_tensor_dtype_singleton_pir(self):
+        """DataType returned from PIR Value.dtype must be the same
+        singleton object as paddle.float32, etc."""
+        x = paddle.static.data('x', shape=[2], dtype='float32')
+        y = paddle.static.data('y', shape=[3], dtype='float64')
+
+        # Value.dtype (PIR path) should return singletons
+        self.assertIs(x.dtype, paddle.float32)
+        self.assertIs(y.dtype, paddle.float64)
+
+        # Dict lookup must work with PIR dtypes
+        dtype_map = {paddle.float32: "fp32", paddle.float64: "fp64"}
+        self.assertEqual(dtype_map[x.dtype], "fp32")
+        self.assertEqual(dtype_map[y.dtype], "fp64")
 
     def test___cuda_array_interface__(self):
         """test Tensor.__cuda_array_interface__"""


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Performance

### Description
<!-- Describe what you’ve done -->

避免对 dtype 进行 hash（如 `hash(paddle.float32)`）走 pybind11 默认的取值行为，该流程性能明显低于默认的 hash 行为（即与地址或者说 id 相关），本 PR 修改前后 `hash(dtype)` 分别为 0.63us -> 0.12us（优化到 1/5），接近 PyTorch 的 0.10us

在此之前，triton kernel launch 前会有多处对所有 Tensor 参数的 dtype 进行 hash，这会导致每个参数 Paddle 会比 PyTorch 慢约 0.5us，多个参数很容易累积 5us x 2 处约 10us 左右额外开销

另外，#76155 在确保所有 `DataType` 实例一致性的时候，只支持了 `ToPyObject` 路径（如 `Tensor.dtype`），没支持 `pybind11` 隐式转换（如 `pir.Value.dtype`），本 PR 因为 hash 与 id 绑定，暴露了该问题，因此顺带修了该问题

与本 PR 无关，在分析 Triton timeline 时发现的 triton 的一些其他调度开销问题：

- autotune 相比非 autotune 的 kernel 在运行时会有额外 25us 左右的开销
- 动态 grid（grid 处传函数）相比非动态 grid 会多 8us 左右的开销

在实际编写 / 生成 triton kernel 时，应尽可能避免上述问题

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否

<div align="right">
   <sup>This PR Co-Authored with GitHub Copilot (Claude Opus 4.6)</sup>
</div>

<!-- PCard-66972 -->