### PR TITLE
[Cpp API Compatibility] Align some compat APIs with libtorch

### DIFF
--- a/paddle/phi/api/include/compat/ATen/native/RangeUtils.h
+++ b/paddle/phi/api/include/compat/ATen/native/RangeUtils.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <ATen/AccumulateType.h>
+#include <c10/core/Scalar.h>
+#include <limits>
+
+namespace at::native {
+
+inline void arange_check_bounds(const c10::Scalar& start,
+                                const c10::Scalar& end,
+                                const c10::Scalar& step) {
+  // use double precision for validation to avoid precision issues
+  double dstart = start.to<double>();
+  double dend = end.to<double>();
+  double dstep = step.to<double>();
+
+  TORCH_CHECK(dstep > 0 || dstep < 0, "step must be nonzero");
+  TORCH_CHECK(std::isfinite(dstart) && std::isfinite(dend),
+              "unsupported range: ",
+              dstart,
+              " -> ",
+              dend);
+  TORCH_CHECK(
+      ((dstep > 0) && (dend >= dstart)) || ((dstep < 0) && (dend <= dstart)),
+      "upper bound and lower bound inconsistent with step sign");
+}
+
+template <typename scalar_t>
+int64_t compute_arange_size(const Scalar& start,
+                            const Scalar& end,
+                            const Scalar& step) {
+  arange_check_bounds(start, end, step);
+
+  // we use double precision for (start - end) / step
+  // to compute size_d for consistency across devices.
+  // The problem with using accscalar_t is that accscalar_t might be float32 on
+  // gpu for a float32 scalar_t, but double on cpu for the same, and the
+  // effective output size starts differing on CPU vs GPU because of precision
+  // issues, which we dont want. the corner-case we do want to take into account
+  // is int64_t, which has higher precision than double
+  double size_d;
+  if constexpr (std::is_same_v<scalar_t, int64_t>) {
+    using accscalar_t = at::acc_type<scalar_t, false>;
+    auto xstart = start.to<accscalar_t>();
+    auto xend = end.to<accscalar_t>();
+    auto xstep = step.to<accscalar_t>();
+    int64_t sgn = (xstep > 0) - (xstep < 0);
+    size_d = std::ceil((xend - xstart + xstep - sgn) / xstep);
+  } else {
+    size_d =
+        std::ceil((end.to<double>() - start.to<double>()) / step.to<double>());
+  }
+
+  TORCH_CHECK(size_d >= 0 && size_d <= static_cast<double>(
+                                           std::numeric_limits<int64_t>::max()),
+              "invalid size, possible overflow?");
+
+  return static_cast<int64_t>(size_d);
+}
+
+}  // namespace at::native

