### PR TITLE
use site-package cublas&cublaslt

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -39,59 +39,48 @@ except ImportError:
      import paddle from the source directory; please install paddlepaddle*.whl firstly.'''
     )
 
-# Preload cublasLt from pip package before loading C extensions,
-# to prevent LD_LIBRARY_PATH from pulling in a mismatched system version.
+
+# Preload CUDA libraries from pip package before loading C extensions,
+# to prevent LD_LIBRARY_PATH from pulling in mismatched system versions.
+# Also used later by CINN to preload libnvrtc-builtins.
+def _preload_nvidia_lib(lib_glob, sub_dirs=None):
+    """Search and preload a library from pip nvidia packages.
+
+    Searches nvidia/cu{major}/lib/ first (CUDA 13+),
+    then nvidia/{sub_dir}/lib/ for each sub_dir (CUDA 12).
+    """
+    import ctypes
+    import glob
+    import os
+
+    from .version import cuda as cuda_version
+
+    pkg_dir = os.path.dirname(os.path.abspath(__file__))
+    nvidia_dir = os.path.join(pkg_dir, '..', 'nvidia')
+    cuda_major = cuda_version().split('.')[0]
+
+    paths = glob.glob(
+        os.path.join(nvidia_dir, f'cu{cuda_major}', 'lib', lib_glob)
+    )
+    for sub_dir in sub_dirs or []:
+        paths += glob.glob(os.path.join(nvidia_dir, sub_dir, 'lib', lib_glob))
+    for path in paths:
+        ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
+        break
+
+
 if __is_metainfo_generated:
-    import os as _os
-    import platform as _platform
+    import platform
 
-    if _platform.system() == 'Linux' and _platform.machine() == 'x86_64':
+    if platform.system() == 'Linux' and platform.machine() == 'x86_64':
         try:
-            from .version import with_pip_cuda_libraries as _with_pip
+            from .version import with_pip_cuda_libraries
 
-            if _with_pip == 'ON':
-                import ctypes as _ctypes
-                import glob as _glob
-
-                from .version import cuda as _cuda_version
-
-                _pkg_dir = _os.path.dirname(_os.path.abspath(__file__))
-                _nvidia_dir = _os.path.join(_pkg_dir, '..', 'nvidia')
-                _cuda_major = _cuda_version().split('.')[0]
-                # CUDA 13+: nvidia/cu{major}/lib/
-                _lt_paths = _glob.glob(
-                    _os.path.join(
-                        _nvidia_dir,
-                        f'cu{_cuda_major}',
-                        'lib',
-                        'libcublasLt.so.*[0-9]',
-                    )
-                )
-                # CUDA 12: nvidia/cublas/lib/
-                _lt_paths += _glob.glob(
-                    _os.path.join(
-                        _nvidia_dir,
-                        'cublas',
-                        'lib',
-                        'libcublasLt.so.*[0-9]',
-                    )
-                )
-                for _lt_path in _lt_paths:
-                    _ctypes.CDLL(_lt_path, mode=_ctypes.RTLD_GLOBAL)
-                    break
-                del (
-                    _ctypes,
-                    _glob,
-                    _cuda_version,
-                    _pkg_dir,
-                    _nvidia_dir,
-                    _cuda_major,
-                    _lt_paths,
-                )
-            del _with_pip
+            if with_pip_cuda_libraries == 'ON':
+                _preload_nvidia_lib('libcublasLt.so.*[0-9]', ['cublas'])
+                _preload_nvidia_lib('libcublas.so.*[0-9]', ['cublas'])
         except Exception:
             pass
-    del _os, _platform
 
 # NOTE(SigureMo): We should place the import of base.core before other modules,
 # because there are some initialization codes in base/core/__init__.py.
@@ -892,33 +881,7 @@ if __is_metainfo_generated and is_compiled_with_cuda():
         if is_compiled_with_cinn():
             cuda_cccl_path = package_dir + "/.." + "/nvidia/cuda_cccl/include/"
             set_flags({"FLAGS_cuda_cccl_dir": cuda_cccl_path})
-
-            def _preload_nvidia_lib(nvidia_package_path: str, lib_glob: str):
-                import ctypes
-                import glob
-
-                from .version import cuda as cuda_version
-
-                cuda_major_version = cuda_version().split('.')[0]
-
-                lib_paths = []
-                lib_paths += glob.glob(
-                    os.path.join(
-                        nvidia_package_path,
-                        f'cu{cuda_major_version}',
-                        'lib',
-                        lib_glob,
-                    )
-                )
-                lib_paths += glob.glob(
-                    os.path.join(nvidia_package_path, 'lib', lib_glob)
-                )
-
-                for lib_path in lib_paths:
-                    ctypes.CDLL(lib_path)
-                    break
-
-            _preload_nvidia_lib(nvidia_package_path, "libnvrtc-builtins.so.*")
+            _preload_nvidia_lib("libnvrtc-builtins.so.*", ['cuda_nvrtc'])
 
     elif (
         platform.system() == 'Windows'

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -39,6 +39,60 @@ except ImportError:
      import paddle from the source directory; please install paddlepaddle*.whl firstly.'''
     )
 
