### PR TITLE
Fix mean grad precision bug to achieve bitwise alignment with Torch 2.9.1

### DIFF
--- a/paddle/phi/kernels/gpu/reduce_kernel.cu
+++ b/paddle/phi/kernels/gpu/reduce_kernel.cu
@@ -114,8 +114,11 @@ void ReduceMeanGradKernel(const Context& dev_ctx,
   std::vector<DenseTensor*> outputs = {x_grad};
 
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  funcs::BroadcastKernel<T>(
-      dev_ctx, inputs, &outputs, kps::DivideFunctor<T, MPType>(reduce_num), 0);
+  funcs::BroadcastKernel<T>(dev_ctx,
+                            inputs,
+                            &outputs,
+                            kps::MPTypeDivideFunctor<T, MPType>(reduce_num),
+                            0);
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/primitive/functor_primitives.h
+++ b/paddle/phi/kernels/primitive/functor_primitives.h
@@ -113,6 +113,28 @@ struct DivideFunctor {
 };
 
 /**
+ * @brief Divide with reciprocal computed in MPType.
+ */
+template <typename Tx, typename Ty = Tx>
+struct MPTypeDivideFunctor {
+ private:
+  using MPType = typename ::phi::dtype::MPTypeTrait<Tx>::Type;
+
+ public:
+  HOSTDEVICE inline MPTypeDivideFunctor() { n_inv = static_cast<MPType>(1.0f); }
+
+  HOSTDEVICE explicit inline MPTypeDivideFunctor(int64_t n)
+      : n_inv(static_cast<MPType>(1.0) / static_cast<MPType>(n)) {}
+
+  HOSTDEVICE inline Ty operator()(const Tx x) const {
+    return static_cast<Ty>(static_cast<MPType>(x) * n_inv);
+  }
+
+ private:
+  MPType n_inv;
+};
+
+/**
  * @brief Default inverse functor
  */
 template <typename Tx, typename Ty = Tx>

--- a/paddle/phi/kernels/primitive/reduce_primitives.h
+++ b/paddle/phi/kernels/primitive/reduce_primitives.h
@@ -94,9 +94,7 @@ struct MinOps {
   }
 
   inline DEVICE MPType reduce(MPType a, MPType b) const {
-    if constexpr ((std::is_floating_point<InT>::value) &&
-                  (!(std::is_same<InT, int32_t>::value ||
-                     (std::is_same<InT, int64_t>::value)))) {
+    if constexpr (std::is_floating_point<InT>::value) {
       if (isnan(a)) {
         return a;
       }
@@ -144,9 +142,7 @@ struct MaxOps {
   }
 
   inline DEVICE MPType reduce(MPType a, MPType b) const {
-    if constexpr ((std::is_floating_point<InT>::value) &&
-                  (!(std::is_same<InT, int32_t>::value ||
-                     (std::is_same<InT, int64_t>::value)))) {
+    if constexpr (std::is_floating_point<InT>::value) {
       if (isnan(a)) {
         return a;
       }
@@ -193,9 +189,7 @@ struct AbsMaxOps {
   }
 
   inline DEVICE MPType reduce(MPType a, MPType b) const {
-    if constexpr ((std::is_floating_point<InT>::value) &&
-                  (!(std::is_same<InT, int32_t>::value ||
-                     (std::is_same<InT, int64_t>::value)))) {
+    if constexpr (std::is_floating_point<InT>::value) {
       if (isnan(a)) {
         return a;
       }
@@ -225,9 +219,7 @@ struct AbsMinOps {
   }
 
   inline DEVICE MPType reduce(MPType a, MPType b) const {
-    if constexpr ((std::is_floating_point<InT>::value) &&
-                  (!(std::is_same<InT, int32_t>::value ||
-                     (std::is_same<InT, int64_t>::value)))) {
+    if constexpr (std::is_floating_point<InT>::value) {
       if (isnan(a)) {
         return a;
       }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
mean big tensor bwd 精度对齐 torch2.9.1
(MPType)(1.0 / n) 改为 static_cast(1.0) / static_cast(n)


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是

Pcard-89071

devPR:https://github.com/PaddlePaddle/Paddle/pull/78246