### PR TITLE
[XPU] Add complex64 support for abs operator

### DIFF
--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -25,7 +25,15 @@ XPUOpMap& get_kl3_ops() {
       {"acos", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"add_act_xpu", XPUKernelSet({FLOAT32, FLOAT16})},
       {"add_layernorm_xpu", XPUKernelSet({FLOAT32, FLOAT16})},
-      {"abs", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
+      {"abs",
+       XPUKernelSet({FLOAT32,
+                     FLOAT16,
+                     BFLOAT16
+#ifdef PADDLE_WITH_XPU_FFT
+                     ,
+                     phi::DataType::COMPLEX64
+#endif
+       })},
       {"abs_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"accuracy", XPUKernelSet({FLOAT32, FLOAT16})},
       {"adadelta", XPUKernelSet({FLOAT32})},

--- a/paddle/phi/kernels/xpu/abs_kernel.cc
+++ b/paddle/phi/kernels/xpu/abs_kernel.cc
@@ -15,7 +15,23 @@
 #include "paddle/phi/kernels/abs_kernel.h"
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/backends/xpu/xpu_context.h"
+#include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/xpu/xpu_api_wrapper.h"
+
+#ifdef PADDLE_WITH_XPU_FFT
+#include "fft/cuComplex.h"
+namespace xfft_internal::xpu {
+// just for declaration here, the real implementation is in libcufft.so
+template <typename TComplex, typename T>
+int complex_spilt(
+    const XPUStream stream, int N, const TComplex* in, T* real, T* imag);
+template <>
+int complex_spilt(
+    const XPUStream stream, int N, const float2* in, float* real, float* imag);
+}  // namespace xfft_internal::xpu
+#endif
 
 namespace phi {
 
@@ -32,6 +48,49 @@ void AbsKernel(const Context& dev_ctx, const DenseTensor& x, DenseTensor* out) {
                             x.numel());
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "abs");
 }
+
+#ifdef PADDLE_WITH_XPU_FFT
+template <>
+void AbsKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
+                                           const DenseTensor& x,
+                                           DenseTensor* out) {
+  using T = phi::complex64;
+  using RealT = phi::dtype::Real<T>;
+  using XPUComplexType = cuFloatComplex;
+
+  dev_ctx.template Alloc<RealT>(out);
+  if (x.numel() == 0) {
+    return;
+  }
+
+  xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+  RealT* real = RAII_GUARD.alloc_l3_or_gm<RealT>(x.numel());
+  RealT* imag = RAII_GUARD.alloc_l3_or_gm<RealT>(x.numel());
+  RealT* imag_sq = RAII_GUARD.alloc_l3_or_gm<RealT>(x.numel());
+  PADDLE_ENFORCE_XDNN_NOT_NULL(real);
+  PADDLE_ENFORCE_XDNN_NOT_NULL(imag);
+  PADDLE_ENFORCE_XDNN_NOT_NULL(imag_sq);
+
+  int r = xfft_internal::xpu::complex_spilt(
+      dev_ctx.x_context()->xpu_stream,
+      x.numel(),
+      reinterpret_cast<const XPUComplexType*>(x.data<T>()),
+      real,
+      imag);
+  PADDLE_ENFORCE_XPU_SUCCESS(r);
+
+  r = xpu::mul(dev_ctx.x_context(), real, real, real, x.numel());
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "mul");
+  r = xpu::mul(dev_ctx.x_context(), imag, imag, imag_sq, x.numel());
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "mul");
+  r = xpu::add(
+      dev_ctx.x_context(), real, imag_sq, out->data<RealT>(), x.numel());
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "add");
+  r = xpu::sqrt<RealT>(
+      dev_ctx.x_context(), out->data<RealT>(), out->data<RealT>(), x.numel());
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "sqrt");
+}
+#endif
 }  // namespace phi
 
 PD_REGISTER_KERNEL(abs,
@@ -43,4 +102,11 @@ PD_REGISTER_KERNEL(abs,
                    phi::bfloat16,
                    int8_t,
                    int32_t,
-                   int64_t) {}
+                   int64_t
+#ifdef PADDLE_WITH_XPU_FFT
+                   ,
+                   phi::complex64
+#endif
+) {
+  kernel->OutputAt(0).SetDataType(phi::dtype::ToReal(kernel_key.dtype()));
+}

--- a/test/xpu/test_activation_op_xpu.py
+++ b/test/xpu/test_activation_op_xpu.py
@@ -478,6 +478,121 @@ for stype in support_types:
     create_test_class(globals(), XPUTestAbsOPZeroSize, stype)
 
 
