### PR TITLE
[BugFix] Wrap system_allocators_ with RetryAllocator for GPU/XPU

### DIFF
--- a/paddle/phi/core/memory/allocation/allocator_facade.cc
+++ b/paddle/phi/core/memory/allocation/allocator_facade.cc
@@ -1605,6 +1605,12 @@ class AllocatorFacadePrivate {
             pair.second, pair.first, retry_time);
       }
     }
+    for (auto& pair : system_allocators_) {
+      if (phi::is_gpu_place(pair.first) || phi::is_xpu_place(pair.first)) {
+        pair.second = std::make_shared<RetryAllocator>(
+            pair.second, pair.first, retry_time);
+      }
+    }
   }
 
   void WrapStatAllocator() {


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
在 `WrapCUDARetryAllocator` 中，原有逻辑仅对 `allocators_` 中的 GPU/XPU 分配器包装了 `RetryAllocator`，但遗漏了 `system_allocators_`。这导致通过 `system_allocators_` 路径进行的显存分配在 OOM 时不会触发重试机制，直接抛出分配失败异常。

本次修复为 `system_allocators_` 中的 GPU/XPU 分配器同样添加 `RetryAllocator` 包装，使其在显存不足时也能进行重试，与 `allocators_` 行为保持一致。

#### 改动要点
- 在 `WrapCUDARetryAllocator` 方法中新增对 `system_allocators_` 的遍历
- 对其中 GPU 和 XPU place 的分配器包装 `RetryAllocator`

### 是否引起精度变化
否