### PR TITLE
[BugFix] Fix memory stat tracking for system allocator and env leak in auto_growth test

### DIFF
--- a/paddle/phi/core/memory/allocation/allocator_facade.cc
+++ b/paddle/phi/core/memory/allocation/allocator_facade.cc
@@ -1617,6 +1617,14 @@ class AllocatorFacadePrivate {
         pair.second = std::make_shared<StatAllocator>(pair.second);
       }
     }
+    for (auto& pair : system_allocators_) {
+      const Place& place = pair.first;
+      if (phi::is_cpu_place(place) || phi::is_cuda_pinned_place(place) ||
+          phi::is_gpu_place(place) || phi::is_custom_place(place) ||
+          phi::is_xpu_place(place) || phi::is_xpu_pinned_place(place)) {
+        pair.second = std::make_shared<StatAllocator>(pair.second);
+      }
+    }
   }
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)

--- a/test/legacy_test/test_auto_growth_allocator_gpu.py
+++ b/test/legacy_test/test_auto_growth_allocator_gpu.py
@@ -32,6 +32,12 @@ def _run_test_case(plan, flags, cuda_visible_devices="0"):
         os.path.dirname(__file__), "auto_growth_allocator_gpu.py"
     )
     env = os.environ.copy()
+    # Remove allocator-related FLAGS inherited from the parent process so that
+    # the subprocess uses the auto_growth allocator as intended by the test.
+    # Tests pass their desired FLAGS via FLAGS_JSON instead.
+    for key in list(env.keys()):
+        if key.startswith("FLAGS_") and key not in ("FLAGS_JSON",):
+            env.pop(key, None)
     env["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
     env["FLAGS_JSON"] = json.dumps(flags)
     env.setdefault("PYTHONUNBUFFERED", "1")


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description

修复 `FLAGS_use_system_allocator=1` 环境下 `test_auto_growth_allocator_gpu` 测试失败的问题（3 个 AssertionError）。

#### 问题背景

当使用 `FLAGS_check_cuda_error=1 FLAGS_use_system_allocator=1 python test_auto_growth_allocator_gpu.py` 运行测试时，出现 3 个测试失败：
- `test_memory_pool_flags`：`max_memory_allocated()` 返回 0
- `test_single_pool`：`max_memory_allocated()` 返回 0  
- `test_large_pool_growth_override_16mb`：`max_memory_reserved()` 增长量不符预期

#### 根因分析

**Bug 1 - C++ 层：StatAllocator 未包装 system_allocators_**

`allocator_facade.cc` 中的 `WrapStatAllocator()` 方法只遍历 `allocators_` map，不遍历 `system_allocators_` map。当 `FLAGS_use_system_allocator=1` 时，GPU 分配走的是 `system_allocators_` 中的裸 `CUDAAllocator`，没有 `StatAllocator` 包装，导致 "Allocated" 统计永远不被更新，`max_memory_allocated()` 始终返回 0。

**Bug 2 - 测试层：FLAGS 环境变量泄漏到子进程**

`_run_test_case()` 使用 `os.environ.copy()` 创建子进程环境，父进程设置的 `FLAGS_use_system_allocator=1` 通过环境变量被继承到子进程中，导致子进程绕过 auto_growth 分配器直接使用 cudaMalloc，所有 pre-alloc/growth-chunk 相关断言失败。

#### 修复方案

1. 在 `WrapStatAllocator()` 中增加对 `system_allocators_` 的遍历，确保系统分配器路径下内存统计也被正确追踪。
2. 在 `_run_test_case()` 中清除从父进程继承的 `FLAGS_*` 环境变量，确保子进程只使用测试通过 `FLAGS_JSON` 明确指定的 flags。

### 是否引起精度变化
否