### PR TITLE
[Auto-Parallel] Fix FSDP ACC mem use

### DIFF
--- a/python/paddle/distributed/auto_parallel/fully_shard_fusion.py
+++ b/python/paddle/distributed/auto_parallel/fully_shard_fusion.py
@@ -335,6 +335,7 @@ class FSDPCommManager:
         # for double buffer mechanism config
         self.double_buffer_limit = double_buffer_limit
         self.buffer_cnt_in_using = 0
+        self.need_zero_grads = True
 
     def _release_one_buffer_if_needed(self):
         # Release a buffer with the READY status if needed
@@ -444,6 +445,11 @@ class FSDPCommManager:
                 group.params_buffer.status = BufferState.READY
 
     def reduce_scatter_grads(self, param):
+        if self.need_zero_grads:
+            self.need_zero_grads = False
+            for group in self.buffer_manager.buffer_groups:
+                if group.grads_buffer is not None:
+                    group.grads_buffer.data_buffer.zero_()
         gid = self.buffer_manager.param_to_buffer_id[param.name]
         group = self.buffer_manager.buffer_groups[gid]
         group.grads_use_cnt += 1
@@ -460,11 +466,11 @@ class FSDPCommManager:
 
             tmp_buffer = grads_buffer.get_tmp_buffer()
             shard_size = grads_buffer.data_buffer.shape[0]
-            rs_output = tmp_buffer._slice(0, shard_size)
+            grad_buffer_shard = tmp_buffer._slice(0, shard_size)
             if self.enable_overlap:
                 # Comm grads async and check all comm_task before optimizer update
                 grads_buffer.comm_task = paddle.distributed.reduce_scatter(
-                    rs_output,
+                    grad_buffer_shard,
                     tmp_buffer,
                     op=paddle.distributed.ReduceOp.SUM,
                     group=self.buffer_manager._fsdp_group,
@@ -475,14 +481,13 @@ class FSDPCommManager:
                 self.grad_reduce_queue.append(grads_buffer)
             else:
                 paddle.distributed.reduce_scatter(
-                    rs_output,
+                    grad_buffer_shard,
                     tmp_buffer,
                     op=paddle.distributed.ReduceOp.SUM,
                     group=self.buffer_manager._fsdp_group,
                     sync_op=False,
                 ).wait()
-
-                grads_buffer.data_buffer.add_(rs_output)
+                grads_buffer.data_buffer.add_(grad_buffer_shard)
                 grads_buffer.clear_tmp_buffer()
 
     def _wait_for_grad_comm(self, queue_limit=2):
@@ -493,9 +498,10 @@ class FSDPCommManager:
             if grads_buffer.comm_task is not None:
                 grads_buffer.comm_task.wait()
                 grads_buffer.comm_task = None
-            shard_size = grads_buffer.data_buffer.shape[0]
-            rs_output = grads_buffer.tmp_data_buffer._slice(0, shard_size)
-            grads_buffer.data_buffer.add_(rs_output)
+                tmp_buffer = grads_buffer.get_tmp_buffer()
+                shard_size = grads_buffer.data_buffer.shape[0]
+                grad_buffer_shard = tmp_buffer._slice(0, shard_size)
+                grads_buffer.data_buffer.add_(grad_buffer_shard)
             grads_buffer.clear_tmp_buffer()
 
     def finish_grads_sync(self):
@@ -585,6 +591,7 @@ class FullyShardFusion:
     def comm_sync_and_reset_status(self):
         self.comm_manager.finish_grads_sync()
         self.comm_manager.reset_params_buffer_status()
+        self.comm_manager.need_zero_grads = True
         # Reset main_grad for all trainable parameters
         for param in self.model.parameters():
             if param.trainable:
@@ -627,7 +634,7 @@ class FullyShardFusion:
                         grad.process_mesh,
                         grad.placements,
                     )
