### PR TITLE
[Cherry-Pick][release/3.3][XPU] Add get_device_properties interface of xpu (#76877)

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3824,6 +3824,40 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("get_xpu_device_count", platform::GetXPUDeviceCount);
   m.def("get_xpu_current_device_id", &platform::GetXPUCurrentDeviceId);
   m.def("xpu_empty_cache", platform::EmptyCache);
+  m.def(
+      "get_device_properties",
+      [](int id) -> const gpuDeviceProp & {
+        return platform::GetDeviceProperties(id);
+      },
+      py::return_value_policy::reference);
+
+  py::class_<gpuDeviceProp>(m, "_gpuDeviceProperties", py::module_local())
+      .def_property_readonly(
+          "name", [](const gpuDeviceProp &prop) { return prop.name; })
+      .def_property_readonly(
+          "major", [](const gpuDeviceProp &prop) { return prop.major; })
+      .def_property_readonly(
+          "minor", [](const gpuDeviceProp &prop) { return prop.minor; })
+      .def_property_readonly(
+          "total_memory",
+          [](const gpuDeviceProp &prop) { return prop.totalGlobalMem; })
+      .def_property_readonly(
+          "multi_processor_count",
+          [](const gpuDeviceProp &prop) { return prop.multiProcessorCount; })
+      .def_property_readonly(
+          "is_multi_gpu_board",
+          [](const gpuDeviceProp &prop) { return prop.isMultiGpuBoard; })
+      .def_property_readonly(
+          "is_integrated",
+          [](const gpuDeviceProp &prop) { return prop.integrated; })
+      .def("__repr__", [](const gpuDeviceProp &prop) {
+        std::stringstream ostr;
+        ostr << "_gpuDeviceProperties(name='" << prop.name
+             << "', major=" << prop.major << ", minor=" << prop.minor
+             << ", total_memory=" << prop.totalGlobalMem / (1024 * 1024)
+             << "MB, multi_processor_count=" << prop.multiProcessorCount << ")";
+        return ostr.str();
+      });
   m.def("get_xpu_device_utilization_rate",
         platform::GetXPUDeviceUtilizationRate);
   m.def("get_xpu_device_total_memory", platform::GetXPUDeviceTotalMemory);

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -102,6 +102,7 @@ elif core.is_compiled_with_xpu():
         create_stream as _create_stream_base,
         device_count,
         empty_cache,
+        get_device_properties as _get_device_properties,
         get_rng_state,
         manual_seed,
         max_memory_allocated,

--- a/python/paddle/device/xpu/__init__.py
+++ b/python/paddle/device/xpu/__init__.py
@@ -25,6 +25,7 @@ from .streams import Event, Stream, create_event, create_stream  # noqa: F401
 
 if TYPE_CHECKING:
     from paddle import XPUPlace
+    from paddle.base.libpaddle import _gpuDeviceProperties
 
     _XPUPlaceLike: TypeAlias = Union[
         XPUPlace,
@@ -47,6 +48,7 @@ __all__ = [
     'memory_reserved',
     'memory_total',  # memory managed by runtime, not paddle
     'memory_used',  # memory managed by runtime, not paddle
+    'get_device_properties',
 ]
 
 
@@ -263,6 +265,80 @@ def empty_cache() -> None:
         )
     else:
         core.xpu_empty_cache()
+
+
+def get_device_properties(
+    device: _XPUPlaceLike | None = None,
+) -> _gpuDeviceProperties:
+    '''
+    Return the properties of given device.
+
+    Args:
+        device(paddle.XPUPlace|int|str|None, optional): The device, the id of the device or
+            the string name of device like 'xpu:x' which to get the properties of the
+            device from. If device is None, the device is the current device.
+            Default: None.
+
+    Returns:
+        _gpuDeviceProperties: The properties of the device which include ASCII string
+        identifying device, major compute capability, minor compute capability, global
+        memory available and the number of multiprocessors on the device.
+
+    Examples:
+
+        .. code-block:: python
+
+            >>> # doctest: +REQUIRES(env:XPU)
+
+            >>> import paddle
+            >>> paddle.device.set_device('xpu')
+            >>> paddle.device.xpu.get_device_properties()
+            >>> # _gpuDeviceProperties(name='GPU', major=8, minor=6, total_memory=98304MB, multi_processor_count=8)
+
+            >>> paddle.device.xpu.get_device_properties(0)
+            >>> # _gpuDeviceProperties(name='GPU', major=8, minor=6, total_memory=98304MB, multi_processor_count=8)
+
+            >>> paddle.device.xpu.get_device_properties('xpu:0')
+            >>> # _gpuDeviceProperties(name='GPU', major=8, minor=6, total_memory=98304MB, multi_processor_count=8)
+
+            >>> paddle.device.xpu.get_device_properties(paddle.XPUPlace(0))
+            >>> # _gpuDeviceProperties(name='GPU', major=8, minor=6, total_memory=98304MB, multi_processor_count=8)
+
+    '''
+
+    if not core.is_compiled_with_xpu():
+        raise ValueError(
+            "The API paddle.device.xpu.get_device_properties is not supported in "
+            "CPU-only PaddlePaddle. Please reinstall PaddlePaddle with XPU support "
+            "to call this API."
+        )
+
+    if device is not None:
+        if isinstance(device, int):
+            device_id = device
+        elif isinstance(device, core.XPUPlace):
+            device_id = device.get_device_id()
+        elif isinstance(device, str):
+            if device.startswith('xpu:'):
+                device_id = int(device[4:])
+            elif device == 'xpu':
+                device_id = 0
+            else:
+                raise ValueError(
+                    f"The current string {device} is not expected. Because paddle.device."
+                    "xpu.get_device_properties only support string which is like 'xpu:x' or 'xpu'. "
+                    "Please input appropriate string again!"
+                )
+        else:
+            raise ValueError(
+                f"The device type {device} is not expected. Because paddle.device.xpu."
+                "get_device_properties only support int, str or paddle.XPUPlace. "
+                "Please input appropriate device again!"
+            )
+    else:
+        device_id = -1
+
+    return core.get_device_properties(device_id)
 
 
 def max_memory_allocated(device: _XPUPlaceLike | None = None) -> int:


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features

### Description
Cherry-pick #76877 to release/3.3 branch for Paddle 3.3.2 release (XPU P800).
Add get_device_properties interface of xpu for device property queries.

devPR:https://github.com/PaddlePaddle/Paddle/pull/76877

### 精度变化
精度无变化