### PR TITLE
[Bug] Fix CMake 'win32' case sensitivity when WITH_ONEMKL=ON on Windows

### DIFF
--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -353,7 +353,7 @@ if(WITH_GPU OR WITH_ROCM)
 endif()
 
 if(MKL_FOUND AND WITH_ONEMKL)
-  if(win32)
+  if(WIN32)
     target_include_directories(phi PRIVATE ${MKL_INCLUDE})
   else()
     target_include_directories(phi_core PRIVATE ${MKL_INCLUDE})


### PR DESCRIPTION
## 关联 Issue
Fixes #77689

## 问题描述
启用 WITH_ONEMKL=ON 时，CMake 脚本中 'win32' 大小写错误导致 Windows 配置失败。

## 修复计划
- 定位 CMake 脚本中与 win32 相关的条件判断
- 修正为正确的平台检测宏（如 WIN32 或 MSVC）
- 确保 OneMKL 在 Windows 下能正确配置

## 说明
本 PR 为 Draft 状态，待补充具体代码修改后更新。