### PR TITLE
[Inference][Others]Supports compiling FlashMLA from Paddle images.

### DIFF
--- a/paddle/phi/api/include/compat/ATen/Utils.h
+++ b/paddle/phi/api/include/compat/ATen/Utils.h
@@ -70,24 +70,24 @@ Tensor tensor_complex_backend(ArrayRef<T> values,
 
 }  // namespace detail
 
-#define TENSOR(T, _1)                                               \
-  Tensor tensor(ArrayRef<T> values, const TensorOptions& options) { \
-    if (options.device().type() != c10::DeviceType::CPU) {          \
-      return at::detail::tensor_backend(values, options);           \
-    } else {                                                        \
-      return at::detail::tensor_cpu(values, options);               \
-    }                                                               \
+#define TENSOR(T, _1)                                                      \
+  inline Tensor tensor(ArrayRef<T> values, const TensorOptions& options) { \
+    if (options.device().type() != c10::DeviceType::CPU) {                 \
+      return at::detail::tensor_backend(values, options);                  \
+    } else {                                                               \
+      return at::detail::tensor_cpu(values, options);                      \
+    }                                                                      \
   }
 AT_FORALL_SCALAR_TYPES_AND3(Bool, Half, BFloat16, TENSOR)
 #undef TENSOR
 
-#define TENSOR(T, _1)                                               \
-  Tensor tensor(ArrayRef<T> values, const TensorOptions& options) { \
-    if (options.device().type() != c10::DeviceType::CPU) {          \
-      return at::detail::tensor_complex_backend(values, options);   \
-    } else {                                                        \
-      return at::detail::tensor_complex_cpu(values, options);       \
-    }                                                               \
+#define TENSOR(T, _1)                                                      \
+  inline Tensor tensor(ArrayRef<T> values, const TensorOptions& options) { \
+    if (options.device().type() != c10::DeviceType::CPU) {                 \
+      return at::detail::tensor_complex_backend(values, options);          \
+    } else {                                                               \
+      return at::detail::tensor_complex_cpu(values, options);              \
+    }                                                                      \
   }
 AT_FORALL_COMPLEX_TYPES(TENSOR)
 #undef TENSOR


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Inference

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
Supports compiling FlashMLA from Paddle images.

```
  tmpxft_00001981_00000000-6_fmha_cutlass_fwd_sm100.cudafe1.cpp:(.text+0x144c0): multiple definition of `at::tensor(c10::ArrayRef<signed char>, c10::TensorOptions const&)'; /workspace/FlashMLA/build/temp.linux-x86_64-cpython-310/build/temp.linux-x86_64-cpython-310/csrc/api/api.o:/opt/_internal/cpython-3.10.0/lib/python3.10/site-packages/paddle/include/paddle/phi/api/include/compat/ATen/Utils.h:81: first defined here
```

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否