### PR TITLE
[Cherry-pick][release/3.3] Fix XPUEventHandle::record() crash on unrecorded events (#78227)

### DIFF
--- a/paddle/phi/backends/xpu/xpu_context.cc
+++ b/paddle/phi/backends/xpu/xpu_context.cc
@@ -739,11 +739,6 @@ XPUEventHandle::XPUEventHandle(XPUStream stream) {
 }
 
 void XPUEventHandle::record(XPUStream stream) {
-  // Wait for the previous record to complete before re-recording.
-  // Use xpu_event_wait instead of xpu_event_query to correctly handle
-  // events that have never been recorded (xpu_event_query returns an
-  // error for unrecorded events, causing test_event_stream_apis to fail).
-  PADDLE_ENFORCE_XRE_SUCCESS(xpu_event_wait(event_));
   PADDLE_ENFORCE_XRE_SUCCESS(xpu_event_record(event_, stream));
 }
 

--- a/paddle/phi/backends/xpu/xpu_context.cc
+++ b/paddle/phi/backends/xpu/xpu_context.cc
@@ -739,7 +739,11 @@ XPUEventHandle::XPUEventHandle(XPUStream stream) {
 }
 
 void XPUEventHandle::record(XPUStream stream) {
-  PADDLE_ENFORCE_XRE_SUCCESS(xpu_event_query(event_));
+  // Wait for the previous record to complete before re-recording.
+  // Use xpu_event_wait instead of xpu_event_query to correctly handle
+  // events that have never been recorded (xpu_event_query returns an
+  // error for unrecorded events, causing test_event_stream_apis to fail).
+  PADDLE_ENFORCE_XRE_SUCCESS(xpu_event_wait(event_));
   PADDLE_ENFORCE_XRE_SUCCESS(xpu_event_record(event_, stream));
 }
 


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description

Cherry-pick of #78227 to `release/3.3`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78227

Fix `test_event_stream_apis` consistent failure on XPU CI by removing the `xpu_event_query` guard in `XPUEventHandle::record()`.

**Root Cause:** `XPUEventHandle::record()` calls `xpu_event_query(event_)` before `xpu_event_record()` as a guard, but `xpu_event_query` returns XPU Runtime Error 600 for events that have never been recorded, which is fatal due to `PADDLE_ENFORCE_XRE_SUCCESS`.

**Fix:** Remove the `xpu_event_query` guard entirely. `xpu_event_record` supports recording the same event multiple times, so no wait/query guard is needed.

**CI Impact:** This fixes the `test_event_stream_apis` failure that has been blocking cherry-pick PRs on `release/3.3` (e.g., #78158).