### PR TITLE
[PAA] use runtime-detected MKL VML for CPU sin/cos/exp to match PyTorch

### DIFF
--- a/paddle/phi/kernels/cpu/activation_kernel.cc
+++ b/paddle/phi/kernels/cpu/activation_kernel.cc
@@ -102,12 +102,12 @@ namespace phi {
   }
 
 // Specialized Sin kernel with vectorized Sleef implementation for float/double
-// This ensures bit-level precision alignment with PyTorch
+// This ensures high precision computation
 template <typename T, typename Context>
 void SinKernel(const Context& dev_ctx, const DenseTensor& x, DenseTensor* out) {
   if constexpr (std::is_same<T, float>::value ||
                 std::is_same<T, double>::value) {
-    // Use vectorized Sleef path for float/double to match PyTorch precision
+    // Use vectorized Sleef path for float/double for high precision
     VectorizedSinImpl<T, Context>(dev_ctx, x, out);
   } else {
     // Use generic path for other types (float16, bfloat16, complex)
@@ -122,7 +122,7 @@ template <typename T, typename Context>
 void CosKernel(const Context& dev_ctx, const DenseTensor& x, DenseTensor* out) {
   if constexpr (std::is_same<T, float>::value ||
                 std::is_same<T, double>::value) {
-    // Use vectorized Sleef path for float/double to match PyTorch precision
+    // Use vectorized Sleef path for float/double for high precision
     VectorizedCosImpl<T, Context>(dev_ctx, x, out);
   } else {
     // Use generic path for other types (float16, bfloat16, complex)
@@ -160,8 +160,24 @@ DEFINE_CPU_ACTIVATION_KERNEL_WITH_INT_IN_FLOAT_OUT(Log, LogFunctor)
 DEFINE_CPU_ACTIVATION_KERNEL_WITH_INT_IN_FLOAT_OUT(Log2, Log2Functor)
 DEFINE_CPU_ACTIVATION_KERNEL_WITH_INT_IN_FLOAT_OUT(Log10, Log10Functor)
 DEFINE_CPU_ACTIVATION_KERNEL_WITH_INT_IN_FLOAT_OUT(Log1p, Log1pFunctor)
-DEFINE_CPU_ACTIVATION_KERNEL_WITH_INT_IN_FLOAT_OUT(Exp, ExpFunctor)
 DEFINE_CPU_ACTIVATION_KERNEL_WITH_INT_IN_FLOAT_OUT(Expm1, Expm1Functor)
+
+// Specialized Exp kernel with vectorized MKL VML/Sleef implementation
+// for float/double. This ensures high precision computation.
+template <typename T, typename Context>
+void ExpKernel(const Context& dev_ctx, const DenseTensor& x, DenseTensor* out) {
+  if constexpr (std::is_same<T, float>::value ||
+                std::is_same<T, double>::value) {
+    // Use vectorized MKL VML/Sleef path for float/double for high precision
+    VectorizedExpImpl<T, Context>(dev_ctx, x, out);
+  } else {
+    // Use generic path for other types (int, int64, float16, complex)
+    funcs::ExpFunctor<T> functor;
+    using U = typename std::conditional_t<std::is_integral<T>::value, float, T>;
+    ActivationImpl<T, U, Context, funcs::ExpFunctor<T>>(
+        dev_ctx, x, out, functor);
+  }
+}
 
 DEFINE_CPU_ACT_KERNEL_WITH_ONE_DOUBLE_ATTRS(LeakyRelu, LeakyReluFunctor, alpha)
 DEFINE_CPU_ACT_KERNEL_WITH_ONE_ATTRS(Mish, MishFunctor, threshold)

--- a/paddle/phi/kernels/funcs/sleef_vectorized_math.h
+++ b/paddle/phi/kernels/funcs/sleef_vectorized_math.h
@@ -330,23 +330,6 @@ inline void vexp_avx2_f32(float* out, const float* in, int64_t n) {
     out[i] = Sleef_expf1_u10(in[i]);
   }
 }
-
-// Vectorized exp for double using AVX2
-inline void vexp_avx2_f64(double* out, const double* in, int64_t n) {
-  constexpr int64_t VEC_SIZE = 4;  // AVX2: 256-bit = 4 doubles
-  int64_t i = 0;
-
-  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
-    __m256d vec_in = _mm256_loadu_pd(in + i);
-    __m256d vec_out = Sleef_expd4_u10(vec_in);
-    _mm256_storeu_pd(out + i, vec_out);
-  }
-
-  for (; i < n; ++i) {
-    out[i] = Sleef_expd1_u10(in[i]);
-  }
-}
-
 #endif  // PADDLE_SLEEF_HAS_AVX2
 
 // -----------------------------------------------------------------------------
@@ -726,8 +709,6 @@ inline void vexp(double* out, const double* in, int64_t n) {
 #endif
 #ifdef PADDLE_SLEEF_HAS_AVX512
   vexp_avx512_f64(out, in, n);
-#elif defined(PADDLE_SLEEF_HAS_AVX2)
-  vexp_avx2_f64(out, in, n);
 #else
   vexp_scalar_f64(out, in, n);
 #endif

--- a/paddle/phi/kernels/funcs/sleef_vectorized_math.h
+++ b/paddle/phi/kernels/funcs/sleef_vectorized_math.h
@@ -14,6 +14,171 @@
 
 #pragma once
 
+#ifdef PADDLE_WITH_MKLML
+#include <dlfcn.h>
+#include <mkl.h>
+
+// Type definitions for MKL VML sin/cos functions
+// These functions may not be available in lightweight mklml (libmklml_intel.so)
+// but are present in full Intel MKL.
+using vmsSin_t = void (*)(MKL_INT, const float*, float*, MKL_INT64);
+using vmdSin_t = void (*)(MKL_INT, const double*, double*, MKL_INT64);
+using vmsCos_t = void (*)(MKL_INT, const float*, float*, MKL_INT64);
+using vmdCos_t = void (*)(MKL_INT, const double*, double*, MKL_INT64);
+using vmsExp_t = void (*)(MKL_INT, const float*, float*, MKL_INT64);
+using vmdExp_t = void (*)(MKL_INT, const double*, double*, MKL_INT64);
+
+// VML mode constant: VML_HA | VML_FTZDAZ_OFF | VML_ERRMODE_IGNORE
+// = 0x2 | 0x00140000 | 0x100 = 0x00140102
+static constexpr MKL_INT64 VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE = 0x00140102LL;
+
+// RTLD_NOLOAD is a GNU extension (available on Linux via _GNU_SOURCE).
+// Provide a fallback definition in case it is not defined.
+#ifndef RTLD_NOLOAD
+#define RTLD_NOLOAD 4
+#endif
+
+namespace detail {
+
+// One-time initialization: try to make MKL VML functions available in global
+// symbol scope. This handles the case where MKL VML symbols (vmsSin, etc.)
+// are not directly exported globally, e.g. when libtorch_cpu.so is loaded
+// with RTLD_LOCAL.
+//
+// Strategies tried in order:
+// 1. Check if symbols are already visible via RTLD_DEFAULT (normal case).
+// 2. Try to load the full Intel MKL runtime (libmkl_rt.so) and promote it
+//    to global scope so its symbols become visible.
+// 3. Try to promote an already-loaded libtorch_cpu.so (which bundles MKL)
+//    to global scope using RTLD_NOLOAD | RTLD_GLOBAL.
+//
+// Thread safety: C++11 guarantees function-local statics are initialized
+// exactly once, even under concurrent access.
+inline void ensure_mkl_vml_probed() {
+  static bool probed = false;
+  if (probed) return;
+  probed = true;
+
+  // Strategy 1: Already in global scope - nothing to do
+  if (dlsym(RTLD_DEFAULT, "vmsSin") != nullptr) return;
+
+  // Strategy 2: Full Intel MKL runtime library
+  // First check if already loaded (RTLD_NOLOAD), then try a fresh load.
+  void* handle = dlopen("libmkl_rt.so", RTLD_LAZY | RTLD_NOLOAD);
+  if (!handle) {
+    handle = dlopen("libmkl_rt.so", RTLD_LAZY);
+  }
+  if (handle && dlsym(handle, "vmsSin") != nullptr) {
+    // Re-open with RTLD_GLOBAL to make symbols visible via RTLD_DEFAULT
+    dlopen("libmkl_rt.so", RTLD_LAZY | RTLD_GLOBAL);
+    return;
+  }
+
+  // Strategy 3: Promote libtorch_cpu.so (which bundles full MKL) to global
+  // scope. RTLD_NOLOAD ensures we do NOT load the library - we only get a
+  // handle if it is already loaded in this process. RTLD_GLOBAL makes its
+  // symbols visible to subsequent dlsym(RTLD_DEFAULT, ...) calls.
+  dlopen("libtorch_cpu.so", RTLD_LAZY | RTLD_NOLOAD | RTLD_GLOBAL);
+  // Whether or not this succeeded, we have tried our best.
+}
+
+}  // namespace detail
+
+// Runtime detection of MKL VML functions via dlsym.
+// Calls ensure_mkl_vml_probed() once to try multiple strategies for making
+// MKL VML symbols visible, then resolves each function via RTLD_DEFAULT.
+// Returns nullptr if the function is not available.
+inline vmsSin_t get_vmsSin() {
+  static vmsSin_t func = nullptr;
+  static bool checked = false;
+  if (!checked) {
+    checked = true;
+    detail::ensure_mkl_vml_probed();
+    func = reinterpret_cast<vmsSin_t>(dlsym(RTLD_DEFAULT, "vmsSin"));
+  }
+  return func;
+}
+
+inline vmdSin_t get_vmdSin() {
+  static vmdSin_t func = nullptr;
+  static bool checked = false;
+  if (!checked) {
+    checked = true;
+    detail::ensure_mkl_vml_probed();
+    func = reinterpret_cast<vmdSin_t>(dlsym(RTLD_DEFAULT, "vmdSin"));
+  }
+  return func;
+}
+
+inline vmsCos_t get_vmsCos() {
+  static vmsCos_t func = nullptr;
+  static bool checked = false;
+  if (!checked) {
+    checked = true;
+    detail::ensure_mkl_vml_probed();
+    func = reinterpret_cast<vmsCos_t>(dlsym(RTLD_DEFAULT, "vmsCos"));
+  }
+  return func;
+}
+
+inline vmdCos_t get_vmdCos() {
+  static vmdCos_t func = nullptr;
+  static bool checked = false;
+  if (!checked) {
+    checked = true;
+    detail::ensure_mkl_vml_probed();
+    func = reinterpret_cast<vmdCos_t>(dlsym(RTLD_DEFAULT, "vmdCos"));
+  }
+  return func;
+}
+
+inline vmsExp_t get_vmsExp() {
+  static vmsExp_t func = nullptr;
+  static bool checked = false;
+  if (!checked) {
+    checked = true;
+    detail::ensure_mkl_vml_probed();
+    func = reinterpret_cast<vmsExp_t>(dlsym(RTLD_DEFAULT, "vmsExp"));
+  }
+  return func;
+}
+
+inline vmdExp_t get_vmdExp() {
+  static vmdExp_t func = nullptr;
+  static bool checked = false;
+  if (!checked) {
+    checked = true;
+    detail::ensure_mkl_vml_probed();
+    func = reinterpret_cast<vmdExp_t>(dlsym(RTLD_DEFAULT, "vmdExp"));
+  }
+  return func;
+}
+
+// Check if MKL VML sin/cos functions are available at runtime
+inline bool mkl_vml_sincos_available() {
+  static bool available = false;
+  static bool checked = false;
+  if (!checked) {
+    checked = true;
+    available = (get_vmsSin() != nullptr && get_vmdSin() != nullptr &&
+                 get_vmsCos() != nullptr && get_vmdCos() != nullptr);
+  }
+  return available;
+}
+
+// Check if MKL VML exp functions are available at runtime
+inline bool mkl_vml_exp_available() {
+  static bool available = false;
+  static bool checked = false;
+  if (!checked) {
+    checked = true;
+    available = (get_vmsExp() != nullptr && get_vmdExp() != nullptr);
+  }
+  return available;
+}
+
+#endif  // PADDLE_WITH_MKLML
+
 #ifdef PADDLE_WITH_SLEEF
 #include <sleef.h>
 
@@ -60,7 +225,7 @@ pow_sleef_scalar(const T a, const T b) {
 #endif  // PADDLE_WITH_SLEEF
 
 // =============================================================================
-// Vectorized Sin/Cos functions - matches PyTorch's precision
+// Vectorized Sin/Cos functions - high precision implementation
 // =============================================================================
 
 #ifdef PADDLE_WITH_SLEEF
@@ -70,7 +235,7 @@ pow_sleef_scalar(const T a, const T b) {
 // -----------------------------------------------------------------------------
 #ifdef PADDLE_SLEEF_HAS_AVX2
 
-// Vectorized sin for float using AVX2 (matches PyTorch's Sleef_sinf8_u35)
+// Vectorized sin for float using AVX2
 inline void vsin_avx2_f32(float* out, const float* in, int64_t n) {
   constexpr int64_t VEC_SIZE = 8;  // AVX2: 256-bit = 8 floats
   int64_t i = 0;
@@ -88,7 +253,7 @@ inline void vsin_avx2_f32(float* out, const float* in, int64_t n) {
   }
 }
 
-// Vectorized cos for float using AVX2 (matches PyTorch's Sleef_cosf8_u35)
+// Vectorized cos for float using AVX2
 inline void vcos_avx2_f32(float* out, const float* in, int64_t n) {
   constexpr int64_t VEC_SIZE = 8;
   int64_t i = 0;
@@ -104,7 +269,7 @@ inline void vcos_avx2_f32(float* out, const float* in, int64_t n) {
   }
 }
 
-// Vectorized sin for double using AVX2 (matches PyTorch's Sleef_sind4_u10)
+// Vectorized sin for double using AVX2
 inline void vsin_avx2_f64(double* out, const double* in, int64_t n) {
   constexpr int64_t VEC_SIZE = 4;  // AVX2: 256-bit = 4 doubles
   int64_t i = 0;
@@ -120,7 +285,7 @@ inline void vsin_avx2_f64(double* out, const double* in, int64_t n) {
   }
 }
 
-// Vectorized cos for double using AVX2 (matches PyTorch's Sleef_cosd4_u10)
+// Vectorized cos for double using AVX2
 inline void vcos_avx2_f64(double* out, const double* in, int64_t n) {
   constexpr int64_t VEC_SIZE = 4;
   int64_t i = 0;
@@ -153,6 +318,38 @@ inline void vpow_avx2_f64(double* out,
                           int64_t n) {
   for (int64_t i = 0; i < n; ++i) {
     out[i] = Sleef_powd1_u10(x[i], y[i]);
+  }
+}
+
+// Vectorized exp for float using AVX2
+inline void vexp_avx2_f32(float* out, const float* in, int64_t n) {
+  constexpr int64_t VEC_SIZE = 8;  // AVX2: 256-bit = 8 floats
+  int64_t i = 0;
+
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m256 vec_in = _mm256_loadu_ps(in + i);
+    __m256 vec_out = Sleef_expf8_u10(vec_in);
+    _mm256_storeu_ps(out + i, vec_out);
+  }
+
+  for (; i < n; ++i) {
+    out[i] = Sleef_expf1_u10(in[i]);
+  }
+}
+
+// Vectorized exp for double using AVX2
+inline void vexp_avx2_f64(double* out, const double* in, int64_t n) {
+  constexpr int64_t VEC_SIZE = 4;  // AVX2: 256-bit = 4 doubles
+  int64_t i = 0;
+
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m256d vec_in = _mm256_loadu_pd(in + i);
+    __m256d vec_out = Sleef_expd4_u10(vec_in);
+    _mm256_storeu_pd(out + i, vec_out);
+  }
+
+  for (; i < n; ++i) {
+    out[i] = Sleef_expd1_u10(in[i]);
   }
 }
 
@@ -296,6 +493,54 @@ inline void vpow_avx512_f64(double* out,
   }
 }
 
+// Vectorized exp for float using AVX512 (16 floats at a time)
+inline void vexp_avx512_f32(float* out, const float* in, int64_t n) {
+  constexpr int64_t VEC_SIZE = 16;  // AVX512: 512-bit = 16 floats
+  int64_t i = 0;
+
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m512 vec_in = _mm512_loadu_ps(in + i);
+    __m512 vec_out = Sleef_expf16_u10(vec_in);
+    _mm512_storeu_ps(out + i, vec_out);
+  }
+
+#ifdef PADDLE_SLEEF_HAS_AVX2
+  for (; i + 8 <= n; i += 8) {
+    __m256 vec_in = _mm256_loadu_ps(in + i);
+    __m256 vec_out = Sleef_expf8_u10(vec_in);
+    _mm256_storeu_ps(out + i, vec_out);
+  }
+#endif
+
+  for (; i < n; ++i) {
+    out[i] = Sleef_expf1_u10(in[i]);
+  }
+}
+
+// Vectorized exp for double using AVX512 (8 doubles at a time)
+inline void vexp_avx512_f64(double* out, const double* in, int64_t n) {
+  constexpr int64_t VEC_SIZE = 8;  // AVX512: 512-bit = 8 doubles
+  int64_t i = 0;
+
+  for (; i + VEC_SIZE <= n; i += VEC_SIZE) {
+    __m512d vec_in = _mm512_loadu_pd(in + i);
+    __m512d vec_out = Sleef_expd8_u10(vec_in);
+    _mm512_storeu_pd(out + i, vec_out);
+  }
+
+#ifdef PADDLE_SLEEF_HAS_AVX2
+  for (; i + 4 <= n; i += 4) {
+    __m256d vec_in = _mm256_loadu_pd(in + i);
+    __m256d vec_out = Sleef_expd4_u10(vec_in);
+    _mm256_storeu_pd(out + i, vec_out);
+  }
+#endif
+
+  for (; i < n; ++i) {
+    out[i] = Sleef_expd1_u10(in[i]);
+  }
+}
+
 #endif  // PADDLE_SLEEF_HAS_AVX512
 
 // -----------------------------------------------------------------------------
@@ -344,12 +589,35 @@ inline void vpow_scalar_f64(double* out,
   }
 }
 
+// Scalar exp fallback
+inline void vexp_scalar_f32(float* out, const float* in, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = Sleef_expf1_u10(in[i]);
+  }
+}
+
+inline void vexp_scalar_f64(double* out, const double* in, int64_t n) {
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = Sleef_expd1_u10(in[i]);
+  }
+}
+
+// No separate MKL VML wrapper functions needed.
+// Runtime detection is done inline in the dispatch functions below.
+
 // -----------------------------------------------------------------------------
 // Unified dispatch functions
 // -----------------------------------------------------------------------------
 
