### PR TITLE
[BugFix] Fix CUDA Graph crash when FLAGS_use_system_allocator is enabled

### DIFF
--- a/paddle/fluid/framework/new_executor/garbage_collector/fast_garbage_collector.cc
+++ b/paddle/fluid/framework/new_executor/garbage_collector/fast_garbage_collector.cc
@@ -14,6 +14,8 @@
 
 #include "paddle/fluid/framework/new_executor/garbage_collector/fast_garbage_collector.h"
 
+#include "paddle/phi/core/platform/cuda_graph_with_memory_pool.h"
+
 namespace paddle {
 namespace framework {
 
@@ -83,6 +85,18 @@ void InterpreterCoreFastGarbageCollector::Add(Garbage garbage) {
   if (!garbage) {
     return;
   }
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  // During CUDA Graph capturing, cudaFree is not permitted.
+  // Always defer the actual deallocation by keeping garbage in the queue,
+  // it will be freed when the garbage collector is destroyed after capturing.
+  if (platform::IsCUDAGraphCapturing()) {
+    std::lock_guard<memory::SpinLock> guard(spinlock_);
+    cur_memory_size_ += static_cast<int64_t>(garbage->size());
+    garbages_->push_back(std::move(garbage));
+    return;
+  }
+#endif
 
   if (max_memory_size_ > 1) {
     std::unique_ptr<GarbageQueue> pending_delete_garbages;

--- a/paddle/fluid/framework/new_executor/garbage_collector/garbage_collector.h
+++ b/paddle/fluid/framework/new_executor/garbage_collector/garbage_collector.h
@@ -25,6 +25,7 @@
 
 COMMON_DECLARE_bool(fast_eager_deletion_mode);
 COMMON_DECLARE_bool(new_executor_use_cuda_graph);
+PD_DECLARE_bool(use_system_allocator);
 
 namespace paddle {
 namespace framework {
@@ -62,17 +63,24 @@ inline bool IsInterpretercoreFastGCEnabled() {
                     common::errors::InvalidArgument(
                         "StreamSafeAllocator and AsyncAllocator shouldn't be "
                         "True together."));
-  PADDLE_ENFORCE_EQ(memory::allocation::AllocatorFacade::Instance()
-                                .IsStreamSafeCUDAAllocatorUsed() == false &&
-                        memory::allocation::AllocatorFacade::Instance()
-                                .IsCUDAMallocAsyncAllocatorUsed() == false &&
-                        FLAGS_new_executor_use_cuda_graph,
-                    false,
-                    common::errors::InvalidArgument(
-                        "When FLAGS_new_executor_use_cuda_graph is true, "
-                        "Either IsStreamSafeCUDAAllocatorUsed or "
-                        "IsCUDAMallocAsyncAllocatorUsed must be true, but "
-                        "got false."));
+  // When FLAGS_use_system_allocator is true, IsStreamSafeCUDAAllocatorUsed()
+  // and IsCUDAMallocAsyncAllocatorUsed() always return false regardless of
+  // their internal state. Skip this check in that case since system allocator
+  // manages memory via cudaMalloc/cudaFree directly and does not conflict
+  // with CUDA Graph capture (memory is allocated before capture begins).
+  if (!FLAGS_use_system_allocator) {
+    PADDLE_ENFORCE_EQ(memory::allocation::AllocatorFacade::Instance()
+                                  .IsStreamSafeCUDAAllocatorUsed() == false &&
+                          memory::allocation::AllocatorFacade::Instance()
+                                  .IsCUDAMallocAsyncAllocatorUsed() == false &&
+                          FLAGS_new_executor_use_cuda_graph,
+                      false,
+                      common::errors::InvalidArgument(
+                          "When FLAGS_new_executor_use_cuda_graph is true, "
+                          "Either IsStreamSafeCUDAAllocatorUsed or "
+                          "IsCUDAMallocAsyncAllocatorUsed must be true, but "
+                          "got false."));
+  }
   return (memory::allocation::AllocatorFacade::Instance()
               .IsStreamSafeCUDAAllocatorUsed() &&
           FLAGS_fast_eager_deletion_mode) ||


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description

修复当 `FLAGS_use_system_allocator=1` 与 CUDA Graph 静态模式同时使用时的两个崩溃问题。

#### 问题背景

使用命令 `FLAGS_check_cuda_error=1 FLAGS_use_system_allocator=1 python test_cuda_graph_static_mode.py` 运行测试时，触发以下错误：

```
ValueError: (InvalidArgument) When FLAGS_new_executor_use_cuda_graph is true, 
Either IsStreamSafeCUDAAllocatorUsed or IsCUDAMallocAsyncAllocatorUsed must be true, but got false.
```

#### 根因分析

**问题一：`IsInterpretercoreFastGCEnabled()` 中的 allocator 检查不兼容 system allocator**

调用链：`test_cuda_graph_static_mode.py` → `BuildStrategy.allow_cuda_graph_capture=True` → `executor.py` 设置 `FLAGS_new_executor_use_cuda_graph=True` → 创建 GC 时调用 `IsInterpretercoreFastGCEnabled()`。

该函数要求 `IsStreamSafeCUDAAllocatorUsed()` 或 `IsCUDAMallocAsyncAllocatorUsed()` 至少一个为 true。但这两个函数的实现（`allocator_facade.cc`）均包含 `LIKELY(FLAGS_use_system_allocator == false)` 的前置条件，当 `FLAGS_use_system_allocator=1` 时无论内部状态如何都返回 false，导致不合理的报错。

**问题二：CUDA Graph capture 期间 Fast GC 触发 cudaFree**

解决问题一后，`InterpreterCoreFastGarbageCollector::Add()` 中的 `shared_ptr<Allocation>` 在引用计数降为 0 时析构，触发 `CUDAAllocator::FreeImpl()` → `cudaFree()`，而 CUDA 规范不允许在 stream capturing 期间调用 `cudaFree`（CUDA error 900）。

#### 修复方案

1. **`garbage_collector.h`**：在 `IsInterpretercoreFastGCEnabled()` 中，当 `FLAGS_use_system_allocator=true` 时跳过 stream-safe/async allocator 的检查。System allocator 通过 `cudaMalloc/cudaFree` 直接管理内存，在 CUDA Graph capture 开始前已完成分配，不与 capture 过程冲突。

2. **`fast_garbage_collector.cc`**：在 `InterpreterCoreFastGarbageCollector::Add(Garbage)` 中增加 CUDA Graph capturing 状态检测——当正在 capture 时，所有 garbage 入队但不释放，延迟到 capture 结束后 GC 析构时再统一释放。

### 是否引起精度变化
否