### PR TITLE
[Bugfix] paddle.cuda.device(tensor.place)

### DIFF
--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -404,7 +404,9 @@ def _convert_to_place(device: PlaceLike) -> Place:
             elif device.is_xpu_place():
                 return core.XPUPlace(device.xpu_device_id())
             elif device.is_custom_place():
-                return core.CustomPlace(device.custom_device_type(), device.custom_device_id())
+                return core.CustomPlace(
+                    device.custom_device_type(), device.custom_device_id()
+                )
         return device
 
     lower_device = device.lower()

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -396,7 +396,16 @@ def device_to_place(device: Place | int | str | None = None) -> Place:
 
 def _convert_to_place(device: PlaceLike) -> Place:
     if not isinstance(device, str):
-        return device  # return directly if not a string
+        if type(device) is core.Place:
+            if device.is_gpu_place():
+                return core.CUDAPlace(device.gpu_device_id())
+            elif device.is_cpu_place():
+                return core.CPUPlace()
+            elif device.is_xpu_place():
+                return core.XPUPlace(device.xpu_device_id())
+            elif device.is_custom_place():
+                return core.CustomPlace(device.custom_device_type(), device.custom_device_id())
+        return device
 
     lower_device = device.lower()
     if lower_device.startswith("cuda"):

--- a/test/legacy_test/test_cuda_unittest.py
+++ b/test/legacy_test/test_cuda_unittest.py
@@ -461,7 +461,6 @@ class TestNvtx(unittest.TestCase):
         with self.assertRaises(TypeError):
             paddle.device.nvtx.range_push(123)
 
-
 class TestDeviceDvice(unittest.TestCase):
     def test_device_device(self):
         current = paddle.device.get_device()
@@ -469,7 +468,32 @@ class TestDeviceDvice(unittest.TestCase):
             self.assertEqual(paddle.device.get_device(), 'cpu')
         self.assertEqual(paddle.device.get_device(), current)
 
+        paddle.disable_static()
+        current = paddle.device.get_device()
 
+        # Test: passing cpu tensor.place to device context manager
+        cpu_tensor = paddle.empty(1, dtype="float32", device='cpu')
+        with paddle.device.device(cpu_tensor.place):
+            self.assertEqual(paddle.device.get_device(), 'cpu')
+        self.assertEqual(paddle.device.get_device(), current)
+
+        if paddle.is_compiled_with_cuda() and paddle.cuda.is_available():
+            device_count = paddle.device.cuda.device_count()
+
+            # Test: passing gpu:0 tensor.place to cuda.device context manager
+            gpu_tensor_0 = paddle.empty(1, dtype="float32", device='cuda:0')
+            with paddle.cuda.device(gpu_tensor_0.place):
+                self.assertEqual(paddle.device.get_device(), 'gpu:0')
+            self.assertEqual(paddle.device.get_device(), current)
+
+            # Test: passing gpu tensor.place with non-zero device id
+            if device_count > 1:
+                gpu_tensor_1 = paddle.empty(
+                    1, dtype="float32", device='cuda:1'
+                )
+                with paddle.device.device(gpu_tensor_1.place):
+                    self.assertEqual(paddle.device.get_device(), 'gpu:1')
+                self.assertEqual(paddle.device.get_device(), current)
 class TestCudaDvice(unittest.TestCase):
     def test_device_device(self):
         current = paddle.device.get_device()

--- a/test/legacy_test/test_cuda_unittest.py
+++ b/test/legacy_test/test_cuda_unittest.py
@@ -461,6 +461,7 @@ class TestNvtx(unittest.TestCase):
         with self.assertRaises(TypeError):
             paddle.device.nvtx.range_push(123)
 
+
 class TestDeviceDvice(unittest.TestCase):
     def test_device_device(self):
         current = paddle.device.get_device()
@@ -488,12 +489,12 @@ class TestDeviceDvice(unittest.TestCase):
 
             # Test: passing gpu tensor.place with non-zero device id
             if device_count > 1:
-                gpu_tensor_1 = paddle.empty(
-                    1, dtype="float32", device='cuda:1'
-                )
+                gpu_tensor_1 = paddle.empty(1, dtype="float32", device='cuda:1')
                 with paddle.device.device(gpu_tensor_1.place):
                     self.assertEqual(paddle.device.get_device(), 'gpu:1')
                 self.assertEqual(paddle.device.get_device(), current)
+
+
 class TestCudaDvice(unittest.TestCase):
     def test_device_device(self):
         current = paddle.device.get_device()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
**功能**
修复paddle.cuda.device()，接收tensor.place并解析正常
⸻
**问题**
tensor.place 返回的是基类 paddle.base.libpaddle.Place，而不是具体子类（如 CUDAPlace）。
当前 _convert_to_place 通过 type(place) is core.Place 判断类型，导致基类 Place 被误识别为需要重新初始化的对象，从而每次都会被解析为默认设备 gpu:0。
⸻
**修复**
修改 _convert_to_place：当输入为 Place 基类对象时，不再仅通过类型判断，而是根据其属性（如 is_gpu_place()、gpu_device_id() 等）正确解析并构造对应的具体 Place 子类实例。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否