### PR TITLE
[API Compatibility] support device.func = place.func

### DIFF
--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -2195,6 +2195,9 @@ class Device(str):
         previous_device = Device._DEFAULT_DEVICE_STACK.pop()
         paddle.set_device(previous_device)
 
+    def __getattr__(self, name: str):
+        return getattr(self._to_place(), name)
+
 
 class _DeviceModule(types.ModuleType):
     """A callable package module: paddle.device(...) -> Device(...)"""

--- a/test/legacy_test/test_paddle_device.py
+++ b/test/legacy_test/test_paddle_device.py
@@ -112,7 +112,7 @@ class TestDevice(unittest.TestCase):
         self.assertFalse(d_cpu.is_xpu_place())
 
         # Test CUDA device methods
-        if paddle.device.cuda.is_available() and paddle.is_compiled_with_cuda():
+        if paddle.device.is_available() and paddle.is_compiled_with_cuda():
             d_cuda = Device("cuda:0")
             self.assertFalse(d_cuda.is_cpu_place())
             self.assertTrue(d_cuda.is_gpu_place())

--- a/test/legacy_test/test_paddle_device.py
+++ b/test/legacy_test/test_paddle_device.py
@@ -104,6 +104,24 @@ class TestDevice(unittest.TestCase):
         with self.assertRaises(ValueError):
             Device("abc:0")
 
+    def test_getattr_forward_to_place(self):
+        # Test that unknown attributes are forwarded to paddle.Place
+        d_cpu = Device("cpu")
+        self.assertTrue(d_cpu.is_cpu_place())
+        self.assertFalse(d_cpu.is_gpu_place())
+        self.assertFalse(d_cpu.is_xpu_place())
+
+        # Test CUDA device methods
+        if paddle.device.cuda.is_available() and paddle.is_compiled_with_cuda():
+            d_cuda = Device("cuda:0")
+            self.assertFalse(d_cuda.is_cpu_place())
+            self.assertTrue(d_cuda.is_gpu_place())
+            self.assertEqual(d_cuda.gpu_device_id(), 0)
+
+            d_gpu = Device("gpu:0")
+            self.assertTrue(d_gpu.is_gpu_place())
+            self.assertEqual(d_gpu.gpu_device_id(), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
当前 paddle.device 在接口层面已对齐 torch.device，但功能上未覆盖 paddle.place 的能力。在 paddle.device 中增加对 paddle.place 接口的转发机制，以复用现有实现。
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否