+# Preload cublasLt from pip package before loading C extensions,
+# to prevent LD_LIBRARY_PATH from pulling in a mismatched system version.
+if __is_metainfo_generated:
+    import os as _os
+    import platform as _platform
+
+    if _platform.system() == 'Linux' and _platform.machine() == 'x86_64':
+        try:
+            from .version import with_pip_cuda_libraries as _with_pip
+
+            if _with_pip == 'ON':
+                import ctypes as _ctypes
+                import glob as _glob
+
+                from .version import cuda as _cuda_version
+
+                _pkg_dir = _os.path.dirname(_os.path.abspath(__file__))
+                _nvidia_dir = _os.path.join(_pkg_dir, '..', 'nvidia')
+                _cuda_major = _cuda_version().split('.')[0]
+                # CUDA 13+: nvidia/cu{major}/lib/
+                _lt_paths = _glob.glob(
+                    _os.path.join(
+                        _nvidia_dir,
+                        f'cu{_cuda_major}',
+                        'lib',
+                        'libcublasLt.so.*[0-9]',
+                    )
+                )
+                # CUDA 12: nvidia/cublas/lib/
+                _lt_paths += _glob.glob(
+                    _os.path.join(
+                        _nvidia_dir,
+                        'cublas',
+                        'lib',
+                        'libcublasLt.so.*[0-9]',
+                    )
+                )
+                for _lt_path in _lt_paths:
+                    _ctypes.CDLL(_lt_path, mode=_ctypes.RTLD_GLOBAL)
+                    break
+                del (
+                    _ctypes,
+                    _glob,
+                    _cuda_version,
+                    _pkg_dir,
+                    _nvidia_dir,
+                    _cuda_major,
+                    _lt_paths,
+                )
+            del _with_pip
+        except Exception:
+            pass
+    del _os, _platform
+
 # NOTE(SigureMo): We should place the import of base.core before other modules,
 # because there are some initialization codes in base/core/__init__.py.
 from .base import core  # noqa: F401

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1300,11 +1300,11 @@ if '${WITH_CINN}' == 'ON':
 
     if '${CMAKE_BUILD_TYPE}' == 'Release' and os.name != 'nt':
         if ('@WITH_GPU@' == 'ON' and tuple(map(int, '@CUDA_VERSION@'.split('.'))) >= (13, 0) and tuple(map(int, '@CUDA_VERSION@'.split('.'))) < (14, 0)):
-            command = "patchelf --set-rpath '$ORIGIN/../../nvidia/cu13/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/' %s/${CINN_LIB_NAME}" % libs_path
+            command = "patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/' %s/${CINN_LIB_NAME}" % libs_path
             if os.system(command) != 0:
                 raise Exception("patch %s/${CINN_LIB_NAME} failed, command: %s" % (libs_path, command))
         else:
-            command = "patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_nvrtc/lib/:$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cublas/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/../../nvidia/curand/lib/:$ORIGIN/../../nvidia/cusolver/lib/:$ORIGIN/../../nvidia/nvtx/lib/:$ORIGIN/' %s/${CINN_LIB_NAME}" % libs_path
+            command = "patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_nvrtc/lib/:$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cublas/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/../../nvidia/curand/lib/:$ORIGIN/../../nvidia/cusolver/lib/:$ORIGIN/../../nvidia/nvtx/lib/:$ORIGIN/' %s/${CINN_LIB_NAME}" % libs_path
             if os.system(command) != 0:
                 raise Exception("patch %s/${CINN_LIB_NAME} failed, command: %s" % (libs_path, command))
 
@@ -1318,7 +1318,7 @@ if '${WITH_ONEDNN}' == 'ON':
         # change rpath of libdnnl.so.1, add $ORIGIN/ to it.
         # The reason is that all thirdparty libraries in the same directory,
         # thus, libdnnl.so.1 will find libmklml_intel.so and libiomp5.so.
