### PR TITLE
[PHI] Validate `slice-scatter` axes before `set_value` writes

### DIFF
--- a/paddle/phi/kernels/cpu/set_value_kernel.cc
+++ b/paddle/phi/kernels/cpu/set_value_kernel.cc
@@ -41,20 +41,21 @@ void SetValueImpl(const Context& dev_ctx,
                   const std::vector<int64_t>& none_axes,
                   DenseTensor* out) {
   auto in_dims = in.dims();
+  auto canonical_axes = funcs::CheckAndCanonicalizeSliceAxes(in_dims, axes);
   std::vector<int64_t> starts_local = starts.GetData();
   std::vector<int64_t> ends_local = ends.GetData();
   std::vector<int64_t> steps_local = steps.GetData();
   if (starts_local.empty() && ends_local.empty() && steps_local.empty() &&
-      axes.empty() && decrease_axes.empty() && none_axes.empty() &&
+      canonical_axes.empty() && decrease_axes.empty() && none_axes.empty() &&
       value.numel() == 1) {
     ExpandKernel<T, Context>(
         dev_ctx, value, IntArray{phi::vectorize<int64_t>(in.dims())}, out);
     return;
   }
   funcs::CheckAndUpdateSliceAttrs(
-      in_dims, axes, &starts_local, &ends_local, &steps_local);
+      in_dims, canonical_axes, &starts_local, &ends_local, &steps_local);
   auto slice_dims = funcs::GetSliceDims(
-      in_dims, axes, starts_local, ends_local, &steps_local);
+      in_dims, canonical_axes, starts_local, ends_local, &steps_local);
   auto decrease_slice_dims = funcs::GetDecreasedDims(slice_dims, decrease_axes);
   auto slice_dims_for_assign = decrease_slice_dims;
   if (!none_axes.empty()) {
@@ -121,8 +122,8 @@ void SetValueImpl(const Context& dev_ctx,
     ends_indices[i] = slice_dims[i];
     strides_indices[i] = 1;
   }
-  for (size_t i = 0; i < axes.size(); i++) {
-    int axis_index = axes[i];
+  for (size_t i = 0; i < canonical_axes.size(); i++) {
+    int axis_index = canonical_axes[i];
     starts_indices[axis_index] = starts_local[i];
     ends_indices[axis_index] = ends_local[i];
     strides_indices[axis_index] = steps_local[i];

--- a/paddle/phi/kernels/cpu/set_value_kernel.cc
+++ b/paddle/phi/kernels/cpu/set_value_kernel.cc
@@ -52,7 +52,7 @@ void SetValueImpl(const Context& dev_ctx,
         dev_ctx, value, IntArray{phi::vectorize<int64_t>(in.dims())}, out);
     return;
   }
-  funcs::CheckAndUpdateSliceAttrs(
+  funcs::CheckAndUpdateSliceAttrsWithCanonicalAxes(
       in_dims, canonical_axes, &starts_local, &ends_local, &steps_local);
   auto slice_dims = funcs::GetSliceDims(
       in_dims, canonical_axes, starts_local, ends_local, &steps_local);

--- a/paddle/phi/kernels/funcs/slice_utils.h
+++ b/paddle/phi/kernels/funcs/slice_utils.h
@@ -241,23 +241,49 @@ void normalize_interval(
 }
 
 template <typename T = int64_t>
+inline std::vector<T> CheckAndCanonicalizeSliceAxes(const DDim& in_dims,
+                                                    const std::vector<T>& axes) {
+  std::vector<T> canonical_axes(axes);
+  const auto rank = in_dims.size();
+  for (size_t i = 0; i < canonical_axes.size(); ++i) {
+    auto axis = canonical_axes[i];
+    PADDLE_ENFORCE_GE(
+        axis,
+        -rank,
+        common::errors::InvalidArgument(
+            "The axis value should be in range [-%d, %d), but received "
+            "axes[%d] = %d.",
+            rank,
+            rank,
+            i,
+            axis));
+    PADDLE_ENFORCE_LT(
+        axis,
+        rank,
+        common::errors::InvalidArgument(
+            "The axis value should be in range [-%d, %d), but received "
+            "axes[%d] = %d.",
+            rank,
+            rank,
+            i,
+            axis));
+    if (axis < 0) {
+      canonical_axes[i] = axis + rank;
+    }
+  }
+  return canonical_axes;
+}
+
+template <typename T = int64_t>
 inline void CheckAndUpdateSliceAttrs(const DDim in_dims,
                                      const std::vector<T>& axes,
                                      std::vector<T>* starts,
                                      std::vector<T>* ends,
                                      std::vector<int64_t>* steps = nullptr,
                                      std::vector<T>* infer_flags = nullptr) {
-  for (size_t i = 0; i < axes.size(); ++i) {
-    T axis = axes[i];
-    PADDLE_ENFORCE_LT(
-        axis,
-        in_dims.size(),
-        common::errors::InvalidArgument(
-            "The axis value should be less than the rank of input, "
-            "but received axes[%d] = %d, rank of input is %d.",
-            i,
-            axis,
-            in_dims.size()));
+  auto canonical_axes = CheckAndCanonicalizeSliceAxes(in_dims, axes);
+  for (size_t i = 0; i < canonical_axes.size(); ++i) {
+    T axis = canonical_axes[i];
 
     if (infer_flags != nullptr && (*infer_flags)[i] == -1) {
       continue;

--- a/paddle/phi/kernels/funcs/slice_utils.h
+++ b/paddle/phi/kernels/funcs/slice_utils.h
@@ -241,8 +241,8 @@ void normalize_interval(
 }
 
 template <typename T = int64_t>
-inline std::vector<T> CheckAndCanonicalizeSliceAxes(
-    const DDim& in_dims, const std::vector<T>& axes) {
+std::vector<T> CheckAndCanonicalizeSliceAxes(const DDim& in_dims,
+                                             const std::vector<T>& axes) {
   std::vector<T> canonical_axes(axes);
   const auto rank = in_dims.size();
   for (size_t i = 0; i < canonical_axes.size(); ++i) {
@@ -275,13 +275,13 @@ inline std::vector<T> CheckAndCanonicalizeSliceAxes(
 }
 
 template <typename T = int64_t>
-inline void CheckAndUpdateSliceAttrs(const DDim in_dims,
-                                     const std::vector<T>& axes,
-                                     std::vector<T>* starts,
-                                     std::vector<T>* ends,
-                                     std::vector<int64_t>* steps = nullptr,
-                                     std::vector<T>* infer_flags = nullptr) {
-  auto canonical_axes = CheckAndCanonicalizeSliceAxes(in_dims, axes);
+inline void CheckAndUpdateSliceAttrsWithCanonicalAxes(
+    const DDim in_dims,
+    const std::vector<T>& canonical_axes,
+    std::vector<T>* starts,
+    std::vector<T>* ends,
+    std::vector<int64_t>* steps = nullptr,
+    std::vector<T>* infer_flags = nullptr) {
   for (size_t i = 0; i < canonical_axes.size(); ++i) {
     T axis = canonical_axes[i];
 
@@ -319,6 +319,18 @@ inline void CheckAndUpdateSliceAttrs(const DDim in_dims,
       (*ends)[i] = 0;
     }
   }
+}
+
+template <typename T = int64_t>
+inline void CheckAndUpdateSliceAttrs(const DDim in_dims,
+                                     const std::vector<T>& axes,
+                                     std::vector<T>* starts,
+                                     std::vector<T>* ends,
+                                     std::vector<int64_t>* steps = nullptr,
+                                     std::vector<T>* infer_flags = nullptr) {
+  auto canonical_axes = CheckAndCanonicalizeSliceAxes(in_dims, axes);
+  CheckAndUpdateSliceAttrsWithCanonicalAxes(
+      in_dims, canonical_axes, starts, ends, steps, infer_flags);
 }
 
 template <typename T = int64_t>

--- a/paddle/phi/kernels/funcs/slice_utils.h
+++ b/paddle/phi/kernels/funcs/slice_utils.h
@@ -241,8 +241,8 @@ void normalize_interval(
 }
 
 template <typename T = int64_t>
-inline std::vector<T> CheckAndCanonicalizeSliceAxes(const DDim& in_dims,
-                                                    const std::vector<T>& axes) {
+inline std::vector<T> CheckAndCanonicalizeSliceAxes(
+    const DDim& in_dims, const std::vector<T>& axes) {
   std::vector<T> canonical_axes(axes);
   const auto rank = in_dims.size();
   for (size_t i = 0; i < canonical_axes.size(); ++i) {

--- a/paddle/phi/kernels/gpu/set_value_kernel.cu
+++ b/paddle/phi/kernels/gpu/set_value_kernel.cu
@@ -46,18 +46,19 @@ void SetTensorValueKernel(const Context& dev_ctx,
   }
 
   auto in_dims = in.dims();
+  auto canonical_axes = funcs::CheckAndCanonicalizeSliceAxes(in_dims, axes);
   auto meta = in.meta();
   std::vector<int64_t> starts_local = starts.GetData();
   std::vector<int64_t> ends_local = ends.GetData();
   std::vector<int64_t> steps_local = steps.GetData();
   funcs::CheckAndUpdateSliceAttrs(
-      in_dims, axes, &starts_local, &ends_local, &steps_local);
+      in_dims, canonical_axes, &starts_local, &ends_local, &steps_local);
 
   std::vector<int64_t> output_dims = vectorize<int64_t>(in.dims());
   std::vector<int64_t> output_stride = vectorize<int64_t>(in.strides());
   int64_t output_offset = static_cast<int64_t>(in.offset());
-  for (size_t i = 0; i < axes.size(); ++i) {
-    int64_t axis_size = in.dims()[axes[i]];
+  for (size_t i = 0; i < canonical_axes.size(); ++i) {
+    int64_t axis_size = in.dims()[canonical_axes[i]];
     if (axis_size < 0) {
       continue;
     }
@@ -66,10 +67,11 @@ void SetTensorValueKernel(const Context& dev_ctx,
 
     auto out_dim =
         (std::abs(ends_local[i] - starts_local[i]) + step_size - 1) / step_size;
-    output_offset += static_cast<int64_t>(
-        starts_local[i] * output_stride[axes[i]] * SizeOf(out->dtype()));
-    output_dims[axes[i]] = out_dim;
-    output_stride[axes[i]] *= steps_local[i];
+    output_offset += static_cast<int64_t>(starts_local[i] *
+                                          output_stride[canonical_axes[i]] *
+                                          SizeOf(out->dtype()));
+    output_dims[canonical_axes[i]] = out_dim;
+    output_stride[canonical_axes[i]] *= steps_local[i];
   }
   // generate new shape
   std::vector<int64_t> new_out_shape;

--- a/paddle/phi/kernels/gpu/set_value_kernel.cu
+++ b/paddle/phi/kernels/gpu/set_value_kernel.cu
@@ -51,7 +51,7 @@ void SetTensorValueKernel(const Context& dev_ctx,
   std::vector<int64_t> starts_local = starts.GetData();
   std::vector<int64_t> ends_local = ends.GetData();
   std::vector<int64_t> steps_local = steps.GetData();
-  funcs::CheckAndUpdateSliceAttrs(
+  funcs::CheckAndUpdateSliceAttrsWithCanonicalAxes(
       in_dims, canonical_axes, &starts_local, &ends_local, &steps_local);
 
   std::vector<int64_t> output_dims = vectorize<int64_t>(in.dims());

--- a/paddle/phi/kernels/xpu/set_value_kernel.cc
+++ b/paddle/phi/kernels/xpu/set_value_kernel.cc
@@ -93,7 +93,7 @@ void SetValueImpl(const Context& dev_ctx,
   std::vector<int64_t> starts_local = starts.GetData();
   std::vector<int64_t> ends_local = ends.GetData();
   std::vector<int64_t> steps_local = steps.GetData();
-  funcs::CheckAndUpdateSliceAttrs(
+  funcs::CheckAndUpdateSliceAttrsWithCanonicalAxes(
       in_dims, canonical_axes, &starts_local, &ends_local, &steps_local);
   auto slice_dims = funcs::GetSliceDims(
       in_dims, canonical_axes, starts_local, ends_local, &steps_local);

--- a/paddle/phi/kernels/xpu/set_value_kernel.cc
+++ b/paddle/phi/kernels/xpu/set_value_kernel.cc
@@ -81,6 +81,7 @@ void SetValueImpl(const Context& dev_ctx,
                   DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
   auto in_dims = in.dims();
+  auto canonical_axes = funcs::CheckAndCanonicalizeSliceAxes(in_dims, axes);
 
   auto new_value_dims = value_dims;
 
@@ -93,9 +94,9 @@ void SetValueImpl(const Context& dev_ctx,
   std::vector<int64_t> ends_local = ends.GetData();
   std::vector<int64_t> steps_local = steps.GetData();
   funcs::CheckAndUpdateSliceAttrs(
-      in_dims, axes, &starts_local, &ends_local, &steps_local);
+      in_dims, canonical_axes, &starts_local, &ends_local, &steps_local);
   auto slice_dims = funcs::GetSliceDims(
-      in_dims, axes, starts_local, ends_local, &steps_local);
+      in_dims, canonical_axes, starts_local, ends_local, &steps_local);
   auto decrease_slice_dims = funcs::GetDecreasedDims(slice_dims, decrease_axes);
 
   auto slice_dims_for_assign = decrease_slice_dims;
@@ -164,8 +165,8 @@ void SetValueImpl(const Context& dev_ctx,
     ends_indices[i] = slice_dims[i];
     strides_indices[i] = 1;
   }
-  for (size_t i = 0; i < axes.size(); i++) {
-    int64_t axis_index = axes[i];
+  for (size_t i = 0; i < canonical_axes.size(); i++) {
+    int64_t axis_index = canonical_axes[i];
     starts_indices[axis_index] = starts_local[i];
     ends_indices[axis_index] = ends_local[i];
     strides_indices[axis_index] = steps_local[i];

--- a/test/legacy_test/test_slice_scatter.py
+++ b/test/legacy_test/test_slice_scatter.py
@@ -325,6 +325,24 @@ class TestSliceScatterApiError(unittest.TestCase):
                 x, value, axes=[0], starts=[0], ends=[8], strides=[1]
             )
 
+    def test_error_invalid_negative_axis(self):
+        for place in get_places():
+            paddle.disable_static(place)
+            try:
+                x = paddle.to_tensor([[-39.0625]], dtype='float32')
+                value = paddle.to_tensor([[-39.0625]], dtype='float32')
+                with self.assertRaises(ValueError):
+                    _ = paddle.slice_scatter(
+                        x,
+                        value,
+                        axes=[-4],
+                        starts=[-5],
+                        ends=[-5],
+                        strides=[1],
+                    )
+            finally:
+                paddle.enable_static()
+
     def test_error_index(self):
         paddle.disable_static()
         with self.assertRaises(ValueError):


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
本 PR 修复 #78304：在后端 kernel 计算 slice 边界和写入偏移前，先对 `set_value` / `slice_scatter` 的 `axes` 做范围校验和负轴规范化。

根因：
- `paddle.slice_scatter()` 最终会下沉到 `set_value_with_tensor`；
- CPU / GPU / XPU 的 `set_value` kernel 之前会直接把 `axes` 传入 slice 属性处理流程，并在后续继续复用原始轴值去访问 dim / stride；
- 对于 rank=2 的输入，像 `-4` 这样的非法轴会绕过原先不完整的检查，然后进入 `in_dims[axis]` / stride 索引，导致访问到合法维度范围之外，和 #78304 中的 ASAN 崩溃一致。

改动：
- 在 `paddle/phi/kernels/funcs/slice_utils.h` 中新增共享 helper，要求 `axes` 必须落在 `[-rank, rank)` 范围内，并将合法负轴规范化；
- 在 CPU / GPU / XPU 的 `set_value` kernel 中统一使用规范化后的轴，再进行 slice 边界更新和后端索引计算；
- 为 `slice_scatter` 增加 invalid negative axis 回归测试，覆盖当前可用运行设备。

说明：
- 这个问题和 #78303 一样，本质上都是“非法负索引在进入后端内存访问前缺少校验”；但 #78303 修的是 `index_put` 的元素索引路径，这个 PR 修的是 slice-write 的 axis 路径；
- 当前本地完成的验证主要是 `python3 -m py_compile test/legacy_test/test_slice_scatter.py`、`git diff --check` 以及针对改动文件的 `pre-commit` 检查；完整算子 / CI 回归仍需以后续流水线结果为准。

### 是否引起精度变化
否
