### PR TITLE
fix full_like int64 out of range

### DIFF
--- a/paddle/phi/kernels/cpu/full_kernel.cc
+++ b/paddle/phi/kernels/cpu/full_kernel.cc
@@ -58,7 +58,8 @@ void FullLikeKernel(const Context& dev_ctx,
     return;
   }
   if (!std::is_same<T, phi::complex64>::value &&
-      !std::is_same<T, phi::complex128>::value) {
+      !std::is_same<T, phi::complex128>::value &&
+      !std::is_same<T, int64_t>::value) {
     auto value = val.to<double>();
     using CommonType = typename std::common_type<
         float,

--- a/paddle/phi/kernels/gpu/full_kernel.cu
+++ b/paddle/phi/kernels/gpu/full_kernel.cu
@@ -72,7 +72,8 @@ void FullLikeKernel(const Context& dev_ctx,
   int64_t numel = out->numel();
 
   if (!std::is_same<T, phi::complex64>::value &&
-      !std::is_same<T, phi::complex128>::value) {
+      !std::is_same<T, phi::complex128>::value &&
+      !std::is_same<T, int64_t>::value) {
     auto value = val.to<double>();
     using CommonType = typename std::common_type<
         float,

--- a/paddle/phi/kernels/xpu/full_kernel.cc
+++ b/paddle/phi/kernels/xpu/full_kernel.cc
@@ -133,7 +133,7 @@ void FullLikeKernel(const Context& dev_ctx,
       int r = xpu::constant(dev_ctx.x_context(),
                             out_data,
                             out->numel(),
-                            static_cast<XPUInTDType>(value));
+                            static_cast<XPUInTDType>(val.to<T>()));
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
     }
   }

--- a/paddle/phi/kernels/xpu/full_kernel.cc
+++ b/paddle/phi/kernels/xpu/full_kernel.cc
@@ -88,44 +88,54 @@ void FullLikeKernel(const Context& dev_ctx,
                     DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   if (out->numel() > 0) {
-    auto value = val.to<double>();
-    using XPUInTDType = typename XPUTypeTrait<T>::Type;
-    using CommonType = typename std::common_type<
-        float,
-        typename std::conditional<std::is_same<T, phi::float16>::value,
-                                  float,
-                                  T>::type>::type;
+    if (!std::is_same<T, int64_t>::value) {
+      auto value = val.to<double>();
+      using XPUInTDType = typename XPUTypeTrait<T>::Type;
+      using CommonType = typename std::common_type<
+          float,
+          typename std::conditional<std::is_same<T, phi::float16>::value,
+                                    float,
+                                    T>::type>::type;
 
-    auto common_type_value = static_cast<CommonType>(value);
-    bool is_out_range = true;
-    if (std::isinf(value) || std::isnan(value)) {
-      is_out_range = false;
+      auto common_type_value = static_cast<CommonType>(value);
+      bool is_out_range = true;
+      if (std::isinf(value) || std::isnan(value)) {
+        is_out_range = false;
+      }
+      if ((common_type_value >=
+           static_cast<CommonType>(std::numeric_limits<T>::lowest())) &&
+          (common_type_value <=
+           static_cast<CommonType>(std::numeric_limits<T>::max()))) {
+        is_out_range = false;
+      }
+
+      PADDLE_ENFORCE_EQ(
+          is_out_range,
+          false,
+          common::errors::InvalidArgument(
+              "The filled value is out of range for target type, "
+              "current kernel type is %s, the range should between %f "
+              "and %f, but now value is %f.",
+              typeid(T).name(),
+              static_cast<CommonType>(std::numeric_limits<T>::lowest()),
+              static_cast<CommonType>(std::numeric_limits<T>::max()),
+              static_cast<float>(value)));
+
+      auto out_data = reinterpret_cast<XPUInTDType*>(out->data<T>());
+      int r = xpu::constant(dev_ctx.x_context(),
+                            out_data,
+                            out->numel(),
+                            static_cast<XPUInTDType>(value));
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
+    } else {
+      using XPUInTDType = typename XPUTypeTrait<T>::Type;
+      auto out_data = reinterpret_cast<XPUInTDType*>(out->data<T>());
+      int r = xpu::constant(dev_ctx.x_context(),
+                            out_data,
+                            out->numel(),
+                            static_cast<XPUInTDType>(value));
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
     }
-    if ((common_type_value >=
-         static_cast<CommonType>(std::numeric_limits<T>::lowest())) &&
-        (common_type_value <=
-         static_cast<CommonType>(std::numeric_limits<T>::max()))) {
-      is_out_range = false;
-    }
-
-    PADDLE_ENFORCE_EQ(
-        is_out_range,
-        false,
-        common::errors::InvalidArgument(
-            "The filled value is out of range for target type, "
-            "current kernel type is %s, the range should between %f "
-            "and %f, but now value is %f.",
-            typeid(T).name(),
-            static_cast<CommonType>(std::numeric_limits<T>::lowest()),
-            static_cast<CommonType>(std::numeric_limits<T>::max()),
-            static_cast<float>(value)));
-
-    auto out_data = reinterpret_cast<XPUInTDType*>(out->data<T>());
-    int r = xpu::constant(dev_ctx.x_context(),
-                          out_data,
-                          out->numel(),
-                          static_cast<XPUInTDType>(value));
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
   }
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 https://github.com/PaddlePaddle/Paddle/issues/78093 提到的 int64最大值越界问题

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否