### PR TITLE
Support non-4-aligned block counts for ue8m0 scale in fp8_quant_blockwise.

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2286,42 +2286,14 @@ void Fp8QuantBlockwiseInferMeta(const MetaTensor& X,
     }
 
     if (output_scale_transpose) {
-      PADDLE_ENFORCE_EQ(
-          scale_outer_dim % 4,
-          0,
-          common::errors::InvalidArgument(
-              "When use_ue8m0 is true, the outer dimension of scale "
-              "must be divisible by 4, but got %d",
-              scale_outer_dim));
-      scale_outer_dim /= 4;
+      scale_outer_dim = (scale_outer_dim + 3) / 4;
       if (input_transpose) {
-        PADDLE_ENFORCE_EQ(scale_transposed_outer_dim % 4,
-                          0,
-                          common::errors::InvalidArgument(
-                              "When use_ue8m0 is true, the outer dimension of "
-                              "transposed scale "
-                              "must be divisible by 4, but got %d",
-                              scale_transposed_outer_dim));
-        scale_transposed_outer_dim /= 4;
+        scale_transposed_outer_dim = (scale_transposed_outer_dim + 3) / 4;
       }
     } else {
-      PADDLE_ENFORCE_EQ(
-          scale_inner_dim % 4,
-          0,
-          common::errors::InvalidArgument(
-              "When use_ue8m0 is true, the inner dimension of scale "
-              "must be divisible by 4, but got %d",
-              scale_inner_dim));
-      scale_inner_dim /= 4;
+      scale_inner_dim = (scale_inner_dim + 3) / 4;
       if (input_transpose) {
-        PADDLE_ENFORCE_EQ(scale_transposed_inner_dim % 4,
-                          0,
-                          common::errors::InvalidArgument(
-                              "When use_ue8m0 is true, the inner dimension of "
-                              "transposed scale "
-                              "must be divisible by 4, but got %d",
-                              scale_transposed_inner_dim));
-        scale_transposed_inner_dim /= 4;
+        scale_transposed_inner_dim = (scale_transposed_inner_dim + 3) / 4;
       }
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism



### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features



### Description
<!-- Describe what you’ve done -->
Support non-4-aligned block counts for ue8m0 scale in fp8_quant_blockwise



### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

Pcard-89071
devPR:https://github.com/PaddlePaddle/Paddle/pull/78315