### PR TITLE
[PAA] Align linalg.solve and linalg.inv with PyTorch

### DIFF
--- a/paddle/phi/kernels/funcs/matrix_inverse.cc
+++ b/paddle/phi/kernels/funcs/matrix_inverse.cc
@@ -22,7 +22,12 @@ template <typename Context, typename T>
 void MatrixInverseFunctor<Context, T>::operator()(const Context& dev_ctx,
                                                   const DenseTensor& a,
                                                   DenseTensor* a_inv) {
-  ComputeInverseEigen<Context, T>(dev_ctx, a, a_inv);
+  if constexpr (std::is_same_v<T, phi::complex64> ||
+                std::is_same_v<T, phi::complex128>) {
+    ComputeInverseEigen<Context, T>(dev_ctx, a, a_inv);
+  } else {
+    ComputeInverseBySolve<Context, T>(dev_ctx, a, a_inv);
+  }
 }
 
 template class MatrixInverseFunctor<CPUContext, float>;

--- a/paddle/phi/kernels/funcs/matrix_inverse.cu
+++ b/paddle/phi/kernels/funcs/matrix_inverse.cu
@@ -25,6 +25,14 @@ void MatrixInverseFunctor<Context, T>::operator()(const Context& dev_ctx,
                                                   const DenseTensor& a,
                                                   DenseTensor* a_inv) {
 #ifndef PADDLE_WITH_HIP
+  if constexpr (!(std::is_same_v<T, phi::complex64> ||
+                  std::is_same_v<T, phi::complex128>)) {
+    // Align real-valued inverse with PyTorch by reusing the shared LU-solve
+    // backend on both CPU and CUDA: inv(A) == solve(A, I).
+    ComputeInverseBySolve<Context, T>(dev_ctx, a, a_inv);
+    return;
+  }
+
   const auto& mat_dims = a.dims();
   const int rank = mat_dims.size();
   if (mat_dims[rank - 1] > std::numeric_limits<int>::max()) {
@@ -136,7 +144,12 @@ void MatrixInverseFunctor<Context, T>::operator()(const Context& dev_ctx,
                           info[i]));
   }
 #else
-  ComputeInverseEigen<Context, T>(dev_ctx, a, a_inv);
+  if constexpr (std::is_same_v<T, phi::complex64> ||
+                std::is_same_v<T, phi::complex128>) {
+    ComputeInverseEigen<Context, T>(dev_ctx, a, a_inv);
+  } else {
+    ComputeInverseBySolve<Context, T>(dev_ctx, a, a_inv);
+  }
 #endif
 }
 

--- a/paddle/phi/kernels/funcs/matrix_inverse.h
+++ b/paddle/phi/kernels/funcs/matrix_inverse.h
@@ -15,15 +15,62 @@ limitations under the License. */
 #pragma once
 
 #include <string>
+#include <type_traits>
 
 #include "Eigen/Core"
 #include "Eigen/LU"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/enforce.h"
