### PR TITLE
[Cherry-Pick][release/3.3] Remove Eigen 32-bit index optimization to fix compilation issues

### DIFF
--- a/paddle/fluid/framework/eigen.h
+++ b/paddle/fluid/framework/eigen.h
@@ -142,27 +142,5 @@ struct EigenScalar {
   }
 };
 
-// Define phi::DenseTensor with 32-bit index.
-template <typename T, int D, int MajorType = Eigen::RowMajor>
-using Tensor32BitIndex =
-    Eigen::TensorMap<Eigen::Tensor<T, D, MajorType, int>, Eigen::Aligned>;
-
-template <typename DSizes>
-Eigen::DSizes<int, DSizes::count> To32BitDims(const DSizes& in) {
-  Eigen::DSizes<int, DSizes::count> out;
-  for (int i = 0; i < DSizes::count; ++i) {
-    out[i] = in[i];
-  }
-  return out;
-}
-
-template <typename EigenTensor>
-Tensor32BitIndex<typename EigenTensor::Scalar, EigenTensor::NumIndices>
-To32BitIndex(EigenTensor in) {
-  using RetType =
-      Tensor32BitIndex<typename EigenTensor::Scalar, EigenTensor::NumIndices>;
-  return RetType(in.data(), To32BitDims(in.dimensions()));
-}
-
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/operators/activation_op.h
+++ b/paddle/fluid/operators/activation_op.h
@@ -36,8 +36,6 @@ limitations under the License. */
 namespace paddle {
 namespace operators {
 
-using phi::To32BitIndex;
-
 using ActBwdOpFwdDeps = phi::funcs::ActBwdOpFwdDeps;
 
 template <typename T>

--- a/paddle/phi/kernels/cpu/soft_relu_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/soft_relu_grad_kernel.cc
@@ -68,20 +68,7 @@ void SoftmaxGradKernel(const Context& dev_ctx,
   auto* eigen_dev = dev_ctx.eigen_device();
   SoftReluGradFunctor<T> functor;
   functor.SetAttrs(threshold);
-  // use 32bit index to speed up computation
-  bool use_32bit_index = out.size() < Eigen::NumTraits<int>::highest();
-  bool is_gpu_place =
-      (dev_ctx.GetPlace().GetType() == phi::AllocationType::GPU) ||
-      (dev_ctx.GetPlace().GetType() == phi::AllocationType::CUSTOM);
-  if (use_32bit_index && is_gpu_place) {
-    functor(*eigen_dev,
-            To32BitIndex(x),
-            To32BitIndex(out),
-            To32BitIndex(dout),
-            To32BitIndex(dx));
-  } else {
-    functor(*eigen_dev, x, out, dout, dx);
-  }
+  functor(*eigen_dev, x, out, dout, dx);
 }
 }  // namespace phi
 

--- a/paddle/phi/kernels/cpu/soft_relu_kernel.cc
+++ b/paddle/phi/kernels/cpu/soft_relu_kernel.cc
@@ -60,16 +60,7 @@ void SoftmaxKernel(const Context& dev_ctx,
   auto* eigen_dev = dev_ctx.eigen_device();
   SoftReluFunctor<T> functor;
   functor.SetAttrs(threshold);
-  // use 32bit index to speed up computation
-  bool use_32bit_index = out_flatten.size() < Eigen::NumTraits<int>::highest();
-  bool is_gpu_place =
-      (dev_ctx.GetPlace().GetType() == phi::AllocationType::GPU) ||
-      (dev_ctx.GetPlace().GetType() == phi::AllocationType::CUSTOM);
-  if (use_32bit_index && is_gpu_place) {
-    functor(*eigen_dev, To32BitIndex(x_flatten), To32BitIndex(out_flatten));
-  } else {
-    functor(*eigen_dev, x_flatten, out_flatten);
-  }
+  functor(*eigen_dev, x_flatten, out_flatten);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/eigen/common.h
+++ b/paddle/phi/kernels/funcs/eigen/common.h
@@ -146,26 +146,4 @@ struct EigenScalar {
   }
 };
 
-// Define Tensor with 32-bit index.
-template <typename T, int D, int MajorType = Eigen::RowMajor>
-using Tensor32BitIndex =
-    Eigen::TensorMap<Eigen::Tensor<T, D, MajorType, int>, Eigen::Aligned>;
-
-template <typename DSizes>
-Eigen::DSizes<int, DSizes::count> To32BitDims(const DSizes& in) {
-  Eigen::DSizes<int, DSizes::count> out;
-  for (int i = 0; i < DSizes::count; ++i) {
-    out[i] = in[i];
-  }
-  return out;
-}
-
-template <typename EigenTensor>
-Tensor32BitIndex<typename EigenTensor::Scalar, EigenTensor::NumIndices>
-To32BitIndex(EigenTensor in) {
-  using RetType =
-      Tensor32BitIndex<typename EigenTensor::Scalar, EigenTensor::NumIndices>;
-  return RetType(in.data(), To32BitDims(in.dimensions()));
-}
-
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/math_function_impl.h
+++ b/paddle/phi/kernels/funcs/math_function_impl.h
@@ -23,8 +23,6 @@ limitations under the License. */
 namespace phi {
 namespace funcs {
 
-using phi::To32BitIndex;
-
 template <typename DeviceContext, typename T>
 void SetConstant<DeviceContext, T>::operator()(const DeviceContext& dev_ctx,
                                                phi::DenseTensor* tensor,
@@ -56,9 +54,6 @@ void Transpose<DeviceContext, T, Rank>::operator()(
   auto eigen_in = phi::EigenTensor<T, Rank>::From(in);
   auto eigen_out = phi::EigenTensor<T, Rank>::From(*out);
   auto* dev = dev_ctx.eigen_device();
-  // use 32bit index to speed up computation
-  bool use_32bit_index = eigen_out.size() < Eigen::NumTraits<int>::highest();
-  bool is_gpu_place = dev_ctx.GetPlace().GetType() == phi::AllocationType::GPU;
   eigen_out.device(*dev) = eigen_in.shuffle(permute);
 }
 

--- a/paddle/phi/kernels/funcs/slice.h
+++ b/paddle/phi/kernels/funcs/slice.h
@@ -47,17 +47,13 @@ void EigenSliceWrapper(const Context& dev_ctx,
   auto eigen_place = *eigen_place_ptr;
   auto out_t = phi::EigenTensor<T, D>::From(*out, out->dims());
   auto in_t = phi::EigenTensor<T, D>::From(*in, in->dims());
-  Eigen::DSizes<int, D> offsets_32bit, extents_32bit;
+  Eigen::DSizes<Eigen::DenseIndex, D> offsets_64bit, extents_64bit;
   for (size_t i = 0; i < D; i++) {
-    offsets_32bit[i] = start[i];
-    extents_32bit[i] = end[i];
+    offsets_64bit[i] = start[i];
+    extents_64bit[i] = end[i];
   }
   EigenSlice<std::decay_t<decltype(eigen_place)>, T, D>::Eval(
-      eigen_place,
-      phi::To32BitIndex(out_t),
-      phi::To32BitIndex(in_t),
-      offsets_32bit,
-      extents_32bit);
+      eigen_place, out_t, in_t, offsets_64bit, extents_64bit);
 }
 
 #define SLICE_RANK_CASE(N)                                                \

--- a/paddle/phi/kernels/impl/activation_grad_impl.h
+++ b/paddle/phi/kernels/impl/activation_grad_impl.h
@@ -68,18 +68,7 @@ void ActivationGradImpl(const Context& dev_ctx,
   auto x = phi::EigenVector<T>::Flatten(
       GET_DATA_SAFELY(X, "Input", "X", "ActivationGrad"));
   auto* place = dev_ctx.eigen_device();
-  // use 32bit index to speed up computation
-  bool use_32bit_index = out.size() < Eigen::NumTraits<int>::highest();
-  bool is_gpu_place = dev_ctx.GetPlace().GetType() == phi::AllocationType::GPU;
-  if (use_32bit_index && is_gpu_place) {
-    functor(*place,
-            To32BitIndex(x),
-            To32BitIndex(out),
-            To32BitIndex(dout),
-            To32BitIndex(dx));
-  } else {
-    functor(*place, x, out, dout, dx);
-  }
+  functor(*place, x, out, dout, dx);
 }
 
 template <typename T, typename Context, typename Functor>

--- a/paddle/phi/kernels/impl/activation_impl.h
+++ b/paddle/phi/kernels/impl/activation_impl.h
@@ -40,14 +40,7 @@ void ActivationImpl(const Context& dev_ctx,
   auto out = phi::EigenVector<U>::Flatten(
       GET_DATA_SAFELY(Out, "Output", "Out", "Activation"));
   auto* place = dev_ctx.eigen_device();
-  // use 32bit index to speed up computation
-  bool use_32bit_index = out.size() < Eigen::NumTraits<int>::highest();
-  bool is_gpu_place = dev_ctx.GetPlace().GetType() == phi::AllocationType::GPU;
-  if (use_32bit_index && is_gpu_place) {
-    functor(*place, To32BitIndex(x), To32BitIndex(out));
-  } else {
-    functor(*place, x, out);
-  }
+  functor(*place, x, out);
 }
 
 // Vectorized Sin implementation for CPU - matches PyTorch precision

--- a/paddle/phi/kernels/impl/expand_kernel_impl.h
+++ b/paddle/phi/kernels/impl/expand_kernel_impl.h
@@ -101,15 +101,8 @@ void Expand(const Context& dev_ctx,
 
   auto y = EigenTensor<T, Rank>::From(*out, out_dims);
   auto& place = *dev_ctx.eigen_device();
-  // use 32-bit index to speed up
-  bool use_32bit_index = y.size() < Eigen::NumTraits<int>::highest();
-  if (use_32bit_index) {
-    phi::funcs::EigenBroadcast<std::decay_t<decltype(place)>, T, Rank>::Eval(
-        place, To32BitIndex(y), To32BitIndex(x0), bcast_dims);
-  } else {
-    phi::funcs::EigenBroadcast<std::decay_t<decltype(place)>, T, Rank>::Eval(
-        place, y, x0, bcast_dims);
-  }
+  phi::funcs::EigenBroadcast<std::decay_t<decltype(place)>, T, Rank>::Eval(
+      place, y, x0, bcast_dims);
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/impl/legacy_expand_kernel_impl.h
+++ b/paddle/phi/kernels/impl/legacy_expand_kernel_impl.h
@@ -55,15 +55,8 @@ void Expand(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out0);
   auto y = EigenTensor<T, Rank>::From(*out0);
   auto& place = *dev_ctx.eigen_device();
-  // use 32-bit index to speed up
-  bool use_32bit_index = y.size() < Eigen::NumTraits<int>::highest();
-  if (use_32bit_index) {
-    phi::funcs::EigenBroadcast<std::decay_t<decltype(place)>, T, Rank>::Eval(
-        place, To32BitIndex(y), To32BitIndex(x), bcast_dims);
-  } else {
-    phi::funcs::EigenBroadcast<std::decay_t<decltype(place)>, T, Rank>::Eval(
-        place, y, x, bcast_dims);
-  }
+  phi::funcs::EigenBroadcast<std::decay_t<decltype(place)>, T, Rank>::Eval(
+      place, y, x, bcast_dims);
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/impl/lu_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lu_kernel_impl.h
@@ -316,24 +316,8 @@ void SliceCompute(const Context& dev_ctx,
   auto out_t = EigenTensor<T, D>::From(*out, slice_dims);
   auto& eigen_place = *dev_ctx.eigen_device();
 
-  if (in->numel() <= Eigen::NumTraits<int>::highest()) {
-    // similar to tf.slice:
-    // if element number less than INT_MAX, change the type of index to int
-    Eigen::DSizes<int, D> offsets_32bit, extents_32bit;
-    for (size_t i = 0; i < D; i++) {
-      offsets_32bit[i] = offsets[i];
-      extents_32bit[i] = extents[i];
-    }
-    funcs::EigenSlice<std::decay_t<decltype(eigen_place)>, T, D>::Eval(
-        eigen_place,
-        To32BitIndex(out_t),
-        To32BitIndex(in_t),
-        offsets_32bit,
-        extents_32bit);
-  } else {
-    funcs::EigenSlice<std::decay_t<decltype(eigen_place)>, T, D>::Eval(
-        eigen_place, out_t, in_t, offsets, extents);
-  }
+  funcs::EigenSlice<std::decay_t<decltype(eigen_place)>, T, D>::Eval(
+      eigen_place, out_t, in_t, offsets, extents);
 
   out->Resize(out_dims);
   dev_ctx.template Alloc<T>(out);

--- a/paddle/phi/kernels/impl/slice_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/slice_grad_kernel_impl.h
@@ -38,18 +38,8 @@ void LaunchEigenPadding(
       *d_out, out_dims);
 
   if (d_input->numel() <= Eigen::NumTraits<int>::highest()) {
-    // similar to tf.pad:
-    // if element number less than INT_MAX, change the type of index to int
-    std::array<std::pair<int, int>, D> paddings_32bit;
-    for (size_t i = 0; i < D; i++) {
-      paddings_32bit[i] = std::make_pair(paddings[i].first, paddings[i].second);
-    }
-    funcs::EigenPad<std::decay_t<decltype(place)>, T, D>::Eval32(
-        place,
-        To32BitIndex(d_in_t),
-        To32BitIndex(d_out_t),
-        paddings_32bit,
-        static_cast<T>(0));
+    funcs::EigenPad<std::decay_t<decltype(place)>, T, D>::Eval(
+        place, d_in_t, d_out_t, paddings, static_cast<T>(0));
   } else {
     funcs::EigenPad<std::decay_t<decltype(place)>, T, D>::Eval(
         place, d_in_t, d_out_t, paddings, static_cast<T>(0));

--- a/paddle/phi/kernels/impl/slice_kernel_impl.h
+++ b/paddle/phi/kernels/impl/slice_kernel_impl.h
@@ -77,24 +77,8 @@ void SliceCompute(const Context& dev_ctx,
   auto out_t = EigenTensor<T, D>::From(*out, slice_dims);
   auto& eigen_place = *dev_ctx.eigen_device();
 
-  if (in->numel() <= Eigen::NumTraits<int>::highest()) {
-    // similar to tf.slice:
-    // if element number less than INT_MAX, change the type of index to int
-    Eigen::DSizes<int, D> offsets_32bit, extents_32bit;
-    for (size_t i = 0; i < D; i++) {
-      offsets_32bit[i] = offsets[i];
-      extents_32bit[i] = extents[i];
-    }
-    funcs::EigenSlice<std::decay_t<decltype(eigen_place)>, T, D>::Eval(
-        eigen_place,
-        To32BitIndex(out_t),
-        To32BitIndex(in_t),
-        offsets_32bit,
-        extents_32bit);
-  } else {
-    funcs::EigenSlice<std::decay_t<decltype(eigen_place)>, T, D>::Eval(
-        eigen_place, out_t, in_t, offsets, extents);
-  }
+  funcs::EigenSlice<std::decay_t<decltype(eigen_place)>, T, D>::Eval(
+      eigen_place, out_t, in_t, offsets, extents);
 
   out->Resize(out_dims);
 }

--- a/paddle/phi/kernels/impl/tile_kernel_impl.h
+++ b/paddle/phi/kernels/impl/tile_kernel_impl.h
@@ -80,15 +80,8 @@ void Tile(const Context& dev_ctx,
   auto eigen_out = EigenTensor<T, Rank>::From(*out, out_dims);
   auto& place = *dev_ctx.eigen_device();
 
-  // use 32-bit index to speed up
-  bool use_32bit_index = eigen_out.size() < Eigen::NumTraits<int>::highest();
-  if (use_32bit_index) {
-    funcs::EigenBroadcast<std::decay_t<decltype(place)>, T, Rank>::Eval(
-        place, To32BitIndex(eigen_out), To32BitIndex(eigen_x), bcast_dims);
-  } else {
-    funcs::EigenBroadcast<std::decay_t<decltype(place)>, T, Rank>::Eval(
-        place, eigen_out, eigen_x, bcast_dims);
-  }
+  funcs::EigenBroadcast<std::decay_t<decltype(place)>, T, Rank>::Eval(
+      place, eigen_out, eigen_x, bcast_dims);
 }
 
 template <typename T, typename Context>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
#### Summary
devPR:https://github.com/PaddlePaddle/Paddle/pull/78376
- Remove unused Eigen 32-bit index optimization (To32BitIndex, To32BitDims, Tensor32BitIndex) from eigen.h and funcs/eigen/common.h
- Remove all call sites of 32-bit index branching logic in kernel implementations (activation, soft_relu, expand, slice, tile, lu, etc.)
- Unify Eigen tensor operations to use the default 64-bit Eigen::DenseIndex, simplifying code and fixing potential compilation issues

#### Affected Modules
- paddle/fluid/framework/eigen.h
- paddle/phi/kernels/funcs/eigen/common.h
- Multiple kernel implementations under paddle/phi/kernels/

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否