### PR TITLE
[release/3.3][PAA] Align sin/cos bfloat16 backward precision with PyTorch

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -3627,7 +3627,8 @@ struct CudaCosGradFunctor : public BaseActivationFunctor<T> {
                                           const T arg_x) const {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType x = static_cast<MPType>(arg_x);
-    if constexpr (std::is_same<T, phi::float16>::value) {
+    if constexpr (std::is_same<T, phi::float16>::value ||
+                  std::is_same<T, phi::dtype::bfloat16>::value) {
       return static_cast<T>(-arg_dout * static_cast<T>(sin(x)));
     } else {
       return static_cast<T>(-dout * sin(x));
@@ -3978,7 +3979,8 @@ struct CudaSinGradFunctor : public BaseActivationFunctor<T> {
                                           const T arg_x) const {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType x = static_cast<MPType>(arg_x);
-    if constexpr (std::is_same<T, phi::float16>::value) {
+    if constexpr (std::is_same<T, phi::float16>::value ||
+                  std::is_same<T, phi::dtype::bfloat16>::value) {
       return static_cast<T>(arg_dout * static_cast<T>(cos(x)));
     } else {
       return static_cast<T>(dout * cos(x));


### PR DESCRIPTION

### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description
devPR:https://github.com/PaddlePaddle/Paddle/pull/78186

Cherry-pick sin/cos bfloat16 backward 精度修复到 release/3.3。

#### 修改内容

修改文件：`paddle/phi/kernels/funcs/activation_functor.h`（+4/-2 行）

在 `CudaSinGradFunctor` 和 `CudaCosGradFunctor` 的 `if constexpr` 条件中添加 `std::is_same<T, phi::dtype::bfloat16>::value`，扩展 float16 的两次截断模式到 bfloat16，与 PyTorch backward 行为对齐。

PyTorch 的 sin/cos backward 分两步执行：cos/sin forward 返回 bf16 后截断一次，再 mul 提升到 float32 后截断回 bf16（两次截断）。Paddle 之前在 float32 中完成全部计算仅做一次截断，导致 ~25% 元素出现 1-ULP（0.001953125）差异。

#### 精度测试结果

| API | 修改前 | 修改后 | 提升 |
|-----|:---:|:---:|:---:|
| paddle.sin bfloat16 backward | 0/2 | 2/2 | +2 |
| paddle.cos bfloat16 backward | 0/2 | 2/2 | +2 |
| paddle.Tensor.sin bfloat16 backward | 0/46 | 46/46 | +46 |
| paddle.Tensor.cos bfloat16 backward | 0/46 | 46/46 | +46 |

### 是否引起精度变化
是
