### PR TITLE
[WarpCTC] fix SIGFPE/CUDA error(700)/SIGSEGV when 0-size tensor passed to ctc_loss

### DIFF
--- a/paddle/phi/kernels/funcs/sequence_padding.cu
+++ b/paddle/phi/kernels/funcs/sequence_padding.cu
@@ -77,6 +77,12 @@ class PaddingDenseTensorFunctor<phi::GPUContext, T> {
     if (pad_seq_len == -1) {
       pad_seq_len = max_seq_len;
     }
+    // Guard against 0-size tensors: avoid division by zero (SIGFPE) when
+    // seq_tensor_dims[0]==0, and avoid invalid GPU memory access when
+    // seq_tensor or pad_tensor has no backing memory (numel==0).
+    if (seq_tensor.numel() == 0 || pad_tensor->numel() == 0) {
+      return;
+    }
     PADDLE_ENFORCE_GE(
         pad_seq_len,
         max_seq_len,
@@ -156,6 +162,12 @@ class UnpaddingDenseTensorFunctor<phi::GPUContext, T> {
     int max_seq_len = MaximumSequenceLength(seq_offsets);
     if (pad_seq_len == -1) {
       pad_seq_len = max_seq_len;
+    }
+    // Guard against 0-size tensors: avoid division by zero (SIGFPE) when
+    // seq_tensor_dims[0]==0, and avoid illegal GPU memory access (CUDA
+    // error 700) when pad_tensor has no backing memory (numel==0).
+    if (seq_tensor->numel() == 0 || pad_tensor.numel() == 0) {
+      return;
     }
     int64_t step_width = seq_tensor->numel() / seq_tensor_dims[0];
     int seq_num = seq_offsets.size() - 1;

--- a/paddle/phi/kernels/impl/warpctc_kernel_impl.h
+++ b/paddle/phi/kernels/impl/warpctc_kernel_impl.h
@@ -279,6 +279,22 @@ void WarpctcKernel(const Context& dev_ctx,
     Copy(dev_ctx, *logits_length, CPUPlace(), false, &logits_length_cpu);
     Copy(dev_ctx, *labels_length, CPUPlace(), false, &labels_length_cpu);
 
+    // Handle 0-size logits_length or labels_length tensors: accessing data()
+    // of empty tensors yields a null pointer, causing SIGSEGV in the loop.
+    if (logits_length_cpu.numel() == 0 || labels_length_cpu.numel() == 0) {
+      auto early_loss_dims =
+          make_ddim({static_cast<int64_t>(num_sequences), 1});
+      loss->Resize(early_loss_dims);
+      dev_ctx.template Alloc<T>(loss);
+      funcs::SetConstant<Context, T>()(dev_ctx, loss, static_cast<T>(0));
+      warpctcgrad->Resize({static_cast<int64_t>(max_sequence_length),
+                           static_cast<int64_t>(num_sequences),
+                           static_cast<int64_t>(sequence_width)});
+      dev_ctx.template Alloc<T>(warpctcgrad);
+      funcs::SetConstant<Context, T>()(dev_ctx, warpctcgrad, static_cast<T>(0));
+      return;
+    }
+
     logits_lod.push_back(0);
     label_lod.push_back(0);
     for (size_t i = 0; i < num_sequences; i++) {
@@ -341,6 +357,20 @@ void WarpctcKernel(const Context& dev_ctx,
   }
 
   auto loss_dims = make_ddim({static_cast<int64_t>(num_sequences), 1});
+
+  // Handle 0-size label tensor: avoid division by zero or illegal GPU memory
+  // access in UnpaddingDenseTensorFunctor when label.numel()==0.
+  if (label.numel() == 0) {
+    loss->Resize(loss_dims);
+    dev_ctx.template Alloc<T>(loss);
+    funcs::SetConstant<Context, T>()(dev_ctx, loss, static_cast<T>(0));
+    warpctcgrad->Resize({static_cast<int64_t>(max_sequence_length),
+                         static_cast<int64_t>(num_sequences),
+                         static_cast<int64_t>(sequence_width)});
+    dev_ctx.template Alloc<T>(warpctcgrad);
+    funcs::SetConstant<Context, T>()(dev_ctx, warpctcgrad, static_cast<T>(0));
+    return;
+  }
 
   // warpctc needs sequences data stored in transposed padding format
   DenseTensor warpctc_logits_tmp =

--- a/test/legacy_test/test_warpctc_op.py
+++ b/test/legacy_test/test_warpctc_op.py
@@ -873,7 +873,9 @@ class TestCTCLossZeroSizeTensor(unittest.TestCase):
             logits, labels, input_lengths, labels_length, 0, 'none'
         )
         self.assertEqual(loss.shape, [N])
-        np.testing.assert_array_equal(loss.numpy(), np.zeros(N, dtype='float32'))
+        np.testing.assert_array_equal(
+            loss.numpy(), np.zeros(N, dtype='float32')
+        )
 
     def test_zero_size_input_lengths(self):
         """input_lengths shape [0] -> logits_length_cpu.numel() == 0"""
@@ -888,7 +890,9 @@ class TestCTCLossZeroSizeTensor(unittest.TestCase):
             logits, labels, input_lengths, labels_length, 0, 'none'
         )
         self.assertEqual(loss.shape, [N])
-        np.testing.assert_array_equal(loss.numpy(), np.zeros(N, dtype='float32'))
+        np.testing.assert_array_equal(
+            loss.numpy(), np.zeros(N, dtype='float32')
+        )
 
     def test_zero_size_labels_length(self):
         """labels_length shape [0] -> labels_length_cpu.numel() == 0"""
@@ -903,7 +907,9 @@ class TestCTCLossZeroSizeTensor(unittest.TestCase):
             logits, labels, input_lengths, labels_length, 0, 'none'
         )
         self.assertEqual(loss.shape, [N])
-        np.testing.assert_array_equal(loss.numpy(), np.zeros(N, dtype='float32'))
+        np.testing.assert_array_equal(
+            loss.numpy(), np.zeros(N, dtype='float32')
+        )
 
     def test_zero_size_label_various_reductions(self):
         """0-size label with different reduction modes and norm_by_times"""

--- a/test/legacy_test/test_warpctc_op.py
+++ b/test/legacy_test/test_warpctc_op.py
@@ -843,5 +843,93 @@ class TestCTCLossAPICase(unittest.TestCase):
         np.testing.assert_allclose(loss.numpy(), [0.0], rtol=1e-6)
 
 
+class TestCTCLossZeroSizeTensor(unittest.TestCase):
+    """Test that ctc_loss handles 0-size tensors gracefully without crash.
+
+    Three 0-size scenarios are covered:
+      1. label has shape [0, max_label_len]  -> label.numel() == 0
+         Previously caused SIGFPE (0/0 division) or CUDA error(700)
+         (illegal memory access) in UnpaddingDenseTensorFunctor.
+      2. input_lengths has shape [0]         -> logits_length_cpu.numel() == 0
+         Previously caused SIGSEGV via null-pointer dereference in the
+         lod-building loop.
+      3. labels_length has shape [0]         -> labels_length_cpu.numel() == 0
+         Same SIGSEGV root cause as scenario 2.
+    """
+
+    def _make_logits(self, T, N, C, dtype="float32"):
+        return paddle.zeros([T, N, C], dtype=dtype)
+
+    def test_zero_size_label(self):
+        """label shape [0, max_label_len] -> numel == 0"""
+        paddle.disable_static()
+        T, N, C = 40, 128, 6625
+        logits = self._make_logits(T, N, C)
+        labels = paddle.zeros([0, 25], dtype='int32')
+        input_lengths = paddle.full([N], T, dtype='int64')
+        labels_length = paddle.full([N], 5, dtype='int64')
+
+        loss = paddle.nn.functional.ctc_loss(
+            logits, labels, input_lengths, labels_length, 0, 'none'
+        )
+        self.assertEqual(loss.shape, [N])
+        np.testing.assert_array_equal(loss.numpy(), np.zeros(N, dtype='float32'))
+
+    def test_zero_size_input_lengths(self):
+        """input_lengths shape [0] -> logits_length_cpu.numel() == 0"""
+        paddle.disable_static()
+        T, N, C = 40, 128, 6625
+        logits = self._make_logits(T, N, C)
+        labels = paddle.zeros([N, 25], dtype='int32')
+        input_lengths = paddle.zeros([0], dtype='int64')
+        labels_length = paddle.full([N], 5, dtype='int64')
+
+        loss = paddle.nn.functional.ctc_loss(
+            logits, labels, input_lengths, labels_length, 0, 'none'
+        )
+        self.assertEqual(loss.shape, [N])
+        np.testing.assert_array_equal(loss.numpy(), np.zeros(N, dtype='float32'))
+
+    def test_zero_size_labels_length(self):
+        """labels_length shape [0] -> labels_length_cpu.numel() == 0"""
+        paddle.disable_static()
+        T, N, C = 40, 128, 6625
+        logits = self._make_logits(T, N, C)
+        labels = paddle.zeros([N, 25], dtype='int32')
+        input_lengths = paddle.full([N], T, dtype='int64')
+        labels_length = paddle.zeros([0], dtype='int64')
+
+        loss = paddle.nn.functional.ctc_loss(
+            logits, labels, input_lengths, labels_length, 0, 'none'
+        )
+        self.assertEqual(loss.shape, [N])
+        np.testing.assert_array_equal(loss.numpy(), np.zeros(N, dtype='float32'))
+
+    def test_zero_size_label_various_reductions(self):
+        """0-size label with different reduction modes and norm_by_times"""
+        paddle.disable_static()
+        T, N, C = 10, 4, 8
+        logits = self._make_logits(T, N, C)
+        labels = paddle.zeros([0, 5], dtype='int32')
+        input_lengths = paddle.full([N], T, dtype='int64')
+        labels_length = paddle.full([N], 3, dtype='int64')
+
+        for reduction in ['none', 'sum', 'mean']:
+            for norm_by_times in [False, True]:
+                loss = paddle.nn.functional.ctc_loss(
+                    logits,
+                    labels,
+                    input_lengths,
+                    labels_length,
+                    0,
+                    reduction,
+                    norm_by_times=norm_by_times,
+                )
+                self.assertFalse(
+                    np.any(np.isnan(loss.numpy())),
+                    f"NaN with reduction={reduction}, norm_by_times={norm_by_times}",
+                )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_warpctc_op.py
+++ b/test/legacy_test/test_warpctc_op.py
@@ -843,6 +843,7 @@ class TestCTCLossAPICase(unittest.TestCase):
         np.testing.assert_allclose(loss.numpy(), [0.0], rtol=1e-6)
 
 
+@unittest.skipUnless(paddle.is_compiled_with_cuda(), "requires CUDA")
 class TestCTCLossZeroSizeTensor(unittest.TestCase):
     """Test that ctc_loss handles 0-size tensors gracefully without crash.
 
@@ -873,7 +874,9 @@ class TestCTCLossZeroSizeTensor(unittest.TestCase):
             logits, labels, input_lengths, labels_length, 0, 'none'
         )
         self.assertEqual(loss.shape, [N])
-        np.testing.assert_array_equal(loss.numpy(), np.zeros(N, dtype='float32'))
+        np.testing.assert_array_equal(
+            loss.numpy(), np.zeros(N, dtype='float32')
+        )
 
     def test_zero_size_input_lengths(self):
         """input_lengths shape [0] -> logits_length_cpu.numel() == 0"""
@@ -888,7 +891,9 @@ class TestCTCLossZeroSizeTensor(unittest.TestCase):
             logits, labels, input_lengths, labels_length, 0, 'none'
         )
         self.assertEqual(loss.shape, [N])
-        np.testing.assert_array_equal(loss.numpy(), np.zeros(N, dtype='float32'))
+        np.testing.assert_array_equal(
+            loss.numpy(), np.zeros(N, dtype='float32')
+        )
 
     def test_zero_size_labels_length(self):
         """labels_length shape [0] -> labels_length_cpu.numel() == 0"""
@@ -903,7 +908,9 @@ class TestCTCLossZeroSizeTensor(unittest.TestCase):
             logits, labels, input_lengths, labels_length, 0, 'none'
         )
         self.assertEqual(loss.shape, [N])
-        np.testing.assert_array_equal(loss.numpy(), np.zeros(N, dtype='float32'))
+        np.testing.assert_array_equal(
+            loss.numpy(), np.zeros(N, dtype='float32')
+        )
 
     def test_zero_size_label_various_reductions(self):
         """0-size label with different reduction modes and norm_by_times"""


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
paddle.nn.functional.ctc_loss 在传入 0-size 张量时会触发进程崩溃，本 PR 对三类场景进行修复。

修复了三类崩溃：
1. label形状[0, max_len]时 SIGFPE/CUDA error(700)：在warpctc_kernel_impl.h中添加label.numel()==0早返回
2. input_lengths形状[0]时 SIGSEGV：在lod构建循环前添加logits_length_cpu.numel()==0检查
3. labels_length形状[0]时 SIGSEGV：同上检查labels_length_cpu.numel()==0

同时在sequence_padding.cu的GPUContext特化版本中添加0-size安全兜底保护。
新增TestCTCLossZeroSizeTensor单测类覆盖三种崩溃场景。

### 是否引起精度变化
否