### PR TITLE
Fix CUDA error(9) when processing zero-size tensors in cross_entropy …

### DIFF
--- a/paddle/phi/kernels/funcs/cross_entropy.cu
+++ b/paddle/phi/kernels/funcs/cross_entropy.cu
@@ -140,6 +140,12 @@ void CrossEntropyFunctor<DeviceContext, T>::operator()(
                         "allowed size is 2 ^ 31 - 1 elements, but got %lld",
                         out->numel()));
 
+  // Handle zero-size tensor to avoid invalid kernel configuration
+  // (e.g., when class_num is 0, std::log2(0) is undefined behavior)
+  if (class_num_int == 0 || batch_size_int == 0) {
+    return;
+  }
+
   if (softLabel) {
     const T* label_data = labels->data<T>();
     int block = class_num_int > kMaxBlockDim

--- a/paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu
@@ -241,6 +241,11 @@ void CrossEntropyWithSoftmaxBwdWithDowncastGPUKernel(
   const int64_t d = funcs::SizeFromAxis(axis_v, logit_grad->dims());
   const int64_t remain = d / axis_dim;
 
+  // Handle zero-size tensor to avoid invalid kernel configuration
+  if (n == 0 || d == 0 || axis_dim == 0) {
+    return;
+  }
+
   const T* softmax_data = softmax.data<T>();
   const auto* label_data = label.data<LabelT>();
 

--- a/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
@@ -170,6 +170,11 @@ void CrossEntropyWithSoftmaxGradGPUKernel(const GPUContext& dev_ctx,
   const int64_t d = funcs::SizeFromAxis(axis_v, logit_grad->dims());
   const int64_t remain = d / axis_dim;
 
+  // Handle zero-size tensor to avoid invalid kernel configuration
+  if (n == 0 || d == 0 || axis_dim == 0) {
+    return;
+  }
+
   int block = 512;
   auto stream = dev_ctx.stream();
 

--- a/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_kernel.cu
@@ -728,6 +728,12 @@ static void SoftmaxWithCrossEntropySoftLabel(const GPUContext& dev_ctx,
                                              int N,
                                              int dim,
                                              int D) {
+  // Handle zero-size tensor to avoid invalid kernel configuration
+  // (e.g., when dim is 0, std::log2(0) is undefined behavior)
+  if (dim == 0 || N == 0) {
+    return;
+  }
+
   constexpr int kMaxBlockDim = 512;
   auto* logits_data = logits.data<T>();
   auto* softmax_data = softmax->data<T>();
@@ -1163,6 +1169,12 @@ static void SoftmaxWithCrossEntropyHardLabel(const GPUContext& dev_ctx,
                                              const int ignore_index) {
   VLOG(7) << "rank=" << rank << ", axis = " << axis << ", N = " << N
           << ", dim = " << dim << ", D = " << D;
+
+  // Handle zero-size tensor to avoid invalid kernel configuration
+  if (dim == 0 || N == 0) {
+    return;
+  }
+
   auto* logits_data = logits.data<T>();
   auto stream = dev_ctx.stream();
   constexpr int max_dim = 320;
@@ -1334,6 +1346,17 @@ void CrossEntropyWithSoftmaxCUDAKernel(const GPUContext& dev_ctx,
 
   const int64_t n = funcs::SizeToAxis(axis_v, logits.dims());
   const int64_t d = funcs::SizeFromAxis(axis_v, logits.dims());
+
+  // Handle zero-size tensor to avoid invalid kernel configuration
+  if (axis_dim == 0 || n == 0) {
+    auto* softmax_data = dev_ctx.template Alloc<T>(softmax);
+    auto* loss_data = dev_ctx.template Alloc<T>(loss);
+
+    funcs::SetConstant<GPUContext, T> set_constant;
+    set_constant(dev_ctx, softmax, static_cast<T>(0));
+    set_constant(dev_ctx, loss, static_cast<T>(0));
+    return;
+  }
 
   if (axis_dim == 1) {
     auto* softmax_data = dev_ctx.template Alloc<T>(softmax);


### PR DESCRIPTION
…kernels

When processing tensors with zero dimensions (e.g., shape (0, 10) or (16, 0)), the cross_entropy kernels encounter invalid configuration arguments because:
1. std::log2(0) is undefined behavior, resulting in -inf
2. The computed block/grid dimensions become invalid

This fix adds zero-dimension checks at the entry of affected kernel functions to avoid launching kernels with invalid configurations.

Files modified:
- paddle/phi/kernels/funcs/cross_entropy.cu
- paddle/phi/kernels/gpu/cross_entropy_kernel.cu
- paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
- paddle/phi/kernels/gpu/cross_entropy_bwd_w_downcast.cu

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->


### Description
<!-- Describe what you’ve done -->


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
