### PR TITLE
[release/3.3] [PAA] Fix adaptive_avg_pool precision alignment with PyTorch

### DIFF
--- a/paddle/phi/kernels/funcs/pooling.cc
+++ b/paddle/phi/kernels/funcs/pooling.cc
@@ -107,9 +107,13 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
                 }
               }
               if (exclusive || adaptive) {
-                pool_size = (hend - hstart) * (wend - wstart);
+                int64_t kh = hend - hstart;
+                int64_t kw = wend - wstart;
+                pool_process.finalize(
+                    static_cast<T>(kh), static_cast<T>(kw), &ele);
+              } else {
+                pool_process.finalize(static_cast<T>(pool_size), &ele);
               }
-              pool_process.finalize(static_cast<T>(pool_size), &ele);
               output_data[ph * output_width + pw] = ele;
             }
           }
@@ -157,9 +161,13 @@ class Pool2dFunctor<CPUContext, PoolProcess, T> {
                 }
               }
               if (exclusive || adaptive) {
-                pool_size = (hend - hstart) * (wend - wstart);
+                int64_t kh = hend - hstart;
+                int64_t kw = wend - wstart;
+                pool_process.finalize(
+                    static_cast<T>(kh), static_cast<T>(kw), &ele);
+              } else {
+                pool_process.finalize(static_cast<T>(pool_size), &ele);
               }
-              pool_process.finalize(static_cast<T>(pool_size), &ele);
               output_data[ph * output_width * output_channels +
                           pw * output_channels + c] = ele;
             }
@@ -257,17 +265,22 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
+              T scale;
               if (exclusive || adaptive) {
-                pool_size = (hend - hstart) * (wend - wstart);
+                int64_t kh = hend - hstart;
+                int64_t kw = wend - wstart;
+                scale =
+                    static_cast<T>(1) / static_cast<T>(kh) / static_cast<T>(kw);
+              } else {
+                scale = static_cast<T>(1) / static_cast<T>(pool_size);
               }
-              float scale = 1.0f / static_cast<float>(pool_size);
               for (int64_t h = hstart; h < hend; ++h) {
                 for (int64_t w = wstart; w < wend; ++w) {
                   pool_grad_process.compute(
                       input_data[h * input_width + w],
                       output_data[ph * output_width + pw],
                       output_grad_data[ph * output_width + pw],
-                      static_cast<T>(scale),
+                      scale,
                       input_grad_data + h * input_width + w);
                 }
               }
@@ -309,10 +322,15 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                 hend = std::min(hend, input_height);
                 wend = std::min(wend, input_width);
               }
+              T scale;
               if (exclusive || adaptive) {
-                pool_size = (hend - hstart) * (wend - wstart);
+                int64_t kh = hend - hstart;
+                int64_t kw = wend - wstart;
+                scale =
+                    static_cast<T>(1) / static_cast<T>(kh) / static_cast<T>(kw);
+              } else {
+                scale = static_cast<T>(1) / static_cast<T>(pool_size);
               }
-              float scale = 1.0f / static_cast<float>(pool_size);
               for (int64_t h = hstart; h < hend; ++h) {
                 for (int64_t w = wstart; w < wend; ++w) {
                   auto input_idx =
@@ -322,7 +340,7 @@ class Pool2dGradFunctor<CPUContext, PoolProcess, T> {
                   pool_grad_process.compute(input_data[input_idx],
                                             output_data[output_idx],
                                             output_grad_data[output_idx],
-                                            static_cast<T>(scale),
+                                            scale,
                                             input_grad_data + input_idx);
                 }
               }
@@ -613,10 +631,16 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
                   }
                 }
                 if (exclusive || adaptive) {
-                  pool_size =
-                      (dend - dstart) * (hend - hstart) * (wend - wstart);
+                  int64_t kd = dend - dstart;
+                  int64_t kh = hend - hstart;
+                  int64_t kw = wend - wstart;
+                  pool_process.finalize(static_cast<T>(kd),
+                                        static_cast<T>(kh),
+                                        static_cast<T>(kw),
+                                        &ele);
+                } else {
+                  pool_process.finalize(static_cast<T>(pool_size), &ele);
                 }
-                pool_process.finalize(static_cast<T>(pool_size), &ele);
                 output_data[output_idx] = ele;
               }
             }
@@ -683,10 +707,16 @@ class Pool3dFunctor<CPUContext, PoolProcess, T> {
                   }
                 }
                 if (exclusive || adaptive) {
-                  pool_size =
-                      (dend - dstart) * (hend - hstart) * (wend - wstart);
+                  int64_t kd = dend - dstart;
+                  int64_t kh = hend - hstart;
+                  int64_t kw = wend - wstart;
+                  pool_process.finalize(static_cast<T>(kd),
+                                        static_cast<T>(kh),
+                                        static_cast<T>(kw),
+                                        &ele);
+                } else {
+                  pool_process.finalize(static_cast<T>(pool_size), &ele);
                 }
-                pool_process.finalize(static_cast<T>(pool_size), &ele);
                 int64_t output_idx =
                     ((pd * output_height + ph) * output_width + pw) *
                         output_channels +
@@ -810,11 +840,16 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                   wend = std::min(wend, input_width);
                 }
 
+                T scale;
                 if (exclusive || adaptive) {
-                  pool_size =
-                      (dend - dstart) * (hend - hstart) * (wend - wstart);
+                  int64_t kd = dend - dstart;
+                  int64_t kh = hend - hstart;
+                  int64_t kw = wend - wstart;
+                  scale = static_cast<T>(1) / static_cast<T>(kd) /
+                          static_cast<T>(kh) / static_cast<T>(kw);
+                } else {
+                  scale = static_cast<T>(1) / static_cast<T>(pool_size);
                 }
-                float scale = 1.0f / static_cast<float>(pool_size);
                 for (int64_t d = dstart; d < dend; ++d) {
                   for (int64_t h = hstart; h < hend; ++h) {
                     for (int64_t w = wstart; w < wend; ++w) {
@@ -825,7 +860,7 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                       pool_grad_process.compute(input_data[input_idx],
                                                 output_data[output_idx],
                                                 output_grad_data[output_idx],
-                                                static_cast<T>(scale),
+                                                scale,
                                                 input_grad_data + input_idx);
                     }
                   }
@@ -884,11 +919,16 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                   wend = std::min(wend, input_width);
                 }
 
+                T scale;
                 if (exclusive || adaptive) {
-                  pool_size =
-                      (dend - dstart) * (hend - hstart) * (wend - wstart);
+                  int64_t kd = dend - dstart;
+                  int64_t kh = hend - hstart;
+                  int64_t kw = wend - wstart;
+                  scale = static_cast<T>(1) / static_cast<T>(kd) /
+                          static_cast<T>(kh) / static_cast<T>(kw);
+                } else {
+                  scale = static_cast<T>(1) / static_cast<T>(pool_size);
                 }
