### PR TITLE
[PHI] Fix tril_triu kernel CUDA error(9) for empty tensor

### DIFF
--- a/paddle/phi/kernels/impl/tril_triu_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/tril_triu_grad_kernel_impl.h
@@ -26,9 +26,14 @@ void TrilTriuGradKernel(const Context& dev_ctx,
                         int diagonal,
                         bool lower,
                         DenseTensor* x_grad) {
-  const auto* dout_data = out_grad.data<T>();
   auto* dx_data = dev_ctx.template Alloc<T>(x_grad);
 
+  // Early return for empty tensor to avoid invalid CUDA kernel launch
+  if (out_grad.numel() == 0) {
+    return;
+  }
+
+  const auto* dout_data = out_grad.data<T>();
   const auto& dims = out_grad.dims();
   const auto H = dims[dims.size() - 2];
   const auto W = dims[dims.size() - 1];

--- a/paddle/phi/kernels/impl/tril_triu_kernel_impl.h
+++ b/paddle/phi/kernels/impl/tril_triu_kernel_impl.h
@@ -26,9 +26,14 @@ void TrilTriuKernel(const Context& dev_ctx,
                     int diagonal,
                     bool lower,
                     DenseTensor* out) {
-  const auto* x_data = x.data<T>();
   auto* out_data = dev_ctx.template Alloc<T>(out);
 
+  // Early return for empty tensor to avoid invalid CUDA kernel launch
+  if (x.numel() == 0) {
+    return;
+  }
+
+  const auto* x_data = x.data<T>();
   const auto& dims = x.dims();
   const auto H = dims[dims.size() - 2];
   const auto W = dims[dims.size() - 1];


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

#### 问题背景
`tril_triu` 算子在处理空 Tensor（numel=0）时会触发 CUDA error(9): invalid configuration argument。

#### 问题原因
`TrilTriuKernel` 和 `TrilTriuGradKernel` 没有检查空 Tensor，当 `numel=0` 时，`ForRange` 以 `limit=0` 被调用，导致 `grid_size=0, block_size=0`，触发无效的 CUDA kernel 配置。

#### 修复方案
在 `TrilTriuKernel` 和 `TrilTriuGradKernel` 入口处添加 `numel==0` 的提前返回检查，避免无效的 CUDA kernel 启动。

#### 修改文件
- `paddle/phi/kernels/impl/tril_triu_kernel_impl.h`
- `paddle/phi/kernels/impl/tril_triu_grad_kernel_impl.h`

#### 复现与验证
```bash
FLAGS_check_cuda_error=1 FLAGS_use_system_allocator=1 python test/legacy_test/test_tril_triu_op.py
```
修复前：6 个 ZeroSize/ZeroDim 相关测试失败
修复后：所有 324 个测试通过

### 是否引起精度变化
否