### PR TITLE
[API Compatibility] Add logic for non-iterable generator in `paddle.io.RandomSampler`

### DIFF
--- a/python/paddle/io/dataloader/sampler.py
+++ b/python/paddle/io/dataloader/sampler.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import warnings
+from collections.abc import Iterator
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -27,7 +29,7 @@ from ...framework import core
 from ...tensor import randperm
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterator, Sequence, Sized
+    from collections.abc import Generator, Sequence, Sized
 
     import numpy.typing as npt
 
@@ -235,7 +237,13 @@ class RandomSampler(Sampler[int]):
         self.data_source = data_source
         self.replacement = replacement
         self._num_samples = num_samples
-        self.generator = generator
+        if isinstance(generator, Iterator):
+            self.generator = generator
+        else:
+            warnings.warn(
+                "the specified generator is not iterable and will be ignored"
+            )
+            self.generator = None
 
         if not isinstance(self.replacement, bool):
             raise TypeError(

--- a/test/legacy_test/test_batch_sampler.py
+++ b/test/legacy_test/test_batch_sampler.py
@@ -17,6 +17,7 @@ import unittest
 
 import numpy as np
 
+import paddle
 from paddle.io import (
     BatchSampler,
     Dataset,
@@ -107,6 +108,17 @@ class TestRandomSampler(unittest.TestCase):
         for i in iter(sampler):
             rets.append(i)
         assert tuple(sorted(rets)) == tuple(range(0, 60))
+
+    def test_with_illegal_generator(self):
+        dataset = RandomDataset(100, 10)
+        generator = paddle.Generator()
+        sampler = RandomSampler(dataset, generator=generator)
+        assert len(sampler) == 100
+
+        rets = []
+        for i in iter(sampler):
+            rets.append(i)
+        assert tuple(sorted(rets)) == tuple(range(0, 100))
 
     def test_with_generator_num_samples(self):
         dataset = RandomDataset(100, 10)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Add logic to ignore the generator when it is not iterable
- Add corresponding test


### 是否引起精度变化
否