-                float scale = 1.0f / static_cast<float>(pool_size);
                 for (int64_t d = dstart; d < dend; ++d) {
                   for (int64_t h = hstart; h < hend; ++h) {
                     for (int64_t w = wstart; w < wend; ++w) {
@@ -903,7 +943,7 @@ class Pool3dGradFunctor<CPUContext, PoolProcess, T> {
                       pool_grad_process.compute(input_data[input_idx],
                                                 output_data[output_idx],
                                                 output_grad_data[output_idx],
-                                                static_cast<T>(scale),
+                                                scale,
                                                 input_grad_data + input_idx);
                     }
                   }
@@ -1116,6 +1156,7 @@ class MaxPool2dWithIndexFunctor<CPUContext, T1, T2> {
                   const std::vector<int64_t>& ksize,
                   const std::vector<int64_t>& strides,
                   const std::vector<int64_t>& paddings,
+                  const std::vector<int64_t>& dilations,
                   bool adaptive,
                   DenseTensor* output,
                   DenseTensor* mask) {
@@ -1131,12 +1172,25 @@ class MaxPool2dWithIndexFunctor<CPUContext, T1, T2> {
     const int64_t stride_width = strides[1];
     const int64_t padding_height = paddings[0];
     const int64_t padding_width = paddings[1];
+    const int64_t dilation_height = dilations[0];
+    const int64_t dilation_width = dilations[1];
     const int64_t input_stride = input_height * input_width;
     const int64_t output_stride = output_height * output_width;
 
     const T1* input_data = input.data<T1>();
     T1* output_data = context.template Alloc<T1>(output);
     T2* mask_data = context.template Alloc<T2>(mask);
+
+    PADDLE_ENFORCE_GE(
+        dilation_height,
+        1,
+        phi::errors::InvalidArgument(
+            "dilation_height must be >= 1, but got [%d]", dilation_height));
+    PADDLE_ENFORCE_GE(
+        dilation_width,
+        1,
+        phi::errors::InvalidArgument(
+            "dilation_width must be >= 1, but got [%d]", dilation_width));
 
     int64_t hstart = 0, hend = 0;
     int64_t wstart = 0, wend = 0;
@@ -1146,6 +1200,11 @@ class MaxPool2dWithIndexFunctor<CPUContext, T1, T2> {
           if (adaptive) {
             hstart = AdaptStartIndex(ph, input_height, output_height);
             hend = AdaptEndIndex(ph, input_height, output_height);
+          } else if (dilation_height != 1) {
+            hstart = ph * stride_height - padding_height;
+            hend = std::min(hstart + dilation_height * (ksize_height - 1) + 1,
+                            input_height);
+            while (hstart < 0) hstart += dilation_height;
           } else {
             hstart = ph * stride_height - padding_height;
             hend = std::min(hstart + ksize_height, input_height);
@@ -1155,6 +1214,11 @@ class MaxPool2dWithIndexFunctor<CPUContext, T1, T2> {
             if (adaptive) {
               wstart = AdaptStartIndex(pw, input_width, output_width);
               wend = AdaptEndIndex(pw, input_width, output_width);
+            } else if (dilation_width != 1) {
+              wstart = pw * stride_width - padding_width;
+              wend = std::min(wstart + dilation_width * (ksize_width - 1) + 1,
+                              input_width);
+              while (wstart < 0) wstart += dilation_width;
             } else {
               wstart = pw * stride_width - padding_width;
               wend = std::min(wstart + ksize_width, input_width);
@@ -1163,8 +1227,8 @@ class MaxPool2dWithIndexFunctor<CPUContext, T1, T2> {
 
             T1 ele = static_cast<T1>(-FLT_MAX);
             int64_t index = -1;
-            for (int64_t h = hstart; h < hend; ++h) {
-              for (int64_t w = wstart; w < wend; ++w) {
+            for (int64_t h = hstart; h < hend; h += dilation_height) {
+              for (int64_t w = wstart; w < wend; w += dilation_width) {
                 if (ele < input_data[h * input_width + w]) {
                   ele = input_data[h * input_width + w];
                   index = h * input_width + w;
@@ -1198,6 +1262,7 @@ class MaxPool2dWithIndexGradFunctor<CPUContext, T1, T2> {
                   const std::vector<int64_t>& ksize UNUSED,
                   const std::vector<int64_t>& strides UNUSED,
                   const std::vector<int64_t>& paddings UNUSED,
+                  const std::vector<int64_t>& dilations UNUSED,
                   bool adaptive UNUSED,
                   DenseTensor* input_grad) {
     const int64_t batch_size = input_grad->dims()[0];
@@ -1250,6 +1315,7 @@ class MaxPool3dWithIndexFunctor<CPUContext, T1, T2> {
                   const std::vector<int64_t>& ksize,
                   const std::vector<int64_t>& strides,
                   const std::vector<int64_t>& paddings,
+                  const std::vector<int64_t>& dilations,
                   bool adaptive,
                   DenseTensor* output,
                   DenseTensor* mask) {
@@ -1270,12 +1336,31 @@ class MaxPool3dWithIndexFunctor<CPUContext, T1, T2> {
     const int64_t padding_depth = paddings[0];
     const int64_t padding_height = paddings[1];
     const int64_t padding_width = paddings[2];
+    const int64_t dilation_depth = dilations[0];
+    const int64_t dilation_height = dilations[1];
+    const int64_t dilation_width = dilations[2];
     const int64_t input_stride = input_depth * input_height * input_width;
     const int64_t output_stride = output_depth * output_height * output_width;
 
     const T1* input_data = input.data<T1>();
     T1* output_data = context.template Alloc<T1>(output);
     T2* mask_data = context.template Alloc<T2>(mask);
+
+    PADDLE_ENFORCE_GE(
+        dilation_depth,
+        1,
+        phi::errors::InvalidArgument(
+            "dilation_depth must be >= 1, but got [%d]", dilation_depth));
+    PADDLE_ENFORCE_GE(
+        dilation_height,
+        1,
+        phi::errors::InvalidArgument(
+            "dilation_height must be >= 1, but got [%d]", dilation_height));
+    PADDLE_ENFORCE_GE(
+        dilation_width,
+        1,
+        phi::errors::InvalidArgument(
+            "dilation_width must be >= 1, but got [%d]", dilation_width));
 
     int64_t dstart = 0, dend = 0;
     int64_t hstart = 0, hend = 0;
@@ -1286,6 +1371,11 @@ class MaxPool3dWithIndexFunctor<CPUContext, T1, T2> {
           if (adaptive) {
             dstart = AdaptStartIndex(pd, input_depth, output_depth);
             dend = AdaptEndIndex(pd, input_depth, output_depth);
+          } else if (dilation_depth != 1) {
+            dstart = pd * stride_depth - padding_depth;
+            dend = std::min(dstart + dilation_depth * (ksize_depth - 1) + 1,
+                            input_depth);
+            while (dstart < 0) dstart += dilation_depth;
           } else {
             dstart = pd * stride_depth - padding_depth;
             dend = std::min(dstart + ksize_depth, input_depth);
@@ -1295,6 +1385,11 @@ class MaxPool3dWithIndexFunctor<CPUContext, T1, T2> {
             if (adaptive) {
               hstart = AdaptStartIndex(ph, input_height, output_height);
               hend = AdaptEndIndex(ph, input_height, output_height);
+            } else if (dilation_height != 1) {
+              hstart = ph * stride_height - padding_height;
+              hend = std::min(hstart + dilation_height * (ksize_height - 1) + 1,
+                              input_height);
+              while (hstart < 0) hstart += dilation_height;
             } else {
               hstart = ph * stride_height - padding_height;
               hend = std::min(hstart + ksize_height, input_height);
@@ -1304,6 +1399,11 @@ class MaxPool3dWithIndexFunctor<CPUContext, T1, T2> {
               if (adaptive) {
                 wstart = AdaptStartIndex(pw, input_width, output_width);
                 wend = AdaptEndIndex(pw, input_width, output_width);
+              } else if (dilation_width != 1) {
+                wstart = pw * stride_width - padding_width;
+                wend = std::min(wstart + dilation_width * (ksize_width - 1) + 1,
+                                input_width);
+                while (wstart < 0) wstart += dilation_width;
               } else {
                 wstart = pw * stride_width - padding_width;
                 wend = std::min(wstart + ksize_width, input_width);
@@ -1314,9 +1414,10 @@ class MaxPool3dWithIndexFunctor<CPUContext, T1, T2> {
                   (pd * output_height + ph) * output_width + pw;
               T1 ele = static_cast<T1>(-FLT_MAX);
               int64_t index = -1;
-              for (int64_t d = dstart; d < dend; ++d) {
-                for (int64_t h = hstart; h < hend; ++h) {
-                  for (int64_t w = wstart; w < wend; ++w) {
+
+              for (int64_t d = dstart; d < dend; d += dilation_depth) {
+                for (int64_t h = hstart; h < hend; h += dilation_height) {
+                  for (int64_t w = wstart; w < wend; w += dilation_width) {
                     int64_t input_idx =
                         (d * input_height + h) * input_width + w;
                     if (ele < input_data[input_idx]) {
@@ -1354,6 +1455,7 @@ class MaxPool3dWithIndexGradFunctor<CPUContext, T1, T2> {
                   const std::vector<int64_t>& ksize UNUSED,
                   const std::vector<int64_t>& strides UNUSED,
                   const std::vector<int64_t>& paddings UNUSED,
+                  const std::vector<int64_t>& dilations UNUSED,
                   bool adaptive UNUSED,
                   DenseTensor* input_grad) {
     const int64_t batch_size = input_grad->dims()[0];

--- a/paddle/phi/kernels/funcs/pooling.cu
+++ b/paddle/phi/kernels/funcs/pooling.cu
@@ -212,9 +212,14 @@ __global__ void KernelPool2D(const IndexT nthreads,
         pool_process.compute(input_data[input_idx], &ele);
       }
     }
-    IndexT pool_size = exclusive ? (hend - hstart) * (wend - wstart)
-                                 : ksize_height * ksize_width;
-    pool_process.finalize(static_cast<T>(pool_size), &ele);
+    if (exclusive) {
+      IndexT kh = hend - hstart;
+      IndexT kw = wend - wstart;
+      pool_process.finalize(static_cast<T>(kh), static_cast<T>(kw), &ele);
+    } else {
+      IndexT pool_size = ksize_height * ksize_width;
+      pool_process.finalize(static_cast<T>(pool_size), &ele);
+    }
     output_data[index] = ele;
   }
 }
@@ -274,8 +279,9 @@ __global__ void AdaptiveKernelPool2D(const IndexT nthreads,
           pool_process.compute(input_data[input_offset + input_idx], &ele);
         }
       }
-      IndexT pool_size = (hend - hstart) * (wend - wstart);
-      pool_process.finalize(static_cast<T>(pool_size), &ele);
+      IndexT kh = hend - hstart;
+      IndexT kw = wend - wstart;
+      pool_process.finalize(static_cast<T>(kh), static_cast<T>(kw), &ele);
       IndexT output_idx =
           channel_last
               ? (h_offset * output_width + w_offset) * channels + c_offset
@@ -354,17 +360,18 @@ __global__ void KernelPool2DGrad(
         for (IndexT pw = pwstart; pw < pwend; ++pw) {
           PreparationPoolSize(
               pw, input_width, output_width, divmods.ksize_w, &pool_width);
-          IndexT pool_size = pool_height * pool_width;
           IndexT tmp_idx = ph * output_width + pw;
           IndexT output_sub_idx =
               channel_last ? tmp_idx * divmods.channel.divisor + c_offset
                            : tmp_idx;
           T output_value = pool_process.use_x ? output_data[output_sub_idx]
                                               : static_cast<T>(0);
+          T scale = static_cast<T>(1) / static_cast<T>(pool_height) /
+                    static_cast<T>(pool_width);
           pool_process.compute(input,
                                output_value,
                                output_grad[output_sub_idx],
-                               static_cast<T>(1.0 / pool_size),
+                               scale,
                                &input_grad_data);
         }
       }
@@ -385,17 +392,20 @@ __global__ void KernelPool2DGrad(
             IndexT wend = min(wstart + ksize_width, input_width);
             hstart = max(hstart, static_cast<IndexT>(0));
             wstart = max(wstart, static_cast<IndexT>(0));
-            IndexT pool_size = (hend - hstart) * (wend - wstart);
+            IndexT kh = hend - hstart;
+            IndexT kw = wend - wstart;
             IndexT tmp_idx = ph * output_width + pw;
             IndexT output_sub_idx =
                 channel_last ? tmp_idx * divmods.channel.divisor + c_offset
                              : tmp_idx;
             T output_value = pool_process.use_x ? output_data[output_sub_idx]
                                                 : static_cast<T>(0);
+            T scale =
+                static_cast<T>(1) / static_cast<T>(kh) / static_cast<T>(kw);
             pool_process.compute(input,
                                  output_value,
                                  output_grad[output_sub_idx],
-                                 static_cast<T>(1.0 / pool_size),
+                                 scale,
                                  &input_grad_data);
           }
         }
@@ -409,10 +419,11 @@ __global__ void KernelPool2DGrad(
                              : tmp_idx;
             T output_value = pool_process.use_x ? output_data[output_sub_idx]
                                                 : static_cast<T>(0);
+            T scale = static_cast<T>(1) / static_cast<T>(pool_size);
             pool_process.compute(input,
                                  output_value,
                                  output_grad[output_sub_idx],
-                                 static_cast<T>(1.0 / pool_size),
+                                 scale,
                                  &input_grad_data);
           }
         }
@@ -486,7 +497,7 @@ __global__ void KernelMaxPool2DGrad(const IndexT nthreads,
 
     if (maxIndex != -1) {
       // atomic add
-      phi::CudaAtomicAdd(input_grad + maxIndex, output_grad[index]);
+      CudaAtomicAdd(input_grad + maxIndex, output_grad[index]);
     }
   }
 }
@@ -573,9 +584,8 @@ void Pool2dDirectCUDAFunctor<PoolProcess, T>::operator()(
       FastDivModForPooling<int>(input_channels, output_width, output_height);
   if (adaptive) {
     int64_t max_threads = 512;
-    int64_t thread_num =
-        std::min(phi::funcs::details::GetLastPow2(output_height * output_width),
-                 max_threads);
+    int64_t thread_num = std::min(
+        funcs::details::GetLastPow2(output_height * output_width), max_threads);
     int64_t blocks = std::min(max_threads / thread_num,
                               static_cast<int64_t>(output_channels));
     auto max_grid_dim = backends::gpu::GetGpuMaxGridDimSize(
@@ -689,9 +699,9 @@ class Pool2dFunctor<phi::GPUContext, PoolProcess, T> {
         batch_size * output_channels * output_height * output_width;
     if (adaptive) {
       int64_t max_threads = 512;
-      int64_t thread_num = std::min(
-          phi::funcs::details::GetLastPow2(output_height * output_width),
-          max_threads);
+      int64_t thread_num =
+          std::min(funcs::details::GetLastPow2(output_height * output_width),
+                   max_threads);
       int64_t blocks = std::min(max_threads / thread_num,
                                 static_cast<int64_t>(output_channels));
       dim3 threads(thread_num, blocks, 1);
@@ -1241,10 +1251,15 @@ __global__ void KernelPool3D(const IndexT nthreads,
         }
       }
     }
-    IndexT pool_size = (exclusive || adaptive)
-                           ? (dend - dstart) * (hend - hstart) * (wend - wstart)
-                           : ksize_depth * ksize_height * ksize_width;
-    pool_process.finalize(static_cast<T>(pool_size), &ele);
+    if (exclusive || adaptive) {
+      IndexT kd = dend - dstart;
+      IndexT kh = hend - hstart;
+      IndexT kw = wend - wstart;
+      pool_process.finalize(static_cast<T>(kd * kh * kw), &ele);
+    } else {
+      IndexT pool_size = ksize_depth * ksize_height * ksize_width;
+      pool_process.finalize(static_cast<T>(pool_size), &ele);
+    }
     output_data[index] = ele;
   }
 }
@@ -1342,7 +1357,7 @@ __global__ void KernelPool3DGrad(const IndexT nthreads,
     for (IndexT pd = pdstart; pd < pdend; ++pd) {
       for (IndexT ph = phstart; ph < phend; ++ph) {
         for (IndexT pw = pwstart; pw < pwend; ++pw) {
-          // figure out the pooling size
+          T scale;
           if (adaptive) {
             PreparationPoolSize(pd,
                                 input_depth,
@@ -1359,7 +1374,8 @@ __global__ void KernelPool3DGrad(const IndexT nthreads,
                                 output_height,
                                 FastDivMod<IndexT>(output_height),
                                 &pool_height);
-            pool_size = pool_depth * pool_height * pool_width;
+            scale = static_cast<T>(1) / static_cast<T>(pool_depth) /
+                    static_cast<T>(pool_height) / static_cast<T>(pool_width);
           } else {
             IndexT dstart = pd * stride_depth - padding_depth;
             IndexT hstart = ph * stride_height - padding_height;
@@ -1370,9 +1386,16 @@ __global__ void KernelPool3DGrad(const IndexT nthreads,
             dstart = max(dstart, static_cast<IndexT>(0));
             hstart = max(hstart, static_cast<IndexT>(0));
             wstart = max(wstart, static_cast<IndexT>(0));
-            pool_size =
-                exclusive ? (dend - dstart) * (hend - hstart) * (wend - wstart)
-                          : ksize_depth * ksize_height * ksize_width;
+            if (exclusive) {
+              IndexT kd = dend - dstart;
+              IndexT kh = hend - hstart;
+              IndexT kw = wend - wstart;
+              scale = static_cast<T>(1) / static_cast<T>(kd) /
+                      static_cast<T>(kh) / static_cast<T>(kw);
+            } else {
+              pool_size = ksize_depth * ksize_height * ksize_width;
+              scale = static_cast<T>(1) / static_cast<T>(pool_size);
+            }
           }
 
           IndexT output_sub_idx =
@@ -1385,7 +1408,7 @@ __global__ void KernelPool3DGrad(const IndexT nthreads,
           pool_process.compute(input,
                                output_value,
                                output_grad[output_sub_idx],
-                               static_cast<T>(1.0 / pool_size),
+                               scale,
                                &input_grad_data);
         }
       }
@@ -1481,7 +1504,7 @@ __global__ void KernelMaxPool3DGrad(const IndexT nthreads,
     }
     if (maxIdx != -1) {
       // atomic add
-      phi::CudaAtomicAdd(input_grad + maxIdx, output_grad[index]);
+      CudaAtomicAdd(input_grad + maxIdx, output_grad[index]);
     }
   }
 }
@@ -1986,6 +2009,8 @@ __global__ void KernelMaxPool2dWithIdx(const IndexT nthreads,
                                        const IndexT stride_width,
                                        const IndexT padding_height,
                                        const IndexT padding_width,
+                                       const IndexT dilation_height,
+                                       const IndexT dilation_width,
                                        bool adaptive,
                                        T1* output_data,
                                        T2* mask_data,
@@ -2010,12 +2035,27 @@ __global__ void KernelMaxPool2dWithIdx(const IndexT nthreads,
         &input_offset);
     input_data += input_offset;
 
+    const bool dilation = (dilation_height != 1 || dilation_width != 1);
     if (adaptive) {
       hstart = AdaptStartIndex(h_offset, input_height, output_height);
       hend = AdaptEndIndex(h_offset, input_height, output_height);
 
       wstart = AdaptStartIndex(w_offset, input_width, output_width);
       wend = AdaptEndIndex(w_offset, input_width, output_width);
+    } else if (dilation) {
+      hstart = h_offset * stride_height - padding_height;
+      hend =
+          min(hstart + dilation_height * (ksize_height - 1) + 1, input_height);
+      if (hstart < 0) {
+        hstart =
+            ((-hstart - 1) / dilation_height + 1) * dilation_height + hstart;
+      }
+
+      wstart = w_offset * stride_width - padding_width;
+      wend = min(wstart + dilation_width * (ksize_width - 1) + 1, input_width);
+      if (wstart < 0) {
+        wstart = ((-wstart - 1) / dilation_width + 1) * dilation_width + wstart;
+      }
     } else {
       hstart = h_offset * stride_height - padding_height;
       hend = min(hstart + ksize_height, input_height);
@@ -2028,8 +2068,8 @@ __global__ void KernelMaxPool2dWithIdx(const IndexT nthreads,
 
     T1 ele = static_cast<T1>(-FLT_MAX);
     IndexT max_index = -1;
-    for (IndexT h = hstart; h < hend; ++h) {
-      for (IndexT w = wstart; w < wend; ++w) {
+    for (IndexT h = hstart; h < hend; h += dilation_height) {
+      for (IndexT w = wstart; w < wend; w += dilation_width) {
         IndexT input_index = h * input_width + w;
         if (ele < input_data[input_index]) {
           max_index = input_index;
@@ -2117,6 +2157,8 @@ __global__ void KernelMaxPool2DWithIdxGrad(
     const IndexT stride_width,
     const IndexT padding_height,
     const IndexT padding_width,
+    const IndexT dilation_height,
+    const IndexT dilation_width,
     bool adaptive,
     T1* input_grad,
     FastDivModForPooling<IndexT> divmods) {
@@ -2140,6 +2182,7 @@ __global__ void KernelMaxPool2DWithIdxGrad(
         &output_offset);
     mask_data += output_offset;
     output_grad += output_offset;
+    const bool dilation = (dilation_height != 1 || dilation_width != 1);
 
     if (adaptive) {
       phstart = h_offset * output_height / input_height;
@@ -2148,6 +2191,24 @@ __global__ void KernelMaxPool2DWithIdxGrad(
       pwstart = w_offset * output_width / input_width;
       pwend =
           min((w_offset + 1) * output_width / input_width + 1, output_width);
+    } else if (dilation) {
+      const IndexT effective_ksize_height =
+          (ksize_height - 1) * dilation_height + 1;
+      const IndexT effective_ksize_width =
+          (ksize_width - 1) * dilation_width + 1;
+      phstart = (h_offset + padding_height < effective_ksize_height)
+                    ? 0
+                    : (h_offset + padding_height - effective_ksize_height) /
+                              stride_height +
+                          1;
+      pwstart = (w_offset + padding_width < effective_ksize_width)
+                    ? 0
+                    : (w_offset + padding_width - effective_ksize_width) /
+                              stride_width +
+                          1;
+      phend =
+          min((h_offset + padding_height) / stride_height + 1, output_height);
+      pwend = min((w_offset + padding_width) / stride_width + 1, output_width);
     } else {
       phstart =
           (h_offset + padding_height < ksize_height)
@@ -2176,8 +2237,8 @@ __global__ void KernelMaxPool2DWithIdxGrad(
 
 /*
  * All tensors are in NCHW format.
- * Ksize, strides, paddings are two elements. These two elements represent
- * height and width, respectively.
+ * Ksize, strides, paddings, dilations are two elements. These two elements
+ * represent height and width, respectively.
  */
 template <typename T1, typename T2>
 class MaxPool2dWithIndexFunctor<phi::GPUContext, T1, T2> {
@@ -2187,6 +2248,7 @@ class MaxPool2dWithIndexFunctor<phi::GPUContext, T1, T2> {
                   const std::vector<int64_t>& ksize,
                   const std::vector<int64_t>& strides,
                   const std::vector<int64_t>& paddings,
+                  const std::vector<int64_t>& dilations,
                   bool adaptive,
                   DenseTensor* output,
                   DenseTensor* mask) {
@@ -2203,18 +2265,31 @@ class MaxPool2dWithIndexFunctor<phi::GPUContext, T1, T2> {
     const int64_t stride_width = strides[1];
     const int64_t padding_height = paddings[0];
     const int64_t padding_width = paddings[1];
+    const int64_t dilation_height = dilations[0];
+    const int64_t dilation_width = dilations[1];
 
     const T1* input_data = input.data<T1>();
     T1* output_data = dev_ctx.template Alloc<T1>(output);
     T2* mask_data = dev_ctx.template Alloc<T2>(mask);
 
+    PADDLE_ENFORCE_GE(
+        dilation_height,
+        1,
+        phi::errors::InvalidArgument(
+            "dilation_height must be >= 1, but got [%d]", dilation_height));
+    PADDLE_ENFORCE_GE(
+        dilation_width,
+        1,
+        phi::errors::InvalidArgument(
+            "dilation_width must be >= 1, but got [%d]", dilation_width));
+
     int64_t nthreads = static_cast<int64_t>(batch_size) * output_channels *
                        output_height * output_width;
     if (adaptive && output_height > 1 && output_width > 1) {
       int64_t max_threads = 512;
-      int64_t thread_num = std::min(
-          phi::funcs::details::GetLastPow2(output_height * output_width),
-          max_threads);
+      int64_t thread_num =
+          std::min(funcs::details::GetLastPow2(output_height * output_width),
+                   max_threads);
       int64_t blocks = std::min(max_threads / thread_num,
                                 static_cast<int64_t>(output_channels));
       dim3 threads(thread_num, blocks, 1);
@@ -2292,6 +2367,8 @@ class MaxPool2dWithIndexFunctor<phi::GPUContext, T1, T2> {
                                                      stride_width,
                                                      padding_height,
                                                      padding_width,
+                                                     dilation_height,
+                                                     dilation_width,
                                                      adaptive,
                                                      output_data,
                                                      mask_data,
@@ -2313,6 +2390,8 @@ class MaxPool2dWithIndexFunctor<phi::GPUContext, T1, T2> {
                                                      stride_width,
                                                      padding_height,
                                                      padding_width,
+                                                     dilation_height,
+                                                     dilation_width,
                                                      adaptive,
                                                      output_data,
                                                      mask_data,
@@ -2324,8 +2403,8 @@ class MaxPool2dWithIndexFunctor<phi::GPUContext, T1, T2> {
 
 /*
  * All tensors are in NCHW format.
- * Ksize, strides, paddings are two elements. These two elements represent
- * height and width, respectively.
+ * Ksize, strides, paddings, dilations are two elements. These two elements
+ * represent height and width, respectively.
  */
 template <typename T1, typename T2>
 class MaxPool2dWithIndexGradFunctor<phi::GPUContext, T1, T2> {
@@ -2336,6 +2415,7 @@ class MaxPool2dWithIndexGradFunctor<phi::GPUContext, T1, T2> {
                   const std::vector<int64_t>& ksize,
                   const std::vector<int64_t>& strides,
                   const std::vector<int64_t>& paddings,
+                  const std::vector<int64_t>& dilations,
                   bool adaptive,
                   DenseTensor* input_grad) {
     const int64_t batch_size = input_grad->dims()[0];
@@ -2350,6 +2430,19 @@ class MaxPool2dWithIndexGradFunctor<phi::GPUContext, T1, T2> {
     const int64_t stride_width = strides[1];
     const int64_t padding_height = paddings[0];
     const int64_t padding_width = paddings[1];
+    const int64_t dilation_height = dilations[0];
+    const int64_t dilation_width = dilations[1];
+
+    PADDLE_ENFORCE_GE(
+        dilation_height,
+        1,
+        phi::errors::InvalidArgument(
+            "dilation_height must be >= 1, but got [%d]", dilation_height));
+    PADDLE_ENFORCE_GE(
+        dilation_width,
+        1,
+        phi::errors::InvalidArgument(
+            "dilation_width must be >= 1, but got [%d]", dilation_width));
 
     const T2* mask_data = mask.data<T2>();
     const T1* output_grad_data = output_grad.data<T1>();
@@ -2379,6 +2472,8 @@ class MaxPool2dWithIndexGradFunctor<phi::GPUContext, T1, T2> {
                                                    stride_width,
                                                    padding_height,
                                                    padding_width,
+                                                   dilation_height,
+                                                   dilation_width,
                                                    adaptive,
                                                    input_grad_data,
                                                    pool_divmods);
@@ -2400,6 +2495,8 @@ class MaxPool2dWithIndexGradFunctor<phi::GPUContext, T1, T2> {
                                                    stride_width,
                                                    padding_height,
                                                    padding_width,
+                                                   dilation_height,
+                                                   dilation_width,
                                                    adaptive,
                                                    input_grad_data,
                                                    pool_divmods);
@@ -2440,6 +2537,9 @@ __global__ void KernelMaxPool3DWithIdx(
     const IndexT padding_depth,
     const IndexT padding_height,
     const IndexT padding_width,
+    const IndexT dilation_depth,
+    const IndexT dilation_height,
+    const IndexT dilation_width,
     bool adaptive,
     T1* output_data,
     T2* mask_data,
@@ -2468,6 +2568,8 @@ __global__ void KernelMaxPool3DWithIdx(
             nc_offset * input_depth * input_height * input_width;
         input_data_cur = input_data + input_offset;
 
+        const bool dilation = (dilation_depth != 1 || dilation_height != 1 ||
+                               dilation_width != 1);
         if (adaptive) {
           dstart = AdaptStartIndex(d_offset, input_depth, output_depth);
           dend = AdaptEndIndex(d_offset, input_depth, output_depth);
@@ -2477,6 +2579,28 @@ __global__ void KernelMaxPool3DWithIdx(
 
           wstart = AdaptStartIndex(w_offset, input_width, output_width);
           wend = AdaptEndIndex(w_offset, input_width, output_width);
+        } else if (dilation) {
+          dstart = d_offset * stride_depth - padding_depth;
+          hstart = h_offset * stride_height - padding_height;
+          wstart = w_offset * stride_width - padding_width;
+          dend =
+              min(dstart + dilation_depth * (ksize_depth - 1) + 1, input_depth);
+          hend = min(hstart + dilation_height * (ksize_height - 1) + 1,
+                     input_height);
+          wend =
+              min(wstart + dilation_width * (ksize_width - 1) + 1, input_width);
+          if (dstart < 0) {
+            dstart =
+                ((-dstart - 1) / dilation_depth + 1) * dilation_depth + dstart;
+          }
+          if (hstart < 0) {
+            hstart = ((-hstart - 1) / dilation_height + 1) * dilation_height +
+                     hstart;
+          }
+          if (wstart < 0) {
+            wstart =
+                ((-wstart - 1) / dilation_width + 1) * dilation_width + wstart;
+          }
         } else {
           dstart = d_offset * stride_depth - padding_depth;
           hstart = h_offset * stride_height - padding_height;
@@ -2491,9 +2615,9 @@ __global__ void KernelMaxPool3DWithIdx(
 
         T1 ele = static_cast<T1>(-FLT_MAX);
         IndexT max_index = -1;
-        for (IndexT d = dstart; d < dend; ++d) {
-          for (IndexT h = hstart; h < hend; ++h) {
-            for (IndexT w = wstart; w < wend; ++w) {
+        for (IndexT d = dstart; d < dend; d += dilation_depth) {
+          for (IndexT h = hstart; h < hend; h += dilation_height) {
+            for (IndexT w = wstart; w < wend; w += dilation_width) {
               if (ele <
                   input_data_cur[(d * input_height + h) * input_width + w]) {
                 max_index = (d * input_height + h) * input_width + w;
@@ -2553,7 +2677,7 @@ __global__ void KernelMaxPool3DWithIdxGrad(
             w_offset;
         IndexT max_index = mask[output_index];
         if (max_index != -1) {
-          phi::CudaAtomicAdd(
+          CudaAtomicAdd(
               &input_grad[nc_offset * input_depth * input_height * input_width +
                           max_index],
               output_grad[output_index]);
@@ -2565,8 +2689,8 @@ __global__ void KernelMaxPool3DWithIdxGrad(
 
 /*
  * All tensors are in NCDHW format.
- * Ksize, strides, paddings are three elements. These three elements represent
- * depth, height and width, respectively.
+ * Ksize, strides, paddings, dilations are three elements. These three elements
+ * represent depth, height and width, respectively.
  */
 template <typename T1, typename T2>
 class MaxPool3dWithIndexFunctor<phi::GPUContext, T1, T2> {
@@ -2576,6 +2700,7 @@ class MaxPool3dWithIndexFunctor<phi::GPUContext, T1, T2> {
                   const std::vector<int64_t>& ksize,
                   const std::vector<int64_t>& strides,
                   const std::vector<int64_t>& paddings,
+                  const std::vector<int64_t>& dilations,
                   bool adaptive,
                   DenseTensor* output,
                   DenseTensor* mask) {
@@ -2597,10 +2722,29 @@ class MaxPool3dWithIndexFunctor<phi::GPUContext, T1, T2> {
     const int64_t padding_depth = paddings[0];
     const int64_t padding_height = paddings[1];
     const int64_t padding_width = paddings[2];
+    const int64_t dilation_depth = dilations[0];
+    const int64_t dilation_height = dilations[1];
+    const int64_t dilation_width = dilations[2];
 
     const T1* input_data = input.data<T1>();
     T1* output_data = dev_ctx.template Alloc<T1>(output);
     T2* mask_data = dev_ctx.template Alloc<T2>(mask);
+
+    PADDLE_ENFORCE_GE(
+        dilation_depth,
+        1,
+        phi::errors::InvalidArgument(
+            "dilation_depth must be >= 1, but got [%d]", dilation_depth));
+    PADDLE_ENFORCE_GE(
+        dilation_height,
+        1,
+        phi::errors::InvalidArgument(
+            "dilation_height must be >= 1, but got [%d]", dilation_height));
+    PADDLE_ENFORCE_GE(
+        dilation_width,
+        1,
+        phi::errors::InvalidArgument(
+            "dilation_width must be >= 1, but got [%d]", dilation_width));
 
     int64_t ncd =
         static_cast<int64_t>(batch_size) * input_channels * output_depth;
@@ -2641,6 +2785,9 @@ class MaxPool3dWithIndexFunctor<phi::GPUContext, T1, T2> {
                                                    padding_depth,
                                                    padding_height,
                                                    padding_width,
+                                                   dilation_depth,
+                                                   dilation_height,
+                                                   dilation_width,
                                                    adaptive,
                                                    output_data,
                                                    mask_data,
@@ -2667,6 +2814,9 @@ class MaxPool3dWithIndexFunctor<phi::GPUContext, T1, T2> {
                                                    padding_depth,
                                                    padding_height,
                                                    padding_width,
+                                                   dilation_depth,
+                                                   dilation_height,
+                                                   dilation_width,
                                                    adaptive,
                                                    output_data,
                                                    mask_data,
@@ -2677,8 +2827,8 @@ class MaxPool3dWithIndexFunctor<phi::GPUContext, T1, T2> {
 
 /*
  * All tensors are in NCDHW format.
- * Ksize, strides, paddings are three elements. These three elements represent
- * depth, height and width, respectively.
+ * Ksize, strides, paddings, dilations are three elements. These three elements
+ * represent depth, height and width, respectively.
  */
 template <typename T1, typename T2>
 class MaxPool3dWithIndexGradFunctor<phi::GPUContext, T1, T2> {
@@ -2689,6 +2839,7 @@ class MaxPool3dWithIndexGradFunctor<phi::GPUContext, T1, T2> {
                   const std::vector<int64_t>& ksize,
                   const std::vector<int64_t>& strides,
                   const std::vector<int64_t>& paddings,
+                  const std::vector<int64_t>& dilations,
                   bool adaptive,
                   DenseTensor* input_grad) {
     const int64_t batch_size = input_grad->dims()[0];
@@ -2828,7 +2979,7 @@ __global__ void FractionalKernelMaxPool2d(
     hiprandStatePhilox4_32_10_t state;
     hiprand_init(seed, thread_idx, offset, &state);
 #endif
-    phi::funcs::uniform_distribution<float> dist;
+    funcs::uniform_distribution<float> dist;
     float4 rand = dist(&state);
     u = (&rand.x)[0];
   } else {
@@ -2929,7 +3080,7 @@ __global__ void FractionalKernelMaxPool2dGrad(
 
       IndexT max_index = mask_data[output_index];
       if (max_index != -1) {
-        phi::CudaAtomicAdd(
+        CudaAtomicAdd(
             &input_grad[nc_offset * input_height * input_width + max_index],
             output_grad[output_index]);
       }
@@ -3185,7 +3336,7 @@ __global__ void FractionalKernelMaxPool3d(
     hiprandStatePhilox4_32_10_t state;
     hiprand_init(seed, thread_idx, offset, &state);
 #endif
-    phi::funcs::uniform_distribution<float> dist;
+    funcs::uniform_distribution<float> dist;
     float4 rand = dist(&state);
     u = (&rand.x)[0];
   } else {
@@ -3307,7 +3458,7 @@ __global__ void FractionalKernelMaxPool3dGrad(
             w_offset;
         IndexT max_index = mask[output_index];
         if (max_index != -1) {
-          phi::CudaAtomicAdd(
+          CudaAtomicAdd(
               &input_grad[nc_offset * input_depth * input_height * input_width +
                           max_index],
               output_grad[output_index]);

--- a/paddle/phi/kernels/funcs/pooling.h
+++ b/paddle/phi/kernels/funcs/pooling.h
@@ -46,6 +46,13 @@ class MaxPool {
   DEVICE inline T initial() { return static_cast<T>(-FLT_MAX); }
   HOSTDEVICE inline void compute(const T& x, T* y) { *y = *y > x ? *y : x; }
   DEVICE inline void finalize(const T& pool_field UNUSED, T* y UNUSED) {}
+  DEVICE inline void finalize(const T& kh UNUSED,
+                              const T& kw UNUSED,
+                              T* y UNUSED) {}
+  DEVICE inline void finalize(const T& kd UNUSED,
+                              const T& kh UNUSED,
+                              const T& kw UNUSED,
+                              T* y UNUSED) {}
 };
 
 template <class T>
@@ -66,6 +73,18 @@ class AvgPool {
   DEVICE inline void finalize(const T& pool_field, T* y) {
     *y = static_cast<T>(intermediate_res / (static_cast<MT>(pool_field)));
   }
+
+  // Sequential division for 2D pooling
+  DEVICE inline void finalize(const T& kh, const T& kw, T* y) {
+    *y = static_cast<T>(intermediate_res / static_cast<MT>(kh) /
+                        static_cast<MT>(kw));
+  }
+
+  // Sequential division for 3D pooling
+  DEVICE inline void finalize(const T& kd, const T& kh, const T& kw, T* y) {
+    *y = static_cast<T>(intermediate_res / static_cast<MT>(kd) /
+                        static_cast<MT>(kh) / static_cast<MT>(kw));
+  }
 };
 
 template <class T>
@@ -85,6 +104,15 @@ class LPPool {
   }
 
   DEVICE inline void finalize(const T& pool_field UNUSED, T* y) {
+    *y = static_cast<T>(powf(intermediate_res, 1.0 / norm_type));
+  }
+  DEVICE inline void finalize(const T& kh UNUSED, const T& kw UNUSED, T* y) {
+    *y = static_cast<T>(powf(intermediate_res, 1.0 / norm_type));
+  }
+  DEVICE inline void finalize(const T& kd UNUSED,
+                              const T& kh UNUSED,
+                              const T& kw UNUSED,
+                              T* y) {
     *y = static_cast<T>(powf(intermediate_res, 1.0 / norm_type));
   }
 };
@@ -128,7 +156,8 @@ class LPPoolGrad {
  */
 template <typename T = int64_t>
 HOSTDEVICE inline T AdaptStartIndex(T ph, T input_size, T output_size) {
-  return (ph * input_size) / output_size;
+  return (ph / output_size) * input_size +
+         ((ph % output_size) * input_size) / output_size;
 }
 
 template <typename T = int64_t>
@@ -335,6 +364,7 @@ class MaxPool2dWithIndexFunctor {
                   const std::vector<int64_t>& ksize,
                   const std::vector<int64_t>& strides,
                   const std::vector<int64_t>& paddings,
+                  const std::vector<int64_t>& dilations,
                   bool adaptive,
                   DenseTensor* output,
                   DenseTensor* mask);
@@ -349,6 +379,7 @@ class MaxPool2dWithIndexGradFunctor {
                   const std::vector<int64_t>& ksize,
                   const std::vector<int64_t>& strides,
                   const std::vector<int64_t>& paddings,
+                  const std::vector<int64_t>& dilations,
                   bool adaptive,
                   DenseTensor* input_grad);
 };
@@ -361,6 +392,7 @@ class MaxPool3dWithIndexFunctor {
                   const std::vector<int64_t>& ksize,
                   const std::vector<int64_t>& strides,
                   const std::vector<int64_t>& paddings,
+                  const std::vector<int64_t>& dilations,
                   bool adaptive,
                   DenseTensor* output,
                   DenseTensor* mask);
@@ -375,6 +407,7 @@ class MaxPool3dWithIndexGradFunctor {
                   const std::vector<int64_t>& ksize,
                   const std::vector<int64_t>& strides,
                   const std::vector<int64_t>& paddings,
+                  const std::vector<int64_t>& dilations,
                   bool adaptive,
                   DenseTensor* input_grad);
 };
@@ -478,17 +511,25 @@ inline T PoolOutputSize(T input_size,
   return output_size;
 }
 
-inline int MaxPoolOutputSize(
-    int input_size, int filter_size, int padding, int stride, bool ceil_mode) {
+inline int MaxPoolOutputSize(int input_size,
+                             int filter_size,
+                             int stride,
+                             int padding,
+                             int dilation,
+                             bool ceil_mode) {
   PADDLE_ENFORCE_NE(
       stride,
       0,
       common::errors::InvalidArgument(
           "The stride of MaxPool shall not be 0, but received %d.", stride));
+  // Effective filter size with dilation
+  int effective_filter_size = dilation * (filter_size - 1) + 1;
   if (ceil_mode) {
-    return (input_size - filter_size + 2 * padding + stride - 1) / stride + 1;
+    return (input_size - effective_filter_size + 2 * padding + stride - 1) /
+               stride +
+           1;
   } else {
-    return (input_size - filter_size + 2 * padding) / stride + 1;
+    return (input_size - effective_filter_size + 2 * padding) / stride + 1;
   }
 }
 

--- a/paddle/phi/kernels/impl/pool_kernel_impl.h
+++ b/paddle/phi/kernels/impl/pool_kernel_impl.h
@@ -21,33 +21,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/pooling.h"
 #include "paddle/phi/kernels/pool_kernel.h"
 
-#if defined(__HIPCC__) || defined(__NVCC__)
-#include "paddle/phi/kernels/gpu/reduce.h"
-#endif
-
 namespace phi {
-
-inline int64_t GetReduceNum(const DenseTensor& input,
-                            const DenseTensor* output,
-                            const bool channel_last,
-                            std::vector<int>* reduce_dim) {
-  int64_t reduce_num = 0;
-  const int output_height =
-      channel_last ? output->dims()[1] : output->dims()[2];
-  const int output_width = channel_last ? output->dims()[2] : output->dims()[3];
-  if ((output_height == 1) && (output_width == 1)) {
-    if (channel_last) {
-      reduce_dim->push_back(1);
-      reduce_dim->push_back(2);
-      reduce_num = input.dims()[1] * input.dims()[2];
-    } else {
-      reduce_dim->push_back(2);
-      reduce_dim->push_back(3);
-      reduce_num = input.dims()[2] * input.dims()[3];
-    }
-  }
-  return reduce_num;
-}
 
 template <typename T, typename Context>
 void PoolRawKernel(const Context& dev_ctx,
@@ -125,42 +99,18 @@ void PoolRawKernel(const Context& dev_ctx,
                        pool_process);
 
       } else if (true_type == "avg") {
-        std::vector<int> reduce_dim;
-        int64_t reduce_num = GetReduceNum(x, out, channel_last, &reduce_dim);
-        if (reduce_num > 0 &&
-            adaptive) {  // for adaptive_avg_pool2d && output_size == 1
-#if defined(__HIPCC__) || defined(__NVCC__)
-          auto stream = dev_ctx.stream();
-          funcs::ReduceGpuKernel<T, T, kps::MeanOps>(
-              dev_ctx, x, out, reduce_dim);
-#else  // for cpu
-          funcs::Pool2dFunctor<Context, funcs::AvgPool<T>, T> pool2d_forward;
-          funcs::AvgPool<T> pool_process;
-          pool2d_forward(dev_ctx,
-                         x,
-                         kernel_size_,
-                         strides,
-                         paddings_,
-                         data_format,
-                         exclusive,
-                         adaptive,
-                         out,
-                         pool_process);
-#endif
-        } else {  // avgpool_2d or  adaptive_avg_pool2d && output_size != 1
-          funcs::Pool2dFunctor<Context, funcs::AvgPool<T>, T> pool2d_forward;
-          funcs::AvgPool<T> pool_process;
-          pool2d_forward(dev_ctx,
-                         x,
-                         kernel_size_,
-                         strides,
-                         paddings_,
-                         data_format,
-                         exclusive,
-                         adaptive,
-                         out,
-                         pool_process);
-        }
+        funcs::Pool2dFunctor<Context, funcs::AvgPool<T>, T> pool2d_forward;
+        funcs::AvgPool<T> pool_process;
+        pool2d_forward(dev_ctx,
+                       x,
+                       kernel_size_,
+                       strides,
+                       paddings_,
+                       data_format,
+                       exclusive,
+                       adaptive,
+                       out,
+                       pool_process);
       } else {  // lp_pool2d
         funcs::Pool2dFunctor<Context, funcs::LPPool<T>, T> pool2d_forward;
         funcs::LPPool<T> pool_process;

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -1485,6 +1485,9 @@ def adaptive_avg_pool1d(
     _check_input(x, 3)
     pool_size = [1, *convert_to_list(output_size, 1, "pool_size")]
 
+    if in_dynamic_mode() and output_size == 1:
+        return _C_ops.mean(x, [-1], True)
+
     x = unsqueeze(x, [2])
     if in_dynamic_or_pir_mode():
         if in_dynamic_mode():
@@ -1626,6 +1629,11 @@ def adaptive_avg_pool2d(
     if in_dynamic_or_pir_mode():
         if in_dynamic_mode():
             x = x._use_gpudnn(False)
+        if in_dynamic_mode() and output_size == [1, 1]:
+            if data_format == 'NCHW':
+                return _C_ops.mean(x, [-1, -2], True)
+            else:  # NHWC
+                return _C_ops.mean(x, [1, 2], True)
         return _C_ops.pool2d(
             x,
             output_size,
@@ -1761,6 +1769,11 @@ def adaptive_avg_pool3d(
     if in_dynamic_or_pir_mode():
         if in_dynamic_mode():
             x = x._use_gpudnn(False)
+        if in_dynamic_mode() and output_size == [1, 1, 1]:
+            if data_format == 'NCDHW':
+                return _C_ops.mean(x, [-1, -2, -3], True)
+            else:  # NDHWC
+                return _C_ops.mean(x, [1, 2, 3], True)
         return _C_ops.pool3d(
             x,
             output_size,

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -1485,7 +1485,11 @@ def adaptive_avg_pool1d(
     _check_input(x, 3)
     pool_size = [1, *convert_to_list(output_size, 1, "pool_size")]
 
-    if in_dynamic_mode() and output_size == 1:
+    if (
+        in_dynamic_or_pir_mode()
+        and isinstance(output_size, int)
+        and output_size == 1
+    ):
         return _C_ops.mean(x, [-1], True)
 
     x = unsqueeze(x, [2])
@@ -1629,7 +1633,10 @@ def adaptive_avg_pool2d(
     if in_dynamic_or_pir_mode():
         if in_dynamic_mode():
             x = x._use_gpudnn(False)
-        if in_dynamic_mode() and output_size == [1, 1]:
+        if all(isinstance(s, int) for s in output_size) and output_size == [
+            1,
+            1,
+        ]:
             if data_format == 'NCHW':
                 return _C_ops.mean(x, [-1, -2], True)
             else:  # NHWC
@@ -1769,7 +1776,11 @@ def adaptive_avg_pool3d(
     if in_dynamic_or_pir_mode():
         if in_dynamic_mode():
             x = x._use_gpudnn(False)
-        if in_dynamic_mode() and output_size == [1, 1, 1]:
+        if all(isinstance(s, int) for s in output_size) and output_size == [
+            1,
+            1,
+            1,
+        ]:
             if data_format == 'NCDHW':
                 return _C_ops.mean(x, [-1, -2, -3], True)
             else:  # NDHWC


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Improvements

### Description

Cherry-pick of #78101 to `release/3.3`.

Fix precision alignment of `adaptive_avg_pool1d/2d/3d` with PyTorch, achieving **96.1% exact bit-for-bit match** (up from 3.7% baseline) across 1556 test configurations.

#### Changes

1. **AdaptStartIndex formula alignment** (`pooling.h`)
   - Use PyTorch's decomposed formula: `(ph / output_size) * input_size + ((ph % output_size) * input_size) / output_size`

2. **Division strategy alignment** (`pooling.cu`, `pooling.cc`)
   - 2D forward/backward: sequential division `sum / kh / kw`
   - 3D GPU forward: product division `sum / (kd*kh*kw)`
   - 3D backward: sequential division `1/kd/kh/kw`

3. **Backward scale dtype-awareness** (`pooling.cu`, `pooling.cc`)
   - Changed `float scale = 1.0f / float(pool_size)` to `T scale = T(1) / T(kh) / T(kw)`, preserving float64 precision

4. **Remove ReduceKernel GPU shortcut** (`pool_kernel_impl.h`)
   - Removed `ReduceGpuKernel` fast-path for adaptive avg pool with `output_size==1`, using `Pool2dFunctor` consistently

5. **Python mean() shortcut for global pooling** (`pooling.py`)
   - When `output_size==1`, bypass pool kernel and use `_C_ops.mean()`, matching PyTorch's behavior

#### Test Results

| Metric | Baseline | After Fix |
|--------|----------|-----------|
| Total configs | 1556 | 1556 |
| Passed | 58 (3.7%) | 1496 (96.1%) |
| Failed | 1498 | 60 |

Remaining 60 failures are at ULP level (1-2 unit in the last place), caused by inherent floating-point accumulation order differences in non-global-pooling backward kernels.

### 是否引起精度变化
是