### PR TITLE
[Precision Depth Alignment] use vectorized Sleef for CPU sin/cos/pow kernels to align with PyTorch precision

### DIFF
--- a/paddle/phi/kernels/cpu/activation_kernel.cc
+++ b/paddle/phi/kernels/cpu/activation_kernel.cc
@@ -101,8 +101,36 @@ namespace phi {
         dev_ctx, x, out, functor);                          \
   }
 
-DEFINE_CPU_ACTIVATION_KERNEL(Sin, SinFunctor)
-DEFINE_CPU_ACTIVATION_KERNEL(Cos, CosFunctor)
+// Specialized Sin kernel with vectorized Sleef implementation for float/double
+// This ensures bit-level precision alignment with PyTorch
+template <typename T, typename Context>
+void SinKernel(const Context& dev_ctx, const DenseTensor& x, DenseTensor* out) {
+  if constexpr (std::is_same<T, float>::value ||
+                std::is_same<T, double>::value) {
+    // Use vectorized Sleef path for float/double to match PyTorch precision
+    VectorizedSinImpl<T, Context>(dev_ctx, x, out);
+  } else {
+    // Use generic path for other types (float16, bfloat16, complex)
+    funcs::SinFunctor<T> functor;
+    ActivationImpl<T, T, Context, funcs::SinFunctor<T>>(
+        dev_ctx, x, out, functor);
+  }
+}
+
+// Specialized Cos kernel with vectorized Sleef implementation for float/double
+template <typename T, typename Context>
+void CosKernel(const Context& dev_ctx, const DenseTensor& x, DenseTensor* out) {
+  if constexpr (std::is_same<T, float>::value ||
+                std::is_same<T, double>::value) {
+    // Use vectorized Sleef path for float/double to match PyTorch precision
+    VectorizedCosImpl<T, Context>(dev_ctx, x, out);
+  } else {
+    // Use generic path for other types (float16, bfloat16, complex)
+    funcs::CosFunctor<T> functor;
+    ActivationImpl<T, T, Context, funcs::CosFunctor<T>>(
+        dev_ctx, x, out, functor);
+  }
+}
 DEFINE_CPU_ACTIVATION_KERNEL(Tan, TanFunctor)
 DEFINE_CPU_ACTIVATION_KERNEL(Asin, AsinFunctor)
 DEFINE_CPU_ACTIVATION_KERNEL(Atan, AtanFunctor)

--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -29,6 +29,10 @@
 
 #include <type_traits>
 
+#ifdef PADDLE_WITH_SLEEF
+#include <sleef.h>
+#endif
+
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/enforce.h"
@@ -61,17 +65,57 @@ struct Sine {
   HOSTDEVICE T operator()(const T& val) const { return sin(val); }
 };
 
+// Specialized Sine for float using Sleef (matches PyTorch's u35 precision)
+template <>
+struct Sine<float> {
+  HOSTDEVICE float operator()(const float& val) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return sin(val);
+#elif defined(PADDLE_WITH_SLEEF)
+    return Sleef_sinf1_u35(val);
+#else
+    return sin(val);
+#endif
+  }
+};
+
+// Specialized Sine for double using Sleef (matches PyTorch's u10 precision)
+template <>
+struct Sine<double> {
+  HOSTDEVICE double operator()(const double& val) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return sin(val);
+#elif defined(PADDLE_WITH_SLEEF)
+    return Sleef_sind1_u10(val);
+#else
+    return sin(val);
+#endif
+  }
+};
+
 template <>
 struct Sine<dtype::float16> {
   HOSTDEVICE dtype::float16 operator()(const dtype::float16& val) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     return dtype::float16(sin(static_cast<float>(val)));
+#elif defined(PADDLE_WITH_SLEEF)
+    return dtype::float16(Sleef_sinf1_u35(static_cast<float>(val)));
+#else
+    return dtype::float16(sin(static_cast<float>(val)));
+#endif
   }
 };
 
 template <>
 struct Sine<dtype::bfloat16> {
   HOSTDEVICE dtype::bfloat16 operator()(const dtype::bfloat16& val) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     return dtype::bfloat16(sin(static_cast<float>(val)));
+#elif defined(PADDLE_WITH_SLEEF)
+    return dtype::bfloat16(Sleef_sinf1_u35(static_cast<float>(val)));
+#else
+    return dtype::bfloat16(sin(static_cast<float>(val)));
+#endif
   }
 };
 
@@ -80,17 +124,57 @@ struct Cosine {
   HOSTDEVICE T operator()(const T& val) const { return cos(val); }
 };
 
+// Specialized Cosine for float using Sleef (matches PyTorch's u35 precision)
+template <>
+struct Cosine<float> {
+  HOSTDEVICE float operator()(const float& val) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return cos(val);
+#elif defined(PADDLE_WITH_SLEEF)
+    return Sleef_cosf1_u35(val);
+#else
+    return cos(val);
+#endif
+  }
+};
+
+// Specialized Cosine for double using Sleef (matches PyTorch's u10 precision)
+template <>
+struct Cosine<double> {
+  HOSTDEVICE double operator()(const double& val) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return cos(val);
+#elif defined(PADDLE_WITH_SLEEF)
+    return Sleef_cosd1_u10(val);
+#else
+    return cos(val);
+#endif
+  }
+};
+
 template <>
 struct Cosine<dtype::float16> {
   HOSTDEVICE dtype::float16 operator()(const dtype::float16& val) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     return dtype::float16(cos(static_cast<float>(val)));
+#elif defined(PADDLE_WITH_SLEEF)
+    return dtype::float16(Sleef_cosf1_u35(static_cast<float>(val)));
+#else
+    return dtype::float16(cos(static_cast<float>(val)));
+#endif
   }
 };
 
 template <>
 struct Cosine<dtype::bfloat16> {
   HOSTDEVICE dtype::bfloat16 operator()(const dtype::bfloat16& val) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     return dtype::bfloat16(cos(static_cast<float>(val)));
+#elif defined(PADDLE_WITH_SLEEF)
+    return dtype::bfloat16(Sleef_cosf1_u35(static_cast<float>(val)));
+#else
+    return dtype::bfloat16(cos(static_cast<float>(val)));
+#endif
   }
 };
 

--- a/paddle/phi/kernels/funcs/elementwise_functor.h
+++ b/paddle/phi/kernels/funcs/elementwise_functor.h
@@ -24,6 +24,7 @@ limitations under the License. */
 #endif
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/type_safe_sign_math.h"
+#include "paddle/phi/kernels/funcs/sleef_vectorized_math.h"
 
 #ifdef PADDLE_WITH_SLEEF
 #include <sleef.h>

--- a/paddle/phi/kernels/funcs/sleef_vectorized_math.h
+++ b/paddle/phi/kernels/funcs/sleef_vectorized_math.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,12 +13,6 @@
 // limitations under the License.
 
 #pragma once
