### PR TITLE
[PHI] Validate `index_put` indices before writing

### DIFF
--- a/paddle/phi/kernels/cpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_kernel.cc
@@ -32,8 +32,8 @@ inline common::ErrorSummary IndexPutIndexOutOfRangeError(int64_t index,
   return common::errors::OutOfRange(
       "The index value %" PRId64
       " is out of bounds for axis %d with size %" PRId64
-      " in index_put. Expected the index to be in range [%" PRId64
-      ", %" PRId64 "), where negative indices are normalized by adding "
+      " in index_put. Expected the index to be in range [%" PRId64 ", %" PRId64
+      "), where negative indices are normalized by adding "
       "the axis size before writing.",
       index,
       axis,
@@ -49,10 +49,9 @@ inline void ValidateIndexPutIndices(const int64_t N,
     for (int i = 0; i < shape.size(); ++i) {
       const int64_t cur_ix = static_cast<int64_t>(*(indices[i] + idx));
       const int64_t axis_size = shape[i];
-      PADDLE_ENFORCE_EQ(
-          IsValidIndexPutIndex(cur_ix, axis_size),
-          true,
-          IndexPutIndexOutOfRangeError(cur_ix, i, axis_size));
+      PADDLE_ENFORCE_EQ(IsValidIndexPutIndex(cur_ix, axis_size),
+                        true,
+                        IndexPutIndexOutOfRangeError(cur_ix, i, axis_size));
     }
   }
 }
@@ -78,10 +77,9 @@ void index_put_kernel(const int64_t N,
       cur_ix = (static_cast<int64_t>(*(indices[i] + idx)));
 #ifndef PADDLE_WITH_MKLML
       const int64_t axis_size = shape[i];
-      PADDLE_ENFORCE_EQ(
-          IsValidIndexPutIndex(cur_ix, axis_size),
-          true,
-          IndexPutIndexOutOfRangeError(cur_ix, i, axis_size));
+      PADDLE_ENFORCE_EQ(IsValidIndexPutIndex(cur_ix, axis_size),
+                        true,
+                        IndexPutIndexOutOfRangeError(cur_ix, i, axis_size));
 #endif
       if (cur_ix < 0) {
         cur_ix += shape[i];

--- a/paddle/phi/kernels/cpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_kernel.cc
@@ -45,19 +45,27 @@ void index_put_kernel(const int64_t N,
           cur_ix,
           -shape[i],
           common::errors::OutOfRange(
-              "The index %" PRId64
-              " is out of bounds for axis %d with size %" PRId64 ".",
+              "The index value %" PRId64
+              " is out of bounds for axis %d with size %" PRId64
+              " in index_put. Expected the index to satisfy -%" PRId64
+              " <= index < %" PRId64 " before negative index normalization.",
               cur_ix,
               i,
+              shape[i],
+              shape[i],
               shape[i]));
       PADDLE_ENFORCE_LT(
           cur_ix,
           shape[i],
           common::errors::OutOfRange(
-              "The index %" PRId64
-              " is out of bounds for axis %d with size %" PRId64 ".",
+              "The index value %" PRId64
+              " is out of bounds for axis %d with size %" PRId64
+              " in index_put. Expected the index to satisfy -%" PRId64
+              " <= index < %" PRId64 " before negative index normalization.",
               cur_ix,
               i,
+              shape[i],
+              shape[i],
               shape[i]));
       if (cur_ix < 0) {
         cur_ix += shape[i];

--- a/paddle/phi/kernels/cpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_kernel.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/kernels/index_put_kernel.h"
 #include <array>
-#include <cinttypes>
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cast_kernel.h"
@@ -45,28 +44,28 @@ void index_put_kernel(const int64_t N,
           cur_ix,
           -shape[i],
           common::errors::OutOfRange(
-              "The index value %" PRId64
-              " is out of bounds for axis %d with size %" PRId64
-              " in index_put. Expected the index to satisfy -%" PRId64
-              " <= index < %" PRId64 " before negative index normalization.",
-              cur_ix,
+              "The index value %lld is out of bounds for axis %d with size "
+              "%lld in index_put. Expected the index to be in range [%lld, "
+              "%lld), where negative indices are normalized by adding the "
+              "axis size before writing.",
+              static_cast<long long>(cur_ix),
               i,
-              shape[i],
-              shape[i],
-              shape[i]));
+              static_cast<long long>(shape[i]),
+              -static_cast<long long>(shape[i]),
+              static_cast<long long>(shape[i])));
       PADDLE_ENFORCE_LT(
           cur_ix,
           shape[i],
           common::errors::OutOfRange(
-              "The index value %" PRId64
-              " is out of bounds for axis %d with size %" PRId64
-              " in index_put. Expected the index to satisfy -%" PRId64
-              " <= index < %" PRId64 " before negative index normalization.",
-              cur_ix,
+              "The index value %lld is out of bounds for axis %d with size "
+              "%lld in index_put. Expected the index to be in range [%lld, "
+              "%lld), where negative indices are normalized by adding the "
+              "axis size before writing.",
+              static_cast<long long>(cur_ix),
               i,
-              shape[i],
-              shape[i],
-              shape[i]));
+              static_cast<long long>(shape[i]),
+              -static_cast<long long>(shape[i]),
+              static_cast<long long>(shape[i])));
       if (cur_ix < 0) {
         cur_ix += shape[i];
       }

