### PR TITLE
Fix precision issue in reduce for large tensors.

### DIFF
--- a/paddle/phi/kernels/funcs/dense_tensor_iterator.cc
+++ b/paddle/phi/kernels/funcs/dense_tensor_iterator.cc
@@ -541,7 +541,7 @@ std::unique_ptr<DenseTensorIterator> DenseTensorIteratorBase::split(int dim) {
   int64_t remaining_size = shape_[dim] - split_size;
 
   split_iter->narrow(dim, 0, split_size);
-  split_iter->final_output_ = !has_overlap;
+  split_iter->final_output_ &= !has_overlap;
 
   narrow(dim, split_size, remaining_size);
   accumulate_ |= has_overlap;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
修复 reduce big tensor 的 bug，以下条件都满足时会触发：

float16 / bfloat16
总元素数超过 INT32_MAX 且需要多轮拆分
reduce 维度在外层


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是

Pcard-89071

devPR:https://github.com/PaddlePaddle/Paddle/pull/78225