-
-// This header provides vectorized math functions using Sleef library
-// to achieve bit-level precision alignment with PyTorch.
-
-#include <cstdint>
-#include <cstring>
 
 #ifdef PADDLE_WITH_SLEEF
 #include <sleef.h>
@@ -37,9 +31,33 @@
 
 #endif  // PADDLE_WITH_SLEEF
 
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
 namespace phi {
 namespace funcs {
 namespace sleef_vec {
+
+// =============================================================================
+// Scalar Sleef functions for pow
+// =============================================================================
+
+#ifdef PADDLE_WITH_SLEEF
+
+template <typename T>
+inline typename std::enable_if<std::is_same<T, float>::value, T>::type
+pow_sleef_scalar(const T a, const T b) {
+  return Sleef_powf1_u10(a, b);
+}
+
+template <typename T>
+inline typename std::enable_if<std::is_same<T, double>::value, T>::type
+pow_sleef_scalar(const T a, const T b) {
+  return Sleef_powd1_u10(a, b);
+}
+
+#endif  // PADDLE_WITH_SLEEF
 
 // =============================================================================
 // Vectorized Sin/Cos functions - matches PyTorch's precision
@@ -52,55 +70,89 @@ namespace sleef_vec {
 // -----------------------------------------------------------------------------
 #ifdef PADDLE_SLEEF_HAS_AVX2
 
+// Vectorized sin for float using AVX2 (matches PyTorch's Sleef_sinf8_u35)
 inline void vsin_avx2_f32(float* out, const float* in, int64_t n) {
-  constexpr int64_t VEC_SIZE = 8;
+  constexpr int64_t VEC_SIZE = 8;  // AVX2: 256-bit = 8 floats
   int64_t i = 0;
+
+  // Process 8 floats at a time
   for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
     __m256 vec_in = _mm256_loadu_ps(in + i);
     __m256 vec_out = Sleef_sinf8_u35(vec_in);
     _mm256_storeu_ps(out + i, vec_out);
   }
+
+  // Handle remaining elements with scalar version
   for (; i < n; ++i) {
     out[i] = Sleef_sinf1_u35(in[i]);
   }
 }
 
+// Vectorized cos for float using AVX2 (matches PyTorch's Sleef_cosf8_u35)
 inline void vcos_avx2_f32(float* out, const float* in, int64_t n) {
   constexpr int64_t VEC_SIZE = 8;
   int64_t i = 0;
+
   for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
     __m256 vec_in = _mm256_loadu_ps(in + i);
     __m256 vec_out = Sleef_cosf8_u35(vec_in);
     _mm256_storeu_ps(out + i, vec_out);
   }
+
   for (; i < n; ++i) {
     out[i] = Sleef_cosf1_u35(in[i]);
   }
 }
 
+// Vectorized sin for double using AVX2 (matches PyTorch's Sleef_sind4_u10)
 inline void vsin_avx2_f64(double* out, const double* in, int64_t n) {
-  constexpr int64_t VEC_SIZE = 4;
+  constexpr int64_t VEC_SIZE = 4;  // AVX2: 256-bit = 4 doubles
   int64_t i = 0;
+
   for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
     __m256d vec_in = _mm256_loadu_pd(in + i);
     __m256d vec_out = Sleef_sind4_u10(vec_in);
     _mm256_storeu_pd(out + i, vec_out);
   }
+
   for (; i < n; ++i) {
     out[i] = Sleef_sind1_u10(in[i]);
   }
 }
 
+// Vectorized cos for double using AVX2 (matches PyTorch's Sleef_cosd4_u10)
 inline void vcos_avx2_f64(double* out, const double* in, int64_t n) {
   constexpr int64_t VEC_SIZE = 4;
   int64_t i = 0;
+
   for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
     __m256d vec_in = _mm256_loadu_pd(in + i);
     __m256d vec_out = Sleef_cosd4_u10(vec_in);
     _mm256_storeu_pd(out + i, vec_out);
   }
+
   for (; i < n; ++i) {
     out[i] = Sleef_cosd1_u10(in[i]);
+  }
+}
+
+// Vectorized pow for float using AVX2 (no native AVX2 pow, use scalar Sleef)
+inline void vpow_avx2_f32(float* out,
+                          const float* x,
+                          const float* y,
+                          int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = Sleef_powf1_u10(x[i], y[i]);
+  }
+}
+
+// Vectorized pow for double using AVX2
+inline void vpow_avx2_f64(double* out,
+                          const double* x,
+                          const double* y,
+                          int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = Sleef_powd1_u10(x[i], y[i]);
   }
 }
 
