### PR TITLE
[API Compatibility No.186] Add target alias support for paddle.nn.functional.mse_loss -part

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1867,7 +1867,7 @@ def kl_div(
             loss = paddle.sum(loss) / batch_size
         return loss
 
-
+@param_one_alias(["label", "target"])
 def mse_loss(
     input: Tensor,
     label: Tensor,
@@ -1895,6 +1895,7 @@ def mse_loss(
     Parameters:
         input (Tensor): Input tensor, the data type should be float32 or float64.
         label (Tensor): Label tensor, the data type should be float32 or float64.
+            Alias: ``target``.
         reduction (string, optional): The reduction method for the output,
             could be 'none' | 'mean' | 'sum'.
             If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned.

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1867,6 +1867,7 @@ def kl_div(
             loss = paddle.sum(loss) / batch_size
         return loss
 
+
 @param_one_alias(["label", "target"])
 def mse_loss(
     input: Tensor,

--- a/test/legacy_test/test_mse_loss.py
+++ b/test/legacy_test/test_mse_loss.py
@@ -355,8 +355,7 @@ class TestNNFunctionalMseLoss_ZeroSize(unittest.TestCase):
 
 class TestNNFunctionalMseLossAlias(unittest.TestCase):
     def test_target_alias_dygraph(self):
-        paddle.disable_static()
-        try:
+        with base.dygraph.guard():
             x = paddle.randn([4, 5], dtype="float32")
             y = paddle.randn([4, 5], dtype="float32")
 
@@ -371,8 +370,6 @@ class TestNNFunctionalMseLossAlias(unittest.TestCase):
             np.testing.assert_allclose(
                 out3.numpy(), out4.numpy(), rtol=1e-6, atol=0.0
             )
-        finally:
-            paddle.enable_static()
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_mse_loss.py
+++ b/test/legacy_test/test_mse_loss.py
@@ -19,6 +19,7 @@ from op_test import get_device_place, is_custom_device
 from utils import dygraph_guard
 
 import paddle
+import paddle.nn.functional as F
 from paddle import base
 from paddle.base import core
 from paddle.base.executor import Executor
@@ -350,6 +351,28 @@ class TestNNFunctionalMseLoss_ZeroSize(unittest.TestCase):
             loss = paddle.sum(dy_ret)
             loss.backward()
             np.testing.assert_allclose(x.grad.shape, x.shape)
+
+
+class TestNNFunctionalMseLossAlias(unittest.TestCase):
+    def test_target_alias_dygraph(self):
+        paddle.disable_static()
+        try:
+            x = paddle.randn([4, 5], dtype="float32")
+            y = paddle.randn([4, 5], dtype="float32")
+
+            out1 = F.mse_loss(input=x, label=y, reduction="none")
+            out2 = F.mse_loss(input=x, target=y, reduction="none")
+            np.testing.assert_allclose(
+                out1.numpy(), out2.numpy(), rtol=1e-6, atol=0.0
+            )
+
+            out3 = F.mse_loss(input=x, label=y, reduction="mean")
+            out4 = F.mse_loss(input=x, target=y, reduction="mean")
+            np.testing.assert_allclose(
+                out3.numpy(), out4.numpy(), rtol=1e-6, atol=0.0
+            )
+        finally:
+            paddle.enable_static()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
- Add `@param_one_alias(["label", "target"])` on `paddle.nn.functional.mse_loss` to support PyTorch-style keyword argument `target` as alias of `label`.
- Update `mse_loss` docstring to document `label` alias: `target`.
- Add dynamic-graph unit test in `test/legacy_test/test_mse_loss.py` to verify `label=` and `target=` produce identical outputs for `reduction="none"` and `reduction="mean"`.

No signature or core logic changes were introduced.

Related task: #76301 (No.186)

### 是否引起精度变化
否