### PR TITLE
[InferMeta] Add input validation for FusedRopeInferMeta

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -6307,54 +6307,47 @@ void FusedRopeInferMeta(const MetaTensor& q,
                         "but got head_dim = %d.",
                         head_dim));
 
-  PADDLE_ENFORCE_GT(batch_size,
-                    0,
-                    common::errors::InvalidArgument(
-                        "The batch_size of q must be greater than 0, "
-                        "but got %d.",
-                        batch_size));
+  // Note: We don't enforce batch_size, seq_len, num_heads, head_dim > 0 here
+  // because 0-sized tensors are valid in some cases (e.g., empty batch).
 
-  PADDLE_ENFORCE_GT(seq_len,
-                    0,
-                    common::errors::InvalidArgument(
-                        "The seq_len of q must be greater than 0, "
-                        "but got %d.",
-                        seq_len));
-
-  PADDLE_ENFORCE_GT(num_heads,
-                    0,
-                    common::errors::InvalidArgument(
-                        "The num_heads of q must be greater than 0, "
-                        "but got %d.",
-                        num_heads));
-
-  PADDLE_ENFORCE_GT(head_dim,
-                    0,
-                    common::errors::InvalidArgument(
-                        "The head_dim of q must be greater than 0, "
-                        "but got %d.",
-                        head_dim));
-
-  // Validate k (optional): must be 4-D with same head_dim as q
+  // Validate k (optional): must have same head_dim as q
+  // Note: k can have different num_heads (supports MQA/GQA)
   if (k) {
     auto k_dims = k.dims();
-    PADDLE_ENFORCE_EQ(k_dims,
-                      input_dims,
-                      common::errors::InvalidArgument(
-                          "The dims of k must be equal to the dims of q, "
-                          "but got [%s].",
-                          k_dims));
+    PADDLE_ENFORCE_EQ(
+        k_dims.size(),
+        4UL,
+        common::errors::InvalidArgument(
+            "The k should be a 4-D tensor, but got %u.", k_dims.size()));
+    auto k_head_dim = k_dims[3];
+    PADDLE_ENFORCE_EQ(
+        k_head_dim,
+        head_dim,
+        common::errors::InvalidArgument(
+            "The head_dim of k must be equal to the head_dim of q, "
+            "but got k's head_dim = %d, q's head_dim = %d.",
+            k_head_dim,
+            head_dim));
   }
 
-  // Validate v (optional): must be 4-D with same head_dim and seq_len as q
+  // Validate v (optional): must have same head_dim as q
+  // Note: v can have different num_heads (supports MQA/GQA)
   if (v) {
     auto v_dims = v.dims();
-    PADDLE_ENFORCE_EQ(v_dims,
-                      input_dims,
-                      common::errors::InvalidArgument(
-                          "The dims of v must be equal to the dims of q, "
-                          "but got [%s].",
-                          v_dims));
+    PADDLE_ENFORCE_EQ(
+        v_dims.size(),
+        4UL,
+        common::errors::InvalidArgument(
+            "The v should be a 4-D tensor, but got %u.", v_dims.size()));
+    auto v_head_dim = v_dims[3];
+    PADDLE_ENFORCE_EQ(
+        v_head_dim,
+        head_dim,
+        common::errors::InvalidArgument(
+            "The head_dim of v must be equal to the head_dim of q, "
+            "but got v's head_dim = %d, q's head_dim = %d.",
+            v_head_dim,
+            head_dim));
   }
 
   // Validate sin (optional): must be 2-D [seq_len, head_dim] or

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -6295,6 +6295,206 @@ void FusedRopeInferMeta(const MetaTensor& q,
                         "Input should be a 4-D tensor of format [N, C, H, W] "
                         "or [N, H, W, C], but got %u.",
                         input_dims.size()));
