### PR TITLE
[phi] Align erfinv out-of-domain behavior with PyTorch

### DIFF
--- a/paddle/phi/kernels/cpu/erfinv_kernel.cc
+++ b/paddle/phi/kernels/cpu/erfinv_kernel.cc
@@ -18,6 +18,8 @@
 
 #include "paddle/phi/kernels/erfinv_kernel.h"
 
+#include <limits>
+
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
@@ -36,7 +38,12 @@ void ErfinvKernel(const Context& dev_ctx,
   auto& place = *dev_ctx.eigen_device();
   constexpr T half = static_cast<T>(0.5);
   constexpr T half_sqrt = static_cast<T>(M_SQRT1_2);
-  eigen_out.device(place) = (eigen_in * half + half).ndtri() * half_sqrt;
+  constexpr T one = static_cast<T>(1);
+  constexpr T neg_one = static_cast<T>(-1);
+  const T nan = std::numeric_limits<T>::quiet_NaN();
+  auto invalid = (eigen_in > one) || (eigen_in < neg_one);
+  eigen_out.device(place) = invalid.select(
+      eigen_in.constant(nan), (eigen_in * half + half).ndtri() * half_sqrt);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/erfinv_kernel.cu
+++ b/paddle/phi/kernels/gpu/erfinv_kernel.cu
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/erfinv_kernel.h"
+
+#include <limits>
+
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
@@ -21,12 +24,22 @@ namespace phi {
 
 template <typename T>
 struct ErfinvFunctor {
-  HOSTDEVICE inline T operator()(const T x) const { return erfinv(x); }
+  HOSTDEVICE inline T operator()(const T x) const {
+    constexpr T one = static_cast<T>(1);
+    constexpr T neg_one = static_cast<T>(-1);
+    if (x > one || x < neg_one) {
+      return std::numeric_limits<T>::quiet_NaN();
+    }
+    return erfinv(x);
+  }
 };
 template <>
 struct ErfinvFunctor<float16> {
   HOSTDEVICE inline float16 operator()(const float16 x) const {
     auto x_ = static_cast<float>(x);
+    if (x_ > 1.0f || x_ < -1.0f) {
+      return static_cast<float16>(std::numeric_limits<float>::quiet_NaN());
+    }
     return static_cast<float16>(erfinv(x_));
   }
 };
@@ -35,6 +48,9 @@ template <>
 struct ErfinvFunctor<bfloat16> {
   HOSTDEVICE inline bfloat16 operator()(const bfloat16 x) const {
     auto x_ = static_cast<float>(x);
+    if (x_ > 1.0f || x_ < -1.0f) {
+      return static_cast<bfloat16>(std::numeric_limits<float>::quiet_NaN());
+    }
     return static_cast<bfloat16>(erfinv(x_));
   }
 };

--- a/test/legacy_test/test_erfinv_op.py
+++ b/test/legacy_test/test_erfinv_op.py
@@ -123,6 +123,33 @@ class TestErfinvAPIOp(unittest.TestCase):
         for place in self.place:
             run(place)
 
+    def test_out_of_domain_returns_nan(self):
+        def run(place):
+            paddle.disable_static(place)
+            x_np = np.array([-1.2, -0.5, 0.0, 0.5, 1.2], dtype=self.dtype)
+            out = paddle.erfinv(paddle.to_tensor(x_np)).numpy()
+            np.testing.assert_array_equal(np.isnan(out), np.isnan(erfinv(x_np)))
+            paddle.enable_static()
+
+        for place in self.place:
+            run(place)
+
+    def test_boundary_keeps_inf(self):
+        def run(place):
+            paddle.disable_static(place)
+            x_np = np.array([-1.0, 1.0], dtype=self.dtype)
+            out = paddle.erfinv(paddle.to_tensor(x_np)).numpy()
+            np.testing.assert_array_equal(
+                np.isneginf(out), np.array([True, False])
+            )
+            np.testing.assert_array_equal(
+                np.isposinf(out), np.array([False, True])
+            )
+            paddle.enable_static()
+
+        for place in self.place:
+            run(place)
+
 
 class TestErfinvFP16Op(TestErfinvOp):
     def init_dtype(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category

<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism

### PR Types

<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description

<!-- Describe what you’ve done -->

Fixes #78121: Align erfinv out-of-domain behavior with PyTorch.

1. For out-of-domain inputs (x < -1 or x > 1): Paddle now matches PyTorch and returns NaN.
2. For boundary inputs:
   - x == -1 -> -inf
   - x == 1 -> +inf
   - also consistent with PyTorch.
3. For valid-domain inputs, Paddle and PyTorch are numerically very close.
   - On float32 test points such as [-0.999, -0.9, -0.5, -0.1, 0, 0.1, 0.5, 0.9, 0.999]:
     - max absolute error: 1.1920929e-05
     - max relative error: 5.123411e-06
   - Why there is still a small difference:
     - PyTorch and Paddle use different numerical implementations:
     - PyTorch uses a dedicated erfinv approximation with Newton refinement.
     - Paddle computes erfinv(x) through the equivalent formula: ndtri((x + 1) / 2).
     - $\mathrm{erfinv}(x)=\frac{1}{\sqrt{2}}\Phi^{-1}\left(\frac{x+1}{2}\right)$

### 是否引起精度变化

<!-- one of the following [ 是 | 否 ]-->

否