--- a/paddle/phi/api/include/compat/ATen/ops/arange.h
+++ b/paddle/phi/api/include/compat/ATen/ops/arange.h
@@ -26,7 +26,7 @@ inline at::Tensor arange(const at::Scalar& end,
                          at::TensorOptions options = {}) {
   return paddle::experimental::arange(
       paddle::experimental::full({}, 0, phi::DataType::FLOAT64),
-      paddle::experimental::full({}, end.to<int64_t>(), phi::DataType::FLOAT64),
+      paddle::experimental::full({}, end.to<double>(), phi::DataType::FLOAT64),
       paddle::experimental::full({}, 1, phi::DataType::FLOAT64),
       compat::_PD_AtenScalarTypeToPhiDataType(options.dtype()),
       options._PD_GetPlace());
@@ -39,7 +39,7 @@ inline at::Tensor arange(const at::Scalar& end,
                          ::std::optional<bool> pin_memory) {
   return paddle::experimental::arange(
       paddle::experimental::full({}, 0, phi::DataType::FLOAT64),
-      paddle::experimental::full({}, end.to<int64_t>(), phi::DataType::FLOAT64),
+      paddle::experimental::full({}, end.to<double>(), phi::DataType::FLOAT64),
       paddle::experimental::full({}, 1, phi::DataType::FLOAT64),
       compat::_PD_AtenScalarTypeToPhiDataType(
           dtype.value_or(c10::get_default_dtype())),
@@ -51,8 +51,8 @@ inline at::Tensor arange(const at::Scalar& start,
                          at::TensorOptions options = {}) {
   return paddle::experimental::arange(
       paddle::experimental::full(
-          {}, start.to<int64_t>(), phi::DataType::FLOAT64),
-      paddle::experimental::full({}, end.to<int64_t>(), phi::DataType::FLOAT64),
+          {}, start.to<double>(), phi::DataType::FLOAT64),
+      paddle::experimental::full({}, end.to<double>(), phi::DataType::FLOAT64),
       paddle::experimental::full({}, 1, phi::DataType::FLOAT64),
       compat::_PD_AtenScalarTypeToPhiDataType(options.dtype()),
       options._PD_GetPlace());
@@ -66,8 +66,8 @@ inline at::Tensor arange(const at::Scalar& start,
                          ::std::optional<bool> pin_memory) {
   return paddle::experimental::arange(
       paddle::experimental::full(
-          {}, start.to<int64_t>(), phi::DataType::FLOAT64),
-      paddle::experimental::full({}, end.to<int64_t>(), phi::DataType::FLOAT64),
+          {}, start.to<double>(), phi::DataType::FLOAT64),
+      paddle::experimental::full({}, end.to<double>(), phi::DataType::FLOAT64),
       paddle::experimental::full({}, 1, phi::DataType::FLOAT64),
       compat::_PD_AtenScalarTypeToPhiDataType(
           dtype.value_or(c10::get_default_dtype())),
@@ -91,11 +91,9 @@ inline at::Tensor arange(const at::Scalar& start,
            " step=",
            st);
   return paddle::experimental::arange(
-      paddle::experimental::full(
-          {}, start.to<int64_t>(), phi::DataType::FLOAT64),
-      paddle::experimental::full({}, end.to<int64_t>(), phi::DataType::FLOAT64),
-      paddle::experimental::full(
-          {}, step.to<int64_t>(), phi::DataType::FLOAT64),
+      paddle::experimental::full({}, s, phi::DataType::FLOAT64),
+      paddle::experimental::full({}, e, phi::DataType::FLOAT64),
+      paddle::experimental::full({}, st, phi::DataType::FLOAT64),
       compat::_PD_AtenScalarTypeToPhiDataType(options.dtype()),
       options._PD_GetPlace());
 }
@@ -120,11 +118,9 @@ inline at::Tensor arange(const at::Scalar& start,
            " step=",
            st);
   return paddle::experimental::arange(
-      paddle::experimental::full(
-          {}, start.to<int64_t>(), phi::DataType::FLOAT64),
-      paddle::experimental::full({}, end.to<int64_t>(), phi::DataType::FLOAT64),
-      paddle::experimental::full(
-          {}, step.to<int64_t>(), phi::DataType::FLOAT64),
+      paddle::experimental::full({}, s, phi::DataType::FLOAT64),
+      paddle::experimental::full({}, e, phi::DataType::FLOAT64),
+      paddle::experimental::full({}, st, phi::DataType::FLOAT64),
       compat::_PD_AtenScalarTypeToPhiDataType(
           dtype.value_or(c10::get_default_dtype())),
       device.value_or(at::kCPU)._PD_GetInner());

--- a/paddle/phi/api/include/compat/ATen/ops/arange.h
+++ b/paddle/phi/api/include/compat/ATen/ops/arange.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <ATen/core/Tensor.h>
+#include <ATen/native/RangeUtils.h>
 #include <c10/core/TensorOptions.h>
 #include <optional>
 
@@ -79,21 +80,12 @@ inline at::Tensor arange(const at::Scalar& start,
                          const at::Scalar& step,
                          at::TensorOptions options = {}) {
   // Match PyTorch: step must be non-zero and consistent with (end - start).
-  double s = start.to<double>();
-  double e = end.to<double>();
-  double st = step.to<double>();
-  PD_CHECK(st != 0, "arange() step must be nonzero");
-  PD_CHECK(((e > s) == (st > 0)) || (e == s),
-           "arange() upper bound and step sign inconsistent: upper=",
-           e,
-           " start=",
-           s,
-           " step=",
-           st);
+  at::native::arange_check_bounds(start, end, step);
   return paddle::experimental::arange(
-      paddle::experimental::full({}, s, phi::DataType::FLOAT64),
-      paddle::experimental::full({}, e, phi::DataType::FLOAT64),
-      paddle::experimental::full({}, st, phi::DataType::FLOAT64),
+      paddle::experimental::full(
+          {}, start.to<double>(), phi::DataType::FLOAT64),
+      paddle::experimental::full({}, end.to<double>(), phi::DataType::FLOAT64),
+      paddle::experimental::full({}, step.to<double>(), phi::DataType::FLOAT64),
       compat::_PD_AtenScalarTypeToPhiDataType(options.dtype()),
       options._PD_GetPlace());
 }
@@ -106,21 +98,12 @@ inline at::Tensor arange(const at::Scalar& start,
                          ::std::optional<at::Device> device,
                          ::std::optional<bool> pin_memory) {
   // Match PyTorch: step must be non-zero and consistent with (end - start).
-  double s = start.to<double>();
-  double e = end.to<double>();
-  double st = step.to<double>();
-  PD_CHECK(st != 0, "arange() step must be nonzero");
-  PD_CHECK(((e > s) == (st > 0)) || (e == s),
-           "arange() upper bound and step sign inconsistent: upper=",
-           e,
-           " start=",
-           s,
-           " step=",
-           st);
+  at::native::arange_check_bounds(start, end, step);
   return paddle::experimental::arange(
-      paddle::experimental::full({}, s, phi::DataType::FLOAT64),
-      paddle::experimental::full({}, e, phi::DataType::FLOAT64),
-      paddle::experimental::full({}, st, phi::DataType::FLOAT64),
+      paddle::experimental::full(
+          {}, start.to<double>(), phi::DataType::FLOAT64),
+      paddle::experimental::full({}, end.to<double>(), phi::DataType::FLOAT64),
+      paddle::experimental::full({}, step.to<double>(), phi::DataType::FLOAT64),
       compat::_PD_AtenScalarTypeToPhiDataType(
           dtype.value_or(c10::get_default_dtype())),
       device.value_or(at::kCPU)._PD_GetInner());

--- a/paddle/phi/api/include/compat/ATen/ops/arange.h
+++ b/paddle/phi/api/include/compat/ATen/ops/arange.h
@@ -78,6 +78,18 @@ inline at::Tensor arange(const at::Scalar& start,
                          const at::Scalar& end,
                          const at::Scalar& step,
                          at::TensorOptions options = {}) {
+  // Match PyTorch: step must be non-zero and consistent with (end - start).
+  double s = start.to<double>();
+  double e = end.to<double>();
+  double st = step.to<double>();
+  PD_CHECK(st != 0, "arange() step must be nonzero");
+  PD_CHECK(((e > s) == (st > 0)) || (e == s),
+           "arange() upper bound and step sign inconsistent: upper=",
+           e,
+           " start=",
+           s,
+           " step=",
+           st);
   return paddle::experimental::arange(
       paddle::experimental::full(
           {}, start.to<int64_t>(), phi::DataType::FLOAT64),
@@ -95,6 +107,18 @@ inline at::Tensor arange(const at::Scalar& start,
                          ::std::optional<at::Layout> layout,
                          ::std::optional<at::Device> device,
                          ::std::optional<bool> pin_memory) {
+  // Match PyTorch: step must be non-zero and consistent with (end - start).
+  double s = start.to<double>();
+  double e = end.to<double>();
+  double st = step.to<double>();
+  PD_CHECK(st != 0, "arange() step must be nonzero");
+  PD_CHECK(((e > s) == (st > 0)) || (e == s),
+           "arange() upper bound and step sign inconsistent: upper=",
+           e,
+           " start=",
+           s,
+           " step=",
+           st);
   return paddle::experimental::arange(
       paddle::experimental::full(
           {}, start.to<int64_t>(), phi::DataType::FLOAT64),

--- a/paddle/phi/api/include/compat/ATen/ops/narrow.h
+++ b/paddle/phi/api/include/compat/ATen/ops/narrow.h
@@ -22,6 +22,38 @@ inline at::Tensor narrow(const at::Tensor& self,
                          int64_t dim,
                          int64_t start,
                          int64_t length) {
+  // Bounds checks matching PyTorch behavior
+  PD_CHECK(self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
+  PD_CHECK(length >= 0, "narrow(): length must be non-negative.");
+
+  // Normalize negative dim
+  int64_t ndim = self.dim();
+  if (dim < 0) dim += ndim;
+  PD_CHECK(dim >= 0 && dim < ndim,
+           "Dimension out of range (expected to be in range of [",
+           -ndim,
+           ", ",
+           ndim - 1,
+           "], but got ",
+           dim,
+           ")");
+
+  int64_t cur_size = self.sizes()[dim];
+
+  // Wrap negative start (matching PyTorch: only wrap when start != cur_size)
+  if (start != cur_size && start < 0) {
+    start += cur_size;
+  }
+
+  PD_CHECK(start >= 0 && start + length <= cur_size,
+           "start (",
+           start,
+           ") + length (",
+           length,
+           ") exceeds dimension size (",
+           cur_size,
+           ").");
+
   // Use slice to implement narrow: narrow(dim, start, length) is equivalent
   // to slice(dim, start, start + length)
   return Tensor(paddle::experimental::slice(

--- a/paddle/phi/api/include/compat/ATen/ops/narrow.h
+++ b/paddle/phi/api/include/compat/ATen/ops/narrow.h
@@ -30,7 +30,7 @@ inline at::Tensor narrow(const at::Tensor& self,
   int64_t ndim = self.dim();
   if (dim < 0) dim += ndim;
   PD_CHECK(dim >= 0 && dim < ndim,
-           "Dimension out of range (expected to be in range of [",
+           "start out of range (expected to be in range of [",
            -ndim,
            ", ",
            ndim - 1,
@@ -41,11 +41,10 @@ inline at::Tensor narrow(const at::Tensor& self,
   int64_t cur_size = self.sizes()[dim];
 
   // Wrap negative start (matching PyTorch: only wrap when start != cur_size)
-  if (start != cur_size && start < 0) {
-    start += cur_size;
+  if (start < 0) {
+    start = start + cur_size;
   }
-
-  PD_CHECK(start >= 0 && start + length <= cur_size,
+  PD_CHECK(start <= cur_size - length,
            "start (",
            start,
            ") + length (",

--- a/paddle/phi/api/include/compat/ATen/ops/sum.h
+++ b/paddle/phi/api/include/compat/ATen/ops/sum.h
@@ -26,11 +26,21 @@ namespace at {
 
 inline at::Tensor sum(const at::Tensor& self,
                       ::std::optional<at::ScalarType> dtype = ::std::nullopt) {
+  // Match PyTorch promotion: integer inputs -> int64; others -> keep input
+  // dtype.
+  at::ScalarType resolved_dtype;
+  if (dtype.has_value()) {
+    resolved_dtype = dtype.value();
+  } else {
+    at::ScalarType input_dtype = self.scalar_type();
+    resolved_dtype = at::isIntegralType(input_dtype, /*includeBool=*/true)
+                         ? at::kLong
+                         : input_dtype;
+  }
   return paddle::experimental::sum(
       self._PD_GetInner(),
       {},
-      compat::_PD_AtenScalarTypeToPhiDataType(
-          dtype.value_or(c10::get_default_dtype())),
+      compat::_PD_AtenScalarTypeToPhiDataType(resolved_dtype),
       /*keepdim=*/false);
 }
 
@@ -38,12 +48,22 @@ inline at::Tensor sum(const at::Tensor& self,
                       at::OptionalIntArrayRef dim,
                       bool keepdim = false,
                       ::std::optional<at::ScalarType> dtype = ::std::nullopt) {
+  // Match PyTorch promotion: integer inputs -> int64; others -> keep input
+  // dtype.
+  at::ScalarType resolved_dtype;
+  if (dtype.has_value()) {
+    resolved_dtype = dtype.value();
+  } else {
+    at::ScalarType input_dtype = self.scalar_type();
+    resolved_dtype = at::isIntegralType(input_dtype, /*includeBool=*/true)
+                         ? at::kLong
+                         : input_dtype;
+  }
   return paddle::experimental::sum(
       self._PD_GetInner(),
       dim.has_value() ? dim.value()._PD_ToPaddleIntArray()
                       : paddle::experimental::IntArray(),
-      compat::_PD_AtenScalarTypeToPhiDataType(
-          dtype.value_or(c10::get_default_dtype())),
+      compat::_PD_AtenScalarTypeToPhiDataType(resolved_dtype),
       keepdim);
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure 


### PR Types
Bug fixes


### Description
对齐 `arange` `narrow` `sum` 接口
abs接口有个测试还没对齐，由于 paddle 和 pytorch 底层实现不一样，paddle 的 abs 强制把 transpose 之后的 tensor 变为连续 tensor ，并根据 shape 重置 stride，pytorch 则是保留 stride 不变，还是非连续 tensor ，导致两者的 data_ptr 存储的数据顺序不同，后面看看能不能对齐下，diff详见 https://github.com/PFCCLab/PaddleCppAPITest/pull/9


### 是否引起精度变化
否
