### PR TITLE
[API Compatibility] Add alias for `paddle.autograd.PyLayerContext`

### DIFF
--- a/python/paddle/autograd/__init__.py
+++ b/python/paddle/autograd/__init__.py
@@ -21,6 +21,7 @@ from ..base.dygraph.base import (  # noqa: F401
 )
 from . import (  # noqa: F401
     backward_mode,
+    function,
     ir_backward,
 )
 from .autograd import hessian, jacobian

--- a/python/paddle/autograd/function.py
+++ b/python/paddle/autograd/function.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .py_layer import PyLayerContext as FunctionCtx  # noqa: F401

--- a/test/legacy_test/test_paddle_autograd_alias.py
+++ b/test/legacy_test/test_paddle_autograd_alias.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import paddle
+
+
+class TestAlias(unittest.TestCase):
+    def setUp(self):
+        self.autogradObject = paddle.autograd.PyLayerContext
+        self.functionObject = paddle.autograd.function.FunctionCtx
+
+    def test_compatibility(self):
+        self.assertTrue(type(self.autogradObject) == type(self.functionObject))
+
+
+class TestMarkNonDifferentiableAlias(TestAlias):
+    def setUp(self):
+        self.autogradObject = (
+            paddle.autograd.PyLayerContext.mark_non_differentiable
+        )
+        self.functionObject = (
+            paddle.autograd.function.FunctionCtx.mark_non_differentiable
+        )
+
+
+class TestSaveForBackwardAlias(TestAlias):
+    def setUp(self):
+        self.autogradObject = paddle.autograd.PyLayerContext.save_for_backward
+        self.functionObject = (
+            paddle.autograd.function.FunctionCtx.save_for_backward
+        )
+
+
+class TestSavedTensorAlias(TestAlias):
+    def setUp(self):
+        self.autogradObject = paddle.autograd.PyLayerContext.saved_tensor
+        self.functionObject = paddle.autograd.function.FunctionCtx.saved_tensor
+
+
+class TestSetMaterializeGradsAlias(TestAlias):
+    def setUp(self):
+        self.autogradObject = (
+            paddle.autograd.PyLayerContext.set_materialize_grads
+        )
+        self.functionObject = (
+            paddle.autograd.function.FunctionCtx.set_materialize_grads
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Add alias for class `paddle.autograd.PyLayerContext` and all functions defined within it

<img width="1322" height="208" alt="alias doc" src="https://github.com/user-attachments/assets/52c4ecee-01fd-4fe5-9ffd-7721e5d6244e" />


**Used AI Studio**


### 是否引起精度变化
否
