### PR TITLE
[API Compatibility No.155] Add kwargs alias for binary_cross_entropy_with_logits-part

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -21,7 +21,7 @@ import paddle
 from paddle import _C_ops, base, in_dynamic_mode
 from paddle.static.nn.control_flow import Assert
 from paddle.utils import deprecated
-from paddle.utils.decorator_utils import param_one_alias
+from paddle.utils.decorator_utils import param_one_alias, param_two_alias
 
 from ...base.data_feeder import check_type, check_variable_and_dtype
 from ...base.framework import (
@@ -744,6 +744,7 @@ def binary_cross_entropy(
             return out
 
 
+@param_two_alias(["logit", "input"], ["label", "target"])
 def binary_cross_entropy_with_logits(
     logit: Tensor,
     label: Tensor,
@@ -793,9 +794,10 @@ def binary_cross_entropy_with_logits(
         logit (Tensor): The input predications tensor. 2-D tensor with shape: [N, *],
             N is batch_size, `*` means number of additional dimensions. The ``logit``
             is usually the output of Linear layer. Available dtype is float32, float64.
+            Alias: ``input``.
         label (Tensor): The target labels tensor. 2-D tensor with the same shape as
             ``logit``. The target labels which values should be numbers between 0 and 1.
-            Available dtype is float32, float64.
+            Available dtype is float32, float64. Alias: ``target``.
         weight (Tensor, optional): A manual rescaling weight given to the loss of each
             batch element. If given, it has to be a 1D Tensor whose size is `[N, ]`,
             The data type is float32, float64. Default is ``'None'``.

--- a/test/legacy_test/test_bce_with_logits_loss.py
+++ b/test/legacy_test/test_bce_with_logits_loss.py
@@ -305,43 +305,42 @@ class TestBCEWithLogitsLoss(unittest.TestCase):
 
     def test_binary_cross_entropy_with_logits_alias(self):
         paddle.disable_static()
-        try:
-            logit = paddle.randn([4, 6], dtype="float32")
-            label = (paddle.rand([4, 6]) > 0.5).astype("float32")
+        self.addCleanup(paddle.enable_static)
 
-            out1 = paddle.nn.functional.binary_cross_entropy_with_logits(
-                logit=logit, label=label, reduction="none"
-            )
-            out2 = paddle.nn.functional.binary_cross_entropy_with_logits(
-                input=logit, target=label, reduction="none"
-            )
-            np.testing.assert_allclose(
-                out1.numpy(), out2.numpy(), rtol=1e-6, atol=1e-6
-            )
+        logit = paddle.randn([4, 6], dtype="float32")
+        label = (paddle.rand([4, 6]) > 0.5).astype("float32")
 
-            out1_mean = paddle.nn.functional.binary_cross_entropy_with_logits(
-                logit=logit, label=label, reduction="mean"
-            )
-            out2_mean = paddle.nn.functional.binary_cross_entropy_with_logits(
-                input=logit, target=label, reduction="mean"
-            )
-            np.testing.assert_allclose(
-                out1_mean.numpy(),
-                out2_mean.numpy(),
-                rtol=1e-6,
-                atol=1e-6,
-            )
+        out1 = paddle.nn.functional.binary_cross_entropy_with_logits(
+            logit=logit, label=label, reduction="none"
+        )
+        out2 = paddle.nn.functional.binary_cross_entropy_with_logits(
+            input=logit, target=label, reduction="none"
+        )
+        np.testing.assert_allclose(
+            out1.numpy(), out2.numpy(), rtol=1e-6, atol=1e-6
+        )
 
-            with self.assertRaises(ValueError):
-                paddle.nn.functional.binary_cross_entropy_with_logits(
-                    logit=logit, input=logit, label=label, reduction="none"
-                )
-            with self.assertRaises(ValueError):
-                paddle.nn.functional.binary_cross_entropy_with_logits(
-                    logit=logit, label=label, target=label, reduction="none"
-                )
-        finally:
-            paddle.enable_static()
+        out1_mean = paddle.nn.functional.binary_cross_entropy_with_logits(
+            logit=logit, label=label, reduction="mean"
+        )
+        out2_mean = paddle.nn.functional.binary_cross_entropy_with_logits(
+            input=logit, target=label, reduction="mean"
+        )
+        np.testing.assert_allclose(
+            out1_mean.numpy(),
+            out2_mean.numpy(),
+            rtol=1e-6,
+            atol=1e-6,
+        )
+
+        with self.assertRaises(ValueError):
+            paddle.nn.functional.binary_cross_entropy_with_logits(
+                logit=logit, input=logit, label=label, reduction="none"
+            )
+        with self.assertRaises(ValueError):
+            paddle.nn.functional.binary_cross_entropy_with_logits(
+                logit=logit, label=label, target=label, reduction="none"
+            )
 
     def test_BCEWithLogitsLoss_error(self):
         paddle.disable_static()

--- a/test/legacy_test/test_bce_with_logits_loss.py
+++ b/test/legacy_test/test_bce_with_logits_loss.py
@@ -303,6 +303,46 @@ class TestBCEWithLogitsLoss(unittest.TestCase):
 
         test_static_or_pir_mode()
 
+    def test_binary_cross_entropy_with_logits_alias(self):
+        paddle.disable_static()
+        try:
+            logit = paddle.randn([4, 6], dtype="float32")
+            label = (paddle.rand([4, 6]) > 0.5).astype("float32")
+
+            out1 = paddle.nn.functional.binary_cross_entropy_with_logits(
+                logit=logit, label=label, reduction="none"
+            )
+            out2 = paddle.nn.functional.binary_cross_entropy_with_logits(
+                input=logit, target=label, reduction="none"
+            )
+            np.testing.assert_allclose(
+                out1.numpy(), out2.numpy(), rtol=1e-6, atol=1e-6
+            )
+
+            out1_mean = paddle.nn.functional.binary_cross_entropy_with_logits(
+                logit=logit, label=label, reduction="mean"
+            )
+            out2_mean = paddle.nn.functional.binary_cross_entropy_with_logits(
+                input=logit, target=label, reduction="mean"
+            )
+            np.testing.assert_allclose(
+                out1_mean.numpy(),
+                out2_mean.numpy(),
+                rtol=1e-6,
+                atol=1e-6,
+            )
+
+            with self.assertRaises(ValueError):
+                paddle.nn.functional.binary_cross_entropy_with_logits(
+                    logit=logit, input=logit, label=label, reduction="none"
+                )
+            with self.assertRaises(ValueError):
+                paddle.nn.functional.binary_cross_entropy_with_logits(
+                    logit=logit, label=label, target=label, reduction="none"
+                )
+        finally:
+            paddle.enable_static()
+
     def test_BCEWithLogitsLoss_error(self):
         paddle.disable_static()
         self.assertRaises(


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
- For `paddle.nn.functional.binary_cross_entropy_with_logits`, add kwargs alias compatibility with PyTorch:
  - `input` as alias of `logit`
  - `target` as alias of `label`
- Implemented with `@param_two_alias([logit, input], [label, target])`.
- Updated docstring alias notes for `logit` and `label`.
- Added legacy test `test_binary_cross_entropy_with_logits_alias` to cover:
  - equivalence of (`logit`, `label`) vs (`input`, `target`) for `reduction=none` and `mean`
  - `ValueError` when both canonical and alias kwargs are passed together.
- Related issue: #76301 (No.155)

### 是否引起精度变化
否