### PR TITLE
[API Compatibility No.55-56] paddle.cummax and paddle.cummin -part

### DIFF
--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -4871,6 +4871,143 @@ def cross(
 )
 
 add_doc_and_signature(
+    "cummax",
+    r"""
+    The cumulative max of the elements along a given axis.
+
+    Note:
+        The first element of the result is the same as the first element of the input.
+
+    Args:
+        x (Tensor): The input tensor needed to be cummaxed.
+        axis (int, optional): The dimension to accumulate along. -1 means the last dimension. The default (None) is to compute the cummax over the flattened array.
+        dtype (str|paddle.dtype|np.dtype, optional): The data type of the indices tensor, can be int32, int64. The default value is int64.
+        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        out (Tensor), The result of cummax operation. The dtype of cummax result is same with input x.
+
+        indices (Tensor), The corresponding index results of cummax operation.
+
+    Examples:
+        .. code-block:: pycon
+
+            >>> import paddle
+
+            >>> data = paddle.to_tensor([-1, 5, 0, -2, -3, 2])
+            >>> data = paddle.reshape(data, (2, 3))
+
+            >>> value, indices = paddle.cummax(data)
+            >>> value
+            Tensor(shape=[6], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [-1,  5,  5,  5,  5,  5])
+            >>> indices
+            Tensor(shape=[6], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [0, 1, 1, 1, 1, 1])
+
+            >>> value, indices = paddle.cummax(data, axis=0)
+            >>> value
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[-1,  5,  0],
+             [-1,  5,  2]])
+            >>> indices
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[0, 0, 0],
+             [0, 0, 1]])
+
+            >>> value, indices = paddle.cummax(data, axis=-1)
+            >>> value
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[-1,  5,  5],
+             [-2, -2,  2]])
+            >>> indices
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[0, 1, 1],
+             [0, 0, 2]])
+
+            >>> value, indices = paddle.cummax(data, dtype='int64')
+            >>> assert indices.dtype == paddle.int64
+""",
+    """
+def cummax(
+    x: Tensor,
+    axis: int | None = None,
+    dtype: DTypeLike = 'int64',
+    out: tuple[Tensor, Tensor] | None = None,
+    name: str | None = None,
+) -> tuple[Tensor, Tensor]
+""",
+)
+
+add_doc_and_signature(
+    "cummin",
+    r"""
+    The cumulative min of the elements along a given axis.
+
+    Note:
+        The first element of the result is the same as the first element of the input.
+
+    Args:
+        x (Tensor): The input tensor needed to be cummined.
+        axis (int, optional): The dimension to accumulate along. -1 means the last dimension. The default (None) is to compute the cummin over the flattened array.
+        dtype (str|paddle.dtype|np.dtype, optional): The data type of the indices tensor, can be int32, int64. The default value is int64.
+        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        out (Tensor), The result of cummin operation. The dtype of cummin result is same with input x.
+
+        indices (Tensor), The corresponding index results of cummin operation.
+
+    Examples:
+        .. code-block:: pycon
+
+            >>> import paddle
+            >>> data = paddle.to_tensor([-1, 5, 0, -2, -3, 2])
+            >>> data = paddle.reshape(data, (2, 3))
+
+            >>> value, indices = paddle.cummin(data)
+            >>> value
+            Tensor(shape=[6], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [-1, -1, -1, -2, -3, -3])
+            >>> indices
+            Tensor(shape=[6], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [0, 0, 0, 3, 4, 4])
+
+            >>> value, indices = paddle.cummin(data, axis=0)
+            >>> value
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[-1,  5,  0],
+             [-2, -3,  0]])
+            >>> indices
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[0, 0, 0],
+             [1, 1, 0]])
+
+            >>> value, indices = paddle.cummin(data, axis=-1)
+            >>> value
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[-1, -1, -1],
+             [-2, -3, -3]])
+            >>> indices
+            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
+            [[0, 0, 0],
+             [0, 1, 1]])
+
+            >>> value, indices = paddle.cummin(data, dtype='int64')
+            >>> assert indices.dtype == paddle.int64
+""",
+    """
+def cummin(
+    x: Tensor,
+    axis: int | None = None,
+    dtype: DTypeLike = 'int64',
+    out: tuple[Tensor, Tensor] | None = None,
+    name: str | None = None,
+) -> tuple[Tensor, Tensor]
+""",
+)
+
+add_doc_and_signature(
     "dist",
     r"""
     Returns the p-norm of (x - y). It is not a norm in a strict sense, only as a measure

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -3228,10 +3228,12 @@ def cumsum_(
         return _C_ops.cumsum_(x, axis, flatten, False, False)
 
 
+@param_two_alias(["x", "input"], ["axis", "dim"]) 
 def cummax(
     x: Tensor,
     axis: int | None = None,
     dtype: DTypeLike = 'int64',
+    out: tuple[Tensor, Tensor] | None = None, 
     name: str | None = None,
 ) -> tuple[Tensor, Tensor]:
     """
@@ -3299,7 +3301,20 @@ def cummax(
         dtype = convert_np_dtype_to_dtype_(dtype)
 
     if in_dynamic_or_pir_mode():
-        return _C_ops.cummax(x, axis, dtype)
+        if out is not None:
+            if not isinstance(out, (tuple, list)) or len(out) != 2:
+                raise ValueError("out must be a tuple of two Tensors (values, indices)")
+            
+            out_value, out_index = out
+
+            result_val, result_idx = _C_ops.cummax(x, axis, dtype)
+            paddle.assign(result_val, out_value)
+            paddle.assign(result_idx, out_index)
+            
+            return out_value, out_index
+        else:
+            return _C_ops.cummax(x, axis, dtype)
+            
     else:
         check_variable_and_dtype(
             x,
@@ -3309,21 +3324,34 @@ def cummax(
         )
         check_type(x, 'x', (Variable), 'cummax')
         helper = LayerHelper('cummax', **locals())
-        out = helper.create_variable_for_type_inference(x.dtype)
-        indices = helper.create_variable_for_type_inference(dtype='int64')
-        helper.append_op(
-            type='cummax',
-            inputs={'x': x},
-            outputs={'out': out, 'indices': indices},
-            attrs={'axis': axis, 'dtype': dtype},
-        )
-        return out, indices
+
+        if out is not None:
+            out_value, out_index = out
+            helper.append_op(
+                type='cummax',
+                inputs={'x': x},
+                outputs={'out': out_value, 'indices': out_index}, 
+                attrs={'axis': axis, 'dtype': dtype},
+            )
+            return out_value, out_index
+        else:
+            out = helper.create_variable_for_type_inference(x.dtype)
+            indices = helper.create_variable_for_type_inference(dtype='int64')
+            helper.append_op(
+                type='cummax',
+                inputs={'x': x},
+                outputs={'out': out, 'indices': indices},
+                attrs={'axis': axis, 'dtype': dtype},
+            )
+            return out, indices
 
 
+@param_two_alias(["x", "input"], ["axis", "dim"]) 
 def cummin(
     x: Tensor,
     axis: int | None = None,
     dtype: DTypeLike = 'int64',
+    out: tuple[Tensor, Tensor] | None = None,
     name: str | None = None,
 ) -> tuple[Tensor, Tensor]:
     """
@@ -3390,7 +3418,20 @@ def cummin(
         dtype = convert_np_dtype_to_dtype_(dtype)
 
     if in_dynamic_or_pir_mode():
-        return _C_ops.cummin(x, axis, dtype)
+        if out is not None:
+            if not isinstance(out, (tuple, list)) or len(out) != 2:
+                raise ValueError("out must be a tuple of two Tensors (values, indices)")
+            
+            out_value, out_index = out
+
+            result_val, result_idx = _C_ops.cummin(x, axis, dtype)
+            paddle.assign(result_val, out_value)
+            paddle.assign(result_idx, out_index)
+            
+            return out_value, out_index
+        else:
+            return _C_ops.cummin(x, axis, dtype)
+                        
     else:
         check_variable_and_dtype(
             x,
@@ -3400,15 +3441,26 @@ def cummin(
         )
         check_type(x, 'x', (Variable), 'cummin')
         helper = LayerHelper('cummin', **locals())
-        out = helper.create_variable_for_type_inference(x.dtype)
-        indices = helper.create_variable_for_type_inference(dtype='int64')
-        helper.append_op(
-            type='cummin',
-            inputs={'x': x},
-            outputs={'out': out, 'indices': indices},
-            attrs={'axis': axis, 'dtype': dtype},
-        )
-        return out, indices
+        
+        if out is not None:
+            out_value, out_index = out
+            helper.append_op(
+                type='cummin',
+                inputs={'x': x},
+                outputs={'out': out_value, 'indices': out_index}, 
+                attrs={'axis': axis, 'dtype': dtype},
+            )
+            return out_value, out_index
+        else:
+            out = helper.create_variable_for_type_inference(x.dtype)
+            indices = helper.create_variable_for_type_inference(dtype='int64')
+            helper.append_op(
+                type='cummin',
+                inputs={'x': x},
+                outputs={'out': out, 'indices': indices},
+                attrs={'axis': axis, 'dtype': dtype},
+            )
+            return out, indices
 
 
 def logcumsumexp(

--- a/test/legacy_test/test_api_compatibility.py
+++ b/test/legacy_test/test_api_compatibility.py
@@ -3208,6 +3208,130 @@ class TestDsplitAPI(unittest.TestCase):
                 np.testing.assert_allclose(fetches[i], ref_out[0])
                 np.testing.assert_allclose(fetches[i + 1], ref_out[1])
 
+class TestCummaxAPI(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+        paddle.enable_static()
+        self.shape = [5, 6]
+        self.dtype = 'float32'
+        self.init_data()
+
+    def init_data(self):
+        self.np_x = np.random.randn(*self.shape).astype(self.dtype)
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        paddle_dygraph_out = []
+
+        out1, idx1 = paddle.cummax(x, 0)
+        paddle_dygraph_out.append((out1, idx1))
+
+        out2, idx2 = paddle.cummax(x=x, axis=0)
+        paddle_dygraph_out.append((out2, idx2))
+
+        out3, idx3 = paddle.cummax(input=x, dim=0)
+        paddle_dygraph_out.append((out3, idx3))
+
+        out_val = paddle.empty(self.shape, dtype=self.dtype)
+        out_idx = paddle.empty(self.shape, dtype='int64')
+        paddle.cummax(x, axis=0, out=(out_val, out_idx))
+        paddle_dygraph_out.append((out_val, out_idx))
+
+        out_val2 = paddle.empty(self.shape, dtype=self.dtype)
+        out_idx2 = paddle.empty(self.shape, dtype='int64')
+        paddle.cummax(input=x, dim=0, out=(out_val2, out_idx2))
+        paddle_dygraph_out.append((out_val2, out_idx2))
+
+        np_val = np.maximum.accumulate(self.np_x, axis=0)
+
+        for val, idx in paddle_dygraph_out:
+            np.testing.assert_allclose(np_val, val.numpy())
+
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.base.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
+
+            out1, idx1 = paddle.cummax(x, 0)
+
+            out2, idx2 = paddle.cummax(x=x, axis=0)
+
+            out3, idx3 = paddle.cummax(input=x, dim=0)
+
+            exe = paddle.base.Executor(paddle.CPUPlace())
+            fetches = exe.run(
+                main, feed={"x": self.np_x}, fetch_list=[out1, idx1, out2, idx2, out3, idx3],
+            )
+
+        np_val = np.maximum.accumulate(self.np_x, axis=0)
+        for i in range(0, len(fetches), 2):
+            np.testing.assert_allclose(np_val, fetches[i])
+
+class TestCumminAPI(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+        paddle.enable_static()
+        self.shape = [5, 6]
+        self.dtype = 'float32'
+        self.init_data()
+
+    def init_data(self):
+        self.np_x = np.random.randn(*self.shape).astype(self.dtype)
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        paddle_dygraph_out = []
+
+        out1, idx1 = paddle.cummin(x, 0)
+        paddle_dygraph_out.append((out1, idx1))
+
+        out2, idx2 = paddle.cummin(x=x, axis=0)
+        paddle_dygraph_out.append((out2, idx2))
+
+        out3, idx3 = paddle.cummin(input=x, dim=0)
+        paddle_dygraph_out.append((out3, idx3))
+
+        out_val = paddle.empty(self.shape, dtype=self.dtype)
+        out_idx = paddle.empty(self.shape, dtype='int64')
+        paddle.cummin(x, axis=0, out=(out_val, out_idx))
+        paddle_dygraph_out.append((out_val, out_idx))
+
+        np_val = np.minimum.accumulate(self.np_x, axis=0)
+
+        for val, idx in paddle_dygraph_out:
+            np.testing.assert_allclose(np_val, val.numpy())
+
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.base.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
+
+            out1, idx1 = paddle.cummin(x, 0)
+
+            out2, idx2 = paddle.cummin(x=x, axis=0)
+
+            out3, idx3 = paddle.cummin(input=x, dim=0)
+
+            exe = paddle.base.Executor(paddle.CPUPlace())
+            fetches = exe.run(
+                main, feed={"x": self.np_x}, fetch_list=[out1, idx1, out2, idx2, out3, idx3],
+            )
+
+        np_val = np.minimum.accumulate(self.np_x, axis=0)
+
+        for i in range(0, len(fetches), 2):
+            np.testing.assert_allclose(np_val, fetches[i])
+
 
 class TestVsplitAPI(unittest.TestCase):
     def setUp(self):

--- a/test/legacy_test/test_cummax_op.py
+++ b/test/legacy_test/test_cummax_op.py
@@ -246,6 +246,35 @@ class TestCummaxAPI(unittest.TestCase):
 
         self.assertRaises(IndexError, test_axis_outrange)
 
+    def test_api_compatibility(self):
+        paddle.disable_static()
+        data_np = np.random.random((10, 10)).astype(np.float32)
+        data = paddle.to_tensor(data_np)
+
+        y1, idx1 = paddle.cummax(data, axis=0)
+        y2, idx2 = paddle.cummax(input=data, dim=0)  
+        
+        np.testing.assert_array_equal(y1.numpy(), y2.numpy())
+        np.testing.assert_array_equal(idx1.numpy(), idx2.numpy())
+        
+        out_val = paddle.empty_like(data)
+        out_idx = paddle.empty((10, 10), dtype=paddle.int64)
+        
+        paddle.cummax(data, axis=0, out=(out_val, out_idx))
+        
+        np.testing.assert_array_equal(y1.numpy(), out_val.numpy())
+        np.testing.assert_array_equal(idx1.numpy(), out_idx.numpy())
+        
+        out_val2 = paddle.empty_like(data)
+        out_idx2 = paddle.empty((10, 10), dtype=paddle.int64)
+        paddle.cummax(input=data, dim=0, out=(out_val2, out_idx2))
+        
+        np.testing.assert_array_equal(y1.numpy(), out_val2.numpy())
+        np.testing.assert_array_equal(idx1.numpy(), out_idx2.numpy())
+
+        paddle.enable_static()
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_cummin_op.py
+++ b/test/legacy_test/test_cummin_op.py
@@ -247,6 +247,36 @@ class TestCumminAPI(unittest.TestCase):
 
         self.assertRaises(IndexError, test_axis_outrange)
 
+    def test_api_compatibility(self):
+
+        paddle.disable_static()
+        data_np = np.random.random((10, 10)).astype(np.float32)
+        data = paddle.to_tensor(data_np)
+
+        y1, idx1 = paddle.cummin(data, axis=0)
+        y2, idx2 = paddle.cummin(input=data, dim=0) 
+        
+        np.testing.assert_array_equal(y1.numpy(), y2.numpy())
+        np.testing.assert_array_equal(idx1.numpy(), idx2.numpy())
+
+        out_val = paddle.empty_like(data)
+        out_idx = paddle.empty((10, 10), dtype=paddle.int64)
+        
+        paddle.cummin(data, axis=0, out=(out_val, out_idx))
+        
+        np.testing.assert_array_equal(y1.numpy(), out_val.numpy())
+        np.testing.assert_array_equal(idx1.numpy(), out_idx.numpy())
+
+        out_val2 = paddle.empty_like(data)
+        out_idx2 = paddle.empty((10, 10), dtype=paddle.int64)
+        paddle.cummin(input=data, dim=0, out=(out_val2, out_idx2))
+        
+        np.testing.assert_array_equal(y1.numpy(), out_val2.numpy())
+        np.testing.assert_array_equal(idx1.numpy(), out_idx2.numpy())
+
+        paddle.enable_static()
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION

###PR Category
User Experience
###PR Types
Improvements
###Description
本次修改增强了 paddle.cummax 和 paddle.cummin API 与 PyTorch 的兼容性，使其能够无缝对接 PyTorch 代码迁移。
##主要改动：
参数别名支持：在 python/paddle/tensor/math.py 中，为 cummax 和 cummin 函数添加了 @param_two_alias(["x", "input"], ["axis", "dim"]) 装饰器。现在，input 可作为 x 的别名，dim 可作为 axis 的别名。例如，paddle.cummax(input=x, dim=1) 与 paddle.cummax(x=x, axis=1) 完全等价。
out 参数支持：在函数签名中新增了 out: tuple[Tensor, Tensor] | None = None 参数。在动态图模式下，计算结果可通过 paddle.assign 写入预分配的张量；在静态图模式下，直接将 out 张量传递给算子。
文档更新：在两个函数的文档字符串中添加了 .. note:: 块，明确说明了别名支持；在参数说明部分添加了 alias: 标注。
测试补充：
在 test_api_compatibility.py 中新增了 TestCummaxAPI 和 TestCumminAPI 测试类，全面验证了位置参数、Paddle风格关键字参数、PyTorch风格别名参数以及 out 参数的功能。
在 test_cummax_op.py 和 test_cummin_op.py 的 TestCummaxAPI 和 TestCumminAPI 类中，新增了 test_api_compatibility 方法，专门测试别名和 out 参数的正确性。
##改动详情：
修改文件：python/paddle/tensor/math.py
新增测试文件：test_api_compatibility.py（已添加对应测试类）
更新测试文件：test_cummax_op.py, test_cummin_op.py
这些改动使得用户在从 PyTorch 迁移代码时，可以更自然地使用 input/dim 参数名，并利用 out 参数优化内存使用，无需修改原有调用习惯，提升了API的易用性和迁移体验。
###是否引起精度变化
否