### PR TITLE
[Cherry-Pick][release/3.3][XPU] Add python interface of set_xpu_current_device_id (#77568)

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3823,6 +3823,7 @@ All parameter, weight, gradient are variables in Paddle.
 #ifdef PADDLE_WITH_XPU
   m.def("get_xpu_device_count", platform::GetXPUDeviceCount);
   m.def("get_xpu_current_device_id", &platform::GetXPUCurrentDeviceId);
+  m.def("set_xpu_current_device_id", &platform::SetXPUDeviceId, py::arg("i"));
   m.def("xpu_empty_cache", platform::EmptyCache);
   m.def("get_xpu_device_utilization_rate",
         platform::GetXPUDeviceUtilizationRate);


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features

### Description
Cherry-pick #77568 to release/3.3 branch for Paddle 3.3.2 release (XPU P800).
Add python interface of set_xpu_current_device_id on xpu platform.

devPR:https://github.com/PaddlePaddle/Paddle/pull/77568

### 精度变化
精度无变化