### PR TITLE
[FIX] test_cuda_memory_allocated.py

### DIFF
--- a/paddle/phi/core/memory/allocation/allocator_facade.cc
+++ b/paddle/phi/core/memory/allocation/allocator_facade.cc
@@ -1617,6 +1617,14 @@ class AllocatorFacadePrivate {
         pair.second = std::make_shared<StatAllocator>(pair.second);
       }
     }
+    for (auto& pair : system_allocators_) {
+      const Place& place = pair.first;
+      if (phi::is_cpu_place(place) || phi::is_cuda_pinned_place(place) ||
+          phi::is_gpu_place(place) || phi::is_custom_place(place) ||
+          phi::is_xpu_place(place) || phi::is_xpu_pinned_place(place)) {
+        pair.second = std::make_shared<StatAllocator>(pair.second);
+      }
+    }
   }
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
  问题
  FLAGS_check_cuda_error=1 FLAGS_use_system_allocator=1 下运行 test_cuda_memory_allocated.py，memory_allocated() 返回 0（预期 1024），导致 2 个
  AssertionError。

  根因
  文件 paddle/phi/core/memory/allocation/allocator_facade.cc 中，WrapStatAllocator() 方法只对 allocators_ 进行了 StatAllocator 包装，遗漏了
  system_allocators_。
  当 FLAGS_use_system_allocator=1 时，内存分配走 system_allocators_ 路径，直接使用裸的 CUDAAllocator，绕过了负责更新 "Allocated" 统计的
  StatAllocator 装饰器，导致 memory_allocated() 始终返回 0。

  修复
  在 WrapStatAllocator() 中增加了对 system_allocators_ 的遍历和 StatAllocator 包装（第 1620-1627 行），与 allocators_ 的处理逻辑完全一致。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否