### PR TITLE
feat: add Muon optimizer support

### DIFF
--- a/ci/h-test.sh
+++ b/ci/h-test.sh
@@ -165,7 +165,8 @@ concurrency_list="^test_fp8_deep_gemm$|\
 ^test_scaled_dot_product_attention$|\
 ^test_compat_scaled_dot_product_attention$|\
 ^test_flash_attention$|\
-^test_batched_gemm$"
+^test_batched_gemm$|\
+^test_parallel_dygraph_muon$"
 
 cd ${work_dir}/build
 tmp_dir=$(mktemp -d)

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -1249,8 +1249,17 @@ class DygraphShardingOptimizerV2:
         self._collect_comm_buffers()
         self._assign_slice_grad()
 
+        # Detect Muon by walking the wrapper chain; use name comparison to avoid
+        # a hard circular import.
+        core_opt = self._inner_opt
+        while hasattr(core_opt, '_inner_opt'):
+            core_opt = core_opt._inner_opt
+        is_muon = type(core_opt).__name__ == 'Muon'
+
         if not isinstance(self._parameter_list[0], dict):
             params_grads = []
+            # Build name→original-param map so Muon can recover full 2-D shape.
+            global_param_map = {p.name: p for p in self._parameter_list}
             for param in self._parameter_list:
                 if (
                     hasattr(param, "regularizer")
@@ -1268,8 +1277,25 @@ class DygraphShardingOptimizerV2:
                 if hasattr(param, "main_grad") and param.main_grad is not None:
                     grad_var = param.main_grad
                 if grad_var is not None:
+                    if is_muon:
+                        from .muon_sharding_annotations import (
+                            annotate_muon_params,
+                        )
+
+                        original_p = global_param_map[param.name]
+                        if not annotate_muon_params(
+                            param, original_p, self._hcg, self.param2bucket
+                        ):
+                            continue
+
                     params_grads.append((param, grad_var))
 
+            if is_muon and params_grads:
+                from .muon_sharding_annotations import (
+                    sort_muon_params_grads,
+                )
+
+                sort_muon_params_grads(params_grads)
             if self._enable_timer:
                 self.timers("apply-optimize").start()
 

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer_v3.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer_v3.py
@@ -1,0 +1,1068 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+DygraphShardingOptimizerV3: Hybrid Tensor-wise + Element-wise Sharding
+=======================================================================
+
+Designed for Muon optimizer compatibility:
+  - 2D (Muon) parameters: assigned as *whole tensors* to ranks (like V1).
+    This avoids the expensive sharding gather in Muon's _muon_update.
+  - Non-2D (AdamW) parameters: split element-wise via reduce-scatter (like V2).
+    This provides memory balancing across ranks.
+  - MoE expert parameters: also 2D (Muon), assigned as whole tensors but
+    using moe_sharding_group for communication instead of regular sharding_group.
+
+The key insight is that Muon requires the full 2D matrix for Newton-Schulz
+orthogonalisation, so keeping 2D params whole on each rank eliminates the
+need for gather_varlen communication during the optimizer step.
+"""
+
+import os
+import warnings
+from collections import defaultdict
+from functools import reduce as functools_reduce
+
+import paddle
+from paddle import framework
+from paddle.base.framework import EagerParamBase
+from paddle.distributed import fleet
+from paddle.distributed.communication.reduce import (
+    ReduceOp,
+    is_avg_reduce_op_supported,
+)
+from paddle.distributed.fleet.utils.muon_comm_utils import should_use_muon
+
+from ...utils import timer_helper as timer
+from ...utils.log_util import logger
+from ...utils.tensor_fusion_helper import (
+    HOOK_ACTION,
+    FusedCommBuffer,
+    assign_group_by_size,
+)
+
+
+def _is_trainable(param):
+    return not param.stop_gradient
+
+
+class DygraphShardingOptimizerV3:
+    """
+    Hybrid sharding optimizer for Muon:
+    - 2D (Muon) parameters: tensor-wise assignment to ranks (no cross-rank split).
+      Gradient communication uses reduce; parameter sync uses broadcast.
+    - Non-2D (AdamW) parameters: element-wise split across ranks (like V2).
+      Gradient communication uses reduce-scatter; parameter sync uses all-gather.
+    - MoE expert 2D parameters: tensor-wise assignment within moe_sharding_group.
+      Uses separate communication group (moe_sharding_group) for reduce/broadcast.
+
+    This avoids the expensive gather_varlen in Muon's _muon_update while
+    maintaining memory balance across ranks.
+    """
+
+    def __init__(self, optimizer, hcg):
+        logger.info("init DygraphShardingOptimizerV3")
+
+        if isinstance(optimizer._parameter_list[0], dict):
+            raise TypeError(
+                "Do not support param_groups now, please set optimizer._parameter_list as a list of Parameter"
+            )
+        if not hasattr(optimizer, '_apply_optimize') or not callable(
+            optimizer._apply_optimize
+        ):
+            raise ValueError(
+                "the optimizer object should have _apply_optimize function"
+            )
+
+        self._inner_opt = optimizer
+        self._hcg = hcg
+        self._sharding_world_size = self._hcg.get_sharding_parallel_world_size()
+        self._sharding_rank = self._hcg.get_sharding_parallel_rank()
+
+        strategy = fleet.fleet._user_defined_strategy
+        sharding_configs = strategy.hybrid_configs['sharding_configs']
+
+        self.tensor_fusion = sharding_configs.tensor_fusion
+        self.accumulate_steps = sharding_configs.accumulate_steps
+        self.comm_overlap = sharding_configs.comm_overlap
+        self.comm_buffer_size_MB = sharding_configs.comm_buffer_size_MB
+        self.use_reduce_avg = sharding_configs.use_reduce_avg
+
+        if self.use_reduce_avg and (not is_avg_reduce_op_supported()):
+            self.use_reduce_avg = False
+            warnings.warn(
+                "nccl reduce_avg requires paddle compiled with cuda and nccl>=2.10.0, "
+                "please check compilation setups."
+            )
+
+        pp_overlap = strategy.hybrid_configs['pp_configs'].sharding_comm_overlap
+        self.pp_overlap = pp_overlap
+
+        self._use_main_grad = hasattr(optimizer._parameter_list[0], "main_grad")
+
+        # The full original parameter list
+        self._parameter_list = list(optimizer._parameter_list)
+        self._origin_parameter_list = list(optimizer._parameter_list)
+
+        # MoE sharding group info
+        self._moe_sharding_group = None
+        self._moe_sharding_world_size = 0
+        self._moe_sharding_rank = 0
+        if hasattr(hcg, "get_moe_sharding_parallel_world_size"):
+            self._moe_sharding_world_size = (
+                hcg.get_moe_sharding_parallel_world_size()
+            )
+            if self._moe_sharding_world_size > 0:
+                self._moe_sharding_group = hcg.get_moe_sharding_parallel_group()
+                self._moe_sharding_rank = self._moe_sharding_group.rank
+
+        # ---- Step 1: Separate params into categories ----
+        # - _params_2d:      Non-MoE 2D (Muon) params → whole tensor, sharding_group
+        # - _params_2d_moe:  MoE expert params (2D or 3D fused) → whole tensor, moe_sharding_group
+        #                    3D fused experts [n_experts, H, I] are split into per-expert
+        #                    2D slices at optimizer step time for individual Muon update.
+        # - _params_1d:      Non-MoE non-2D (AdamW) params → element-wise split via FusedCommBuffer
+        self._params_2d = []
+        self._params_2d_moe = []
+        self._params_1d = []
+
+        for p in self._parameter_list:
+            if not _is_trainable(p):
+                continue
+            color = getattr(p, 'color', -1)
+            if isinstance(color, dict):
+                color_val = color.get('color', -1)
+            else:
+                color_val = color
+
+            if color_val == 'moe_expert':
+                # All MoE expert params go to _params_2d_moe (whole tensor path).
+                # - 2D experts: Muon updates directly.
+                # - 3D fused experts [n_experts, H, I]: each expert's 2D slice
+                #   is updated individually by Muon in step().
+                self._params_2d_moe.append(p)
+            elif should_use_muon(p.name, p.shape):
+                self._params_2d.append(p)
+            else:
+                self._params_1d.append(p)
+
+        # ---- Step 2a: Greedy assign non-MoE 2D params to sharding ranks ----
+        self._rank2params_2d = self._partition_2d_parameters(
+            self._params_2d, self._sharding_world_size, label="non-MoE"
+        )
+        self._param2rank_2d = {}
+        for rank, params in self._rank2params_2d.items():
+            for p in params:
+                self._param2rank_2d[p.name] = rank
+
+        # ---- Step 2b: Partition MoE expert 2D params within moe_sharding_group ----
+        self._rank2params_2d_moe = {}
+        self._param2rank_2d_moe = {}
+        if self._params_2d_moe:
+            if self._moe_sharding_world_size > 1:
+                # Need to partition MoE expert params across moe_sharding ranks
+                self._rank2params_2d_moe = self._partition_2d_parameters(
+                    self._params_2d_moe,
+                    self._moe_sharding_world_size,
+                    label="MoE",
+                )
+            else:
+                # moe_sharding_degree=1: each rank owns all its local experts, no partition needed
+                # All MoE expert params stay on rank 0 (the only rank in moe_sharding_group)
+                self._rank2params_2d_moe = {0: list(self._params_2d_moe)}
+            for rank, params in self._rank2params_2d_moe.items():
+                for p in params:
+                    self._param2rank_2d_moe[p.name] = rank
+
+            # Assert: when moe_sharding_degree > 1, expert count must be divisible
+            if self._moe_sharding_world_size > 1:
+                n_experts_local = len(self._params_2d_moe)
+                assert n_experts_local % self._moe_sharding_world_size == 0, (
+                    f"Number of local MoE expert params ({n_experts_local}) must be "
+                    f"divisible by moe_sharding_degree ({self._moe_sharding_world_size}). "
+                    f"Please adjust expert_model_parallel_size or moe_sharding_degree."
+                )
+
+        # ---- Step 3: Build comm buffers for 1D params (V2-style) ----
+        self._slice_params = {}
+        self._comm_buffer_list = []
+        self._local_parameter_list_1d = [
+            self._create_slice_param(p) for p in self._params_1d
+        ]
+
+        self.param2bucket = {}
+        self.sd_release_grads = (
+            strategy.hybrid_configs['pp_configs'].release_gradients
+            or sharding_configs.release_gradients
+        )
+        self._build_1d_comm_buffers()
+
+        # ---- Step 4: Build the optimizer's parameter list ----
+        # The optimizer should see:
+        #   - Non-MoE 2D params assigned to this rank (as whole tensors)
+        #   - MoE expert 2D params assigned to this rank in moe_sharding_group
+        #   - 1D slice_params for all non-2D params (element-wise shards)
+        local_2d_params = list(
+            self._rank2params_2d.get(self._sharding_rank, [])
+        )
+
+        if self._moe_sharding_world_size > 1:
+            local_2d_moe_params = list(
+                self._rank2params_2d_moe.get(self._moe_sharding_rank, [])
+            )
+        else:
+            # moe_sharding_degree=1: this rank owns all its MoE expert params
+            local_2d_moe_params = list(self._rank2params_2d_moe.get(0, []))
+
+        local_opt_params = (
+            local_2d_params
+            + local_2d_moe_params
+            + list(self._local_parameter_list_1d)
+        )
+
+        self._set_inner_opt_attr('_parameter_list', local_opt_params)
+        self._set_inner_opt_attr('_param_groups', local_opt_params)
+
+        # For external iteration (clear_grad, etc.), expose all params
+        self._local_parameter_list = local_opt_params
+
+        self._enable_timer = strategy.hybrid_configs.get(
+            "enable_optimizer_timer", False
+        )
+        if self._enable_timer:
+            if not timer.is_timer_initialized():
+                timer.set_timers()
+            self.timers = timer.get_timers()
+
+        logger.info(
+            f"ShardingV3: rank={self._sharding_rank}, "
+            f"non-MoE 2D on this rank={len(local_2d_params)}, "
+            f"MoE 2D on this rank={len(local_2d_moe_params)}, "
+            f"1D slice params={len(self._local_parameter_list_1d)}, "
+            f"total non-MoE 2D={len(self._params_2d)}, "
+            f"total MoE 2D={len(self._params_2d_moe)}, "
+            f"total 1D={len(self._params_1d)}, "
+            f"moe_sharding_degree={self._moe_sharding_world_size}"
+        )
+
+        # --- [VERIFY] Print group info for each category ---
+        _sg = hcg.get_sharding_parallel_group()
+        logger.info(
+            f"[V3-init rank={self._sharding_rank}] "
+            f"sharding_group: ranks={_sg.ranks} nranks={_sg.nranks}"
+        )
+        if self._moe_sharding_group is not None:
+            logger.info(
+                f"[V3-init rank={self._sharding_rank}] "
+                f"moe_sharding_group: ranks={self._moe_sharding_group.ranks} "
+                f"nranks={self._moe_sharding_group.nranks}"
+            )
+
+        # --- [VERIFY] Print param categorization: name, shape, category, group ---
+        # Non-MoE 2D params (Muon, sharding_group)
+        logger.info(
+            f"[V3-init rank={self._sharding_rank}] "
+            f"CATEGORY non_moe_2d (Muon, sharding_group nranks={_sg.nranks}): "
+            f"total={len(self._params_2d)}"
+        )
+        for _p in self._params_2d[:5]:
+            logger.info(
+                f"[V3-init rank={self._sharding_rank}]   non_moe_2d: "
+                f"name={_p.name!r} shape={list(_p.shape)} "
+                f"should_muon={should_use_muon(_p.name, _p.shape)} "
+                f"owner_rank={self._param2rank_2d.get(_p.name, -1)}"
+            )
+
+        # MoE 2D params (Muon, moe_sharding_group)
+        _moe_sg_nranks = (
+            self._moe_sharding_group.nranks if self._moe_sharding_group else 0
+        )
+        logger.info(
+            f"[V3-init rank={self._sharding_rank}] "
+            f"CATEGORY moe_2d (Muon, moe_sharding_group nranks={_moe_sg_nranks}): "
+            f"total={len(self._params_2d_moe)}"
+        )
+        for _p in self._params_2d_moe[:3]:
+            logger.info(
+                f"[V3-init rank={self._sharding_rank}]   moe_2d: "
+                f"name={_p.name!r} shape={list(_p.shape)} "
+                f"should_muon={should_use_muon(_p.name, _p.shape)} "
+                f"no_sync={getattr(_p, 'no_sync', None)} "
+                f"owner_rank={self._param2rank_2d_moe.get(_p.name, -1)}"
+            )
+
+        # 1D params (AdamW, sharding_group via FusedCommBuffer)
+        logger.info(
+            f"[V3-init rank={self._sharding_rank}] "
+            f"CATEGORY 1d_adamw (AdamW, sharding_group reduce-scatter): "
+            f"total={len(self._params_1d)}"
+        )
+        for _p in self._params_1d[:5]:
+            _color = getattr(_p, 'color', None)
+            _color_group = (
+                _color.get('group', None) if isinstance(_color, dict) else None
+            )
+            _cg_nranks = (
+                _color_group.nranks if _color_group is not None else _sg.nranks
+            )
+            logger.info(
+                f"[V3-init rank={self._sharding_rank}]   1d_adamw: "
+                f"name={_p.name!r} shape={list(_p.shape)} "
+                f"should_muon={should_use_muon(_p.name, _p.shape)} "
+                f"color={getattr(_p, 'color', None)} "
+                f"comm_group_nranks={_cg_nranks}"
+            )
+
+        # --- [SLICE SIZE SUMMARY] Per-rank slice param sizes within this PP stage ---
+        import math as _math
+
+        _sg_group = hcg.get_sharding_parallel_group()
+        _N = self._sharding_world_size
+
+        # 2D (non-MoE) params owned by this rank
+        _local_2d_numel = sum(
+            int(functools_reduce(lambda x, y: x * y, p.shape, 1))
+            for p in self._rank2params_2d.get(self._sharding_rank, [])
+        )
+        # 2D (MoE) params owned by this rank
+        _moe_rank_key = (
+            self._moe_sharding_rank if self._moe_sharding_world_size > 1 else 0
+        )
+        _local_2d_moe_numel = sum(
+            int(functools_reduce(lambda x, y: x * y, p.shape, 1))
+            for p in self._rank2params_2d_moe.get(_moe_rank_key, [])
+        )
+        # 1D (AdamW) slice: each rank owns ceil(param.numel / world_size) elements per param.
+        # Sum over all 1D params in this sharding group (same color).
+        _local_1d_numel = sum(
+            _math.ceil(
+                int(functools_reduce(lambda x, y: x * y, p.shape, 1)) / _N
+            )
+            for p in self._params_1d
+        )
+
+        _local_total_numel = (
+            _local_2d_numel + _local_2d_moe_numel + _local_1d_numel
+        )
+        _local_total_MB = (
+            _local_total_numel * 2 / (1024 * 1024)
+        )  # bf16/fp16 = 2 bytes
+
+        # All-gather total numel from all sharding ranks in this PP stage
+        _local_numel_tensor = paddle.to_tensor(
+            [_local_total_numel], dtype='int64'
+        )
+        _all_numel_list = []
+        paddle.distributed.all_gather(
+            _all_numel_list, _local_numel_tensor, group=_sg_group
+        )
+        _all_numel = [int(t.item()) for t in _all_numel_list]
+        _all_MB = [n * 2 / (1024 * 1024) for n in _all_numel]
+
+        _max_MB = max(_all_MB)
+        _min_MB = min(_all_MB)
+        _imbalance = (_max_MB - _min_MB) / _max_MB if _max_MB > 0 else 0.0
+
+        if self._sharding_rank == 0:
+            logger.info(
+                f"[ShardingV3 SliceSize] PP-stage sharding_group ranks={_sg_group.ranks} | "
+                f"per-rank MB: {[f'{mb:.1f}' for mb in _all_MB]} | "
+                f"max memory diff={_imbalance * 100:.2f}%"
+            )
+
+    # ------------------------------------------------------------------
+    # 2D partition (V1-style greedy)
+    # ------------------------------------------------------------------
+
+    def _partition_2d_parameters(self, params, world_size, label=""):
+        """Partition 2D parameters among ranks using greedy bin-packing."""
+        mapping = {}
+        for rank in range(world_size):
+            mapping[rank] = []
+        sizes = [0] * world_size
+
+        parameters = list(params)
+        parameters.sort(
+            key=lambda p: functools_reduce(lambda x, y: x * y, p.shape),
+            reverse=True,
+        )
+
+        for param in parameters:
+            rank = sizes.index(min(sizes))
+            mapping[rank].append(param)
+            numel = functools_reduce(lambda x, y: x * y, param.shape, 1)
+            sizes[rank] += numel
+
+        for r in range(world_size):
+            logger.info(
+                f"ShardingV3 {label} 2D partition: rank {r} -> {len(mapping[r])} params, "
+                f"{sizes[r]:,} elements"
+            )
+
+        return mapping
+
+    # ------------------------------------------------------------------
+    # 1D slice creation (V2-style)
+    # ------------------------------------------------------------------
+
+    def _create_slice_param(self, param):
+        """Create a placeholder slice parameter for 1D (element-wise) sharding."""
+        slice_param = EagerParamBase(shape=[1], dtype=param.dtype)
+        slice_param.name = param.name
+
+        def copy_attr(attr_name):
+            if hasattr(param, attr_name):
+                setattr(slice_param, attr_name, getattr(param, attr_name))
+
+        copy_attr("is_distributed")
+        copy_attr("optimize_attr")
+        copy_attr("do_model_average")
+        copy_attr("need_clip")
+        copy_attr("no_sync")
+
+        self._slice_params[param.name] = slice_param
+        return slice_param
+
+    def _build_1d_comm_buffers(self):
+        """Build communication buffers for 1D (AdamW) parameters using reduce-scatter."""
+        if self.pp_overlap:
+            return
+
+        comm_group = self._hcg.get_sharding_parallel_group()
+        group_size = (
+            self.comm_buffer_size_MB * 1024 * 1024
+            if self.comm_buffer_size_MB > 0
+            else 256 * 1024 * 1024
+        )
+
+        # Group 1D params by color (for MoE compatibility)
+        color_dict = defaultdict(list)
+        for param in self._params_1d:
+            color = getattr(param, 'color', -1)
+            color_group = comm_group
+            if isinstance(color, dict):
+                color_color = color.get('color', -1)
+                color_group = color.get('group', comm_group)
+            else:
+                color_color = color
+            color_dict[(color_color, color_group)].append(param)
+
+        if not self.comm_overlap:
+            for color, params in color_dict.items():
+                params.sort(key=lambda x: str(x.dtype))
+
+        group_idx = 0
+        for color, params in color_dict.items():
+            g_color = color[0]
+            g_group = color[1]
+            logger.info(
+                f"ShardingV3 1D Buffer: Color {g_color}, Group {g_group}"
+            )
+            # --- [VERIFY] Log which group each 1D buffer uses ---
+            logger.info(
+                f"[V3-1d-buffer rank={self._sharding_rank}] "
+                f"color={g_color!r} group_ranks={g_group.ranks} "
+                f"group_nranks={g_group.nranks} param_count={len(params)} "
+                f"sample_names={[p.name for p in params[:3]]}"
+            )
+            var_groups = assign_group_by_size(params, group_size)
+            for _, parameters in var_groups.items():
+                buffer = FusedCommBuffer(
+                    group_idx,
+                    parameters,
+                    g_group,
+                    self.accumulate_steps,
+                    act=HOOK_ACTION.REDUCE_SCATTER,
+                    release_grads=self.sd_release_grads,
+                    use_reduce_avg=self.use_reduce_avg,
+                    free_grads_in_comm=False,
+                    init_slice_param=False,
+                    slice_params=self._slice_params,
+                )
+                group_idx += 1
+                self._comm_buffer_list.append(buffer)
+
+                for p in parameters:
+                    if p.name in self.param2bucket:
+                        self.param2bucket[p.name].append(buffer)
+                    else:
+                        self.param2bucket[p.name] = [buffer]
+
+        self._comm_buffer_list.sort(key=lambda x: x._dst)
+
+    # ------------------------------------------------------------------
+    # Gradient communication
+    # ------------------------------------------------------------------
+
+    def _get_param_grad(self, param):
+        if not param.trainable:
+            return None
+        if hasattr(param, "main_grad"):
+            assert param._grad_ivar() is None, (
+                "param.grad should be None when using main_grad"
+            )
+            return param.main_grad
+        return param._grad_ivar()
+
+    def _reduce_2d_grads(self, params, param2rank, comm_group):
+        """Reduce gradients for 2D params to their owner rank within comm_group."""
+        for param in params:
+            g_var = self._get_param_grad(param)
+            if g_var is None:
+                if hasattr(param, "main_grad"):
+                    g_var = paddle.zeros_like(param, dtype=paddle.float32)
+                    param.main_grad = g_var
+                else:
+                    g_var = paddle.zeros_like(param, dtype=param.dtype)
+                    param.grad = g_var
+
+            reduce_op = ReduceOp.AVG
+            if not self.use_reduce_avg:
+                nranks = comm_group.nranks
+                g_var.scale_(1.0 / nranks)
+                reduce_op = ReduceOp.SUM
+
+            if paddle.distributed.in_auto_parallel_align_mode():
+                reduce_op = ReduceOp.SUM
+
+            param_rank = param2rank[param.name]
+            paddle.distributed.reduce(
+                g_var,
+                dst=comm_group.ranks[param_rank],
+                op=reduce_op,
+                group=comm_group,
+                sync_op=True,
+            )
+
+    def reduce_gradients(self, parameter_list, hcg):
+        """Reduce gradients: reduce for 2D params, reduce-scatter for 1D params."""
+        logger.debug("ShardingV3: start gradient sync")
+
+        if (
+            paddle.is_compiled_with_xpu()
+            and os.getenv("XPU_CDNN_CLUSTER_PARALLEL") is not None
+        ):
+            paddle.device.synchronize()
+
+        with framework.no_grad():
+            # --- Non-MoE 2D params: reduce to owner rank via sharding_group ---
+            sharding_group = hcg.get_sharding_parallel_group()
+            self._reduce_2d_grads(
+                self._params_2d, self._param2rank_2d, sharding_group
+            )
+
+            # --- MoE expert 2D params: reduce to owner rank via moe_sharding_group ---
+            if self._params_2d_moe and self._moe_sharding_group is not None:
+                if self._moe_sharding_world_size > 1:
+                    self._reduce_2d_grads(
+                        self._params_2d_moe,
+                        self._param2rank_2d_moe,
+                        self._moe_sharding_group,
+                    )
+                # When moe_sharding_degree=1, no reduce needed (single rank group)
+
+            # --- 1D params: reduce-scatter via comm buffers ---
+            for comm_buffer in self._comm_buffer_list:
+                if self.sd_release_grads and comm_buffer.grad_storage is None:
+                    if comm_buffer.need_reduce_scale_sync():
+                        for param in comm_buffer.params:
+                            comm_buffer._copy_grad_to_buffer(param)
+
+                if not self.comm_overlap:
+                    comm_buffer._comm_grads()
+                comm_buffer.scale_grads()
+
+    def filter_parameters(self, parameter_list, hcg):
+        """Filter parameters: return local 2D params + initialized 1D slices."""
+        sharding_rank = hcg.get_sharding_parallel_rank()
+        local_2d = [
+            p
+            for p in parameter_list
+            if p.name in self._param2rank_2d
+            and self._param2rank_2d[p.name] == sharding_rank
+        ]
+        # Also include MoE 2D params owned by this rank
+        if self._moe_sharding_world_size > 1:
+            moe_rank = self._moe_sharding_rank
+        else:
+            moe_rank = 0
+        local_2d_moe = [
+            p
+            for p in parameter_list
+            if p.name in self._param2rank_2d_moe
+            and self._param2rank_2d_moe[p.name] == moe_rank
+        ]
+        local_1d = [
+            self._slice_params[p.name]
+            for p in parameter_list
+            if p.name in self._slice_params
+        ]
+        local_1d = [p for p in local_1d if p._is_initialized()]
+        return local_2d + local_2d_moe + local_1d
+
+    # ------------------------------------------------------------------
+    # Parameter sync after optimizer step
+    # ------------------------------------------------------------------
+
+    def _broadcast_2d_params(self, rank2params, comm_group):
+        """Broadcast 2D params from owner ranks within comm_group."""
+        broadcast_tasks = []
+        for rank, params in rank2params.items():
+            src_rank = comm_group.ranks[rank]
+            for param in params:
+                if param.stop_gradient:
+                    continue
+                task = paddle.distributed.broadcast(
+                    param,
+                    src=src_rank,
+                    group=comm_group,
+                    sync_op=False,
+                )
+                broadcast_tasks.append(task)
+        return broadcast_tasks
+
+    def _sharding_sync_parameters(self):
+        """Sync parameters: broadcast 2D, all-gather 1D."""
+        logger.debug("ShardingV3: start parameter sync")
+        comm_group = self._hcg.get_sharding_parallel_group()
+
+        with framework.no_grad():
+            all_tasks = []
+
+            # --- Non-MoE 2D params: broadcast from owner via sharding_group ---
+            all_tasks.extend(
+                self._broadcast_2d_params(self._rank2params_2d, comm_group)
+            )
+
+            # --- MoE expert 2D params: broadcast from owner via moe_sharding_group ---
+            if self._params_2d_moe and self._moe_sharding_group is not None:
+                if self._moe_sharding_world_size > 1:
+                    all_tasks.extend(
+                        self._broadcast_2d_params(
+                            self._rank2params_2d_moe, self._moe_sharding_group
+                        )
+                    )
+                # When moe_sharding_degree=1, no broadcast needed (single rank group)
+
+            for task in all_tasks:
+                task.wait()
+
+            # --- 1D params: all-gather via comm buffers ---
+            for comm_buffer in self._comm_buffer_list:
+                comm_buffer.sync_params()
+
+    # ------------------------------------------------------------------
+    # Clear gradients
+    # ------------------------------------------------------------------
+
+    def clear_grad(self, set_to_zero=True):
+        """Clear gradients for all parameters."""
+        # Clear 2D param grads (non-MoE + MoE)
+        all_2d_params = list(self._params_2d) + list(self._params_2d_moe)
+        for p in all_2d_params:
+            if hasattr(p, "main_grad") and p.main_grad is not None:
+                assert p._grad_ivar() is None
+                if set_to_zero:
+                    p.main_grad.zero_()
+                else:
+                    p.main_grad._clear()
+                    p.main_grad = None
+            elif not hasattr(p, "main_grad"):
+                p.clear_gradient(set_to_zero)
+
+        # 1D params are managed by comm buffers
+        if self.sd_release_grads and not self.pp_overlap:
+            for comm_buffer in self._comm_buffer_list:
+                if comm_buffer.need_reduce_scale_sync():
+                    comm_buffer._clear_grad_storage()
+
+    # ------------------------------------------------------------------
+    # Optimizer step
+    # ------------------------------------------------------------------
+
+    def _collect_comm_buffers(self):
+        """Collect communication buffers (for PP overlap compatibility)."""
+        if self._comm_buffer_list:
+            return
+        for param in self._params_1d:
+            if not hasattr(param, "comm_buffer_ref"):
+                continue
+            comm_buffer_ref = param.comm_buffer_ref
+            del param.comm_buffer_ref
+            comm_buffer = comm_buffer_ref()
+            self._comm_buffer_list.append(comm_buffer)
+
+        for bucket in self._comm_buffer_list:
+            for p in bucket._params:
+                if p.name in self.param2bucket:
+                    self.param2bucket[p.name].append(bucket)
+                else:
+                    self.param2bucket[p.name] = [bucket]
+
+    def _assign_slice_grad(self):
+        """Assign gradients from comm buffers to slice params for 1D params."""
+        for comm_buffer in self._comm_buffer_list:
+            for param in comm_buffer.params:
+                if param.name in self._slice_params:
+                    slice_param = self._slice_params[param.name]
+                    if self.sd_release_grads and hasattr(
+                        slice_param, "main_grad"
+                    ):
+                        if not slice_param.main_grad._is_initialized():
+                            del slice_param.main_grad
+                    comm_buffer.assign_slice_grad(param, slice_param)
+
+    def step(self):
+        """Optimizer step: update local 2D params and 1D slices, then sync."""
+        self._collect_comm_buffers()
+        self._assign_slice_grad()
+
+        if not isinstance(self._origin_parameter_list[0], dict):
+            params_grads = []
+
+            # --- Non-MoE 2D params on this rank: full tensors ---
+            local_2d = self._rank2params_2d.get(self._sharding_rank, [])
+            for param in local_2d:
+                if param.stop_gradient:
+                    continue
+                grad_var = param._grad_ivar()
+                if hasattr(param, "main_grad") and param.main_grad is not None:
+                    grad_var = param.main_grad
+                if grad_var is not None:
+                    params_grads.append((param, grad_var))
+
+            # --- MoE expert params on this rank ---
+            # Pass the original param (2D or 3D) directly to the optimizer.
+            # _muon_update already handles both shapes:
+            #   - 2D [H, I]: standard Newton-Schulz
+            #   - 3D [n_experts, H, I]: per-expert Newton-Schulz loop (Step 4)
+            # Keeping the original name avoids registering _expert_N accumulator
+            # keys that are absent from model_sharded_state_dict, which would
+            # break sharded_state_dict (checkpoint save).
+            #
+            # NOTE: MoEHybridParallelClipGrad._dygraph_clip has `assert 0` for
+            # params with is_moe_param=True.  Temporarily clear is_moe_param so
+            # clip skips the assert and routes via the no_sync/is_distributed
+            # branch instead.  We restore the attribute after _apply_optimize.
+            if self._moe_sharding_world_size > 1:
+                local_2d_moe = self._rank2params_2d_moe.get(
+                    self._moe_sharding_rank, []
+                )
+            else:
+                local_2d_moe = self._rank2params_2d_moe.get(0, [])
+            moe_params_to_restore = []  # params that had is_moe_param=True
+            for param in local_2d_moe:
+                if param.stop_gradient:
+                    continue
+                grad_var = param._grad_ivar()
+                if hasattr(param, "main_grad") and param.main_grad is not None:
+                    grad_var = param.main_grad
+                if grad_var is None:
+                    continue
+                if getattr(param, "is_moe_param", False):
+                    param.is_moe_param = False
+                    moe_params_to_restore.append(param)
+                params_grads.append((param, grad_var))
+
+            # --- 1D params: slice params (element-wise shards) ---
+            for param in self._params_1d:
+                if param.stop_gradient:
+                    continue
+                if param.name not in self._slice_params:
+                    continue
+                slice_p = self._slice_params[param.name]
+                grad_var = slice_p._grad_ivar()
+                if (
+                    hasattr(slice_p, "main_grad")
+                    and slice_p.main_grad is not None
+                ):
+                    grad_var = slice_p.main_grad
+                if grad_var is not None:
+                    params_grads.append((slice_p, grad_var))
+
+            self._apply_optimize(
+                loss=None,
+                startup_program=None,
+                params_grads=params_grads,
+            )
+
+            # Restore is_moe_param on MoE params after optimizer step.
+            for _p in moe_params_to_restore:
+                _p.is_moe_param = True
+
+        # Sync parameters across sharding ranks
+        self._sharding_sync_parameters()
+
+    # ------------------------------------------------------------------
+    # State dict (checkpoint save/load)
+    # ------------------------------------------------------------------
+
+    @framework.dygraph_only
+    def set_state_dict(self, state_dict):
+        inner_state = {}
+        # Local parameters = local 2D + local MoE 2D + 1D slice params
+        local_2d = list(self._rank2params_2d.get(self._sharding_rank, []))
+        if self._moe_sharding_world_size > 1:
+            local_2d_moe = list(
+                self._rank2params_2d_moe.get(self._moe_sharding_rank, [])
+            )
+        else:
+            local_2d_moe = list(self._rank2params_2d_moe.get(0, []))
+        parameters = local_2d + local_2d_moe
+        # Add 1D params (use original param names for matching)
+        for p in self._params_1d:
+            parameters.append(p)
+
+        if "LR_Scheduler" in state_dict:
+            inner_state["LR_Scheduler"] = state_dict.pop("LR_Scheduler")
+
+        if "master_weights" in state_dict:
+            master = state_dict.pop("master_weights")
+            inner_state["master_weights"] = {}
+            for p in parameters:
+                for k, v in master.items():
+                    if p.name == k:
+                        v.name = self._inner_opt._gen_master_weight_var_name(p)
+                        inner_state["master_weights"][k] = v
+
+        for p in parameters:
+            for k, v in state_dict.items():
+                if p.name in k:
+                    inner_state[k] = v
+
+        self._inner_opt.set_state_dict(inner_state)
+
+    # ------------------------------------------------------------------
+    # Utility
+    # ------------------------------------------------------------------
+
+    def _set_inner_opt_attr(self, attr_name, value):
+        inner_opt = self._inner_opt
+        inner_opt_name = '_inner_opt'
+        if not isinstance(attr_name, str):
+            raise TypeError(
+                f"attr_name should be str type, but is {type(attr_name)}"
+            )
+        while hasattr(inner_opt, attr_name):
+            setattr(inner_opt, attr_name, value)
+            inner_opt = getattr(inner_opt, inner_opt_name, None)
+            if inner_opt is None:
+                break
+
+    def sharded_state_dict(self, model_sharded_state_dict):
+        """Build a sharded optimizer state dict for flex checkpoint save/load.
+
+        Overrides the inner Muon optimizer's sharded_state_dict to handle V3's
+        hybrid sharding scheme:
+          - 2D Muon params (non-MoE and MoE): whole tensor, shape matches
+            model's local_shape. Handled by delegating to the inner Muon's
+            sharded_state_dict after filtering out 1D param states.
+          - 1D AdamW params: accumulators are 1D shards (from reduce-scatter);
+            wrapped with is_flattened=True + flattened_range, like V2.
+        """
+        import paddle as _paddle
+        from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
+            ShardedWeight,
+            create_sharded_weight_with_new_local,
+        )
+
+        # ---- Step 1: Collect flattened_range for each 1D (AdamW) param ----
+        # Identical logic to DygraphShardingOptimizerV2.sharded_state_dict.
+        param_slice_info = {}  # param_name -> slice(begin, end)
+        padded_param = set()
+        for buffer in self._comm_buffer_list:
+            for (
+                param_name,
+                grad_view,
+            ) in buffer._sharding_param_grad_view.items():
+                numel = grad_view._param.numel().item()
+                param_begin = grad_view._param_begin
+                param_end = grad_view._param_end
+                index = grad_view._index
+                padding_begin = index + numel
+                flattened_range = slice(
+                    param_begin - index,
+                    max(
+                        min(padding_begin - index, param_end - index),
+                        param_begin - index,
+                    ),
+                )
+                if param_end > padding_begin:
+                    padded_param.add(param_name)
+                param_slice_info[param_name] = flattened_range
+
+        # ---- Step 2: Build static_name → struct_name mapping ----
+        model_sharded_sorted = dict(sorted(model_sharded_state_dict.items()))
+        static_to_struct = {}
+        for struct_name, sw in model_sharded_sorted.items():
+            if sw.local_tensor.name not in static_to_struct:
+                static_to_struct[sw.local_tensor.name] = struct_name
+
+        # ---- Step 3: Process all optimizer states ----
+        _FP32_MASTER = "fp32_master_0"
+        _optimizer_scalar_names = ["beta1_pow_acc_0", "beta2_pow_acc_0"]
+        _optimizer_vector_names = ["moment1_0", "moment2_0"]
+
+        def _split_state_name(vname):
+            if _FP32_MASTER in vname:
+                return tuple(vname.split("_" + _FP32_MASTER + "_", 1))
+            for suffix in _optimizer_scalar_names + _optimizer_vector_names:
+                if vname.endswith(suffix):
+                    return vname[: -(len(suffix) + 1)], suffix
+            raise ValueError(
+                f"Cannot parse optimizer state variable name: {vname!r}"
+            )
+
+        optimizer_state_dict = self._inner_opt.state_dict()
+        master_weights = optimizer_state_dict.pop("master_weights", None)
+        optimizer_state_dict.pop("LR_Scheduler", None)
+
+        sharded_state = {}
+
+        for key, tensor in optimizer_state_dict.items():
+            static_name, state_type = _split_state_name(key)
+            if static_name not in static_to_struct:
+                logger.error(
+                    f"[V3-sharded_state_dict] KeyError: static_name={static_name!r} "
+                    f"not found in model_sharded_state_dict."
+                )
+                continue
+
+            struct_name = static_to_struct[static_name]
+            sharded_param = model_sharded_sorted[struct_name]
+            unified_name = f"{struct_name}.{state_type}"
+
+            is_1d_param = static_name in param_slice_info
+
+            if state_type in _optimizer_vector_names:
+                if is_1d_param:
+                    # 1D AdamW shard: wrap with is_flattened=True (like V2)
+                    flattened_range = param_slice_info[static_name]
+                    if flattened_range.stop - flattened_range.start == 0:
+                        continue
+                    is_padded = static_name in padded_param
+                    if is_padded:
+                        local_tensor = _paddle.slice(
+                            tensor,
+                            axes=[0],
+                            starts=[0],
+                            ends=[flattened_range.stop - flattened_range.start],
+                        )
+                    else:
+                        local_tensor = tensor
+                    sharded_state[unified_name] = ShardedWeight(
+                        key=unified_name,
+                        local_tensor=local_tensor,
+                        local_shape=sharded_param.local_shape,
+                        global_shape=sharded_param.global_shape,
+                        global_offset=sharded_param.global_offset,
+                        is_flattened=True,
+                        flattened_range=flattened_range,
+                    )
+                elif tensor.is_dist():
+                    sharded_state[unified_name] = ShardedWeight(
+                        key=unified_name,
+                        local_tensor=tensor,
+                        local_shape=tensor.shape,
+                        global_shape=tensor.shape,
+                        global_offset=sharded_param.global_offset,
+                    )
+                else:
+                    # 2D Muon param (non-MoE or MoE): shape may differ between
+                    # Python param.shape (3D view) and model storage (2D).
+                    # Reshape if numel matches but shape doesn't.
+                    target_shape = sharded_param.local_shape
+                    if (
+                        tuple(tensor.shape) != tuple(target_shape)
+                        and tensor.numel()
+                        == _paddle.to_tensor(list(target_shape)).prod().item()
+                    ):
+                        tensor = tensor.reshape(target_shape)
+                    sharded_state[unified_name] = (
+                        create_sharded_weight_with_new_local(
+                            unified_name, tensor, sharded_param
+                        )
+                    )
+            else:
+                # Scalar states (beta_pow): replicated
+                sharded_state[unified_name] = ShardedWeight(
+                    key=unified_name,
+                    local_tensor=tensor,
+                    local_shape=(1,),
+                    global_shape=(1,),
+                    global_offset=(0,),
+                )
+
+        # FP32 master weights
+        if master_weights:
+            for weight_key, tensor in master_weights.items():
+                if weight_key not in static_to_struct:
+                    continue
+                struct_name = static_to_struct[weight_key]
+                sharded_param = model_sharded_sorted[struct_name]
+                unified_name = f"{struct_name}.w_0"
+                is_1d_param = weight_key in param_slice_info
+
+                if is_1d_param:
+                    flattened_range = param_slice_info[weight_key]
+                    if flattened_range.stop - flattened_range.start == 0:
+                        continue
+                    is_padded = weight_key in padded_param
+                    if is_padded:
+                        local_tensor = _paddle.slice(
+                            tensor,
+                            axes=[0],
+                            starts=[0],
+                            ends=[flattened_range.stop - flattened_range.start],
+                        )
+                    else:
+                        local_tensor = tensor
+                    sharded_state[unified_name] = ShardedWeight(
+                        key=unified_name,
+                        local_tensor=local_tensor,
+                        local_shape=sharded_param.local_shape,
+                        global_shape=sharded_param.global_shape,
+                        global_offset=sharded_param.global_offset,
+                        is_flattened=True,
+                        flattened_range=flattened_range,
+                    )
+                elif tensor.is_dist():
+                    sharded_state[unified_name] = ShardedWeight(
+                        key=unified_name,
+                        local_tensor=tensor,
+                        local_shape=tensor.shape,
+                        global_shape=tensor.shape,
+                        global_offset=sharded_param.global_offset,
+                    )
+                else:
+                    # Same reshape logic as for optimizer vector states:
+                    # FP32 master weight may be 3D (e.g. grouped_gemm_experts
+                    # [n_experts, H, I]) while model storage is 2D [n_experts*H, I].
+                    target_shape = sharded_param.local_shape
+                    if (
+                        tuple(tensor.shape) != tuple(target_shape)
+                        and tensor.numel()
+                        == _paddle.to_tensor(list(target_shape)).prod().item()
+                    ):
+                        tensor = tensor.reshape(target_shape)
+                    sharded_state[unified_name] = (
+                        create_sharded_weight_with_new_local(
+                            unified_name, tensor, sharded_param
+                        )
+                    )
+
+        return sharded_state
+
+    def __getattr__(self, item):
+        return getattr(self._inner_opt, item)

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/hybrid_parallel_optimizer.py
@@ -23,6 +23,9 @@ from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.dygraph_sharding
     DygraphShardingOptimizer,
     DygraphShardingOptimizerV2,
 )
+from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.dygraph_sharding_optimizer_v3 import (
+    DygraphShardingOptimizerV3,
+)
 from paddle.distributed.fleet.utils.hybrid_parallel_util import (
     obtain_optimizer_parameters_list,
 )
@@ -284,11 +287,13 @@ class HybridParallelOptimizer:
             split_param = strategy.hybrid_configs[
                 'sharding_configs'
             ].split_param
-            ShardingOptimizer = (
-                DygraphShardingOptimizerV2
-                if split_param
-                else DygraphShardingOptimizer
-            )
+            use_sharding_v3 = os.environ.get("FLAGS_sharding_v3", "0") == "1"
+            if use_sharding_v3 and split_param:
+                ShardingOptimizer = DygraphShardingOptimizerV3
+            elif split_param:
+                ShardingOptimizer = DygraphShardingOptimizerV2
+            else:
+                ShardingOptimizer = DygraphShardingOptimizer
             optimizer = ShardingOptimizer(optimizer, hcg)
 
         self._enable_timer = strategy.hybrid_configs["enable_optimizer_timer"]
@@ -335,6 +340,7 @@ class HybridParallelOptimizer:
                     MixPrecisionOptimizer,
                     DygraphShardingOptimizer,
                     DygraphShardingOptimizerV2,
+                    DygraphShardingOptimizerV3,
                 ),
             )
 
@@ -628,7 +634,11 @@ class HybridParallelOptimizer:
         if self._sharding_enable:
             assert isinstance(
                 self._inner_opt,
-                (DygraphShardingOptimizer, DygraphShardingOptimizerV2),
+                (
+                    DygraphShardingOptimizer,
+                    DygraphShardingOptimizerV2,
+                    DygraphShardingOptimizerV3,
+                ),
             )
             self._inner_opt.reduce_gradients(parameter_list, self._hcg)
             dp_parameter_list = self._inner_opt.filter_parameters(

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/muon_sharding_annotations.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/muon_sharding_annotations.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Muon-specific parameter annotation utilities for DygraphShardingOptimizerV2.
+
+When the inner optimizer is Muon, each parameter slice needs to be annotated
+with metadata (original shape, sharding indices, etc.) so that `_muon_update`
+can correctly gather/scatter the full 2-D matrix across sharding ranks.
+"""
+
+import numpy as np
+
+from ...utils.muon_comm_utils import (
+    get_sharding_info,
+    should_use_muon,
+)
+
+
+def annotate_muon_params(param, original_p, hcg, param2bucket):
+    """Annotate a single parameter slice with Muon sharding metadata.
+
+    Args:
+        param: The local 1-D shard held by this rank.
+        original_p: The original (unsliced) parameter from the model.
+        hcg: The hybrid communicate group.
+        param2bucket: Mapping from param name to (FusedCommBuffer, ...).
+
+    Returns:
+        True if the param was annotated (and should be kept), False if it
+        should be skipped (uninitialised or sentinel).
+    """
+    if not should_use_muon(original_p.name, original_p.shape):
+        return True
+
+    # Skip uninitialised slices and shape-[1] sentinels.
+    if not param._is_initialized():
+        return False
+    if list(param.shape) == [1] and list(original_p.shape) != [1]:
+        return False
+
+    # Annotate whether this rank holds a partial shard or the full weight.
+    param.is_sharded_gather = int(param.numel()) < int(original_p.numel())
+    param.original_shape = original_p.shape
+    param.split_axis = getattr(original_p, "split_axis", None)
+    param.needs_qkv_split = getattr(original_p, "needs_qkv_split", False)
+    param.head_num = getattr(original_p, "head_num", 0)
+    param.kv_head_num = getattr(original_p, "kv_head_num", 0)
+    param.is_muon = True
+
+    # MoE experts use a dedicated expert-parallel sharding group.
+    if getattr(original_p, "no_sync", False):
+        sharding_group = hcg.get_moe_sharding_parallel_group()
+    else:
+        sharding_group = hcg.get_sharding_parallel_group()
+
+    sharding_rank = sharding_group.rank
+    if sharding_rank == -1:
+        sharding_rank = 0
+    sharding_world_size = sharding_group.nranks
+
+    if param.is_sharded_gather:
+        # Compute per-rank element counts for the variable-length gather.
+        target_buffer = param2bucket[param.name][0]
+        indices, my_offset = get_sharding_info(
+            target_buffer,
+            param.name,
+            sharding_world_size,
+            sharding_rank,
+        )
+        param.sharding_indices = indices
+        param.sharding_my_offset = my_offset
+
+    return True
+
+
+def sort_muon_params_grads(params_grads):
+    """Sort params_grads so that largest fully-owned params come first.
+
+    This improves GPU memory allocator locality by processing large contiguous
+    allocations before smaller fragmented ones.
+    """
+    params_grads.sort(
+        key=lambda x: (
+            getattr(x[0], "is_sharded_gather", False),
+            np.prod(getattr(x[0], "original_shape", []))
+            if getattr(x[0], "original_shape", None)
+            else 0,
+        ),
+        reverse=True,
+    )

--- a/python/paddle/distributed/fleet/utils/muon_comm_utils.py
+++ b/python/paddle/distributed/fleet/utils/muon_comm_utils.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import paddle.distributed as dist
+from paddle.distributed.communication.batch_isend_irecv import (
+    _coalescing_manager as batch_isend_irecv_coalescing_manager,
+)
+
+
+def gather_varlen(input, dst, group, all_shape_and_dtype):
+    """Gather variable-length tensors from all ranks to *dst*.
+
+    The destination rank pre-allocates a single contiguous buffer for all
+    incoming data to avoid memory fragmentation from intermediate concat.
+    Non-destination ranks send their local slice and return None.
+
+    Args:
+        input: Local tensor slice (may be None if this rank contributes nothing).
+        dst: Global rank of the destination.
+        group: The process group.
+        all_shape_and_dtype: List of (shape, dtype) tuples, one per rank.
+            shape is None (or shape[0] == 0) when a rank has no data.
+
+    Returns:
+        Concatenated 1-D tensor on the destination rank; None elsewhere.
+    """
+    tasks = []
+
+    if group.ranks[group.rank] == dst:
+        # Destination: allocate one contiguous buffer and receive all slices.
+        total_len = sum([s[0] for s, _ in all_shape_and_dtype if s is not None])
+        dtype = all_shape_and_dtype[0][1]
+        output_tensor = paddle.empty([total_len], dtype=dtype)
+
+        task_info_list = []
+        current_offset = 0
+
+        with batch_isend_irecv_coalescing_manager(group, tasks):
+            for src in range(group.nranks):
+                shape = all_shape_and_dtype[src][0]
+                if shape is None or shape[0] == 0:
+                    continue
+                length = shape[0]
+                if src != group.rank:
+                    recv_tensor = paddle.empty(
+                        shape, dtype=all_shape_and_dtype[src][1]
+                    )
+                    task = dist.irecv(
+                        recv_tensor, group.ranks[src], group=group
+                    )
+                    tasks.append(task)
+                    task_info_list.append(
+                        (task, recv_tensor, current_offset, length)
+                    )
+                else:
+                    output_tensor[current_offset : current_offset + length] = (
+                        input
+                    )
+                current_offset += length
+
+        for task, recv_tensor, offset, length in task_info_list:
+            task.wait()
+            output_tensor[offset : offset + length] = recv_tensor
+            del recv_tensor
+
+        return output_tensor
+
+    else:
+        # Sender: push local slice to dst and return None.
+        with batch_isend_irecv_coalescing_manager(group, tasks):
+            if input is not None and input.shape[0] != 0:
+                task = dist.isend(input, dst, group=group)
+                tasks.append(task)
+
+        for task in tasks:
+            task.wait()
+
+        return None
+
+
+def get_sharding_info(buffer, param_name, world_size, rank):
+    """Compute per-rank element counts and local offset for a sharded parameter.
+
+    ShardingV2 splits the flat param storage evenly across ranks.  This
+    function intersects each rank's slice of that storage with the parameter's
+    global range to produce the element count each rank owns.
+
+    Args:
+        buffer: The FusedCommBuffer that contains the parameter.
+        param_name: Name of the parameter.
+        world_size: Number of ranks in the sharding group.
+        rank: Local rank in the sharding group.
+
+    Returns:
+        indices: List of element counts per rank (length == world_size).
+        my_slice_offset: Offset of this rank's slice within the full flat param.
+    """
+    grad_view = buffer._sharding_param_grad_view[param_name]
+
+    param_global_start = grad_view._index
+    param_global_end = grad_view._index + grad_view._padded_size
+
+    # ShardingV2 splits the storage buffer evenly across ranks.
+    shard_size = buffer.param_storage.shape[0] // world_size
+
+    indices = []
+    my_slice_offset = 0
+    current_relative_offset = 0
+
+    for r in range(world_size):
+        r_start = r * shard_size
+        r_end = (r + 1) * shard_size
+        start = max(param_global_start, r_start)
+        end = min(param_global_end, r_end)
+        length = max(0, end - start)
+        indices.append(length)
+        if r == rank:
+            my_slice_offset = current_relative_offset
+        current_relative_offset += length
+
+    return indices, my_slice_offset
+
+
+def should_use_muon(name, shape):
+    """Return True if a parameter should receive Muon (orthogonal) updates.
+
+    Muon applies to 2-D weight matrices, and also to 3-D fused MoE expert
+    tensors [n_experts, H, I] where each expert's 2-D slice is updated
+    independently via Newton-Schulz.  Embeddings, biases, and LM-head
+    weights fall back to AdamW.
+    """
+    if len(shape) not in (2, 3):
+        return False
+    name = name.lower()
+    if "embed" in name or "bias" in name or "lm_head" in name:
+        return False
+    return True

--- a/python/paddle/optimizer/__init__.py
+++ b/python/paddle/optimizer/__init__.py
@@ -22,6 +22,7 @@ from .asgd import ASGD
 from .lamb import Lamb
 from .lbfgs import LBFGS
 from .momentum import Momentum
+from .muon import Muon
 from .nadam import NAdam
 from .optimizer import Optimizer
 from .radam import RAdam
@@ -45,4 +46,5 @@ __all__ = [
     'NAdam',
     'Lamb',
     'LBFGS',
+    'Muon',
 ]

--- a/python/paddle/optimizer/muon.py
+++ b/python/paddle/optimizer/muon.py
@@ -1,0 +1,741 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import paddle
+from paddle.base import framework
+from paddle.distributed.fleet.utils.muon_comm_utils import (
+    gather_varlen,
+    should_use_muon,
+)
+from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
+    ShardedStateDict,
+    ShardedWeight,
+    create_sharded_weight_with_new_local,
+)
+
+from ..nn.clip import GradientClipBase
+from .optimizer import Optimizer
+
+__all__ = []
+
+
+class Muon(Optimizer):
+    r"""
+    Muon optimizer with Sharding/TP-aware parameter updates.
+
+    For 2-D weight matrices (identified by :func:`should_use_muon`), Muon
+    applies orthogonal gradient updates via Newton-Schulz iteration.  For all
+    other parameters (embeddings, biases, expert weights, …) it falls back to
+    a standard AdamW update.
+
+    The optimizer is designed for ``DygraphShardingOptimizerV2``-wrapped usage
+    where each parameter is stored as a 1-D shard.  During each step it
+    temporarily gathers the full matrix across sharding/TP ranks, performs the
+    orthogonal update, then scatters back only the local shard.
+
+    Args:
+        learning_rate (float | LRScheduler): Learning rate. Default: ``0.02``.
+        parameters (list[Tensor]): Flat list of parameters to optimize.
+        momentum (float): Momentum coefficient for the Muon update. Default: ``0.95``.
+        adam_beta1 (float): β₁ for the AdamW fallback. Default: ``0.9``.
+        adam_beta2 (float): β₂ for the AdamW fallback. Default: ``0.95``.
+        weight_decay (float): Decoupled weight decay. Default: ``0.01``.
+        ns_steps (int): Newton-Schulz iteration steps. Default: ``5``.
+        nesterov (bool): Use Nesterov momentum in Muon. Default: ``True``.
+        adam_epsilon (float): ε for numerical stability in AdamW. Default: ``1e-9``.
+        grad_clip (GradientClipBase | None): Gradient clipping. Default: ``None``.
+        apply_decay_param_fun (callable | None): Function to select which
+            parameters receive weight decay. Default: ``None``.
+        muon_version (int): Scaling-function version (1/2/3). Default: ``1``.
+        is_split_qkv (bool): Apply per-head orthogonalisation for QKV weights.
+            Default: ``True``.
+        multi_precision (bool): Maintain FP32 master weights when training in
+            BF16/FP16. Default: ``False``.
+        name (str | None): Optional name for the optimizer instance.
+    """
+
+    _moment_acc_str = "moment1"
+    _moment2_acc_str = "moment2"
+    _beta1_pow_acc_str = "beta1_pow_acc"
+    _beta2_pow_acc_str = "beta2_pow_acc"
+
+    def __init__(
+        self,
+        learning_rate=0.02,
+        parameters=None,
+        momentum=0.95,
+        adam_beta1=0.9,
+        adam_beta2=0.95,
+        weight_decay=0.01,
+        ns_steps=5,
+        nesterov=True,
+        adam_epsilon=1e-9,
+        grad_clip=None,
+        apply_decay_param_fun=None,
+        muon_version=1,
+        is_split_qkv=True,
+        multi_precision=False,
+        name=None,
+        **kwargs,
+    ):
+        if parameters is None:
+            raise ValueError(
+                "parameters argument given to the Optimizer should not be None."
+            )
+        if not isinstance(parameters, list):
+            raise TypeError("parameters must be a list.")
+        if len(parameters) > 0 and isinstance(parameters[0], dict):
+            raise TypeError(
+                "Muon optimizer only supports a flat list of parameters, "
+                "not a list of parameter groups."
+            )
+        if grad_clip is not None and not isinstance(
+            grad_clip, GradientClipBase
+        ):
+            raise TypeError(
+                "'grad_clip' should be an instance of GradientClipBase's derived class"
+            )
+
+        defaults = {
+            "momentum": momentum,
+            "adam_beta1": adam_beta1,
+            "adam_beta2": adam_beta2,
+            "weight_decay": weight_decay,
+            "ns_steps": ns_steps,
+            "nesterov": nesterov,
+            "epsilon": adam_epsilon,
+            "muon_version": muon_version,
+            "is_split_qkv": is_split_qkv,
+        }
+
+        super().__init__(
+            learning_rate=learning_rate,
+            parameters=parameters,
+            weight_decay=weight_decay,
+            grad_clip=grad_clip,
+            name=name,
+        )
+
+        self._multi_precision = multi_precision
+        self._master_weights = {}
+        self._apply_decay_param_fun = apply_decay_param_fun
+        self._default_dict.update(defaults)
+
+    # ------------------------------------------------------------------
+    # Accumulator management
+    # ------------------------------------------------------------------
+
+    def _ensure_accumulators(self, param, use_muon, group):
+        """Create optimizer accumulators for *param* if they do not exist yet.
+
+        ``param`` is the 1-D shard held by this rank under ShardingV2.  All
+        accumulators share that 1-D shape so that no extra memory is needed.
+        """
+        if (
+            self._moment_acc_str in self._accumulators
+            and param.name in self._accumulators[self._moment_acc_str]
+        ):
+            return
+
+        # FP32 master weight for mixed-precision training
+        if self._multi_precision and self._is_dtype_fp16_or_bf16(param.dtype):
+            if param.name not in self._master_weights:
+                self._create_master_weight(param)
+
+        self._add_accumulator(
+            self._moment_acc_str,
+            param,
+            dtype=paddle.float32,
+            fill_value=0.0,
+            shape=param.shape,
+            type=framework.core.VarDesc.VarType.DENSE_TENSOR,
+        )
+
+        if not use_muon:
+            # AdamW-specific states
+            self._add_accumulator(
+                self._moment2_acc_str,
+                param,
+                dtype=paddle.float32,
+                fill_value=0.0,
+                shape=param.shape,
+                type=framework.core.VarDesc.VarType.DENSE_TENSOR,
+            )
+            for acc_name, init_val in [
+                (self._beta1_pow_acc_str, group.get("adam_beta1", 0.9)),
+                (self._beta2_pow_acc_str, group.get("adam_beta2", 0.95)),
+            ]:
+                self._add_accumulator(
+                    acc_name,
+                    param,
+                    dtype=paddle.float32,
+                    fill_value=1.0,
+                    shape=[1],
+                    type=framework.core.VarDesc.VarType.DENSE_TENSOR,
+                )
+
+    def _create_accumulators(self, block, parameters):
+        """Standard entry-point used by checkpoint-resume infrastructure.
+
+        Delegates to _ensure_accumulators so that accumulators are keyed by
+        the slice_param name (consistent with _apply_optimize) rather than by
+        a master-weight name, which would cause a key mismatch under AMP O2.
+        """
+        if isinstance(parameters, dict):
+            parameters = self._update_param_group(parameters)
+        for p in parameters:
+            use_muon = should_use_muon(
+                p.name, getattr(p, "original_shape", p.shape)
+            )
+            self._ensure_accumulators(p, use_muon, self._default_dict)
+
+    # ------------------------------------------------------------------
+    # Newton-Schulz orthogonalisation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _zeropower_via_newtonschulz5(X, steps=5, eps=1e-9):
+        """Approximate the matrix sign function via 5th-order Newton-Schulz."""
+        a, b, c = 3.4445, -4.7750, 2.0315
+
+        if X.shape[-2] > X.shape[-1]:
+            X = X.T
+            transpose = True
+        else:
+            transpose = False
+
+        orig_shape = X.shape
+        X_flat = X.flatten(start_axis=-2)
+        X_flat = paddle.nn.functional.normalize(
+            X_flat, p=2, axis=-1, epsilon=eps
+        )
+        X = X_flat.reshape(orig_shape).astype(paddle.bfloat16)
+
+        for _ in range(steps):
+            A = paddle.matmul(X, X, transpose_y=True)
+            B = paddle.addmm(input=A, x=A, y=A, beta=b, alpha=c)
+            X = paddle.addmm(input=X, x=B, y=X, beta=a, alpha=1.0)
+
+        return X.T if transpose else X
+
+    @staticmethod
+    def _scaling_fn(orthogonal_update, version):
+        """Apply dimension-dependent scaling to the orthogonal update."""
+        din, dout = orthogonal_update.shape[0], orthogonal_update.shape[1]
+        if version == 1:
+            scale = max(1, dout / din) ** 0.5
+        elif version == 2:
+            scale = (dout / din) ** 0.5
+        else:  # version == 3 (default)
+            scale = 0.2 * (max(dout, din) ** 0.5)
+        return orthogonal_update * scale
+
+    # ------------------------------------------------------------------
+    # Per-parameter update rules
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _adamw_update(
+        param,
+        grad,
+        lr,
+        moment1,
+        moment2,
+        beta1_pow,
+        beta2_pow,
+        beta1,
+        beta2,
+        epsilon,
+        weight_decay,
+    ):
+        """In-place AdamW update for 1-D sharded parameters."""
+        with paddle.no_grad():
+            beta1_pow.scale_(beta1)
+            beta2_pow.scale_(beta2)
+
+            if weight_decay > 0:
+                param.scale_(1.0 - lr * weight_decay)
+
+            grad_f32 = (
+                grad.astype(paddle.float32)
+                if grad.dtype != paddle.float32
+                else grad
+            )
+
+            moment1.scale_(beta1).add_(grad_f32, alpha=1.0 - beta1)
+            moment2.scale_(beta2).add_(
+                paddle.square(grad_f32), alpha=1.0 - beta2
+            )
+
+            bias1 = 1.0 - beta1_pow
+            bias2 = 1.0 - beta2_pow
+            update = (
+                (moment1 / bias1)
+                / ((paddle.sqrt(moment2) / paddle.sqrt(bias2)) + epsilon)
+                * lr
+            )
+
+            if update.dtype != param.dtype:
+                update = update.astype(param.dtype)
+
+            if hasattr(param, "subtract_"):
+                param.subtract_(update)
+            else:
+                paddle.assign(param - update, param)
+
+    @staticmethod
+    def _muon_update(
+        param,
+        grad,
+        lr,
+        momentum_buffer,
+        momentum_beta,
+        ns_steps,
+        nesterov,
+        epsilon,
+        weight_decay,
+        version,
+        is_split_qkv,
+    ):
+        """In-place Muon update for 1-D sharded parameters.
+
+        Temporarily gathers the full 2-D weight matrix across sharding and TP
+        ranks, applies Newton-Schulz orthogonalisation, then scatters the
+        local shard back.
+        """
+        from paddle.distributed import fleet
+
+        hcg = fleet.get_hybrid_communicate_group()
+        sharding_group = hcg.get_sharding_parallel_group()
+        tp_group = hcg.get_model_parallel_group()
+
+        is_sharded_gather = getattr(param, "is_sharded_gather", False)
+        tp_slice_shape = getattr(param, "original_shape", param.shape)
+        split_axis = getattr(param, "split_axis", None)
+        sharding_indices = getattr(param, "sharding_indices", None)
+        needs_qkv_split = getattr(param, "needs_qkv_split", False)
+        is_sharding_v2 = param.ndim == 1
+
+        with paddle.no_grad():
+            grad_f32 = (
+                grad.astype(momentum_buffer.dtype)
+                if grad.dtype != momentum_buffer.dtype
+                else grad
+            )
+
+            # Step 1: Momentum update
+            new_momentum = paddle.lerp(
+                momentum_buffer, grad_f32, 1.0 - momentum_beta
+            )
+            paddle.assign(new_momentum, momentum_buffer)
+            update_buffer = (
+                paddle.lerp(grad_f32, momentum_buffer, momentum_beta)
+                if nesterov
+                else momentum_buffer
+            )
+
+            # Step 2: Sharding gather → full TP-slice
+            if not is_sharding_v2:
+                matrix_2d_tp = update_buffer
+            else:
+                if is_sharded_gather:
+                    assert sharding_indices is not None, (
+                        "sharding_indices must be set when is_sharded_gather=True"
+                    )
+                    s_rank = sharding_group.rank
+                    all_shape_and_dtype = [
+                        ([length], update_buffer.dtype)
+                        if length > 0
+                        else (None, None)
+                        for length in sharding_indices
+                    ]
+                    input_tensor = (
+                        update_buffer if sharding_indices[s_rank] > 0 else None
+                    )
+
+                    for r in range(sharding_group.nranks):
+                        if sharding_indices[r] == 0:
+                            continue
+                        gathered_chunk = gather_varlen(
+                            input=input_tensor,
+                            dst=sharding_group.ranks[r],
+                            group=sharding_group,
+                            all_shape_and_dtype=all_shape_and_dtype,
+                        )
+                        if r == s_rank:
+                            full_1d_tp_slice = gathered_chunk
+
+                    if full_1d_tp_slice is None:
+                        raise RuntimeError(
+                            f"Rank {s_rank} failed to gather Muon param {param.name}"
+                        )
+                else:
+                    full_1d_tp_slice = update_buffer
+
+                tp_numel = 1
+                for s in tp_slice_shape:
+                    tp_numel *= s
+                sharding_total_len = full_1d_tp_slice.numel()
+                if sharding_total_len != tp_numel:
+                    full_1d_tp_slice = full_1d_tp_slice[:tp_numel]
+
+                matrix_2d_tp = full_1d_tp_slice.reshape(tp_slice_shape)
+
+            # Step 3: TP all-gather → full global matrix
+            has_tp = tp_group.nranks > 1
+            if has_tp:
+                tp_tensor_list = []
+                paddle.distributed.all_gather(
+                    tp_tensor_list, matrix_2d_tp, group=tp_group
+                )
+                axis = split_axis if split_axis is not None else -1
+                matrix_2d_global = paddle.concat(tp_tensor_list, axis=axis)
+            else:
+                matrix_2d_global = matrix_2d_tp
+
+            # Step 4: Newton-Schulz orthogonalisation
+            if matrix_2d_global.ndim == 3:
+                # 3D fused MoE expert tensor [n_experts, H, I].
+                # Apply Newton-Schulz independently to each expert's 2D slice.
+                n_experts = matrix_2d_global.shape[0]
+                expert_updates = []
+                for ei in range(n_experts):
+                    expert_slice = matrix_2d_global[ei]  # [H, I]
+                    expert_ortho = Muon._scaling_fn(
+                        Muon._zeropower_via_newtonschulz5(
+                            expert_slice, steps=ns_steps, eps=epsilon
+                        ),
+                        version,
+                    )
+                    expert_updates.append(expert_ortho)
+                orthogonal_update = paddle.stack(expert_updates, axis=0)
+            elif is_split_qkv and needs_qkv_split:
+                # Per-head update: orthogonalise each Q/K/V head independently.
+                # param.head_num / kv_head_num are set by the trainer before
+                # the optimizer is constructed.
+                head_num = param.head_num
+                kv_head_num = param.kv_head_num
+                unit_size = matrix_2d_global.shape[1] // (
+                    head_num + 2 * kv_head_num
+                )
+                q_size = head_num * unit_size
+                kv_size = kv_head_num * unit_size
+
+                q_block, k_block, v_block = paddle.split(
+                    matrix_2d_global, [q_size, kv_size, kv_size], axis=1
+                )
+
+                def _ortho_per_head(block, num_heads):
+                    """Orthogonalise each head slice independently, then concat."""
+                    heads = paddle.split(block, num_heads, axis=1)
+                    return paddle.concat(
+                        [
+                            Muon._scaling_fn(
+                                Muon._zeropower_via_newtonschulz5(
+                                    h, steps=ns_steps, eps=epsilon
+                                ),
+                                version,
+                            )
+                            for h in heads
+                        ],
+                        axis=1,
+                    )
+
+                orthogonal_update = paddle.concat(
+                    [
+                        _ortho_per_head(q_block, head_num),
+                        _ortho_per_head(k_block, kv_head_num),
+                        _ortho_per_head(v_block, kv_head_num),
+                    ],
+                    axis=1,
+                )
+            else:
+                orthogonal_update = Muon._scaling_fn(
+                    Muon._zeropower_via_newtonschulz5(
+                        matrix_2d_global, steps=ns_steps, eps=epsilon
+                    ),
+                    version,
+                )
+
+            # Step 5: TP scatter → local TP-slice
+            if has_tp:
+                axis = split_axis if split_axis is not None else -1
+                tp_rank = tp_group.rank
+                chunk_size = orthogonal_update.shape[axis] // tp_group.nranks
+                start = tp_rank * chunk_size
+                matrix_2d_tp_new = paddle.slice(
+                    orthogonal_update,
+                    axes=[axis],
+                    starts=[start],
+                    ends=[start + chunk_size],
+                )
+            else:
+                matrix_2d_tp_new = orthogonal_update
+
+            # Step 6: Flatten + padding + sharding scatter → local shard
+            if is_sharding_v2:
+                flat_new = matrix_2d_tp_new.flatten()
+                if flat_new.numel() < sharding_total_len:
+                    padding = paddle.zeros(
+                        [sharding_total_len - flat_new.numel()],
+                        dtype=flat_new.dtype,
+                    )
+                    flat_new = paddle.concat([flat_new, padding])
+
+                if is_sharded_gather:
+                    rank = sharding_group.rank
+                    start_idx = sum(sharding_indices[:rank])
+                    my_len = sharding_indices[rank]
+                    local_update_slice = flat_new[
+                        start_idx : start_idx + my_len
+                    ]
+                    if local_update_slice.shape[0] != update_buffer.shape[0]:
+                        raise RuntimeError(
+                            f"Muon split shape mismatch: got {local_update_slice.shape[0]}, "
+                            f"expected {update_buffer.shape[0]} for {param.name}"
+                        )
+                else:
+                    local_update_slice = flat_new
+            else:
+                local_update_slice = matrix_2d_tp_new
+
+            # Step 7: Apply update with optional weight decay
+            if weight_decay > 0:
+                param.scale_(1.0 - lr * weight_decay)
+
+            final_step = local_update_slice * lr
+            if final_step.dtype != param.dtype:
+                final_step = final_step.astype(param.dtype)
+
+            if hasattr(param, "subtract_"):
+                param.subtract_(final_step)
+            else:
+                paddle.assign(param - final_step, param)
+
+    # ------------------------------------------------------------------
+    # Core optimization step
+    # ------------------------------------------------------------------
+
+    def _apply_optimize(self, loss, startup_program, params_grads):
+        if not framework.in_dygraph_mode():
+            raise NotImplementedError(
+                "Muon optimizer only supports dygraph mode."
+            )
+
+        if self._grad_clip is not None:
+            params_grads = self._grad_clip(params_grads)
+
+        group = self._default_dict
+        lr = self._learning_rate
+        if isinstance(lr, paddle.optimizer.lr.LRScheduler):
+            lr = lr()
+        wd = group.get("weight_decay", 0.0)
+
+        muon_params = []
+        adamw_params = []
+        for param, grad in params_grads:
+            if grad is None:
+                continue
+            use_muon = getattr(
+                param,
+                "is_muon",
+                should_use_muon(
+                    param.name, getattr(param, "original_shape", param.shape)
+                ),
+            )
+            self._ensure_accumulators(param, use_muon, group)
+            if use_muon:
+                muon_params.append((param, grad))
+            else:
+                adamw_params.append((param, grad))
+
+        # --- Pass 1: Muon updates (large temporary tensors) ---
+        for param, grad in muon_params:
+            self._muon_update(
+                param,
+                grad,
+                lr,
+                self._get_accumulator(self._moment_acc_str, param),
+                group.get("momentum", 0.95),
+                group.get("ns_steps", 5),
+                group.get("nesterov", True),
+                group.get("epsilon", 1e-9),
+                wd,
+                version=group.get("muon_version", 3),
+                is_split_qkv=group.get("is_split_qkv", True),
+            )
+            if self._multi_precision and param.name in self._master_weights:
+                with paddle.no_grad():
+                    _cast_tmp = paddle.cast(param, paddle.float32)
+                    paddle.assign(_cast_tmp, self._master_weights[param.name])
+                    del _cast_tmp
+
+        # --- Pass 2: AdamW updates ---
+        for param, grad in adamw_params:
+            self._adamw_update(
+                param,
+                grad,
+                lr,
+                self._get_accumulator(self._moment_acc_str, param),
+                self._get_accumulator(self._moment2_acc_str, param),
+                self._get_accumulator(self._beta1_pow_acc_str, param),
+                self._get_accumulator(self._beta2_pow_acc_str, param),
+                group.get("adam_beta1", 0.9),
+                group.get("adam_beta2", 0.95),
+                group.get("epsilon", 1e-9),
+                wd,
+            )
+            if self._multi_precision and param.name in self._master_weights:
+                with paddle.no_grad():
+                    _cast_tmp = paddle.cast(param, paddle.float32)
+                    paddle.assign(_cast_tmp, self._master_weights[param.name])
+                    del _cast_tmp
+
+    @framework.dygraph_only
+    def step(self) -> None:
+        params_grads = [
+            (param, param._grad_ivar())
+            for param in self._parameter_list
+            if not param.stop_gradient and param._grad_ivar() is not None
+        ]
+        self._apply_optimize(
+            loss=None, startup_program=None, params_grads=params_grads
+        )
+
+    def sharded_state_dict(
+        self,
+        model_sharded_state_dict: ShardedStateDict,
+    ) -> ShardedStateDict:
+        """Build a sharded optimizer state dict for flex checkpoint save/load.
+
+        The layout mirrors :class:`paddle.optimizer.AdamW`'s implementation so
+        that the same ``dist.save_state_dict`` / ``dist.load_state_dict`` path
+        works for Muon checkpoints.
+
+        Args:
+            model_sharded_state_dict: Sharded model state dict produced by
+                ``model.sharded_state_dict()``.
+
+        Returns:
+            A dict mapping ``"<struct_name>.<state_type>"`` keys to
+            :class:`ShardedWeight` objects.
+        """
+        _FP32_MASTER = "fp32_master_0"
+        _optimizer_scalar_names = [
+            "beta1_pow_acc_0",
+            "beta2_pow_acc_0",
+        ]
+        _optimizer_vector_names = [
+            "moment1_0",
+            "moment2_0",
+        ]
+
+        def _split_state_name(vname):
+            if _FP32_MASTER in vname:
+                return tuple(vname.split("_" + _FP32_MASTER + "_", 1))
+            for suffix in _optimizer_scalar_names + _optimizer_vector_names:
+                if vname.endswith(suffix):
+                    return vname[: -(len(suffix) + 1)], suffix
+            raise ValueError(
+                f"Cannot parse optimizer state variable name: {vname!r}"
+            )
+
+        model_sharded_state_dict = dict(
+            sorted(model_sharded_state_dict.items())
+        )
+
+        # Build static-name → struct-name mapping (handles shared weights)
+        static_to_struct = {}
+        for struct_name, sw in model_sharded_state_dict.items():
+            local_name = sw.local_tensor.name
+            if local_name not in static_to_struct:
+                static_to_struct[local_name] = struct_name
+
+        optimizer_state_dict = self.state_dict()
+        master_weights = optimizer_state_dict.pop("master_weights", None)
+        optimizer_state_dict.pop("LR_Scheduler", None)
+
+        sharded_state: ShardedStateDict = {}
+
+        # Optimizer states (moment1, moment2, beta_pow scalars)
+        for key, tensor in optimizer_state_dict.items():
+            static_name, state_type = _split_state_name(key)
+            struct_name = static_to_struct[static_name]
+            sharded_param = model_sharded_state_dict[struct_name]
+            unified_name = f"{struct_name}.{state_type}"
+
+            if state_type in _optimizer_vector_names:
+                # Vector states share the same sharding layout as the parameter
+                if tensor.is_dist():
+                    sharded_state[unified_name] = ShardedWeight(
+                        key=unified_name,
+                        local_tensor=tensor,
+                        local_shape=tensor.shape,
+                        global_shape=tensor.shape,
+                        global_offset=sharded_param.global_offset,
+                    )
+                else:
+                    # Reshape accumulator if numel matches but shape differs.
+                    # V3 MoE: grouped_gemm_experts param.shape is 3D
+                    # [n_experts, H, I] but model.state_dict() returns actual
+                    # C++ storage shape 2D [n_experts*H, I].  moment1 was
+                    # created with 3D shape, so we need to reshape here.
+                    # V2 is unaffected: its moments are always 1D shards,
+                    # so shape always matches and reshape is never triggered.
+                    target_shape = sharded_param.local_shape
+                    if (
+                        tuple(tensor.shape) != tuple(target_shape)
+                        and tensor.numel()
+                        == paddle.to_tensor(list(target_shape)).prod().item()
+                    ):
+                        tensor = tensor.reshape(target_shape)
+                    sharded_state[unified_name] = (
+                        create_sharded_weight_with_new_local(
+                            unified_name, tensor, sharded_param
+                        )
+                    )
+            else:
+                # Scalar states (beta_pow) are replicated – save as-is
+                sharded_state[unified_name] = ShardedWeight(
+                    key=unified_name,
+                    local_tensor=tensor,
+                    local_shape=(1,),
+                    global_shape=(1,),
+                    global_offset=(0,),
+                )
+
+        # FP32 master weights
+        if master_weights:
+            for weight_key, tensor in master_weights.items():
+                struct_name = static_to_struct[weight_key]
+                sharded_param = model_sharded_state_dict[struct_name]
+                unified_name = f"{struct_name}.w_0"
+
+                if tensor.is_dist():
+                    sharded_state[unified_name] = ShardedWeight(
+                        key=unified_name,
+                        local_tensor=tensor,
+                        local_shape=tensor.shape,
+                        global_shape=tensor.shape,
+                        global_offset=sharded_param.global_offset,
+                    )
+                else:
+                    sharded_state[unified_name] = (
+                        create_sharded_weight_with_new_local(
+                            unified_name, tensor, sharded_param
+                        )
+                    )
+
+        return sharded_state