@@ -112,13 +164,16 @@ inline void vcos_avx2_f64(double* out, const double* in, int64_t n) {
 #ifdef PADDLE_SLEEF_HAS_AVX512
 
 inline void vsin_avx512_f32(float* out, const float* in, int64_t n) {
-  constexpr int64_t VEC_SIZE = 16;
+  constexpr int64_t VEC_SIZE = 16;  // AVX512: 512-bit = 16 floats
   int64_t i = 0;
+
   for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
     __m512 vec_in = _mm512_loadu_ps(in + i);
     __m512 vec_out = Sleef_sinf16_u35(vec_in);
     _mm512_storeu_ps(out + i, vec_out);
   }
+
+  // Fallback to AVX2 for remaining >= 8 elements
 #ifdef PADDLE_SLEEF_HAS_AVX2
   for (; i + 8 <= n; i += 8) {
     __m256 vec_in = _mm256_loadu_ps(in + i);
@@ -126,6 +181,7 @@ inline void vsin_avx512_f32(float* out, const float* in, int64_t n) {
     _mm256_storeu_ps(out + i, vec_out);
   }
 #endif
+
   for (; i < n; ++i) {
     out[i] = Sleef_sinf1_u35(in[i]);
   }
@@ -134,11 +190,13 @@ inline void vsin_avx512_f32(float* out, const float* in, int64_t n) {
 inline void vcos_avx512_f32(float* out, const float* in, int64_t n) {
   constexpr int64_t VEC_SIZE = 16;
   int64_t i = 0;
+
   for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
     __m512 vec_in = _mm512_loadu_ps(in + i);
     __m512 vec_out = Sleef_cosf16_u35(vec_in);
     _mm512_storeu_ps(out + i, vec_out);
   }
+
 #ifdef PADDLE_SLEEF_HAS_AVX2
   for (; i + 8 <= n; i += 8) {
     __m256 vec_in = _mm256_loadu_ps(in + i);
@@ -146,19 +204,22 @@ inline void vcos_avx512_f32(float* out, const float* in, int64_t n) {
     _mm256_storeu_ps(out + i, vec_out);
   }
 #endif
+
   for (; i < n; ++i) {
     out[i] = Sleef_cosf1_u35(in[i]);
   }
 }
 
 inline void vsin_avx512_f64(double* out, const double* in, int64_t n) {
-  constexpr int64_t VEC_SIZE = 8;
+  constexpr int64_t VEC_SIZE = 8;  // AVX512: 512-bit = 8 doubles
   int64_t i = 0;
+
   for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
     __m512d vec_in = _mm512_loadu_pd(in + i);
     __m512d vec_out = Sleef_sind8_u10(vec_in);
     _mm512_storeu_pd(out + i, vec_out);
   }
+
 #ifdef PADDLE_SLEEF_HAS_AVX2
   for (; i + 4 <= n; i += 4) {
     __m256d vec_in = _mm256_loadu_pd(in + i);
@@ -166,6 +227,7 @@ inline void vsin_avx512_f64(double* out, const double* in, int64_t n) {
     _mm256_storeu_pd(out + i, vec_out);
   }
 #endif
+
   for (; i < n; ++i) {
     out[i] = Sleef_sind1_u10(in[i]);
   }
@@ -174,11 +236,13 @@ inline void vsin_avx512_f64(double* out, const double* in, int64_t n) {
 inline void vcos_avx512_f64(double* out, const double* in, int64_t n) {
   constexpr int64_t VEC_SIZE = 8;
   int64_t i = 0;
+
   for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
     __m512d vec_in = _mm512_loadu_pd(in + i);
     __m512d vec_out = Sleef_cosd8_u10(vec_in);
     _mm512_storeu_pd(out + i, vec_out);
   }
+
 #ifdef PADDLE_SLEEF_HAS_AVX2
   for (; i + 4 <= n; i += 4) {
     __m256d vec_in = _mm256_loadu_pd(in + i);
@@ -186,40 +250,105 @@ inline void vcos_avx512_f64(double* out, const double* in, int64_t n) {
     _mm256_storeu_pd(out + i, vec_out);
   }
 #endif
+
   for (; i < n; ++i) {
     out[i] = Sleef_cosd1_u10(in[i]);
+  }
+}
+
+// Vectorized pow for float using AVX512 (16 floats at a time)
+inline void vpow_avx512_f32(float* out,
+                            const float* x,
+                            const float* y,
+                            int64_t n) {
+  constexpr int64_t VEC_SIZE = 16;
+  int64_t i = 0;
+
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m512 vec_x = _mm512_loadu_ps(x + i);
+    __m512 vec_y = _mm512_loadu_ps(y + i);
+    __m512 vec_out = Sleef_powf16_u10(vec_x, vec_y);
+    _mm512_storeu_ps(out + i, vec_out);
+  }
+
+  for (; i < n; ++i) {
+    out[i] = Sleef_powf1_u10(x[i], y[i]);
+  }
+}
+
+// Vectorized pow for double using AVX512 (8 doubles at a time)
+inline void vpow_avx512_f64(double* out,
+                            const double* x,
+                            const double* y,
+                            int64_t n) {
+  constexpr int64_t VEC_SIZE = 8;
+  int64_t i = 0;
+
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m512d vec_x = _mm512_loadu_pd(x + i);
+    __m512d vec_y = _mm512_loadu_pd(y + i);
+    __m512d vec_out = Sleef_powd8_u10(vec_x, vec_y);
+    _mm512_storeu_pd(out + i, vec_out);
+  }
+
+  for (; i < n; ++i) {
+    out[i] = Sleef_powd1_u10(x[i], y[i]);
   }
 }
 
 #endif  // PADDLE_SLEEF_HAS_AVX512
 
 // -----------------------------------------------------------------------------
-// Scalar fallback
+// Scalar fallback (when SIMD is not available)
 // -----------------------------------------------------------------------------
 inline void vsin_scalar_f32(float* out, const float* in, int64_t n) {
   for (int64_t i = 0; i < n; ++i) {
     out[i] = Sleef_sinf1_u35(in[i]);
   }
 }
+
 inline void vcos_scalar_f32(float* out, const float* in, int64_t n) {
   for (int64_t i = 0; i < n; ++i) {
     out[i] = Sleef_cosf1_u35(in[i]);
   }
 }
+
 inline void vsin_scalar_f64(double* out, const double* in, int64_t n) {
   for (int64_t i = 0; i < n; ++i) {
     out[i] = Sleef_sind1_u10(in[i]);
   }
 }
+
 inline void vcos_scalar_f64(double* out, const double* in, int64_t n) {
   for (int64_t i = 0; i < n; ++i) {
     out[i] = Sleef_cosd1_u10(in[i]);
   }
 }
 
+// Scalar pow fallback
+inline void vpow_scalar_f32(float* out,
+                            const float* x,
+                            const float* y,
+                            int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = Sleef_powf1_u10(x[i], y[i]);
+  }
+}
+
+inline void vpow_scalar_f64(double* out,
+                            const double* x,
+                            const double* y,
+                            int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = Sleef_powd1_u10(x[i], y[i]);
+  }
+}
+
 // -----------------------------------------------------------------------------
 // Unified dispatch functions
 // -----------------------------------------------------------------------------
+
+// Vectorized sin for float - dispatches to best available SIMD
 inline void vsin(float* out, const float* in, int64_t n) {
 #ifdef PADDLE_SLEEF_HAS_AVX512
   vsin_avx512_f32(out, in, n);
@@ -230,6 +359,7 @@ inline void vsin(float* out, const float* in, int64_t n) {
 #endif
 }
 
+// Vectorized cos for float
 inline void vcos(float* out, const float* in, int64_t n) {
 #ifdef PADDLE_SLEEF_HAS_AVX512
   vcos_avx512_f32(out, in, n);
@@ -240,6 +370,7 @@ inline void vcos(float* out, const float* in, int64_t n) {
 #endif
 }
 
+// Vectorized sin for double
 inline void vsin(double* out, const double* in, int64_t n) {
 #ifdef PADDLE_SLEEF_HAS_AVX512
   vsin_avx512_f64(out, in, n);
@@ -250,6 +381,7 @@ inline void vsin(double* out, const double* in, int64_t n) {
 #endif
 }
 
+// Vectorized cos for double
 inline void vcos(double* out, const double* in, int64_t n) {
 #ifdef PADDLE_SLEEF_HAS_AVX512
   vcos_avx512_f64(out, in, n);
@@ -260,35 +392,81 @@ inline void vcos(double* out, const double* in, int64_t n) {
 #endif
 }
 
+// Vectorized pow for float - dispatches to best available SIMD
+inline void vpow(float* out, const float* x, const float* y, int64_t n) {
+#ifdef PADDLE_SLEEF_HAS_AVX512
+  vpow_avx512_f32(out, x, y, n);
+#elif defined(PADDLE_SLEEF_HAS_AVX2)
+  vpow_avx2_f32(out, x, y, n);
+#else
+  vpow_scalar_f32(out, x, y, n);
+#endif
+}
+
+// Vectorized pow for double
+inline void vpow(double* out, const double* x, const double* y, int64_t n) {
+#ifdef PADDLE_SLEEF_HAS_AVX512
+  vpow_avx512_f64(out, x, y, n);
+#elif defined(PADDLE_SLEEF_HAS_AVX2)
+  vpow_avx2_f64(out, x, y, n);
+#else
+  vpow_scalar_f64(out, x, y, n);
+#endif
+}
+
 #else  // !PADDLE_WITH_SLEEF
 
+// Fallback to standard library when Sleef is not available
 #include <cmath>
+
 inline void vsin(float* out, const float* in, int64_t n) {
   for (int64_t i = 0; i < n; ++i) {
     out[i] = std::sin(in[i]);
   }
 }
+
 inline void vcos(float* out, const float* in, int64_t n) {
   for (int64_t i = 0; i < n; ++i) {
     out[i] = std::cos(in[i]);
   }
 }
+
 inline void vsin(double* out, const double* in, int64_t n) {
   for (int64_t i = 0; i < n; ++i) {
     out[i] = std::sin(in[i]);
   }
 }
+
 inline void vcos(double* out, const double* in, int64_t n) {
   for (int64_t i = 0; i < n; ++i) {
     out[i] = std::cos(in[i]);
   }
 }
 
+inline void vpow(float* out, const float* x, const float* y, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = std::pow(x[i], y[i]);
+  }
+}
+
+inline void vpow(double* out, const double* x, const double* y, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = std::pow(x[i], y[i]);
+  }
+}
+
 #endif  // PADDLE_WITH_SLEEF
 
+// -----------------------------------------------------------------------------
+// Check if vectorized path should be used
+// -----------------------------------------------------------------------------
 inline bool should_use_vectorized_path(const void* in_ptr,
                                        const void* out_ptr,
                                        int64_t numel) {
+  // Use vectorized path when:
+  // 1. SLEEF is available
+  // 2. Element count is large enough to benefit from SIMD
+  // 3. Memory is reasonably aligned (not strictly required for unaligned loads)
 #ifdef PADDLE_WITH_SLEEF
   constexpr int64_t MIN_ELEMENTS_FOR_SIMD = 8;
   return numel >= MIN_ELEMENTS_FOR_SIMD;

--- a/paddle/phi/kernels/funcs/sleef_vectorized_math.h
+++ b/paddle/phi/kernels/funcs/sleef_vectorized_math.h
@@ -1,0 +1,302 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// This header provides vectorized math functions using Sleef library
+// to achieve bit-level precision alignment with PyTorch.
+
+#include <cstdint>
+#include <cstring>
+
+#ifdef PADDLE_WITH_SLEEF
+#include <sleef.h>
+
+#if defined(__AVX512F__) || defined(__AVX2__) || defined(__AVX__)
+#include <immintrin.h>
+#endif
+
+#if defined(__AVX2__) || defined(__AVX__)
+#define PADDLE_SLEEF_HAS_AVX2 1
+#endif
+
+#if defined(__AVX512F__)
+#define PADDLE_SLEEF_HAS_AVX512 1
+#endif
+
+#endif  // PADDLE_WITH_SLEEF
+
+namespace phi {
+namespace funcs {
+namespace sleef_vec {
+
+// =============================================================================
+// Vectorized Sin/Cos functions - matches PyTorch's precision
+// =============================================================================
+
+#ifdef PADDLE_WITH_SLEEF
+
+// -----------------------------------------------------------------------------
+// AVX2 implementation (8 floats / 4 doubles at a time)
+// -----------------------------------------------------------------------------
+#ifdef PADDLE_SLEEF_HAS_AVX2
+
+inline void vsin_avx2_f32(float* out, const float* in, int64_t n) {
+  constexpr int64_t VEC_SIZE = 8;
+  int64_t i = 0;
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m256 vec_in = _mm256_loadu_ps(in + i);
+    __m256 vec_out = Sleef_sinf8_u35(vec_in);
+    _mm256_storeu_ps(out + i, vec_out);
+  }
+  for (; i < n; ++i) {
+    out[i] = Sleef_sinf1_u35(in[i]);
+  }
+}
+
+inline void vcos_avx2_f32(float* out, const float* in, int64_t n) {
+  constexpr int64_t VEC_SIZE = 8;
+  int64_t i = 0;
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m256 vec_in = _mm256_loadu_ps(in + i);
+    __m256 vec_out = Sleef_cosf8_u35(vec_in);
+    _mm256_storeu_ps(out + i, vec_out);
+  }
+  for (; i < n; ++i) {
+    out[i] = Sleef_cosf1_u35(in[i]);
+  }
+}
+
+inline void vsin_avx2_f64(double* out, const double* in, int64_t n) {
+  constexpr int64_t VEC_SIZE = 4;
+  int64_t i = 0;
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m256d vec_in = _mm256_loadu_pd(in + i);
+    __m256d vec_out = Sleef_sind4_u10(vec_in);
+    _mm256_storeu_pd(out + i, vec_out);
+  }
+  for (; i < n; ++i) {
+    out[i] = Sleef_sind1_u10(in[i]);
+  }
+}
+
+inline void vcos_avx2_f64(double* out, const double* in, int64_t n) {
+  constexpr int64_t VEC_SIZE = 4;
+  int64_t i = 0;
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m256d vec_in = _mm256_loadu_pd(in + i);
+    __m256d vec_out = Sleef_cosd4_u10(vec_in);
+    _mm256_storeu_pd(out + i, vec_out);
+  }
+  for (; i < n; ++i) {
+    out[i] = Sleef_cosd1_u10(in[i]);
+  }
+}
+
+#endif  // PADDLE_SLEEF_HAS_AVX2
+
+// -----------------------------------------------------------------------------
+// AVX512 implementation (16 floats / 8 doubles at a time)
+// -----------------------------------------------------------------------------
+#ifdef PADDLE_SLEEF_HAS_AVX512
+
+inline void vsin_avx512_f32(float* out, const float* in, int64_t n) {
+  constexpr int64_t VEC_SIZE = 16;
+  int64_t i = 0;
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m512 vec_in = _mm512_loadu_ps(in + i);
+    __m512 vec_out = Sleef_sinf16_u35(vec_in);
+    _mm512_storeu_ps(out + i, vec_out);
+  }
+#ifdef PADDLE_SLEEF_HAS_AVX2
+  for (; i + 8 <= n; i += 8) {
+    __m256 vec_in = _mm256_loadu_ps(in + i);
+    __m256 vec_out = Sleef_sinf8_u35(vec_in);
+    _mm256_storeu_ps(out + i, vec_out);
+  }
+#endif
+  for (; i < n; ++i) {
+    out[i] = Sleef_sinf1_u35(in[i]);
+  }
+}
+
+inline void vcos_avx512_f32(float* out, const float* in, int64_t n) {
+  constexpr int64_t VEC_SIZE = 16;
+  int64_t i = 0;
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m512 vec_in = _mm512_loadu_ps(in + i);
+    __m512 vec_out = Sleef_cosf16_u35(vec_in);
+    _mm512_storeu_ps(out + i, vec_out);
+  }
+#ifdef PADDLE_SLEEF_HAS_AVX2
+  for (; i + 8 <= n; i += 8) {
+    __m256 vec_in = _mm256_loadu_ps(in + i);
+    __m256 vec_out = Sleef_cosf8_u35(vec_in);
+    _mm256_storeu_ps(out + i, vec_out);
+  }
+#endif
+  for (; i < n; ++i) {
+    out[i] = Sleef_cosf1_u35(in[i]);
+  }
+}
+
+inline void vsin_avx512_f64(double* out, const double* in, int64_t n) {
+  constexpr int64_t VEC_SIZE = 8;
+  int64_t i = 0;
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m512d vec_in = _mm512_loadu_pd(in + i);
+    __m512d vec_out = Sleef_sind8_u10(vec_in);
+    _mm512_storeu_pd(out + i, vec_out);
+  }
+#ifdef PADDLE_SLEEF_HAS_AVX2
+  for (; i + 4 <= n; i += 4) {
+    __m256d vec_in = _mm256_loadu_pd(in + i);
+    __m256d vec_out = Sleef_sind4_u10(vec_in);
+    _mm256_storeu_pd(out + i, vec_out);
+  }
+#endif
+  for (; i < n; ++i) {
+    out[i] = Sleef_sind1_u10(in[i]);
+  }
+}
+
+inline void vcos_avx512_f64(double* out, const double* in, int64_t n) {
+  constexpr int64_t VEC_SIZE = 8;
+  int64_t i = 0;
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m512d vec_in = _mm512_loadu_pd(in + i);
+    __m512d vec_out = Sleef_cosd8_u10(vec_in);
+    _mm512_storeu_pd(out + i, vec_out);
+  }
+#ifdef PADDLE_SLEEF_HAS_AVX2
+  for (; i + 4 <= n; i += 4) {
+    __m256d vec_in = _mm256_loadu_pd(in + i);
+    __m256d vec_out = Sleef_cosd4_u10(vec_in);
+    _mm256_storeu_pd(out + i, vec_out);
+  }
+#endif
+  for (; i < n; ++i) {
+    out[i] = Sleef_cosd1_u10(in[i]);
+  }
+}
+
+#endif  // PADDLE_SLEEF_HAS_AVX512
+
+// -----------------------------------------------------------------------------
+// Scalar fallback
+// -----------------------------------------------------------------------------
+inline void vsin_scalar_f32(float* out, const float* in, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = Sleef_sinf1_u35(in[i]);
+  }
+}
+inline void vcos_scalar_f32(float* out, const float* in, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = Sleef_cosf1_u35(in[i]);
+  }
+}
+inline void vsin_scalar_f64(double* out, const double* in, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = Sleef_sind1_u10(in[i]);
+  }
+}
+inline void vcos_scalar_f64(double* out, const double* in, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = Sleef_cosd1_u10(in[i]);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Unified dispatch functions
+// -----------------------------------------------------------------------------
+inline void vsin(float* out, const float* in, int64_t n) {
+#ifdef PADDLE_SLEEF_HAS_AVX512
+  vsin_avx512_f32(out, in, n);
+#elif defined(PADDLE_SLEEF_HAS_AVX2)
+  vsin_avx2_f32(out, in, n);
+#else
+  vsin_scalar_f32(out, in, n);
+#endif
+}
+
+inline void vcos(float* out, const float* in, int64_t n) {
+#ifdef PADDLE_SLEEF_HAS_AVX512
+  vcos_avx512_f32(out, in, n);
+#elif defined(PADDLE_SLEEF_HAS_AVX2)
+  vcos_avx2_f32(out, in, n);
+#else
+  vcos_scalar_f32(out, in, n);
+#endif
+}
+
+inline void vsin(double* out, const double* in, int64_t n) {
+#ifdef PADDLE_SLEEF_HAS_AVX512
+  vsin_avx512_f64(out, in, n);
+#elif defined(PADDLE_SLEEF_HAS_AVX2)
+  vsin_avx2_f64(out, in, n);
+#else
+  vsin_scalar_f64(out, in, n);
+#endif
+}
+
+inline void vcos(double* out, const double* in, int64_t n) {
+#ifdef PADDLE_SLEEF_HAS_AVX512
+  vcos_avx512_f64(out, in, n);
+#elif defined(PADDLE_SLEEF_HAS_AVX2)
+  vcos_avx2_f64(out, in, n);
+#else
+  vcos_scalar_f64(out, in, n);
+#endif
+}
+
+#else  // !PADDLE_WITH_SLEEF
+
+#include <cmath>
+inline void vsin(float* out, const float* in, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = std::sin(in[i]);
+  }
+}
+inline void vcos(float* out, const float* in, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = std::cos(in[i]);
+  }
+}
+inline void vsin(double* out, const double* in, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = std::sin(in[i]);
+  }
+}
+inline void vcos(double* out, const double* in, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = std::cos(in[i]);
+  }
+}
+
+#endif  // PADDLE_WITH_SLEEF
+
+inline bool should_use_vectorized_path(const void* in_ptr,
+                                       const void* out_ptr,
+                                       int64_t numel) {
+#ifdef PADDLE_WITH_SLEEF
+  constexpr int64_t MIN_ELEMENTS_FOR_SIMD = 8;
+  return numel >= MIN_ELEMENTS_FOR_SIMD;
+#else
+  return false;
+#endif
+}
+
+}  // namespace sleef_vec
+}  // namespace funcs
+}  // namespace phi

