### PR TITLE
[XPU] Fix XPUEventHandle::record() crash on unrecorded events

### DIFF
--- a/paddle/phi/backends/xpu/xpu_context.cc
+++ b/paddle/phi/backends/xpu/xpu_context.cc
@@ -739,11 +739,6 @@ XPUEventHandle::XPUEventHandle(XPUStream stream) {
 }
 
 void XPUEventHandle::record(XPUStream stream) {
-  // Wait for the previous record to complete before re-recording.
-  // Use xpu_event_wait instead of xpu_event_query to correctly handle
-  // events that have never been recorded (xpu_event_query returns an
-  // error for unrecorded events, causing test_event_stream_apis to fail).
-  PADDLE_ENFORCE_XRE_SUCCESS(xpu_event_wait(event_));
   PADDLE_ENFORCE_XRE_SUCCESS(xpu_event_record(event_, stream));
 }
 

--- a/paddle/phi/backends/xpu/xpu_context.cc
+++ b/paddle/phi/backends/xpu/xpu_context.cc
@@ -739,7 +739,11 @@ XPUEventHandle::XPUEventHandle(XPUStream stream) {
 }
 
 void XPUEventHandle::record(XPUStream stream) {
-  PADDLE_ENFORCE_XRE_SUCCESS(xpu_event_query(event_));
+  // Wait for the previous record to complete before re-recording.
+  // Use xpu_event_wait instead of xpu_event_query to correctly handle
+  // events that have never been recorded (xpu_event_query returns an
+  // error for unrecorded events, causing test_event_stream_apis to fail).
+  PADDLE_ENFORCE_XRE_SUCCESS(xpu_event_wait(event_));
   PADDLE_ENFORCE_XRE_SUCCESS(xpu_event_record(event_, stream));
 }
 


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description

Fix `test_event_stream_apis` consistent failure on XPU CI by removing the `xpu_event_query` guard in `XPUEventHandle::record()`.

**Root Cause:**

`XPUEventHandle::record()` calls `xpu_event_query(event_)` before `xpu_event_record()` as a guard to ensure the previous record has completed. However, `xpu_event_query` returns **XPU Runtime Error 600** for events that have **never been recorded**, which is fatal due to `PADDLE_ENFORCE_XRE_SUCCESS`.

This affects the test case `test_event_stream_apis_xpu` where:
1. `event3` is created via `Event(enable_timing=True, blocking=True)` — the `XPUEventHandle()` constructor creates the event from pool but does not record it
2. `stream1.record_event(event3)` calls `record()`, which queries the unrecorded event and crashes

**Fix:**

Remove the `xpu_event_query` guard entirely, keeping only `xpu_event_record`:
- `xpu_event_record` supports recording the same event multiple times, so no wait/query guard is needed
- This aligns with GPU behavior where `cudaEventRecord` is called directly without any prior query or wait

**CI Impact:** This fixes the `test_event_stream_apis` failure that has been blocking cherry-pick PRs on `release/3.3` (e.g., [#78158](https://github.com/PaddlePaddle/Paddle/pull/78158)).

### 是否引起精度变化
否