### PR TITLE
[ZeroDim] fix put_along_axis with 0-size indices tensor

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -7510,6 +7510,16 @@ def put_along_axis(
             "`indices` and `arr` must have the same number of dimensions!"
         )
     axis = non_negative_axis(arr, axis)
+    # When indices is empty (numel == 0) there are no scatter operations to
+    # perform.  Return a copy of arr immediately to avoid passing a 0-size
+    # index tensor through the broadcast path, which would attempt an invalid
+    # expand (e.g. values dim 4 -> 0) and raise an error.
+    # In dynamic mode use numel(); in static mode indices.numel() returns a
+    # symbolic Value so we check the shape directly instead.
+    if (paddle.in_dynamic_mode() and indices.numel() == 0) or (
+        not paddle.in_dynamic_mode() and 0 in indices.shape
+    ):
+        return paddle.assign(arr)
     if broadcast:
         if has_dynamic_shape(arr.shape) or has_dynamic_shape(indices.shape):
             arr_shape = paddle.shape(arr)
@@ -7629,6 +7639,10 @@ def put_along_axis_(
             "`indices` and `arr` must have the same number of dimensions!"
         )
     axis = non_negative_axis(arr, axis)
+    if (paddle.in_dynamic_mode() and indices.numel() == 0) or (
+        not paddle.in_dynamic_mode() and 0 in indices.shape
+    ):
+        return arr
     if broadcast:
         broadcast_shape = infer_broadcast_shape(arr, indices, axis)
         values = (

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -1586,6 +1586,66 @@ class TestPutAlongAxisDynamicShape_ZeroSize(TestPutAlongAxisDynamicShape):
         self.arr = np.random.random([0, 10, 10, 10]).astype(self.dtype)
 
 
+class TestPutAlongAxisZeroSizeIndex(unittest.TestCase):
+    """
+    When indices has a 0-size dimension (numel == 0), put_along_axis should
+    return a copy of arr unchanged regardless of the shape of values.
+
+    Before the fix, the Python wrapper tried to broadcast_to(values, [2, 0])
+    which failed because a non-1/non-0 input dimension cannot be expanded to 0
+    (that is a valid constraint in expand). The fix adds an early return when
+    indices.numel() == 0, matching PyTorch scatter_ behaviour.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+
+    def _check(self, arr_shape, index_shape, val_shape, axis):
+        arr = paddle.rand(arr_shape, dtype='float32')
+        idx = paddle.zeros(index_shape, dtype='int64')
+        val = paddle.rand(val_shape, dtype='float32')
+        out = paddle.put_along_axis(arr, idx, val, axis=axis)
+        # Output shape must equal arr shape; values must be unchanged.
+        np.testing.assert_equal(list(out.shape), arr_shape)
+        np.testing.assert_allclose(
+            out.numpy(), arr.numpy(), rtol=1e-6, atol=1e-6
+        )
+
+    def test_index_zero_dim_values_non_zero(self):
+        """Original bug: arr[2,60] idx[2,0] val[2,4] axis=1."""
+        self._check([2, 60], [2, 0], [2, 4], axis=1)
+
+    def test_index_zero_first_dim(self):
+        self._check([60, 2], [0, 2], [4, 2], axis=0)
+
+    def test_index_zero_mid_dim(self):
+        self._check([3, 5, 7], [3, 0, 7], [3, 4, 7], axis=1)
+
+    def test_all_zero_size(self):
+        self._check([2, 60], [2, 0], [2, 0], axis=1)
+
+    def test_inplace_zero_index(self):
+        """Inplace variant should also return arr unchanged."""
+        arr = paddle.rand([2, 60], dtype='float32')
+        arr_copy = arr.clone()
+        idx = paddle.zeros([2, 0], dtype='int64')
+        val = paddle.rand([2, 4], dtype='float32')
+        arr.put_along_axis_(idx, val, axis=1)
+        np.testing.assert_allclose(
+            arr.numpy(), arr_copy.numpy(), rtol=1e-6, atol=1e-6
+        )
+
+    def test_reduce_mul_zero_index(self):
+        arr = paddle.ones([2, 60], dtype='float32')
+        idx = paddle.zeros([2, 0], dtype='int64')
+        val = paddle.rand([2, 4], dtype='float32') + 2.0
+        out = paddle.put_along_axis(arr, idx, val, axis=1, reduce='mul')
+        np.testing.assert_equal(list(out.shape), [2, 60])
+        np.testing.assert_allclose(
+            out.numpy(), arr.numpy(), rtol=1e-6, atol=1e-6
+        )
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

#### 问题背景

当 `paddle.put_along_axis(arr, indices, values, axis)` 中 `indices` 存在大小为 0 的维度（即 `indices.numel() == 0`）时，调用会报错：
- GPU：`CUDA error(9): cudaErrorInvalidConfiguration`
- CPU：`InvalidArgument: The value (4) of the non-singleton dimension does not match the corresponding value (0) in shape`

触发复现命令示例：
```
paddle.put_along_axis(Tensor([2, 60],"float32"), Tensor([2, 0],"int64"), Tensor([2, 4],"float32"), axis=1)
```

#### 根本原因

Python 层在执行 scatter 之前，会先推断 `values` 的广播目标 shape（由 `infer_broadcast_shape` 得出，包含 0-size 维度），然后调用 `paddle.broadcast_to(values, broadcast_shape)`。

`expand_kernel` 中有一条正确且必要的约束：当目标 shape 中某个维度为 0 时，输入在该维度上必须已经是 0 或 1。然而此时 `values` 的对应维度为 4，不满足条件，因此抛出错误。

C++ scatter kernel（`gather_scatter_functor.cu`）已有 `if (index.numel() == 0) return;` 的守护逻辑，但 Python 层在进入 kernel 之前就崩溃了。

#### 修复方案

在 Python 层的 `put_along_axis` 和 `put_along_axis_` 函数中，于进入广播路径之前增加提前返回：当 `indices.numel() == 0` 时，不存在任何需要散布的元素，直接返回 `arr` 的副本即可。

修改文件：`python/paddle/tensor/manipulation.py`

#### 单测

在 `test/legacy_test/test_put_along_axis_op.py` 中新增 `TestPutAlongAxisZeroSizeIndex` 测试类，覆盖：
- 原始复现用例（`arr[2,60]`, `idx[2,0]`, `val[2,4]`, `axis=1`）
- 0-size 在首维、中间维的情况
- `values` 与 `indices` 同为 0-size 的情况
- inplace 变体（`put_along_axis_`）
- 带 `reduce` 参数的情况

### 是否引起精度变化
否
