### PR TITLE
[API Compability NO.59] support 'input' argument alias for paddle.diagflat

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -15,6 +15,8 @@
 from __future__ import annotations
 
 import builtins
+import functools
+import inspect
 import math
 import numbers
 import os
@@ -2965,7 +2967,24 @@ def diag_embed(
     out.stop_gradient = True
     return out
 
-@param_one_alias(["x", "input"])
+def _diagflat_input_alias(func):
+    signature = inspect.signature(func)
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if 'input' in kwargs:
+            if 'x' in kwargs or len(args) > 0:
+                raise ValueError(
+                    "Cannot specify both 'x' and its alias 'input'"
+                )
+            kwargs['x'] = kwargs.pop('input')
+        return func(*args, **kwargs)
+
+    wrapper.__signature__ = signature
+    return wrapper
+
+
+@_diagflat_input_alias
 def diagflat(
     x: paddle.Tensor, offset: int = 0, name: str | None = None
 ) -> paddle.Tensor:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2965,7 +2965,7 @@ def diag_embed(
     out.stop_gradient = True
     return out
 
-
+@param_one_alias(["x", "input"])
 def diagflat(
     x: paddle.Tensor, offset: int = 0, name: str | None = None
 ) -> paddle.Tensor:
@@ -2982,6 +2982,10 @@ def diagflat(
     If ``offset`` > 0, it is superdiagonal.
 
     If ``offset`` < 0, it is subdiagonal.
+
+    .. note::
+        Alias Support: The parameter name ``input`` can be used as an alias for ``x``.
+        For example, ``diagflat(input=tensor_x)`` is equivalent to ``diagflat(x=tensor_x)``.
 
     Args:
         x (Tensor): The input tensor. It can be any shape. Its data type should be float16, float32, float64, int32, int64.

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -15,8 +15,6 @@
 from __future__ import annotations
 
 import builtins
-import functools
-import inspect
 import math
 import numbers
 import os
@@ -2967,24 +2965,7 @@ def diag_embed(
     out.stop_gradient = True
     return out
 
-def _diagflat_input_alias(func):
-    signature = inspect.signature(func)
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        if 'input' in kwargs:
-            if 'x' in kwargs or len(args) > 0:
-                raise ValueError(
-                    "Cannot specify both 'x' and its alias 'input'"
-                )
-            kwargs['x'] = kwargs.pop('input')
-        return func(*args, **kwargs)
-
-    wrapper.__signature__ = signature
-    return wrapper
-
-
-@_diagflat_input_alias
+@param_one_alias(["x", "input"])
 def diagflat(
     x: paddle.Tensor, offset: int = 0, name: str | None = None
 ) -> paddle.Tensor:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2983,12 +2983,9 @@ def diagflat(
 
     If ``offset`` < 0, it is subdiagonal.
 
-    .. note::
-        Alias Support: The parameter name ``input`` can be used as an alias for ``x``.
-        For example, ``diagflat(input=tensor_x)`` is equivalent to ``diagflat(x=tensor_x)``.
-
     Args:
         x (Tensor): The input tensor. It can be any shape. Its data type should be float16, float32, float64, int32, int64.
+            Alias: ``input``.
         offset (int, optional): The diagonal offset. A positive value represents superdiagonal, 0 represents the main diagonal, and a negative value represents subdiagonal. Default: 0 (main diagonal).
         name(str|None, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
 

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -174,26 +174,17 @@ def param_one_alias(
     alias_list,
 ) -> Callable[[Callable[_InputT, _RetT]], Callable[_InputT, _RetT]]:
     def decorator(func: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
-        parameters = tuple(inspect.signature(func).parameters)
-        original_index = (
-            parameters.index(alias_list[0])
-            if alias_list[0] in parameters
-            else None
-        )
-
         @functools.wraps(func)
         def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
             if not kwargs:
                 return func(*args, **kwargs)
             if alias_list[1] in kwargs:
-                if alias_list[0] in kwargs or (
-                    original_index is not None and original_index < len(args)
-                ):
+                if alias_list[0] not in kwargs:
+                    kwargs[alias_list[0]] = kwargs.pop(alias_list[1])
+                else:
                     raise ValueError(
                         f"Cannot specify both '{alias_list[0]}' and its alias '{alias_list[1]}'"
                     )
-                else:
-                    kwargs[alias_list[0]] = kwargs.pop(alias_list[1])
             return func(*args, **kwargs)
 
         wrapper.__signature__ = inspect.signature(func)

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -174,17 +174,26 @@ def param_one_alias(
     alias_list,
 ) -> Callable[[Callable[_InputT, _RetT]], Callable[_InputT, _RetT]]:
     def decorator(func: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
+        parameters = tuple(inspect.signature(func).parameters)
+        original_index = (
+            parameters.index(alias_list[0])
+            if alias_list[0] in parameters
+            else None
+        )
+
         @functools.wraps(func)
         def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
             if not kwargs:
                 return func(*args, **kwargs)
             if alias_list[1] in kwargs:
-                if alias_list[0] not in kwargs:
-                    kwargs[alias_list[0]] = kwargs.pop(alias_list[1])
-                else:
+                if alias_list[0] in kwargs or (
+                    original_index is not None and original_index < len(args)
+                ):
                     raise ValueError(
                         f"Cannot specify both '{alias_list[0]}' and its alias '{alias_list[1]}'"
                     )
+                else:
+                    kwargs[alias_list[0]] = kwargs.pop(alias_list[1])
             return func(*args, **kwargs)
 
         wrapper.__signature__ = inspect.signature(func)

--- a/test/legacy_test/test_diagflat.py
+++ b/test/legacy_test/test_diagflat.py
@@ -37,14 +37,29 @@ class TestDiagFlatAPI(unittest.TestCase):
         y = paddle.diagflat(x)
         np.testing.assert_allclose(y.numpy(), self.expected0, rtol=1e-05)
 
+        y = paddle.diagflat(x=x)
+        np.testing.assert_allclose(y.numpy(), self.expected0, rtol=1e-05)
+
+        y = paddle.diagflat(input=x)
+        np.testing.assert_allclose(y.numpy(), self.expected0, rtol=1e-05)
+
         y = paddle.diagflat(x, offset=1)
+        np.testing.assert_allclose(y.numpy(), self.expected1, rtol=1e-05)
+
+        y = paddle.diagflat(input=x, offset=1)
         np.testing.assert_allclose(y.numpy(), self.expected1, rtol=1e-05)
 
         y = paddle.diagflat(x, offset=-1)
         np.testing.assert_allclose(y.numpy(), self.expected2, rtol=1e-05)
 
+        y = paddle.diagflat(input=x, offset=-1)
+        np.testing.assert_allclose(y.numpy(), self.expected2, rtol=1e-05)
+
         x = paddle.to_tensor(self.input_np2)
         y = paddle.diagflat(x)
+        np.testing.assert_allclose(y.numpy(), self.expected3, rtol=1e-05)
+
+        y = paddle.diagflat(input=x)
         np.testing.assert_allclose(y.numpy(), self.expected3, rtol=1e-05)
 
         y = paddle.diagflat(x, offset=1)
@@ -62,19 +77,76 @@ class TestDiagFlatAPI(unittest.TestCase):
             )
             x2 = paddle.static.data(name='input2', shape=[20], dtype='float64')
             result0 = paddle.diagflat(x)
+            result1 = paddle.diagflat(input=x)
             result3 = paddle.diagflat(x2)
+            result4 = paddle.diagflat(input=x2, offset=-1)
 
             place = get_device_place() if use_gpu else paddle.CPUPlace()
             exe = paddle.static.Executor(place)
             exe.run(startup)
-            res0, res3 = exe.run(
+            res0, res1, res3, res4 = exe.run(
                 main,
                 feed={"input": self.input_np, 'input2': self.input_np2},
-                fetch_list=[result0, result3],
+                fetch_list=[result0, result1, result3, result4],
             )
 
             np.testing.assert_allclose(res0, self.expected0, rtol=1e-05)
+            np.testing.assert_allclose(res1, self.expected0, rtol=1e-05)
             np.testing.assert_allclose(res3, self.expected3, rtol=1e-05)
+            np.testing.assert_allclose(res4, self.expected5, rtol=1e-05)
+
+    def test_input_param_name_dtype(self):
+        paddle.disable_static(place=paddle.CPUPlace())
+        try:
+            float_input = paddle.to_tensor([1, 2, 3], dtype='float32')
+            float_result = paddle.diagflat(input=float_input)
+            float_expected = np.diagflat(np.array([1, 2, 3], dtype=np.float32))
+            np.testing.assert_allclose(float_result.numpy(), float_expected)
+            self.assertEqual(float_result.dtype, paddle.float32)
+
+            complex_input = paddle.to_tensor(
+                np.array([1 + 0j, 2 + 0j], dtype=np.complex64)
+            )
+            complex_result = paddle.diagflat(input=complex_input)
+            complex_expected = np.diagflat(
+                np.array([1 + 0j, 2 + 0j], dtype=np.complex64)
+            )
+            np.testing.assert_allclose(
+                complex_result.numpy(), complex_expected
+            )
+            self.assertEqual(complex_result.dtype, paddle.complex64)
+        finally:
+            paddle.enable_static()
+
+    def test_input_param_name_scalar(self):
+        paddle.disable_static(place=paddle.CPUPlace())
+        try:
+            scalar = paddle.to_tensor(7)
+            result = paddle.diagflat(input=scalar)
+            expected = np.diagflat(np.array(7))
+            np.testing.assert_array_equal(result.numpy(), expected)
+        finally:
+            paddle.enable_static()
+
+    def test_input_param_name_negative_offset(self):
+        paddle.disable_static(place=paddle.CPUPlace())
+        try:
+            x = paddle.to_tensor([[1, 2], [3, 4]])
+            result = paddle.diagflat(input=x, offset=-3)
+            expected = np.diagflat(np.array([[1, 2], [3, 4]]), k=-3)
+            np.testing.assert_array_equal(result.numpy(), expected)
+        finally:
+            paddle.enable_static()
+
+    def test_input_param_name_conflict(self):
+        t1 = paddle.to_tensor([1, 2])
+        t2 = paddle.to_tensor([3, 4])
+        with self.assertRaises(ValueError) as context:
+            paddle.diagflat(t1, input=t2)
+        self.assertIn(
+            "Cannot specify both 'x' and its alias 'input'",
+            str(context.exception),
+        )
 
     def test_cpu(self):
         paddle.disable_static(place=paddle.CPUPlace())

--- a/test/legacy_test/test_diagflat.py
+++ b/test/legacy_test/test_diagflat.py
@@ -142,7 +142,7 @@ class TestDiagFlatAPI(unittest.TestCase):
         t1 = paddle.to_tensor([1, 2])
         t2 = paddle.to_tensor([3, 4])
         with self.assertRaises(ValueError) as context:
-            paddle.diagflat(t1, input=t2)
+            paddle.diagflat(x=t1, input=t2)
         self.assertIn(
             "Cannot specify both 'x' and its alias 'input'",
             str(context.exception),


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New Features

### Description
为 `paddle.diagflat` 增加 `input` 参数别名支持，满足 (`torch.diagflat -> paddle.diagflat`) 的兼容需求。

本次改动包括：
1. 支持 `paddle.diagflat(input=...)` 调用方式；
2. 保持原有 `paddle.diagflat(x=...)` 用法不变；
3. 当 `x` 和 `input` 同时传入时，抛出明确的参数冲突错误；
4. 补充 `diagflat` 相关测试，覆盖 `input` 别名、scalar 输入、负 offset、`float32/complex64` dtype 以及参数冲突场景。

说明：
1. 本 PR 的改动范围仅限 `diagflat`，未修改共享参数别名装饰器的通用行为；
2. 本 PR 主要解决参数兼容问题，不涉及底层 kernel 的 dtype 扩展；
3. 当前 `bool` dtype 与 PyTorch 仍存在差异，该问题后续可单独跟踪处理。

### 是否引起精度变化
否

Ref comment:
https://github.com/PaddlePaddle/Paddle/issues/76301#issuecomment-3977504548