### PR TITLE
[release/3.3][XPU] add synchronize when copy from/to pinned memory

### DIFF
--- a/paddle/phi/core/memory/memcpy.cc
+++ b/paddle/phi/core/memory/memcpy.cc
@@ -399,6 +399,7 @@ void Copy<phi::XPUPinnedPlace, phi::XPUPlace>(phi::XPUPinnedPlace dst_place,
                     reinterpret_cast<cudaStream_t>(stream));
 
   } else {
+    cudaDeviceSynchronize();
     phi::RecordEvent record_event(
         "cudaMemcpy:XPU->XPUPinned", phi::TracerEventType::UserDefined, 1);
     cudaMemcpy(dst, src, num, cudaMemcpyDeviceToHost);
@@ -435,6 +436,7 @@ void Copy<phi::XPUPlace, phi::XPUPinnedPlace>(phi::XPUPlace dst_place,
                     cudaMemcpyHostToDevice,
                     reinterpret_cast<cudaStream_t>(stream));
   } else {
+    cudaDeviceSynchronize();
     phi::RecordEvent record_event(
         "cudaMemcpy:XPUPinned->XPU", phi::TracerEventType::UserDefined, 1);
     cudaMemcpy(dst, src, num, cudaMemcpyHostToDevice);


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
Cherry-pick #77217 to release/3.3 branch for Paddle 3.3.1 release (XPU P800).
Add synchronize when copy from/to pinned memory.

devPR:https://github.com/PaddlePaddle/Paddle/pull/77217

### 精度变化
精度无变化