+  auto batch_size = time_major ? input_dims[1] : input_dims[0];
+  auto seq_len = time_major ? input_dims[0] : input_dims[1];
+  auto num_heads = input_dims[2];
+  auto head_dim = input_dims[3];
+
+  PADDLE_ENFORCE_EQ(head_dim % 2,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The head_dim of q must be a multiple of 2, "
+                        "but got head_dim = %d.",
+                        head_dim));
+
+  PADDLE_ENFORCE_GT(batch_size,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The batch_size of q must be greater than 0, "
+                        "but got %d.",
+                        batch_size));
+
+  PADDLE_ENFORCE_GT(seq_len,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The seq_len of q must be greater than 0, "
+                        "but got %d.",
+                        seq_len));
+
+  PADDLE_ENFORCE_GT(num_heads,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The num_heads of q must be greater than 0, "
+                        "but got %d.",
+                        num_heads));
+
+  PADDLE_ENFORCE_GT(head_dim,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The head_dim of q must be greater than 0, "
+                        "but got %d.",
+                        head_dim));
+
+  // Validate k (optional): must be 4-D with same head_dim as q
+  if (k) {
+    auto k_dims = k.dims();
+    PADDLE_ENFORCE_EQ(k_dims,
+                      input_dims,
+                      common::errors::InvalidArgument(
+                          "The dims of k must be equal to the dims of q, "
+                          "but got [%s].",
+                          k_dims));
+  }
+
+  // Validate v (optional): must be 4-D with same head_dim and seq_len as q
+  if (v) {
+    auto v_dims = v.dims();
+    PADDLE_ENFORCE_EQ(v_dims,
+                      input_dims,
+                      common::errors::InvalidArgument(
+                          "The dims of v must be equal to the dims of q, "
+                          "but got [%s].",
+                          v_dims));
+  }
+
+  // Validate sin (optional): must be 2-D [seq_len, head_dim] or
+  // 4-D [1, seq_len, 1, head_dim], head_dim must be a multiple of 2
+  if (sin) {
+    auto sin_dims = sin.dims();
+    PADDLE_ENFORCE_EQ(
+        (sin_dims.size() == 2 || sin_dims.size() == 4),
+        true,
+        common::errors::InvalidArgument(
+            "The dims of sin is expected to be 2 or 4, but received %d.",
+            sin_dims.size()));
+
+    auto sin_head_dim = sin_dims[sin_dims.size() - 1];
+    PADDLE_ENFORCE_EQ(sin_head_dim % 2,
+                      0,
+                      common::errors::InvalidArgument(
+                          "The last dim of sin must be a multiple of 2, "
+                          "but got %d.",
+                          sin_head_dim));
+
+    // Validate sin seq_len and head_dim must match q
+    auto sin_seq_len = sin_dims.size() == 2 ? sin_dims[0] : sin_dims[1];
+    PADDLE_ENFORCE_EQ(
+        sin_seq_len,
+        seq_len,
+        common::errors::InvalidArgument(
+            "The seq_len of sin must be equal to the seq_len of q, "
+            "but got %d and %d.",
+            sin_seq_len,
+            seq_len));
+    PADDLE_ENFORCE_EQ(
+        sin_head_dim,
+        head_dim,
+        common::errors::InvalidArgument(
+            "The head_dim of sin must be equal to the head_dim of q, "
+            "but got %d and %d.",
+            sin_head_dim,
+            head_dim));
+
+    if (sin_dims.size() == 4) {
+      PADDLE_ENFORCE_EQ(
+          (sin_dims[0] == 1 && sin_dims[2] == 1),
+          true,
+          common::errors::InvalidArgument(
+              "When sin is 4-D, its shape must be [1, seq_len, 1, head_dim], "
+              "but got [%d, %d, %d, %d].",
+              sin_dims[0],
+              sin_dims[1],
+              sin_dims[2],
+              sin_dims[3]));
+    }
+  }
+
+  // Validate cos (optional): must be 2-D [seq_len, head_dim] or
+  // 4-D [1, seq_len, 1, head_dim], head_dim must be a multiple of 2
+  if (cos) {
+    auto cos_dims = cos.dims();
+    PADDLE_ENFORCE_EQ(
+        (cos_dims.size() == 2 || cos_dims.size() == 4),
+        true,
+        common::errors::InvalidArgument(
+            "The dims of cos is expected to be 2 or 4, but received %d.",
+            cos_dims.size()));
+
+    auto cos_head_dim = cos_dims[cos_dims.size() - 1];
+    PADDLE_ENFORCE_EQ(cos_head_dim % 2,
+                      0,
+                      common::errors::InvalidArgument(
+                          "The last dim of cos must be a multiple of 2, "
+                          "but got %d.",
+                          cos_head_dim));
+
+    // Validate cos seq_len and head_dim must match q
+    auto cos_seq_len = cos_dims.size() == 2 ? cos_dims[0] : cos_dims[1];
+    PADDLE_ENFORCE_EQ(
+        cos_seq_len,
+        seq_len,
+        common::errors::InvalidArgument(
+            "The seq_len of cos must be equal to the seq_len of q, "
+            "but got %d and %d.",
+            cos_seq_len,
+            seq_len));
+    PADDLE_ENFORCE_EQ(
+        cos_head_dim,
+        head_dim,
+        common::errors::InvalidArgument(
+            "The head_dim of cos must be equal to the head_dim of q, "
+            "but got %d and %d.",
+            cos_head_dim,
+            head_dim));
+
+    if (cos_dims.size() == 4) {
+      PADDLE_ENFORCE_EQ(
+          (cos_dims[0] == 1 && cos_dims[2] == 1),
+          true,
+          common::errors::InvalidArgument(
+              "When cos is 4-D, its shape must be [1, seq_len, 1, head_dim], "
+              "but got [%d, %d, %d, %d].",
+              cos_dims[0],
+              cos_dims[1],
+              cos_dims[2],
+              cos_dims[3]));
+    }
+  }
+
+  // Validate sin and cos must be both provided or both absent
+  if (sin && cos) {
+    PADDLE_ENFORCE_EQ(
+        sin.dims(),
+        cos.dims(),
+        common::errors::InvalidArgument(
+            "The dims of sin and cos must be the same. "
+            "But received sin's dims is {%s}, cos's dims is {%s}.",
+            sin.dims(),
+            cos.dims()));
+  }
+
+  // Validate position_ids (optional): must be 2-D [batch_size, seq_len]
+  if (position_ids) {
+    auto pos_dims = position_ids.dims();
+    PADDLE_ENFORCE_EQ(
+        pos_dims.size(),
+        2,
+        common::errors::InvalidArgument(
+            "The dims of position_ids is expected to be 2, but received %d.",
+            pos_dims.size()));
+
+    PADDLE_ENFORCE_EQ(
+        (pos_dims[0] == batch_size && pos_dims[1] == seq_len),
+        true,
+        common::errors::InvalidArgument(
+            "The shape of position_ids must be [batch_size, seq_len], "
+            "i.e., [%d, %d], but got [%d, %d].",
+            batch_size,
+            seq_len,
+            pos_dims[0],
+            pos_dims[1]));
+  }
+
   out_q->set_dims(q.dims());
   out_q->set_dtype(q.dtype());
   if (k) {


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Improvements

### Description
修复 `FusedRopeInferMeta` 函数中的输入验证逻辑：

1. **移除过于严格的维度验证**：
   - 移除 `batch_size > 0`、`seq_len > 0`、`num_heads > 0`、`head_dim > 0` 的验证
   - 因为测试用例中存在 batch_size=0 的情况（如 `TestFusedRotaryPositionEmbeddingZeroSize` 中 `qkv_shape = [0, 1, 8, 8]`）

2. **修复 k 和 v 的验证逻辑**：
   - 原验证要求 k/v 的维度与 q 完全相同，这过于严格
   - 支持 MQA (Multi-Query Attention) 和 GQA (Grouped-Query Attention)，k/v 可以有不同的 num_heads
   - 现在只验证 `head_dim` 相同即可

根据测试文件 `test/legacy_test/test_fused_rotary_position_embedding.py` 中的用例：
- MQA: k/v 的 num_heads 可以是 1，如 `[2, 8, 1, 8]` vs `[2, 8, 4, 8]`
- GQA: k/v 的 num_heads 可以不同，如 `[1, 8, 2, 8]` vs `[1, 8, 4, 8]`

### 是否引起精度变化
否