--- a/paddle/phi/kernels/cpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_kernel.cc
@@ -22,25 +22,12 @@
 
 namespace phi {
 
-template <typename T>
-void index_put_kernel(const int64_t N,
-                      const T* x UNUSED,
-                      const T* vals,
-                      const int64_t** indices,
-                      const DDim& stride,
-                      const DDim& shape,
-                      int64_t is_single_val_tensor,
-                      bool accumulate,
-                      T* out) {
-#ifdef PADDLE_WITH_MKLML
-#pragma omp parallel for
-#endif
+inline void ValidateIndexPutIndices(const int64_t N,
+                                    const int64_t** indices,
+                                    const DDim& shape) {
   for (int64_t idx = 0; idx < N; ++idx) {
-    int64_t cur_ix = 0;
-    int64_t offset = 0;
-
     for (int i = 0; i < shape.size(); ++i) {
-      cur_ix = (static_cast<int64_t>(*(indices[i] + idx)));
+      const int64_t cur_ix = static_cast<int64_t>(*(indices[i] + idx));
       const int64_t axis_size = shape[i];
       const int64_t lower_bound = -axis_size;
       const int64_t upper_bound = axis_size;
@@ -72,6 +59,29 @@ void index_put_kernel(const int64_t N,
               axis_size,
               lower_bound,
               upper_bound));
+    }
+  }
+}
+
+template <typename T>
+void index_put_kernel(const int64_t N,
+                      const T* x UNUSED,
+                      const T* vals,
+                      const int64_t** indices,
+                      const DDim& stride,
+                      const DDim& shape,
+                      int64_t is_single_val_tensor,
+                      bool accumulate,
+                      T* out) {
+#ifdef PADDLE_WITH_MKLML
+#pragma omp parallel for
+#endif
+  for (int64_t idx = 0; idx < N; ++idx) {
+    int64_t cur_ix = 0;
+    int64_t offset = 0;
+
+    for (int i = 0; i < shape.size(); ++i) {
+      cur_ix = (static_cast<int64_t>(*(indices[i] + idx)));
       if (cur_ix < 0) {
         cur_ix += shape[i];
       }
@@ -118,6 +128,8 @@ void LaunchIndexPutKernel(const Context& dev_ctx,
   for (size_t i = 0; i < indices.size(); ++i) {
     pd_indices[i] = indices[i]->data<int64_t>();
   }
+
+  ValidateIndexPutIndices(numel, pd_indices.data(), x_dims);
 
   index_put_kernel<T>(numel,
                       x_data,

--- a/paddle/phi/kernels/cpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_kernel.cc
@@ -22,6 +22,26 @@
 
 namespace phi {
 
+inline bool IsValidIndexPutIndex(int64_t index, int64_t axis_size) {
+  return index >= -axis_size && index < axis_size;
+}
+
+inline common::ErrorSummary IndexPutIndexOutOfRangeError(int64_t index,
+                                                         int axis,
+                                                         int64_t axis_size) {
+  return common::errors::OutOfRange(
+      "The index value %" PRId64
+      " is out of bounds for axis %d with size %" PRId64
+      " in index_put. Expected the index to be in range [%" PRId64
+      ", %" PRId64 "), where negative indices are normalized by adding "
+      "the axis size before writing.",
+      index,
+      axis,
+      axis_size,
+      -axis_size,
+      axis_size);
+}
+
 inline void ValidateIndexPutIndices(const int64_t N,
                                     const int64_t** indices,
                                     const DDim& shape) {
@@ -29,36 +49,10 @@ inline void ValidateIndexPutIndices(const int64_t N,
     for (int i = 0; i < shape.size(); ++i) {
       const int64_t cur_ix = static_cast<int64_t>(*(indices[i] + idx));
       const int64_t axis_size = shape[i];
-      const int64_t lower_bound = -axis_size;
-      const int64_t upper_bound = axis_size;
-      PADDLE_ENFORCE_GE(
-          cur_ix,
-          lower_bound,
-          common::errors::OutOfRange(
-              "The index value %" PRId64
-              " is out of bounds for axis %d with size %" PRId64
-              " in index_put. Expected the index to be in range [%" PRId64
-              ", %" PRId64 "), where negative indices are normalized by "
-              "adding the axis size before writing.",
-              cur_ix,
-              i,
-              axis_size,
-              lower_bound,
-              upper_bound));
-      PADDLE_ENFORCE_LT(
-          cur_ix,
-          upper_bound,
-          common::errors::OutOfRange(
-              "The index value %" PRId64
-              " is out of bounds for axis %d with size %" PRId64
-              " in index_put. Expected the index to be in range [%" PRId64
-              ", %" PRId64 "), where negative indices are normalized by "
-              "adding the axis size before writing.",
-              cur_ix,
-              i,
-              axis_size,
-              lower_bound,
-              upper_bound));
+      PADDLE_ENFORCE_EQ(
+          IsValidIndexPutIndex(cur_ix, axis_size),
+          true,
+          IndexPutIndexOutOfRangeError(cur_ix, i, axis_size));
     }
   }
 }
@@ -82,6 +76,13 @@ void index_put_kernel(const int64_t N,
 
     for (int i = 0; i < shape.size(); ++i) {
       cur_ix = (static_cast<int64_t>(*(indices[i] + idx)));
+#ifndef PADDLE_WITH_MKLML
+      const int64_t axis_size = shape[i];
+      PADDLE_ENFORCE_EQ(
+          IsValidIndexPutIndex(cur_ix, axis_size),
+          true,
+          IndexPutIndexOutOfRangeError(cur_ix, i, axis_size));
+#endif
       if (cur_ix < 0) {
         cur_ix += shape[i];
       }
@@ -129,7 +130,9 @@ void LaunchIndexPutKernel(const Context& dev_ctx,
     pd_indices[i] = indices[i]->data<int64_t>();
   }
 
+#ifdef PADDLE_WITH_MKLML
   ValidateIndexPutIndices(numel, pd_indices.data(), x_dims);
+#endif
 
   index_put_kernel<T>(numel,
                       x_data,

--- a/paddle/phi/kernels/cpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_kernel.cc
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/index_put_kernel.h"
 #include <array>
+#include <cinttypes>
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cast_kernel.h"
@@ -40,6 +41,24 @@ void index_put_kernel(const int64_t N,
 
     for (int i = 0; i < shape.size(); ++i) {
       cur_ix = (static_cast<int64_t>(*(indices[i] + idx)));
+      PADDLE_ENFORCE_GE(
+          cur_ix,
+          -shape[i],
+          common::errors::OutOfRange(
+              "The index %" PRId64
+              " is out of bounds for axis %d with size %" PRId64 ".",
+              cur_ix,
+              i,
+              shape[i]));
+      PADDLE_ENFORCE_LT(
+          cur_ix,
+          shape[i],
+          common::errors::OutOfRange(
+              "The index %" PRId64
+              " is out of bounds for axis %d with size %" PRId64 ".",
+              cur_ix,
+              i,
+              shape[i]));
       if (cur_ix < 0) {
         cur_ix += shape[i];
       }

--- a/paddle/phi/kernels/cpu/index_put_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_put_kernel.cc
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/index_put_kernel.h"
 #include <array>
+#include <cinttypes>
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cast_kernel.h"
@@ -40,32 +41,37 @@ void index_put_kernel(const int64_t N,
 
     for (int i = 0; i < shape.size(); ++i) {
       cur_ix = (static_cast<int64_t>(*(indices[i] + idx)));
+      const int64_t axis_size = shape[i];
+      const int64_t lower_bound = -axis_size;
+      const int64_t upper_bound = axis_size;
       PADDLE_ENFORCE_GE(
           cur_ix,
-          -shape[i],
+          lower_bound,
           common::errors::OutOfRange(
-              "The index value %lld is out of bounds for axis %d with size "
-              "%lld in index_put. Expected the index to be in range [%lld, "
-              "%lld), where negative indices are normalized by adding the "
-              "axis size before writing.",
-              static_cast<long long>(cur_ix),
+              "The index value %" PRId64
+              " is out of bounds for axis %d with size %" PRId64
+              " in index_put. Expected the index to be in range [%" PRId64
+              ", %" PRId64 "), where negative indices are normalized by "
+              "adding the axis size before writing.",
+              cur_ix,
               i,
-              static_cast<long long>(shape[i]),
-              -static_cast<long long>(shape[i]),
-              static_cast<long long>(shape[i])));
+              axis_size,
+              lower_bound,
+              upper_bound));
       PADDLE_ENFORCE_LT(
           cur_ix,
-          shape[i],
+          upper_bound,
           common::errors::OutOfRange(
-              "The index value %lld is out of bounds for axis %d with size "
-              "%lld in index_put. Expected the index to be in range [%lld, "
-              "%lld), where negative indices are normalized by adding the "
-              "axis size before writing.",
-              static_cast<long long>(cur_ix),
+              "The index value %" PRId64
+              " is out of bounds for axis %d with size %" PRId64
+              " in index_put. Expected the index to be in range [%" PRId64
+              ", %" PRId64 "), where negative indices are normalized by "
+              "adding the axis size before writing.",
+              cur_ix,
               i,
-              static_cast<long long>(shape[i]),
-              -static_cast<long long>(shape[i]),
-              static_cast<long long>(shape[i])));
+              axis_size,
+              lower_bound,
+              upper_bound));
       if (cur_ix < 0) {
         cur_ix += shape[i];
       }

--- a/paddle/phi/kernels/gpu/index_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_kernel.cu
@@ -13,14 +13,48 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/index_put_kernel.h"
+#include <cinttypes>
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/funcs/index_put_utils.h"
 
 namespace phi {
+
+__global__ void ValidateIndexPutCudaKernel(
+    int64_t** indices,
+    Array<int64_t, DDim::kMaxRank> shape,
+    const int rank,
+    const int64_t numel,
+    int* has_error,
+    int64_t* invalid_index,
+    int* invalid_axis) {
+  int64_t idx =
+      static_cast<int64_t>(threadIdx.x) +
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x);
+
+  if (idx >= numel || *has_error) {
+    return;
+  }
+
+#pragma unroll
+  for (int i = 0; i < DDim::kMaxRank; ++i) {
+    if (i >= rank) {
+      break;
+    }
+    int64_t cur_ix = static_cast<int64_t>(*(indices[i] + idx));
+    if (cur_ix < -shape[i] || cur_ix >= shape[i]) {
+      if (atomicCAS(has_error, 0, 1) == 0) {
+        *invalid_index = cur_ix;
+        *invalid_axis = i;
+      }
+      return;
+    }
+  }
+}
 
 template <typename T>
 __global__ void IndexPutCudaKernel(const T* x,
@@ -94,7 +128,81 @@ void LaunchIndexPutCudaKernel(const Context& dev_ctx,
   auto pd_indices =
       funcs::GetDevicePointerArray<int64_t, Context>(dev_ctx, indices, &holder);
 
+  int host_has_error = 0;
+  int64_t host_invalid_index = 0;
+  int host_invalid_axis = 0;
+  auto error_flag = phi::memory_utils::Alloc(
+      dev_ctx.GetPlace(), sizeof(int), dev_ctx.stream());
+  auto invalid_index = phi::memory_utils::Alloc(
+      dev_ctx.GetPlace(), sizeof(int64_t), dev_ctx.stream());
+  auto invalid_axis = phi::memory_utils::Alloc(
+      dev_ctx.GetPlace(), sizeof(int), dev_ctx.stream());
+  phi::memory_utils::Copy(dev_ctx.GetPlace(),
+                          error_flag->ptr(),
+                          phi::CPUPlace(),
+                          &host_has_error,
+                          sizeof(int),
+                          dev_ctx.stream());
+  phi::memory_utils::Copy(dev_ctx.GetPlace(),
+                          invalid_index->ptr(),
+                          phi::CPUPlace(),
+                          &host_invalid_index,
+                          sizeof(int64_t),
+                          dev_ctx.stream());
+  phi::memory_utils::Copy(dev_ctx.GetPlace(),
+                          invalid_axis->ptr(),
+                          phi::CPUPlace(),
+                          &host_invalid_axis,
+                          sizeof(int),
+                          dev_ctx.stream());
+
   auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
+  ValidateIndexPutCudaKernel<<<config.block_per_grid,
+                               config.thread_per_block,
+                               0,
+                               dev_ctx.stream()>>>(pd_indices,
+                                                   shape_array,
+                                                   rank,
+                                                   numel,
+                                                   reinterpret_cast<int*>(
+                                                       error_flag->ptr()),
+                                                   reinterpret_cast<int64_t*>(
+                                                       invalid_index->ptr()),
+                                                   reinterpret_cast<int*>(
+                                                       invalid_axis->ptr()));
+  phi::memory_utils::Copy(phi::CPUPlace(),
+                          &host_has_error,
+                          dev_ctx.GetPlace(),
+                          error_flag->ptr(),
+                          sizeof(int),
+                          dev_ctx.stream());
+  dev_ctx.Wait();
+  if (host_has_error != 0) {
+    phi::memory_utils::Copy(phi::CPUPlace(),
+                            &host_invalid_index,
+                            dev_ctx.GetPlace(),
+                            invalid_index->ptr(),
+                            sizeof(int64_t),
+                            dev_ctx.stream());
+    phi::memory_utils::Copy(phi::CPUPlace(),
+                            &host_invalid_axis,
+                            dev_ctx.GetPlace(),
+                            invalid_axis->ptr(),
+                            sizeof(int),
+                            dev_ctx.stream());
+    dev_ctx.Wait();
+    PADDLE_THROW(common::errors::OutOfRange(
+        "The index value %" PRId64
+        " is out of bounds for axis %d with size %" PRId64
+        " in index_put. Expected the index to satisfy -%" PRId64
+        " <= index < %" PRId64 " before negative index normalization.",
+        host_invalid_index,
+        host_invalid_axis,
+        x_dims[host_invalid_axis],
+        x_dims[host_invalid_axis],
+        x_dims[host_invalid_axis]));
+  }
+
   IndexPutCudaKernel<T>
       <<<config.block_per_grid, config.thread_per_block, 0, dev_ctx.stream()>>>(
           x_data,

--- a/paddle/phi/kernels/gpu/index_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_put_kernel.cu
@@ -13,48 +13,14 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/index_put_kernel.h"
-#include <cinttypes>
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
-#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/funcs/index_put_utils.h"
 
 namespace phi {
-
-__global__ void ValidateIndexPutCudaKernel(
-    int64_t** indices,
-    Array<int64_t, DDim::kMaxRank> shape,
-    const int rank,
-    const int64_t numel,
-    int* has_error,
-    int64_t* invalid_index,
-    int* invalid_axis) {
-  int64_t idx =
-      static_cast<int64_t>(threadIdx.x) +
-      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x);
-
-  if (idx >= numel || *has_error) {
-    return;
-  }
-
-#pragma unroll
-  for (int i = 0; i < DDim::kMaxRank; ++i) {
-    if (i >= rank) {
-      break;
-    }
-    int64_t cur_ix = static_cast<int64_t>(*(indices[i] + idx));
-    if (cur_ix < -shape[i] || cur_ix >= shape[i]) {
-      if (atomicCAS(has_error, 0, 1) == 0) {
-        *invalid_index = cur_ix;
-        *invalid_axis = i;
-      }
-      return;
-    }
-  }
-}
 
 template <typename T>
 __global__ void IndexPutCudaKernel(const T* x,
@@ -128,81 +94,7 @@ void LaunchIndexPutCudaKernel(const Context& dev_ctx,
   auto pd_indices =
       funcs::GetDevicePointerArray<int64_t, Context>(dev_ctx, indices, &holder);
 
-  int host_has_error = 0;
-  int64_t host_invalid_index = 0;
-  int host_invalid_axis = 0;
-  auto error_flag = phi::memory_utils::Alloc(
-      dev_ctx.GetPlace(), sizeof(int), dev_ctx.stream());
-  auto invalid_index = phi::memory_utils::Alloc(
-      dev_ctx.GetPlace(), sizeof(int64_t), dev_ctx.stream());
-  auto invalid_axis = phi::memory_utils::Alloc(
-      dev_ctx.GetPlace(), sizeof(int), dev_ctx.stream());
-  phi::memory_utils::Copy(dev_ctx.GetPlace(),
-                          error_flag->ptr(),
-                          phi::CPUPlace(),
-                          &host_has_error,
-                          sizeof(int),
-                          dev_ctx.stream());
-  phi::memory_utils::Copy(dev_ctx.GetPlace(),
-                          invalid_index->ptr(),
-                          phi::CPUPlace(),
-                          &host_invalid_index,
-                          sizeof(int64_t),
-                          dev_ctx.stream());
-  phi::memory_utils::Copy(dev_ctx.GetPlace(),
-                          invalid_axis->ptr(),
-                          phi::CPUPlace(),
-                          &host_invalid_axis,
-                          sizeof(int),
-                          dev_ctx.stream());
-
   auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
-  ValidateIndexPutCudaKernel<<<config.block_per_grid,
-                               config.thread_per_block,
-                               0,
-                               dev_ctx.stream()>>>(pd_indices,
-                                                   shape_array,
-                                                   rank,
-                                                   numel,
-                                                   reinterpret_cast<int*>(
-                                                       error_flag->ptr()),
-                                                   reinterpret_cast<int64_t*>(
-                                                       invalid_index->ptr()),
-                                                   reinterpret_cast<int*>(
-                                                       invalid_axis->ptr()));
-  phi::memory_utils::Copy(phi::CPUPlace(),
-                          &host_has_error,
-                          dev_ctx.GetPlace(),
-                          error_flag->ptr(),
-                          sizeof(int),
-                          dev_ctx.stream());
-  dev_ctx.Wait();
-  if (host_has_error != 0) {
-    phi::memory_utils::Copy(phi::CPUPlace(),
-                            &host_invalid_index,
-                            dev_ctx.GetPlace(),
-                            invalid_index->ptr(),
-                            sizeof(int64_t),
-                            dev_ctx.stream());
-    phi::memory_utils::Copy(phi::CPUPlace(),
-                            &host_invalid_axis,
-                            dev_ctx.GetPlace(),
-                            invalid_axis->ptr(),
-                            sizeof(int),
-                            dev_ctx.stream());
-    dev_ctx.Wait();
-    PADDLE_THROW(common::errors::OutOfRange(
-        "The index value %" PRId64
-        " is out of bounds for axis %d with size %" PRId64
-        " in index_put. Expected the index to satisfy -%" PRId64
-        " <= index < %" PRId64 " before negative index normalization.",
-        host_invalid_index,
-        host_invalid_axis,
-        x_dims[host_invalid_axis],
-        x_dims[host_invalid_axis],
-        x_dims[host_invalid_axis]));
-  }
-
   IndexPutCudaKernel<T>
       <<<config.block_per_grid, config.thread_per_block, 0, dev_ctx.stream()>>>(
           x_data,

--- a/test/legacy_test/test_index_put_op.py
+++ b/test/legacy_test/test_index_put_op.py
@@ -659,6 +659,9 @@ class TestIndexPutInplaceAPI1(TestIndexPutInplaceAPI):
 
 class TestIndexPutOutOfBoundsIndex(unittest.TestCase):
     def test_inplace_negative_index_out_of_bounds_cpu(self):
+        if core.is_compiled_with_rocm():
+            return
+
         paddle.disable_static()
         paddle.device.set_device("cpu")
 

--- a/test/legacy_test/test_index_put_op.py
+++ b/test/legacy_test/test_index_put_op.py
@@ -659,9 +659,6 @@ class TestIndexPutInplaceAPI1(TestIndexPutInplaceAPI):
 
 class TestIndexPutOutOfBoundsIndex(unittest.TestCase):
     def test_inplace_negative_index_out_of_bounds_cpu(self):
-        if core.is_compiled_with_rocm():
-            return
-
         paddle.disable_static()
         paddle.device.set_device("cpu")
 

--- a/test/legacy_test/test_index_put_op.py
+++ b/test/legacy_test/test_index_put_op.py
@@ -657,6 +657,31 @@ class TestIndexPutInplaceAPI1(TestIndexPutInplaceAPI):
         self.accumulate = True
 
 
+class TestIndexPutOutOfBoundsIndex(unittest.TestCase):
+    def test_inplace_negative_index_out_of_bounds(self):
+        paddle.disable_static()
+        paddle.device.set_device("cpu")
+
+        x = paddle.to_tensor([-39.0625], dtype="float64")
+        indices = (paddle.to_tensor([-2], dtype="int32"),)
+        value = paddle.to_tensor([-39.0625], dtype="float64")
+
+        with self.assertRaises(IndexError):
+            paddle.index_put_(x, indices, value, accumulate=False)
+
+    def test_valid_negative_index(self):
+        paddle.disable_static()
+        paddle.device.set_device("cpu")
+
+        x = paddle.to_tensor([1.0], dtype="float64")
+        indices = (paddle.to_tensor([-1], dtype="int32"),)
+        value = paddle.to_tensor([2.0], dtype="float64")
+
+        out = paddle.index_put_(x, indices, value, accumulate=False)
+
+        np.testing.assert_allclose(np.array([2.0]), out.numpy(), atol=1e-7)
+
+
 class TestIndexPutAPIBackward(unittest.TestCase):
     def setUp(self):
         self.setPlace()

--- a/test/legacy_test/test_index_put_op.py
+++ b/test/legacy_test/test_index_put_op.py
@@ -658,9 +658,9 @@ class TestIndexPutInplaceAPI1(TestIndexPutInplaceAPI):
 
 
 class TestIndexPutOutOfBoundsIndex(unittest.TestCase):
-    def _run_out_of_bounds_case(self, place):
+    def test_inplace_negative_index_out_of_bounds_cpu(self):
         paddle.disable_static()
-        paddle.device.set_device(place)
+        paddle.device.set_device("cpu")
 
         x = paddle.to_tensor([-39.0625], dtype="float64")
         indices = (paddle.to_tensor([-2], dtype="int32"),)
@@ -668,15 +668,6 @@ class TestIndexPutOutOfBoundsIndex(unittest.TestCase):
 
         with self.assertRaises(IndexError):
             paddle.index_put_(x, indices, value, accumulate=False)
-
-    def test_inplace_negative_index_out_of_bounds_cpu(self):
-        self._run_out_of_bounds_case("cpu")
-
-    @unittest.skipIf(
-        not core.is_compiled_with_cuda(), 'core is not compiled with CUDA'
-    )
-    def test_inplace_negative_index_out_of_bounds_cuda(self):
-        self._run_out_of_bounds_case("gpu")
 
     def test_valid_negative_index(self):
         paddle.disable_static()

--- a/test/legacy_test/test_index_put_op.py
+++ b/test/legacy_test/test_index_put_op.py
@@ -658,9 +658,9 @@ class TestIndexPutInplaceAPI1(TestIndexPutInplaceAPI):
 
 
 class TestIndexPutOutOfBoundsIndex(unittest.TestCase):
-    def test_inplace_negative_index_out_of_bounds(self):
+    def _run_out_of_bounds_case(self, place):
         paddle.disable_static()
-        paddle.device.set_device("cpu")
+        paddle.device.set_device(place)
 
         x = paddle.to_tensor([-39.0625], dtype="float64")
         indices = (paddle.to_tensor([-2], dtype="int32"),)
@@ -668,6 +668,15 @@ class TestIndexPutOutOfBoundsIndex(unittest.TestCase):
 
         with self.assertRaises(IndexError):
             paddle.index_put_(x, indices, value, accumulate=False)
+
+    def test_inplace_negative_index_out_of_bounds_cpu(self):
+        self._run_out_of_bounds_case("cpu")
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda(), 'core is not compiled with CUDA'
+    )
+    def test_inplace_negative_index_out_of_bounds_cuda(self):
+        self._run_out_of_bounds_case("gpu")
 
     def test_valid_negative_index(self):
         paddle.disable_static()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
本 PR 修复 #78302：在 CPU `index_put` 计算写入偏移前，先校验索引范围。

根因：
- CPU `index_put` kernel 在执行 `cur_ix += shape[i]` 进行负索引归一化前，没有先检查原始索引是否落在 `[-shape[i], shape[i])` 内；
- 当目标张量长度为 1、索引为 `-2` 时，会得到负的写入偏移，并写到目标缓冲区左侧，和 issue 中的 ASAN 报告一致。

改动：
- 在 `paddle/phi/kernels/cpu/index_put_kernel.cc` 中，为 CPU 路径补充索引范围检查，再计算 offset；
- 在 `test/legacy_test/test_index_put_op.py` 中补充 CPU 越界负索引回归测试；
- 保持合法负索引（如 `-1`）的现有语义不变。

说明：
- 我最初尝试在本 PR 中一并补 CUDA 修复，但第一版 GPU 方案会在热路径引入额外校验 pass 和 host 同步。根据 review，我已将该版本从本 PR 中移除，避免引入性能回退；
- CUDA 路径仍需后续以“不影响成功路径异步执行”的方案单独处理。

验证：
- `python3 -m py_compile test/legacy_test/test_index_put_op.py`
- 由于当前环境没有本地 Paddle build / runtime，无法在本地完成完整运行复现和单测执行。

### 是否引起精度变化
否