-        command = "patchelf --set-rpath '$ORIGIN/' ${ONEDNN_SHARED_LIB}"
+        command = "patchelf --force-rpath --set-rpath '$ORIGIN/' ${ONEDNN_SHARED_LIB}"
         if os.system(command) != 0:
             raise Exception("patch libdnnl.so failed, command: %s" % command)
     shutil.copy('${ONEDNN_SHARED_LIB}', libs_path)
@@ -1430,24 +1430,24 @@ if '${CMAKE_BUILD_TYPE}' == 'Release':
                 commands.append("install_name_tool -add_rpath '@loader_path' ${PADDLE_BINARY_DIR}/python/paddle/libs/${IR_NAME}")
         else:
             if ('@WITH_GPU@' == 'ON' and tuple(map(int, '@CUDA_VERSION@'.split('.'))) >= (13, 0) and tuple(map(int, '@CUDA_VERSION@'.split('.'))) < (14, 0)):
-                commands = ["patchelf --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../nvidia/cusparselt/lib:$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/python/paddle/base/${FLUID_CORE_NAME}" + '.so']
+                commands = ["patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../cusparselt/lib:$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/python/paddle/base/${FLUID_CORE_NAME}" + '.so']
                 if('${WITH_SHARED_PHI}' == 'ON'):
                     # change rpath of phi.ext for loading 3rd party lib
-                    commands.append("patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_NAME}")
-                    commands.append("patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_CORE_NAME}")
+                    commands.append("patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_NAME}")
+                    commands.append("patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_CORE_NAME}")
                     if('${WITH_GPU}' == 'ON' or '${WITH_ROCM}' == 'ON'):
-                        commands.append("patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_GPU_NAME}")
+                        commands.append("patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_GPU_NAME}")
             else:
-                commands = ["patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN/../../nvidia/cuda_nvrtc/lib:$ORIGIN/../../nvidia/cublas/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/curand/lib:$ORIGIN/../../nvidia/cusparse/lib:$ORIGIN/../../nvidia/nvjitlink/lib:$ORIGIN/../../nvidia/cuda_cupti/lib:$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN/../../nvidia/cufft/lib:$ORIGIN/../../nvidia/cufft/lib:$ORIGIN/../../nvidia/cusolver/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../nvidia/nvtx/lib:$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/python/paddle/base/${FLUID_CORE_NAME}" + '.so']
+                commands = ["patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN/../../nvidia/cuda_nvrtc/lib:$ORIGIN/../../nvidia/cublas/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/curand/lib:$ORIGIN/../../nvidia/cusparse/lib:$ORIGIN/../../nvidia/nvjitlink/lib:$ORIGIN/../../nvidia/cuda_cupti/lib:$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN/../../nvidia/cufft/lib:$ORIGIN/../../nvidia/cufft/lib:$ORIGIN/../../nvidia/cusolver/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../nvidia/nvtx/lib:$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/python/paddle/base/${FLUID_CORE_NAME}" + '.so']
                 if('${WITH_SHARED_PHI}' == 'ON'):
                     # change rpath of phi.ext for loading 3rd party lib
-                    commands.append("patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_NAME}")
-                    commands.append("patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_CORE_NAME}")
+                    commands.append("patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_NAME}")
+                    commands.append("patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_CORE_NAME}")
                     if('${WITH_GPU}' == 'ON' or '${WITH_ROCM}' == 'ON'):
-                        commands.append("patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_GPU_NAME}")
+                        commands.append("patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_GPU_NAME}")
             if('${WITH_SHARED_IR}' == 'ON'):
                 # change rpath of pir.ext for loading 3rd party lib
-                commands.append("patchelf --set-rpath '$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${IR_NAME}")
+                commands.append("patchelf --force-rpath --set-rpath '$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${IR_NAME}")
         # The sw_64 not support patchelf, so we just disable that.
         if platform.machine() != 'sw_64' and platform.machine() != 'mips64':
             for command in commands:
@@ -1677,6 +1677,7 @@ class InstallCommand(InstallCommandBase):
         self.install_lib = self.install_platlib
         self.install_headers = os.path.join(self.install_platlib, 'paddle', 'include')
         return ret