--- a/test/collective/fleet/CMakeLists.txt
+++ b/test/collective/fleet/CMakeLists.txt
@@ -946,3 +946,19 @@ if(LOCAL_ALL_ARCH AND LOCAL_ALL_PLAT)
     test_schedule_node MODULES test_schedule_node ENVS
     "http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python")
 endif()
+if(WITH_NCCL)
+  if((WITH_GPU) AND LOCAL_ALL_PLAT)
+    bash_test_modules(
+      test_parallel_dygraph_muon
+      START_BASH
+      ../../legacy_test/dist_test.sh
+      TIMEOUT
+      "400"
+      LABELS
+      "RUN_TYPE=DIST"
+      ENVS
+      "PADDLE_DIST_UT_PORT=22348;http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python"
+    )
+    set_tests_properties(test_parallel_dygraph_muon PROPERTIES TIMEOUT "400")
+  endif()
+endif()

--- a/test/collective/fleet/hybrid_parallel_sharding_mp_qkv_split_model.py
+++ b/test/collective/fleet/hybrid_parallel_sharding_mp_qkv_split_model.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Validates Muon is_split_qkv=True: each Q/K/V head is orthogonalised
+# independently rather than the whole Q/K/V block at once.
+#
+# Topology: embedding -> fused qkv_proj -> out_proj -> lm_head
+# Parallelism: mp_degree=2, sharding_degree=1 (2 ranks total)
+
+import random
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.distributed import fleet
+from paddle.distributed.fleet.utils.mix_precision_utils import (
+    MixPrecisionLayer,
+    MixPrecisionOptimizer,
+)
+
+# Model hyper-parameters
+vocab_size = 32
+hidden_size = 64
+head_num = 4  # Q heads
+kv_head_num = 2  # K/V heads (GQA)
+head_dim = hidden_size // head_num
+qkv_out_dim = (head_num + 2 * kv_head_num) * head_dim
+output_size = vocab_size
+seq_length = 4
+batch_size = 4
+STEPS = 3
+
+sharding_degree = 1
+mp_degree = 2
+
+
+class SimpleMPQKVNet(paddle.nn.Layer):
+    """TP model: column-parallel qkv_proj, row-parallel out_proj."""
+
+    def __init__(self, np_emb, np_qkv, np_out, np_lm):
+        super().__init__()
+
+        hcg = fleet.get_hybrid_communicate_group()
+        mp_id = hcg.get_model_parallel_rank()
+        mp_deg = hcg.get_model_parallel_world_size()
+
+        self.embedding = paddle.nn.Embedding(
+            vocab_size,
+            hidden_size,
+            weight_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Assign(np_emb)
+            ),
+        )
+
+        qkv_per_rank = qkv_out_dim // mp_deg
+        col_start = mp_id * qkv_per_rank
+        col_end = col_start + qkv_per_rank
+        self.qkv_proj = fleet.meta_parallel.ColumnParallelLinear(
+            hidden_size,
+            qkv_out_dim,
+            weight_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Assign(
+                    np_qkv[:, col_start:col_end]
+                ),
+            ),
+            gather_output=False,
+            has_bias=False,
+        )
+
+        self.out_proj = fleet.meta_parallel.RowParallelLinear(
+            qkv_out_dim,
+            hidden_size,
+            weight_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Assign(
+                    np_out[col_start:col_end, :]
+                ),
+            ),
+            input_is_parallel=True,
+            has_bias=False,
+        )
+
+        self.lm_head = paddle.nn.Linear(
+            hidden_size,
+            output_size,
+            weight_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Assign(np_lm)
+            ),
+            bias_attr=False,
+        )
+
+    def forward(self, x):
+        x = self.embedding(x)
+        x = self.qkv_proj(x)
+        x = self.out_proj(x)
+        x = self.lm_head(x)
+        return x
+
+
+class SimpleDPQKVNet(paddle.nn.Layer):
+    """Single-rank reference model with identical weight initialisation."""
+
+    def __init__(self, np_emb, np_qkv, np_out, np_lm):
+        super().__init__()
+
+        self.embedding = paddle.nn.Embedding(
+            vocab_size,
+            hidden_size,
+            weight_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Assign(np_emb)
+            ),
+        )
+
+        self.qkv_proj = paddle.nn.Linear(
+            hidden_size,
+            qkv_out_dim,
+            weight_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Assign(np_qkv),
+            ),
+            bias_attr=False,
+        )
+
+        self.out_proj = paddle.nn.Linear(
+            qkv_out_dim,
+            hidden_size,
+            weight_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Assign(np_out)
+            ),
+            bias_attr=False,
+        )
+
+        self.lm_head = paddle.nn.Linear(
+            hidden_size,
+            output_size,
+            weight_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Assign(np_lm)
+            ),
+            bias_attr=False,
+        )
+
+    def forward(self, x):
+        x = self.embedding(x)
+        x = self.qkv_proj(x)
+        x = self.out_proj(x)
+        x = self.lm_head(x)
+        return x
+
+
+class TestDistMPQKVSplitTraining(unittest.TestCase):
+    def setUp(self):
+        random.seed(2024)
+        np.random.seed(2024)
+        paddle.seed(2024)
+
+        self.strategy = fleet.DistributedStrategy()
+        self.strategy.hybrid_configs = {
+            "sharding_degree": sharding_degree,
+            "dp_degree": 1,
+            "mp_degree": mp_degree,
+            "pp_degree": 1,
+        }
+
+        fleet.init(is_collective=True, strategy=self.strategy)
+
+        self.data = [
+            np.random.randint(0, vocab_size, (batch_size, seq_length))
+            for _ in range(STEPS)
+        ]
+
+    def _random_weights(self):
+        np_emb = np.random.random_sample((vocab_size, hidden_size)).astype(
+            "float32"
+        )
+        np_qkv = np.random.random_sample((hidden_size, qkv_out_dim)).astype(
+            "float32"
+        )
+        np_out = np.random.random_sample((qkv_out_dim, hidden_size)).astype(
+            "float32"
+        )
+        np_lm = np.random.random_sample((hidden_size, output_size)).astype(
+            "float32"
+        )
+        return np_emb, np_qkv, np_out, np_lm
+
+    def _mark_qkv_params(self, model):
+        """Set needs_qkv_split / head_num / kv_head_num on every qkv_proj weight."""
+        for name, param in model.named_parameters():
+            if "qkv_proj" in name and param.ndim == 2:
+                param.needs_qkv_split = True
+                param.head_num = head_num
+                param.kv_head_num = kv_head_num
+
+    def _build_muon_optimizer(self, model):
+        return paddle.optimizer.Muon(
+            parameters=model.parameters(),
+            learning_rate=0.001,
+            weight_decay=0.00001,
+            is_split_qkv=True,
+            grad_clip=paddle.nn.ClipGradByGlobalNorm(0.5),
+        )
+
+    def _train_batch(self, batch, model, optimizer):
+        loss = model(batch).mean()
+        loss.backward()
+        optimizer.step()
+        optimizer.clear_grad()
+        return loss
+
+    def _run_split_qkv(self, amp_level=None):
+        np_emb, np_qkv, np_out, np_lm = self._random_weights()
+
+        model_a = SimpleMPQKVNet(np_emb, np_qkv, np_out, np_lm)
+        self._mark_qkv_params(model_a)
+        optimizer_a = self._build_muon_optimizer(model_a)
+
+        model_b = SimpleDPQKVNet(np_emb, np_qkv, np_out, np_lm)
+        self._mark_qkv_params(model_b)
+        optimizer_b = self._build_muon_optimizer(model_b)
+
+        if amp_level == "O2":
+            model_a = MixPrecisionLayer(model_a)
+            optimizer_a = MixPrecisionOptimizer(optimizer_a)
+            model_b = MixPrecisionLayer(model_b)
+            optimizer_b = MixPrecisionOptimizer(optimizer_b)
+
+        model_a = fleet.distributed_model(model_a)
+        optimizer_a = fleet.distributed_optimizer(optimizer_a)
+
+        hcg = fleet.get_hybrid_communicate_group()
+        tp_group = hcg.get_model_parallel_group()
+
+        for idx in range(STEPS):
+            batch = paddle.to_tensor(self.data[idx])
+
+            loss_a = self._train_batch(batch, model_a, optimizer_a)
+            loss_b = self._train_batch(batch, model_b, optimizer_b)
+
+            for param_a, param_b in zip(
+                model_a.parameters(), model_b.parameters()
+            ):
+                val_a_local = param_a.numpy()
+                val_b = param_b.numpy()
+
+                if val_a_local.shape != val_b.shape:
+                    gathered = []
+                    paddle.distributed.all_gather(
+                        gathered, param_a, group=tp_group
+                    )
+                    concat_axis = next(
+                        (
+                            d
+                            for d in range(len(val_b.shape))
+                            if val_b.shape[d]
+                            == val_a_local.shape[d] * mp_degree
+                        ),
+                        -1,
+                    )
+                    if concat_axis == -1:
+                        continue
+                    val_a_global = np.concatenate(
+                        [t.numpy() for t in gathered], axis=concat_axis
+                    )
+                else:
+                    val_a_global = val_a_local
+
+                np.testing.assert_allclose(
+                    val_a_global,
+                    val_b,
+                    rtol=1e-4,
+                    atol=3e-4,
+                    err_msg=f"Param {param_a.name} mismatch at step {idx}!",
+                )
+
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda()
+        or paddle.device.cuda.get_device_capability()[0] < 8,
+        "BF16 matmul requires GPU compute capability >= 80 (Ampere+)",
+    )
+    def test_muon_split_qkv_per_head(self):
+        """Muon per-head QKV split: TP only, BF16 AMP O2."""
+        self._run_split_qkv(amp_level="O2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/hybrid_parallel_sharding_muon_model.py
+++ b/test/collective/fleet/hybrid_parallel_sharding_muon_model.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Validates Muon optimizer with sharding v2 (split_param), no tensor parallelism.
+# Topology: sharding_degree=2, mp_degree=1 (2 ranks total)
+
+import os
+import random
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.distributed import fleet
+from paddle.distributed.fleet.utils.mix_precision_utils import (
+    MixPrecisionLayer,
+    MixPrecisionOptimizer,
+)
+
+g_shard_split_param = int(os.environ.get("FLAGS_shard_split_param", 0))
+g_sharding_v3 = os.environ.get("FLAGS_sharding_v3", "0") == "1"
+
+vocab_size = 20
+hidden_size = 100
+inner_size = 100
+output_size = 100
+seq_length = 2
+batch_size = 4
+STEPS = 3
+
+sharding_degree = 2
+mp_degree = 1
+
+
+class SimpleNet(paddle.nn.Layer):
+    """Model used by both distributed (sharding) and reference."""
+
+    def __init__(self, np_fc1, np_fc2, np_fc3, np_emb):
+        super().__init__()
+
+        self.embedding = paddle.nn.Embedding(
+            vocab_size,
+            hidden_size,
+            weight_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Assign(np_emb)
+            ),
+        )
+
+        self.linear1 = paddle.nn.Linear(
+            hidden_size,
+            inner_size,
+            weight_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Assign(np_fc1)
+            ),
+        )
+
+        self.linear2 = paddle.nn.Linear(
+            inner_size,
+            hidden_size,
+            weight_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Assign(np_fc2)
+            ),
+        )
+
+        self.linear3 = paddle.nn.Linear(
+            hidden_size,
+            output_size,
+            weight_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Assign(np_fc3)
+            ),
+            bias_attr=paddle.framework.ParamAttr(
+                initializer=paddle.nn.initializer.Constant(0.5)
+            ),
+        )
+
+    def forward(self, x):
+        x = self.embedding(x)
+        x = self.linear1(x)
+        x = self.linear2(x)
+        x = self.linear3(x)
+        x = paddle.matmul(x, self.embedding.weight, transpose_y=True)
+        return x
+
+
+class TestDistShardingMuonTraining(unittest.TestCase):
+    def setUp(self):
+        random.seed(2021)
+        np.random.seed(2021)
+        paddle.seed(2021)
+
+        self.strategy = fleet.DistributedStrategy()
+        self.strategy.hybrid_configs = {
+            "sharding_degree": sharding_degree,
+            "dp_degree": 1,
+            "mp_degree": mp_degree,
+            "pp_degree": 1,
+        }
+        self.strategy.hybrid_configs[
+            "sharding_configs"
+        ].split_param = g_shard_split_param
+
+        fleet.init(is_collective=True, strategy=self.strategy)
+        self.data = [
+            np.random.randint(0, vocab_size, (batch_size, seq_length))
+            for _ in range(STEPS)
+        ]
+
+    def train_batch(self, batch, model, optimizer):
+        output = model(batch)
+        loss = output.mean()
+        loss.backward()
+        optimizer.step()
+        optimizer.clear_grad()
+        return loss
+
+    def build_optimizer(self, model):
+        clip = paddle.nn.ClipGradByGlobalNorm(0.5)
+        return paddle.optimizer.Muon(
+            parameters=model.parameters(),
+            learning_rate=0.001,
+            weight_decay=0.00001,
+            grad_clip=clip,
+        )
+
+    def sharding_model(self, amp_level=None):
+        np_fc1 = np.random.random_sample((hidden_size, inner_size)).astype(
+            "float32"
+        )
+        np_fc2 = np.random.random_sample((inner_size, hidden_size)).astype(
+            "float32"
+        )
+        np_fc3 = np.random.random_sample((hidden_size, output_size)).astype(
+            "float32"
+        )
+        np_emb = np.random.random_sample((vocab_size, hidden_size)).astype(
+            "float32"
+        )
+
+        model_a = SimpleNet(np_fc1, np_fc2, np_fc3, np_emb)
+        optimizer_a = self.build_optimizer(model_a)
+
+        model_b = SimpleNet(np_fc1, np_fc2, np_fc3, np_emb)
+        optimizer_b = self.build_optimizer(model_b)
+
+        if amp_level == "O2":
+            model_a = MixPrecisionLayer(model_a)
+            optimizer_a = MixPrecisionOptimizer(optimizer_a)
+            model_b = MixPrecisionLayer(model_b)
+            optimizer_b = MixPrecisionOptimizer(optimizer_b)
+
+        model_a = fleet.distributed_model(model_a)
+        optimizer_a = fleet.distributed_optimizer(optimizer_a)
+
+        hcg = fleet.get_hybrid_communicate_group()
+        sharding_rank = hcg.get_sharding_parallel_rank()
+        local_batch_size = batch_size // sharding_degree
+
+        for idx in range(STEPS):
+            start = sharding_rank * local_batch_size
+            batch_a = paddle.to_tensor(
+                self.data[idx][start : start + local_batch_size]
+            )
+            batch_b = paddle.to_tensor(self.data[idx])
+
+            loss_a = self.train_batch(batch_a, model_a, optimizer_a)
+            loss_b = self.train_batch(batch_b, model_b, optimizer_b)
+
+            for param_a, param_b in zip(
+                model_a.parameters(), model_b.parameters()
+            ):
+                # V3 uses reduce+broadcast (vs V2 allgather), so allow
+                # slightly larger numerical tolerance.
+                tol = 5e-4 if g_sharding_v3 else 1e-4
+                np.testing.assert_allclose(
+                    param_a.numpy(),
+                    param_b.numpy(),
+                    rtol=tol,
+                    atol=tol,
+                    err_msg=f"Param {param_a.name} mismatch at step {idx}!",
+                )
+
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda()
+        or paddle.device.cuda.get_device_capability()[0] < 8,
+        "BF16 matmul requires GPU compute capability >= 80 (Ampere+)",
+    )
+    def test_sharding_muon(self):
+        if g_shard_split_param:
+            self.sharding_model(amp_level="O2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/test_parallel_dygraph_muon.py
+++ b/test/collective/fleet/test_parallel_dygraph_muon.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
+
+import paddle
+
+
+class TestMuonParallel(TestMultipleAccelerators):
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda()
+        or paddle.device.cuda.get_device_capability()[0] < 8,
+        "BF16 matmul requires GPU compute capability >= 80 (Ampere+)",
+    )
+    def test_muon_sharding(self):
+        os.environ["FLAGS_shard_split_param"] = "1"
+        self.run_mnist_2accelerators('hybrid_parallel_sharding_muon_model.py')
+
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda()
+        or paddle.device.cuda.get_device_capability()[0] < 8,
+        "BF16 matmul requires GPU compute capability >= 80 (Ampere+)",
+    )
+    def test_muon_mp_qkv_split(self):
+        self.run_mnist_2accelerators(
+            'hybrid_parallel_sharding_mp_qkv_split_model.py'
+        )
+
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda()
+        or paddle.device.cuda.get_device_capability()[0] < 8,
+        "BF16 matmul requires GPU compute capability >= 80 (Ampere+)",
+    )
+    def test_muon_sharding_v3(self):
+        os.environ["FLAGS_shard_split_param"] = "1"
+        os.environ["FLAGS_sharding_v3"] = "1"
+        self.run_mnist_2accelerators('hybrid_parallel_sharding_muon_model.py')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

