### PR TITLE
[DataLoader] Fix DataLoader to support non-Tensor batch data

### DIFF
--- a/paddle/fluid/operators/reader/read_op.cc
+++ b/paddle/fluid/operators/reader/read_op.cc
@@ -112,7 +112,7 @@ class ReadOp : public framework::OperatorBase {
         Type().c_str(), phi::TracerEventType::UserDefined, 1);
 
     reader->ReadNext(&ins);
-    if (ins.empty()) {
+    if (ins.empty() && reader->Get()->HasReachedEnd()) {
       VLOG(3) << "throw_eof_exp";
       PADDLE_THROW_EOF();
     }

--- a/paddle/fluid/pybind/reader_py.cc
+++ b/paddle/fluid/pybind/reader_py.cc
@@ -308,7 +308,9 @@ class MultiDeviceFeedReader {
       futures_[i] = pool_->enqueue([this, i] {
         try {
           readers_[i]->ReadNext(&ret_[i]);
-          return ret_[i].empty() ? Status::kEOF : Status::kSuccess;
+          return (ret_[i].empty() && readers_[i]->HasReachedEnd())
+                     ? Status::kEOF
+                     : Status::kSuccess;
         } catch (...) {
           exceptions_[i] = std::current_exception();
           return Status::kException;

--- a/paddle/phi/core/framework/reader.cc
+++ b/paddle/phi/core/framework/reader.cc
@@ -71,6 +71,8 @@ void ReaderBase::Start() {
   }
 }
 
+bool ReaderBase::HasReachedEnd() const { return false; }
+
 ReaderBase::~ReaderBase() = default;
 
 DecoratedReader::~DecoratedReader() {

--- a/paddle/phi/core/framework/reader.h
+++ b/paddle/phi/core/framework/reader.h
@@ -200,6 +200,14 @@ class ReaderHolder {
     reader_->Start();
   }
 
+  bool HasReachedEnd() const {
+    PADDLE_ENFORCE_NOT_NULL(
+        reader_,
+        common::errors::InvalidArgument(
+            "The underlying reader of ReaderHolder should not be null"));
+    return reader_->HasReachedEnd();
+  }
+
   const std::vector<DDim>& Shapes() const { return reader_->Shapes(); }
 
   const std::vector<proto::VarType::Type>& VarTypes() const {

--- a/paddle/phi/core/framework/reader.h
+++ b/paddle/phi/core/framework/reader.h
@@ -54,6 +54,8 @@ class ReaderBase {
 
   PADDLE_API virtual void Start();
 
+  PADDLE_API virtual bool HasReachedEnd() const;
+
   // Return the readers which are the end of decorating chain. Basically
   // they are readers just before read op.
   PADDLE_API std::unordered_set<ReaderBase*> GetEndPoints();
@@ -131,6 +133,8 @@ class DecoratedReader : public ReaderBase,
   void ShutdownImpl() override { reader_->Shutdown(); }
 
   void StartImpl() override { reader_->Start(); }
+
+  bool HasReachedEnd() const override { return reader_->HasReachedEnd(); }
 
   std::shared_ptr<ReaderBase> reader_;
 };

--- a/paddle/phi/core/operators/reader/py_reader.cc
+++ b/paddle/phi/core/operators/reader/py_reader.cc
@@ -31,6 +31,7 @@ PyReader::PyReader(
 void PyReader::ReadNext(phi::TensorArray* out) {
   bool success = false;
   *out = queue_->Pop(&success);
+  reached_end_.store(!success, std::memory_order_relaxed);
   if (!success) out->clear();
 }
 
@@ -40,6 +41,13 @@ PyReader::~PyReader() {  // NOLINT
 
 void PyReader::Shutdown() { queue_->Close(); }
 
-void PyReader::Start() { queue_->ReOpen(); }
+void PyReader::Start() {
+  reached_end_.store(false, std::memory_order_relaxed);
+  queue_->ReOpen();
+}
+
+bool PyReader::HasReachedEnd() const {
+  return reached_end_.load(std::memory_order_relaxed);
+}
 
 }  // namespace paddle::operators::reader

--- a/paddle/phi/core/operators/reader/py_reader.h
+++ b/paddle/phi/core/operators/reader/py_reader.h
@@ -43,8 +43,11 @@ class PADDLE_API PyReader : public framework::FileReader {
 
   void Start() override;
 
+  bool HasReachedEnd() const override;
+
  private:
   std::shared_ptr<DenseTensorBlockingQueue> queue_;
+  std::atomic<bool> reached_end_{false};
 };
 
 }  // namespace reader

--- a/python/paddle/io/dataloader/dataloader_iter.py
+++ b/python/paddle/io/dataloader/dataloader_iter.py
@@ -306,6 +306,8 @@ class _DataLoaderIterSingleProcess(_DataLoaderIterBase):
                 data = core.eager.read_next_tensor_list(
                     self._reader.read_next_list()[0]
                 )
+                if len(data) == 0 and len(self._structure_infos) == 0:
+                    raise StopIteration
                 data = _restore_batch(data, self._structure_infos.pop(0))
             else:
                 # in static graph mode
@@ -851,6 +853,8 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
                 data = core.eager.read_next_tensor_list(
                     self._reader.read_next_list()[0]
                 )
+                if len(data) == 0 and len(self._structure_infos) == 0:
+                    raise StopIteration
                 data = _restore_batch(data, self._structure_infos.pop(0))
             else:
                 if self._return_list:

--- a/test/cpp/fluid/reader/CMakeLists.txt
+++ b/test/cpp/fluid/reader/CMakeLists.txt
@@ -1,1 +1,2 @@
 cc_test(reader_blocking_queue_test SRCS reader_blocking_queue_test.cc)
+cc_test(py_reader_test SRCS py_reader_test.cc DEPS phi)

--- a/test/cpp/fluid/reader/CMakeLists.txt
+++ b/test/cpp/fluid/reader/CMakeLists.txt
@@ -1,2 +1,5 @@
 cc_test(reader_blocking_queue_test SRCS reader_blocking_queue_test.cc)
-cc_test(py_reader_test SRCS py_reader_test.cc DEPS phi)
+cc_test(
+  py_reader_test
+  SRCS py_reader_test.cc
+  DEPS phi)

--- a/test/cpp/fluid/reader/py_reader_test.cc
+++ b/test/cpp/fluid/reader/py_reader_test.cc
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+
+#include "paddle/phi/core/operators/reader/py_reader.h"
+
+TEST(PyReader, EmptyBatchIsNotEOF) {
+  auto queue =
+      std::make_shared<paddle::operators::reader::DenseTensorBlockingQueue>(2);
+  paddle::operators::reader::PyReader reader(queue, {}, {}, {});
+
+  EXPECT_TRUE(queue->Push(phi::TensorArray{}));
+  queue->Close();
+
+  phi::TensorArray batch;
+  reader.ReadNext(&batch);
+  EXPECT_TRUE(batch.empty());
+  EXPECT_FALSE(reader.HasReachedEnd());
+
+  reader.ReadNext(&batch);
+  EXPECT_TRUE(batch.empty());
+  EXPECT_TRUE(reader.HasReachedEnd());
+}
+
+TEST(PyReader, StartClearsEOFState) {
+  auto queue =
+      std::make_shared<paddle::operators::reader::DenseTensorBlockingQueue>(2);
+  paddle::operators::reader::PyReader reader(queue, {}, {}, {});
+
+  queue->Close();
+
+  phi::TensorArray batch;
+  reader.ReadNext(&batch);
+  EXPECT_TRUE(reader.HasReachedEnd());
+
+  reader.Start();
+  EXPECT_FALSE(reader.HasReachedEnd());
+
+  EXPECT_TRUE(queue->Push(phi::TensorArray{}));
+  queue->Close();
+
+  reader.ReadNext(&batch);
+  EXPECT_TRUE(batch.empty());
+  EXPECT_FALSE(reader.HasReachedEnd());
+}

--- a/test/legacy_test/test_multiprocess_dataloader_dynamic.py
+++ b/test/legacy_test/test_multiprocess_dataloader_dynamic.py
@@ -221,5 +221,96 @@ class TestDygraphDataLoaderWithBatchedDataset(TestDygraphDataLoader):
         return ret
 
 
+class StringDataset(paddle.io.Dataset):
+    def __init__(self, num_samples):
+        self.num_samples = num_samples
+
+    def __getitem__(self, idx):
+        return "a"
+
+    def __len__(self):
+        return self.num_samples
+
+
+class CustomObj:
+    def __init__(self, val):
+        self.val = val
+
+    def __repr__(self):
+        return f'CustomObj({self.val})'
+
+    def __eq__(self, other):
+        return isinstance(other, CustomObj) and self.val == other.val
+
+
+class CustomObjDataset(paddle.io.Dataset):
+    def __init__(self, num_samples):
+        self.num_samples = num_samples
+
+    def __getitem__(self, idx):
+        return CustomObj(idx)
+
+    def __len__(self):
+        return self.num_samples
+
+
+class TestDataLoaderNonTensorData(unittest.TestCase):
+    def test_string_data_single_process(self):
+        dataset = StringDataset(20)
+        loader = DataLoader(
+            dataset,
+            batch_size=10,
+            drop_last=True,
+            collate_fn=lambda d: d,
+        )
+        batches = list(loader)
+        self.assertEqual(len(batches), 2)
+        for batch in batches:
+            self.assertEqual(len(batch), 10)
+            self.assertTrue(all(item == "a" for item in batch))
+
+    def test_string_data_multi_process(self):
+        dataset = StringDataset(20)
+        loader = DataLoader(
+            dataset,
+            batch_size=10,
+            num_workers=2,
+            drop_last=True,
+            collate_fn=lambda d: d,
+        )
+        batches = list(loader)
+        self.assertEqual(len(batches), 2)
+        for batch in batches:
+            self.assertEqual(len(batch), 10)
+            self.assertTrue(all(item == "a" for item in batch))
+
+    def test_custom_obj_data_single_process(self):
+        dataset = CustomObjDataset(6)
+        loader = DataLoader(
+            dataset,
+            batch_size=3,
+            collate_fn=lambda d: d,
+        )
+        batches = list(loader)
+        self.assertEqual(len(batches), 2)
+        for batch in batches:
+            self.assertEqual(len(batch), 3)
+            self.assertTrue(all(isinstance(item, CustomObj) for item in batch))
+
+    def test_custom_obj_data_multi_process(self):
+        dataset = CustomObjDataset(6)
+        loader = DataLoader(
+            dataset,
+            batch_size=3,
+            num_workers=2,
+            collate_fn=lambda d: d,
+        )
+        batches = list(loader)
+        self.assertEqual(len(batches), 2)
+        for batch in batches:
+            self.assertEqual(len(batch), 3)
+            self.assertTrue(all(isinstance(item, CustomObj) for item in batch))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
#### What PR does
This PR fixes DataLoader / PyReader EOF detection so that non-Tensor batch data is supported correctly. Previously, an empty batch could be treated as EOF directly, which caused the reading process to stop early even when the batch itself was valid.

It also fixes the Python-side DataLoader iterator logic so that a real EOF (empty tensor list with no pending recorded structure) raises `StopIteration` instead of trying to restore a non-existent batch structure.

#### Why need this PR
In the current implementation, `ins.empty()` is used to determine whether the reader has reached EOF. However, for non-Tensor data paths, a valid empty batch can still be produced, for example an empty `TensorArray`. Treating every empty batch as EOF is incorrect and breaks normal data loading behavior.

After refining the C++ EOF semantics, the Python iterator still assumed every empty tensor list corresponded to a recorded structure entry. On the final EOF path for pure non-Tensor batches, this led to `self._structure_infos.pop(0)` raising `IndexError: pop from empty list`.

#### How to fix
This PR refines the EOF semantics in both the C++ reader path and the Python DataLoader iterator:
- Add a `HasReachedEnd()` virtual interface to `ReaderBase` to distinguish real EOF from an empty batch.
- Let `PyReader` maintain its own `reached_end_` state instead of binding EOF to empty batch data.
- Update `read_op` to check EOF with `ins.empty() && reader->HasReachedEnd()`.
- Expose the related interface through pybind and add tests for the empty-batch-but-not-EOF case.
- In Python single-process and multi-process DataLoader iterators, treat `len(data) == 0 && len(self._structure_infos) == 0` as real EOF and raise `StopIteration` before restoring batch structure.

#### Test performed
- Added C++ unit test: `test/cpp/fluid/reader/py_reader_test.cc`
- Updated `test/cpp/fluid/reader/CMakeLists.txt` to include the new test
- Added Python integration tests for non-Tensor batch support: `test/legacy_test/test_multiprocess_dataloader_dynamic.py`
- Local syntax check: `python3 -m py_compile python/paddle/io/dataloader/dataloader_iter.py test/legacy_test/test_multiprocess_dataloader_dynamic.py`

#### Related issue
- Fixes #77754

#### Notes
- This PR supersedes #78213, which was based on a branch containing unrelated commits.

### 是否引起精度变化
否
