### PR TITLE
Fix 0-size index tensor crash in put_along_axis

### DIFF
--- a/paddle/phi/kernels/cpu/put_along_axis_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/put_along_axis_grad_kernel.cc
@@ -35,6 +35,24 @@ void PutAlongAxisGradKernel(const Context& dev_ctx,
                             bool include_self,
                             DenseTensor* x_grad,
                             DenseTensor* value_grad) {
+  // Early return when x or index is empty (has a 0-size dimension).
+  // When index is empty, no scatter was performed in forward, so
+  // x_grad = out_grad and value_grad is all zeros (with 0-size shape).
+  if (x.numel() == 0 || index.numel() == 0) {
+    if (x_grad) {
+      dev_ctx.template Alloc<T>(x_grad);
+      if (x.numel() == 0) {
+        return;
+      }
+      Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
+    }
+    if (value_grad) {
+      value_grad->Resize(index.dims());
+      dev_ctx.template Alloc<T>(value_grad);
+      // value_grad has 0-size (since index has 0-size), no memset needed
+    }
+    return;
+  }
   const auto& index_type = index.dtype();
   if (x_grad) {
     Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);

--- a/paddle/phi/kernels/cpu/put_along_axis_kernel.cc
+++ b/paddle/phi/kernels/cpu/put_along_axis_kernel.cc
@@ -33,6 +33,11 @@ void PutAlongAxisKernel(const Context& dev_ctx,
                         bool include_self,
                         DenseTensor* out) {
   Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+  // Early return when the index tensor is empty (has a 0-size dimension).
+  // Nothing to scatter; the output is just a copy of the input.
+  if (index.numel() == 0) {
+    return;
+  }
   const auto& index_type = index.dtype();
   if (reduce == "add") {
     if (index_type == DataType::INT32) {

--- a/paddle/phi/kernels/gpu/put_along_axis_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/put_along_axis_grad_kernel.cu
@@ -36,12 +36,21 @@ void PutAlongAxisGradKernel(const Context& dev_ctx,
                             bool include_self,
                             DenseTensor* x_grad,
                             DenseTensor* value_grad) {
-  if (x.numel() == 0) {
+  // Early return when x or index is empty (has a 0-size dimension).
+  // When index is empty, no scatter was performed in forward, so
+  // x_grad = out_grad and value_grad is all zeros (with 0-size shape).
+  if (x.numel() == 0 || index.numel() == 0) {
     if (x_grad) {
       dev_ctx.template Alloc<T>(x_grad);
+      if (x.numel() == 0) {
+        return;
+      }
+      Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
     }
     if (value_grad) {
+      value_grad->Resize(index.dims());
       dev_ctx.template Alloc<T>(value_grad);
+      // value_grad has 0-size (since index has 0-size), no need to fill
     }
     return;
   }

--- a/paddle/phi/kernels/gpu/put_along_axis_kernel.cu
+++ b/paddle/phi/kernels/gpu/put_along_axis_kernel.cu
@@ -35,6 +35,11 @@ void PutAlongAxisKernel(const Context& dev_ctx,
   const auto& index_type = index.dtype();
 
   Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+  // Early return when the index tensor is empty (has a 0-size dimension).
+  // Nothing to scatter; the output is just a copy of the input.
+  if (index.numel() == 0) {
+    return;
+  }
   if (reduce == "add") {
     if (index_type == DataType::INT32) {
       funcs::gpu_scatter_add_kernel<T, int32_t>(

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -7506,6 +7506,10 @@ def put_along_axis(
             "`indices` and `arr` must have the same number of dimensions!"
         )
     axis = non_negative_axis(arr, axis)
+    # Early return when the index tensor is empty (has a 0-size dimension).
+    # Nothing to scatter; the output is just a copy of the input.
+    if in_dynamic_mode() and 0 in indices.shape:
+        return arr.clone()
     if broadcast:
         if has_dynamic_shape(arr.shape) or has_dynamic_shape(indices.shape):
             arr_shape = paddle.shape(arr)
@@ -7625,6 +7629,10 @@ def put_along_axis_(
             "`indices` and `arr` must have the same number of dimensions!"
         )
     axis = non_negative_axis(arr, axis)
+    # Early return when the index tensor is empty (has a 0-size dimension).
+    # Nothing to scatter; return the original tensor unchanged.
+    if 0 in indices.shape:
+        return arr
     if broadcast:
         broadcast_shape = infer_broadcast_shape(arr, indices, axis)
         values = (


### PR DESCRIPTION
## PR Category

Bug fix

## Description

Fix `paddle.Tensor.put_along_axis` crash with `(External) CUDA error(9)` (`cudaErrorInvalidConfiguration`) when the index tensor has a 0-size dimension (e.g., shape `[2, 0]`).

**Root cause**: When the index tensor has a 0-size dimension, the CUDA scatter kernel launches with invalid grid/block dimensions, causing `cudaErrorInvalidConfiguration`. PyTorch handles this gracefully via early-return guards in both `scatter_shape_check` and `_launch_scatter_gather_kernel`.

**Fix**: Add early-return guards at multiple layers:
- **Python layer** (`manipulation.py`): `put_along_axis()` and `put_along_axis_()` return early when any index dimension is 0
- **C++ forward kernels** (CPU & GPU): Return after copying input to output when `index.numel() == 0`
- **C++ grad kernels** (CPU & GPU): Properly handle 0-size index by copying `out_grad` to `x_grad` and sizing `value_grad` with the 0-size shape

## Testing

- 16/16 custom tests passed (CPU + GPU), covering:
  - Original crash case (index `[2, 0]`, axis=1)
  - 0-size on different axes (axis=0)
  - All-zero-size tensors
  - Normal (non-zero) tensor regression
  - 3D tensors with 0-size dimension
  - int32 index dtype
  - All 6 reduce operations (assign, add, mul, mean, amin, amax)
  - Inplace `put_along_axis_`
- 77/77 existing unit tests passed (`test_put_along_axis_op.py`)
- All pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>