-                    param.main_grad._local_value().add_(grad._local_value())
+                    param.main_grad._local_value().copy_(grad._local_value())
                     grad._clear_data()
                 comm_manager.shard_params([param], is_backward=True)
                 comm_manager.reduce_scatter_grads(param)

--- a/python/paddle/distributed/auto_parallel/fully_shard_fusion.py
+++ b/python/paddle/distributed/auto_parallel/fully_shard_fusion.py
@@ -447,6 +447,7 @@ class FSDPCommManager:
         gid = self.buffer_manager.param_to_buffer_id[param.name]
         group = self.buffer_manager.buffer_groups[gid]
         group.grads_use_cnt += 1
+        param.main_grad = None
 
         if group.grads_use_cnt == group.grads_use_sum:
             group.grads_use_cnt = 0
@@ -458,10 +459,12 @@ class FSDPCommManager:
             self._wait_for_grad_comm()
 
             tmp_buffer = grads_buffer.get_tmp_buffer()
+            shard_size = grads_buffer.data_buffer.shape[0]
+            rs_output = tmp_buffer._slice(0, shard_size)
             if self.enable_overlap:
                 # Comm grads async and check all comm_task before optimizer update
                 grads_buffer.comm_task = paddle.distributed.reduce_scatter(
-                    grads_buffer.data_buffer,
+                    rs_output,
                     tmp_buffer,
                     op=paddle.distributed.ReduceOp.SUM,
                     group=self.buffer_manager._fsdp_group,
@@ -472,13 +475,14 @@ class FSDPCommManager:
                 self.grad_reduce_queue.append(grads_buffer)
             else:
                 paddle.distributed.reduce_scatter(
-                    grads_buffer.data_buffer,
+                    rs_output,
                     tmp_buffer,
                     op=paddle.distributed.ReduceOp.SUM,
                     group=self.buffer_manager._fsdp_group,
                     sync_op=False,
                 ).wait()
 
+                grads_buffer.data_buffer.add_(rs_output)
                 grads_buffer.clear_tmp_buffer()
 
     def _wait_for_grad_comm(self, queue_limit=2):
@@ -489,6 +493,9 @@ class FSDPCommManager:
             if grads_buffer.comm_task is not None:
                 grads_buffer.comm_task.wait()
                 grads_buffer.comm_task = None
+            shard_size = grads_buffer.data_buffer.shape[0]
+            rs_output = grads_buffer.tmp_data_buffer._slice(0, shard_size)
+            grads_buffer.data_buffer.add_(rs_output)
             grads_buffer.clear_tmp_buffer()
 
     def finish_grads_sync(self):
@@ -613,15 +620,13 @@ class FullyShardFusion:
             def comm_hook(grad):
                 if grad is not None and grad._is_initialized():
                     # Share mem with grads_tmp_buffer
-                    if param.main_grad is None:
-                        # Reset main_grad to None after each step and rebind it here
-                        _main_grad = param.get_main_grad()
-                        _main_grad.get_tensor()._set_dims(grad._local_shape)
-                        param.main_grad = _dtensor_from_local(
-                            _main_grad,
-                            grad.process_mesh,
-                            grad.placements,
-                        )
+                    _main_grad = param.get_main_grad()
+                    _main_grad.get_tensor()._set_dims(grad._local_shape)
+                    param.main_grad = _dtensor_from_local(
+                        _main_grad,
+                        grad.process_mesh,
+                        grad.placements,
+                    )
                     param.main_grad._local_value().add_(grad._local_value())
                     grad._clear_data()
                 comm_manager.shard_params([param], is_backward=True)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix FSDP acc mem use:

- in `main_grad_hook`, `copy_` full grad into `tmp_buffer` of `grad_buffer`.

- once a complete `tmp_buffer` is assembled, perform comm in `reduce_scatter_hook`.

- `add_` the comm result `grad_buffer_shard` to `data_buffer` of `grad_buffer`.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否