### PR TITLE
[CI] Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/Approval.yml
+++ b/.github/workflows/Approval.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 200

--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
     steps:
       - name: Clone paddle
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check PR Template
         env:

--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout base repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 1000
@@ -37,7 +37,7 @@ jobs:
           git checkout -b test FETCH_HEAD
 
       - name: Setup python3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"

--- a/.github/workflows/Preview-Url-Comment.yml
+++ b/.github/workflows/Preview-Url-Comment.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Download artifacts
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         continue-on-error: true
         with:
           name: doc-preview-comment

--- a/.github/workflows/_Clone-linux.yml
+++ b/.github/workflows/_Clone-linux.yml
@@ -58,7 +58,7 @@ jobs:
         run: git submodule foreach --recursive 'git rev-parse HEAD || rm -rf $PWD' || true
 
       - name: Clone paddle
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           submodules: "recursive"

--- a/.github/workflows/_Clone-linux.yml
+++ b/.github/workflows/_Clone-linux.yml
@@ -68,9 +68,6 @@ jobs:
         id: check-execution
         if: ${{ inputs.is_pr == 'true' }}
         run: |
-          # checkout v6 stores credentials via includeIf, so extraheader may be absent.
-          git config --unset http.https://github.com/.extraheader || true
-          git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader' || :"
           git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           git switch ${{ github.event.pull_request.base.ref }}
           set +e

--- a/.github/workflows/_Clone-linux.yml
+++ b/.github/workflows/_Clone-linux.yml
@@ -68,8 +68,9 @@ jobs:
         id: check-execution
         if: ${{ inputs.is_pr == 'true' }}
         run: |
-          git config --unset http.https://github.com/.extraheader
-          git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader'"
+          # checkout v6 stores credentials via includeIf, so extraheader may be absent.
+          git config --unset http.https://github.com/.extraheader || true
+          git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader' || :"
           git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           git switch ${{ github.event.pull_request.base.ref }}
           set +e

--- a/.github/workflows/_Clone-windows.yml
+++ b/.github/workflows/_Clone-windows.yml
@@ -38,7 +38,8 @@ jobs:
 
       - name: Merge pr
         run: |
-          git config --unset http.https://github.com/.extraheader
+          REM checkout v6 stores credentials via includeIf, so extraheader may be absent.
+          git config --local --name-only --get-regexp http.https://github.com/.extraheader >nul 2>&1 && git config --unset http.https://github.com/.extraheader
           REM git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader'"
           REM git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           git switch %BRANCH%

--- a/.github/workflows/_Clone-windows.yml
+++ b/.github/workflows/_Clone-windows.yml
@@ -38,9 +38,6 @@ jobs:
 
       - name: Merge pr
         run: |
-          REM checkout v6 stores credentials via includeIf, so extraheader may be absent.
-          git config --local --name-only --get-regexp http.https://github.com/.extraheader >nul 2>&1 && git config --unset http.https://github.com/.extraheader
-          REM git submodule foreach --recursive sh -c "git config --local --unset-all 'http.https://github.com/.extraheader'"
           REM git submodule foreach --recursive sh -c "git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'"
           git switch %BRANCH%
           git branch -D test

--- a/.github/workflows/_Clone-windows.yml
+++ b/.github/workflows/_Clone-windows.yml
@@ -31,7 +31,7 @@ jobs:
           git config --global core.longpaths true
 
       - name: Clone paddle
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 1000

--- a/.github/workflows/_Doc-Preview.yml
+++ b/.github/workflows/_Doc-Preview.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload comment artifacts
         if: steps.generate_comment.outputs.comment_body != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: doc-preview-comment
           path: |

--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Get PR labels
         id: get-labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -34,7 +34,7 @@ jobs:
 
       - name: Remove skip-ci labels
         if: steps.get-labels.outputs.has-skip-ci-labels == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Rerun all failed jobs
         if: ${{ contains(github.event.comment.body, 'all-failed') }}

--- a/.github/workflows/validate-pir-versions.yml
+++ b/.github/workflows/validate-pir-versions.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release/') && github.repository_owner == 'PaddlePaddle'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Check DEVELOP_VERSION and RELEASE_VERSION equality
         id: check_versions
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create Issue if versions not equal
         if: steps.check_versions.outputs.equal == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           DEVELOP_VERSION: ${{ steps.check_versions.outputs.develop_version }}
           RELEASE_VERSION: ${{ steps.check_versions.outputs.release_version }}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

#### Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

#### Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v3`](https://github.com/actions/checkout/releases/tag/v3), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | Approval.yml, CheckPRTemplate.yml, Codestyle-Check.yml, _Clone-linux.yml, _Clone-windows.yml, rerun.yml, validate-pir-versions.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v8`](https://github.com/actions/download-artifact/releases/tag/v8) | [Release](https://github.com/actions/download-artifact/releases/tag/v8) | Preview-Url-Comment.yml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | remove-skip-ci-labels.yml, validate-pir-versions.yml |
| `actions/setup-python` | [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | Codestyle-Check.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/upload-artifact/releases/tag/v7) | [Release](https://github.com/actions/upload-artifact/releases/tag/v7) | _Doc-Preview.yml |

#### Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting June 2nd, 2026.

##### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: June 2nd, 2026
- **Action**: Update to latest action versions that support Node 24

##### ⚠️ Breaking Changes

- **actions/checkout** (v4 → v6): Major version upgrade — review the [release notes](https://github.com/actions/checkout/releases) for breaking changes
- **actions/setup-python** (v5 → v6): Major version upgrade — review the [release notes](https://github.com/actions/setup-python/releases) for breaking changes
- **actions/download-artifact** (v4 → v8): Major version upgrade — review the [release notes](https://github.com/actions/download-artifact/releases) for breaking changes
- **actions/upload-artifact** (v4 → v7): Major version upgrade — review the [release notes](https://github.com/actions/upload-artifact/releases) for breaking changes
- **actions/github-script** (v7 → v8): Major version upgrade — review the [release notes](https://github.com/actions/github-script/releases) for breaking changes

##### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

##### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否