### PR TITLE
[0 SIZE] Add zero-size input validation for WarpCTC kernel

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -5698,9 +5698,9 @@ void WarpctcInferMeta(const MetaTensor& logits,
     num_sequences = logits_dims[1];
     sequence_width = logits_dims[2];
 
-    size_t labels_batch_size = label.dims()[0];
-    size_t logits_length_batch_size = logits_length.dims()[0];
-    size_t labels_length_batch_size = labels_length.dims()[0];
+    int64_t labels_batch_size = label.dims()[0];
+    int64_t logits_length_batch_size = logits_length.dims()[0];
+    int64_t labels_length_batch_size = labels_length.dims()[0];
 
     PADDLE_ENFORCE_EQ(
         labels_batch_size,

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -5706,7 +5706,7 @@ void WarpctcInferMeta(const MetaTensor& logits,
         labels_batch_size,
         num_sequences,
         common::errors::InvalidArgument(
-            "Expected label to have size %zu at dimension 0, but got size %d",
+            "Expected label to have size %lld at dimension 0, but got size %d",
             num_sequences,
             labels_batch_size));
 
@@ -5714,7 +5714,7 @@ void WarpctcInferMeta(const MetaTensor& logits,
         logits_length_batch_size,
         num_sequences,
         common::errors::InvalidArgument("Expected logits_length to have size "
-                                        "%zu at dimension 0, but got size %d",
+                                        "%lld at dimension 0, but got size %d",
                                         num_sequences,
                                         logits_length_batch_size));
 
@@ -5722,7 +5722,7 @@ void WarpctcInferMeta(const MetaTensor& logits,
         labels_length_batch_size,
         num_sequences,
         common::errors::InvalidArgument("Expected labels_length to have size "
-                                        "%zu at dimension 0, but got size %d",
+                                        "%lld at dimension 0, but got size %d",
                                         num_sequences,
                                         labels_length_batch_size));
   } else {

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -5697,6 +5697,34 @@ void WarpctcInferMeta(const MetaTensor& logits,
     max_sequence_length = logits_dims[0];
     num_sequences = logits_dims[1];
     sequence_width = logits_dims[2];
+
+    size_t labels_batch_size = label.dims()[0];
+    size_t logits_length_batch_size = logits_length.dims()[0];
+    size_t labels_length_batch_size = labels_length.dims()[0];
+
+    PADDLE_ENFORCE_EQ(
+        labels_batch_size,
+        num_sequences,
+        common::errors::InvalidArgument(
+            "Expected label to have size %zu at dimension 0, but got size %d",
+            num_sequences,
+            labels_batch_size));
+
+    PADDLE_ENFORCE_EQ(
+        logits_length_batch_size,
+        num_sequences,
+        common::errors::InvalidArgument("Expected logits_length to have size "
+                                        "%zu at dimension 0, but got size %d",
+                                        num_sequences,
+                                        logits_length_batch_size));
+
+    PADDLE_ENFORCE_EQ(
+        labels_length_batch_size,
+        num_sequences,
+        common::errors::InvalidArgument("Expected labels_length to have size "
+                                        "%zu at dimension 0, but got size %d",
+                                        num_sequences,
+                                        labels_length_batch_size));
   } else {
     max_sequence_length = -1;
     num_sequences = -1;

--- a/paddle/phi/kernels/impl/warpctc_kernel_impl.h
+++ b/paddle/phi/kernels/impl/warpctc_kernel_impl.h
@@ -235,17 +235,13 @@ void WarpctcKernel(const Context& dev_ctx,
                    bool norm_by_times UNUSED,
                    DenseTensor* loss,
                    DenseTensor* warpctcgrad) {
-  size_t num_sequences, sequence_width, max_sequence_length, labels_batch_size,
-      logits_length_batch_size, labels_length_batch_size;
+  size_t num_sequences, sequence_width, max_sequence_length;
   phi::Vector<size_t> logits_lod;
   phi::Vector<size_t> label_lod;
   if (logits_length.is_initialized() && labels_length.is_initialized()) {
     num_sequences = logits.dims()[1];
     sequence_width = logits.dims()[2];
     max_sequence_length = logits.dims()[0];
-    labels_batch_size = label.dims()[0];
-    logits_length_batch_size = logits_length.get().dims()[0];
-    labels_length_batch_size = labels_length.get().dims()[0];
 
     PADDLE_ENFORCE_GT(max_sequence_length,
                       0,
@@ -277,30 +273,6 @@ void WarpctcKernel(const Context& dev_ctx,
             "but received %d",
             std::numeric_limits<int>::max(),
             num_sequences * sequence_width * max_sequence_length));
-
-    PADDLE_ENFORCE_GT(
-        labels_batch_size,
-        0,
-        common::errors::InvalidArgument(
-            "Expected label to have size %zu at dimension 0, but got size %d",
-            max_sequence_length,
-            labels_batch_size));
-
-    PADDLE_ENFORCE_GT(
-        logits_length_batch_size,
-        0,
-        common::errors::InvalidArgument("Expected logits_length to have size "
-                                        "%zu at dimension 0, but got size %d",
-                                        max_sequence_length,
-                                        logits_length_batch_size));
-
-    PADDLE_ENFORCE_GT(
-        labels_length_batch_size,
-        0,
-        common::errors::InvalidArgument("Expected labels_length to have size "
-                                        "%zu at dimension 0, but got size %d",
-                                        max_sequence_length,
-                                        labels_length_batch_size));
 
     DenseTensor logits_length_cpu;
     DenseTensor labels_length_cpu;

--- a/paddle/phi/kernels/impl/warpctc_kernel_impl.h
+++ b/paddle/phi/kernels/impl/warpctc_kernel_impl.h
@@ -235,13 +235,17 @@ void WarpctcKernel(const Context& dev_ctx,
                    bool norm_by_times UNUSED,
                    DenseTensor* loss,
                    DenseTensor* warpctcgrad) {
-  size_t num_sequences, sequence_width, max_sequence_length;
+  size_t num_sequences, sequence_width, max_sequence_length, labels_batch_size,
+      logits_length_batch_size, labels_length_batch_size;
   phi::Vector<size_t> logits_lod;
   phi::Vector<size_t> label_lod;
   if (logits_length.is_initialized() && labels_length.is_initialized()) {
     num_sequences = logits.dims()[1];
     sequence_width = logits.dims()[2];
     max_sequence_length = logits.dims()[0];
+    labels_batch_size = label.dims()[0];
+    logits_length_batch_size = logits_length.get().dims()[0];
+    labels_length_batch_size = labels_length.get().dims()[0];
 
     PADDLE_ENFORCE_GT(max_sequence_length,
                       0,
@@ -273,6 +277,30 @@ void WarpctcKernel(const Context& dev_ctx,
             "but received %d",
             std::numeric_limits<int>::max(),
             num_sequences * sequence_width * max_sequence_length));
+
+    PADDLE_ENFORCE_GT(
+        labels_batch_size,
+        0,
+        common::errors::InvalidArgument(
+            "Expected label to have size %zu at dimension 0, but got size %d",
+            max_sequence_length,
+            labels_batch_size));
+
+    PADDLE_ENFORCE_GT(
+        logits_length_batch_size,
+        0,
+        common::errors::InvalidArgument("Expected logits_length to have size "
+                                        "%zu at dimension 0, but got size %d",
+                                        max_sequence_length,
+                                        logits_length_batch_size));
+
+    PADDLE_ENFORCE_GT(
+        labels_length_batch_size,
+        0,
+        common::errors::InvalidArgument("Expected labels_length to have size "
+                                        "%zu at dimension 0, but got size %d",
+                                        max_sequence_length,
+                                        labels_length_batch_size));
 
     DenseTensor logits_length_cpu;
     DenseTensor labels_length_cpu;

--- a/test/legacy_test/test_layers.py
+++ b/test/legacy_test/test_layers.py
@@ -1087,7 +1087,7 @@ class TestBook(LayerTest):
         # TODO(minqiyang): dygraph do not support lod now
         with self.static_graph():
             input_length = paddle.static.data(
-                name='logits_length', shape=[11], dtype='int64'
+                name='logits_length', shape=[12], dtype='int64'
             )
             label_length = paddle.static.data(
                 name='labels_length', shape=[12], dtype='int64'
@@ -1096,7 +1096,7 @@ class TestBook(LayerTest):
                 name='label', shape=[12, 1], dtype='int32'
             )
             predict = paddle.static.data(
-                name='predict', shape=[4, 4, 8], dtype='float32'
+                name='predict', shape=[4, 12, 8], dtype='float32'
             )
             output = paddle.nn.functional.ctc_loss(
                 log_probs=predict,

--- a/test/legacy_test/test_warpctc_op.py
+++ b/test/legacy_test/test_warpctc_op.py
@@ -677,17 +677,17 @@ class TestWarpCTCOpError(unittest.TestCase):
 
         self.assertRaisesRegex(
             ValueError,
-            f"Expected label to have size {max_sequence_length} at dimension 0, but got size 0",
+            f"Expected label to have size {batch_size} at dimension 0, but got size 0",
             test_zero_labels_batch_size,
         )
         self.assertRaisesRegex(
             ValueError,
-            f"Expected logits_length to have size {max_sequence_length} at dimension 0, but got size 0",
+            f"Expected logits_length to have size {batch_size} at dimension 0, but got size 0",
             test_zero_logits_length_batch_size,
         )
         self.assertRaisesRegex(
             ValueError,
-            f"Expected labels_length to have size {max_sequence_length} at dimension 0, but got size 0",
+            f"Expected labels_length to have size {batch_size} at dimension 0, but got size 0",
             test_zero_labels_length_batch_size,
         )
 

--- a/test/legacy_test/test_warpctc_op.py
+++ b/test/legacy_test/test_warpctc_op.py
@@ -630,6 +630,69 @@ class TestWarpCTCOpError(unittest.TestCase):
         self.assertRaises(ValueError, test_dygraph_zero_size)
         paddle.enable_static()
 
+    def test_dygraph_zero_size_with_padding(self):
+        """Test zero size inputs when using LogitsLength and LabelLength."""
+        paddle.disable_static()
+
+        batch_size = 4
+        num_classes = 8
+        max_sequence_length = 5
+        logits = paddle.uniform(
+            [max_sequence_length, batch_size, num_classes],
+            min=0.1,
+            max=1.0,
+        )
+        labels = paddle.randint(
+            0, num_classes - 1, [batch_size, num_classes], dtype="int32"
+        )
+        labels_length = paddle.to_tensor([2, 1, 3, 2])
+        logits_length = paddle.to_tensor([5, 4, 3, 2])
+
+        def test_zero_labels_batch_size():
+            labels = paddle.zeros([0, 3], dtype="int32")
+            paddle.nn.functional.ctc_loss(
+                log_probs=logits,
+                labels=labels,
+                input_lengths=logits_length,
+                label_lengths=labels_length,
+            )
+
+        def test_zero_logits_length_batch_size():
+            logits_length = paddle.zeros([0], dtype="int32")
+            paddle.nn.functional.ctc_loss(
+                log_probs=logits,
+                labels=labels,
+                input_lengths=logits_length,
+                label_lengths=labels_length,
+            )
+
+        def test_zero_labels_length_batch_size():
+            labels_length = paddle.zeros([0], dtype="int32")
+            paddle.nn.functional.ctc_loss(
+                log_probs=logits,
+                labels=labels,
+                input_lengths=logits_length,
+                label_lengths=labels_length,
+            )
+
+        self.assertRaisesRegex(
+            ValueError,
+            f"Expected label to have size {max_sequence_length} at dimension 0, but got size 0",
+            test_zero_labels_batch_size,
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            f"Expected logits_length to have size {max_sequence_length} at dimension 0, but got size 0",
+            test_zero_logits_length_batch_size,
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            f"Expected labels_length to have size {max_sequence_length} at dimension 0, but got size 0",
+            test_zero_labels_length_batch_size,
+        )
+
+        paddle.enable_static()
+
 
 class TestCTCLossAPICase(unittest.TestCase):
     def test_class_api(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->

针对 `ctc_loss` 的 0 Size 问题做出如下改动：

**paddle/phi/kernels/impl/warpctc_kernel_impl.h**
   - 新增对 `labels`、`logits_length`、`labels_length` 三个输入的 batch_size 校验

**test/legacy_test/test_warpctc_op.py**
   - 新增 `test_dygraph_zero_size_with_padding` 单测用例


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否