### PR TITLE
Precision alignment agent/layer norm

### DIFF
--- a/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
+++ b/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
@@ -220,6 +220,7 @@ __global__ void LayerNormForward(
     U *var,
     float epsilon,
     int64_t feature_size,
+    const bool use_accuracy_compatible = false,
     const float *dequant_out_scale_data = nullptr,
     const int quant_out_scale_offset = 0,
     const float quant_in_scale = 1.0,
@@ -240,24 +241,37 @@ __global__ void LayerNormForward(
       (static_cast<int64_t>(blockIdx.x) * gridDim.y + blockIdx.y + 1) *
       feature_size;
 
-  // Step 1: Reduce to calculate mean and var
+  // Precision alignment: two-pass approach for numerically stable variance.
+  // Pass 1: Compute sum -> mean
   U mean_val = 0;
-  U var_val = 0;
   for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
-    U tmp = static_cast<U>(x[i]);
-    mean_val += tmp;
-    var_val += (tmp * tmp);
+    mean_val += static_cast<U>(x[i]);
   }
 
   mean_val = BlockReduceSum<U>(mean_val, shared_mean);
+
+  if (threadIdx.x == 0) {
+    auto inv_feature_size = static_cast<U>(static_cast<float>(1.) /
+                                           static_cast<float>(feature_size));
+    mean[blockIdx.x] = mean_share = static_cast<U>(mean_val * inv_feature_size);
+  }
+  __syncthreads();
+
+  // Pass 2: Compute sum of (x - mean)^2 -> variance
+  // Re-read data from global memory for numerical stability.
+  U local_mean = mean_share;
+  U var_val = 0;
+  for (int64_t i = beg_idx; i < end_idx; i += BlockDim) {
+    U diff = static_cast<U>(x[i]) - local_mean;
+    var_val += diff * diff;
+  }
+
   var_val = BlockReduceSum<U>(var_val, shared_var);
 
   if (threadIdx.x == 0) {
-    auto scale = static_cast<U>(static_cast<float>(1.) /
-                                static_cast<float>(feature_size));
-    auto tmp = mean_val * scale;
-    mean[blockIdx.x] = mean_share = static_cast<U>(tmp);
-    var_share = static_cast<U>(var_val * scale - mean_share * mean_share);
+    auto inv_feature_size = static_cast<U>(static_cast<float>(1.) /
+                                           static_cast<float>(feature_size));
+    var_share = static_cast<U>(var_val * inv_feature_size);
     var_share = var_share > U(0) ? var_share : U(0);
     var[blockIdx.x] = var_share;
   }
@@ -267,41 +281,51 @@ __global__ void LayerNormForward(
   U invvar = rsqrt_<U>(var_share + static_cast<U>(epsilon));
 
   // Step 2: Calculate y
+  // Precision alignment: when use_accuracy_compatible is true, match PyTorch
+  // evaluation order: scale * (invvar * (x - mean)) + bias
+  // Default Paddle order: scale * (x - mean) * invvar + bias
   if (scale != nullptr) {
     if (bias != nullptr) {
       for (int64_t i = beg_idx, j = threadIdx.x; i < end_idx;
            i += BlockDim, j += BlockDim) {
+        U normalized;
+        if (use_accuracy_compatible) {
+          normalized = invvar * (static_cast<U>(x[i]) - mean_val);
+        } else {
+          normalized = (static_cast<U>(x[i]) - mean_val) * invvar;
+        }
         if (std::is_same<OutType, int8_t>::value) {
           y[i] = quant_helper(
-              static_cast<T>(static_cast<U>(scale[j]) *
-                                 (static_cast<U>(x[i]) - mean_val) * invvar +
+              static_cast<T>(static_cast<U>(scale[j]) * normalized +
                              static_cast<U>(bias[j])),
               quant_in_scale,
               quant_round_type,
               quant_max_bound,
               quant_min_bound);
         } else {
-          y[i] = static_cast<OutType>(static_cast<U>(scale[j]) *
-                                          (static_cast<U>(x[i]) - mean_val) *
-                                          invvar +
+          y[i] = static_cast<OutType>(static_cast<U>(scale[j]) * normalized +
                                       static_cast<U>(bias[j]));
         }
       }
     } else {
       for (int64_t i = beg_idx, j = threadIdx.x; i < end_idx;
            i += BlockDim, j += BlockDim) {
+        U normalized;
+        if (use_accuracy_compatible) {
+          normalized = invvar * (static_cast<U>(x[i]) - mean_val);
+        } else {
+          normalized = (static_cast<U>(x[i]) - mean_val) * invvar;
+        }
         if (std::is_same<OutType, int8_t>::value) {
           y[i] = quant_helper(
-              static_cast<T>(static_cast<U>(scale[j]) *
-                             (static_cast<U>(x[i]) - mean_val) * invvar),
+              static_cast<T>(static_cast<U>(scale[j]) * normalized),
               quant_in_scale,
               quant_round_type,
               quant_max_bound,
               quant_min_bound);
         } else {
           y[i] =
-              static_cast<OutType>(static_cast<U>(scale[j]) *
-                                   (static_cast<U>(x[i]) - mean_val) * invvar);
+              static_cast<OutType>(static_cast<U>(scale[j]) * normalized);
         }
       }
     }
@@ -309,33 +333,42 @@ __global__ void LayerNormForward(
     if (bias != nullptr) {
       for (int64_t i = beg_idx, j = threadIdx.x; i < end_idx;
            i += BlockDim, j += BlockDim) {
+        U normalized;
+        if (use_accuracy_compatible) {
+          normalized = invvar * (static_cast<U>(x[i]) - mean_val);
+        } else {
+          normalized = (static_cast<U>(x[i]) - mean_val) * invvar;
+        }
         if (std::is_same<OutType, int8_t>::value) {
           y[i] = quant_helper(
-              static_cast<T>((static_cast<U>(x[i]) - mean_val) * invvar +
-                             static_cast<U>(bias[j])),
+              static_cast<T>(normalized + static_cast<U>(bias[j])),
               quant_in_scale,
               quant_round_type,
               quant_max_bound,
               quant_min_bound);
         } else {
           y[i] =
-              static_cast<OutType>((static_cast<U>(x[i]) - mean_val) * invvar +
-                                   static_cast<U>(bias[j]));
+              static_cast<OutType>(normalized + static_cast<U>(bias[j]));
         }
       }
     } else {
       for (int64_t i = beg_idx, j = threadIdx.x; i < end_idx;
            i += BlockDim, j += BlockDim) {
+        U normalized;
+        if (use_accuracy_compatible) {
+          normalized = invvar * (static_cast<U>(x[i]) - mean_val);
+        } else {
+          normalized = (static_cast<U>(x[i]) - mean_val) * invvar;
+        }
         if (std::is_same<OutType, int8_t>::value) {
           y[i] = quant_helper(
-              static_cast<T>((static_cast<U>(x[i]) - mean_val) * invvar),
+              static_cast<T>(normalized),
               quant_in_scale,
               quant_round_type,
               quant_max_bound,
               quant_min_bound);
         } else {
-          y[i] =
-              static_cast<OutType>((static_cast<U>(x[i]) - mean_val) * invvar);
+          y[i] = static_cast<OutType>(normalized);
         }
       }
     }

--- a/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
+++ b/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
@@ -18,6 +18,7 @@ limitations under the License. */
 
 #include "glog/logging.h"
 #include "paddle/common/ddim.h"
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
 #include "paddle/phi/backends/gpu/gpu_dnn.h"
@@ -26,6 +27,8 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/cub.h"
 #include "paddle/phi/kernels/funcs/fake_quantize_functor.h"
 #include "paddle/phi/kernels/funcs/fast_ln_v1.h"
+
+COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
 
 namespace phi {
 namespace funcs {
@@ -1955,11 +1958,16 @@ static void LayerNormBackward(
     {
 #ifdef PADDLE_WITH_CUDA
       bool can_call_fast_kernel = false;
-      // todo: rule out double type.
-      if ((feature_size == 1024 || feature_size == 384 ||
-           feature_size == 256) &&
-          sizeof(T) <= 4) {
-        can_call_fast_kernel = true;
+      // Precision alignment: when accuracy compatible mode is enabled,
+      // bypass the fused fast backward kernel and use the generic path
+      // to match PyTorch's backward computation order.
+      if (!FLAGS_use_accuracy_compatible_kernel) {
+        // todo: rule out double type.
+        if ((feature_size == 1024 || feature_size == 384 ||
+             feature_size == 256) &&
+            sizeof(T) <= 4) {
+          can_call_fast_kernel = true;
+        }
       }
 
       VLOG(6) << "can_call_fast_kernel = " << can_call_fast_kernel;

--- a/paddle/phi/kernels/fusion/gpu/attention_layer.norm.h
+++ b/paddle/phi/kernels/fusion/gpu/attention_layer.norm.h
@@ -67,6 +67,7 @@ class AttnLayerNorm {
                                                   var_data,
                                                   epsilon_,
                                                   feature_size_,
+                                                  false,
                                                   dequant_out_scale_data,
                                                   quant_out_scale_offset,
                                                   quant_in_scale,

--- a/paddle/phi/kernels/gpu/layer_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_grad_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/layer_norm_grad_kernel.h"
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cast_kernel.h"
@@ -23,6 +24,8 @@
 #if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
 #include "paddle/phi/kernels/funcs/fast_ln_v2.h"
 #endif
+COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
+
 namespace phi {
 enum class LayerNormGadKernelVariant { FAST_LN_V2, GENERIC };
 static inline LayerNormGadKernelVariant LayerNormGradKernelDispatch(
@@ -34,6 +37,11 @@ static inline LayerNormGadKernelVariant LayerNormGradKernelDispatch(
     const int64_t x_numel,
     const DenseTensor* scale,
     const DenseTensor* bias) {
+  // Precision alignment: when accuracy compatible mode is enabled,
+  // bypass FAST_LN_V2 backward and use the generic backward kernel.
+  if (FLAGS_use_accuracy_compatible_kernel) {
+    return LayerNormGadKernelVariant::GENERIC;
+  }
 #if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
   if (scale != nullptr && bias != nullptr &&
       input_type != paddle::DataType::FLOAT32 && hidden_size != 4096 &&

--- a/paddle/phi/kernels/gpu/layer_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_kernel.cu
@@ -22,6 +22,7 @@
 #include "paddle/phi/kernels/funcs/layer_norm_impl.cu.h"
 #include "paddle/phi/kernels/funcs/layer_norm_util.h"
 COMMON_DECLARE_bool(use_fast_math);
+COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
 
 namespace phi {
 
@@ -503,6 +504,11 @@ static inline LayerNormKernelVariant LayerNormKernelDispatch(
     const int64_t x_numel,
     const DenseTensor* scale,
     const DenseTensor* bias) {
+  // Precision alignment: when accuracy compatible mode is enabled,
+  // bypass FAST_LN_V1/V2 and use the generic (two-pass) kernel.
+  if (FLAGS_use_accuracy_compatible_kernel) {
+    return LayerNormKernelVariant::GENERIC;
+  }
   if (scale == nullptr || bias == nullptr) {
     return LayerNormKernelVariant::GENERIC;
   }
@@ -600,7 +606,8 @@ void LayerNormKernel(const Context& dev_ctx,
               mean_data,                                                      \
               var_data,                                                       \
               epsilon,                                                        \
-              feature_size));                                                 \
+              feature_size,                                                   \
+              FLAGS_use_accuracy_compatible_kernel));                          \
       default:                                                                \
         PADDLE_THROW(common::errors::InvalidArgument(                         \
             "Product from begin_norm_axis to end must be larger than 1"));    \
@@ -698,7 +705,11 @@ void LayerNormKernel(const Context& dev_ctx,
     default:
 #ifdef PADDLE_WITH_CUDA
       // WarpShuffle intrinsics is involved in LaunchLayerNormKernel.
-      if (FLAGS_use_fast_math && feature_size <= 1024 &&
+      // Precision alignment: skip Welford fast-math path when accuracy
+      // compatible mode is enabled, to ensure the generic two-pass kernel
+      // is used for maximum precision alignment with PyTorch.
+      if (!FLAGS_use_accuracy_compatible_kernel &&
+          FLAGS_use_fast_math && feature_size <= 1024 &&
           (!std::is_same<T, int8_t>::value)) {
         LaunchLayerNormKernel<Context, T, U>(dev_ctx,
                                              x_data,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
一、问题背景                                                                                                                                                         
   
  Paddle 的 layer_norm GPU 实现与 PyTorch 存在精度差异，核心原因：                                                                                                     
                                                            
  ┌──────────────────┬────────────────────────────────────────────────┬──────────────────────────────────┐
  │      差异点      │                Paddle (修改前)                 │             PyTorch              │
  ├──────────────────┼────────────────────────────────────────────────┼──────────────────────────────────┤
  │ 方差计算         │ E[x²] - E[x]² (数值不稳定)                     │ Welford 在线算法 (数值稳定)      │
  ├──────────────────┼────────────────────────────────────────────────┼──────────────────────────────────┤
  │ 前向 kernel 路径 │ FAST_LN_V1/V2/Welford 多路径,各自实现不同      │ 统一 Welford + vectorized        │
  ├──────────────────┼────────────────────────────────────────────────┼──────────────────────────────────┤
  │ 归一化公式顺序   │ scale * (x-mean) * invvar + bias               │ gamma * (rstd * (x-mean)) + beta │
  ├──────────────────┼────────────────────────────────────────────────┼──────────────────────────────────┤
  │ 反向 kernel 路径 │ FAST_LN_V2 bwd / fused_fast_bwd / generic 三种 │ 统一 vectorized backward         │
  └──────────────────┴────────────────────────────────────────────────┴──────────────────────────────────┘

  二、修改内容（4 个文件，5 项修复）

  文件 1：paddle/phi/kernels/funcs/layer_norm_impl.cu.h（核心修改）

  Fix 1 [无条件改进] — 替换方差计算算法：
  // 修改前（单 pass，数值不稳定）：
  sum_x += x[i];  sum_x2 += x[i] * x[i];
  var = sum_x2/N - (sum_x/N)²    // ← 大均值时灾难性抵消

  // 修改后（两 pass，数值稳定）：
  Pass 1: mean = sum(x) / N
  Pass 2: var = sum((x - mean)²) / N   // ← 不存在抵消问题

  Fix 3 [FLAG 控制] — 匹配 PyTorch 归一化公式顺序：
  if (use_accuracy_compatible) {
      normalized = invvar * (x[i] - mean);      // PyTorch 顺序
  } else {
      normalized = (x[i] - mean) * invvar;       // Paddle 原始顺序
  }

  Fix 5 [FLAG 控制] — 跳过反向 fused fast kernel：
  if (!FLAGS_use_accuracy_compatible_kernel) {
      if (feature_size == 1024 || feature_size == 384 || feature_size == 256)
          can_call_fast_kernel = true;  // 仅非精度模式启用
  }

  文件 2：paddle/phi/kernels/gpu/layer_norm_kernel.cu

  Fix 2 [FLAG 控制] — 前向跳过 FAST_LN_V1/V2 和 Welford fast-math 路径：
  static inline LayerNormKernelVariant LayerNormKernelDispatch(...) {
      if (FLAGS_use_accuracy_compatible_kernel) {
          return LayerNormKernelVariant::GENERIC;  // 强制走通用 kernel
      }
      // ... 原有 FAST_LN_V2 / V1 逻辑不变
  }

  文件 3：paddle/phi/kernels/gpu/layer_norm_grad_kernel.cu

  Fix 5 [FLAG 控制] — 反向跳过 FAST_LN_V2：
  static inline LayerNormGadKernelVariant LayerNormGradKernelDispatch(...) {
      if (FLAGS_use_accuracy_compatible_kernel) {
          return LayerNormGadKernelVariant::GENERIC;
      }
      // ... 原有逻辑不变
  }

  文件 4：paddle/phi/kernels/fusion/gpu/attention_layer.norm.h

  适配新增 use_accuracy_compatible 参数，传入 false 保持 fusion kernel 不受影响。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是