### PR TITLE
[BugFix] Skip cudaFree when CUDA context is unavailable after fork

### DIFF
--- a/paddle/phi/core/platform/device/gpu/gpu_info.cc
+++ b/paddle/phi/core/platform/device/gpu/gpu_info.cc
@@ -335,6 +335,34 @@ class RecordedGpuMallocHelper {
     // driver has already shutdown. This happens only if the
     // process is terminating, in which case we don't care if
     // cudaFree succeeds.
+    //
+    // Also skip cudaFree when CUDA context is not available in the
+    // current process. This can happen when a forked child process
+    // (e.g., DataLoader worker) inherits GPU tensors from the parent
+    // but cannot use CUDA after fork. In this case, the GPU memory
+    // will be reclaimed by the OS when the process exits.
+#ifdef PADDLE_WITH_HIP
+    {
+      int device_id;
+      auto device_err = hipGetDevice(&device_id);
+      if (device_err == hipErrorNoDevice ||
+          device_err == hipErrorInsufficientDriver) {
+        hipGetLastError();
+        return;
+      }
+    }
+#else
+    {
+      int device_id;
+      auto device_err = cudaGetDevice(&device_id);
+      if (device_err == cudaErrorInitializationError ||
+          device_err == cudaErrorNoDevice ||
+          device_err == cudaErrorInsufficientDriver) {
+        cudaGetLastError();
+        return;
+      }
+    }
+#endif
     CUDADeviceGuard guard(dev_id_);
 #ifdef PADDLE_WITH_HIP
     auto err = hipFree(ptr);
@@ -368,6 +396,30 @@ class RecordedGpuMallocHelper {
     // driver has already shutdown. This happens only if the
     // process is terminating, in which case we don't care if
     // cudaFree succeeds.
+    //
+    // Also skip when CUDA context is not available after fork.
+#ifdef PADDLE_WITH_HIP
+    {
+      int device_id;
+      auto device_err = hipGetDevice(&device_id);
+      if (device_err == hipErrorNoDevice ||
+          device_err == hipErrorInsufficientDriver) {
+        hipGetLastError();
+        return;
+      }
+    }
+#else
+    {
+      int device_id;
+      auto device_err = cudaGetDevice(&device_id);
+      if (device_err == cudaErrorInitializationError ||
+          device_err == cudaErrorNoDevice ||
+          device_err == cudaErrorInsufficientDriver) {
+        cudaGetLastError();
+        return;
+      }
+    }
+#endif
     CUDADeviceGuard guard(dev_id_);
 #ifdef PADDLE_WITH_CUDA
     auto err = cudaFreeAsync(ptr, stream);


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
在 fork 出的子进程（例如 DataLoader worker）中，子进程会继承父进程的 GPU 张量，但 fork 后无法正常使用 CUDA 上下文。当子进程退出并尝试调用 `cudaFree` / `hipFree` 释放这些继承的 GPU 内存时，会因为 CUDA 上下文不可用而报错。

本 PR 在 `RecordedGpuMallocHelper` 的两处内存释放路径（`Free` 和 `FreeAsync`）中，增加了对 CUDA/HIP 上下文可用性的检查：
- 在调用 `cudaFree` / `hipFree` 之前，先通过 `cudaGetDevice` / `hipGetDevice` 探测当前进程的 CUDA 上下文状态
- 如果返回 `cudaErrorInitializationError`、`cudaErrorNoDevice` 或 `cudaErrorInsufficientDriver`（HIP 侧对应错误码），则跳过释放操作并直接返回
- 这些 GPU 内存最终会在进程退出时由操作系统回收，不会造成实际泄漏

此修复解决了使用多进程数据加载（如 `paddle.io.DataLoader` 配合 `num_workers > 0`）时，子进程退出阶段可能出现的 CUDA 错误。

### 是否引起精度变化
否