### PR TITLE
[release/3.3] fix transpose eigen int32 overflow

### DIFF
--- a/paddle/phi/kernels/funcs/math_function_impl.h
+++ b/paddle/phi/kernels/funcs/math_function_impl.h
@@ -56,8 +56,15 @@ void Transpose<DeviceContext, T, Rank>::operator()(
   auto eigen_in = phi::EigenTensor<T, Rank>::From(in);
   auto eigen_out = phi::EigenTensor<T, Rank>::From(*out);
   auto* dev = dev_ctx.eigen_device();
-  // use 32bit index to speed up computation
-  bool use_32bit_index = eigen_out.size() < Eigen::NumTraits<int>::highest();
+  // use 32bit index to speed up computation.
+  // NOTE: Use INT32_MAX/2 as threshold instead of INT32_MAX to prevent int32
+  // overflow in Eigen's GPU grid-stride loop. The loop does `i += step_size`
+  // where step_size = blockDim.x * gridDim.x. When size is close to INT32_MAX,
+  // `i + step_size` can overflow int32 to a negative value, causing the loop
+  // condition `i < size` to remain true and producing illegal memory accesses.
+  bool use_32bit_index =
+      eigen_in.size() < Eigen::NumTraits<int>::highest() / 2 &&
+      eigen_out.size() < Eigen::NumTraits<int>::highest() / 2;
   bool is_gpu_place = dev_ctx.GetPlace().GetType() == phi::AllocationType::GPU;
   if (use_32bit_index && is_gpu_place) {
     To32BitIndex(eigen_out).device(*dev) =

--- a/paddle/phi/kernels/funcs/transpose_function.cu.h
+++ b/paddle/phi/kernels/funcs/transpose_function.cu.h
@@ -1625,6 +1625,19 @@ void TransposeGPUKernelDriver(const phi::GPUContext& dev_ctx,
   if (!ret) {
     auto simplifier = phi::funcs::PermuteDimsSimplifier(
         rank, numel, perm, common::vectorize<int64_t>(in.dims()));
+
+    // If simplifier reduces to rank 1, the permutation is an identity
+    // (sequential perm). Just do a device-to-device memcpy instead of
+    // going through Eigen or the general permute path.
+    if (simplifier.GetRank() == 1) {
+      phi::backends::gpu::GpuMemcpyAsync(out->data<T>(),
+                                         in.data<T>(),
+                                         numel * sizeof(T),
+                                         phi::gpuMemcpyDeviceToDevice,
+                                         dev_ctx.stream());
+      return;
+    }
+
     auto* tuner = phi::autotune::MakeTransposeTuner<T>(PermuteWithEigen<T>);
     tuner->AddCallBack(PermuteAndTranspose<T>);
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

```cpp
// transpose_function.cu.h, TransposeGPUKernelDriver 中:
if (simplifier.GetRank() == 1) {
    // sequential perm = identity → 直接 memcpy
    phi::backends::gpu::GpuMemcpyAsync(out->data<T>(), in.data<T>(),
                                       numel * sizeof(T),
                                       phi::gpuMemcpyDeviceToDevice,
                                       dev_ctx.stream());
    return;
}
```

**原理**：`PermuteDimsSimplifier` 合并连续维度、消除 size=1 维度后，如果 perm 退化为恒等排列（`is_sequential_perm_=true`, `rank_=1`），说明 transpose 不改变内存布局，直接 memcpy 即可。语义正确且性能最优。



在 `math_function_impl.h:60` 中修改 `use_32bit_index` 的判定条件：

```cpp
// 当前 (有溢出风险):
bool use_32bit_index = eigen_out.size() < Eigen::NumTraits<int>::highest();

// 建议修改:
// 预留 step_size 的余量, 防止 grid-stride loop 中 i += step_size 溢出。
// step_size 最大 = maxThreadsPerBlock(1024) × maxBlocks(~100000) ≈ 10^8，
// 保守使用 INT32_MAX / 2 作为阈值。
bool use_32bit_index =
    eigen_in.size()  < Eigen::NumTraits<int>::highest() / 2 &&
    eigen_out.size() < Eigen::NumTraits<int>::highest() / 2;
```

这个修改：
- **同时检查 input 和 output**
- **阈值 INT32_MAX/2 ≈ 10.7 亿**：确保 `size + step_size` 不可能超过 INT32_MAX
- **影响面**：numel 在 [10.7 亿, 21.5 亿] 范围内的 Eigen transpose 会走 int64 路径，性能略降（此区间很窄，且 Eigen transpose 本身不是最优路径，autotune 通常会切换到 `PermuteAndTranspose`）


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否