+#include "paddle/phi/kernels/funcs/for_range.h"
+#include "paddle/phi/kernels/funcs/math_function.h"
+#include "paddle/phi/kernels/funcs/matrix_solve.h"
 
 namespace phi {
 namespace funcs {
+
+template <typename T>
+struct BatchedEyeFunctor {
+  BatchedEyeFunctor(int64_t batch_stride, int64_t n, T* out)
+      : batch_stride_(batch_stride), n_(n), out_(out) {}
+
+  HOSTDEVICE void operator()(size_t idx) const {
+    const int64_t batch_idx = idx / n_;
+    const int64_t diag_idx = idx % n_;
+    out_[batch_idx * batch_stride_ + diag_idx * n_ + diag_idx] =
+        static_cast<T>(1);
+  }
+
+  int64_t batch_stride_;
+  int64_t n_;
+  T* out_;
+};
+
+template <typename Context, typename T>
+void CreateBatchedIdentityMatrix(const Context& dev_ctx,
+                                 const DDim& dims,
+                                 DenseTensor* identity) {
+  identity->Resize(dims);
+  T* identity_data = dev_ctx.template Alloc<T>(identity);
+  funcs::SetConstant<Context, T> set_zero;
+  set_zero(dev_ctx, identity, static_cast<T>(0));
+
+  const int rank = dims.size();
+  const int64_t n = dims[rank - 1];
+  const int64_t batch_size = rank > 2 ? identity->numel() / (n * n) : 1;
+  funcs::ForRange<Context> for_range(dev_ctx, batch_size * n);
+  for_range(BatchedEyeFunctor<T>(n * n, n, identity_data));
+}
+
+template <typename Context, typename T>
+void ComputeInverseBySolve(const Context& dev_ctx,
+                           const DenseTensor& a,
+                           DenseTensor* a_inv) {
+  DenseTensor identity(a.dtype());
+  CreateBatchedIdentityMatrix<Context, T>(dev_ctx, a.dims(), &identity);
+  MatrixSolveFunctor<Context, T> mat_solve;
+  mat_solve(dev_ctx, a, identity, a_inv);
+}
 
 template <typename Context, typename T>
 struct MapMatrixInverseFunctor {

--- a/paddle/phi/kernels/funcs/matrix_solve.cu
+++ b/paddle/phi/kernels/funcs/matrix_solve.cu
@@ -23,6 +23,23 @@ limitations under the License. */
 namespace phi {
 namespace funcs {
 
+namespace {
+// Checked narrowing cast from int64_t to int, following PyTorch's
+// cuda_int_cast pattern. Throws a clear error when the value overflows.
+inline int CudaIntCast(int64_t v, const char* name) {
+  PADDLE_ENFORCE_LE(
+      v,
+      static_cast<int64_t>(std::numeric_limits<int>::max()),
+      common::errors::InvalidArgument(
+          "cuBLAS API requires %s <= %d, but got %lld. "
+          "This is likely because the tensor is too large for cuBLAS.",
+          name,
+          std::numeric_limits<int>::max(),
+          static_cast<long long>(v)));  // NOLINT
+  return static_cast<int>(v);
+}
+}  // namespace
+
 #ifndef PADDLE_WITH_HIP
 /**
  * Transform pivot array to permutation by swapping perm[i] and perm[pivot[i]]
@@ -72,11 +89,14 @@ __global__ void UnpackPivot(const int* __restrict__ pivot,
  */
 template <typename Context, typename T>
 void SolveLU(const funcs::BlasT<Context, T>& blas,
-             int m,
-             int n,
+             int64_t m,
+             int64_t n,
              const T* A,
              T* B,
-             int batch_size) {
+             int64_t batch_size) {
+  // cuBLAS TRSM requires int parameters; checked cast at the boundary.
+  int m_int = CudaIntCast(m, "m (nrhs)");
+  int n_int = CudaIntCast(n, "n");
   constexpr T alpha = 1.0;
   for (int64_t i = 0; i < batch_size; ++i) {
     // Before: U^T @ L^T @ P @ X = B
@@ -84,25 +104,25 @@ void SolveLU(const funcs::BlasT<Context, T>& blas,
               CblasLower,
               CblasTrans,
               CblasNonUnit,
-              m,
-              n,
+              m_int,
+              n_int,
               alpha,
               A + i * n * n,
-              n,
+              n_int,
               B + i * m * n,
-              n);
+              n_int);
     // After: L^T @ P @ X = U^T^-1 @ B
     blas.TRSM(CblasRight,
               CblasUpper,
               CblasTrans,
               CblasUnit,
-              m,
-              n,
+              m_int,
+              n_int,
               alpha,
               A + i * n * n,
-              n,
+              n_int,
               B + i * m * n,
-              n);
+              n_int);
     // After: P @ X = L^T^-1 @ U^T^-1 @ B
   }
 }
@@ -110,36 +130,40 @@ void SolveLU(const funcs::BlasT<Context, T>& blas,
 // Batched version of SolveLU.
 template <typename Context, typename T>
 void BatchedSolveLU(const funcs::BlasT<Context, T>& blas,
-                    int m,
-                    int n,
+                    int64_t m,
+                    int64_t n,
                     const T** A,
                     T** B,
-                    int batch_size) {
+                    int64_t batch_size) {
+  // cuBLAS BatchedTRSM requires int parameters; checked cast at the boundary.
+  int m_int = CudaIntCast(m, "m (nrhs)");
+  int n_int = CudaIntCast(n, "n");
+  int batch_int = CudaIntCast(batch_size, "batch_size");
   constexpr T alpha = 1.0;
   blas.BatchedTRSM(CblasRight,
                    CblasLower,
                    CblasTrans,
                    CblasNonUnit,
-                   m,
-                   n,
+                   m_int,
+                   n_int,
                    alpha,
                    A,
-                   n,
+                   n_int,
                    B,
-                   n,
-                   batch_size);
+                   n_int,
+                   batch_int);
   blas.BatchedTRSM(CblasRight,
                    CblasUpper,
                    CblasTrans,
                    CblasUnit,
-                   m,
-                   n,
+                   m_int,
+                   n_int,
                    alpha,
                    A,
-                   n,
+                   n_int,
                    B,
-                   n,
-                   batch_size);
+                   n_int,
+                   batch_int);
 }
 #endif
 
@@ -159,16 +183,17 @@ void MatrixSolveFunctor<Context, T>::operator()(const Context& dev_ctx,
   // https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-getrfbatched
   const auto& a_dims = a.dims();
   const int a_rank = a_dims.size();
-  int n = a_dims[a_rank - 1];
-  int lda = n;
+  int64_t n = a_dims[a_rank - 1];
   int64_t batch_size = a_rank > 2 ? a.numel() / (n * n) : 1;
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(a);
 
   const auto& b_dims = b.dims();
   const int b_rank = b_dims.size();
-  int nrhs = b_dims[b_rank - 1];
-  int ldb = n;
-  CUDNN_ENFORCE_TENSOR_SIZE_SUPPORTED(b);
+  int64_t nrhs = b_dims[b_rank - 1];
+
+  // Validate that dimensions fit into int for cuBLAS calls.
+  int n_int = CudaIntCast(n, "n");
+  CudaIntCast(nrhs, "nrhs");
+  CudaIntCast(batch_size, "batch_size");
 
   // 1. Copy input A to a temporary tensor tmp_a for LU factorization.
   DenseTensor tmp_a(a.dtype());
@@ -227,11 +252,11 @@ void MatrixSolveFunctor<Context, T>::operator()(const Context& dev_ctx,
       reinterpret_cast<int*>(tmp_gpu_info_data->ptr()) + batch_size;
 
   // 5. Performs LU factorization on A.
-  blas.BatchedGETRF(n,
+  blas.BatchedGETRF(n_int,
                     reinterpret_cast<T**>(tmp_gpu_ptrs_data->ptr()),
                     gpu_pivot_ptr,
                     gpu_info_ptr,
-                    batch_size);
+                    CudaIntCast(batch_size, "batch_size"));
   // After: P @ A^T = L @ U
 
   // check whether BatchedGETRF is executed successfully or not
@@ -241,7 +266,7 @@ void MatrixSolveFunctor<Context, T>::operator()(const Context& dev_ctx,
                      gpu_info_ptr,
                      sizeof(int) * batch_size,
                      dev_ctx.stream());
-  for (int i = 0; i < batch_size; ++i) {
+  for (int64_t i = 0; i < batch_size; ++i) {
     PADDLE_ENFORCE_EQ(info[i],
                       0,
                       common::errors::PreconditionNotMet(
@@ -258,7 +283,7 @@ void MatrixSolveFunctor<Context, T>::operator()(const Context& dev_ctx,
   // large shapes. In this case, we call the non-batched version for batch_size
   // times instead.
   // Ref: https://docs.nvidia.com/cuda/cublas/#cublas-t-trsmbatched
-  constexpr int max_batch_nrhs = 65535 * 8;  // max(gridDim.y) * 8
+  constexpr int64_t max_batch_nrhs = 65535LL * 8;  // max(gridDim.y) * 8
   if (batch_size > 1 && nrhs <= max_batch_nrhs) {
     BatchedSolveLU(blas,
                    nrhs,

--- a/paddle/phi/kernels/funcs/matrix_solve.h
+++ b/paddle/phi/kernels/funcs/matrix_solve.h
@@ -98,15 +98,15 @@ void compute_solve_eigen(const Context& dev_ctx,
   // prepare for a
   const auto& a_mat_dims = a.dims();
   const int a_rank = a_mat_dims.size();
-  int n = a_mat_dims[a_rank - 1];
-  int a_batch_size = a_rank > 2 ? a.numel() / (n * n) : 1;
+  int64_t n = a_mat_dims[a_rank - 1];
+  int64_t a_batch_size = a_rank > 2 ? a.numel() / (n * n) : 1;
 
   // prepare for b
   const auto& b_mat_dims = b.dims();
   const int b_rank = b_mat_dims.size();
-  int b_h = n;
-  int b_w = b_mat_dims[b_rank - 1];
-  int b_batch_size = b_rank > 2 ? b.numel() / (b_h * b_w) : 1;
+  int64_t b_h = n;
+  int64_t b_w = b_mat_dims[b_rank - 1];
+  int64_t b_batch_size = b_rank > 2 ? b.numel() / (b_h * b_w) : 1;
 
   const T* a_ptr = a.data<T>();
   const T* b_ptr = b.data<T>();
@@ -114,7 +114,7 @@ void compute_solve_eigen(const Context& dev_ctx,
 
   T* out_ptr = dev_ctx.template Alloc<T>(out);
   if (a_batch_size == b_batch_size) {
-    for (int i = 0; i < a_batch_size; ++i) {
+    for (int64_t i = 0; i < a_batch_size; ++i) {
       ConstEigenMatrixMap a_mat(a_ptr + i * n * n, n, n);
       ConstEigenMatrixMap b_mat(b_ptr + i * b_h * b_w, b_h, b_w);
       EigenMatrixMap out_mat(out_ptr + i * b_h * b_w, b_h, b_w);

--- a/paddle/phi/kernels/impl/inverse_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/inverse_grad_kernel_impl.h
@@ -31,7 +31,11 @@ void InverseGradKernel(const Context& dev_ctx,
                        DenseTensor* in_grad) {
   if (in_grad) {
     dev_ctx.template Alloc<T>(in_grad);
-    if (out_grad.numel() == 0) {
+    if (out.numel() == 0 || out_grad.numel() == 0) {
+      if (in_grad->numel() != 0) {
+        funcs::SetConstant<Context, T> set_zero;
+        set_zero(dev_ctx, in_grad, static_cast<T>(0));
+      }
       return;
     }
     auto blas = funcs::GetBlas<Context, T>(dev_ctx);

--- a/paddle/phi/kernels/impl/solve_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/solve_grad_kernel_impl.h
@@ -79,7 +79,8 @@ void SolveGradKernel(const Context& dev_ctx,
                      const DenseTensor& dout,
                      DenseTensor* dx,
                      DenseTensor* dy) {
-  if (dout.numel() == 0) {
+  if (x.numel() == 0 || y.numel() == 0 || out.numel() == 0 ||
+      dout.numel() == 0) {
     if (dx) {
       dev_ctx.template Alloc<T>(dx);
       if (dx->numel() != 0) {


### PR DESCRIPTION
## Summary

Align `paddle.linalg.solve` and `paddle.linalg.inv` with PyTorch's implementations to improve precision consistency and fix critical bugs.

### Changes

- **`linalg.inv` algorithm alignment**: Switch real-type (float32/float64) inverse from `matinvBatched`/`getriBatched` to **solve-on-identity** strategy (`inv(A) = solve(A, I)`), matching PyTorch's `linalg_solve_ex` based implementation. Complex types retain the existing path.
- **`linalg.solve` large tensor fix**: Replace `int` with `int64_t` for dimension variables and add `CudaIntCast` (checked narrowing cast) at cuBLAS API boundaries, following PyTorch's `cuda_int_cast` pattern. Prevents integer overflow for tensors with large dimensions.
- **`solve_grad` 0-size tensor crash fix**: Widen the early-return guard in `SolveGradKernel` to check all inputs (`x`, `y`, `out`, `dout`) for zero numel, not just `dout`. Fixes crash `"The value of target shape cannot be zero"` in `expand_as_kernel.cu`.
- **`inverse_grad` 0-size tensor crash fix**: Add guard for `out.numel() == 0` with proper zero-fill of gradient tensor.
- **CPU path int64 fix**: Use `int64_t` for dimension variables in the Eigen CPU solve path to prevent overflow in batch_size and pointer arithmetic.

### Files Modified (7)

| File | Change |
|------|--------|
| `paddle/phi/kernels/funcs/matrix_inverse.h` | New `ComputeInverseBySolve` (solve-on-identity) |
| `paddle/phi/kernels/funcs/matrix_inverse.cc` | CPU: real types → solve-on-identity |
| `paddle/phi/kernels/funcs/matrix_inverse.cu` | GPU: real types → solve-on-identity |
| `paddle/phi/kernels/funcs/matrix_solve.cu` | `int` → `int64_t` + `CudaIntCast` |
| `paddle/phi/kernels/funcs/matrix_solve.h` | CPU Eigen path `int` → `int64_t` |
| `paddle/phi/kernels/impl/solve_grad_kernel_impl.h` | 0-size backward fix |
| `paddle/phi/kernels/impl/inverse_grad_kernel_impl.h` | 0-size backward fix |

### Precision Validation (Paddle vs PyTorch on GPU)

| Test | Max Diff |
|------|----------|
| `linalg.solve` fp64 | 4.44e-16 |
| `linalg.solve` fp32 | 0.00 |
| `linalg.solve` batched fp64 | 0.00 |
| `linalg.inv` fp64 | 2.22e-16 |
| `linalg.inv` fp32 | 1.49e-08 |
| `linalg.inv` batched fp64 | 0.00 |
| 0-size solve fwd+bwd | ✅ PASS (was crash) |
| 0-size inv fwd+bwd | ✅ PASS (was crash) |

## Test plan

- [x] GPU compilation passes (libphi_gpu.so, libphi.so)
- [x] Pre-commit hooks pass (clang-format, cpplint, clang-tidy, copyright)
- [x] Forward precision matches PyTorch at machine epsilon (fp64) / 1e-8 (fp32)
- [x] 0-size tensor forward produces correct empty output shapes
- [x] 0-size tensor backward no longer crashes (both solve and inv)
- [x] CPU gradient computation is correct
- [ ] CI unit tests pass
- [ ] PaddleAPITest precision validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)