### PR TITLE
[BugFix] Disable FLAGS_use_system_allocator in test_allocator_visitor

### DIFF
--- a/test/legacy_test/test_allocator_visitor.py
+++ b/test/legacy_test/test_allocator_visitor.py
@@ -42,6 +42,10 @@ class TestAllocatorVisitor(unittest.TestCase):
             ["Free", 1 * self.MB, "0x100000010"],
             ["Free", 2 * self.MB, "0x100000013"],
         ]
+        # FLAGS_use_system_allocator bypasses VMM allocator entirely,
+        # causing VMM-specific APIs to return empty results. Disable it
+        # so the VMM allocator is actually used.
+        paddle.set_flags({'FLAGS_use_system_allocator': False})
         paddle.set_flags({'FLAGS_use_virtual_memory_auto_growth': True})
 
     def allocate_cmds(self, cmds):


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
`test_allocator_visitor` 测试用例在某些环境下会失败，原因是 `FLAGS_use_system_allocator` 默认启用后会绕过 VMM allocator，导致 VMM 相关的 API 返回空结果，测试断言失败。

本 PR 在测试 setUp 中显式设置 `FLAGS_use_system_allocator` 为 `False`，确保 VMM allocator 被实际使用，使得测试能够正确验证 VMM allocator visitor 的行为。

### 是否引起精度变化
否