### PR TITLE
[API Compatibility No.188] Add target alias for F.nll_loss -part

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1474,6 +1474,7 @@ def l1_loss(
             return paddle.abs(paddle.subtract(x=input, y=label, name=name))
 
 
+@param_one_alias(["label", "target"])
 def nll_loss(
     input: Tensor,
     label: Tensor,
@@ -1492,7 +1493,7 @@ def nll_loss(
              But in K-dimension situation, the shape is :math:`[N, C, d_1, d_2, ..., d_K]`.
              The data type is float32, float64.
          label (Tensor): Label tensor, the shape is :math:`[N,]` or :math:`[N, d_1, d_2, ..., d_K]`.
-             The data type is int64.
+             The data type is int64. Alias: ``target``.
          weight (Tensor, optional): Weight tensor, a manual rescaling weight given
              to each class. If given, it has to be a 1D Tensor whose size is `[C, ]`. Otherwise,
              it treated as if having all ones. the data type is

--- a/test/legacy_test/test_nll_loss.py
+++ b/test/legacy_test/test_nll_loss.py
@@ -1184,8 +1184,7 @@ class TestNLLLossName(unittest.TestCase):
 
 class TestNLLLossTargetAlias(unittest.TestCase):
     def test_nll_loss_target_alias(self):
-        paddle.disable_static()
-        try:
+        with base.dygraph.guard():
             logits = paddle.randn([3, 5], dtype='float32')
             log_probs = paddle.nn.functional.log_softmax(logits, axis=1)
             label = paddle.to_tensor([0, 3, 4], dtype='int64')
@@ -1226,8 +1225,6 @@ class TestNLLLossTargetAlias(unittest.TestCase):
             np.testing.assert_allclose(
                 out_with_label.numpy(), out_with_target.numpy()
             )
-        finally:
-            paddle.enable_static()
 
 
 class TestNLLLossInvalidArgs(unittest.TestCase):

--- a/test/legacy_test/test_nll_loss.py
+++ b/test/legacy_test/test_nll_loss.py
@@ -1182,6 +1182,54 @@ class TestNLLLossName(unittest.TestCase):
                 self.assertTrue(res.name.startswith('nll_loss'))
 
 
+class TestNLLLossTargetAlias(unittest.TestCase):
+    def test_nll_loss_target_alias(self):
+        paddle.disable_static()
+        try:
+            logits = paddle.randn([3, 5], dtype='float32')
+            log_probs = paddle.nn.functional.log_softmax(logits, axis=1)
+            label = paddle.to_tensor([0, 3, 4], dtype='int64')
+
+            out_with_label = paddle.nn.functional.nll_loss(
+                input=log_probs, label=label, reduction='none'
+            )
+            out_with_target = paddle.nn.functional.nll_loss(
+                input=log_probs, target=label, reduction='none'
+            )
+            np.testing.assert_allclose(
+                out_with_label.numpy(), out_with_target.numpy()
+            )
+
+            out_with_label = paddle.nn.functional.nll_loss(
+                input=log_probs, label=label, reduction='mean'
+            )
+            out_with_target = paddle.nn.functional.nll_loss(
+                input=log_probs, target=label, reduction='mean'
+            )
+            np.testing.assert_allclose(
+                out_with_label.numpy(), out_with_target.numpy()
+            )
+
+            label_with_ignore = paddle.to_tensor([0, -100, 4], dtype='int64')
+            out_with_label = paddle.nn.functional.nll_loss(
+                input=log_probs,
+                label=label_with_ignore,
+                ignore_index=-100,
+                reduction='sum',
+            )
+            out_with_target = paddle.nn.functional.nll_loss(
+                input=log_probs,
+                target=label_with_ignore,
+                ignore_index=-100,
+                reduction='sum',
+            )
+            np.testing.assert_allclose(
+                out_with_label.numpy(), out_with_target.numpy()
+            )
+        finally:
+            paddle.enable_static()
+
+
 class TestNLLLossInvalidArgs(unittest.TestCase):
     def test_x_dim_value_error(self):
         def test_x_dim_lt_2():


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
- Add `@param_one_alias(["label", "target"])` for `paddle.nn.functional.nll_loss` to support PyTorch-style keyword argument `target` as alias of `label`.
- Update `nll_loss` docstring to mark `label` alias: `target`.
- Add legacy unit tests in `test/legacy_test/test_nll_loss.py` to verify `label=` and `target=` are equivalent for `reduction="none"` and `reduction="mean"`.
- Add an alias-equivalence case with `ignore_index=-100` and `reduction="sum"`.

No signature/default/numerical logic changes were introduced.

Related task: #76301 (No.188)

### 是否引起精度变化
否