### PR TITLE
[BugFix] Fix error handling in CudaEvent::ElapsedTime

### DIFF
--- a/paddle/phi/api/profiler/event.cc
+++ b/paddle/phi/api/profiler/event.cc
@@ -65,13 +65,29 @@ bool CudaEvent::Query() {
 float CudaEvent::ElapsedTime(CudaEvent *end_event) {
   float milliseconds = 0;
 #ifdef PADDLE_WITH_HIP
-  hipEventSynchronize(end_event->GetRawCudaEvent());
-  PADDLE_ENFORCE_GPU_SUCCESS(
-      hipEventElapsedTime(&milliseconds, event_, end_event->GetRawCudaEvent()));
+  gpuError_t sync_err = hipEventSynchronize(end_event->GetRawCudaEvent());
+  if (sync_err != hipSuccess) {
+    hipGetLastError();  // Clear the CUDA last error
+    PADDLE_ENFORCE_GPU_SUCCESS(sync_err);
+  }
+  gpuError_t elapsed_err =
+      hipEventElapsedTime(&milliseconds, event_, end_event->GetRawCudaEvent());
+  if (elapsed_err != hipSuccess) {
+    hipGetLastError();  // Clear the CUDA last error
+    PADDLE_ENFORCE_GPU_SUCCESS(elapsed_err);
+  }
 #else
-  cudaEventSynchronize(end_event->GetRawCudaEvent());
-  PADDLE_ENFORCE_GPU_SUCCESS(cudaEventElapsedTime(
-      &milliseconds, event_, end_event->GetRawCudaEvent()));
+  gpuError_t sync_err = cudaEventSynchronize(end_event->GetRawCudaEvent());
+  if (sync_err != cudaSuccess) {
+    cudaGetLastError();  // Clear the CUDA last error
+    PADDLE_ENFORCE_GPU_SUCCESS(sync_err);
+  }
+  gpuError_t elapsed_err =
+      cudaEventElapsedTime(&milliseconds, event_, end_event->GetRawCudaEvent());
+  if (elapsed_err != cudaSuccess) {
+    cudaGetLastError();  // Clear the CUDA last error
+    PADDLE_ENFORCE_GPU_SUCCESS(elapsed_err);
+  }
 #endif
   return milliseconds;
 }


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
修复 `CudaEvent::ElapsedTime` 中 GPU event 同步和计时的错误处理问题。

#### 改动背景
原实现中，`cudaEventSynchronize` 和 `cudaEventElapsedTime`（以及对应的 HIP 版本）调用失败后，直接通过 `PADDLE_ENFORCE_GPU_SUCCESS` 抛出异常，但未清除 CUDA/HIP 的 last error 状态。这会导致残留的错误状态传播到后续的 GPU API 调用中，可能引发难以定位的连锁错误。

#### 主要改动
- 在 `PADDLE_ENFORCE_GPU_SUCCESS` 之前，先检查返回值是否为错误状态
- 若出错，先调用 `cudaGetLastError()` / `hipGetLastError()` 清除 CUDA/HIP 的 last error，再抛出异常
- 同时覆盖了 CUDA 和 HIP 两个分支的处理逻辑

### 是否引起精度变化
否