### PR TITLE
Fix GeneratorState useless construct for mt19937_64

### DIFF
--- a/paddle/phi/core/generator.h
+++ b/paddle/phi/core/generator.h
@@ -42,21 +42,19 @@ class PADDLE_API Generator {
                    uint64_t offset_ = 0,
                    std::shared_ptr<std::mt19937_64> engine = nullptr)
         : device(device_), seed(seed_), offset(offset_) {
-      std::seed_seq seq({seed_});
-      cpu_engine = std::make_shared<std::mt19937_64>(seq);
       if (engine != nullptr) {
         // Clone the engine state
-        *(cpu_engine) = *(engine);
+        cpu_engine = std::make_shared<std::mt19937_64>(*(engine));
+      } else {
+        std::seed_seq seq({seed_});
+        cpu_engine = std::make_shared<std::mt19937_64>(seq);
       }
     }
 
     GeneratorState(const GeneratorState& state)
         : device(state.device), seed(state.seed), offset(state.offset) {
       if (state.cpu_engine) {
-        std::seed_seq seq({state.seed});
-        cpu_engine = std::make_shared<std::mt19937_64>(seq);
-        // Clone the engine state
-        *(cpu_engine) = *(state.cpu_engine);
+        cpu_engine = std::make_shared<std::mt19937_64>(*(state.cpu_engine));
       }
     }
 
@@ -67,9 +65,7 @@ class PADDLE_API Generator {
         offset = state.offset;
 
         if (state.cpu_engine) {
-          std::seed_seq seq({state.seed});
-          cpu_engine = std::make_shared<std::mt19937_64>(seq);
-          *cpu_engine = *(state.cpu_engine);
+          cpu_engine = std::make_shared<std::mt19937_64>(*(state.cpu_engine));
         } else {
           cpu_engine = nullptr;
         }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
修复`GeneratorState `中存在的
```cpp
        std::seed_seq seq({state.seed});
        cpu_engine = std::make_shared<std::mt19937_64>(seq);
        // Clone the engine state
        *(cpu_engine) = *(state.cpu_engine);
```
这种不规范且性能低的用法
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否