--- a/paddle/phi/kernels/impl/activation_impl.h
+++ b/paddle/phi/kernels/impl/activation_impl.h
@@ -17,6 +17,7 @@
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/funcs/activation_functor.h"
+#include "paddle/phi/kernels/funcs/sleef_vectorized_math.h"
 // #include "paddle/phi/kernels/funcs/blas/blas.h"
 
 namespace phi {
@@ -46,6 +47,65 @@ void ActivationImpl(const Context& dev_ctx,
     functor(*place, To32BitIndex(x), To32BitIndex(out));
   } else {
     functor(*place, x, out);
+  }
+}
+
+// Vectorized Sin implementation for CPU - matches PyTorch precision
+// Only enabled for float/double on CPU to ensure bit-level alignment
+template <typename T, typename Context>
+void VectorizedSinImpl(const Context& dev_ctx,
+                       const DenseTensor& X,
+                       DenseTensor* Out) {
+  PADDLE_ENFORCE_NOT_NULL(Out,
+                          errors::NotFound("Output Out should not be nullptr"));
+  dev_ctx.template Alloc<T>(Out);
+  if (Out->numel() == 0) {
+    return;
+  }
+
+  const T* x_data = X.data<T>();
+  T* out_data = Out->data<T>();
+  int64_t numel = X.numel();
+
+  // Check if data is contiguous and use vectorized path
+  if (funcs::sleef_vec::should_use_vectorized_path(x_data, out_data, numel)) {
+    funcs::sleef_vec::vsin(out_data, x_data, numel);
+  } else {
+    // Fallback to Eigen-based implementation
+    auto x = EigenVector<T>::Flatten(GET_DATA_SAFELY(&X, "Input", "X", "Sin"));
+    auto out =
+        EigenVector<T>::Flatten(GET_DATA_SAFELY(Out, "Output", "Out", "Sin"));
+    auto* place = dev_ctx.eigen_device();
+    out.device(*place) = x.unaryExpr(funcs::Sine<T>()).eval();
+  }
+}
+
+// Vectorized Cos implementation for CPU - matches PyTorch precision
+template <typename T, typename Context>
+void VectorizedCosImpl(const Context& dev_ctx,
+                       const DenseTensor& X,
+                       DenseTensor* Out) {
+  PADDLE_ENFORCE_NOT_NULL(Out,
+                          errors::NotFound("Output Out should not be nullptr"));
+  dev_ctx.template Alloc<T>(Out);
+  if (Out->numel() == 0) {
+    return;
+  }
+
+  const T* x_data = X.data<T>();
+  T* out_data = Out->data<T>();
+  int64_t numel = X.numel();
+
+  // Check if data is contiguous and use vectorized path
+  if (funcs::sleef_vec::should_use_vectorized_path(x_data, out_data, numel)) {
+    funcs::sleef_vec::vcos(out_data, x_data, numel);
+  } else {
+    // Fallback to Eigen-based implementation
+    auto x = EigenVector<T>::Flatten(GET_DATA_SAFELY(&X, "Input", "X", "Cos"));
+    auto out =
+        EigenVector<T>::Flatten(GET_DATA_SAFELY(Out, "Output", "Out", "Cos"));
+    auto* place = dev_ctx.eigen_device();
+    out.device(*place) = x.unaryExpr(funcs::Cosine<T>()).eval();
   }
 }
 

