### PR TITLE
[Bug Fix] resolve CUDA error(3) in test_dataloader_dataset.py

### DIFF
--- a/python/paddle/io/dataloader/collate.py
+++ b/python/paddle/io/dataloader/collate.py
@@ -56,7 +56,16 @@ def default_collate_fn(batch):
         batch = np.stack(batch, axis=0)
         return batch
     elif isinstance(sample, paddle.Tensor):
-        return paddle.stack(batch, axis=0)
+        # In worker process, CUDA context is not valid after fork, so we must
+        # avoid any CUDA operations and use numpy for stacking
+        from .worker import get_worker_info
+        if get_worker_info() is not None:
+            # In worker subprocess: convert to numpy, stack, return CPU tensor
+            stacked = np.stack([t.numpy() for t in batch], axis=0)
+            return paddle.to_tensor(stacked, place=paddle.CPUPlace())
+        else:
+            # In main process: can use paddle.stack normally
+            return paddle.stack(batch, axis=0)
     elif isinstance(sample, numbers.Number):
         batch = np.array(batch)
         return batch


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

- Modify default_collate_fn to use numpy in worker subprocesses
- Avoid CUDA operations after fork to prevent CUDA error(3)
- Verified by passing test_dataloader_dataset.py


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否