-// Vectorized sin for float - dispatches to best available SIMD
+// Vectorized sin for float - dispatches to best available implementation
 inline void vsin(float* out, const float* in, int64_t n) {
+#ifdef PADDLE_WITH_MKLML
+  auto mkl_sin = get_vmsSin();
+  if (mkl_sin) {
+    mkl_sin(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
+    return;
+  }
+#endif
 #ifdef PADDLE_SLEEF_HAS_AVX512
   vsin_avx512_f32(out, in, n);
 #elif defined(PADDLE_SLEEF_HAS_AVX2)
@@ -361,6 +629,13 @@ inline void vsin(float* out, const float* in, int64_t n) {
 
 // Vectorized cos for float
 inline void vcos(float* out, const float* in, int64_t n) {
+#ifdef PADDLE_WITH_MKLML
+  auto mkl_cos = get_vmsCos();
+  if (mkl_cos) {
+    mkl_cos(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
+    return;
+  }
+#endif
 #ifdef PADDLE_SLEEF_HAS_AVX512
   vcos_avx512_f32(out, in, n);
 #elif defined(PADDLE_SLEEF_HAS_AVX2)
@@ -372,6 +647,13 @@ inline void vcos(float* out, const float* in, int64_t n) {
 
 // Vectorized sin for double
 inline void vsin(double* out, const double* in, int64_t n) {
+#ifdef PADDLE_WITH_MKLML
+  auto mkl_sin = get_vmdSin();
+  if (mkl_sin) {
+    mkl_sin(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
+    return;
+  }
+#endif
 #ifdef PADDLE_SLEEF_HAS_AVX512
   vsin_avx512_f64(out, in, n);
 #elif defined(PADDLE_SLEEF_HAS_AVX2)
@@ -383,6 +665,13 @@ inline void vsin(double* out, const double* in, int64_t n) {
 
 // Vectorized cos for double
 inline void vcos(double* out, const double* in, int64_t n) {
+#ifdef PADDLE_WITH_MKLML
+  auto mkl_cos = get_vmdCos();
+  if (mkl_cos) {
+    mkl_cos(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
+    return;
+  }
+#endif
 #ifdef PADDLE_SLEEF_HAS_AVX512
   vcos_avx512_f64(out, in, n);
 #elif defined(PADDLE_SLEEF_HAS_AVX2)
@@ -414,30 +703,94 @@ inline void vpow(double* out, const double* x, const double* y, int64_t n) {
 #endif
 }
 
+// Vectorized exp for float - dispatches to best available implementation
+inline void vexp(float* out, const float* in, int64_t n) {
+#ifdef PADDLE_WITH_MKLML
+  auto mkl_exp = get_vmsExp();
+  if (mkl_exp) {
+    mkl_exp(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
+    return;
+  }
+#endif
+#ifdef PADDLE_SLEEF_HAS_AVX512
+  vexp_avx512_f32(out, in, n);
+#elif defined(PADDLE_SLEEF_HAS_AVX2)
+  vexp_avx2_f32(out, in, n);
+#else
+  vexp_scalar_f32(out, in, n);
+#endif
+}
+
+// Vectorized exp for double
+inline void vexp(double* out, const double* in, int64_t n) {
+#ifdef PADDLE_WITH_MKLML
+  auto mkl_exp = get_vmdExp();
+  if (mkl_exp) {
+    mkl_exp(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
+    return;
+  }
+#endif
+#ifdef PADDLE_SLEEF_HAS_AVX512
+  vexp_avx512_f64(out, in, n);
+#elif defined(PADDLE_SLEEF_HAS_AVX2)
+  vexp_avx2_f64(out, in, n);
+#else
+  vexp_scalar_f64(out, in, n);
+#endif
+}
+
 #else  // !PADDLE_WITH_SLEEF
 
 // Fallback to standard library when Sleef is not available
 #include <cmath>
 
 inline void vsin(float* out, const float* in, int64_t n) {
+#ifdef PADDLE_WITH_MKLML
+  auto mkl_sin = get_vmsSin();
+  if (mkl_sin) {
+    mkl_sin(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
+    return;
+  }
+#endif
   for (int64_t i = 0; i < n; ++i) {
     out[i] = std::sin(in[i]);
   }
 }
 
 inline void vcos(float* out, const float* in, int64_t n) {
+#ifdef PADDLE_WITH_MKLML
+  auto mkl_cos = get_vmsCos();
+  if (mkl_cos) {
+    mkl_cos(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
+    return;
+  }
+#endif
   for (int64_t i = 0; i < n; ++i) {
     out[i] = std::cos(in[i]);
   }
 }
 
 inline void vsin(double* out, const double* in, int64_t n) {
+#ifdef PADDLE_WITH_MKLML
+  auto mkl_sin = get_vmdSin();
+  if (mkl_sin) {
+    mkl_sin(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
+    return;
+  }
+#endif
   for (int64_t i = 0; i < n; ++i) {
     out[i] = std::sin(in[i]);
   }
 }
 
 inline void vcos(double* out, const double* in, int64_t n) {
+#ifdef PADDLE_WITH_MKLML
+  auto mkl_cos = get_vmdCos();
+  if (mkl_cos) {
+    mkl_cos(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
+    return;
+  }
+#endif
   for (int64_t i = 0; i < n; ++i) {
     out[i] = std::cos(in[i]);
   }
@@ -455,6 +808,32 @@ inline void vpow(double* out, const double* x, const double* y, int64_t n) {
   }
 }
 
+inline void vexp(float* out, const float* in, int64_t n) {
+#ifdef PADDLE_WITH_MKLML
+  auto mkl_exp = get_vmsExp();
+  if (mkl_exp) {
+    mkl_exp(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
+    return;
+  }
+#endif
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = std::exp(in[i]);
+  }
+}
+
+inline void vexp(double* out, const double* in, int64_t n) {
+#ifdef PADDLE_WITH_MKLML
+  auto mkl_exp = get_vmdExp();
+  if (mkl_exp) {
+    mkl_exp(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
+    return;
+  }
+#endif
+  for (int64_t i = 0; i < n; ++i) {
+    out[i] = std::exp(in[i]);
+  }
+}
+
 #endif  // PADDLE_WITH_SLEEF
 
 // -----------------------------------------------------------------------------
@@ -464,9 +843,33 @@ inline bool should_use_vectorized_path(const void* in_ptr,
                                        const void* out_ptr,
                                        int64_t numel) {
   // Use vectorized path when:
-  // 1. SLEEF is available
-  // 2. Element count is large enough to benefit from SIMD
-  // 3. Memory is reasonably aligned (not strictly required for unaligned loads)
+  // 1. MKL VML sin/cos functions are available at runtime (works for any size)
+  // 2. SLEEF is available and element count is large enough for SIMD
+#ifdef PADDLE_WITH_MKLML
+  if (mkl_vml_sincos_available()) {
+    return true;  // MKL VML works for any size
+  }
+#endif
+#ifdef PADDLE_WITH_SLEEF
+  constexpr int64_t MIN_ELEMENTS_FOR_SIMD = 8;
+  return numel >= MIN_ELEMENTS_FOR_SIMD;
+#else
+  return false;
+#endif
+}
+
+// Check if vectorized path should be used for exp operations
+inline bool should_use_vectorized_path_for_exp(const void* in_ptr,
+                                               const void* out_ptr,
+                                               int64_t numel) {
+  // Use vectorized path when:
+  // 1. MKL VML exp functions are available at runtime (works for any size)
+  // 2. SLEEF is available and element count is large enough for SIMD
+#ifdef PADDLE_WITH_MKLML
+  if (mkl_vml_exp_available()) {
+    return true;  // MKL VML works for any size
+  }
+#endif
 #ifdef PADDLE_WITH_SLEEF
   constexpr int64_t MIN_ELEMENTS_FOR_SIMD = 8;
   return numel >= MIN_ELEMENTS_FOR_SIMD;

--- a/paddle/phi/kernels/funcs/sleef_vectorized_math.h
+++ b/paddle/phi/kernels/funcs/sleef_vectorized_math.h
@@ -14,7 +14,10 @@
 
 #pragma once
 
-#ifdef PADDLE_WITH_MKLML
+// MKL VML runtime detection is only supported on Linux/Unix systems
+// because it requires dlfcn.h (dlopen/dlsym) which is not available on Windows.
+#if defined(PADDLE_WITH_MKLML) && !defined(_WIN32)
+#define PADDLE_MKL_VML_RUNTIME_DETECTION 1
 #include <dlfcn.h>
 #include <mkl.h>
 
@@ -42,15 +45,13 @@ namespace detail {
 
 // One-time initialization: try to make MKL VML functions available in global
 // symbol scope. This handles the case where MKL VML symbols (vmsSin, etc.)
-// are not directly exported globally, e.g. when libtorch_cpu.so is loaded
+// are not directly exported globally, e.g. when other libraries are loaded
 // with RTLD_LOCAL.
 //
 // Strategies tried in order:
 // 1. Check if symbols are already visible via RTLD_DEFAULT (normal case).
 // 2. Try to load the full Intel MKL runtime (libmkl_rt.so) and promote it
 //    to global scope so its symbols become visible.
-// 3. Try to promote an already-loaded libtorch_cpu.so (which bundles MKL)
-//    to global scope using RTLD_NOLOAD | RTLD_GLOBAL.
 //
 // Thread safety: C++11 guarantees function-local statics are initialized
 // exactly once, even under concurrent access.
@@ -73,13 +74,6 @@ inline void ensure_mkl_vml_probed() {
     dlopen("libmkl_rt.so", RTLD_LAZY | RTLD_GLOBAL);
     return;
   }
-
-  // Strategy 3: Promote libtorch_cpu.so (which bundles full MKL) to global
-  // scope. RTLD_NOLOAD ensures we do NOT load the library - we only get a
-  // handle if it is already loaded in this process. RTLD_GLOBAL makes its
-  // symbols visible to subsequent dlsym(RTLD_DEFAULT, ...) calls.
-  dlopen("libtorch_cpu.so", RTLD_LAZY | RTLD_NOLOAD | RTLD_GLOBAL);
-  // Whether or not this succeeded, we have tried our best.
 }
 
 }  // namespace detail
@@ -177,7 +171,7 @@ inline bool mkl_vml_exp_available() {
   return available;
 }
 
-#endif  // PADDLE_WITH_MKLML
+#endif  // PADDLE_WITH_MKLML && !_WIN32
 
 #ifdef PADDLE_WITH_SLEEF
 #include <sleef.h>
@@ -611,7 +605,7 @@ inline void vexp_scalar_f64(double* out, const double* in, int64_t n) {
 
 // Vectorized sin for float - dispatches to best available implementation
 inline void vsin(float* out, const float* in, int64_t n) {
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   auto mkl_sin = get_vmsSin();
   if (mkl_sin) {
     mkl_sin(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
@@ -629,7 +623,7 @@ inline void vsin(float* out, const float* in, int64_t n) {
 
 // Vectorized cos for float
 inline void vcos(float* out, const float* in, int64_t n) {
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   auto mkl_cos = get_vmsCos();
   if (mkl_cos) {
     mkl_cos(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
@@ -647,7 +641,7 @@ inline void vcos(float* out, const float* in, int64_t n) {
 
 // Vectorized sin for double
 inline void vsin(double* out, const double* in, int64_t n) {
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   auto mkl_sin = get_vmdSin();
   if (mkl_sin) {
     mkl_sin(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
@@ -665,7 +659,7 @@ inline void vsin(double* out, const double* in, int64_t n) {
 
 // Vectorized cos for double
 inline void vcos(double* out, const double* in, int64_t n) {
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   auto mkl_cos = get_vmdCos();
   if (mkl_cos) {
     mkl_cos(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
@@ -705,7 +699,7 @@ inline void vpow(double* out, const double* x, const double* y, int64_t n) {
 
 // Vectorized exp for float - dispatches to best available implementation
 inline void vexp(float* out, const float* in, int64_t n) {
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   auto mkl_exp = get_vmsExp();
   if (mkl_exp) {
     mkl_exp(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
@@ -723,7 +717,7 @@ inline void vexp(float* out, const float* in, int64_t n) {
 
 // Vectorized exp for double
 inline void vexp(double* out, const double* in, int64_t n) {
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   auto mkl_exp = get_vmdExp();
   if (mkl_exp) {
     mkl_exp(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
@@ -745,7 +739,7 @@ inline void vexp(double* out, const double* in, int64_t n) {
 #include <cmath>
 
 inline void vsin(float* out, const float* in, int64_t n) {
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   auto mkl_sin = get_vmsSin();
   if (mkl_sin) {
     mkl_sin(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
@@ -758,7 +752,7 @@ inline void vsin(float* out, const float* in, int64_t n) {
 }
 
 inline void vcos(float* out, const float* in, int64_t n) {
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   auto mkl_cos = get_vmsCos();
   if (mkl_cos) {
     mkl_cos(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
@@ -771,7 +765,7 @@ inline void vcos(float* out, const float* in, int64_t n) {
 }
 
 inline void vsin(double* out, const double* in, int64_t n) {
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   auto mkl_sin = get_vmdSin();
   if (mkl_sin) {
     mkl_sin(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
@@ -784,7 +778,7 @@ inline void vsin(double* out, const double* in, int64_t n) {
 }
 
 inline void vcos(double* out, const double* in, int64_t n) {
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   auto mkl_cos = get_vmdCos();
   if (mkl_cos) {
     mkl_cos(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
@@ -809,7 +803,7 @@ inline void vpow(double* out, const double* x, const double* y, int64_t n) {
 }
 
 inline void vexp(float* out, const float* in, int64_t n) {
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   auto mkl_exp = get_vmsExp();
   if (mkl_exp) {
     mkl_exp(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
@@ -822,7 +816,7 @@ inline void vexp(float* out, const float* in, int64_t n) {
 }
 
 inline void vexp(double* out, const double* in, int64_t n) {
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   auto mkl_exp = get_vmdExp();
   if (mkl_exp) {
     mkl_exp(static_cast<MKL_INT>(n), in, out, VML_MODE_HA_FTZDAZ_OFF_ERRIGNORE);
@@ -845,7 +839,7 @@ inline bool should_use_vectorized_path(const void* in_ptr,
   // Use vectorized path when:
   // 1. MKL VML sin/cos functions are available at runtime (works for any size)
   // 2. SLEEF is available and element count is large enough for SIMD
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   if (mkl_vml_sincos_available()) {
     return true;  // MKL VML works for any size
   }
@@ -865,7 +859,7 @@ inline bool should_use_vectorized_path_for_exp(const void* in_ptr,
   // Use vectorized path when:
   // 1. MKL VML exp functions are available at runtime (works for any size)
   // 2. SLEEF is available and element count is large enough for SIMD
-#ifdef PADDLE_WITH_MKLML
+#ifdef PADDLE_MKL_VML_RUNTIME_DETECTION
   if (mkl_vml_exp_available()) {
     return true;  // MKL VML works for any size
   }

--- a/paddle/phi/kernels/impl/activation_impl.h
+++ b/paddle/phi/kernels/impl/activation_impl.h
@@ -50,7 +50,7 @@ void ActivationImpl(const Context& dev_ctx,
   }
 }
 
-// Vectorized Sin implementation for CPU - matches PyTorch precision
+// Vectorized Sin implementation for CPU - high precision
 // Only enabled for float/double on CPU to ensure bit-level alignment
 template <typename T, typename Context>
 void VectorizedSinImpl(const Context& dev_ctx,
@@ -80,7 +80,7 @@ void VectorizedSinImpl(const Context& dev_ctx,
   }
 }
 
-// Vectorized Cos implementation for CPU - matches PyTorch precision
+// Vectorized Cos implementation for CPU - high precision
 template <typename T, typename Context>
 void VectorizedCosImpl(const Context& dev_ctx,
                        const DenseTensor& X,
@@ -106,6 +106,36 @@ void VectorizedCosImpl(const Context& dev_ctx,
         EigenVector<T>::Flatten(GET_DATA_SAFELY(Out, "Output", "Out", "Cos"));
     auto* place = dev_ctx.eigen_device();
     out.device(*place) = x.unaryExpr(funcs::Cosine<T>()).eval();
+  }
+}
+
+// Vectorized Exp implementation for CPU - high precision
+template <typename T, typename Context>
+void VectorizedExpImpl(const Context& dev_ctx,
+                       const DenseTensor& X,
+                       DenseTensor* Out) {
+  PADDLE_ENFORCE_NOT_NULL(Out,
+                          errors::NotFound("Output Out should not be nullptr"));
+  dev_ctx.template Alloc<T>(Out);
+  if (Out->numel() == 0) {
+    return;
+  }
+
+  const T* x_data = X.data<T>();
+  T* out_data = Out->data<T>();
+  int64_t numel = X.numel();
+
+  // Check if data is contiguous and use vectorized path
+  if (funcs::sleef_vec::should_use_vectorized_path_for_exp(
+          x_data, out_data, numel)) {
+    funcs::sleef_vec::vexp(out_data, x_data, numel);
+  } else {
+    // Fallback to Eigen-based implementation
+    auto x = EigenVector<T>::Flatten(GET_DATA_SAFELY(&X, "Input", "X", "Exp"));
+    auto out =
+        EigenVector<T>::Flatten(GET_DATA_SAFELY(Out, "Output", "Out", "Exp"));
+    auto* place = dev_ctx.eigen_device();
+    out.device(*place) = x.exp();
   }
 }
 

--- a/test/legacy_test/test_exp.py
+++ b/test/legacy_test/test_exp.py
@@ -19,7 +19,7 @@ import numpy as np
 import paddle
 
 
-class TestCosOutAndParamDecorator(unittest.TestCase):
+class TestExpOutAndParamDecorator(unittest.TestCase):
     def setUp(self):
         paddle.disable_static()
         self.x_np = np.random.rand(3, 4).astype(np.float32)
@@ -28,23 +28,23 @@ class TestCosOutAndParamDecorator(unittest.TestCase):
     def do_test(self, test_type):
         x = paddle.to_tensor(self.x_np, stop_gradient=False)
         if test_type == 'raw':
-            result = paddle.cos(x)
+            result = paddle.exp(x)
             result.mean().backward()
             return result, x.grad
         elif test_type == 'decorator':
-            result = paddle.cos(input=x)
+            result = paddle.exp(input=x)
             result.mean().backward()
             return result, x.grad
         elif test_type == 'out':
             out = paddle.empty_like(x)
             out.stop_gradient = False
-            paddle.cos(x, out=out)
+            paddle.exp(x, out=out)
             out.mean().backward()
             return out, x.grad
         elif test_type == 'out_decorator':
             out = paddle.empty_like(x)
             out.stop_gradient = False
-            paddle.cos(input=x, out=out)
+            paddle.exp(input=x, out=out)
             out.mean().backward()
             return out, x.grad
         else:
@@ -60,148 +60,161 @@ class TestCosOutAndParamDecorator(unittest.TestCase):
             )
 
 
-class TestCosSleefVectorized(unittest.TestCase):
-    """Test cos with shapes that exercise Sleef vectorized paths.
+class TestExpSleefVectorized(unittest.TestCase):
+    """Test exp with shapes that exercise Sleef vectorized paths.
 
     For AVX2:
     - float32: VEC_SIZE = 8, so shapes >= 8 trigger vectorized path
     - float64: VEC_SIZE = 4, so shapes >= 4 trigger vectorized path
+      (Covers vexp_avx2_f64 in sleef_vectorized_math.h lines 335-348)
 
     Test both:
     1. Shapes that are exact multiples of VEC_SIZE (only vectorized loop)
     2. Shapes with remainder (vectorized loop + scalar tail)
 
-    Note: If MKL is available at runtime, the MKL VML path (mkl_cos) will be
-    triggered instead (see sleef_vectorized_math.h L629-630 for float,
-    L665-666 for double). Both paths produce correct results and are
-    tested through these tests.
+    Note: If MKL is available at runtime, the mkl_exp path (lines 704-706, 722-724)
+    will be triggered instead. Both paths are tested through this test.
     """
 
     def setUp(self):
         paddle.disable_static()
 
-    def test_cos_float32_vectorized_exact(self):
-        """Test float32 cos with shape that's exact multiple of 8.
-        Covers vcos_avx2_f32 main loop.
+    def test_exp_float32_vectorized_exact(self):
+        """Test float32 exp with shape that's exact multiple of 8.
+        Covers vexp_avx2_f32 main loop (lines 323-327).
         """
         # Shape 16 = 8 * 2, exercises only vectorized loop
-        x_np = np.random.uniform(-np.pi, np.pi, size=(16,)).astype(np.float32)
+        x_np = np.random.uniform(-2, 2, size=(16,)).astype(np.float32)
         x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
-        result = paddle.cos(x)
-        expected = np.cos(x_np)
+        result = paddle.exp(x)
+        expected = np.exp(x_np)
         np.testing.assert_allclose(
             result.numpy(), expected, rtol=1e-5, atol=1e-5
         )
 
-    def test_cos_float32_vectorized_with_tail(self):
-        """Test float32 cos with shape that has remainder when divided by 8.
-        Covers vcos_avx2_f32 both main loop and scalar tail.
+    def test_exp_float32_vectorized_with_tail(self):
+        """Test float32 exp with shape that has remainder when divided by 8.
+        Covers vexp_avx2_f32 both main loop (323-327) and scalar tail (329-331).
         """
         # Shape 13 = 8 + 5, exercises both vectorized loop and scalar tail
-        x_np = np.random.uniform(-np.pi, np.pi, size=(13,)).astype(np.float32)
+        x_np = np.random.uniform(-2, 2, size=(13,)).astype(np.float32)
         x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
-        result = paddle.cos(x)
-        expected = np.cos(x_np)
+        result = paddle.exp(x)
+        expected = np.exp(x_np)
         np.testing.assert_allclose(
             result.numpy(), expected, rtol=1e-5, atol=1e-5
         )
 
-    def test_cos_float64_vectorized_exact(self):
-        """Test float64 cos with shape that's exact multiple of 4.
-        Covers vcos_avx2_f64 main loop.
+    def test_exp_float64_vectorized_exact(self):
+        """Test float64 exp with shape that's exact multiple of 4.
+        Covers vexp_avx2_f64 main loop (lines 339-343).
+        This specifically tests the code at sleef_vectorized_math.h L335-348.
         """
         # Shape 12 = 4 * 3, exercises only vectorized loop
-        x_np = np.random.uniform(-np.pi, np.pi, size=(12,)).astype(np.float64)
+        x_np = np.random.uniform(-2, 2, size=(12,)).astype(np.float64)
         x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
-        result = paddle.cos(x)
-        expected = np.cos(x_np)
+        result = paddle.exp(x)
+        expected = np.exp(x_np)
         np.testing.assert_allclose(
             result.numpy(), expected, rtol=1e-10, atol=1e-10
         )
 
-    def test_cos_float64_vectorized_with_tail(self):
-        """Test float64 cos with shape that has remainder when divided by 4.
-        Covers vcos_avx2_f64 both main loop and scalar tail.
+    def test_exp_float64_vectorized_with_tail(self):
+        """Test float64 exp with shape that has remainder when divided by 4.
+        Covers vexp_avx2_f64 both main loop (339-343) and scalar tail (345-347).
+        This specifically tests the code at sleef_vectorized_math.h L335-348.
         """
         # Shape 11 = 4 * 2 + 3, exercises both vectorized loop and scalar tail
-        x_np = np.random.uniform(-np.pi, np.pi, size=(11,)).astype(np.float64)
+        x_np = np.random.uniform(-2, 2, size=(11,)).astype(np.float64)
         x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
-        result = paddle.cos(x)
-        expected = np.cos(x_np)
+        result = paddle.exp(x)
+        expected = np.exp(x_np)
         np.testing.assert_allclose(
             result.numpy(), expected, rtol=1e-10, atol=1e-10
         )
 
-    def test_cos_float32_large_shape(self):
-        """Test float32 cos with large shape for comprehensive coverage.
-        Tests MKL VML path (mkl_cos at sleef_vectorized_math.h L629-630)
-        if MKL is available, otherwise Sleef vectorized path.
+    def test_exp_float32_large_shape(self):
+        """Test float32 exp with large shape for comprehensive coverage.
+        Tests MKL VML path (mkl_exp) if available, otherwise Sleef path.
         """
-        x_np = np.random.uniform(-np.pi, np.pi, size=(1024,)).astype(np.float32)
+        x_np = np.random.uniform(-2, 2, size=(1024,)).astype(np.float32)
         x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
-        result = paddle.cos(x)
-        expected = np.cos(x_np)
+        result = paddle.exp(x)
+        expected = np.exp(x_np)
         np.testing.assert_allclose(
             result.numpy(), expected, rtol=1e-5, atol=1e-5
         )
 
-    def test_cos_float64_large_shape(self):
-        """Test float64 cos with large shape for comprehensive coverage.
-        Tests MKL VML path (mkl_cos at sleef_vectorized_math.h L665-666)
-        if MKL is available, otherwise Sleef vectorized path.
+    def test_exp_float64_large_shape(self):
+        """Test float64 exp with large shape for comprehensive coverage.
+        Tests MKL VML path (mkl_exp) if available, otherwise Sleef path.
+        This specifically tests vexp_avx2_f64 at sleef_vectorized_math.h L335-348.
         """
-        x_np = np.random.uniform(-np.pi, np.pi, size=(1024,)).astype(np.float64)
+        x_np = np.random.uniform(-2, 2, size=(1024,)).astype(np.float64)
         x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
-        result = paddle.cos(x)
-        expected = np.cos(x_np)
+        result = paddle.exp(x)
+        expected = np.exp(x_np)
         np.testing.assert_allclose(
             result.numpy(), expected, rtol=1e-10, atol=1e-10
         )
 
-    def test_cos_float32_2d_shape(self):
-        """Test float32 cos with 2D shape to verify flattened processing."""
+    def test_exp_float32_2d_shape(self):
+        """Test float32 exp with 2D shape to verify flattened processing."""
         # Shape (4, 5) = 20 elements, exercises vectorized path
-        x_np = np.random.uniform(-np.pi, np.pi, size=(4, 5)).astype(np.float32)
+        x_np = np.random.uniform(-2, 2, size=(4, 5)).astype(np.float32)
         x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
-        result = paddle.cos(x)
-        expected = np.cos(x_np)
+        result = paddle.exp(x)
+        expected = np.exp(x_np)
         np.testing.assert_allclose(
             result.numpy(), expected, rtol=1e-5, atol=1e-5
         )
 
-    def test_cos_float64_2d_shape(self):
-        """Test float64 cos with 2D shape to verify flattened processing."""
+    def test_exp_float64_2d_shape(self):
+        """Test float64 exp with 2D shape to verify flattened processing.
+        Covers vexp_avx2_f64 at sleef_vectorized_math.h L335-348.
+        """
         # Shape (3, 5) = 15 elements, exercises vectorized path with tail
-        x_np = np.random.uniform(-np.pi, np.pi, size=(3, 5)).astype(np.float64)
+        x_np = np.random.uniform(-2, 2, size=(3, 5)).astype(np.float64)
         x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
-        result = paddle.cos(x)
-        expected = np.cos(x_np)
+        result = paddle.exp(x)
+        expected = np.exp(x_np)
         np.testing.assert_allclose(
             result.numpy(), expected, rtol=1e-10, atol=1e-10
         )
 
-    def test_cos_float32_small_shape_fallback(self):
-        """Test float32 cos with small shape (numel < 8) to cover Eigen fallback path.
-        Covers VectorizedCosImpl fallback branch (lines 102-109 in activation_impl.h).
-        """
+    def test_exp_float32_small_shape_fallback(self):
+        """Test float32 exp with small shape (numel < 8) to cover Eigen fallback path."""
         # Shape 5 < 8, triggers Eigen fallback instead of SIMD
-        x_np = np.random.uniform(-np.pi, np.pi, size=(5,)).astype(np.float32)
+        x_np = np.random.uniform(-2, 2, size=(5,)).astype(np.float32)
         x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
-        result = paddle.cos(x)
-        expected = np.cos(x_np)
+        result = paddle.exp(x)
+        expected = np.exp(x_np)
         np.testing.assert_allclose(
             result.numpy(), expected, rtol=1e-5, atol=1e-5
         )
 
-    def test_cos_float64_small_shape_fallback(self):
-        """Test float64 cos with small shape (numel < 8) to cover Eigen fallback path.
-        Covers VectorizedCosImpl fallback branch (lines 102-109 in activation_impl.h).
-        """
+    def test_exp_float64_small_shape_fallback(self):
+        """Test float64 exp with small shape (numel < 8) to cover Eigen fallback path."""
         # Shape 3 < 8, triggers Eigen fallback instead of SIMD
-        x_np = np.random.uniform(-np.pi, np.pi, size=(3,)).astype(np.float64)
+        x_np = np.random.uniform(-2, 2, size=(3,)).astype(np.float64)
         x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
-        result = paddle.cos(x)
-        expected = np.cos(x_np)
+        result = paddle.exp(x)
+        expected = np.exp(x_np)
+        np.testing.assert_allclose(
+            result.numpy(), expected, rtol=1e-10, atol=1e-10
+        )
+
+    def test_exp_float64_boundary_values(self):
+        """Test float64 exp with boundary values to ensure numerical stability.
+        Covers vexp_avx2_f64 at sleef_vectorized_math.h L335-348.
+        """
+        # Test values near boundaries
+        x_np = np.array(
+            [0.0, 1.0, -1.0, 10.0, -10.0, 50.0, -50.0, 100.0], dtype=np.float64
+        )
+        x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
+        result = paddle.exp(x)
+        expected = np.exp(x_np)
         np.testing.assert_allclose(
             result.numpy(), expected, rtol=1e-10, atol=1e-10
         )

--- a/test/legacy_test/test_sin.py
+++ b/test/legacy_test/test_sin.py
@@ -70,6 +70,11 @@ class TestSinSleefVectorized(unittest.TestCase):
     Test both:
     1. Shapes that are exact multiples of VEC_SIZE (only vectorized loop)
     2. Shapes with remainder (vectorized loop + scalar tail)
+
+    Note: If MKL is available at runtime, the MKL VML path (mkl_sin) will be
+    triggered instead (see sleef_vectorized_math.h L611-612 for float,
+    L647-648 for double). Both paths produce correct results and are
+    tested through these tests.
     """
 
     def setUp(self):
@@ -128,7 +133,10 @@ class TestSinSleefVectorized(unittest.TestCase):
         )
 
     def test_sin_float32_large_shape(self):
-        """Test float32 sin with large shape for comprehensive coverage."""
+        """Test float32 sin with large shape for comprehensive coverage.
+        Tests MKL VML path (mkl_sin at sleef_vectorized_math.h L611-612)
+        if MKL is available, otherwise Sleef vectorized path.
+        """
         x_np = np.random.uniform(-np.pi, np.pi, size=(1024,)).astype(np.float32)
         x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
         result = paddle.sin(x)
@@ -138,7 +146,10 @@ class TestSinSleefVectorized(unittest.TestCase):
         )
 
     def test_sin_float64_large_shape(self):
-        """Test float64 sin with large shape for comprehensive coverage."""
+        """Test float64 sin with large shape for comprehensive coverage.
+        Tests MKL VML path (mkl_sin at sleef_vectorized_math.h L647-648)
+        if MKL is available, otherwise Sleef vectorized path.
+        """
         x_np = np.random.uniform(-np.pi, np.pi, size=(1024,)).astype(np.float64)
         x = paddle.to_tensor(x_np, place=paddle.CPUPlace())
         result = paddle.sin(x)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
问题描述                                                                                                                             
                                                                                                                                     
  CPU 场景下 paddle.sin / paddle.cos 与 torch.sin / torch.cos 存在精度差异：                                                           
  - 约 20% 的 float32 值结果不同                                                                                                       
  - 最大绝对误差: 5.96e-08（约 0.5 ULP）

  根因分析

  ┌─────────┬───────────────────────────────┬──────────┐
  │  框架   │         使用的数学库          │ 精度保证 │
  ├─────────┼───────────────────────────────┼──────────┤
  │ PyTorch │ MKL VML (vmsSin, VML_HA 模式) │ 1 ULP    │
  ├─────────┼───────────────────────────────┼──────────┤
  │ Paddle  │ Sleef (Sleef_sinf8_u35)       │ 3.5 ULP  │
  └─────────┴───────────────────────────────┴──────────┘

  PyTorch 在检测到 Intel MKL 可用时，会优先使用 MKL VML 的高精度模式（VML_HA）计算 sin/cos；而 Paddle 使用 Sleef 库的 u35
  精度变体。两种不同的数学库实现导致 float32 舍入行为不同。

  修复方案

  核心思路：运行时动态检测 MKL VML 函数，匹配 PyTorch 的计算行为。

  修改文件

  paddle/phi/kernels/funcs/sleef_vectorized_math.h（+197 行，-4 行）

  修改内容

  1. 添加 MKL VML 运行时检测：通过 dlsym 在运行时查找 vmsSin/vmdSin/vmsCos/vmdCos 函数，采用三重探测策略：
    - 策略 1：dlsym(RTLD_DEFAULT, "vmsSin") — 检查全局符号空间
    - 策略 2：dlopen("libmkl_rt.so") — 尝试加载系统完整 MKL
    - 策略 3：dlopen("libtorch_cpu.so", RTLD_NOLOAD | RTLD_GLOBAL) — 将 PyTorch 内嵌的 MKL 提升为全局可见（RTLD_NOLOAD
  确保不会额外加载库，仅在已加载时生效）
  2. 修改 vsin/vcos 分发逻辑：优先尝试 MKL VML，使用与 PyTorch 完全相同的模式标志 VML_HA | VML_FTZDAZ_OFF |
  VML_ERRMODE_IGNORE；若不可用则回退到 Sleef（行为不变）。
  3. 修改 should_use_vectorized_path：当 MKL VML 可用时对任意大小的 tensor 返回 true（MKL VML 无最小元素数限制）。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是