### PR TITLE
[BugFix] Fix CUDA error(900) in test_cuda_graph_static_mode_error due to orphaned stream capture

### DIFF
--- a/paddle/phi/backends/gpu/cuda/cuda_graph.cc
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph.cc
@@ -220,6 +220,16 @@ void CUDAGraph::EndSegmentCapture() {
   cudaGraph_t graph;
   PADDLE_ENFORCE_GPU_SUCCESS(
       cudaStreamEndCapture(capturing_graph_->stream_, &graph));
+
+  // When capture was invalidated (e.g., due to a disallowed operation during
+  // capturing), cudaStreamEndCapture returns a NULL graph. In this case, we
+  // simply skip the rest of the capture processing.
+  if (graph == nullptr) {
+    VLOG(1) << "CUDA Graph capture was invalidated, skipping segment capture "
+            << "for graph ID " << capturing_graph_->id_;
+    return;
+  }
+
   auto num_nodes = static_cast<size_t>(-1);
   PADDLE_ENFORCE_GPU_SUCCESS(cudaGraphGetNodes(graph, nullptr, &num_nodes));
   if (num_nodes == 0) {

--- a/test/legacy_test/test_cuda_graph_static_mode_error.py
+++ b/test/legacy_test/test_cuda_graph_static_mode_error.py
@@ -21,6 +21,15 @@ import paddle
 from paddle.base.dygraph.base import switch_to_static_graph
 from paddle.device.cuda.graphs import CUDAGraph
 
+try:
+    from paddle.base.core import (
+        CUDAGraph as CoreCUDAGraph,
+        is_cuda_graph_capturing,
+    )
+except ImportError:
+    CoreCUDAGraph = None
+    is_cuda_graph_capturing = None
+
 
 @unittest.skipIf(
     not (paddle.is_compiled_with_cuda() or is_custom_device())
@@ -81,6 +90,17 @@ class TestCUDAGraphInFirstBatch(unittest.TestCase):
 
                     if cuda_graph:
                         cuda_graph.reset()
+
+                # After the exception is caught by assertRaises, the CUDA
+                # stream is still in capturing state because capture_end()
+                # was never called.  We must abort the capture to avoid
+                # CUDA error(900) when cudaFree is called during cleanup.
+                if (
+                    is_cuda_graph_capturing is not None
+                    and is_cuda_graph_capturing()
+                ):
+                    cuda_graph._graph = CoreCUDAGraph.end_capture()
+                    cuda_graph._graph.reset()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description

#### 问题
运行 `FLAGS_check_cuda_error=1 FLAGS_use_system_allocator=1 python test_cuda_graph_static_mode_error.py` 时，测试本身通过（`OK`），但进程退出时在 ScopePool 清理阶段触发 `CUDA error(900), operation not permitted when stream is capturing`，导致进程崩溃。

#### 根因
测试脚本使用 `assertRaises(RuntimeError)` 验证第一批次不允许 CUDA Graph capture。当 `exe.run()` 抛出预期的 RuntimeError 后，`capture_end()` 永远不会执行，CUDA stream 残留在 capturing 状态。进程退出时 `ScopePool::Clear()` 清理 DenseTensor 触发 `cudaFree()`，而 `cudaFree` 在 stream capturing 期间被 CUDA Runtime 禁止，导致 error(900)。

#### 修复
**C++ 框架层 (`cuda_graph.cc`)**：在 `EndSegmentCapture()` 中增加对 invalidated capture 的防御处理。当 capture 被异常操作打断时，`cudaStreamEndCapture` 返回 NULL graph，原代码直接对 NULL graph 调用 `cudaGraphGetNodes` 会崩溃。修复后检测 NULL graph 并安全跳过后续处理。

**测试脚本**：在 `assertRaises` 块之后，检测是否仍处于 capturing 状态，如果是则显式调用 `end_capture()` 和 `reset()` 来正确终止残留的 CUDA stream capture。

### 是否引起精度变化
否