### PR TITLE
[API compatibility NO.37]sinking bincount into c++

### DIFF
--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -166,8 +166,8 @@
   name : [paddle.bincount, paddle.Tensor.bincount]
   args_alias :
     use_default_mapping : True
-  pre_process :
-    func : BinCountPreProcess(x, weights, minlength)
+  # pre_process :
+  #   func : BinCountPreProcess(x, weights, minlength)
 
 - op : bitwise_and
   name : [paddle.bitwise_and, paddle.Tensor.bitwise_and]

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -4120,7 +4120,7 @@ add_doc_and_signature(
     Computes frequency of each value in the input tensor.
 
     Args:
-        x (Tensor): A Tensor with non-negative integer. Should be 1-D tensor.
+        x (Tensor): A Tensor with non-negative integer. Should be 1-D tensor. Alias: ``input``.
         weights (Tensor, optional): Weight for each value in the input tensor. Should have the same shape as input. Default is None.
         minlength (int, optional): Minimum number of bins. Should be non-negative integer. Default is 0.
         name (str|None, optional): Normally there is no need for user to set this property.
@@ -4133,21 +4133,21 @@ add_doc_and_signature(
         .. code-block:: pycon
 
             >>> import paddle
-            >>> x = paddle.to_tensor([1, 2, 1, 4, 5])
-            >>> result1 = paddle.bincount(x)
+            >>> input = paddle.to_tensor([1, 2, 1, 4, 5])
+            >>> result1 = paddle.bincount(input)
             >>> print(result1)
             Tensor(shape=[6], dtype=int64, place=Place(cpu), stop_gradient=True,
             [0, 2, 1, 0, 1, 1])
 
             >>> w = paddle.to_tensor([2.1, 0.4, 0.1, 0.5, 0.5])
-            >>> result2 = paddle.bincount(x, weights=w)
+            >>> result2 = paddle.bincount(input, weights=w)
             >>> print(result2)
             Tensor(shape=[6], dtype=float32, place=Place(cpu), stop_gradient=True,
             [0.        , 2.19999981, 0.40000001, 0.        , 0.50000000, 0.50000000])
 """,
     """
 def bincount(
-    x: Tensor,
+    input: Tensor,
     weights: Tensor | None = None,
     minlength: int = 0,
     name: str | None = None,


### PR DESCRIPTION
Related to https://github.com/PaddlePaddle/Paddle/issues/76301

### PR Category
User Experience

### PR Types
Improvements

### Description
1. 下沉 `paddle.bincount`、`paddle.Tensor.bincount` 到 C++ 层（通过 `python_api_info.yaml` 配置）。
2. 兼容 Torch `input` 参数，支持 `paddle.bincount(input=...)` 调用方式。
3. 将 API 文档下沉至 `python/paddle/_paddle_docs.py`，并增加 `input` 别名说明。

### 是否引起精度变化
否