--- a/paddle/phi/kernels/legacy/cpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/legacy/cpu/elementwise_kernel.cc
@@ -15,10 +15,8 @@
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cpu/elementwise.h"
+#include "paddle/phi/kernels/funcs/sleef_vectorized_math.h"
 #include "paddle/phi/kernels/impl/elementwise_kernel_impl.h"
-#if defined(__AVX512F__)
-#include <immintrin.h>
-#endif
 
 namespace phi {
 
@@ -103,9 +101,9 @@ void ElementwisePowSameDimsHelper(const Context& dev_ctx,
                                   const DenseTensor& y,
                                   int axis,
                                   DenseTensor* out) {
-  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  if constexpr (std::is_same<MPType, float>::value ||
-                std::is_same<MPType, double>::value) {
+  // Use unified vectorized Sleef implementation from sleef_vectorized_math.h
+  if constexpr (std::is_same<T, float>::value ||
+                std::is_same<T, double>::value) {
     bool is_contiguous = true;
     auto x_strides = x.strides();
     auto y_strides = y.strides();
@@ -125,69 +123,8 @@ void ElementwisePowSameDimsHelper(const Context& dev_ctx,
       T* out_data = out->data<T>();
       int64_t numel = x.numel();
 
-#if defined(__AVX512F__)
-      if constexpr (std::is_same<T, float>::value) {
-        int vec_size = 16;
-        int64_t aligned_n = (numel / vec_size) * vec_size;
-        for (int64_t i = 0; i < aligned_n; i += vec_size) {
-          _mm512_storeu_ps(
-              out_data + i,
-              funcs::compute_pow_sleef_vec(_mm512_loadu_ps(x_data + i),
-                                           _mm512_loadu_ps(y_data + i)));
-        }
-        for (int64_t i = aligned_n; i < numel; ++i) {
-          out_data[i] = static_cast<T>(std::pow(
-              static_cast<MPType>(x_data[i]), static_cast<MPType>(y_data[i])));
-        }
-      } else if constexpr (std::is_same<T, double>::value) {
-        int vec_size = 8;
-        int64_t aligned_n = (numel / vec_size) * vec_size;
-        for (int64_t i = 0; i < aligned_n; i += vec_size) {
-          _mm512_storeu_pd(
-              out_data + i,
-              funcs::compute_pow_sleef_vec(_mm512_loadu_pd(x_data + i),
-                                           _mm512_loadu_pd(y_data + i)));
-        }
-        for (int64_t i = aligned_n; i < numel; ++i) {
-          out_data[i] = static_cast<T>(std::pow(
-              static_cast<MPType>(x_data[i]), static_cast<MPType>(y_data[i])));
-        }
-      } else {
-        int vec_size;
-        if constexpr (std::is_same<MPType, float>::value) {
-          vec_size = 32;
-        } else if constexpr (std::is_same<MPType, double>::value) {
-          vec_size = 16;
-        }
-        int64_t aligned_n = (numel / vec_size) * vec_size;
-
-        for (int64_t i = 0; i < aligned_n; ++i) {
-          out_data[i] = funcs::compute_pow_sleef<MPType>(
-              static_cast<MPType>(x_data[i]), static_cast<MPType>(y_data[i]));
-        }
-        for (int64_t i = aligned_n; i < numel; ++i) {
-          out_data[i] = static_cast<T>(std::pow(
-              static_cast<MPType>(x_data[i]), static_cast<MPType>(y_data[i])));
-        }
-      }
-#else
-      int vec_size;
-      if constexpr (std::is_same<MPType, float>::value) {
-        vec_size = 32;
-      } else if constexpr (std::is_same<MPType, double>::value) {
-        vec_size = 16;
-      }
-      int64_t aligned_n = (numel / vec_size) * vec_size;
-
-      for (int64_t i = 0; i < aligned_n; ++i) {
-        out_data[i] = funcs::compute_pow_sleef<MPType>(
-            static_cast<MPType>(x_data[i]), static_cast<MPType>(y_data[i]));
-      }
-      for (int64_t i = aligned_n; i < numel; ++i) {
-        out_data[i] = static_cast<T>(std::pow(static_cast<MPType>(x_data[i]),
-                                              static_cast<MPType>(y_data[i])));
-      }
-#endif
+      // Use unified vectorized implementation
+      funcs::sleef_vec::vpow(out_data, x_data, y_data, numel);
     } else {
       funcs::ElementwiseCompute<funcs::ElementwisePowFunctor<T>, T>(
           dev_ctx, x, y, funcs::ElementwisePowFunctor<T>(), out, axis);

--- a/test/legacy_test/test_cos.py
+++ b/test/legacy_test/test_cos.py
@@ -60,5 +60,141 @@ class TestCosOutAndParamDecorator(unittest.TestCase):
             )
 
 
+class TestCosSleefVectorized(unittest.TestCase):
+    """Test cos with shapes that exercise Sleef vectorized paths.
+
+    For AVX2:
+    - float32: VEC_SIZE = 8, so shapes >= 8 trigger vectorized path
+    - float64: VEC_SIZE = 4, so shapes >= 4 trigger vectorized path
+
+    Test both:
+    1. Shapes that are exact multiples of VEC_SIZE (only vectorized loop)
+    2. Shapes with remainder (vectorized loop + scalar tail)
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+
+    def test_cos_float32_vectorized_exact(self):
+        """Test float32 cos with shape that's exact multiple of 8.
+        Covers vcos_avx2_f32 main loop.
+        """
+        # Shape 16 = 8 * 2, exercises only vectorized loop
+        x_np = np.random.uniform(-np.pi, np.pi, size=(16,)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.cos(x)
+        expected = np.cos(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_cos_float32_vectorized_with_tail(self):
+        """Test float32 cos with shape that has remainder when divided by 8.
+        Covers vcos_avx2_f32 both main loop and scalar tail.
+        """
+        # Shape 13 = 8 + 5, exercises both vectorized loop and scalar tail
+        x_np = np.random.uniform(-np.pi, np.pi, size=(13,)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.cos(x)
+        expected = np.cos(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_cos_float64_vectorized_exact(self):
+        """Test float64 cos with shape that's exact multiple of 4.
+        Covers vcos_avx2_f64 main loop.
+        """
+        # Shape 12 = 4 * 3, exercises only vectorized loop
+        x_np = np.random.uniform(-np.pi, np.pi, size=(12,)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.cos(x)
+        expected = np.cos(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+    def test_cos_float64_vectorized_with_tail(self):
+        """Test float64 cos with shape that has remainder when divided by 4.
+        Covers vcos_avx2_f64 both main loop and scalar tail.
+        """
+        # Shape 11 = 4 * 2 + 3, exercises both vectorized loop and scalar tail
+        x_np = np.random.uniform(-np.pi, np.pi, size=(11,)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.cos(x)
+        expected = np.cos(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+    def test_cos_float32_large_shape(self):
+        """Test float32 cos with large shape for comprehensive coverage."""
+        x_np = np.random.uniform(-np.pi, np.pi, size=(1024,)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.cos(x)
+        expected = np.cos(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_cos_float64_large_shape(self):
+        """Test float64 cos with large shape for comprehensive coverage."""
+        x_np = np.random.uniform(-np.pi, np.pi, size=(1024,)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.cos(x)
+        expected = np.cos(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+    def test_cos_float32_2d_shape(self):
+        """Test float32 cos with 2D shape to verify flattened processing."""
+        # Shape (4, 5) = 20 elements, exercises vectorized path
+        x_np = np.random.uniform(-np.pi, np.pi, size=(4, 5)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.cos(x)
+        expected = np.cos(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_cos_float64_2d_shape(self):
+        """Test float64 cos with 2D shape to verify flattened processing."""
+        # Shape (3, 5) = 15 elements, exercises vectorized path with tail
+        x_np = np.random.uniform(-np.pi, np.pi, size=(3, 5)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.cos(x)
+        expected = np.cos(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+    def test_cos_float32_small_shape_fallback(self):
+        """Test float32 cos with small shape (numel < 8) to cover Eigen fallback path.
+        Covers VectorizedCosImpl fallback branch (lines 102-109 in activation_impl.h).
+        """
+        # Shape 5 < 8, triggers Eigen fallback instead of SIMD
+        x_np = np.random.uniform(-np.pi, np.pi, size=(5,)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.cos(x)
+        expected = np.cos(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_cos_float64_small_shape_fallback(self):
+        """Test float64 cos with small shape (numel < 8) to cover Eigen fallback path.
+        Covers VectorizedCosImpl fallback branch (lines 102-109 in activation_impl.h).
+        """
+        # Shape 3 < 8, triggers Eigen fallback instead of SIMD
+        x_np = np.random.uniform(-np.pi, np.pi, size=(3,)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.cos(x)
+        expected = np.cos(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_pow.py
+++ b/test/legacy_test/test_pow.py
@@ -417,5 +417,136 @@ class TestPowOutAndParamDecorator(unittest.TestCase):
             )
 
 
+class TestPowSleefVectorized(unittest.TestCase):
+    """Test pow with shapes that exercise Sleef vectorized paths on CPU.
+
+    For AVX2:
+    - float32: VEC_SIZE = 8, uses Sleef_powf8_u10 for vectorized loop
+    - float64: VEC_SIZE = 4, uses Sleef_powd4_u10 for vectorized loop
+
+    The sleef path is triggered when:
+    1. dtype is float32 or float64
+    2. Both x and y are contiguous tensors (same shape)
+    3. Running on CPU
+
+    Test both:
+    1. Shapes that are exact multiples of VEC_SIZE (only vectorized loop)
+    2. Shapes with remainder (vectorized loop + scalar tail)
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+
+    def test_pow_float32_vectorized_exact_cpu(self):
+        """Test float32 pow with shape that's exact multiple of 8.
+        Covers vpow_avx2_f32 main loop only.
+        """
+        # Shape 16 = 8 * 2, exercises only vectorized loop
+        x_np = np.random.uniform(0.5, 2.0, size=(16,)).astype(np.float32)
+        y_np = np.random.uniform(0.5, 2.0, size=(16,)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        y = paddle.to_tensor(y_np, place=paddle.CPUPlace())
+        result = paddle.pow(x, y)
+        expected = np.power(x_np, y_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_pow_float32_vectorized_with_tail_cpu(self):
+        """Test float32 pow with shape that has remainder when divided by 8.
+        Covers vpow_avx2_f32 both main loop and scalar tail.
+        """
+        # Shape 13 = 8 + 5, exercises both vectorized loop and scalar tail
+        x_np = np.random.uniform(0.5, 2.0, size=(13,)).astype(np.float32)
+        y_np = np.random.uniform(0.5, 2.0, size=(13,)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        y = paddle.to_tensor(y_np, place=paddle.CPUPlace())
+        result = paddle.pow(x, y)
+        expected = np.power(x_np, y_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_pow_float64_vectorized_exact_cpu(self):
+        """Test float64 pow with shape that's exact multiple of 4.
+        Covers vpow_avx2_f64 main loop only.
+        """
+        # Shape 12 = 4 * 3, exercises only vectorized loop
+        x_np = np.random.uniform(0.5, 2.0, size=(12,)).astype(np.float64)
+        y_np = np.random.uniform(0.5, 2.0, size=(12,)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        y = paddle.to_tensor(y_np, place=paddle.CPUPlace())
+        result = paddle.pow(x, y)
+        expected = np.power(x_np, y_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+    def test_pow_float64_vectorized_with_tail_cpu(self):
+        """Test float64 pow with shape that has remainder when divided by 4.
+        Covers vpow_avx2_f64 both main loop and scalar tail.
+        """
+        # Shape 11 = 4 * 2 + 3, exercises both vectorized loop and scalar tail
+        x_np = np.random.uniform(0.5, 2.0, size=(11,)).astype(np.float64)
+        y_np = np.random.uniform(0.5, 2.0, size=(11,)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        y = paddle.to_tensor(y_np, place=paddle.CPUPlace())
+        result = paddle.pow(x, y)
+        expected = np.power(x_np, y_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+    def test_pow_float32_large_shape_cpu(self):
+        """Test float32 pow with large shape on CPU for comprehensive coverage."""
+        x_np = np.random.uniform(0.5, 2.0, size=(1024,)).astype(np.float32)
+        y_np = np.random.uniform(0.5, 2.0, size=(1024,)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        y = paddle.to_tensor(y_np, place=paddle.CPUPlace())
+        result = paddle.pow(x, y)
+        expected = np.power(x_np, y_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_pow_float64_large_shape_cpu(self):
+        """Test float64 pow with large shape on CPU for comprehensive coverage."""
+        x_np = np.random.uniform(0.5, 2.0, size=(1024,)).astype(np.float64)
+        y_np = np.random.uniform(0.5, 2.0, size=(1024,)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        y = paddle.to_tensor(y_np, place=paddle.CPUPlace())
+        result = paddle.pow(x, y)
+        expected = np.power(x_np, y_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+    def test_pow_float32_2d_shape_cpu(self):
+        """Test float32 pow with 2D shape on CPU."""
+        # Shape (4, 5) = 20 elements, exercises vectorized path
+        x_np = np.random.uniform(0.5, 2.0, size=(4, 5)).astype(np.float32)
+        y_np = np.random.uniform(0.5, 2.0, size=(4, 5)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        y = paddle.to_tensor(y_np, place=paddle.CPUPlace())
+        result = paddle.pow(x, y)
+        expected = np.power(x_np, y_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_pow_float64_2d_shape_cpu(self):
+        """Test float64 pow with 2D shape on CPU."""
+        # Shape (3, 5) = 15 elements, exercises vectorized path with tail
+        x_np = np.random.uniform(0.5, 2.0, size=(3, 5)).astype(np.float64)
+        y_np = np.random.uniform(0.5, 2.0, size=(3, 5)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        y = paddle.to_tensor(y_np, place=paddle.CPUPlace())
+        result = paddle.pow(x, y)
+        expected = np.power(x_np, y_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_sin.py
+++ b/test/legacy_test/test_sin.py
@@ -60,5 +60,141 @@ class TestSinOutAndParamDecorator(unittest.TestCase):
             )
 
 
+class TestSinSleefVectorized(unittest.TestCase):
+    """Test sin with shapes that exercise Sleef vectorized paths.
+
+    For AVX2:
+    - float32: VEC_SIZE = 8, so shapes >= 8 trigger vectorized path
+    - float64: VEC_SIZE = 4, so shapes >= 4 trigger vectorized path
+
+    Test both:
+    1. Shapes that are exact multiples of VEC_SIZE (only vectorized loop)
+    2. Shapes with remainder (vectorized loop + scalar tail)
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+
+    def test_sin_float32_vectorized_exact(self):
+        """Test float32 sin with shape that's exact multiple of 8.
+        Covers vsin_avx2_f32 main loop (lines 79-83).
+        """
+        # Shape 16 = 8 * 2, exercises only vectorized loop
+        x_np = np.random.uniform(-np.pi, np.pi, size=(16,)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.sin(x)
+        expected = np.sin(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_sin_float32_vectorized_with_tail(self):
+        """Test float32 sin with shape that has remainder when divided by 8.
+        Covers vsin_avx2_f32 both main loop (79-83) and scalar tail (86-88).
+        """
+        # Shape 13 = 8 + 5, exercises both vectorized loop and scalar tail
+        x_np = np.random.uniform(-np.pi, np.pi, size=(13,)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.sin(x)
+        expected = np.sin(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_sin_float64_vectorized_exact(self):
+        """Test float64 sin with shape that's exact multiple of 4.
+        Covers vsin_avx2_f64 main loop (lines 112-116).
+        """
+        # Shape 12 = 4 * 3, exercises only vectorized loop
+        x_np = np.random.uniform(-np.pi, np.pi, size=(12,)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.sin(x)
+        expected = np.sin(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+    def test_sin_float64_vectorized_with_tail(self):
+        """Test float64 sin with shape that has remainder when divided by 4.
+        Covers vsin_avx2_f64 both main loop (112-116) and scalar tail (118-120).
+        """
+        # Shape 11 = 4 * 2 + 3, exercises both vectorized loop and scalar tail
+        x_np = np.random.uniform(-np.pi, np.pi, size=(11,)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.sin(x)
+        expected = np.sin(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+    def test_sin_float32_large_shape(self):
+        """Test float32 sin with large shape for comprehensive coverage."""
+        x_np = np.random.uniform(-np.pi, np.pi, size=(1024,)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.sin(x)
+        expected = np.sin(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_sin_float64_large_shape(self):
+        """Test float64 sin with large shape for comprehensive coverage."""
+        x_np = np.random.uniform(-np.pi, np.pi, size=(1024,)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.sin(x)
+        expected = np.sin(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+    def test_sin_float32_2d_shape(self):
+        """Test float32 sin with 2D shape to verify flattened processing."""
+        # Shape (4, 5) = 20 elements, exercises vectorized path
+        x_np = np.random.uniform(-np.pi, np.pi, size=(4, 5)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.sin(x)
+        expected = np.sin(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_sin_float64_2d_shape(self):
+        """Test float64 sin with 2D shape to verify flattened processing."""
+        # Shape (3, 5) = 15 elements, exercises vectorized path with tail
+        x_np = np.random.uniform(-np.pi, np.pi, size=(3, 5)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.sin(x)
+        expected = np.sin(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+    def test_sin_float32_small_shape_fallback(self):
+        """Test float32 sin with small shape (numel < 8) to cover Eigen fallback path.
+        Covers VectorizedSinImpl fallback branch (lines 74-80 in activation_impl.h).
+        """
+        # Shape 5 < 8, triggers Eigen fallback instead of SIMD
+        x_np = np.random.uniform(-np.pi, np.pi, size=(5,)).astype(np.float32)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.sin(x)
+        expected = np.sin(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-5, atol=1e-5
+        )
+
+    def test_sin_float64_small_shape_fallback(self):
+        """Test float64 sin with small shape (numel < 8) to cover Eigen fallback path.
+        Covers VectorizedSinImpl fallback branch (lines 74-80 in activation_impl.h).
+        """
+        # Shape 3 < 8, triggers Eigen fallback instead of SIMD
+        x_np = np.random.uniform(-np.pi, np.pi, size=(3,)).astype(np.float64)
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.sin(x)
+        expected = np.sin(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
**Commit 1: sin/cos精度对齐**
- 新增 `sleef_vectorized_math.h` 头文件，提供统一的向量化Sleef接口
- 支持AVX512（16 floats / 8 doubles并行）和AVX2（8 floats / 4 doubles并行）
- 修改 `activation_impl.h` 添加 `VectorizedSinImpl/VectorizedCosImpl`
- 修改 `activation_kernel.cc` 使float/double类型使用向量化路径

**Commit 2: pow实现规范化**
- 将pow的Sleef向量化实现统一到 `sleef_vectorized_math.h`
- 简化 `elementwise_kernel.cc` 中的 `ElementwisePowSameDimsHelper`，使用统一的 `vpow` 接口
- 添加pow的AVX512向量化支持


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是