### PR TITLE
[Fix][Conv] Fix 0-size kernel crash in conv1d/conv2d/conv3d

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -644,6 +644,18 @@ void ConvInferMeta(const MetaTensor& input,
         0,
         common::errors::InvalidArgument(
             "the size of filter at axis 0 should be greater than 0"));
+    for (int i = 2; i < filter_dims.size(); ++i) {
+      PADDLE_ENFORCE_GT(
+          filter_dims[i],
+          0,
+          common::errors::InvalidArgument(
+              "The kernel size of Op(Conv) should be greater than 0, but "
+              "received kernel size at dimension %d is %d. The filter's shape "
+              "is [%s].",
+              i,
+              filter_dims[i],
+              filter_dims));
+    }
   }
 
   DDim in_data_dims;

--- a/paddle/phi/kernels/gpu/depthwise_conv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/depthwise_conv_grad_kernel.cu
@@ -40,8 +40,10 @@ void DepthwiseConvGradKernel(const Context& dev_ctx,
 
   if (!input_grad && !filter_grad) return;
   // 0-size
-  if (input.numel() == 0) {
-    if (input_grad) dev_ctx.template Alloc<T>(input_grad);
+  if (input.numel() == 0 || filter.numel() == 0) {
+    if (input_grad) {
+      Full<T, Context>(dev_ctx, input_grad->dims(), 0, input_grad);
+    }
     if (filter_grad) {
       Full<T, Context>(dev_ctx, filter_grad->dims(), 0, filter_grad);
     }

--- a/paddle/phi/kernels/gpu/depthwise_conv_kernel.cu
+++ b/paddle/phi/kernels/gpu/depthwise_conv_kernel.cu
@@ -32,7 +32,7 @@ void DepthwiseConvKernel(const Context& dev_ctx,
                          const std::vector<int>& dilations_t,
                          const std::string& data_format,
                          DenseTensor* out) {
-  if (input.numel() == 0) {
+  if (input.numel() == 0 || filter.numel() == 0) {
     Full<T, Context>(dev_ctx, out->dims(), 0, out);
     return;
   }

--- a/test/legacy_test/test_functional_conv1d.py
+++ b/test/legacy_test/test_functional_conv1d.py
@@ -144,5 +144,65 @@ class TestFunctionalConv1D_ZeroSize2(TestFunctionalConv1D_ZeroSize):
         self.np_out = np.zeros([0, 0, 1])
 
 
+class TestFunctionalConv1D_ZeroKernelError(TestCase):
+    """kernel_size=0 should raise InvalidArgument, not crash with CUDA error."""
+
+    def _assert_raises(self, x_shape, w_shape, **kwargs):
+        places = get_places()
+        for place in places:
+            with dg.guard(place):
+                x = paddle.randn(x_shape)
+                w = paddle.to_tensor(
+                    np.random.randn(*w_shape).astype('float32')
+                )
+                with self.assertRaises(ValueError):
+                    F.conv1d(x, w, **kwargs)
+
+    def test_depthwise_zero_kernel(self):
+        # depthwise path (groups == in_channels), kernel_size=0
+        self._assert_raises(
+            [13, 64, 1007],
+            [64, 1, 0],
+            padding=3,
+            stride=1,
+            dilation=1,
+            groups=64,
+            data_format='NCL',
+        )
+
+    def test_depthwise_zero_kernel_small(self):
+        # smaller depthwise, kernel_size=0, NCL
+        self._assert_raises(
+            [2, 3, 4],
+            [6, 1, 0],
+            padding=0,
+            stride=2,
+            dilation=1,
+            groups=3,
+            data_format='NCL',
+        )
+
+    def test_depthwise_zero_kernel_nlc(self):
+        # NLC data format, kernel_size=0
+        self._assert_raises(
+            [13, 7, 32],
+            [32, 1, 0],
+            padding=1,
+            stride=1,
+            dilation=1,
+            groups=32,
+            data_format='NLC',
+        )
+
+    def test_depthwise_zero_kernel_float64(self):
+        places = get_places()
+        for place in places:
+            with dg.guard(place):
+                x = paddle.randn([2, 3, 4]).cast('float64')
+                w = paddle.to_tensor(np.random.randn(6, 1, 0).astype('float64'))
+                with self.assertRaises(ValueError):
+                    F.conv1d(x, w, padding=0, stride=2, groups=3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_functional_conv2d.py
+++ b/test/legacy_test/test_functional_conv2d.py
@@ -300,6 +300,67 @@ class TestFunctionalConv2D_ZeroSize2(TestFunctionalConv2D_ZeroSize):
         self.np_out = np.zeros([0, 0, 2, 2])
 
 
+class TestFunctionalConv2D_ZeroKernelError(TestCase):
+    """kernel_size=0 in any spatial dim should raise InvalidArgument."""
+
+    def _assert_raises(self, x_shape, w_shape, **kwargs):
+        places = get_places()
+        for place in places:
+            with dg.guard(place):
+                x = paddle.randn(x_shape)
+                w = paddle.to_tensor(
+                    np.random.randn(*w_shape).astype('float32')
+                )
+                with self.assertRaises(ValueError):
+                    F.conv2d(x, w, **kwargs)
+
+    def test_depthwise_zero_kH(self):
+        # depthwise, kernel_height=0
+        self._assert_raises(
+            [16, 3, 260, 260],
+            [3, 1, 0, 5],
+            groups=3,
+        )
+
+    def test_depthwise_zero_kW(self):
+        # depthwise, kernel_width=0
+        self._assert_raises(
+            [16, 3, 260, 260],
+            [3, 1, 5, 0],
+            groups=3,
+        )
+
+    def test_depthwise_large_zero_kH(self):
+        self._assert_raises(
+            [16, 3, 268, 268],
+            [3, 1, 0, 13],
+            groups=3,
+        )
+
+    def test_depthwise_large_zero_kW(self):
+        self._assert_raises(
+            [16, 3, 268, 268],
+            [3, 1, 13, 0],
+            groups=3,
+        )
+
+    def test_regular_conv_zero_kH(self):
+        # regular conv2d (groups=1), kernel_height=0
+        self._assert_raises(
+            [2, 3, 8, 8],
+            [6, 3, 0, 3],
+            groups=1,
+        )
+
+    def test_regular_conv_zero_kW(self):
+        # regular conv2d (groups=1), kernel_width=0
+        self._assert_raises(
+            [2, 3, 8, 8],
+            [6, 3, 3, 0],
+            groups=1,
+        )
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

When `kernel_size=0` (e.g. `weight` shape `[64, 1, 0]` in `conv1d`), the operator triggers **CUDA error(9): invalid configuration argument** (crash) instead of a clean error message.

**Root Cause**

`conv1d`/`conv2d` with `groups == in_channels` routes through `depthwise_conv2d`. The GPU kernel early-exit in `depthwise_conv_kernel.cu` only guarded against empty **input** (`input.numel() == 0`), but not empty **filter** (`filter.numel() == 0`). The downstream CUDA kernel was then launched with an invalid thread/grid configuration, causing the crash.

By contrast, the regular `conv2d` path (`conv_kernel_impl.h:42`) already correctly checks both:
```cpp
if (input.numel() == 0 || filter.numel() == 0) { ... }
```

**Fix**

1. `paddle/phi/infermeta/binary.cc` — front-line guard (covers all conv ops): Add a `kernel_size > 0` validation inside `ConvInferMeta()` for all spatial filter dimensions (`dim >= 2`). This catches the error early with a clear message, before any kernel is launched. Covers `conv1d`, `conv2d`, `conv3d` and their depthwise variants.

2. `paddle/phi/kernels/gpu/depthwise_conv_kernel.cu` — defensive kernel guard: Extend the early-exit condition from `input.numel() == 0` to `input.numel() == 0 || filter.numel() == 0`.

3. `paddle/phi/kernels/gpu/depthwise_conv_grad_kernel.cu` — grad kernel guard: Same extension; also change `input_grad` handling from bare `Alloc` to `Full<0>` for consistent zero-fill behavior.

4. `test/legacy_test/test_functional_conv1d.py` and `test/legacy_test/test_functional_conv2d.py` — Add `TestFunctionalConv1D_ZeroKernelError` and `TestFunctionalConv2D_ZeroKernelError` to cover the fixed cases.

**Verification**

All the following cases now raise a clean `ValueError: (InvalidArgument)` instead of crashing:
```
paddle.nn.functional.conv1d(Tensor([13, 64, 1007]), Tensor([64, 1, 0]), padding=3, groups=64)
paddle.nn.functional.conv1d(Tensor([2, 3, 4], float64), Tensor([6, 1, 0], float64), stride=2, groups=3)
paddle.nn.functional.conv2d(Tensor([16, 3, 260, 260]), Tensor([3, 1, 0, 5]),  groups=3)
paddle.nn.functional.conv2d(Tensor([16, 3, 260, 260]), Tensor([3, 1, 5, 0]),  groups=3)
paddle.nn.functional.conv2d(Tensor([16, 3, 268, 268]), Tensor([3, 1, 0, 13]), groups=3)
paddle.nn.functional.conv2d(Tensor([16, 3, 268, 268]), Tensor([3, 1, 13, 0]), groups=3)
```

Error message example:
```
ValueError: (InvalidArgument) The kernel size of Op(Conv) should be greater than 0,
but received kernel size at dimension 3 is 0. The filter's shape is [64, 1, 1, 0].
```

### 是否引起精度变化
否