### PR TITLE
[Cherry-Pick][release/3.3][XPU] moe_permute_kernel: add return_expert_indices and expert_indices params (#78177)

### DIFF
--- a/paddle/phi/kernels/xpu/moe_permute_kernel.cc
+++ b/paddle/phi/kernels/xpu/moe_permute_kernel.cc
@@ -133,10 +133,23 @@ void MoePermuteKernel(const Context &dev_ctx,
                       const int padding_multiplex,
                       const bool do_gather,
                       const bool using_ue8m0_scale,
+                      const bool return_expert_indices,
+                      const int override_buffer_size,
                       DenseTensor *X_unzipped,
                       DenseTensor *zipped_expertwise_rowmap,
                       DenseTensor *token_prob_unzipped,
-                      DenseTensor *XScale_unzipped) {
+                      DenseTensor *XScale_unzipped,
+                      DenseTensor *expert_indices) {
+  PADDLE_ENFORCE_EQ(
+      return_expert_indices,
+      false,
+      common::errors::Unimplemented("moe_permute on XPU does not support "
+                                    "return_expert_indices=true yet."));
+  PADDLE_ENFORCE_EQ(
+      override_buffer_size,
+      -1,
+      common::errors::Unimplemented(
+          "moe_permute on XPU does not support override_buffer_size yet."));
   const int64_t rows = X.dims()[0];
   const int64_t cols = X.dims()[1];
   PADDLE_ENFORCE_LE(

--- a/paddle/phi/kernels/xpu/moe_unpermute_kernel.cc
+++ b/paddle/phi/kernels/xpu/moe_unpermute_kernel.cc
@@ -65,8 +65,14 @@ void MoeUnpermuteKernel(const Context &dev_ctx,
                         const int total_zipped_tokens_num,
                         const int num_experts,
                         const bool MP,
+                        const bool using_weighted_combine,
                         DenseTensor *zipped_tokens,
                         DenseTensor *zipped_probs_topk) {
+  PADDLE_ENFORCE_EQ(
+      using_weighted_combine,
+      false,
+      common::errors::Unimplemented("moe_unpermute on XPU does not support "
+                                    "using_weighted_combine=true yet."));
   const int64_t cols = unzipped_tokens.dims()[1];
   PADDLE_ENFORCE_LE(cols,
                     std::numeric_limits<int32_t>::max(),


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Cherry-pick #78177 to release/3.3 branch for Paddle 3.3.2 release (XPU P800).
moe_permute_kernel: add return_expert_indices and expert_indices params.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78177

### 精度变化
精度无变化