+class XPUTestAbsOPComplex(XPUOpTestWrapper):
+    def __init__(self):
+        self.op_name = 'abs'
+        self.use_dynamic_create_class = False
+
+    class XPUTestAbsComplex(TestActivationOPBase):
+        def set_shape(self):
+            self.shape = [4, 25]
+
+        def init_random_config(self):
+            self.seed = 2026
+            self.dist = "uniform"
+            self.low = -1.0
+            self.high = 1.0
+            self.mean = 0.0
+            self.std = 1.0
+
+        def gen_random_part(self, rng):
+            if self.dist == "normal":
+                val = rng.normal(loc=self.mean, scale=self.std, size=self.shape)
+            else:
+                val = rng.uniform(low=self.low, high=self.high, size=self.shape)
+            return np.asarray(val, dtype=np.float32)
+
+        def set_case(self):
+            self.op_type = "abs"
+            self.dtype = np.complex64
+            self.init_random_config()
+            rng = np.random.default_rng(self.seed)
+
+            # Generate complex numbers with both real and imaginary parts
+            real_part = self.gen_random_part(rng)
+            imag_part = self.gen_random_part(rng)
+            # Avoid values too close to zero
+            real_part = np.where(
+                np.abs(real_part) < 0.005, np.float32(0.02), real_part
+            )
+            imag_part = np.where(
+                np.abs(imag_part) < 0.005, np.float32(0.02), imag_part
+            )
+            x = real_part + 1j * imag_part
+
+            # abs(complex64) returns float32
+            out = np.abs(x).astype(np.float32)
+
+            self.attrs = {'use_xpu': True}
+            self.inputs = {'X': OpTest.np_dtype_to_base_dtype(x)}
+            self.outputs = {'Out': out}
+
+    class XPUTestAbsComplexZeroSize(XPUTestAbsComplex):
+        def set_shape(self):
+            self.shape = [0, 25]
+
+    class XPUTestAbsComplexZeroDim(XPUTestAbsComplex):
+        def set_shape(self):
+            self.shape = []
+
+    class XPUTestAbsComplexOneDim(XPUTestAbsComplex):
+        def set_shape(self):
+            self.shape = [97]
+
+    class XPUTestAbsComplexRandomUniform1(XPUTestAbsComplex):
+        def set_shape(self):
+            self.shape = [13, 9]
+
+        def init_random_config(self):
+            self.seed = 1
+            self.dist = "uniform"
+            self.low = -2.0
+            self.high = 2.0
+            self.mean = 0.0
+            self.std = 1.0
+
+    class XPUTestAbsComplexRandomUniform2(XPUTestAbsComplex):
+        def set_shape(self):
+            self.shape = [2, 3, 17]
+
+        def init_random_config(self):
+            self.seed = 17
+            self.dist = "uniform"
+            self.low = -5.0
+            self.high = 5.0
+            self.mean = 0.0
+            self.std = 1.0
+
+    class XPUTestAbsComplexRandomNormal(XPUTestAbsComplex):
+        def set_shape(self):
+            self.shape = [5, 11]
+
+        def init_random_config(self):
+            self.seed = 97
+            self.dist = "normal"
+            self.low = -1.0
+            self.high = 1.0
+            self.mean = 0.0
+            self.std = 2.5
+
+    class XPUTestAbsComplexRandomWideRange(XPUTestAbsComplex):
+        def set_shape(self):
+            self.shape = [3, 7, 19]
+
+        def init_random_config(self):
+            self.seed = 311
+            self.dist = "uniform"
+            self.low = -20.0
+            self.high = 20.0
+            self.mean = 0.0
+            self.std = 1.0
+
+
+complex_support_types = get_xpu_op_support_types('abs')
+if 'complex64' in complex_support_types:
+    create_test_class(globals(), XPUTestAbsOPComplex, 'complex64')
+
+
 class XPUTestReluOP(XPUOpTestWrapper):
     def __init__(self):
         self.op_name = 'relu'


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Custom Device

### PR Types
New features

### Description

**背景：**
XPU 平台的 `abs` 算子之前不支持 complex64（复数）类型，限制了复数计算场景的使用。

**实现内容：**
1. 在 `paddle/phi/kernels/xpu/abs_kernel.cc` 中实现 `AbsKernel<phi::complex64, XPUContext>` 特化版本
    - 利用 XPU FFT 库的 `complex_spilt` 函数分离实部和虚部
    - 通过 `sqrt(real² + imag²)` 计算复数的模
    - 使用 L3/GM 临时缓冲区优化内存访问

2. 在 `test/xpu/test_activation_op_xpu.py` 中新增全面的测试覆盖
    - 支持多种形状：零大小、零维、一维、多维张量
    - 支持多种数据分布：均匀分布、正态分布、宽范围随机数
    - 共添加 8 个测试用例确保正确性

**验证方法：**
- 所有新增测试用例通过
- 已通过 pre-commit hooks 检查（格式化、cpplint、clang-tidy 等）

### 是否引起精度变化

否