### PR TITLE
[Unpool] Fix CUDA error when input tensor is zero-size

### DIFF
--- a/paddle/phi/kernels/gpu/unpool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/unpool_grad_kernel.cu
@@ -106,6 +106,10 @@ class Unpool2dMaxGradFunctor {
     const T* output_data = output.data<T>();
     const T* output_grad_data = output_grad.data<T>();
     T* input_grad_data = dev_ctx.template Alloc<T>(input_grad);
+    // Early return for zero-size input to avoid invalid CUDA kernel launch
+    if (input.numel() == 0) {
+      return;
+    }
     int threads = 1024;
     int64_t grid_max = dev_ctx.GetCUDAMaxGridDimSize()[0];
     int grid = std::min((input.numel() + threads - 1) / threads, grid_max);
@@ -170,6 +174,10 @@ class Unpool3dMaxGradFunctor {
     const T* output_data = output.data<T>();
     const T* output_grad_data = output_grad.data<T>();
     T* input_grad_data = dev_ctx.template Alloc<T>(input_grad);
+    // Early return for zero-size input to avoid invalid CUDA kernel launch
+    if (input.numel() == 0) {
+      return;
+    }
     int threads = 1024;
     int64_t grid_max = dev_ctx.GetCUDAMaxGridDimSize()[0];
     int grid = std::min((input.numel() + threads - 1) / threads, grid_max);

--- a/paddle/phi/kernels/gpu/unpool_kernel.cu
+++ b/paddle/phi/kernels/gpu/unpool_kernel.cu
@@ -100,6 +100,10 @@ class Unpool2dMaxFunctor {
     const T* input_data = input.data<T>();
     const IndT* indices_data = indices.data<IndT>();
     T* output_data = dev_ctx.template Alloc<T>(output);
+    // Early return for zero-size input to avoid invalid CUDA kernel launch
+    if (input.numel() == 0) {
+      return;
+    }
     int threads = 1024;
     int64_t grid_max = dev_ctx.GetCUDAMaxGridDimSize()[0];
     int grid = std::min((input.numel() + threads - 1) / threads, grid_max);
@@ -158,6 +162,10 @@ class Unpool3dMaxFunctor {
     const T* input_data = input.data<T>();
     const IndT* indices_data = indices.data<IndT>();
     T* output_data = dev_ctx.template Alloc<T>(output);
+    // Early return for zero-size input to avoid invalid CUDA kernel launch
+    if (input.numel() == 0) {
+      return;
+    }
     int threads = 1024;
     int64_t grid_max = dev_ctx.GetCUDAMaxGridDimSize()[0];
     int grid = std::min((input.numel() + threads - 1) / threads, grid_max);


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
ls CUDA error(9) cudaErrorInvalidConfiguration 

#### 问题原因
 shape [3, 2, 5, 0]），input.numel() 为 0，导致 CUDA kernel 启动时计算的 grid 大 0，启动非法的 kernel 配置触发 CUDA 错误。

#### 修复方案
于 kernel 启动前添加空输入检查并提前返回：
- Unpool2dMaxFunctor (unpool_kernel.cu)
- Unpool3dMaxFunctor (unpool_kernel.cu)
- Unpool2dMaxGradFunctor (unpool_grad_kernel.cu)
- Unpool3dMaxGradFunctor (unpool_grad_kernel.cu)

### 是否引起精度变化
否
