### PR TITLE
Fix eager elementwise type promotion for tensor overloads

### DIFF
--- a/paddle/fluid/pybind/eager_math_op_patch.cc
+++ b/paddle/fluid/pybind/eager_math_op_patch.cc
@@ -216,40 +216,35 @@ Tensor CallScalarFunction(const Tensor& self_tensor,
   return ret;
 }
 
-void TypePromotionForZeroDimTensor(std::string func,
-                                   Tensor& self_tensor,  // NOLINT
-                                   Tensor& other_tensor  // NOLINT
+void TypePromotionForTensorOperands(const std::string& op_name,
+                                    Tensor& self_tensor,  // NOLINT
+                                    Tensor& other_tensor  // NOLINT
 ) {
-  if ((self_tensor.shape().size() == 0 || other_tensor.shape().size() == 0) &&
-      self_tensor.dtype() != other_tensor.dtype()) {
-    VLOG(5) << "got 0-d tensor and need to do type promotion, x: "
-            << self_tensor.dtype() << " y: " << other_tensor.dtype();
+  if (!phi::NeedTypePromotion(op_name,
+                              self_tensor.dtype(),
+                              other_tensor.dtype(),
+                              self_tensor.shape(),
+                              other_tensor.shape())) {
+    return;
+  }
 
-    DataType promote_type;
-    // different major types or both 0-d tensor follow with T+T rule.
-    if (!is_common_dtype_for_scalar(self_tensor.dtype(),
-                                    other_tensor.dtype()) ||
-        (self_tensor.shape().size() == 0 && other_tensor.shape().size() == 0)) {
-      promote_type =
-          GetPromoteDtype(func, self_tensor.dtype(), other_tensor.dtype());
-    } else {
-      // common major types follow with tensor: int32(tensor) + int64(scalar)
-      // = int32
-      if (self_tensor.shape().size() == 0) {
-        promote_type = other_tensor.dtype();
-      } else {
-        promote_type = self_tensor.dtype();
-      }
-    }
-    SetPythonStack();
-    if (self_tensor.dtype() != promote_type) {
-      eager_gil_scoped_release guard;
-      self_tensor = cast_ad_func(self_tensor, promote_type);
-    }
-    if (other_tensor.dtype() != promote_type) {
-      eager_gil_scoped_release guard;
-      other_tensor = cast_ad_func(other_tensor, promote_type);
-    }
+  VLOG(5) << "Need to do type promotion for eager tensor method, op: "
+          << op_name << ", x: " << self_tensor.dtype()
+          << ", y: " << other_tensor.dtype();
+
+  auto promote_type = phi::GetPromoteDtype(op_name,
+                                           self_tensor.dtype(),
+                                           other_tensor.dtype(),
+                                           self_tensor.shape(),
+                                           other_tensor.shape());
+  SetPythonStack();
+  if (self_tensor.dtype() != promote_type) {
+    eager_gil_scoped_release guard;
+    self_tensor = cast_ad_func(self_tensor, promote_type);
+  }
+  if (other_tensor.dtype() != promote_type) {
+    eager_gil_scoped_release guard;
+    other_tensor = cast_ad_func(other_tensor, promote_type);
   }
 }
 
@@ -356,6 +351,8 @@ static PyObject* tensor__add__method(TensorObject* self,
 
   // 3. calculation
   VLOG(6) << "Calling add_ad_func in tensor__add__method";
+
+  TypePromotionForTensorOperands("add", self_tensor, other_tensor);
 
   {
     eager_gil_scoped_release guard;
@@ -469,6 +466,7 @@ static PyObject* tensor__sub__method(TensorObject* self,
 
   // 3. calculation
   VLOG(6) << "Calling subtract_ad_func in tensor__sub__method";
+  TypePromotionForTensorOperands("subtract", self_tensor, other_tensor);
   {
     eager_gil_scoped_release guard;
     ret = subtract_ad_func(self_tensor, other_tensor);
@@ -564,6 +562,7 @@ static PyObject* tensor__rsub__method(TensorObject* self,
 
   // 3. calculation
   VLOG(6) << "Calling subtract_ad_func in tensor__rsub__method";
+  TypePromotionForTensorOperands("subtract", self_tensor, other_tensor);
   {
     eager_gil_scoped_release guard;
     ret = subtract_ad_func(other_tensor, self_tensor);
@@ -696,6 +695,7 @@ static PyObject* tensor__mul__method(TensorObject* self,
 
   // 3. calculation
   VLOG(6) << "Calling multiply_ad_func in tensor__mul__method";
+  TypePromotionForTensorOperands("multiply", self_tensor, other_tensor);
   {
     eager_gil_scoped_release guard;
     ret = multiply_ad_func(self_tensor, other_tensor);
@@ -808,6 +808,7 @@ static PyObject* tensor__div__method(TensorObject* self,
 
   // 3. calculation
   VLOG(6) << "Calling divide_ad_func in tensor__div__method";
+  TypePromotionForTensorOperands("divide", self_tensor, other_tensor);
   {
     eager_gil_scoped_release guard;
     ret = divide_ad_func(self_tensor, other_tensor);
@@ -897,6 +898,7 @@ static PyObject* tensor__rdiv__method(TensorObject* self,
 
   // 3. calculation
   VLOG(6) << "Calling divide_ad_func in tensor__rdiv__method";
+  TypePromotionForTensorOperands("divide", self_tensor, other_tensor);
   {
     eager_gil_scoped_release guard;
     ret = divide_ad_func(other_tensor, self_tensor);

--- a/paddle/phi/common/type_promotion.h
+++ b/paddle/phi/common/type_promotion.h
@@ -13,6 +13,11 @@
 // limitations under the License.
 #pragma once
 
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "paddle/common/errors.h"
 #include "paddle/phi/common/data_type.h"
 namespace phi {
 
@@ -91,6 +96,7 @@ static std::unordered_set<std::string> support_promotion_ops = {
     "pow",       "elementwise_pow", "equal",           "not_equal",
     "less_than", "less_equal",      "greater_than",    "greater_equal",
     "copysign",  "cross",           "trunc_divide",    "equal_all",
+    "minimum",
 };
 
 static std::unordered_set<std::string> support_autocast_ops = {
@@ -140,26 +146,32 @@ inline bool is_common_dtype_for_scalar(DataType x, DataType y) {
   }
 }
 
+inline bool IsTrueDividePromotionOp(const std::string& op_name) {
+  // Keep all true-div aliases on the same promotion rule so eager/generated/PIR
+  // paths do not drift on integral inputs.
+  return op_name == "divide" || op_name == "divide_" ||
+         op_name == "elementwise_div" || op_name == "truediv";
+}
+
 inline phi::DataType GetPromoteDtype(
     const std::string& op_name,
     const DataType& x_dtype,
     const DataType& y_dtype,
     const std::vector<int64_t>& x_shape = std::vector<int64_t>(),
     const std::vector<int64_t>& y_shape = std::vector<int64_t>()) {
-  if (op_name == "divide" || op_name == "divide_" ||
-      op_name == "elementwise_div") {
+  if (IsTrueDividePromotionOp(op_name)) {
     if (is_support_int(x_dtype) && is_support_int(y_dtype)) {
       return DataType::FLOAT32;
     }
   }
   // Tensor + 0-d Tensor
   if (support_promotion_ops.find(op_name) != support_promotion_ops.end() &&
-      (x_shape.size() == 0 || y_shape.size() == 0)) {
+      (x_shape.empty() || y_shape.empty())) {
     if (!is_common_dtype_for_scalar(x_dtype, y_dtype) ||
-        (x_shape.size() == 0 && y_shape.size() == 0)) {
+        (x_shape.empty() && y_shape.empty())) {
       return phi::promoteTypes(x_dtype, y_dtype);
     } else {
-      if (x_shape.size() == 0) {
+      if (x_shape.empty()) {
         return y_dtype;
       } else {
         return x_dtype;
@@ -173,7 +185,7 @@ inline phi::DataType GetPromoteDtype(
 inline phi::DataType GetPromoteDtypeOldIr(const std::string& op_name,
                                           const DataType x,
                                           const DataType y) {
-  if (op_name == "divide" || op_name == "divide_") {
+  if (IsTrueDividePromotionOp(op_name)) {
     // only T+S can run into this branch
     if (is_support_int(x) && is_support_int(y)) {
       return DataType::FLOAT32;
@@ -189,7 +201,7 @@ inline bool NeedTypePromotion(
     const std::vector<int64_t>& x_shape = std::vector<int64_t>(),
     const std::vector<int64_t>& y_shape = std::vector<int64_t>()) {
   if (x_dtype == y_dtype) {
-    if (op_name == "divide" || op_name == "divide_") {
+    if (IsTrueDividePromotionOp(op_name)) {
       if (is_support_int(x_dtype) && is_support_int(y_dtype)) {
         return true;
       }
@@ -198,7 +210,7 @@ inline bool NeedTypePromotion(
   }
   // Tensor + 0-d Tensor
   if (support_promotion_ops.find(op_name) != support_promotion_ops.end() &&
-      (x_shape.size() == 0 || y_shape.size() == 0)) {
+      (x_shape.empty() || y_shape.empty())) {
     return true;
   }
   // Tensor + Tensor type promotion only support calculations between
@@ -232,6 +244,14 @@ inline bool NeedTypePromotion(
 inline bool NeedTypePromotionOldIr(const std::string& op_name,
                                    const DataType x,
                                    const DataType y) {
+  if (x == y) {
+    if (IsTrueDividePromotionOp(op_name)) {
+      if (is_support_int(x) && is_support_int(y)) {
+        return true;
+      }
+    }
+    return false;
+  }
   // Tensor + Tensor type promotion only support calculations between
   // floating-point numbers and between complex and real numbers.
   if (x != y) {

--- a/python/paddle/compat/__init__.py
+++ b/python/paddle/compat/__init__.py
@@ -378,6 +378,8 @@ def _min_max_param_checker(func_name: str, *args: Any, **kwargs: Any):
         else:
             if "dim" in kwargs:
                 dim_or_other = kwargs["dim"]
+                if isinstance(dim_or_other, (Variable, paddle.pir.Value)):
+                    raise invalid_arguments_exception()
             elif "other" in kwargs:
                 dim_or_other = kwargs["other"]
                 if not isinstance(dim_or_other, (Variable, paddle.pir.Value)):


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
- 本 PR 对 elementwise 家族的共享 eager-overload / type-promotion 路径做统一对齐：在 `paddle/fluid/pybind/eager_math_op_patch.cc` 中，让 eager Tensor overload（如 `__add__`、`__sub__`、`__mul__`、`__div__` / `__truediv__` 及反向形式）在分发前复用共享的 tensor-tensor promotion check，减少方法形式与函数形式在 mixed-dtype 场景下的行为分叉。
- 在 `paddle/phi/common/type_promotion.h` 中统一 true-div alias 的归一化入口，补强 `divide` / `truediv` 相关路径的一致性，并覆盖整数除法 `int / int -> float32` 的共享 promotion 语义；同时将 `minimum` 纳入共享 scalar / 0-d promotion handling，使其与 add / sub / mul / div 家族保持一致。
- 验证结果：build 与 smoke test 已通过；`test_zero_dim_binary_api.py`、`test_tensor_scalar_type_promotion_dynamic.py` 在 `FLAGS_use_accuracy_compatible_kernel=0/1` 下均通过。PaddleAPITest 聚焦配置后修复结果为 **69/69 passed**；reviewer 独立复验 **7/7 passed**，并额外覆盖 `paddle.divide(int32, int32)` 与 `paddle.Tensor.divide(int64, int64)` 的 forward case。当前暂无同配置 pre-fix baseline，可作为 post-fix 证据看待；剩余盲点主要在 backward 覆盖以及 PaddleAPITest 对 `paddle.Tensor.__add__` 的 dtype-check blind spot。

### 是否引起精度变化
是