+
 
 class InstallHeaders(Command):
     """Override how headers are copied.

--- a/setup.py
+++ b/setup.py
@@ -1717,12 +1717,12 @@ def get_package_data_and_package_dir():
                 < (14, 0)
             ):
                 command = (
-                    f"patchelf --set-rpath '$ORIGIN/../../nvidia/cu13/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/' {libs_path}/"
+                    f"patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/' {libs_path}/"
                     + env_dict.get("CINN_LIB_NAME")
                 )
             else:
                 command = (
-                    f"patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_nvrtc/lib/:$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cublas/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/../../nvidia/curand/lib/:$ORIGIN/../../nvidia/cusolver/lib/:$ORIGIN/../../nvidia/nvtx/lib/:$ORIGIN/' {libs_path}/"
+                    f"patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_nvrtc/lib/:$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cublas/lib/:$ORIGIN/../../nvidia/cudnn/lib/:$ORIGIN/../../nvidia/curand/lib/:$ORIGIN/../../nvidia/cusolver/lib/:$ORIGIN/../../nvidia/nvtx/lib/:$ORIGIN/' {libs_path}/"
                     + env_dict.get("CINN_LIB_NAME")
                 )
             if os.system(command) != 0:
@@ -1743,8 +1743,9 @@ def get_package_data_and_package_dir():
             # change rpath of libdnnl.so.1, add $ORIGIN/ to it.
             # The reason is that all thirdparty libraries in the same directory,
             # thus, libdnnl.so.1 will find libmklml_intel.so and libiomp5.so.
-            command = "patchelf --set-rpath '$ORIGIN/' " + env_dict.get(
-                "ONEDNN_SHARED_LIB"
+            command = (
+                "patchelf --force-rpath --set-rpath '$ORIGIN/' "
+                + env_dict.get("ONEDNN_SHARED_LIB")
             )
             if os.system(command) != 0:
                 raise Exception(f"patch libdnnl.so failed, command: {command}")
@@ -1931,7 +1932,7 @@ def get_package_data_and_package_dir():
                     < (14, 0)
                 ):
                     commands = [
-                        "patchelf --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../nvidia/cusparselt/lib:$ORIGIN/../libs/' "
+                        "patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../cusparselt/lib:$ORIGIN/../libs/' "
                         + env_dict.get("PADDLE_BINARY_DIR")
                         + '/python/paddle/base/'
                         + env_dict.get("FLUID_CORE_NAME")
@@ -1939,13 +1940,13 @@ def get_package_data_and_package_dir():
                     ]
                     if env_dict.get("WITH_SHARED_PHI") == "ON":
                         commands.append(
-                            "patchelf --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' "
+                            "patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' "
                             + env_dict.get("PADDLE_BINARY_DIR")
                             + '/python/paddle/libs/'
                             + env_dict.get("PHI_NAME")
                         )
                         commands.append(
-                            "patchelf --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' "
+                            "patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' "
                             + env_dict.get("PADDLE_BINARY_DIR")
                             + '/python/paddle/libs/'
                             + env_dict.get("PHI_CORE_NAME")
@@ -1955,14 +1956,14 @@ def get_package_data_and_package_dir():
                             or env_dict.get("WITH_ROCM") == "ON"
                         ):
                             commands.append(
-                                "patchelf --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' "
+                                "patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' "
                                 + env_dict.get("PADDLE_BINARY_DIR")
                                 + '/python/paddle/libs/'
                                 + env_dict.get("PHI_GPU_NAME")
                             )
                 else:
                     commands = [
-                        "patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN/../../nvidia/cuda_nvrtc/lib:$ORIGIN/../../nvidia/cublas/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/curand/lib:$ORIGIN/../../nvidia/cusparse/lib:$ORIGIN/../../nvidia/nvjitlink/lib:$ORIGIN/../../nvidia/cuda_cupti/lib:$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN/../../nvidia/cufft/lib:$ORIGIN/../../nvidia/cufft/lib:$ORIGIN/../../nvidia/cusolver/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../nvidia/nvtx/lib:$ORIGIN/../libs/' "
+                        "patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN/../../nvidia/cuda_nvrtc/lib:$ORIGIN/../../nvidia/cublas/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/curand/lib:$ORIGIN/../../nvidia/cusparse/lib:$ORIGIN/../../nvidia/nvjitlink/lib:$ORIGIN/../../nvidia/cuda_cupti/lib:$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN/../../nvidia/cufft/lib:$ORIGIN/../../nvidia/cufft/lib:$ORIGIN/../../nvidia/cusolver/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../nvidia/nvtx/lib:$ORIGIN/../libs/' "
                         + env_dict.get("PADDLE_BINARY_DIR")
                         + '/python/paddle/base/'
                         + env_dict.get("FLUID_CORE_NAME")
@@ -1970,13 +1971,13 @@ def get_package_data_and_package_dir():
                     ]
                     if env_dict.get("WITH_SHARED_PHI") == "ON":
                         commands.append(
-                            "patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN:$ORIGIN/../libs' "
+                            "patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN:$ORIGIN/../libs' "
                             + env_dict.get("PADDLE_BINARY_DIR")
                             + '/python/paddle/libs/'
                             + env_dict.get("PHI_NAME")
                         )
                         commands.append(
-                            "patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN:$ORIGIN/../libs' "
+                            "patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN:$ORIGIN/../libs' "
                             + env_dict.get("PADDLE_BINARY_DIR")
                             + '/python/paddle/libs/'
                             + env_dict.get("PHI_CORE_NAME")
@@ -1986,7 +1987,7 @@ def get_package_data_and_package_dir():
                             or env_dict.get("WITH_ROCM") == "ON"
                         ):
                             commands.append(
-                                "patchelf --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN:$ORIGIN/../libs' "
+                                "patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN:$ORIGIN/../libs' "
                                 + env_dict.get("PADDLE_BINARY_DIR")
                                 + '/python/paddle/libs/'
                                 + env_dict.get("PHI_GPU_NAME")
@@ -1994,7 +1995,7 @@ def get_package_data_and_package_dir():
 
                 if env_dict.get("WITH_SHARED_IR") == "ON":
                     commands.append(
-                        "patchelf --set-rpath '$ORIGIN:$ORIGIN/../libs' "
+                        "patchelf --force-rpath --set-rpath '$ORIGIN:$ORIGIN/../libs' "
                         + env_dict.get("PADDLE_BINARY_DIR")
                         + '/python/paddle/libs/'
                         + env_dict.get("IR_NAME")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
原始问题
libpaddle.so 编译后默认使用 RUNPATH。当 LD_LIBRARY_PATH 含系统 CUDA 路径时，libcublas.so 和 libcublasLt.so 全部从系统加载，而非 pip 包。

第一次修复：force-rpath
将 libpaddle.so 的链接选项改为 force-rpath（RPATH），使其搜索优先级高于 LD_LIBRARY_PATH：
RPATH 搜索顺序: RPATH > LD_LIBRARY_PATH > RUNPATH > /etc/ld.so.cache
效果：libpaddle.so 的直接依赖 libcublas.so 通过 RPATH 正确从 pip 包加载了。但 libcublasLt.so 仍从系统加载 —— 因为它是 libcublas.so 的依赖，而 libcublas.so（NVIDIA pip 包，不受paddle控制）用的是 RUNPATH：
libpaddle.so (RPATH ✓ )
  → libcublas.so.12 从 pip 包加载                    ✓ RPATH 生效
    → libcublasLt.so.12 (libcublas 的 RUNPATH=$ORIGIN)
       搜索: LD_LIBRARY_PATH > RUNPATH($ORIGIN)
       → 系统版被加载                                 ✗ 控制不了 NVIDIA 的包
RPATH 不会传递给子依赖。libpaddle.so 的 RPATH 只对它自己的 DT_NEEDED 生效，libcublas.so 的 DT_NEEDED（libcublasLt.so）走的是 libcublas.so 自身的 RUNPATH。

第二次修复：Python 层 preload
由于 NVIDIA pip 包的 libcublas.so 使用 RUNPATH 是无法修改的，只能从 Python 层绕过：在 dlopen libpaddle.so 之前，用 ctypes.CDLL(mode=RTLD_GLOBAL) 将 pip 包的 libcublasLt.so 和 libcublas.so 注册到全局符号表。
动态链接器在解析依赖时发现同 SONAME 已加载，就不会再搜索 LD_LIBRARY_PATH。

采用了预加载方式已经能够完成从pip目录加载cublas及cublaslt，改RUNPATH为RPATH是为了对齐torch

方案 | force-rpath | Python preload | 效果
-- | -- | -- | --
只改 force-rpath | 需要 | 不需要 | cublas ✓ cublasLt ✗
只做 preload（cublas + cublasLt） | 不需要 | 需要 | cublas ✓ cublasLt ✓
两者都做 | 有 | 有 | cublas ✓ cublasLt ✓（冗余）


torch：
<img width="930" height="176" alt="d681d37b6a7c585a94883cea272fc11b" src="https://github.com/user-attachments/assets/e09aa7c6-e867-44f4-a5fa-692f4dd40a70" />
修改后的paddle：
<img width="924" height="168" alt="a348568a959683b784d5eeb953edd50f" src="https://github.com/user-attachments/assets/ba30b024-3401-4da5-a595-b39c4335ea8d" />
修改前的paddle：
<img width="1159" height="95" alt="547a095efa808d925a0c5a45deb441d1" src="https://github.com/user-attachments/assets/735be19f-ae3d-4079-b887-ce31e8ec9b14" />

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否