### PR TITLE
[CI] Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -368,7 +368,7 @@ jobs:
           '
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           directory: build/coverage_files
           verbose: true

--- a/.github/workflows/Preview-Url-Comment.yml
+++ b/.github/workflows/Preview-Url-Comment.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Create or update comment
         if: steps.download.outcome == 'success'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ steps.artifacts-data.outputs.pr_number }}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

#### Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

#### Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `codecov/codecov-action` | [`v4`](https://github.com/codecov/codecov-action/releases/tag/v4) | [`v5`](https://github.com/codecov/codecov-action/releases/tag/v5) | [Release](https://github.com/codecov/codecov-action/releases/tag/v5) | Coverage.yml |
| `peter-evans/create-or-update-comment` | [`v4`](https://github.com/peter-evans/create-or-update-comment/releases/tag/v4) | [`v5`](https://github.com/peter-evans/create-or-update-comment/releases/tag/v5) | [Release](https://github.com/peter-evans/create-or-update-comment/releases/tag/v5) | Preview-Url-Comment.yml |

#### Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

##### ⚠️ Breaking Changes

- **codecov/codecov-action** (v4 → v5): Major version upgrade — review the [release notes](https://github.com/codecov/codecov-action/releases) for breaking changes
  - ⚠️ Input `file` was **removed** — if your workflow uses it, the step may fail
  - ⚠️ Input `plugin` was **removed** — if your workflow uses it, the step may fail
- **peter-evans/create-or-update-comment** (v4 → v5): Major version upgrade — review the [release notes](https://github.com/peter-evans/create-or-update-comment/releases) for breaking changes

##### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

##### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否