### PR TITLE
【FlexCheckpoint】fix transpose warning

### DIFF
--- a/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
@@ -57,6 +57,7 @@ from .utils import (
     is_sharded_state_dict,
     merge_state_dict_metadata,
     minimal_nd_slice,
+    need_transpose,
     ravel_index,
 )
 
@@ -613,7 +614,9 @@ def _handle_aoa(
                 src_desc_to_postprocess_list[src_desc] = (
                     mapping.postprocess_list
                 )
-            if len(shard_mappings) == 1 and mapping.postprocess_list is None:
+            if len(shard_mappings) == 1 and not need_transpose(
+                mapping.postprocess_list
+            ):
                 if src_desc.global_shape != dst_desc.global_shape:
                     logger.warning(
                         f"Shape mismatch for parameter '{param_name}': "

--- a/python/paddle/distributed/flex_checkpoint/dcp/utils.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/utils.py
@@ -743,6 +743,9 @@ def check_resumable_locally(
 
 
 def need_transpose(postprocess_list):
+    if postprocess_list is None:
+        return False
+
     for pp in postprocess_list:
         if "[" in pp:
             return True

--- a/python/paddle/distributed/flex_checkpoint/dcp/utils.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/utils.py
@@ -487,6 +487,7 @@ def create_hf_ckpt_metadata(
         'F32': 'float32',
         'F64': 'float64',
         'BF16': 'bfloat16',
+        'I64': 'int64',
     }
 
     use_dist = paddle.distributed.get_world_size() > 1
@@ -739,3 +740,11 @@ def check_resumable_locally(
         return all(global_local_loads)
     else:
         return local_load
+
+
+def need_transpose(postprocess_list):
+    for pp in postprocess_list:
+        if "[" in pp:
+            return True
+    else:
+        return False


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Auto Parallel

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
load_state_dict 中当 aoa statements 未声明 transpose（src_state_dict 的权重形状与对应 target_state_dict 的权重形状不一致）时的拦截需要更加精确，即 postprocesslist 中没有 permutation list 时才进行拦截，而非 postprocesslist 为空时才拦截。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否