### PR TITLE
[Cherry Pick | Pipeline Parallel] Merge PaddleFleet Pipeline Parallel (LayerSpec and NoPipelineParallel) into Paddle

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/__init__.py
+++ b/python/paddle/distributed/fleet/meta_parallel/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 # isort: skip_file
+from .meta_parallel_base import MetaParallelBase  # noqa: F401
+
 from .parallel_layers import (  # noqa: F401
     ColumnParallelLinear,
     LayerDesc,
@@ -25,8 +27,13 @@ from .parallel_layers import (  # noqa: F401
     VocabParallelEmbedding,
     get_rng_state_tracker,
     model_parallel_random_seed,
+    LayerSpec,
+    import_spec_layer,
+    get_spec_layer,
+    build_spec_layer,
 )
 from .pipeline_parallel import (  # noqa: F401
+    NoPipelineParallel,
     PipelineParallel,
     PipelineParallelMicroStepLocations,
     PipelineParallelWithInterleave,
@@ -42,6 +49,9 @@ from .tensor_parallel import TensorParallel  # noqa: F401
 from .pp_utils.forward_backward_overlap_utils import (  # noqa: F401
     ScheduleNode,
     ScheduleChunk,
+)
+from .pp_utils.utils import (  # noqa: F401
+    dict_to_tuple_helper,
 )
 
 __all__ = []

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/__init__.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/__init__.py
@@ -29,5 +29,11 @@ from .random import (  # noqa: F401
     get_rng_state_tracker,
     model_parallel_random_seed,
 )
+from .spec_utils import (
+    LayerSpec as LayerSpec,
+    build_spec_layer as build_spec_layer,
+    get_spec_layer as get_spec_layer,
+    import_spec_layer as import_spec_layer,
+)
 
 __all__ = []

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -426,7 +426,6 @@ class PipelineLayer(nn.Layer):
                 "virtual_pipeline_stage should be None or an int"
             )
             if num_virtual_pipeline_stages > 1:
-                assert num_stages > 1, "Cannot enable vpp under no pp."
                 logger.info(
                     "set num_virtual_pipeline_stages > 1 means using interleave scheduler instead of 1f1b scheduler"
                 )

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -60,35 +60,55 @@ from paddle.incubate.distributed.fleet import recompute_hybrid
 from ..pp_utils.forward_backward_overlap_utils import (
     ScheduleChunk,
 )
+from .spec_utils import LayerSpec, build_spec_layer
 
 __all__ = []
 
 
 class LayerDesc:
-    def __init__(self, layer_func, *inputs, **kwargs):
-        self.layer_func = layer_func
-        self.inputs = inputs
+    def __init__(self, layer_func_or_spec, *inputs, **kwargs):
         self.kwargs = kwargs
+        self.using_layer_spec = False
 
-        if not issubclass(layer_func, nn.Layer):
-            raise TypeError(
-                "The input(layer_func) should be a derived class of Layer."
-            )
+        if isinstance(layer_func_or_spec, LayerSpec):
+            self.using_layer_spec = True
+            self.layer_spec = layer_func_or_spec
+        else:
+            self.inputs = inputs
+            self.layer_func = layer_func_or_spec
+            if not issubclass(layer_func_or_spec, nn.Layer):
+                raise TypeError(
+                    "The input(layer_func) should be a derived class of Layer."
+                )
 
     def build_layer(self, **extra_kwargs):
-        return self.layer_func(*self.inputs, **{**self.kwargs, **extra_kwargs})
+        if self.using_layer_spec:
+            all_extra_kwargs = {
+                **self.layer_spec.extra_kwargs,
+                **self.kwargs,
+                **extra_kwargs,
+            }
+            self.layer_spec.extra_kwargs = all_extra_kwargs
+            return build_spec_layer(self.layer_spec)
+        else:
+            return self.layer_func(
+                *self.inputs, **{**self.kwargs, **extra_kwargs}
+            )
 
     def __repr__(self):
-        return layer_to_str(
-            self.layer_func.__name__, *self.inputs, **self.kwargs
-        )
+        if self.using_layer_spec:
+            return layer_to_str(repr(self.layer_spec), **self.kwargs)
+        else:
+            return layer_to_str(
+                self.layer_func.__name__, *self.inputs, **self.kwargs
+            )
 
 
 class SharedLayerDesc(LayerDesc):
     def __init__(
         self,
         key,
-        layer_func,
+        layer_func,  # May be layer_func or layer_spec
         forward_func=None,
         shared_weight_attr='weight',
         *inputs,
@@ -106,6 +126,7 @@ class SharedLayerDesc(LayerDesc):
         self.shared_weight_attr = shared_weight_attr
 
 
+# TODO: PaddleFleet LayerSpec Support dualpipev
 class LocalSharedLayerDesc(LayerDesc):
     """
     Used for dualpipev, some layers can be shared locally
@@ -221,7 +242,13 @@ class SegmentLayers:
             if isinstance(layer, nn.Layer):
                 name = layer.__class__.__name__
             elif isinstance(layer, LayerDesc):
-                name = layer.layer_func.__name__
+                if layer.using_layer_spec:
+                    if not isinstance(layer.layer_spec.layer, tuple):
+                        name = layer.layer_spec.layer.__name__
+                    else:
+                        continue
+                else:
+                    name = layer.layer_func.__name__
             else:
                 try:
                     name = layer.__name__
@@ -399,6 +426,7 @@ class PipelineLayer(nn.Layer):
                 "virtual_pipeline_stage should be None or an int"
             )
             if num_virtual_pipeline_stages > 1:
+                assert num_stages > 1, "Cannot enable vpp under no pp."
                 logger.info(
                     "set num_virtual_pipeline_stages > 1 means using interleave scheduler instead of 1f1b scheduler"
                 )
@@ -768,7 +796,7 @@ class PipelineLayer(nn.Layer):
                         grad_var = param.grad
                     with paddle.framework.no_grad():
                         paddle.distributed.all_reduce(
-                            grad_var,
+                            grad_var.contiguous(),
                             group=comm['group'],
                         )
                 else:
@@ -1128,9 +1156,26 @@ class PipelineLayer(nn.Layer):
             self.run_function = model_chunk.get_run_function()
 
     def get_schedule_chunk(self, chunk_id):
+        """
+        Get the schedule chunk for the specified chunk_id and build schedule nodes.
+
+        This method is used in pipeline parallel to retrieve the model chunk
+        (run_function) corresponding to the chunk_id and build schedule nodes for that chunk.
+
+        Args:
+            chunk_id (int): The ID of the virtual pipeline chunk to retrieve
+
+        Returns:
+            list: The built schedule nodes list
+
+        Raises:
+            AssertionError: If recompute_interval is not 0, as overlap schedule mode requires recompute_interval to be 0
+        """
         self.update_run_function(chunk_id)
 
-        assert self._recompute_interval == 0
+        assert self._recompute_interval == 0, (
+            "overlap_schedule_mode requires recompute_interval==0."
+        )
         return self.build_schedule_nodes(0, len(self.run_function))
 
     def forward(self, input, chunk_id=None):

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/spec_utils.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/spec_utils.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+from __future__ import annotations
+
+import types
+import warnings
+from dataclasses import dataclass, field
+
+
+@dataclass
+class LayerSpec:
+    """This is a Layer Specification dataclass.
+
+    Specification defines the location of the layer (to import dynamically)
+    or the imported layer itself. It also defines the extra_kwargs that need to be
+    passed to initialize the layer.
+
+    Args:
+        layer (tuple | type): A tuple describing the location of the
+            layer class e.g. `(layer.location, LayerClass)` or the imported
+            layer class itself e.g. `LayerClass` (which is already imported
+            using `from layer.location import LayerClass`).
+        extra_kwargs (dict): A dictionary of extra_kwargs that need to be passed while init.
+
+    """
+
+    layer: tuple | type
+    extra_kwargs: dict = field(default_factory=lambda: {})
+    sublayers_spec: type = None
+
+    def __repr__(self):
+        rst = ""
+        if isinstance(self.layer, tuple):
+            for sub_layer in self.layer:
+                rst = rst + repr(sub_layer) + ","
+        else:
+            rst = repr(self.layer) + repr(self.extra_kwargs)
+        return rst
+
+
+def import_spec_layer(layer_path: tuple[str]):
+    """Import a named object from a layer in the context of this function."""
+    base_path, name = layer_path
+    try:
+        layer = __import__(base_path, globals(), locals(), [name])
+    except ImportError as e:
+        print(f"couldn't import layer due to {e}")
+        return None
+    return vars(layer)[name]
+
+
+def get_spec_layer(spec_or_layer: LayerSpec | type, **additional_kwargs):
+    # If a layer class is already provided return it as is
+    if isinstance(spec_or_layer, (type, types.FunctionType)):
+        return spec_or_layer
+
+    # If the layer is provided instead of layer path, then return it as is
+    if isinstance(spec_or_layer.layer, (type, types.FunctionType)):
+        return spec_or_layer.layer
+
+    # Otherwise, return the dynamically imported layer from the layer path
+    return import_spec_layer(spec_or_layer.layer)
+
+
+def build_spec_layer(spec_or_layer: LayerSpec | type, *args, **kwargs):
+    # If the passed `spec_or_layer` is
+    # a `Function`, then return it as it is
+    # NOTE: to support an already initialized layer add the following condition
+    # `or isinstance(spec_or_layer, paddle.nn.Layer)` to the following if check
+    if isinstance(spec_or_layer, types.FunctionType):
+        return spec_or_layer
+
+    # If the passed `spec_or_layer` is actually a spec (instance of
+    # `LayerSpec`) and it specifies a `Function` using its `layer`
+    # field, return the `Function` as it is
+    if isinstance(spec_or_layer, LayerSpec) and isinstance(
+        spec_or_layer.layer, types.FunctionType
+    ):
+        return spec_or_layer.layer
+
+    # Check if a layer class is provided as a spec or if the layer path
+    # itself is a class
+    if isinstance(spec_or_layer, type):
+        layer = spec_or_layer
+    elif hasattr(spec_or_layer, "layer") and isinstance(
+        spec_or_layer.layer, type
+    ):
+        layer = spec_or_layer.layer
+    else:
+        # Otherwise, dynamically import the layer from the layer path
+        layer = import_spec_layer(spec_or_layer.layer)
+
+    # If the imported layer is actually a `Function` return it as it is
+    if isinstance(layer, types.FunctionType):
+        return layer
+
+    # Finally return the initialized layer with extra_kwargs from the spec as well
+    # as those passed as **kwargs from the code
+
+    # Add the `sublayers_spec` argument to the layer init call if it exists in the
+    # spec.
+    if (
+        hasattr(spec_or_layer, "sublayers_spec")
+        and spec_or_layer.sublayers_spec is not None
+    ):
+        kwargs["sublayers_spec"] = spec_or_layer.sublayers_spec
+    if hasattr(spec_or_layer, "extra_kwargs"):
+        for key in spec_or_layer.extra_kwargs.keys():
+            if key in kwargs:
+                warnings.warn(
+                    f"Got same key {key} in extra_kwargs and kwargs during init {layer.__name__}. Will keep the value ing extra_kwargs."
+                )
+                kwargs.pop(key)
+    try:
+        return layer(
+            *args,
+            **spec_or_layer.extra_kwargs
+            if hasattr(spec_or_layer, "extra_kwargs")
+            else {},
+            **kwargs,
+        )
+    except Exception as e:
+        # improve the error message since we hide the layer name in the line above
+        import sys
+
+        raise type(e)(
+            f"{e!s} when instantiating {layer.__name__}"
+        ).with_traceback(sys.exc_info()[2])

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -58,6 +58,7 @@ from paddle.distributed.fleet.utils.tensor_fusion_helper import (
 from .pipeline_hooks import (
     PipelineHook,
 )
+from .pp_utils.utils import dict_to_tuple_helper, tuple_to_dict_helper
 
 g_profile_pipeline_details_steps = int(
     os.getenv("FLAGS_profile_pipeline_details_steps", "0")
@@ -187,6 +188,11 @@ class FakeMicroDataset:
             assert len(inputs) == self._acc_steps, (
                 f"length of data should be {self._acc_steps}, but it is {len(inputs)}"
             )
+            if isinstance(inputs[micro_step], list):
+                return [
+                    tensor.detach() if tensor is not None else None
+                    for tensor in inputs[micro_step]
+                ]
             return inputs[micro_step].detach()
         elif inputs is not None:
             self._check_data_valid(inputs)
@@ -287,6 +293,308 @@ def register_global_pipeline_parallel_hook(
     Registering global hooks for pipeline parallelism.
     """
     pipeline_parallel_callbacks_.register_hook(location, hook)
+
+
+class NoPipelineParallel(MetaParallelBase):
+    def __init__(self, layers, strategy, hcg=None):
+        assert isinstance(layers, PipelineLayer)
+        super().__init__(layers, hcg, strategy)
+        self._layers = layers
+        self._strategy = strategy
+        self._hcg = hcg
+
+        self.micro_batch_size = self._strategy.pipeline_configs[
+            "micro_batch_size"
+        ]
+        self.accumulate_steps = self._strategy.pipeline_configs[
+            "accumulate_steps"
+        ]
+        self._delay_scale_loss = self._strategy.hybrid_configs[
+            "pp_configs"
+        ].delay_scale_loss
+        self._dp_comm_overlap = False
+        self._sharding_comm_overlap = False
+
+        # store total loss of entire batch. It contains the loss of each micro batch in a list, then contains many loss_fn's list in total_loss.
+        self.total_loss = None
+
+        # default loss function index
+        self.loss_fn_idx = 0
+
+        if self._hcg is not None:
+            self.use_data_parallel = (
+                self._hcg.get_data_parallel_world_size() > 1
+            )
+            self.use_model_parallel = (
+                self._hcg.get_model_parallel_world_size() > 1
+            )
+            self.use_sep_parallel = self._hcg.get_sep_parallel_world_size() > 1
+            self.use_sharding_parallel = (
+                self._hcg.get_sharding_parallel_world_size() > 1
+            )
+            self.use_moe_sharding_parallel = (
+                self._hcg.get_moe_sharding_parallel_world_size() > 1
+            )
+
+            self.dp_group = self._hcg.get_data_parallel_group()
+            # fused sep and dp
+            if self.use_sep_parallel:
+                self.dp_group = self._hcg.get_dp_sep_parallel_group()
+
+            if self.use_model_parallel:
+                logger.info("start broadcast mp parameters")
+                broadcast_mp_parameters(self._layers, self._hcg)
+
+            if self.use_sep_parallel:
+                logger.info("start broadcast sep parameters")
+                broadcast_sep_parameters(self._layers, self._hcg)
+
+            if self.use_sharding_parallel:
+                logger.info("start broadcast sharding parameters")
+                broadcast_sharding_parameters(self._layers, self._hcg)
+
+            if self.use_data_parallel:
+                logger.info("start broadcast dp parameters")
+                broadcast_dp_parameters(self._layers, self._hcg)
+
+            if self.use_moe_sharding_parallel:
+                logger.info("start broadcast moe_sharding parameters")
+                broadcast_moe_sharding_parameters(self._layers, self._hcg)
+
+    def is_pipeline_last_stage(self, ignore_virtual=False):
+        return True
+
+    def _check_micro_batch_data_valid(self, micro_batch_data):
+        if isinstance(micro_batch_data, (tuple, list)):
+            for data in micro_batch_data:
+                self._check_micro_batch_data_valid(data)
+        elif isinstance(micro_batch_data, dict):
+            for value in micro_batch_data.values():
+                self._check_micro_batch_data_valid(value)
+        elif micro_batch_data is not None:
+            assert isinstance(micro_batch_data, paddle.Tensor)
+
+    def _prepare_training(self, data, optimizer, lr_scheduler):
+        assert framework._dygraph_tracer()._has_grad, (
+            "Please enable the generation of gradients."
+        )
+        self.optimizer = optimizer
+        self.lr_scheduler = lr_scheduler
+        self._layers.train()
+        return data
+
+    def _optimizer_step(self):
+        if self._delay_scale_loss:
+            for p in self._layers.parameters():
+                if hasattr(p, "main_grad") and p.main_grad is not None:
+                    assert p.grad is None
+                    p.main_grad = p.main_grad.scale(1.0 / self.accumulate_steps)
+                elif p.grad is not None:
+                    p.grad = p.grad.scale(1.0 / self.accumulate_steps)
+
+        if self.scaler:
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+        else:
+            self.optimizer.step()
+
+        self.optimizer.clear_grad()
+
+        if self.lr_scheduler:
+            self.lr_scheduler.step()
+
+    def forward_backward_pipeline(
+        self,
+        data,
+        scaler=None,
+        return_micro_batch_loss=False,
+    ):
+        self.scaler = scaler
+        self.total_loss = None
+
+        if isinstance(data, PipelineDatasetPreprocessor):
+            data = data()
+
+        if (not isinstance(data, tuple)) and (not isinstance(data, list)):
+            micro_dataset = data
+        else:
+            micro_dataset = FakeMicroDataset(
+                data,
+                True,
+                True,
+                self.accumulate_steps,
+                self.micro_batch_size,
+            )
+
+        loss_list = []
+        for _ in range(self.accumulate_steps):
+            # data prepare
+            data_iter = next(micro_dataset)
+            input_tensor = data_iter[0]
+            label = data_iter[1]
+            self._check_micro_batch_data_valid(input_tensor)
+            self._check_micro_batch_data_valid(label)
+
+            # forward
+            output_tensor = self._layers.forward(input_tensor)
+
+            # loss is loss_fn[loss_fn_idx]'s result
+            loss = None
+            # cal loss
+            for idx, loss_fn in enumerate(self._layers._loss_fn):
+                loss_tensor = loss_fn(output_tensor, label)
+                assert isinstance(loss_tensor, paddle.Tensor), (
+                    "Currently, loss_fn should obtain Paddle.Tensor dtype"
+                )
+                with paddle.amp.auto_cast(enable=False):
+                    if self.accumulate_steps > 1 and not self._delay_scale_loss:
+                        loss_tensor = loss_tensor / self.accumulate_steps
+                if self.total_loss is None:
+                    self.total_loss = []
+                # when self.total_loss length is less than idx, append a new tensor
+                if len(self.total_loss) <= idx:
+                    self.total_loss.append([])
+
+                self.total_loss[idx].append(loss_tensor.detach())
+
+                if idx == self.loss_fn_idx:
+                    loss = loss_tensor
+
+            # backward
+            with paddle.amp.auto_cast(enable=False):
+                if self.scaler:
+                    paddle.autograd.backward(self.scaler.scale(loss))
+                else:
+                    paddle.autograd.backward(loss)
+
+            assert self.total_loss is not None, (
+                "train_batch() in last stage should obtain valid loss"
+            )
+
+        losses = []
+        with paddle.amp.auto_cast(enable=False):
+            for idx in range(len(self._layers._loss_fn)):
+                self.total_loss[idx] = paddle.to_tensor(self.total_loss[idx])
+                if not return_micro_batch_loss:
+                    # TODO(shenliang03): it will use mean/sum to calculate loss
+                    tmp = paddle.zeros_like(self.total_loss[idx][0])
+                    for loss in self.total_loss[idx]:
+                        tmp += loss.detach()
+                    if not self._delay_scale_loss:
+                        losses.append(tmp)
+                    else:
+                        losses.append(tmp / self.accumulate_steps)
+                else:
+                    losses.append(self.total_loss[idx].detach())
+        return losses[0] if len(losses) == 1 else losses
+
+    def train_batch(
+        self,
+        data,
+        optimizer,
+        lr_scheduler=None,
+        scaler=None,
+        loss_fn_idx=0,
+        return_micro_batch_loss=False,
+    ):
+        data = self._prepare_training(data, optimizer, lr_scheduler)
+
+        # check loss_fn_idx is valid and loss_fn exists
+        assert (
+            loss_fn_idx in range(len(self._layers._loss_fn))
+            and self._layers._loss_fn[loss_fn_idx] is not None
+        ), f"loss function {loss_fn_idx} should exist to compute loss"
+        self.loss_fn_idx = loss_fn_idx
+
+        # no pipeline parallel
+        train_loss = self.forward_backward_pipeline(
+            data, scaler, return_micro_batch_loss=return_micro_batch_loss
+        )
+
+        # optimizer
+        with paddle.amp.auto_cast(enable=False):
+            self._optimizer_step()
+
+        return train_loss
+
+    def eval_batch(self, data, compute_loss=False, loss_fn_idx=0):
+        # check loss_fn_idx is valid and loss_fn exists
+        assert (
+            loss_fn_idx in range(len(self._layers._loss_fn))
+            and self._layers._loss_fn[loss_fn_idx] is not None
+        ), f"loss function {loss_fn_idx} should exist to compute loss"
+        self.loss_fn_idx = loss_fn_idx
+
+        self.total_loss = None
+
+        if isinstance(data, PipelineDatasetPreprocessor):
+            data = data()
+
+        if (not isinstance(data, tuple)) and (not isinstance(data, list)):
+            micro_dataset = data
+        else:
+            micro_dataset = FakeMicroDataset(
+                data,
+                True,
+                True,
+                self.accumulate_steps,
+                self.micro_batch_size,
+            )
+
+        loss_list = []
+        for _ in range(self.accumulate_steps):
+            # data prepare
+            data_iter = next(micro_dataset)
+            input_tensor = data_iter[0]
+            label = data_iter[1]
+            self._check_micro_batch_data_valid(input_tensor)
+            self._check_micro_batch_data_valid(label)
+
+            # forward
+            output_tensor = self._layers.forward(input_tensor)
+
+            # loss is loss_fn[loss_fn_idx]'s result
+            loss = None
+            # cal loss
+            for idx, loss_fn in enumerate(self._layers._loss_fn):
+                loss_tensor = loss_fn(output_tensor, label)
+                assert isinstance(loss_tensor, paddle.Tensor), (
+                    "Currently, loss_fn should obtain Paddle.Tensor dtype"
+                )
+                with paddle.amp.auto_cast(enable=False):
+                    if self.accumulate_steps > 1 and not self._delay_scale_loss:
+                        loss_tensor = loss_tensor / self.accumulate_steps
+                if self.total_loss is None:
+                    self.total_loss = []
+                # when self.total_loss length is less than idx, append a new tensor
+                if len(self.total_loss) <= idx:
+                    self.total_loss.append([])
+
+                self.total_loss[idx].append(loss_tensor.detach())
+
+                if idx == self.loss_fn_idx:
+                    loss = loss_tensor
+
+            assert self.total_loss is not None, (
+                "train_batch() in last stage should obtain valid loss"
+            )
+
+        losses = []
+        return_micro_batch_loss = False
+        for idx in range(len(self._layers._loss_fn)):
+            self.total_loss[idx] = paddle.to_tensor(self.total_loss[idx])
+            if not return_micro_batch_loss:
+                # TODO(shenliang03): it will use mean/sum to calculate loss
+                tmp = paddle.zeros_like(self.total_loss[idx][0])
+                for loss in self.total_loss[idx]:
+                    tmp += loss.detach()
+                if not self._delay_scale_loss:
+                    losses.append(tmp)
+                else:
+                    losses.append(tmp / self.accumulate_steps)
+            else:
+                losses.append(self.total_loss[idx].detach())
+        return losses[0] if len(losses) == 1 else losses
 
 
 class PipelineParallel(MetaParallelBase):
@@ -1113,6 +1421,9 @@ class PipelineParallel(MetaParallelBase):
                 batch_p2p_comm=self._use_batch_p2p_comm,
             )
 
+            # p2p data type: tuple
+            # model input/return type: dict
+            # here, convert p2p tuple -> dict input
             input_tensor_dict, use_dict = tuple_to_dict_helper(input_tensor)
 
             output_tensor, _, _ = self._forward_step(
@@ -1998,6 +2309,8 @@ class PipelineParallelWithInterleave(PipelineParallel):
                 self.forward_hooks.run_hook()
 
             forward_inputs = self._get_forward_input(forward_virtual_pp_rank)
+
+            input_tensor_dict, use_dict = tuple_to_dict_helper(forward_inputs)
             if self.is_pipeline_first_stage():
                 forward_inputs = next(micro_dataset)[0]
                 self._check_micro_batch_data_valid(forward_inputs)
@@ -2049,7 +2362,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
             output_tensor, forward_loss, input_tensor_grad = (
                 self._layers.overlapped_forward_backward(
                     forward_chunk,
-                    forward_inputs,
+                    input_tensor_dict if use_dict else forward_inputs,
                     forward_loss_fn_node,
                     backward_chunk,
                     backward_loss_fn_node,
@@ -2058,6 +2371,9 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     p2p_async_handle=p2p_async_handle,
                 )
             )
+
+            output_tensor_tuple = dict_to_tuple_helper(output_tensor)
+
             if self.processed_steps < g_profile_pipeline_details_steps:
                 profile_pipeline_details(
                     "[Pipeline details] After_forward_backward_step"
@@ -2072,7 +2388,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
             self.set_virtual_pipeline_rank(forward_virtual_pp_rank)
             self._store_forward_outputs(
                 forward_virtual_pp_rank,
-                output_tensor,
+                output_tensor_tuple,
                 forward_chunk,
                 forward_loss_fn_node,
             )
@@ -2095,7 +2411,7 @@ class PipelineParallelWithInterleave(PipelineParallel):
             self.set_virtual_pipeline_rank(backward_virtual_pp_rank)
             self._overlap_comm_grads()
 
-            return output_tensor, input_tensor_grad
+            return output_tensor_tuple, input_tensor_grad
 
     def bw_hook_func(self, buffer, param):
         # For pipeline with interleave, we need to add grad to buffer without communication.
@@ -2129,6 +2445,36 @@ class PipelineParallelWithInterleave(PipelineParallel):
         static_scheduler=False,
         return_micro_batch_loss=False,
     ):
+        """
+        Executes forward and backward passes for pipeline parallel training with interleaved scheduling.
+
+        This method implements pipeline parallel training using interleaved scheduling strategy,
+        inspired by Megatron-LM's implementation. It handles forward pass, backward pass, and
+        gradient computation while managing communication and synchronization between stages.
+
+        Args:
+            data: Input data that will be wrapped into micro-batches
+            scaler: Gradient scaler for mixed precision training
+            forward_only: Whether to only perform forward pass (default: False)
+            compute_loss: Whether to compute loss (default: True)
+            return_micro_batch_loss: Whether to return micro-batch level loss (default: False)
+
+        Returns:
+            Training loss or logits if compute_loss is True;
+            Otherwise returns output logits from the last stage
+
+        Raises:
+            AssertionError:
+                - When compute_loss=False but forward_only=False
+                - When cache is disabled but using interleaved pipeline
+                - When buffers are not empty after execution
+
+        Note:
+            - Uses interleaved scheduling strategy (requires cache to be enabled)
+            - Supports overlapping communication and computation for optimization
+            - Handles startup phase, steady phase, and cooldown phase
+            - Supports best unbalanced scheduler (_best_unbalanced_scheduler)
+        """
         self._reset_user_hooks_status()
         if self.processed_steps < g_profile_pipeline_details_steps:
             profile_pipeline_details(
@@ -2954,6 +3300,29 @@ class PipelineParallelWithInterleave(PipelineParallel):
         loss_fn_idx=0,
         return_micro_batch_loss=False,
     ):
+        """
+        Execute one training batch with pipeline parallel interleaving schedule.
+
+        Performs forward/backward passes and optimizer update for a batch of data
+        using pipeline parallel with interleaved scheduling.
+
+        Args:
+            data: Input data for the batch
+            optimizer: Optimizer instance for parameter updates
+            lr_scheduler: Learning rate scheduler (optional)
+            scaler: Gradient scaler for mixed precision training (optional)
+            loss_fn_idx: Index of loss function to use (default: 0)
+            return_micro_batch_loss: Whether to return per-micro-batch losses (default: False)
+
+        Returns:
+            The computed training loss. If return_micro_batch_loss is True,
+            returns a tuple of (total_loss, micro_batch_losses).
+
+        Note:
+            - Handles both FP16/FP32 mixed precision training when scaler is provided
+            - Supports multiple loss functions through loss_fn_idx
+            - Uses interleaved pipeline parallel schedule for efficient training
+        """
         data = self._prepare_training(data, optimizer, lr_scheduler)
 
         # check loss_fn_idx is valid and loss_fn exists
@@ -3010,7 +3379,9 @@ class PipelineParallelWithInterleave(PipelineParallel):
 
 class PipelineParallelWithInterleaveFthenB(PipelineParallelWithInterleave):
     def __init__(self, layers, hcg, strategy):
+        # Initialize the basic parameters of the parent class PipelineParallel
         super().__init__(layers=layers, hcg=hcg, strategy=strategy)
+        # Whether to enable overlapped scheduling mode (disabled by default)
         self.overlap_schedule_mode = False
 
     def _get_scheduler_name(self):
@@ -3622,55 +3993,3 @@ class VPPFhenBInBalancedMemory(PipelineParallelWithInterleaveFthenB):
         self.processed_steps += 1
         self._check_user_hooks_status_at_step_end()
         return train_loss_or_logits
-
-
-def tuple_to_dict_helper(input_tensor):
-    # recv tuple -> fwd input dict
-    use_dict = False
-    if isinstance(input_tensor, tuple):
-        use_dict = hasattr(input_tensor[0], "key")
-    else:  # single tensor
-        use_dict = hasattr(input_tensor, "key")
-    if use_dict:
-        input_tensor = convert_tensor_tuple_to_dict(input_tensor)
-    return input_tensor, use_dict
-
-
-def dict_to_tuple_helper(output_tensor):
-    if isinstance(output_tensor, dict):
-        output_tensor_tuple = convert_tensor_dict_to_tuple(
-            output_tensor_dict=output_tensor
-        )
-    else:  # single tensor or tensor tuple
-        output_tensor_tuple = output_tensor
-    return output_tensor_tuple
-
-
-def convert_tensor_dict_to_tuple(output_tensor_dict):
-    output_tensor = []
-    for key, tensor in output_tensor_dict.items():
-        if isinstance(tensor, (list, tuple)):
-            for idx, t in enumerate(tensor):
-                t.key = key + " " + str(idx)
-                output_tensor.append(t)
-        else:  # single tensor
-            tensor.key = key
-            output_tensor.append(tensor)
-
-    return tuple(output_tensor)
-
-
-def convert_tensor_tuple_to_dict(input_tensor_tuple):
-    input_tensor_dict = {}
-    for tensor in input_tensor_tuple:
-        key = tensor.key
-        if " " in key:
-            real_key, _ = key.split(" ")
-            if real_key in input_tensor_dict.keys():
-                input_tensor_dict[real_key].append(tensor)
-            else:
-                input_tensor_dict[real_key] = [tensor]
-        else:
-            input_tensor_dict[key] = tensor
-        delattr(tensor, "key")
-    return input_tensor_dict

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/forward_backward_overlap_utils.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/forward_backward_overlap_utils.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import paddle
+
+from .utils import dict_to_tuple_helper
 
 
 class ScheduleChunk:
@@ -44,13 +47,24 @@ def detach_and_requires_grad(inputs):
         for input in inputs:
             if isinstance(input, (tuple, list)):
                 ret.append(detach_and_requires_grad(input))
-            else:
+            elif isinstance(input, paddle.Tensor):
                 tmp = input.detach() if input is not None else None
                 if tmp is not None:
                     tmp.stop_gradient = input.stop_gradient
                 ret.append(tmp)
+            else:
+                ret.append(input)
         if is_tuple:
             ret = tuple(ret)
+        return ret
+    elif isinstance(inputs, dict):
+        ret = {}
+        for key in inputs.keys():
+            input = inputs[key]
+            tmp = input.detach() if input is not None else None
+            if tmp is not None:
+                tmp.stop_gradient = input.stop_gradient
+            ret[key] = tmp
         return ret
     else:
         tmp = inputs.detach()
@@ -72,6 +86,16 @@ def clone_and_clear_dataptr(outputs, clear_dataptr=False):
                 o._clear_dataptr()
         if is_tuple:
             ret = tuple(ret)
+        return ret
+    elif isinstance(outputs, dict):
+        ret = {}
+        for key in outputs.keys():
+            o = outputs[key]
+            if o is not None and isinstance(o, paddle.Tensor):
+                ret[key] = FakeClone.apply(o)
+        if clear_dataptr:
+            for key in ret:
+                ret[key]._clear_dataptr()
         return ret
     else:
         ret = FakeClone.apply(outputs)
@@ -105,13 +129,13 @@ class ScheduleNode:
         self.labels = None
         self.scale_loss_factor = None
 
-    def forward(self, inputs=()):
+    def forward(self, inputs=(), **kwargs):
         detached_inputs = detach_and_requires_grad(inputs)
         self.inputs = detached_inputs
         if self.labels is not None:
-            outputs = self.fwd_func(self.inputs, self.labels)
+            outputs = self.fwd_func(self.inputs, self.labels, **kwargs)
         else:
-            outputs = self.fwd_func(self.inputs)
+            outputs = self.fwd_func(self.inputs, **kwargs)
         if self.scale_loss_factor is not None:
             outputs /= self.scale_loss_factor
 
@@ -136,24 +160,31 @@ class ScheduleNode:
             if not isinstance(output_grad, (tuple, list)):
                 output_grad = (output_grad,)
 
-            outputs = self.outputs
+            outputs = dict_to_tuple_helper(self.outputs)
             if not isinstance(outputs, (tuple, list)):
                 outputs = (outputs,)
+            outputs = [t for t in outputs if not t.stop_gradient]
             assert len(outputs) == len(output_grad), (
                 f"{len(outputs)} of {type(outputs[0])} vs {len(output_grad)} of {type(output_grad[0])}"
             )
 
             paddle.autograd.backward(outputs, output_grad)
 
-        if not isinstance(self.inputs, (tuple, list)):
-            inputs = (self.inputs,)
-        else:
-            inputs = self.inputs
-        grad = tuple([e.grad if e is not None else None for e in inputs])
+        inputs = dict_to_tuple_helper(self.inputs)
+        if not isinstance(inputs, (tuple, list)):
+            inputs = (inputs,)
+        grad = tuple(
+            [
+                t.grad
+                for t in inputs
+                if isinstance(t, paddle.Tensor) and not t.stop_gradient
+            ]
+        )
+        # grad = tuple([e.grad if e is not None and not e.stop_gradient else None for e in inputs])
         self._reset_states()
 
-        if len(grad) == 1:
-            grad = grad[0]
+        # if len(grad) == 1:
+        #     grad = grad[0]
         return grad
 
     def _reset_states(self):

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/forward_backward_overlap_utils.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/forward_backward_overlap_utils.py
@@ -157,13 +157,26 @@ class ScheduleNode:
             else:
                 paddle.autograd.backward(outputs)
         else:
+            # Record the original type (tuple or list) to preserve it after filtering
+            is_output_grad_tuple = isinstance(output_grad, tuple)
             if not isinstance(output_grad, (tuple, list)):
+                is_output_grad_tuple = True  # Single value becomes tuple
                 output_grad = (output_grad,)
 
             outputs = dict_to_tuple_helper(self.outputs)
             if not isinstance(outputs, (tuple, list)):
                 outputs = (outputs,)
             outputs = [t for t in outputs if not t.stop_gradient]
+
+            # Filter None values from output_grad
+            output_grad = [grad for grad in output_grad if grad is not None]
+            # Preserve original type (tuple or list)
+            output_grad = (
+                tuple(output_grad)
+                if is_output_grad_tuple
+                else list(output_grad)
+            )
+
             assert len(outputs) == len(output_grad), (
                 f"{len(outputs)} of {type(outputs[0])} vs {len(output_grad)} of {type(output_grad[0])}"
             )
@@ -173,13 +186,7 @@ class ScheduleNode:
         inputs = dict_to_tuple_helper(self.inputs)
         if not isinstance(inputs, (tuple, list)):
             inputs = (inputs,)
-        grad = tuple(
-            [
-                t.grad
-                for t in inputs
-                if isinstance(t, paddle.Tensor) and not t.stop_gradient
-            ]
-        )
+        grad = tuple([e.grad if e is not None else None for e in inputs])
         # grad = tuple([e.grad if e is not None and not e.stop_gradient else None for e in inputs])
         self._reset_states()
 

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/utils.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/utils.py
@@ -106,3 +106,55 @@ def _all_gather(tensor, group=None, use_calc_stream=True):
         ring_id,
         nranks,
     )
+
+
+def tuple_to_dict_helper(input_tensor):
+    # recv tuple -> fwd input dict
+    use_dict = False
+    if isinstance(input_tensor, tuple):
+        use_dict = hasattr(input_tensor[0], "key")
+    else:  # single tensor
+        use_dict = hasattr(input_tensor, "key")
+    if use_dict:
+        input_tensor = convert_tensor_tuple_to_dict(input_tensor)
+    return input_tensor, use_dict
+
+
+def dict_to_tuple_helper(output_tensor):
+    if isinstance(output_tensor, dict):
+        output_tensor_tuple = convert_tensor_dict_to_tuple(
+            output_tensor_dict=output_tensor
+        )
+    else:  # single tensor or tensor tuple
+        output_tensor_tuple = output_tensor
+    return output_tensor_tuple
+
+
+def convert_tensor_dict_to_tuple(output_tensor_dict):
+    output_tensor = []
+    for key, tensor in output_tensor_dict.items():
+        if isinstance(tensor, (list, tuple)):
+            for idx, t in enumerate(tensor):
+                t.key = key + " " + str(idx)
+                output_tensor.append(t)
+        else:  # single tensor
+            tensor.key = key
+            output_tensor.append(tensor)
+
+    return tuple(output_tensor)
+
+
+def convert_tensor_tuple_to_dict(input_tensor_tuple):
+    input_tensor_dict = {}
+    for tensor in input_tensor_tuple:
+        key = tensor.key
+        if " " in key:
+            real_key, _ = key.split(" ")
+            if real_key in input_tensor_dict.keys():
+                input_tensor_dict[real_key].append(tensor)
+            else:
+                input_tensor_dict[real_key] = [tensor]
+        else:
+            input_tensor_dict[key] = tensor
+        delattr(tensor, "key")
+    return input_tensor_dict

--- a/python/paddle/distributed/fleet/model.py
+++ b/python/paddle/distributed/fleet/model.py
@@ -18,6 +18,7 @@ from paddle.distributed import fleet
 from .base.topology import ParallelMode
 from .meta_parallel import (
     DualPipeVParallel,
+    NoPipelineParallel,
     PipelineLayer,
     PipelineParallel,
     PipelineParallelWithInterleave,
@@ -83,12 +84,12 @@ def distributed_model(model):
 
     """
     fleet_env = fleet.fleet
-
+    strategy = fleet_env._user_defined_strategy
     assert model is not None, "model should not be None"
     if paddle.distributed.get_world_size() <= 1:
+        model = NoPipelineParallel(model, strategy=strategy)
         return model
 
-    strategy = fleet_env._user_defined_strategy
     if strategy.amp:
         level = (
             "O2"
@@ -132,30 +133,7 @@ def distributed_model(model):
             use_dynamic_loss_scaling=use_dynamic_loss_scaling,
         )
 
-    if strategy.heter_ccl_mode:
-        distributed_model = paddle.DataParallel(
-            model,
-            comm_buffer_size=strategy.fuse_grad_size_in_MB,
-            last_comm_buffer_size=strategy.last_comm_group_size_MB,
-            find_unused_parameters=strategy.find_unused_parameters,
-        )
-        return distributed_model
-
-    if fleet_env._hcg.get_parallel_mode() == ParallelMode.SHARDING_PARALLEL:
-        model = ShardingParallel(model, fleet_env._hcg, strategy=strategy)
-    elif fleet_env._hcg.get_parallel_mode() == ParallelMode.DATA_PARALLEL:
-        model = paddle.DataParallel(
-            model,
-            comm_buffer_size=strategy.fuse_grad_size_in_MB,
-            last_comm_buffer_size=strategy.last_comm_group_size_MB,
-            find_unused_parameters=strategy.find_unused_parameters,
-            group=fleet_env._hcg.get_data_parallel_group(),
-        )
-    elif fleet_env._hcg.get_parallel_mode() == ParallelMode.SEGMENT_PARALLEL:
-        model = SegmentParallel(model, fleet_env._hcg, strategy=strategy)
-    elif fleet_env._hcg.get_parallel_mode() == ParallelMode.TENSOR_PARALLEL:
-        model = TensorParallel(model, fleet_env._hcg, strategy=strategy)
-    elif fleet_env._hcg.get_parallel_mode() == ParallelMode.PIPELINE_PARALLEL:
+    if fleet_env._hcg.get_parallel_mode() == ParallelMode.PIPELINE_PARALLEL:
         assert isinstance(model, PipelineLayer), (
             "For pipeline parallel, the model should an instance of PipelineLayer"
         )
@@ -187,5 +165,50 @@ def distributed_model(model):
                 raise ValueError(
                     f"The accumulate_steps({accumulate_steps}) should be greater than or equal to pp_degree({pp_degree})"
                 )
+    else:
+        if isinstance(model, PipelineLayer):
+            # PaddleFleet Model
+            model = NoPipelineParallel(
+                model, strategy=strategy, hcg=fleet_env._hcg
+            )
+        else:
+            if strategy.heter_ccl_mode:
+                distributed_model = paddle.DataParallel(
+                    model,
+                    comm_buffer_size=strategy.fuse_grad_size_in_MB,
+                    last_comm_buffer_size=strategy.last_comm_group_size_MB,
+                    find_unused_parameters=strategy.find_unused_parameters,
+                )
+                return distributed_model
+
+            if (
+                fleet_env._hcg.get_parallel_mode()
+                == ParallelMode.SHARDING_PARALLEL
+            ):
+                model = ShardingParallel(
+                    model, fleet_env._hcg, strategy=strategy
+                )
+            elif (
+                fleet_env._hcg.get_parallel_mode() == ParallelMode.DATA_PARALLEL
+            ):
+                model = paddle.DataParallel(
+                    model,
+                    comm_buffer_size=strategy.fuse_grad_size_in_MB,
+                    last_comm_buffer_size=strategy.last_comm_group_size_MB,
+                    find_unused_parameters=strategy.find_unused_parameters,
+                    group=fleet_env._hcg.get_data_parallel_group(),
+                )
+            elif (
+                fleet_env._hcg.get_parallel_mode()
+                == ParallelMode.SEGMENT_PARALLEL
+            ):
+                model = SegmentParallel(
+                    model, fleet_env._hcg, strategy=strategy
+                )
+            elif (
+                fleet_env._hcg.get_parallel_mode()
+                == ParallelMode.TENSOR_PARALLEL
+            ):
+                model = TensorParallel(model, fleet_env._hcg, strategy=strategy)
 
     return model

--- a/test/collective/fleet/CMakeLists.txt
+++ b/test/collective/fleet/CMakeLists.txt
@@ -908,3 +908,41 @@ if((WITH_GPU) AND LOCAL_ALL_PLAT)
   )
   set_tests_properties(test_sharding_stage3_bugfix PROPERTIES TIMEOUT "500")
 endif()
+if((WITH_GPU) AND LOCAL_ALL_PLAT)
+  bash_test_modules(
+    test_pp_layers
+    START_BASH
+    ../../legacy_test/dist_test.sh
+    TIMEOUT
+    "500"
+    LABELS
+    "RUN_TYPE=DIST"
+    ENVS
+    "PADDLE_DIST_UT_PORT=21282;http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python"
+  )
+  set_tests_properties(test_pp_layers PROPERTIES TIMEOUT "500")
+endif()
+if((WITH_GPU) AND LOCAL_ALL_PLAT)
+  bash_test_modules(
+    test_pp_with_shared_weight
+    START_BASH
+    ../../legacy_test/dist_test.sh
+    TIMEOUT
+    "500"
+    LABELS
+    "RUN_TYPE=DIST"
+    ENVS
+    "PADDLE_DIST_UT_PORT=21282;http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python"
+  )
+  set_tests_properties(test_pp_with_shared_weight PROPERTIES TIMEOUT "500")
+endif()
+if(LOCAL_ALL_ARCH AND LOCAL_ALL_PLAT)
+  py_test_modules(
+    test_layer_spec MODULES test_layer_spec ENVS
+    "http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python")
+endif()
+if(LOCAL_ALL_ARCH AND LOCAL_ALL_PLAT)
+  py_test_modules(
+    test_schedule_node MODULES test_schedule_node ENVS
+    "http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python")
+endif()

--- a/test/collective/fleet/hybrid_parallel_pp_layers.py
+++ b/test/collective/fleet/hybrid_parallel_pp_layers.py
@@ -1,0 +1,348 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass
+
+import numpy as np
+from dist_amp_base import (
+    create_optimizer,
+)
+
+import paddle
+from paddle import nn
+from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_parallel import (
+    LayerDesc,
+    LayerSpec,
+    NoPipelineParallel,
+    PipelineLayer,
+    build_spec_layer,
+)
+from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+    PipelineDatasetPreprocessor,
+)
+from paddle.nn import Layer
+from paddle.nn.layer import Identity
+
+
+class ReshapeHelp(Layer):
+    def __init__(self, shape):
+        super().__init__()
+        self.shape = shape
+
+    def forward(self, x):
+        return x.reshape(shape=self.shape)
+
+
+@dataclass
+class AlexNetLayerSpec:
+    features: list[LayerSpec] | list[Identity]
+    reshape_layer: LayerSpec | type = Identity
+    classifier: LayerSpec | type = Identity
+
+
+class AlexNet(PipelineLayer):
+    def __init__(self, sublayers_spec: AlexNetLayerSpec, **kwargs):
+        self.layers = AlexNet.get_layer_desc_list(sublayers_spec)
+
+        super().__init__(layers=self.layers, **kwargs)
+
+    @staticmethod
+    def get_layer_desc_list(spec: AlexNetLayerSpec):
+        layers = []
+        for features_spec in spec.features:
+            layers.append(LayerDesc(features_spec))
+        layers.append(LayerDesc(spec.reshape_layer))
+        layers.append(LayerDesc(spec.classifier))
+        return layers
+
+
+def get_alex_spec(num_classes=10):
+    spec = LayerSpec(
+        layer=AlexNet,
+        sublayers_spec=AlexNetLayerSpec(
+            features=[
+                LayerSpec(
+                    layer=nn.Conv2D,
+                    extra_kwargs={
+                        "in_channels": 3,
+                        "out_channels": 3,
+                        "kernel_size": 11,
+                        "stride": 4,
+                        "padding": 5,
+                    },
+                ),
+                LayerSpec(
+                    layer=nn.ReLU,
+                ),
+                LayerSpec(
+                    layer=nn.MaxPool2D,
+                    extra_kwargs={"kernel_size": 2, "stride": 2},
+                ),
+                LayerSpec(
+                    layer=nn.Conv2D,
+                    extra_kwargs={
+                        "in_channels": 3,
+                        "out_channels": 3,
+                        "kernel_size": 5,
+                        "padding": 2,
+                    },
+                ),
+                LayerSpec(
+                    layer=nn.ReLU,
+                ),
+                LayerSpec(
+                    layer=nn.MaxPool2D,
+                    extra_kwargs={"kernel_size": 2, "stride": 2},
+                ),
+                LayerSpec(
+                    layer=nn.Conv2D,
+                    extra_kwargs={
+                        "in_channels": 3,
+                        "out_channels": 3,
+                        "kernel_size": 3,
+                        "padding": 1,
+                    },
+                ),
+                LayerSpec(
+                    layer=nn.ReLU,
+                ),
+                LayerSpec(
+                    layer=nn.Conv2D,
+                    extra_kwargs={
+                        "in_channels": 3,
+                        "out_channels": 3,
+                        "kernel_size": 3,
+                        "padding": 1,
+                    },
+                ),
+                LayerSpec(
+                    layer=nn.ReLU,
+                ),
+                LayerSpec(
+                    layer=nn.Conv2D,
+                    extra_kwargs={
+                        "in_channels": 3,
+                        "out_channels": 3,
+                        "kernel_size": 3,
+                        "padding": 1,
+                    },
+                ),
+                LayerSpec(
+                    layer=nn.ReLU,
+                ),
+                LayerSpec(
+                    layer=nn.MaxPool2D,
+                    extra_kwargs={"kernel_size": 2, "stride": 2},
+                ),
+            ],
+            reshape_layer=LayerSpec(
+                layer=ReshapeHelp, extra_kwargs={"shape": [-1, 256]}
+            ),
+            classifier=LayerSpec(
+                layer=nn.Linear,
+                extra_kwargs={"in_features": 256, "out_features": num_classes},
+            ),
+        ),
+        extra_kwargs={
+            "loss_fn": nn.CrossEntropyLoss(),
+        },
+    )
+    return spec
+
+
+class TestPipeLayerAPI(unittest.TestCase):
+    def setUp(self):
+        strategy = fleet.DistributedStrategy()
+        self.pipeline_parallel_size = 2
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": self.pipeline_parallel_size,
+        }
+        batch_size = 8
+        micro_batch_size = 2
+        strategy.pipeline_configs = {
+            "accumulate_steps": batch_size // micro_batch_size,
+            "micro_batch_size": micro_batch_size,
+        }
+        self.strategy = strategy
+        fleet.init(is_collective=True, strategy=strategy)
+        self.hcg = fleet.get_hybrid_communicate_group()
+
+    def test_pipelayer_desc(self):
+        alex_desc = get_alex_spec()
+        pipe_model = build_spec_layer(
+            alex_desc, num_stages=self.pipeline_parallel_size
+        )
+        np.testing.assert_array_equal(len(pipe_model.parameters()), 6)
+
+    def test_pipelayer_desc_single(self):
+        alex_desc = get_alex_spec()
+        pipe_model = build_spec_layer(alex_desc, num_stages=1)
+        np.testing.assert_array_equal(len(pipe_model.parameters()), 12)
+        pipe_model = NoPipelineParallel(pipe_model, self.strategy, self.hcg)
+        input = paddle.randn([256, 3, 224, 224])
+        label = paddle.randint(0, 10, [147, 1])
+
+        # Test with list data
+        data = [[input, input, input, input], [label, label, label, label]]
+        optimizer = create_optimizer(
+            model=pipe_model, use_pure_bf16=True, use_main_grad=True
+        )
+        base_lr = 0.1
+        lr_scheduler = paddle.optimizer.lr.CosineAnnealingDecay(
+            learning_rate=base_lr, T_max=1
+        )
+        pipe_model.train_batch(data, optimizer, lr_scheduler)
+        pipe_model.eval_batch(data, optimizer)
+
+        pipe_model._delay_scale_loss = True
+        pipe_model.train_batch(data, optimizer)
+        pipe_model.eval_batch(data, optimizer)
+        pipe_model.is_pipeline_last_stage()
+
+        pipe_model.train_batch(data, optimizer, return_micro_batch_loss=True)
+
+        scaler = paddle.amp.GradScaler(init_loss_scaling=4096)
+        scaler = fleet.distributed_scaler(scaler)
+        pipe_model.train_batch(data, optimizer, scaler=scaler)
+
+    def test_pipelayer_segment_method_list(self):
+        alex_desc = get_alex_spec()
+        pipe_model = build_spec_layer(
+            alex_desc, num_stages=self.pipeline_parallel_size, seg_method=[0, 4]
+        )
+        stage_id = self.hcg.get_stage_id()
+        if stage_id == 0:
+            np.testing.assert_array_equal(len(pipe_model.parameters()), 4)
+        elif stage_id == 1:
+            np.testing.assert_array_equal(len(pipe_model.parameters()), 8)
+
+    def test_pipelayer_segment_method_spec(self):
+        alex_desc = get_alex_spec()
+        pipe_model = build_spec_layer(
+            alex_desc,
+            num_stages=self.pipeline_parallel_size,
+            seg_method="layer:Conv2D|MaxPool2D",
+        )
+        stage_id = self.hcg.get_stage_id()
+        if stage_id == 0:
+            np.testing.assert_array_equal(len(pipe_model.parameters()), 4)
+        elif stage_id == 1:
+            np.testing.assert_array_equal(len(pipe_model.parameters()), 8)
+
+    def test_pipelayer_segment_method_vpp(self):
+        alex_desc = get_alex_spec()
+        pipe_model = build_spec_layer(
+            alex_desc,
+            num_stages=self.pipeline_parallel_size,
+            seg_method="layer:Conv2D|MaxPool2D",
+            num_virtual_pipeline_stages=2,
+        )
+        stage_id = self.hcg.get_stage_id()
+        if stage_id == 0:
+            np.testing.assert_array_equal(len(pipe_model.parameters()), 6)
+        elif stage_id == 1:
+            np.testing.assert_array_equal(len(pipe_model.parameters()), 6)
+
+    def test_check_micro_batch_data_valid_with_tuple(self):
+        """Test _check_micro_batch_data_valid with tuple data."""
+
+        alex_desc = get_alex_spec()
+        pipe_model = build_spec_layer(alex_desc, num_stages=1)
+        pipe_model = NoPipelineParallel(pipe_model, self.strategy, self.hcg)
+
+        # Test with tuple data
+        tensor1 = paddle.randn([2, 3])
+        tensor2 = paddle.randn([2, 3])
+        tuple_data = (tensor1, tensor2)
+
+        # This should not raise any exception
+        pipe_model._check_micro_batch_data_valid(tuple_data)
+
+    def test_check_micro_batch_data_valid_with_dict(self):
+        """Test _check_micro_batch_data_valid with dict data."""
+
+        alex_desc = get_alex_spec()
+        pipe_model = build_spec_layer(alex_desc, num_stages=1)
+        pipe_model = NoPipelineParallel(pipe_model, self.strategy, self.hcg)
+
+        # Test with dict data
+        dict_data = {
+            "input": paddle.randn([2, 3]),
+            "label": paddle.randn([2, 1]),
+        }
+
+        # This should not raise any exception
+        pipe_model._check_micro_batch_data_valid(dict_data)
+
+    def test_eval_batch_with_pipeline_dataset_preprocessor(self):
+        """Test eval_batch with wrapper PipelineDatasetPreprocessor."""
+
+        alex_desc = get_alex_spec()
+        pipe_model = build_spec_layer(alex_desc, num_stages=1)
+        pipe_model = NoPipelineParallel(pipe_model, self.strategy, self.hcg)
+
+        input = paddle.randn([256, 3, 224, 224])
+        label = paddle.randint(0, 10, [147, 1])
+
+        # Test with list data
+        data = [[input, input, input, input], [label, label, label, label]]
+
+        # Test with PipelineDatasetPreprocessor wrapper
+        def data_generator():
+            return data
+
+        preprocessed_data = PipelineDatasetPreprocessor(data_generator)
+        # This should work - calling preprocessed_data() should return the data
+        result = preprocessed_data()
+        self.assertEqual(result, data)
+
+        # Test eval_batch with this preprocessed data
+        pipe_model.eval_batch(preprocessed_data)
+
+    def test_eval_batch_with_non_tuple_list_data(self):
+        """Test eval_batch with non-tuple/list data (iterable like generator)."""
+        from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+            NoPipelineParallel,
+        )
+
+        alex_desc = get_alex_spec()
+        pipe_model = build_spec_layer(alex_desc, num_stages=1)
+        pipe_model = NoPipelineParallel(pipe_model, self.strategy, self.hcg)
+
+        # Test with a generator (not tuple or list) - this covers the branch
+        # where data is not tuple/list but is an iterable
+        input = paddle.randn([256, 3, 224, 224])
+        label = paddle.randint(0, 10, [147, 1])
+
+        # Create a generator that yields (input, label) pairs
+        def data_generator():
+            for _ in range(pipe_model.accumulate_steps):
+                yield (input, label)
+
+        # This should work - generator is not tuple/list, so it goes to micro_dataset directly
+        # Note: This test validates the code path, actual behavior depends on implementation
+        try:
+            pipe_model.eval_batch(data_generator)
+        except (TypeError, StopIteration):
+            # The generator gets exhausted or other expected errors
+            pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/hybrid_parallel_pp_with_shared_weight.py
+++ b/test/collective/fleet/hybrid_parallel_pp_with_shared_weight.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import random
+import unittest
+from dataclasses import dataclass
+
+import numpy as np
+
+os.environ["FLAGS_profile_optimizer_details_steps"] = "1"
+import paddle
+import paddle.distributed as dist
+from paddle import nn
+from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_parallel import (
+    LayerDesc,
+    LayerSpec,
+    PipelineLayer,
+    SharedLayerDesc,
+    build_spec_layer,
+)
+from paddle.nn import Layer
+
+
+def set_random_seed(seed, dp_id, rank_id):
+    """Set random seed for reproducibility."""
+    random.seed(seed)
+    np.random.seed(seed + dp_id)
+    paddle.seed(seed + dp_id)
+
+
+batch_size = 8
+micro_batch_size = 2
+vocab_size = 128
+hidden_size = 16
+
+
+class SimpleNetBase(Layer):
+    def __init__(self):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(vocab_size, hidden_size)
+
+        self.softmax_weight = self.create_parameter(
+            shape=[hidden_size, vocab_size]
+        )
+        self.softmax_bias = self.create_parameter(
+            shape=[vocab_size], is_bias=False
+        )
+
+    def forward(self, x1, x2, y1):
+        x_emb = self.embed_tokens(x1)
+        fc = paddle.matmul(x_emb, self.softmax_weight)
+        fc = paddle.add(fc, self.softmax_bias)
+        projection = paddle.reshape(fc, shape=[-1, vocab_size])
+
+        projection = paddle.matmul(projection, self.embed_tokens.weight)
+
+        loss = paddle.nn.functional.softmax_with_cross_entropy(
+            logits=projection, label=y1, soft_label=False
+        )
+        return loss.mean()
+
+
+class EmbeddingPipe(Layer):
+    def __init__(self):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(vocab_size, hidden_size)
+
+    @property
+    def embedding_weight(self):
+        return self.embed_tokens.weight
+
+    def forward(self, args):
+        x1, x2 = args
+        x_emb = self.embed_tokens(x1)
+        return x_emb, x2
+
+
+class MatmulNet(Layer):
+    def __init__(self):
+        super().__init__()
+        self.softmax_weight = self.create_parameter(
+            shape=[hidden_size, vocab_size]
+        )
+
+    def forward(self, args):
+        x1, x2 = args
+        fc = paddle.matmul(x1, self.softmax_weight)
+
+        return fc, x2
+
+
+class BiasNet(Layer):
+    def __init__(self):
+        super().__init__()
+        self.softmax_bias = self.create_parameter(shape=[vocab_size])
+
+    def forward(self, args):
+        fc, x2 = args
+        fc = paddle.add(fc, self.softmax_bias)
+        projection = paddle.reshape(fc, shape=[-1, vocab_size])
+        return projection, x2
+
+
+class LossNet(Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, args, y1):
+        projection = args
+        loss = paddle.nn.functional.softmax_with_cross_entropy(
+            logits=projection, label=y1[0], soft_label=False
+        )
+        return loss.mean()
+
+
+@dataclass
+class SimpleNetSpec:
+    embed_tokens: LayerSpec
+    matmul_net: LayerSpec
+    bias_net: LayerSpec
+
+
+class SimpleNet(PipelineLayer):
+    def __init__(self, sublayers_spec: SimpleNetSpec, **kwargs):
+        self.layers = SimpleNet.get_layer_desc_list(sublayers_spec)
+
+        super().__init__(layers=self.layers, **kwargs)
+
+    @staticmethod
+    def get_layer_desc_list(spec: SimpleNetSpec):
+        def _logits_helper(embedding, output):
+            return paddle.matmul(output[0], embedding.embedding_weight)
+
+        layers = [
+            SharedLayerDesc(
+                "embed",
+                spec.embed_tokens,
+                shared_weight_attr="embedding_weight",
+            ),
+            LayerDesc(spec.matmul_net),
+            LayerDesc(spec.bias_net),
+            SharedLayerDesc(
+                "embed",
+                spec.embed_tokens,
+                forward_func=_logits_helper,
+                shared_weight_attr="embedding_weight",
+            ),
+        ]
+        return layers
+
+
+def get_simple_net_spec():
+    spec = LayerSpec(
+        layer=SimpleNet,
+        sublayers_spec=SimpleNetSpec(
+            embed_tokens=LayerSpec(layer=EmbeddingPipe),
+            matmul_net=LayerSpec(layer=MatmulNet),
+            bias_net=LayerSpec(layer=BiasNet),
+        ),
+        extra_kwargs={
+            "loss_fn": LossNet(),
+        },
+    )
+    return spec
+
+
+class TestDistEmbeddingTraining(unittest.TestCase):
+    def setUp(self):
+        strategy = fleet.DistributedStrategy()
+        self.model_parallel_size = 1
+        self.data_parallel_size = 1
+        self.pipeline_parallel_size = 2
+        strategy.hybrid_configs = {
+            "dp_degree": self.data_parallel_size,
+            "mp_degree": self.model_parallel_size,
+            "pp_degree": self.pipeline_parallel_size,
+        }
+        strategy.pipeline_configs = {
+            "accumulate_steps": batch_size // micro_batch_size,
+            "micro_batch_size": micro_batch_size,
+        }
+        strategy.hybrid_configs["pp_configs"].clear_every_step_cache = True
+        self.strategy = strategy
+
+        fleet.init(is_collective=True, strategy=strategy)
+
+    def test_pp_model(self):
+        hcg = fleet.get_hybrid_communicate_group()
+        dp_id = hcg.get_data_parallel_rank()
+        pp_id = hcg.get_stage_id()
+        rank_id = dist.get_rank()
+        set_random_seed(1024, dp_id, rank_id)
+
+        # construct model a
+        model_a = SimpleNetBase()
+        scheduler_a = paddle.optimizer.lr.PiecewiseDecay(
+            boundaries=[2, 3, 4], values=[0.01, 0.02, 0.03, 0.04], verbose=True
+        )
+        optimizer_a = paddle.optimizer.SGD(
+            learning_rate=scheduler_a, parameters=model_a.parameters()
+        )
+
+        simple_net_spec = get_simple_net_spec()
+        model_b = build_spec_layer(simple_net_spec, topology=hcg.topology())
+
+        scheduler_b = paddle.optimizer.lr.PiecewiseDecay(
+            boundaries=[2, 3, 4], values=[0.01, 0.02, 0.03, 0.04], verbose=True
+        )
+        optimizer_b = paddle.optimizer.SGD(
+            learning_rate=scheduler_b, parameters=model_b.parameters()
+        )
+        model_b = fleet.distributed_model(model_b)
+
+        optimizer_b = fleet.distributed_optimizer(optimizer_b)
+
+        parameters = []
+        for param in model_a.parameters():
+            parameters.append(param.numpy())
+
+        model_b_params = model_b.parameters()
+
+        if pp_id == 0:
+            model_b_params[0].set_value(parameters[2])
+            model_b_params[1].set_value(parameters[0])
+
+        else:
+            model_b_params[0].set_value(parameters[2])
+            model_b_params[1].set_value(parameters[1])
+
+        # enable this test when simple pp is ready
+
+        for step in range(5):
+            x1_data = np.random.randint(0, vocab_size, size=[batch_size, 1])
+            x2_data = np.random.randint(0, vocab_size, size=[batch_size, 1])
+            y1_data = np.random.randint(0, hidden_size, size=[batch_size, 1])
+
+            x1 = paddle.to_tensor(x1_data)
+            x2 = paddle.to_tensor(x2_data)
+            y1 = paddle.to_tensor(y1_data)
+
+            x1.stop_gradient = True
+            x2.stop_gradient = True
+            y1.stop_gradient = True
+
+            loss_a = model_a(x1, x2, y1)
+            loss_a.backward()
+
+            optimizer_a.step()
+            optimizer_a.clear_grad()
+            scheduler_a.step()
+
+            loss_b = model_b.train_batch(
+                [(x1, x2), (y1,)], optimizer_b, scheduler_b
+            )
+
+            print("loss", loss_a.numpy(), loss_b.numpy())
+            np.testing.assert_allclose(loss_a.numpy(), loss_b.numpy())
+
+
+class TestDistEmbeddingTrainingWithSync(TestDistEmbeddingTraining):
+    def setUp(self):
+        strategy = fleet.DistributedStrategy()
+        self.model_parallel_size = 1
+        self.data_parallel_size = 1
+        self.pipeline_parallel_size = 2
+        strategy.hybrid_configs = {
+            "dp_degree": self.data_parallel_size,
+            "mp_degree": self.model_parallel_size,
+            "pp_degree": self.pipeline_parallel_size,
+        }
+        strategy.pipeline_configs = {
+            "accumulate_steps": batch_size // micro_batch_size,
+            "micro_batch_size": micro_batch_size,
+        }
+        strategy.hybrid_configs["pp_configs"].clear_every_step_cache = True
+        strategy.hybrid_configs["pp_configs"].sync_moment = True
+        strategy.hybrid_configs["pp_configs"].sync_param = True
+        self.strategy = strategy
+
+        fleet.init(is_collective=True, strategy=strategy)
+
+    def test_pp_model(self):
+        super().test_pp_model()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/test_layer_spec.py
+++ b/test/collective/fleet/test_layer_spec.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+from paddle.distributed.fleet.meta_parallel import (
+    LayerSpec,
+    build_spec_layer,
+    get_spec_layer,
+    import_spec_layer,
+)
+from paddle.nn import Identity
+
+
+class SimpleRotaryEmbeddingForTest(paddle.nn.Layer):
+    def __init__(
+        self,
+        head_dim: int,
+        rotary_percent: float,
+        rotary_interleaved: bool = False,
+        rotary_base: int = 10000,
+        rope_scaling: bool = False,
+    ) -> None:
+        super().__init__()
+        self.head_dim = head_dim
+        self.rotary_percent = rotary_percent
+        self.rotary_interleaved = rotary_interleaved
+        self.rotary_base = rotary_base
+        self.rope_scaling = rope_scaling
+
+
+class TestSpecCustomization(unittest.TestCase):
+    def setUp(self):
+        head_dim = 128
+        rotary_base = 10000
+        rotary_percent = 1.0
+        rope_scaling = False
+
+        rotary_emb_extra_kwargs = {
+            "head_dim": head_dim // 2,
+            "rotary_base": rotary_base,
+            "rope_scaling": rope_scaling,
+            "rotary_percent": rotary_percent,
+        }
+        self.embedding_spec = LayerSpec(
+            layer=SimpleRotaryEmbeddingForTest,
+            extra_kwargs=rotary_emb_extra_kwargs,
+        )
+
+    def tearDown(self):
+        pass
+
+    def test_import_layer(self):
+        identity_cls = import_spec_layer(
+            layer_path=('paddle.nn.layer.common', 'Identity')
+        )
+        self.assertEqual(identity_cls, Identity)
+
+    def test_build_layer(self):
+        head_dim = 128
+        rotary_percent = 1.0
+        rotary_base = 10000
+        rope_scaling = False
+
+        self.rotary_pos_emb = build_spec_layer(
+            self.embedding_spec,
+            head_dim=head_dim,
+            rotary_percent=rotary_percent,
+            rotary_base=rotary_base,
+            rope_scaling=rope_scaling,
+        )
+        self.assertIsInstance(self.rotary_pos_emb, SimpleRotaryEmbeddingForTest)
+
+    def test_layer_spec_basic(self):
+        """Test basic LayerSpec functionality."""
+        # Test LayerSpec with class
+        spec = LayerSpec(layer=Identity)
+        self.assertEqual(spec.layer, Identity)
+        self.assertEqual(spec.extra_kwargs, {})
+        self.assertIsNone(spec.sublayers_spec)
+
+        # Test LayerSpec with extra_kwargs
+        spec_with_kwargs = LayerSpec(
+            layer=Identity, extra_kwargs={"test_param": 123}
+        )
+        self.assertEqual(spec_with_kwargs.extra_kwargs, {"test_param": 123})
+
+        # Test LayerSpec with layer path tuple
+        spec_with_path = LayerSpec(layer=("paddle.nn.layer.common", "Identity"))
+        self.assertEqual(
+            spec_with_path.layer, ("paddle.nn.layer.common", "Identity")
+        )
+
+    def test_build_layer_with_identity_op(self):
+        """Test building layers with Identity."""
+        # Build Identity
+        identity = build_spec_layer(LayerSpec(layer=Identity))
+        self.assertIsInstance(identity, Identity)
+
+        # Test forward pass
+        test_input = paddle.randn([2, 3])
+        result = identity(test_input)
+        self.assertEqual(result.shape, test_input.shape)
+
+    def test_get_spec_layer_with_type(self):
+        """Test get_spec_layer with a type directly."""
+        # Test with a type directly
+        result = get_spec_layer(Identity)
+        self.assertEqual(result, Identity)
+
+    def test_get_spec_layer_with_layer_spec(self):
+        """Test get_spec_layer with LayerSpec containing a type."""
+        # Test with LayerSpec containing a type
+        spec = LayerSpec(layer=Identity)
+        result = get_spec_layer(spec)
+        self.assertEqual(result, Identity)
+
+    def test_get_spec_layer_with_layer_path(self):
+        """Test get_spec_layer with LayerSpec containing a layer path tuple."""
+        # Test with LayerSpec containing a layer path
+        spec = LayerSpec(layer=("paddle.nn.layer.common", "Identity"))
+        result = get_spec_layer(spec)
+        self.assertEqual(result, Identity)
+
+    def test_get_spec_layer_with_function(self):
+        """Test get_spec_layer with a function."""
+        # Test with a function (using a lambda for testing)
+        test_func = lambda x: x
+        result = get_spec_layer(test_func)
+        self.assertEqual(result, test_func)
+
+    def test_get_spec_layer_with_extra_kwargs(self):
+        """Test get_spec_layer with extra kwargs (should be ignored)."""
+        # extra_kwargs should be ignored by get_spec_layer
+        spec = LayerSpec(layer=Identity, extra_kwargs={"test_param": 123})
+        result = get_spec_layer(spec, additional_arg=456)
+        self.assertEqual(result, Identity)
+
+    def test_layer_spec_repr_with_tuple(self):
+        """Test LayerSpec __repr__ with tuple layer."""
+        # Test with a tuple of layer path
+        spec = LayerSpec(layer=("paddle.nn.layer.common", "Identity"))
+        repr_str = repr(spec)
+        self.assertIn("paddle.nn.layer.common", repr_str)
+        self.assertIn("Identity", repr_str)
+
+    def test_import_spec_layer_with_import_error(self):
+        """Test import_spec_layer with invalid import path."""
+        # Test with invalid module path that raises ImportError
+        result = import_spec_layer(("nonexistent.module.path", "SomeClass"))
+        self.assertIsNone(result)
+
+    def test_build_spec_layer_with_function(self):
+        """Test build_spec_layer with a function directly."""
+        # Test with a function directly
+        test_func = lambda x: x * 2
+        result = build_spec_layer(test_func)
+        self.assertEqual(result, test_func)
+
+    def test_build_spec_layer_with_layer_spec_function(self):
+        """Test build_spec_layer with LayerSpec containing a function."""
+        # Test with LayerSpec containing a function
+        test_func = lambda x: x + 1
+        spec = LayerSpec(layer=test_func, extra_kwargs={})
+        result = build_spec_layer(spec)
+        self.assertEqual(result, test_func)
+
+    def test_build_spec_layer_with_type(self):
+        """Test build_spec_layer with a type directly."""
+        # Test with a type directly - should instantiate the class
+        result = build_spec_layer(Identity)
+        self.assertIsInstance(result, Identity)
+
+    def test_build_spec_layer_with_layer_spec_type(self):
+        """Test build_spec_layer with LayerSpec containing a type."""
+        # Test with LayerSpec containing a type (class)
+        spec = LayerSpec(layer=Identity)
+        result = build_spec_layer(spec)
+        self.assertIsInstance(result, Identity)
+
+    def test_build_spec_layer_with_imported_function(self):
+        """Test build_spec_layer with layer path that imports a function."""
+        # Test with LayerSpec containing a layer path that resolves to a function
+        # Using a simple function from paddle.nn.functional
+        spec = LayerSpec(layer=("paddle.nn.functional", "relu"))
+        result = build_spec_layer(spec)
+        # The imported layer should be a function
+        self.assertTrue(callable(result))
+
+    def test_build_spec_layer_exception_handling(self):
+        """Test build_spec_layer with invalid kwargs that cause exception."""
+        # Test that exception is raised with improved error message
+        # Use paddle.nn.Linear which requires in_features and out_features
+        # Passing empty extra_kwargs will cause TypeError at instantiation
+        spec = LayerSpec(layer=paddle.nn.Linear, extra_kwargs={})
+        with self.assertRaises(Exception) as context:
+            build_spec_layer(spec)
+        # Verify the error message includes the layer name
+        self.assertIn("Linear", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/test_pp_layers.py
+++ b/test/collective/fleet/test_pp_layers.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
+
+
+class TestPipelineParallel(TestMultipleAccelerators):
+    def test_pipeline_parallel(self):
+        self.run_mnist_2accelerators('hybrid_parallel_pp_layers.py')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/test_pp_with_shared_weight.py
+++ b/test/collective/fleet/test_pp_with_shared_weight.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
+
+
+class TestPipelineParallel(TestMultipleAccelerators):
+    def test_pipeline_parallel(self):
+        self.run_mnist_2accelerators('hybrid_parallel_pp_with_shared_weight.py')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/test_schedule_node.py
+++ b/test/collective/fleet/test_schedule_node.py
@@ -1,0 +1,396 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+from paddle.distributed.fleet.meta_parallel.pp_utils.forward_backward_overlap_utils import (
+    ScheduleNode,
+    clone_and_clear_dataptr,
+    detach_and_requires_grad,
+)
+
+
+def simple_forward_func(inputs):
+    return inputs * 2
+
+
+def forward_func_with_labels(inputs, labels):
+    return (inputs * 2, labels * 3)
+
+
+class TestScheduleNode(unittest.TestCase):
+    def test_init(self):
+        """Test ScheduleNode initialization."""
+        node = ScheduleNode(simple_forward_func, name="test_node")
+        self.assertEqual(node.name, "test_node")
+        self.assertEqual(node.fwd_func, simple_forward_func)
+        self.assertIsNone(node.inputs)
+        self.assertIsNone(node.outputs)
+        self.assertIsNone(node.labels)
+        self.assertIsNone(node.scale_loss_factor)
+
+    def test_init_default_name(self):
+        """Test ScheduleNode initialization with default name."""
+        node = ScheduleNode(simple_forward_func)
+        self.assertEqual(node.name, "")
+
+    def test_forward_basic(self):
+        """Test forward pass with basic inputs."""
+        node = ScheduleNode(simple_forward_func)
+        inputs = paddle.randn([2, 3])
+        outputs = node.forward(inputs)
+
+        self.assertIsNotNone(node.inputs)
+        self.assertIsNotNone(node.outputs)
+        self.assertEqual(outputs.shape, inputs.shape)
+        self.assertTrue(paddle.allclose(outputs, inputs * 2))
+
+    def test_forward_with_tuple_inputs(self):
+        """Test forward pass with tuple inputs."""
+        node = ScheduleNode(lambda inputs: (inputs[0] * 2, inputs[1] * 3))
+        input1 = paddle.randn([2, 3])
+        input2 = paddle.randn([2, 3])
+        outputs = node.forward((input1, input2))
+
+        self.assertIsInstance(outputs, tuple)
+        self.assertEqual(len(outputs), 2)
+
+    def test_forward_with_kwargs(self):
+        """Test forward pass with keyword arguments."""
+        node = ScheduleNode(lambda x, factor=1: x * factor)
+        inputs = paddle.randn([2, 3])
+        outputs = node.forward(inputs, factor=3)
+
+        self.assertTrue(paddle.allclose(outputs, inputs * 3))
+
+    def test_forward_with_labels(self):
+        """Test forward pass with labels set."""
+        node = ScheduleNode(forward_func_with_labels, name="test_node")
+        node.labels = paddle.ones([2, 3])
+        inputs = paddle.randn([2, 3])
+        outputs = node.forward(inputs)
+
+        self.assertIsNotNone(node.outputs)
+
+    def test_forward_with_scale_loss_factor(self):
+        """Test forward pass with scale_loss_factor."""
+        node = ScheduleNode(simple_forward_func)
+        node.scale_loss_factor = 2.0
+        inputs = paddle.randn([2, 3])
+        outputs = node.forward(inputs)
+
+        # Output should be scaled by 1/scale_loss_factor
+        self.assertTrue(paddle.allclose(outputs, inputs))
+
+    def test_backward_basic(self):
+        """Test backward pass."""
+        node = ScheduleNode(simple_forward_func)
+        inputs = paddle.randn([2, 3])
+        inputs.stop_gradient = False
+        outputs = node.forward(inputs)
+        grads = node.backward()
+
+        # Check that gradients are returned
+        self.assertIsInstance(grads, tuple)
+
+    def test_backward_with_scaler(self):
+        """Test backward pass with scaler."""
+        node = ScheduleNode(simple_forward_func)
+        inputs = paddle.randn([2, 3])
+        inputs.stop_gradient = False
+        node.forward(inputs)
+
+        scaler = paddle.amp.GradScaler(init_loss_scaling=2.0)
+        grads = node.backward(scaler=scaler)
+
+        self.assertIsInstance(grads, tuple)
+
+    def test_backward_with_output_grad(self):
+        """Test backward pass with provided output gradients."""
+        node = ScheduleNode(simple_forward_func)
+        inputs = paddle.randn([2, 3])
+        inputs.stop_gradient = False
+        node.forward(inputs)
+
+        output_grad = paddle.ones([2, 3])
+        grads = node.backward(output_grad=output_grad)
+
+        self.assertIsInstance(grads, tuple)
+
+    def test_reset_states(self):
+        """Test _reset_states method."""
+        node = ScheduleNode(simple_forward_func)
+        node.labels = paddle.ones([2, 3])
+        node.scale_loss_factor = 2.0
+
+        node._reset_states()
+
+        self.assertIsNone(node.inputs)
+        self.assertIsNone(node.outputs)
+        self.assertIsNone(node.labels)
+        self.assertIsNone(node.scale_loss_factor)
+
+
+class TestDetachAndRequiresGrad(unittest.TestCase):
+    def test_detach_single_tensor(self):
+        """Test detach_and_requires_grad with a single tensor."""
+        tensor = paddle.randn([2, 3])
+        tensor.stop_gradient = False
+        result = detach_and_requires_grad(tensor)
+
+        self.assertIsInstance(result, paddle.Tensor)
+        self.assertFalse(result.stop_gradient)
+
+    def test_detach_tensor_with_stop_gradient_true(self):
+        """Test detach_and_requires_grad with stop_gradient=True."""
+        tensor = paddle.randn([2, 3])
+        tensor.stop_gradient = True
+        result = detach_and_requires_grad(tensor)
+
+        self.assertTrue(result.stop_gradient)
+
+    def test_detach_list_of_tensors(self):
+        """Test detach_and_requires_grad with a list of tensors."""
+        tensor1 = paddle.randn([2, 3])
+        tensor1.stop_gradient = False
+        tensor2 = paddle.randn([2, 3])
+        tensor2.stop_gradient = True
+        inputs = [tensor1, tensor2]
+        result = detach_and_requires_grad(inputs)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertFalse(result[0].stop_gradient)
+        self.assertTrue(result[1].stop_gradient)
+
+    def test_detach_tuple_of_tensors(self):
+        """Test detach_and_requires_grad with a tuple of tensors."""
+        tensor1 = paddle.randn([2, 3])
+        tensor1.stop_gradient = False
+        tensor2 = paddle.randn([2, 3])
+        tensor2.stop_gradient = False
+        inputs = (tensor1, tensor2)
+        result = detach_and_requires_grad(inputs)
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        self.assertFalse(result[0].stop_gradient)
+        self.assertFalse(result[1].stop_gradient)
+
+    def test_detach_nested_tuple(self):
+        """Test detach_and_requires_grad with nested tuple."""
+        tensor1 = paddle.randn([2, 3])
+        tensor1.stop_gradient = False
+        tensor2 = paddle.randn([2, 3])
+        tensor2.stop_gradient = True
+        inputs = ((tensor1,), (tensor2,))
+        result = detach_and_requires_grad(inputs)
+
+        self.assertIsInstance(result, tuple)
+        self.assertIsInstance(result[0], tuple)
+        self.assertFalse(result[0][0].stop_gradient)
+        self.assertTrue(result[1][0].stop_gradient)
+
+    def test_detach_nested_list(self):
+        """Test detach_and_requires_grad with nested list."""
+        tensor1 = paddle.randn([2, 3])
+        tensor1.stop_gradient = False
+        tensor2 = paddle.randn([2, 3])
+        tensor2.stop_gradient = True
+        inputs = [[tensor1], [tensor2]]
+        result = detach_and_requires_grad(inputs)
+
+        self.assertIsInstance(result, list)
+        self.assertIsInstance(result[0], list)
+        self.assertFalse(result[0][0].stop_gradient)
+        self.assertTrue(result[1][0].stop_gradient)
+
+    def test_detach_list_with_none(self):
+        """Test detach_and_requires_grad with list containing None."""
+        tensor = paddle.randn([2, 3])
+        tensor.stop_gradient = False
+        inputs = [tensor, None, "string_value", 123]
+        result = detach_and_requires_grad(inputs)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 4)
+        self.assertFalse(result[0].stop_gradient)
+        self.assertIsNone(result[1])
+        self.assertEqual(result[2], "string_value")
+        self.assertEqual(result[3], 123)
+
+    def test_detach_tuple_with_none(self):
+        """Test detach_and_requires_grad with tuple containing None."""
+        tensor = paddle.randn([2, 3])
+        tensor.stop_gradient = False
+        inputs = (tensor, None, "string")
+        result = detach_and_requires_grad(inputs)
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 3)
+        self.assertFalse(result[0].stop_gradient)
+        self.assertIsNone(result[1])
+        self.assertEqual(result[2], "string")
+
+    def test_detach_dict(self):
+        """Test detach_and_requires_grad with dict."""
+        tensor1 = paddle.randn([2, 3])
+        tensor1.stop_gradient = False
+        tensor2 = paddle.randn([2, 3])
+        tensor2.stop_gradient = True
+        inputs = {"key1": tensor1, "key2": tensor2}
+        result = detach_and_requires_grad(inputs)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result), 2)
+        self.assertFalse(result["key1"].stop_gradient)
+        self.assertTrue(result["key2"].stop_gradient)
+
+    def test_detach_dict_with_none(self):
+        """Test detach_and_requires_grad with dict containing None."""
+        tensor = paddle.randn([2, 3])
+        tensor.stop_gradient = False
+        inputs = {"key1": tensor, "key2": None}
+        result = detach_and_requires_grad(inputs)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result), 2)
+        self.assertFalse(result["key1"].stop_gradient)
+        self.assertIsNone(result["key2"])
+
+
+class TestCloneAndClearDataptr(unittest.TestCase):
+    def test_clone_single_tensor(self):
+        """Test clone_and_clear_dataptr with a single tensor."""
+        tensor = paddle.randn([2, 3])
+        result = clone_and_clear_dataptr(tensor, clear_dataptr=False)
+
+        self.assertIsInstance(result, paddle.Tensor)
+        self.assertEqual(result.shape, tensor.shape)
+
+    def test_clone_single_tensor_clear_dataptr(self):
+        """Test clone_and_clear_dataptr with clear_dataptr=True."""
+        tensor = paddle.randn([2, 3])
+        result = clone_and_clear_dataptr(tensor, clear_dataptr=True)
+
+        self.assertIsInstance(result, paddle.Tensor)
+        # After _clear_dataptr(), the shape may be cleared
+
+    def test_clone_list_of_tensors(self):
+        """Test clone_and_clear_dataptr with a list of tensors."""
+        tensor1 = paddle.randn([2, 3])
+        tensor2 = paddle.randn([2, 3])
+        outputs = [tensor1, tensor2]
+        result = clone_and_clear_dataptr(outputs, clear_dataptr=False)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].shape, tensor1.shape)
+        self.assertEqual(result[1].shape, tensor2.shape)
+
+    def test_clone_list_clear_dataptr(self):
+        """Test clone_and_clear_dataptr with list and clear_dataptr=True."""
+        tensor1 = paddle.randn([2, 3])
+        tensor2 = paddle.randn([2, 3])
+        outputs = [tensor1, tensor2]
+        result = clone_and_clear_dataptr(outputs, clear_dataptr=True)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+    def test_clone_tuple_of_tensors(self):
+        """Test clone_and_clear_dataptr with a tuple of tensors."""
+        tensor1 = paddle.randn([2, 3])
+        tensor2 = paddle.randn([2, 3])
+        outputs = (tensor1, tensor2)
+        result = clone_and_clear_dataptr(outputs, clear_dataptr=False)
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].shape, tensor1.shape)
+        self.assertEqual(result[1].shape, tensor2.shape)
+
+    def test_clone_tuple_clear_dataptr(self):
+        """Test clone_and_clear_dataptr with tuple and clear_dataptr=True."""
+        tensor1 = paddle.randn([2, 3])
+        tensor2 = paddle.randn([2, 3])
+        outputs = (tensor1, tensor2)
+        result = clone_and_clear_dataptr(outputs, clear_dataptr=True)
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+
+    def test_clone_list_with_none(self):
+        """Test clone_and_clear_dataptr with list containing None and non-tensors."""
+        tensor1 = paddle.randn([2, 3])
+        tensor2 = paddle.randn([2, 3])
+        outputs = [tensor1, None, "string", tensor2, 123]
+        result = clone_and_clear_dataptr(outputs, clear_dataptr=False)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)  # Only tensors are included
+        self.assertEqual(result[0].shape, tensor1.shape)
+        self.assertEqual(result[1].shape, tensor2.shape)
+
+    def test_clone_tuple_with_none(self):
+        """Test clone_and_clear_dataptr with tuple containing None and non-tensors."""
+        tensor1 = paddle.randn([2, 3])
+        tensor2 = paddle.randn([2, 3])
+        outputs = (tensor1, None, "string", tensor2)
+        result = clone_and_clear_dataptr(outputs, clear_dataptr=False)
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)  # Only tensors are included
+        self.assertEqual(result[0].shape, tensor1.shape)
+        self.assertEqual(result[1].shape, tensor2.shape)
+
+    def test_clone_dict(self):
+        """Test clone_and_clear_dataptr with dict."""
+        tensor1 = paddle.randn([2, 3])
+        tensor2 = paddle.randn([2, 3])
+        outputs = {"key1": tensor1, "key2": tensor2}
+        result = clone_and_clear_dataptr(outputs, clear_dataptr=False)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result), 2)
+        self.assertIn("key1", result)
+        self.assertIn("key2", result)
+        self.assertEqual(result["key1"].shape, tensor1.shape)
+        self.assertEqual(result["key2"].shape, tensor2.shape)
+
+    def test_clone_dict_clear_dataptr(self):
+        """Test clone_and_clear_dataptr with dict and clear_dataptr=True."""
+        tensor1 = paddle.randn([2, 3])
+        tensor2 = paddle.randn([2, 3])
+        outputs = {"key1": tensor1, "key2": tensor2}
+        result = clone_and_clear_dataptr(outputs, clear_dataptr=True)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result), 2)
+
+    def test_clone_dict_with_none(self):
+        """Test clone_and_clear_dataptr with dict containing None and non-tensors."""
+        tensor = paddle.randn([2, 3])
+        outputs = {"key1": tensor, "key2": None, "key3": "value"}
+        result = clone_and_clear_dataptr(outputs, clear_dataptr=False)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result), 1)  # Only tensors are included
+        self.assertIn("key1", result)
+        self.assertEqual(result["key1"].shape, tensor.shape)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/testslist.csv
+++ b/test/collective/fleet/testslist.csv
@@ -72,3 +72,7 @@ test_dualpipe.py,,GPU,500,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;htt
 test_zero_bubble_utils,LINUX;APPLE,,500,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_shutdown_process_group,,GPU,,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=,
 test_pp_send_recv_dict.py,,GPU,500,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
+test_pp_layers,,GPU,500,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
+test_pp_with_shared_weight,,GPU,500,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
+test_layer_spec,,,,,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
+test_schedule_node,,,,,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,


### PR DESCRIPTION
### PR Category
Execute Infrastructure 


### PR Types
Improvements


### Description
Cherry Pick
Merged in dev: https://github.com/PaddlePaddle/Paddle/pull/77812
Merged in dev: https://github.com/PaddlePaddle/Paddle/pull/78229

devPR:https://github.com/PaddlePaddle/Paddle/pull/77812
devPR:https://github.com/PaddlePaddle/Paddle/pull/78229

feat(meta_parallel): 新增 LayerSpec 支持与 NoPipelineParallel 类

- 新增 LayerSpec 数据类用于动态导入和构建层
  - 新增 import_spec_layer、get_spec_layer 和 build_spec_layer 工具函数
  - 扩展 LayerDesc 以支持 LayerSpec 参数
- 新增 NoPipelineParallel 类用于非流水线并行场景
  - 在 distributed_model 中集成 NoPipelineParallel 支持
- 添加 Tensor dict 与 tuple 转换工具函数
  - 扩展 forward_backward_overlap_utils 支持字典类型张量
- 新增测试用例验证 LayerSpec 和共享权重功能

### 是否引起精度变化
否