Add `paddle.optimizer.Muon`, a Newton-Schulz orthogonalisation-based optimizer
that applies orthogonal updates to 2-D & 3-D parameter matrices (e.g. Linear weights, MoE weights)
while automatically falling back to AdamW for non-2D parameters (embeddings,
biases, layer norms).

#### Core optimizer (`python/paddle/optimizer/muon.py`)
- Newton-Schulz iteration (5th-order, 6 steps by default) for computing the
  orthogonal projection of gradients
- Per-head QKV split: when a fused QKV weight is annotated with `needs_qkv_split`,
  each attention head is orthogonalised independently
- `sharded_state_dict` support for distributed checkpointing

#### ShardingV2 integration
- `muon_sharding_annotations.py`: annotate each 1-D parameter shard with
  original shape, sharding indices, and gather metadata
- `dygraph_sharding_optimizer.py`: call annotation helpers during parameter
  registration; sort Muon params for better GPU memory locality

#### ShardingV3 implementation (`dygraph_sharding_optimizer_v3.py`)
- Full-parameter ownership model: each 2-D Muon parameter is owned by one
  sharding rank (round-robin assignment)
- Forward: broadcast owned params to all ranks
- Backward: reduce gradients to owner rank, apply Muon update locally, then
  broadcast updated params
- Non-Muon parameters use conventional element-wise sharding with allgather

#### Shared utilities (`muon_comm_utils.py`)
- `should_use_muon(name, shape)`: determine whether a parameter should use
  Muon based on its name and dimensionality
- `gather_varlen`: variable-length allgather for V2 split-param sharding
- `get_sharding_info`: compute per-rank element counts and offsets

#### Tests
- `test_parallel_dygraph_muon.py` with 3 test cases:
  - `test_muon_sharding`: ShardingV2 + AMP O2 vs single-device reference
  - `test_muon_sharding_v3`: ShardingV3 + AMP O2 vs single-device reference
  - `test_muon_mp_qkv_split`: Tensor parallel + sharding with fused QKV
- All tests run on 2 GPUs and validate with `assert_allclose`

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否