### PR TITLE
Fix allow_tf32_cublas default value for custom device.

### DIFF
--- a/paddle/phi/backends/context_pool.cc
+++ b/paddle/phi/backends/context_pool.cc
@@ -28,7 +28,7 @@ namespace phi {
     defined(PADDLE_WITH_CUSTOM_DEVICE)
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
 bool allow_tf32_cublas = true;
-#else // PADDLE_WITH_CUSTOM_DEVICE
+#else
 bool allow_tf32_cublas = false;
 #endif
 void SetAllowTF32Cublas(bool active) { allow_tf32_cublas = active; }

--- a/paddle/phi/backends/context_pool.cc
+++ b/paddle/phi/backends/context_pool.cc
@@ -26,7 +26,11 @@ namespace phi {
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
     defined(PADDLE_WITH_CUSTOM_DEVICE)
+#if defined(PADDLE_WITH_CUSTOM_DEVICE)
+bool allow_tf32_cublas = true;
+#else // PADDLE_WITH_CUSTOM_DEVICE
 bool allow_tf32_cublas = false;
+#endif
 void SetAllowTF32Cublas(bool active) { allow_tf32_cublas = active; }
 bool AllowTF32Cublas() { return allow_tf32_cublas; }
 bool allow_tf32_cudnn = true;

--- a/test/legacy_test/test_tf32_cublas.py
+++ b/test/legacy_test/test_tf32_cublas.py
@@ -25,7 +25,8 @@ class TestTF32Switch(unittest.TestCase):
     def test_on_off(self):
         if core.is_compiled_with_cuda() or is_custom_device():
             place = get_device_place()
-            self.assertFalse(core.get_cublas_switch())  # default
+            if core.is_compiled_with_cuda():
+                self.assertFalse(core.get_cublas_switch())  # default
             core.set_cublas_switch(False)
             self.assertFalse(core.get_cublas_switch())  # turn off
             core.set_cublas_switch(True)


### PR DESCRIPTION
### PR Category
Custom Device


### PR Types
Bug fixes


### Description
解决PR:[77874](https://github.com/PaddlePaddle/Paddle/pull/77874)对metax（沐曦）硬件引入的精度问题，不影响NV精度性能。


### 是否引起精度变化
否