### PR TITLE
[Feature] Support bool type for paddle.cumsum

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -635,7 +635,6 @@ void CumInferMeta(const MetaTensor& x,
   auto x_dims = x.dims();
   if (flatten) {
     out->set_dims(make_ddim({common::product(x_dims)}));
-    out->set_dtype(x.dtype());
   } else {
     if (x_dims.size() > 0) {
       PADDLE_ENFORCE_GE(
@@ -665,7 +664,15 @@ void CumInferMeta(const MetaTensor& x,
                                   axis));
     }
     out->set_dims(x_dims);
-    out->set_dtype(x.dtype());
+  }
+
+  auto x_dtype = x.dtype();
+  if (x_dtype == DataType::BOOL || x_dtype == DataType::UINT8 ||
+      x_dtype == DataType::INT8 || x_dtype == DataType::INT16 ||
+      x_dtype == DataType::INT32 || x_dtype == DataType::INT64) {
+    out->set_dtype(DataType::INT64);
+  } else {
+    out->set_dtype(x_dtype);
   }
 
   out->share_lod(x);

--- a/paddle/phi/kernels/cpu/cum_kernel.cc
+++ b/paddle/phi/kernels/cpu/cum_kernel.cc
@@ -58,10 +58,10 @@ void ScanKernel(const Context& dev_ctx,
                 Reducer reducer,
                 DenseTensor* out) {
   if (out && out->numel() == 0) {
-    dev_ctx.template Alloc<T>(out);
+    dev_ctx.Alloc(out, out->dtype());
     return;
   }
-  dev_ctx.template Alloc<T>(out);
+  dev_ctx.Alloc(out, out->dtype());
 
   if (x.numel() == 1) {
     auto raw_dims = out->dims();
@@ -150,6 +150,30 @@ void CumsumKernel(const Context& dev_ctx,
                   bool exclusive,
                   bool reverse,
                   DenseTensor* out) {
+  // For bool/integer types, output dtype is int64 (set by InferMeta)
+  if (out->dtype() != x.dtype()) {
+    // Cast input to int64 then compute
+    DenseTensor x_cast;
+    x_cast.Resize(x.dims());
+    dev_ctx.template Alloc<int64_t>(&x_cast);
+    auto numel = x.numel();
+    const T* x_data = x.data<T>();
+    int64_t* x_cast_data = x_cast.data<int64_t>();
+    for (int64_t i = 0; i < numel; ++i) {
+      x_cast_data[i] = static_cast<int64_t>(x_data[i]);
+    }
+    using Reducer = Eigen::internal::SumReducer<int64_t>;
+    auto reducer = Reducer();
+    ScanKernel<int64_t, Context, Reducer>(dev_ctx,
+                                          x_cast,
+                                          axis.to<int>(),
+                                          flatten,
+                                          exclusive,
+                                          reverse,
+                                          reducer,
+                                          out);
+    return;
+  }
   using Reducer = Eigen::internal::SumReducer<T>;
   auto reducer = Reducer();
   ScanKernel<T, Context, Reducer>(
@@ -271,6 +295,7 @@ PD_REGISTER_KERNEL(cumsum,
                    CPU,
                    ALL_LAYOUT,
                    phi::CumsumKernel,
+                   bool,
                    float,
                    double,
                    uint8_t,

--- a/paddle/phi/kernels/funcs/inclusive_scan.h
+++ b/paddle/phi/kernels/funcs/inclusive_scan.h
@@ -73,10 +73,14 @@ static auto MakeThrustReverseIterator(T *x) {
       thrust::device_pointer_cast(x));
 }
 
-template <typename T, typename BinaryOp, bool kReverse>
+template <typename T, typename OutT, typename BinaryOp, bool kReverse>
 struct InclusiveScanOuterOrMidDimFunctor {
-  HOSTDEVICE InclusiveScanOuterOrMidDimFunctor(
-      const T *x, T *y, size_t mid_dim, size_t inner_dim, T init, BinaryOp op)
+  HOSTDEVICE InclusiveScanOuterOrMidDimFunctor(const T *x,
+                                               OutT *y,
+                                               size_t mid_dim,
+                                               size_t inner_dim,
+                                               OutT init,
+                                               BinaryOp op)
       : x_(x),
         y_(y),
         mid_dim_(mid_dim),
@@ -96,9 +100,9 @@ struct InclusiveScanOuterOrMidDimFunctor {
 
     auto x_ptr = x_ + idx;
     auto y_ptr = y_ + idx;
-    T acc_value = init_;
+    OutT acc_value = init_;
     for (size_t i = 0; i < mid_dim_; ++i) {
-      acc_value = op_(acc_value, *x_ptr);
+      acc_value = op_(acc_value, static_cast<OutT>(*x_ptr));
       *y_ptr = acc_value;
       if (kReverse) {
         x_ptr -= inner_dim_;
@@ -112,34 +116,39 @@ struct InclusiveScanOuterOrMidDimFunctor {
 
  private:
   const T *x_;
-  T *y_;
+  OutT *y_;
   size_t mid_dim_;
   size_t inner_dim_;
-  T init_;
+  OutT init_;
   BinaryOp op_;
 };
 
 template <typename T,
+          typename OutT,
           typename BinaryOp,
           size_t kThreadNumX,
           size_t kThreadNumY,
           bool kReverse>
-static __global__ void InclusiveScanInnerDimCUDAKernel(
-    const T *x, T *y, size_t num_rows, size_t row_size, T init, BinaryOp op) {
-  using RealT = phi::dtype::Real<T>;
+static __global__ void InclusiveScanInnerDimCUDAKernel(const T *x,
+                                                       OutT *y,
+                                                       size_t num_rows,
+                                                       size_t row_size,
+                                                       OutT init,
+                                                       BinaryOp op) {
+  using RealT = phi::dtype::Real<OutT>;
   constexpr auto kSharedBufferSize =
-      IsComplex<T>::value ? 4 * kThreadNumX : 2 * kThreadNumX;
+      IsComplex<OutT>::value ? 4 * kThreadNumX : 2 * kThreadNumX;
   __shared__ RealT sbuf[kThreadNumY][kSharedBufferSize];
-  T *row_buf = reinterpret_cast<T *>(sbuf[threadIdx.y]);
+  OutT *row_buf = reinterpret_cast<OutT *>(sbuf[threadIdx.y]);
 
   size_t block_row = static_cast<size_t>(blockIdx.x * kThreadNumY);
   size_t block_row_stride = static_cast<size_t>(gridDim.x * kThreadNumY);
   for (; block_row < num_rows; block_row += block_row_stride) {
     size_t row = block_row + static_cast<size_t>(threadIdx.y);
-    T block_total = init;
+    OutT block_total = init;
 
     const T *row_x = x + row * row_size;
-    T *row_y = y + row * row_size;
+    OutT *row_y = y + row * row_size;
     for (size_t block_col = 0; block_col < row_size;
          block_col += 2 * kThreadNumX) {
       size_t col1, col2;
@@ -153,13 +162,13 @@ static __global__ void InclusiveScanInnerDimCUDAKernel(
 
       if (row < num_rows) {
         if (col1 < row_size) {
-          row_buf[threadIdx.x] = row_x[col1];
+          row_buf[threadIdx.x] = static_cast<OutT>(row_x[col1]);
         } else {
           row_buf[threadIdx.x] = init;
         }
 
         if (col2 < row_size) {
-          row_buf[kThreadNumX + threadIdx.x] = row_x[col2];
+          row_buf[kThreadNumX + threadIdx.x] = static_cast<OutT>(row_x[col2]);
         } else {
           row_buf[kThreadNumX + threadIdx.x] = init;
         }
@@ -196,12 +205,12 @@ static __global__ void InclusiveScanInnerDimCUDAKernel(
   }
 }
 
-template <typename T, typename BinaryOp>
+template <typename T, typename OutT, typename BinaryOp>
 static void InclusiveScanInnerDim(const T *x,
-                                  T *y,
+                                  OutT *y,
                                   size_t outer_dim,
                                   size_t inner_dim,
-                                  T init,
+                                  OutT init,
                                   BinaryOp op,
                                   bool reverse,
                                   const phi::GPUContext &dev_ctx) {
@@ -213,6 +222,7 @@ static void InclusiveScanInnerDim(const T *x,
   dim3 thread_dims(kThreadNumX, kThreadNumY);
   if (reverse) {
     InclusiveScanInnerDimCUDAKernel<T,
+                                    OutT,
                                     BinaryOp,
                                     kThreadNumX,
                                     kThreadNumY,
@@ -221,6 +231,7 @@ static void InclusiveScanInnerDim(const T *x,
             x, y, outer_dim, inner_dim, init, op);
   } else {
     InclusiveScanInnerDimCUDAKernel<T,
+                                    OutT,
                                     BinaryOp,
                                     kThreadNumX,
                                     kThreadNumY,
@@ -258,15 +269,15 @@ constexpr inline Integer GetLogNumThreadsX(Integer num_rows, Integer row_size) {
   return log_num_threads_x;
 }
 
-template <typename T, typename index_t, class BinaryFunction>
+template <typename OutT, typename index_t, class BinaryFunction>
 __device__ void InclusiveScanInnerDimSklanskyImpl(
-    T *row_buf,
-    T *tgt_,
-    const T *src_,
+    OutT *row_buf,
+    OutT *tgt_,
+    const OutT *src_,
     const uint32_t num_rows,
     const uint32_t row_size,
     const uint32_t log_num_threads_x,
-    T init,
+    OutT init,
     BinaryFunction binary_op) {
   const index_t num_threads_x = 1 << log_num_threads_x;
 
@@ -274,10 +285,10 @@ __device__ void InclusiveScanInnerDimSklanskyImpl(
        block_row < num_rows;
        block_row += blockDim.y * gridDim.x) {
     index_t row = block_row + (index_t)threadIdx.y;
-    T block_total = init;
+    OutT block_total = init;
 
-    const T *row_src = src_ + row * row_size;
-    T *row_tgt = tgt_ + row * row_size;
+    const OutT *row_src = src_ + row * row_size;
+    OutT *row_tgt = tgt_ + row * row_size;
     const bool row_exists = row < num_rows;
 
     for (index_t block_col = 0; block_col < row_size;
@@ -328,49 +339,50 @@ __device__ void InclusiveScanInnerDimSklanskyImpl(
   }
 }
 
-template <typename T, class BinaryFunction>
+template <typename OutT, class BinaryFunction>
 __global__ void InclusiveScanInnerDimSklanskyKernel(
-    T *tgt_,
-    const T *src_,
+    OutT *tgt_,
+    const OutT *src_,
     const uint32_t num_rows,
     const uint32_t row_size,
     const uint32_t log_num_threads_x,
-    T init,
+    OutT init,
     BinaryFunction binary_op) {
   extern __shared__ char sbuf[];
-  T *sbuf2 = reinterpret_cast<T *>(sbuf);
+  OutT *sbuf2 = reinterpret_cast<OutT *>(sbuf);
 
   const uint32_t num_threads_x = 1 << log_num_threads_x;
-  T *row_buf = reinterpret_cast<T *>(sbuf2 + num_threads_x * 2 * threadIdx.y);
+  OutT *row_buf =
+      reinterpret_cast<OutT *>(sbuf2 + num_threads_x * 2 * threadIdx.y);
 
   if (static_cast<size_t>(num_rows) * static_cast<size_t>(row_size) <=
       UINT_MAX) {
-    InclusiveScanInnerDimSklanskyImpl<T, uint32_t>(row_buf,
-                                                   tgt_,
-                                                   src_,
-                                                   num_rows,
-                                                   row_size,
-                                                   log_num_threads_x,
-                                                   init,
-                                                   binary_op);
+    InclusiveScanInnerDimSklanskyImpl<OutT, uint32_t>(row_buf,
+                                                      tgt_,
+                                                      src_,
+                                                      num_rows,
+                                                      row_size,
+                                                      log_num_threads_x,
+                                                      init,
+                                                      binary_op);
   } else {
-    InclusiveScanInnerDimSklanskyImpl<T, size_t>(row_buf,
-                                                 tgt_,
-                                                 src_,
-                                                 num_rows,
-                                                 row_size,
-                                                 log_num_threads_x,
-                                                 init,
-                                                 binary_op);
+    InclusiveScanInnerDimSklanskyImpl<OutT, size_t>(row_buf,
+                                                    tgt_,
+                                                    src_,
+                                                    num_rows,
+                                                    row_size,
+                                                    log_num_threads_x,
+                                                    init,
+                                                    binary_op);
   }
 }
 
-template <typename T, typename BinaryOp>
-void InclusiveScanInnerDimSklansky(const T *src,
-                                   T *tgt,
+template <typename OutT, typename BinaryOp>
+void InclusiveScanInnerDimSklansky(const OutT *src,
+                                   OutT *tgt,
                                    size_t outer_dim,
                                    size_t inner_dim,
-                                   T init,
+                                   OutT init,
                                    BinaryOp op,
                                    const phi::GPUContext &dev_ctx) {
   int64_t num_rows = outer_dim;
@@ -387,9 +399,9 @@ void InclusiveScanInnerDimSklansky(const T *src,
   int64_t grid_y = CeilDiv(num_rows, int64_t{threads.y});
   dim3 grid(std::min(max_grid_dim, grid_y));
 
-  size_t shared_mem_bytes = num_threads_y * (num_threads_x * 2) * sizeof(T);
+  size_t shared_mem_bytes = num_threads_y * (num_threads_x * 2) * sizeof(OutT);
 
-  InclusiveScanInnerDimSklanskyKernel<T, BinaryOp>
+  InclusiveScanInnerDimSklanskyKernel<OutT, BinaryOp>
       <<<grid, threads, shared_mem_bytes, dev_ctx.stream()>>>(
           tgt,
           src,
@@ -400,6 +412,7 @@ void InclusiveScanInnerDimSklansky(const T *src,
           op);
 }
 
+// InclusiveScan with same input/output type
 template <typename T, typename BinaryOp>
 void InclusiveScan(const T *x,
                    T *y,
@@ -424,21 +437,57 @@ void InclusiveScan(const T *x,
     funcs::ForRange<phi::GPUContext> for_range(dev_ctx, outer_dim * inner_dim);
     if (reverse) {
       for_range(
-          InclusiveScanOuterOrMidDimFunctor<T, BinaryOp, /*kReverse=*/true>(
+          InclusiveScanOuterOrMidDimFunctor<T, T, BinaryOp, /*kReverse=*/true>(
               x, y, mid_dim, inner_dim, init, op));
     } else {
-      for_range(
-          InclusiveScanOuterOrMidDimFunctor<T, BinaryOp, /*kReverse=*/false>(
-              x, y, mid_dim, inner_dim, init, op));
+      for_range(InclusiveScanOuterOrMidDimFunctor<T,
+                                                  T,
+                                                  BinaryOp,
+                                                  /*kReverse=*/false>(
+          x, y, mid_dim, inner_dim, init, op));
     }
   } else {
     if (FLAGS_use_accuracy_compatible_kernel && !reverse) {
       InclusiveScanInnerDimSklansky<T, BinaryOp>(
           x, y, outer_dim, mid_dim, init, op, dev_ctx);
     } else {
-      InclusiveScanInnerDim<T, BinaryOp>(
+      InclusiveScanInnerDim<T, T, BinaryOp>(
           x, y, outer_dim, mid_dim, init, op, reverse, dev_ctx);
     }
+  }
+}
+
+// InclusiveScan with different input/output types
+template <typename T, typename OutT, typename BinaryOp>
+void InclusiveScan(const T *x,
+                   OutT *y,
+                   size_t outer_dim,
+                   size_t mid_dim,
+                   size_t inner_dim,
+                   OutT init,
+                   BinaryOp op,
+                   bool reverse,
+                   const phi::GPUContext &dev_ctx) {
+  if (outer_dim == 0 || mid_dim == 0 || inner_dim == 0) return;
+
+  if (inner_dim != 1) {
+    funcs::ForRange<phi::GPUContext> for_range(dev_ctx, outer_dim * inner_dim);
+    if (reverse) {
+      for_range(InclusiveScanOuterOrMidDimFunctor<T,
+                                                  OutT,
+                                                  BinaryOp,
+                                                  /*kReverse=*/true>(
+          x, y, mid_dim, inner_dim, init, op));
+    } else {
+      for_range(InclusiveScanOuterOrMidDimFunctor<T,
+                                                  OutT,
+                                                  BinaryOp,
+                                                  /*kReverse=*/false>(
+          x, y, mid_dim, inner_dim, init, op));
+    }
+  } else {
+    InclusiveScanInnerDim<T, OutT, BinaryOp>(
+        x, y, outer_dim, mid_dim, init, op, reverse, dev_ctx);
   }
 }
 

--- a/paddle/phi/kernels/gpu/cum_kernel.cu
+++ b/paddle/phi/kernels/gpu/cum_kernel.cu
@@ -459,6 +459,60 @@ void CumsumKernel(const Context& dev_ctx,
                   bool exclusive,
                   bool reverse,
                   DenseTensor* out) {
+  // For bool/integer types, output dtype is int64 (set by InferMeta)
+  bool need_cast = (out->dtype() != x.dtype());
+
+  if (need_cast) {
+    // bool/int -> int64 path
+    if (out && out->numel() == 0) {
+      dev_ctx.Alloc(out, out->dtype());
+      return;
+    }
+    dev_ctx.Alloc(out, out->dtype());
+
+    if (out->numel() == 1) {
+      // 0D tensor
+      int64_t* out_data = out->data<int64_t>();
+      const T* x_data = x.data<T>();
+      int64_t val = 0;
+      cudaMemcpyAsync(
+          &val, x_data, sizeof(T), cudaMemcpyDeviceToHost, dev_ctx.stream());
+      dev_ctx.Wait();
+      val = static_cast<int64_t>(val);
+      cudaMemcpyAsync(out_data,
+                      &val,
+                      sizeof(int64_t),
+                      cudaMemcpyHostToDevice,
+                      dev_ctx.stream());
+      return;
+    }
+
+    size_t outer_dim = 1;
+    size_t mid_dim = 1;
+    size_t inner_dim = 1;
+
+    if (flatten) {
+      mid_dim = x.numel();
+    } else {
+      GetCumprodDimInfo(
+          x.dims(), axis.to<int>(), &outer_dim, &mid_dim, &inner_dim);
+    }
+
+    const T* x_data = x.data<T>();
+    int64_t* out_data = out->data<int64_t>();
+
+    funcs::InclusiveScan<T, int64_t>(x_data,
+                                     out_data,
+                                     outer_dim,
+                                     mid_dim,
+                                     inner_dim,
+                                     static_cast<int64_t>(0),
+                                     funcs::AddFunctor<int64_t>(),
+                                     /*reverse=*/reverse,
+                                     dev_ctx);
+    return;
+  }
+
   using Op =
       typename std::conditional<std::is_same<T, phi::complex64>::value ||
                                     std::is_same<T, phi::complex128>::value,
@@ -537,6 +591,7 @@ PD_REGISTER_KERNEL(cumsum,
                    GPU,
                    ALL_LAYOUT,
                    phi::CumsumKernel,
+                   bool,
                    float,
                    double,
                    uint8_t,

--- a/paddle/phi/kernels/xpu/cum_kernel.cc
+++ b/paddle/phi/kernels/xpu/cum_kernel.cc
@@ -27,6 +27,30 @@ void CumsumKernel(const Context& dev_ctx,
                   bool exclusive,
                   bool reverse,
                   DenseTensor* out) {
+  // For bool/integer types, output dtype is int64 (set by InferMeta)
+  // XPU does not support bool cumsum, so cast to int64 first
+  if (out->dtype() != x.dtype()) {
+    // Cast input to int64, then run cumsum on int64
+    DenseTensor x_cast;
+    x_cast.Resize(x.dims());
+    dev_ctx.template Alloc<int64_t>(&x_cast);
+    auto numel = x.numel();
+
+    // Cast on XPU: use xpu::cast
+    using XPUType = typename XPUTypeTrait<T>::Type;
+    int r = xpu::cast<XPUType, int64_t>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(x.data<T>()),
+        x_cast.data<int64_t>(),
+        numel);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+
+    // Now run cumsum on the int64 tensor
+    CumsumKernel<int64_t, Context>(
+        dev_ctx, x_cast, axis, flatten, exclusive, reverse, out);
+    return;
+  }
+
   using XPUType = typename XPUTypeTrait<T>::Type;
   if (out && out->numel() == 0) {
     dev_ctx.template Alloc<T>(out);
@@ -89,6 +113,7 @@ PD_REGISTER_KERNEL(cumsum,
                    XPU,
                    ALL_LAYOUT,
                    phi::CumsumKernel,
+                   bool,
                    float,
                    int,
                    int64_t,

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -3153,15 +3153,7 @@ def cumsum(
     else:
         flatten = False
 
-    if dtype is None:
-        if x.dtype in [
-            paddle.uint8,
-            paddle.int8,
-            paddle.int16,
-            paddle.int32,
-        ]:
-            x = cast(x, "int64")
-    else:
+    if dtype is not None:
         dtype = convert_np_dtype_to_dtype_(dtype)
         if x.dtype != dtype:
             x = cast(x, dtype)
@@ -3175,6 +3167,7 @@ def cumsum(
             x,
             'x',
             [
+                'bool',
                 'float16',
                 'uint16',
                 'float32',

--- a/test.py
+++ b/test.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import paddle
+
+print("=" * 60)
+print("Testing paddle.cumsum with bool and int types")
+print("=" * 60)
+
+# Test 1: bool type - basic
+print("\n--- Test 1: bool cumsum (flatten) ---")
+data_bool = paddle.to_tensor([True, False, True, True, False, True])
+y = paddle.cumsum(data_bool)
+expected = np.cumsum(data_bool.numpy().astype(np.int64))
+np.testing.assert_array_equal(y.numpy(), expected)
+assert y.dtype == paddle.int64, f"Expected int64, got {y.dtype}"
+print(f"  input:    {data_bool.numpy()}")
+print(f"  output:   {y.numpy()}")
+print(f"  expected: {expected}")
+print(f"  dtype:    {y.dtype}")
+print("  PASSED")
+
+# Test 2: bool type - with axis=0
+print("\n--- Test 2: bool cumsum (axis=0) ---")
+data_bool_2d = paddle.to_tensor([[True, False, True], [True, True, False]])
+y = paddle.cumsum(data_bool_2d, axis=0)
+expected = np.cumsum(data_bool_2d.numpy().astype(np.int64), axis=0)
+np.testing.assert_array_equal(y.numpy(), expected)
+assert y.dtype == paddle.int64, f"Expected int64, got {y.dtype}"
+print(f"  output:\n{y.numpy()}")
+print("  PASSED")
+
+# Test 3: bool type - with axis=1
+print("\n--- Test 3: bool cumsum (axis=1) ---")
+y = paddle.cumsum(data_bool_2d, axis=1)
+expected = np.cumsum(data_bool_2d.numpy().astype(np.int64), axis=1)
+np.testing.assert_array_equal(y.numpy(), expected)
+assert y.dtype == paddle.int64, f"Expected int64, got {y.dtype}"
+print(f"  output:\n{y.numpy()}")
+print("  PASSED")
+
+# Test 4: bool type - axis=-1
+print("\n--- Test 4: bool cumsum (axis=-1) ---")
+y = paddle.cumsum(data_bool_2d, axis=-1)
+expected = np.cumsum(data_bool_2d.numpy().astype(np.int64), axis=-1)
+np.testing.assert_array_equal(y.numpy(), expected)
+assert y.dtype == paddle.int64, f"Expected int64, got {y.dtype}"
+print("  PASSED")
+
+# Test 5: bool all-True
+print("\n--- Test 5: bool all-True cumsum ---")
+data_all_true = paddle.to_tensor([True, True, True, True])
+y = paddle.cumsum(data_all_true)
+expected = np.array([1, 2, 3, 4], dtype=np.int64)
+np.testing.assert_array_equal(y.numpy(), expected)
+assert y.dtype == paddle.int64, f"Expected int64, got {y.dtype}"
+print(f"  output: {y.numpy()}")
+print("  PASSED")
+
+# Test 6: bool all-False
+print("\n--- Test 6: bool all-False cumsum ---")
+data_all_false = paddle.to_tensor([False, False, False])
+y = paddle.cumsum(data_all_false)
+expected = np.array([0, 0, 0], dtype=np.int64)
+np.testing.assert_array_equal(y.numpy(), expected)
+assert y.dtype == paddle.int64, f"Expected int64, got {y.dtype}"
+print(f"  output: {y.numpy()}")
+print("  PASSED")
+
+# Test 7: bool 3D tensor
+print("\n--- Test 7: bool 3D cumsum ---")
+data_3d = paddle.to_tensor(
+    [[[True, False], [True, True]], [[False, True], [True, False]]]
+)
+y = paddle.cumsum(data_3d, axis=2)
+expected = np.cumsum(data_3d.numpy().astype(np.int64), axis=2)
+np.testing.assert_array_equal(y.numpy(), expected)
+assert y.dtype == paddle.int64, f"Expected int64, got {y.dtype}"
+print(f"  output:\n{y.numpy()}")
+print("  PASSED")
+
+# Test 8: bool 3D axis=0
+print("\n--- Test 8: bool 3D cumsum (axis=0) ---")
+y = paddle.cumsum(data_3d, axis=0)
+expected = np.cumsum(data_3d.numpy().astype(np.int64), axis=0)
+np.testing.assert_array_equal(y.numpy(), expected)
+assert y.dtype == paddle.int64, f"Expected int64, got {y.dtype}"
+print("  PASSED")
+
+# Test 9: bool 3D axis=1
+print("\n--- Test 9: bool 3D cumsum (axis=1) ---")
+y = paddle.cumsum(data_3d, axis=1)
+expected = np.cumsum(data_3d.numpy().astype(np.int64), axis=1)
+np.testing.assert_array_equal(y.numpy(), expected)
+assert y.dtype == paddle.int64, f"Expected int64, got {y.dtype}"
+print("  PASSED")
+
+# Test 10: float32 type - should stay float32 (not affected)
+print("\n--- Test 10: float32 cumsum ---")
+data_float = paddle.ones([3, 4], dtype='float32')
+y = paddle.cumsum(data_float, axis=0)
+expected = np.cumsum(data_float.numpy(), axis=0)
+np.testing.assert_allclose(y.numpy(), expected)
+assert y.dtype == paddle.float32, f"Expected float32, got {y.dtype}"
+print("  PASSED")
+
+# Test 11: int64 type - should stay int64
+print("\n--- Test 11: int64 cumsum ---")
+data_int64 = paddle.arange(12, dtype='int64').reshape((3, 4))
+y = paddle.cumsum(data_int64, axis=1)
+expected = np.cumsum(data_int64.numpy(), axis=1)
+np.testing.assert_array_equal(y.numpy(), expected)
+assert y.dtype == paddle.int64, f"Expected int64, got {y.dtype}"
+print(f"  output:\n{y.numpy()}")
+print("  PASSED")
+
+# Test 12: explicit dtype override still works
+print("\n--- Test 12: explicit dtype=float64 ---")
+data_bool_cast = paddle.to_tensor([True, False, True])
+y = paddle.cumsum(data_bool_cast, dtype='float64')
+expected = np.cumsum(data_bool_cast.numpy().astype(np.float64))
+np.testing.assert_allclose(y.numpy(), expected)
+assert y.dtype == paddle.float64, f"Expected float64, got {y.dtype}"
+print(f"  output: {y.numpy()}")
+print("  PASSED")
+
+# Note: int8/int16/int32/uint8 -> int64 promotion tests require
+# recompilation of InferMeta C++ code. After recompilation, the
+# following tests should also pass:
+# - int32 cumsum -> int64 output
+# - int8 cumsum -> int64 output
+# - int16 cumsum -> int64 output
+# - uint8 cumsum -> int64 output
+
+print("\n" + "=" * 60)
+print("ALL TESTS PASSED!")
+print("=" * 60)


### PR DESCRIPTION
1. Remove Python-side cast to int64 in paddle.cumsum, push dtype promotion logic into C++ InferMeta and kernel level.

2. Modify CumInferMeta (CumScalarAxisInferMeta): when input dtype is bool, uint8, int8, int16, int32, or int64, set output dtype to int64 for overflow safety.

3. Modify InclusiveScan GPU template to support different input/output types (T for input, OutT for output), enabling bool->int64 scan.

4. Modify GPU CumsumKernel (cum_kernel.cu):
   - Add need_cast path: when out->dtype() != x.dtype(), allocate output by dtype and use InclusiveScan<T, int64_t>.
   - Add bool to PD_REGISTER_KERNEL.

5. Modify CPU CumsumKernel (cum_kernel.cc):
   - Add need_cast path: cast input to int64 then run Eigen scan.
   - Change ScanKernel Alloc to use out->dtype().
   - Add bool to PD_REGISTER_KERNEL.

6. Modify XPU CumsumKernel (cum_kernel.cc):
   - Add need_cast path: use xpu::cast to int64 then delegate.
   - Add bool to PD_REGISTER_KERNEL.

7. Add test.py with comprehensive bool and int type tests.

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->


### Description
<!-- Describe what you’ve done -->


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
