### PR TITLE
[BugFix] Wrap system_allocators_ with StatAllocator for memory stats tracking

### DIFF
--- a/paddle/phi/core/memory/allocation/allocator_facade.cc
+++ b/paddle/phi/core/memory/allocation/allocator_facade.cc
@@ -1617,6 +1617,14 @@ class AllocatorFacadePrivate {
         pair.second = std::make_shared<StatAllocator>(pair.second);
       }
     }
+    for (auto& pair : system_allocators_) {
+      const Place& place = pair.first;
+      if (phi::is_cpu_place(place) || phi::is_cuda_pinned_place(place) ||
+          phi::is_gpu_place(place) || phi::is_custom_place(place) ||
+          phi::is_xpu_place(place) || phi::is_xpu_pinned_place(place)) {
+        pair.second = std::make_shared<StatAllocator>(pair.second);
+      }
+    }
   }
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description

#### 问题现象

使用 `FLAGS_use_system_allocator=1` 运行 `test_cuda_reset_max_memory_allocated` 测试时，`max_memory_allocated()` 和 `memory_allocated()` 始终返回 0，导致测试断言失败：

```
FLAGS_check_cuda_error=1 FLAGS_use_system_allocator=1 python test_cuda_reset_max_memory_allocated.py
AssertionError: 0 not less than 0
```

#### 根因分析

当 `FLAGS_use_system_allocator=1` 时，内存分配走 `system_allocators_` 路径。而 `WrapStatAllocator()` 函数只对 `allocators_` map 中的 allocator 进行了 `StatAllocator` 包装，遗漏了 `system_allocators_`。

`StatAllocator` 是唯一调用 `DEVICE_MEMORY_STAT_UPDATE(Allocated, ...)` 的地方（在 `AllocateImpl` 和 `FreeImpl` 中），因此 system allocator 路径下 "Allocated" 统计永远不会被更新。

#### 修复方案

在 `WrapStatAllocator()` 中增加对 `system_allocators_` 的遍历，使用与 `allocators_` 相同的条件判断进行 `StatAllocator` 包装。

#### 验证

| 场景 | 修复前 | 修复后 |
|---|---|---|
| `FLAGS_use_system_allocator=1` | FAIL: `0 not less than 0` | OK |
| 默认路径（不设置 flag） | OK | OK |

### 是否引起精度变化
否