### PR TITLE
[Cherry-pick][Refactor] Remove IndexType template param from EigenTensor and unify Eigen index type to int64_t

### DIFF
--- a/paddle/fluid/framework/eigen.h
+++ b/paddle/fluid/framework/eigen.h
@@ -45,17 +45,14 @@ struct EigenDim {
 };
 
 // Interpret paddle::platform::Tensor as EigenTensor and EigenConstTensor.
-template <typename T,
-          size_t D,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
+template <typename T, size_t D, int MajorType = Eigen::RowMajor>
 struct EigenTensor {
   // TODO(qijun) Now, default type in unaligned, and we will make a benchmark on
   // the speed of aligned and unaligned version in future.
-  using Type = Eigen::TensorMap<Eigen::Tensor<T, D, MajorType, IndexType>>;
+  using Type = Eigen::TensorMap<Eigen::Tensor<T, D, MajorType, int64_t>>;
 
   using ConstType =
-      Eigen::TensorMap<Eigen::Tensor<const T, D, MajorType, IndexType>>;
+      Eigen::TensorMap<Eigen::Tensor<const T, D, MajorType, int64_t>>;
 
   static Type From(phi::DenseTensor& tensor, DDim dims) {  // NOLINT
     return Type(tensor.data<T>(), EigenDim<D>::From(dims));
@@ -74,11 +71,9 @@ struct EigenTensor {
   }
 };
 
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-struct EigenMatrix : public EigenTensor<T, 2, MajorType, IndexType> {
-  static typename EigenMatrix::Type Reshape(phi::DenseTensor& tensor,  // NOLINT
+template <typename T, int MajorType = Eigen::RowMajor>
+struct EigenMatrix : public EigenTensor<T, 2, MajorType> {
+  static typename EigenMatrix::Type Reshape(DenseTensor& tensor,  // NOLINT
                                             int num_col_dims) {
     int rank = tensor.dims().size();
     PADDLE_ENFORCE_EQ((num_col_dims > 0 && num_col_dims < rank),
@@ -107,13 +102,10 @@ struct EigenMatrix : public EigenTensor<T, 2, MajorType, IndexType> {
   }
 };
 
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-struct EigenVector : public EigenTensor<T, 1, MajorType, IndexType> {
-  // Flatten reshapes a phi::DenseTensor into an EigenVector.
-  static typename EigenVector::Type Flatten(
-      phi::DenseTensor& tensor) {  // NOLINT
+template <typename T, int MajorType = Eigen::RowMajor>
+struct EigenVector : public EigenTensor<T, 1, MajorType> {
+  // Flatten reshapes a DenseTensor into an EigenVector.
+  static typename EigenVector::Type Flatten(DenseTensor& tensor) {  // NOLINT
     return EigenVector::From(tensor, {product(tensor.dims())});
   }
 
@@ -123,15 +115,13 @@ struct EigenVector : public EigenTensor<T, 1, MajorType, IndexType> {
   }
 };
 
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
+template <typename T, int MajorType = Eigen::RowMajor>
 struct EigenScalar {
   // Scalar tensor (implemented as a rank-0 tensor) of scalar type T.
   using Type = Eigen::TensorMap<
-      Eigen::TensorFixedSize<T, Eigen::Sizes<>, MajorType, IndexType>>;
+      Eigen::TensorFixedSize<T, Eigen::Sizes<>, MajorType, int64_t>>;
   using ConstType = Eigen::TensorMap<
-      Eigen::TensorFixedSize<const T, Eigen::Sizes<>, MajorType, IndexType>>;
+      Eigen::TensorFixedSize<const T, Eigen::Sizes<>, MajorType, int64_t>>;
 
   static Type From(phi::DenseTensor& tensor) {  // NOLINT
     return Type(tensor.data<T>());
@@ -142,14 +132,14 @@ struct EigenScalar {
   }
 };
 
-// Define phi::DenseTensor with 32-bit index.
+// Define DenseTensor with 64-bit index.
 template <typename T, int D, int MajorType = Eigen::RowMajor>
 using Tensor32BitIndex =
-    Eigen::TensorMap<Eigen::Tensor<T, D, MajorType, int>, Eigen::Aligned>;
+    Eigen::TensorMap<Eigen::Tensor<T, D, MajorType, int64_t>, Eigen::Aligned>;
 
 template <typename DSizes>
-Eigen::DSizes<int, DSizes::count> To32BitDims(const DSizes& in) {
-  Eigen::DSizes<int, DSizes::count> out;
+Eigen::DSizes<int64_t, DSizes::count> To32BitDims(const DSizes& in) {
+  Eigen::DSizes<int64_t, DSizes::count> out;
   for (int i = 0; i < DSizes::count; ++i) {
     out[i] = in[i];
   }

--- a/paddle/fluid/framework/eigen.h
+++ b/paddle/fluid/framework/eigen.h
@@ -73,7 +73,7 @@ struct EigenTensor {
 
 template <typename T, int MajorType = Eigen::RowMajor>
 struct EigenMatrix : public EigenTensor<T, 2, MajorType> {
-  static typename EigenMatrix::Type Reshape(DenseTensor& tensor,  // NOLINT
+  static typename EigenMatrix::Type Reshape(phi::DenseTensor& tensor,  // NOLINT
                                             int num_col_dims) {
     int rank = tensor.dims().size();
     PADDLE_ENFORCE_EQ((num_col_dims > 0 && num_col_dims < rank),
@@ -105,7 +105,8 @@ struct EigenMatrix : public EigenTensor<T, 2, MajorType> {
 template <typename T, int MajorType = Eigen::RowMajor>
 struct EigenVector : public EigenTensor<T, 1, MajorType> {
   // Flatten reshapes a DenseTensor into an EigenVector.
-  static typename EigenVector::Type Flatten(DenseTensor& tensor) {  // NOLINT
+  static typename EigenVector::Type Flatten(
+      phi::DenseTensor& tensor) {  // NOLINT
     return EigenVector::From(tensor, {product(tensor.dims())});
   }
 

--- a/paddle/fluid/framework/eigen.h
+++ b/paddle/fluid/framework/eigen.h
@@ -26,7 +26,7 @@ namespace framework {
 // EigenDim converts paddle::platform::DDim into Eigen::DSizes.
 template <int D>
 struct EigenDim {
-  using Type = Eigen::DSizes<Eigen::DenseIndex, D>;
+  using Type = Eigen::DSizes<int64_t, D>;
 
   static Type From(const DDim& dims) {
     PADDLE_ENFORCE_EQ(arity(dims),

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -719,12 +719,8 @@ void _sliceCompute(const phi::DenseTensor *in,
     start = std::max(start, 0);
     offsets[axes[i]] = start;
   }
-  auto in_t =
-      framework::EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(
-          *in);
-  auto out_t =
-      framework::EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(
-          *out);
+  auto in_t = framework::EigenTensor<T, D, Eigen::RowMajor>::From(*in);
+  auto out_t = framework::EigenTensor<T, D, Eigen::RowMajor>::From(*out);
   phi::funcs::EigenSlice<std::decay_t<decltype(eigen_place)>, T, D>::Eval(
       eigen_place, out_t, in_t, offsets, extents);
 }

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -704,8 +704,8 @@ void _sliceCompute(const phi::DenseTensor *in,
   auto out_dims = common::vectorize<int>(out->dims());
   auto in_dims = in->dims();
 
-  auto offsets = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto extents = Eigen::DSizes<Eigen::DenseIndex, D>();
+  auto offsets = Eigen::DSizes<int64_t, D>();
+  auto extents = Eigen::DSizes<int64_t, D>();
   for (size_t i = 0; i < D; ++i) {
     offsets[i] = 0;
     extents[i] = out_dims[i];

--- a/paddle/phi/kernels/cpu/broadcast_tensors_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/broadcast_tensors_grad_kernel.cc
@@ -25,7 +25,7 @@
 #include "paddle/phi/kernels/funcs/math_function.h"
 #define SWITCH_RESHAPE_DIMS(n)                                                \
   case n: {                                                                   \
-    Eigen::DSizes<Eigen::DenseIndex, n> reshape_dims;                         \
+    Eigen::DSizes<int64_t, n> reshape_dims;                                   \
     for (size_t i = 0; i < reshape_dims_vec.size(); ++i) {                    \
       reshape_dims[i] = reshape_dims_vec[i];                                  \
     }                                                                         \
@@ -36,7 +36,7 @@
 
 #define UPPER_SWITCH_REDUCE_DIMS(m)                       \
   case m: {                                               \
-    Eigen::DSizes<Eigen::DenseIndex, m> reduce_dims;      \
+    Eigen::DSizes<int64_t, m> reduce_dims;                \
     for (size_t i = 0; i < reduce_dims_vec.size(); ++i) { \
       reduce_dims[i] = reduce_dims_vec[i];                \
     }                                                     \

--- a/paddle/phi/kernels/cpu/cum_kernel.cc
+++ b/paddle/phi/kernels/cpu/cum_kernel.cc
@@ -98,7 +98,7 @@ void ScanKernel(const Context& dev_ctx,
   auto out0 = EigenVector<T>::Flatten(*out);
   auto& place = *dev_ctx.eigen_device();
 
-  using IndexT = Eigen::DenseIndex;
+  using IndexT = int64_t;
   if (pre == 1) {
     if (post == 1) {
       ComputeImp(place,

--- a/paddle/phi/kernels/cpu/l1_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/l1_norm_grad_kernel.cc
@@ -42,7 +42,7 @@ void L1NormGradKernel(const Context& dev_ctx,
   auto d_out_eigen = phi::EigenVector<T>::Flatten(out_grad);
   auto dx_eigen = phi::EigenVector<T>::Flatten(*x_grad);
   auto& dev = *dev_ctx.eigen_device();
-  Eigen::DSizes<Eigen::DenseIndex, 1> x_dsize(x.numel());
+  Eigen::DSizes<int64_t, 1> x_dsize(x.numel());
   funcs::EigenL1NormGrad<std::decay_t<decltype(dev)>, T>::Eval(
       dev, dx_eigen, d_out_eigen, x_eigen, x_dsize);
 }

--- a/paddle/phi/kernels/cpu/l1_norm_kernel.cc
+++ b/paddle/phi/kernels/cpu/l1_norm_kernel.cc
@@ -42,7 +42,7 @@ void L1NormGradKernel(const Context& dev_ctx,
   auto d_out_eigen = phi::EigenVector<T>::Flatten(out_grad);
   auto dx_eigen = phi::EigenVector<T>::Flatten(*x_grad);
   auto& dev = *dev_ctx.eigen_device();
-  Eigen::DSizes<Eigen::DenseIndex, 1> x_dsize(x.numel());
+  Eigen::DSizes<int64_t, 1> x_dsize(x.numel());
   funcs::EigenL1NormGrad<std::decay_t<decltype(dev)>, T>::Eval(
       dev, dx_eigen, d_out_eigen, x_eigen, x_dsize);
 }

--- a/paddle/phi/kernels/cpu/lars_momentum_kernel.cc
+++ b/paddle/phi/kernels/cpu/lars_momentum_kernel.cc
@@ -44,12 +44,11 @@ void LarsMomentumKernel(
     dev_ctx.template Alloc<T>(param_out[i]);
     dev_ctx.template Alloc<T>(velocity_out[i]);
 
-    auto p_out = phi::EigenVector<T>::Flatten(*(param_out[i]));
-    auto v_out = phi::EigenVector<T>::Flatten(*(velocity_out[i]));
-    auto p = phi::EigenVector<T>::Flatten(*(param[i]));
-    auto v = phi::EigenVector<T>::Flatten(*(velocity[i]));
-    Eigen::TensorMap<Eigen::Tensor<const T, 1, 1>> g =
-        phi::EigenVector<T>::Flatten(*(grad[i]));
+    auto p_out = EigenVector<T>::Flatten(*(param_out[i]));
+    auto v_out = EigenVector<T>::Flatten(*(velocity_out[i]));
+    auto p = EigenVector<T>::Flatten(*(param[i]));
+    auto v = EigenVector<T>::Flatten(*(velocity[i]));
+    auto g = EigenVector<T>::Flatten(*(grad[i]));
     auto rescale_g = static_cast<T>(rescale_grad) * g;
 
     phi::DenseTensor p_norm_t, g_norm_t;

--- a/paddle/phi/kernels/cpu/log_softmax_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/log_softmax_grad_kernel.cc
@@ -23,10 +23,8 @@
 
 namespace phi {
 
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenMatrixTemplate = EigenMatrix<T, MajorType, IndexType>;
+template <typename T, int MajorType = Eigen::RowMajor>
+using EigenMatrixTemplate = EigenMatrix<T, MajorType>;
 
 template <typename Context, typename T>
 struct LogSoftmaxGradFunctor {

--- a/paddle/phi/kernels/cpu/log_softmax_kernel.cc
+++ b/paddle/phi/kernels/cpu/log_softmax_kernel.cc
@@ -23,10 +23,8 @@
 
 namespace phi {
 
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenMatrixTemplate = EigenMatrix<T, MajorType, IndexType>;
+template <typename T, int MajorType = Eigen::RowMajor>
+using EigenMatrixTemplate = EigenMatrix<T, MajorType>;
 
 template <typename T>
 struct ValueClip {

--- a/paddle/phi/kernels/cpu/nce_kernel.cc
+++ b/paddle/phi/kernels/cpu/nce_kernel.cc
@@ -220,7 +220,7 @@ void NCEKernel(const Context &dev_ctx,
 
   auto weight_mat = EigenMatrix<T>::From(weight_in);
   for (int64_t i = 0; i < sample_labels->numel(); ++i) {
-    Eigen::Tensor<T, 0, Eigen::RowMajor, Eigen::DenseIndex> result =
+    Eigen::Tensor<T, 0, Eigen::RowMajor, int64_t> result =
         (input_mat.chip(static_cast<int>(i / sample_labels->dims()[1]), 0) *
          weight_mat.chip(sample_labels_data[i], 0))
             .sum();

--- a/paddle/phi/kernels/cpu/set_value_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/set_value_grad_kernel.cc
@@ -133,12 +133,10 @@ void SetValueGradImpl(const Context& dev_ctx,
     // Set gradient of `Input`
     Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
 
-    auto x_grad_t =
-        EigenTensor<T, RANK, Eigen::RowMajor, Eigen::DenseIndex>::From(*x_grad);
+    auto x_grad_t = EigenTensor<T, RANK, Eigen::RowMajor>::From(*x_grad);
 
     DenseTensor tmp = Full<T>(dev_ctx, out_dims_vector, static_cast<T>(0));
-    auto tmp_t =
-        EigenTensor<T, RANK, Eigen::RowMajor, Eigen::DenseIndex>::From(tmp);
+    auto tmp_t = EigenTensor<T, RANK, Eigen::RowMajor>::From(tmp);
 
     x_grad_t.stridedSlice(starts_indices, ends_indices, steps_indices)
         .device(place) = tmp_t;
@@ -147,17 +145,14 @@ void SetValueGradImpl(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(value_grad);
     set_zero(dev_ctx, value_grad, static_cast<T>(0));
 
-    auto in_t = EigenTensor<T, RANK, Eigen::RowMajor, Eigen::DenseIndex>::From(
-        out_grad);
+    auto in_t = EigenTensor<T, RANK, Eigen::RowMajor>::From(out_grad);
 
     if (value_grad->dims() == out_dims) {
       auto value_grad_t =
-          EigenTensor<T, RANK, Eigen::RowMajor, Eigen::DenseIndex>::From(
-              *value_grad);
+          EigenTensor<T, RANK, Eigen::RowMajor>::From(*value_grad);
       if (need_reverse) {
         DenseTensor tmp = Full<T>(dev_ctx, out_dims_vector, static_cast<T>(0));
-        auto tmp_t =
-            EigenTensor<T, RANK, Eigen::RowMajor, Eigen::DenseIndex>::From(tmp);
+        auto tmp_t = EigenTensor<T, RANK, Eigen::RowMajor>::From(tmp);
 
         tmp_t.device(place) =
             in_t.stridedSlice(starts_indices, ends_indices, steps_indices);
@@ -217,13 +212,11 @@ void SetValueGradImpl(const Context& dev_ctx,
       std::vector<DDim> offsets;
       GetOffsets(out_dims, fake_value_grad_dims, offset, 0, &offsets);
 
-      auto value_grad_t =
-          EigenTensor<T, RANK, Eigen::RowMajor, Eigen::DenseIndex>::From(
-              *value_grad, fake_value_grad_dims);
+      auto value_grad_t = EigenTensor<T, RANK, Eigen::RowMajor>::From(
+          *value_grad, fake_value_grad_dims);
 
       DenseTensor tmp = Full<T>(dev_ctx, out_dims_vector, static_cast<T>(0));
-      auto tmp_t =
-          EigenTensor<T, RANK, Eigen::RowMajor, Eigen::DenseIndex>::From(tmp);
+      auto tmp_t = EigenTensor<T, RANK, Eigen::RowMajor>::From(tmp);
 
       tmp_t.device(place) =
           in_t.stridedSlice(starts_indices, ends_indices, steps_indices);
@@ -239,8 +232,7 @@ void SetValueGradImpl(const Context& dev_ctx,
                     {fake_value_grad_dims.Get(), fake_value_grad_dims.size()},
                     static_cast<T>(0));
         auto tmp_value_t =
-            EigenTensor<T, RANK, Eigen::RowMajor, Eigen::DenseIndex>::From(
-                tmp_value);
+            EigenTensor<T, RANK, Eigen::RowMajor>::From(tmp_value);
         tmp_value_t.device(place) = value_grad_t.reverse(reverse_axis);
         value_grad_t.device(place) = tmp_value_t;
       }

--- a/paddle/phi/kernels/cpu/set_value_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/set_value_grad_kernel.cc
@@ -98,9 +98,9 @@ void SetValueGradImpl(const Context& dev_ctx,
                              decrease_axis_int32,
                              starts_local.size());
 
-  auto starts_indices = Eigen::DSizes<Eigen::DenseIndex, RANK>();
-  auto ends_indices = Eigen::DSizes<Eigen::DenseIndex, RANK>();
-  auto steps_indices = Eigen::DSizes<Eigen::DenseIndex, RANK>();
+  auto starts_indices = Eigen::DSizes<int64_t, RANK>();
+  auto ends_indices = Eigen::DSizes<int64_t, RANK>();
+  auto steps_indices = Eigen::DSizes<int64_t, RANK>();
   auto reverse_axis = Eigen::array<bool, RANK>();
 
   for (size_t axis = 0; axis < RANK; axis++) {
@@ -203,7 +203,7 @@ void SetValueGradImpl(const Context& dev_ctx,
               << "([" << value_grad_dims << "])is broadcasted into ["
               << fake_value_grad_dims << "].";
 
-      auto extent = Eigen::DSizes<Eigen::DenseIndex, RANK>();
+      auto extent = Eigen::DSizes<int64_t, RANK>();
       auto offset = out_dims;
       for (int i = 0; i < out_dims_size; i++) {
         offset[i] = 0;

--- a/paddle/phi/kernels/cpu/set_value_kernel.cc
+++ b/paddle/phi/kernels/cpu/set_value_kernel.cc
@@ -112,9 +112,9 @@ void SetValueImpl(const Context& dev_ctx,
   auto out_e = EigenTensor<T, RANK>::From(*out);
   auto value_e = EigenTensor<T, RANK>::From(expand_tensor);
 
-  auto starts_indices = Eigen::DSizes<Eigen::DenseIndex, RANK>();
-  auto ends_indices = Eigen::DSizes<Eigen::DenseIndex, RANK>();
-  auto strides_indices = Eigen::DSizes<Eigen::DenseIndex, RANK>();
+  auto starts_indices = Eigen::DSizes<int64_t, RANK>();
+  auto ends_indices = Eigen::DSizes<int64_t, RANK>();
+  auto strides_indices = Eigen::DSizes<int64_t, RANK>();
 
   for (size_t i = 0; i < RANK; ++i) {
     starts_indices[i] = 0;

--- a/paddle/phi/kernels/funcs/cross_entropy.cc
+++ b/paddle/phi/kernels/funcs/cross_entropy.cc
@@ -20,11 +20,8 @@ limitations under the License. */
 namespace phi {
 namespace funcs {
 
-using Tensor = phi::DenseTensor;
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenMatrix = phi::EigenMatrix<T, MajorType, IndexType>;
+template <typename T, int MajorType = Eigen::RowMajor>
+using EigenMatrix = EigenMatrix<T, MajorType>;
 
 template <typename T>
 struct HardLabelCrossEntropyCPUFunctorImpl {

--- a/paddle/phi/kernels/funcs/detail/gru_cpu_kernel.h
+++ b/paddle/phi/kernels/funcs/detail/gru_cpu_kernel.h
@@ -24,10 +24,8 @@ namespace phi {
 namespace funcs {
 namespace detail {
 using Array1 = Eigen::DSizes<int64_t, 1>;
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenVector = phi::EigenVector<T, MajorType, IndexType>;
+template <typename T, int MajorType = Eigen::RowMajor>
+using EigenVector = EigenVector<T, MajorType>;
 
 #if !defined(__NVCC__) && !defined(__HIPCC___)  // @{ Group for GRU CPU
 template <class OpResetOutput, typename T>

--- a/paddle/phi/kernels/funcs/detail/lstm_cpu_kernel.h
+++ b/paddle/phi/kernels/funcs/detail/lstm_cpu_kernel.h
@@ -31,10 +31,8 @@ namespace funcs {
 namespace detail {
 
 using Array1 = Eigen::DSizes<int64_t, 1>;
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenVector = phi::EigenVector<T, MajorType, IndexType>;
+template <typename T, int MajorType = Eigen::RowMajor>
+using EigenVector = EigenVector<T, MajorType>;
 
 #if !defined(__NVCC__) && !defined(__HIPCC___)  // @{ Group LSTM CPU
 

--- a/paddle/phi/kernels/funcs/eigen/broadcast.cc
+++ b/paddle/phi/kernels/funcs/eigen/broadcast.cc
@@ -18,15 +18,15 @@ namespace phi::funcs {
 template <typename T, int Rank>
 struct EigenBroadcast<Eigen::DefaultDevice, T, Rank> {
   using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
   using InType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
-  using OutType = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using OutType =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   using OutType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
 
   static void Eval(const Eigen::DefaultDevice& dev,
@@ -49,10 +49,10 @@ template <typename T, int Rank>
 struct EigenBroadcastGrad<Eigen::DefaultDevice, T, Rank> {
   using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
   using Array2 = Eigen::DSizes<Eigen::DenseIndex, Rank * 2>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType out,
                    InType in,

--- a/paddle/phi/kernels/funcs/eigen/broadcast.cc
+++ b/paddle/phi/kernels/funcs/eigen/broadcast.cc
@@ -17,7 +17,7 @@ namespace phi::funcs {
 
 template <typename T, int Rank>
 struct EigenBroadcast<Eigen::DefaultDevice, T, Rank> {
-  using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
+  using Array = Eigen::DSizes<int64_t, Rank>;
   using InType =
       Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
   using InType32BitIndex =
@@ -47,8 +47,8 @@ struct EigenBroadcast<Eigen::DefaultDevice, T, Rank> {
 
 template <typename T, int Rank>
 struct EigenBroadcastGrad<Eigen::DefaultDevice, T, Rank> {
-  using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
-  using Array2 = Eigen::DSizes<Eigen::DenseIndex, Rank * 2>;
+  using Array = Eigen::DSizes<int64_t, Rank>;
+  using Array2 = Eigen::DSizes<int64_t, Rank * 2>;
   using InType =
       Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =

--- a/paddle/phi/kernels/funcs/eigen/broadcast.cu
+++ b/paddle/phi/kernels/funcs/eigen/broadcast.cu
@@ -17,7 +17,7 @@ namespace funcs {
 
 template <typename T, int Rank>
 struct EigenBroadcast<Eigen::GpuDevice, T, Rank> {
-  using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
+  using Array = Eigen::DSizes<int64_t, Rank>;
   using InType =
       Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
   using InType32BitIndex =
@@ -46,8 +46,8 @@ struct EigenBroadcast<Eigen::GpuDevice, T, Rank> {
 
 template <typename T, int Rank>
 struct EigenBroadcastGrad<Eigen::GpuDevice, T, Rank> {
-  using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
-  using Array2 = Eigen::DSizes<Eigen::DenseIndex, Rank * 2>;
+  using Array = Eigen::DSizes<int64_t, Rank>;
+  using Array2 = Eigen::DSizes<int64_t, Rank * 2>;
   using InType =
       Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =

--- a/paddle/phi/kernels/funcs/eigen/broadcast.cu
+++ b/paddle/phi/kernels/funcs/eigen/broadcast.cu
@@ -18,15 +18,15 @@ namespace funcs {
 template <typename T, int Rank>
 struct EigenBroadcast<Eigen::GpuDevice, T, Rank> {
   using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
   using InType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
-  using OutType = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using OutType =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   using OutType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
 
   static void Eval(const Eigen::GpuDevice& dev,
@@ -48,10 +48,10 @@ template <typename T, int Rank>
 struct EigenBroadcastGrad<Eigen::GpuDevice, T, Rank> {
   using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
   using Array2 = Eigen::DSizes<Eigen::DenseIndex, Rank * 2>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType out,
                    InType in,

--- a/paddle/phi/kernels/funcs/eigen/common.h
+++ b/paddle/phi/kernels/funcs/eigen/common.h
@@ -44,17 +44,14 @@ struct EigenDim {
 };
 
 // Interpret phi::Tensor as EigenTensor and EigenConstTensor.
-template <typename T,
-          size_t D,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
+template <typename T, size_t D, int MajorType = Eigen::RowMajor>
 struct EigenTensor {
   // TODO(qijun) Now, default type in unaligned, and we will make a benchmark on
   // the speed of aligned and unaligned version in future.
-  using Type = Eigen::TensorMap<Eigen::Tensor<T, D, MajorType, IndexType>>;
+  using Type = Eigen::TensorMap<Eigen::Tensor<T, D, MajorType, int64_t>>;
 
   using ConstType =
-      Eigen::TensorMap<Eigen::Tensor<const T, D, MajorType, IndexType>>;
+      Eigen::TensorMap<Eigen::Tensor<const T, D, MajorType, int64_t>>;
 
   static Type From(phi::DenseTensor& tensor, DDim dims) {  // NOLINT
     // why tensor.data<T>() not work?
@@ -78,11 +75,9 @@ struct EigenTensor {
   }
 };
 
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-struct EigenMatrix : public EigenTensor<T, 2, MajorType, IndexType> {
-  static typename EigenMatrix::Type Reshape(phi::DenseTensor& tensor,  // NOLINT
+template <typename T, int MajorType = Eigen::RowMajor>
+struct EigenMatrix : public EigenTensor<T, 2, MajorType> {
+  static typename EigenMatrix::Type Reshape(DenseTensor& tensor,  // NOLINT
                                             int num_col_dims) {
     int rank = tensor.dims().size();
     PADDLE_ENFORCE_EQ((num_col_dims > 0 && num_col_dims < rank),
@@ -111,10 +106,8 @@ struct EigenMatrix : public EigenTensor<T, 2, MajorType, IndexType> {
   }
 };
 
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-struct EigenVector : public EigenTensor<T, 1, MajorType, IndexType> {
+template <typename T, int MajorType = Eigen::RowMajor>
+struct EigenVector : public EigenTensor<T, 1, MajorType> {
   // Flatten reshapes a Tensor into an EigenVector.
   static typename EigenVector::Type Flatten(
       phi::DenseTensor& tensor) {  // NOLINT
@@ -127,15 +120,13 @@ struct EigenVector : public EigenTensor<T, 1, MajorType, IndexType> {
   }
 };
 
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
+template <typename T, int MajorType = Eigen::RowMajor>
 struct EigenScalar {
   // Scalar tensor (implemented as a rank-0 tensor) of scalar type T.
   using Type = Eigen::TensorMap<
-      Eigen::TensorFixedSize<T, Eigen::Sizes<>, MajorType, IndexType>>;
+      Eigen::TensorFixedSize<T, Eigen::Sizes<>, MajorType, int64_t>>;
   using ConstType = Eigen::TensorMap<
-      Eigen::TensorFixedSize<const T, Eigen::Sizes<>, MajorType, IndexType>>;
+      Eigen::TensorFixedSize<const T, Eigen::Sizes<>, MajorType, int64_t>>;
 
   static Type From(phi::DenseTensor& tensor) {  // NOLINT
     return Type(const_cast<T*>(tensor.data<T>()));
@@ -146,14 +137,14 @@ struct EigenScalar {
   }
 };
 
-// Define Tensor with 32-bit index.
+// Define Tensor with 64-bit index.
 template <typename T, int D, int MajorType = Eigen::RowMajor>
 using Tensor32BitIndex =
-    Eigen::TensorMap<Eigen::Tensor<T, D, MajorType, int>, Eigen::Aligned>;
+    Eigen::TensorMap<Eigen::Tensor<T, D, MajorType, int64_t>, Eigen::Aligned>;
 
 template <typename DSizes>
-Eigen::DSizes<int, DSizes::count> To32BitDims(const DSizes& in) {
-  Eigen::DSizes<int, DSizes::count> out;
+Eigen::DSizes<int64_t, DSizes::count> To32BitDims(const DSizes& in) {
+  Eigen::DSizes<int64_t, DSizes::count> out;
   for (int i = 0; i < DSizes::count; ++i) {
     out[i] = in[i];
   }

--- a/paddle/phi/kernels/funcs/eigen/common.h
+++ b/paddle/phi/kernels/funcs/eigen/common.h
@@ -77,7 +77,7 @@ struct EigenTensor {
 
 template <typename T, int MajorType = Eigen::RowMajor>
 struct EigenMatrix : public EigenTensor<T, 2, MajorType> {
-  static typename EigenMatrix::Type Reshape(DenseTensor& tensor,  // NOLINT
+  static typename EigenMatrix::Type Reshape(phi::DenseTensor& tensor,  // NOLINT
                                             int num_col_dims) {
     int rank = tensor.dims().size();
     PADDLE_ENFORCE_EQ((num_col_dims > 0 && num_col_dims < rank),

--- a/paddle/phi/kernels/funcs/eigen/common.h
+++ b/paddle/phi/kernels/funcs/eigen/common.h
@@ -25,7 +25,7 @@ namespace phi {
 // EigenDim converts phi::DDim into Eigen::DSizes.
 template <int D>
 struct EigenDim {
-  using Type = Eigen::DSizes<Eigen::DenseIndex, D>;
+  using Type = Eigen::DSizes<int64_t, D>;
 
   static Type From(const DDim& dims) {
     PADDLE_ENFORCE_EQ(arity(dims),

--- a/paddle/phi/kernels/funcs/eigen/constant.cc
+++ b/paddle/phi/kernels/funcs/eigen/constant.cc
@@ -17,8 +17,8 @@ namespace phi::funcs {
 
 template <typename T, int Rank>
 struct EigenConstant<Eigen::DefaultDevice, T, Rank> {
-  using Type = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using Type =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev, Type out, const T value) {
     out.device(dev) = out.constant(value);
   }

--- a/paddle/phi/kernels/funcs/eigen/constant.cu
+++ b/paddle/phi/kernels/funcs/eigen/constant.cu
@@ -18,8 +18,8 @@ namespace funcs {
 
 template <typename T, int Rank>
 struct EigenConstant<Eigen::GpuDevice, T, Rank> {
-  using Type = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using Type =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev, Type out, const T value) {
     out.device(dev) = out.constant(value);
   }

--- a/paddle/phi/kernels/funcs/eigen/eigen_function.h
+++ b/paddle/phi/kernels/funcs/eigen/eigen_function.h
@@ -28,15 +28,15 @@ namespace funcs {
 template <typename EigenDevice, typename T, int Rank>
 struct EigenBroadcast {
   using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
   using InType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
-  using OutType = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using OutType =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   using OutType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
   static void Eval(const EigenDevice& dev,
                    OutType out,
@@ -52,10 +52,10 @@ template <typename EigenDevice, typename T, int Rank>
 struct EigenBroadcastGrad {
   using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
   using Array2 = Eigen::DSizes<Eigen::DenseIndex, Rank * 2>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType out,
                    InType in,
@@ -65,27 +65,27 @@ struct EigenBroadcastGrad {
 
 template <typename EigenDevice, typename T, int Rank>
 struct EigenConstant {
-  using Type = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using Type =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev, Type out, const T value);
 };
 
 template <typename EigenDevice, typename T>
 struct EigenSign {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev, OutType out, const InType& in);
 };
 
 template <typename EigenDevice, typename T, int Rank>
 struct EigenReverse {
   using Array = Eigen::DSizes<bool, Rank>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
-  using OutType = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
+  using OutType =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType out,
                    const InType& in,
@@ -94,14 +94,11 @@ struct EigenReverse {
 
 template <typename EigenDevice, typename T>
 struct EigenAdd {
-  using InType = Eigen::TensorMap<Eigen::TensorFixedSize<const T,
-                                                         Eigen::Sizes<>,
-                                                         Eigen::RowMajor,
-                                                         Eigen::DenseIndex>>;
-  using OutType = Eigen::TensorMap<Eigen::TensorFixedSize<T,
-                                                          Eigen::Sizes<>,
-                                                          Eigen::RowMajor,
-                                                          Eigen::DenseIndex>>;
+  using InType = Eigen::TensorMap<
+      Eigen::
+          TensorFixedSize<const T, Eigen::Sizes<>, Eigen::RowMajor, int64_t>>;
+  using OutType = Eigen::TensorMap<
+      Eigen::TensorFixedSize<T, Eigen::Sizes<>, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType out,
                    const InType& in,
@@ -110,10 +107,10 @@ struct EigenAdd {
 
 template <typename EigenDevice, typename T>
 struct EigenSub {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType out,
                    const InType& left,
@@ -122,10 +119,10 @@ struct EigenSub {
 
 template <typename EigenDevice, typename T>
 struct EigenDiv {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType out,
                    const InType& in,
@@ -135,16 +132,16 @@ struct EigenDiv {
 template <typename EigenDevice, typename T, int Rank>
 struct EigenSlice {
   using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
-  using Array32Bit = Eigen::DSizes<int, Rank>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using Array32Bit = Eigen::DSizes<int64_t, Rank>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
   using InType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
-  using OutType = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using OutType =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   using OutType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
   static void Eval(const EigenDevice& dev,
                    OutType out,
@@ -162,15 +159,15 @@ template <typename EigenDevice, typename T, int Rank>
 struct EigenPad {
   using Array = std::array<std::pair<int64_t, int64_t>, Rank>;
   using Array32Bit = std::array<std::pair<int, int>, Rank>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
   using InType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
-  using OutType = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using OutType =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   using OutType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
   static void Eval(const EigenDevice& dev,
                    OutType out,
@@ -186,10 +183,10 @@ struct EigenPad {
 
 template <typename EigenDevice, typename T>
 struct EigenScale {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType out,
                    const InType& in,
@@ -200,19 +197,19 @@ struct EigenScale {
 
 template <typename EigenDevice, typename T>
 struct EigenErf {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev, OutType out, const InType& in);
 };
 
 template <typename EigenDevice, typename T>
 struct EigenErfGrad {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType din,
                    const InType& in,
@@ -221,10 +218,10 @@ struct EigenErfGrad {
 
 template <typename EigenDevice, typename T>
 struct EigenRankLoss {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType out,
                    const InType& label,
@@ -234,10 +231,10 @@ struct EigenRankLoss {
 
 template <typename EigenDevice, typename T>
 struct EigenRankLossGrad {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void EvalLeft(const EigenDevice& dev,
                        OutType dleft,
                        const InType& dout,
@@ -254,10 +251,10 @@ struct EigenRankLossGrad {
 
 template <typename EigenDevice, typename T>
 struct EigenLogLoss {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType out,
                    const InType& pred,
@@ -267,10 +264,10 @@ struct EigenLogLoss {
 
 template <typename EigenDevice, typename T>
 struct EigenLogLossGrad {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType dpred,
                    const InType& dloss,
@@ -281,10 +278,10 @@ struct EigenLogLossGrad {
 
 template <typename EigenDevice, typename T>
 struct EigenHingeLoss {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType loss,
                    const InType& pred,
@@ -293,10 +290,10 @@ struct EigenHingeLoss {
 
 template <typename EigenDevice, typename T>
 struct EigenHingeLossGrad {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType dpred,
                    const InType& dloss,
@@ -306,22 +303,20 @@ struct EigenHingeLossGrad {
 
 template <typename EigenDevice, typename T>
 struct EigenL1Norm {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
-  using OutType = Eigen::TensorMap<Eigen::TensorFixedSize<T,
-                                                          Eigen::Sizes<>,
-                                                          Eigen::RowMajor,
-                                                          Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
+  using OutType = Eigen::TensorMap<
+      Eigen::TensorFixedSize<T, Eigen::Sizes<>, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev, OutType out, const InType& in);
 };
 
 template <typename EigenDevice, typename T>
 struct EigenL1NormGrad {
   using Array = Eigen::DSizes<Eigen::DenseIndex, 1>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const EigenDevice& dev,
                    OutType din,
                    const InType& dout,

--- a/paddle/phi/kernels/funcs/eigen/eigen_function.h
+++ b/paddle/phi/kernels/funcs/eigen/eigen_function.h
@@ -27,7 +27,7 @@ namespace funcs {
 
 template <typename EigenDevice, typename T, int Rank>
 struct EigenBroadcast {
-  using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
+  using Array = Eigen::DSizes<int64_t, Rank>;
   using InType =
       Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
   using InType32BitIndex =
@@ -50,8 +50,8 @@ struct EigenBroadcast {
 
 template <typename EigenDevice, typename T, int Rank>
 struct EigenBroadcastGrad {
-  using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
-  using Array2 = Eigen::DSizes<Eigen::DenseIndex, Rank * 2>;
+  using Array = Eigen::DSizes<int64_t, Rank>;
+  using Array2 = Eigen::DSizes<int64_t, Rank * 2>;
   using InType =
       Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
@@ -131,7 +131,7 @@ struct EigenDiv {
 
 template <typename EigenDevice, typename T, int Rank>
 struct EigenSlice {
-  using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
+  using Array = Eigen::DSizes<int64_t, Rank>;
   using Array32Bit = Eigen::DSizes<int64_t, Rank>;
   using InType =
       Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
@@ -312,7 +312,7 @@ struct EigenL1Norm {
 
 template <typename EigenDevice, typename T>
 struct EigenL1NormGrad {
-  using Array = Eigen::DSizes<Eigen::DenseIndex, 1>;
+  using Array = Eigen::DSizes<int64_t, 1>;
   using InType =
       Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =

--- a/paddle/phi/kernels/funcs/eigen/elementwise.cc
+++ b/paddle/phi/kernels/funcs/eigen/elementwise.cc
@@ -17,14 +17,11 @@ namespace phi::funcs {
 
 template <typename T>
 struct EigenAdd<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<Eigen::TensorFixedSize<const T,
-                                                         Eigen::Sizes<>,
-                                                         Eigen::RowMajor,
-                                                         Eigen::DenseIndex>>;
-  using OutType = Eigen::TensorMap<Eigen::TensorFixedSize<T,
-                                                          Eigen::Sizes<>,
-                                                          Eigen::RowMajor,
-                                                          Eigen::DenseIndex>>;
+  using InType = Eigen::TensorMap<
+      Eigen::
+          TensorFixedSize<const T, Eigen::Sizes<>, Eigen::RowMajor, int64_t>>;
+  using OutType = Eigen::TensorMap<
+      Eigen::TensorFixedSize<T, Eigen::Sizes<>, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType out,
                    const InType& in,
@@ -40,10 +37,10 @@ template struct EigenAdd<Eigen::DefaultDevice, int64_t>;
 
 template <typename T>
 struct EigenSub<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType out,
                    const InType& left,
@@ -56,10 +53,10 @@ template struct EigenSub<Eigen::DefaultDevice, float>;
 
 template <typename T>
 struct EigenDiv<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType out,
                    const InType& in,

--- a/paddle/phi/kernels/funcs/eigen/elementwise.cu
+++ b/paddle/phi/kernels/funcs/eigen/elementwise.cu
@@ -18,14 +18,11 @@ namespace funcs {
 
 template <typename T>
 struct EigenAdd<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<Eigen::TensorFixedSize<const T,
-                                                         Eigen::Sizes<>,
-                                                         Eigen::RowMajor,
-                                                         Eigen::DenseIndex>>;
-  using OutType = Eigen::TensorMap<Eigen::TensorFixedSize<T,
-                                                          Eigen::Sizes<>,
-                                                          Eigen::RowMajor,
-                                                          Eigen::DenseIndex>>;
+  using InType = Eigen::TensorMap<
+      Eigen::
+          TensorFixedSize<const T, Eigen::Sizes<>, Eigen::RowMajor, int64_t>>;
+  using OutType = Eigen::TensorMap<
+      Eigen::TensorFixedSize<T, Eigen::Sizes<>, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType out,
                    const InType& in,
@@ -41,10 +38,10 @@ template struct EigenAdd<Eigen::GpuDevice, int64_t>;
 
 template <typename T>
 struct EigenSub<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType out,
                    const InType& left,
@@ -57,10 +54,10 @@ template struct EigenSub<Eigen::GpuDevice, float>;
 
 template <typename T>
 struct EigenDiv<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType out,
                    const InType& in,

--- a/paddle/phi/kernels/funcs/eigen/erf.cc
+++ b/paddle/phi/kernels/funcs/eigen/erf.cc
@@ -18,10 +18,10 @@ namespace phi::funcs {
 
 template <typename T>
 struct EigenErf<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType out,
                    const InType& in) {
@@ -31,10 +31,10 @@ struct EigenErf<Eigen::DefaultDevice, T> {
 
 template <typename T>
 struct EigenErfGrad<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType din,
                    const InType& in,

--- a/paddle/phi/kernels/funcs/eigen/erf.cu
+++ b/paddle/phi/kernels/funcs/eigen/erf.cu
@@ -22,10 +22,10 @@ namespace funcs {
 
 template <typename T>
 struct EigenErf<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev, OutType out, const InType& in) {
     out.device(dev) = in.erf();
   }
@@ -33,10 +33,10 @@ struct EigenErf<Eigen::GpuDevice, T> {
 
 template <typename T>
 struct EigenErfGrad<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType din,
                    const InType& in,

--- a/paddle/phi/kernels/funcs/eigen/l1_norm.cc
+++ b/paddle/phi/kernels/funcs/eigen/l1_norm.cc
@@ -30,7 +30,7 @@ struct EigenL1Norm<Eigen::DefaultDevice, T> {
 
 template <typename T>
 struct EigenL1NormGrad<Eigen::DefaultDevice, T> {
-  using Array = Eigen::DSizes<Eigen::DenseIndex, 1>;
+  using Array = Eigen::DSizes<int64_t, 1>;
   using InType =
       Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =

--- a/paddle/phi/kernels/funcs/eigen/l1_norm.cc
+++ b/paddle/phi/kernels/funcs/eigen/l1_norm.cc
@@ -17,12 +17,10 @@ namespace phi::funcs {
 
 template <typename T>
 struct EigenL1Norm<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
-  using OutType = Eigen::TensorMap<Eigen::TensorFixedSize<T,
-                                                          Eigen::Sizes<>,
-                                                          Eigen::RowMajor,
-                                                          Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
+  using OutType = Eigen::TensorMap<
+      Eigen::TensorFixedSize<T, Eigen::Sizes<>, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType out,
                    const InType& in) {
@@ -33,10 +31,10 @@ struct EigenL1Norm<Eigen::DefaultDevice, T> {
 template <typename T>
 struct EigenL1NormGrad<Eigen::DefaultDevice, T> {
   using Array = Eigen::DSizes<Eigen::DenseIndex, 1>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType din,
                    const InType& dout,

--- a/paddle/phi/kernels/funcs/eigen/l1_norm.cu
+++ b/paddle/phi/kernels/funcs/eigen/l1_norm.cu
@@ -18,12 +18,10 @@ namespace funcs {
 
 template <typename T>
 struct EigenL1Norm<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
-  using OutType = Eigen::TensorMap<Eigen::TensorFixedSize<T,
-                                                          Eigen::Sizes<>,
-                                                          Eigen::RowMajor,
-                                                          Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
+  using OutType = Eigen::TensorMap<
+      Eigen::TensorFixedSize<T, Eigen::Sizes<>, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev, OutType out, const InType& in) {
     out.device(dev) = in.abs().sum();
   }
@@ -32,10 +30,10 @@ struct EigenL1Norm<Eigen::GpuDevice, T> {
 template <typename T>
 struct EigenL1NormGrad<Eigen::GpuDevice, T> {
   using Array = Eigen::DSizes<Eigen::DenseIndex, 1>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType din,
                    const InType& dout,

--- a/paddle/phi/kernels/funcs/eigen/l1_norm.cu
+++ b/paddle/phi/kernels/funcs/eigen/l1_norm.cu
@@ -29,7 +29,7 @@ struct EigenL1Norm<Eigen::GpuDevice, T> {
 
 template <typename T>
 struct EigenL1NormGrad<Eigen::GpuDevice, T> {
-  using Array = Eigen::DSizes<Eigen::DenseIndex, 1>;
+  using Array = Eigen::DSizes<int64_t, 1>;
   using InType =
       Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =

--- a/paddle/phi/kernels/funcs/eigen/loss.cc
+++ b/paddle/phi/kernels/funcs/eigen/loss.cc
@@ -17,10 +17,10 @@ namespace phi::funcs {
 
 template <typename T>
 struct EigenRankLoss<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType out,
                    const InType& label,
@@ -33,10 +33,10 @@ struct EigenRankLoss<Eigen::DefaultDevice, T> {
 
 template <typename T>
 struct EigenRankLossGrad<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
 
   static void EvalLeft(const Eigen::DefaultDevice& dev,
                        OutType dleft,
@@ -62,10 +62,10 @@ template struct EigenRankLossGrad<Eigen::DefaultDevice, float>;
 
 template <typename T>
 struct EigenLogLoss<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType out,
                    const InType& pred,
@@ -79,10 +79,10 @@ struct EigenLogLoss<Eigen::DefaultDevice, T> {
 
 template <typename T>
 struct EigenLogLossGrad<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType dpred,
                    const InType& dloss,
@@ -101,10 +101,10 @@ template struct EigenLogLossGrad<Eigen::DefaultDevice, float>;
 
 template <typename T>
 struct EigenHingeLoss<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType loss,
                    const InType& pred,
@@ -117,10 +117,10 @@ struct EigenHingeLoss<Eigen::DefaultDevice, T> {
 
 template <typename T>
 struct EigenHingeLossGrad<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType dpred,
                    const InType& dloss,

--- a/paddle/phi/kernels/funcs/eigen/loss.cu
+++ b/paddle/phi/kernels/funcs/eigen/loss.cu
@@ -18,10 +18,10 @@ namespace funcs {
 
 template <typename T>
 struct EigenRankLoss<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType out,
                    const InType& label,
@@ -34,10 +34,10 @@ struct EigenRankLoss<Eigen::GpuDevice, T> {
 
 template <typename T>
 struct EigenRankLossGrad<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
 
   static void EvalLeft(const Eigen::GpuDevice& dev,
                        OutType dleft,
@@ -63,10 +63,10 @@ template struct EigenRankLossGrad<Eigen::GpuDevice, float>;
 
 template <typename T>
 struct EigenLogLoss<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType out,
                    const InType& pred,
@@ -80,10 +80,10 @@ struct EigenLogLoss<Eigen::GpuDevice, T> {
 
 template <typename T>
 struct EigenLogLossGrad<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType dpred,
                    const InType& dloss,
@@ -102,10 +102,10 @@ template struct EigenLogLossGrad<Eigen::GpuDevice, float>;
 
 template <typename T>
 struct EigenHingeLoss<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType loss,
                    const InType& pred,
@@ -118,10 +118,10 @@ struct EigenHingeLoss<Eigen::GpuDevice, T> {
 
 template <typename T>
 struct EigenHingeLossGrad<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType dpred,
                    const InType& dloss,

--- a/paddle/phi/kernels/funcs/eigen/pad.cc
+++ b/paddle/phi/kernels/funcs/eigen/pad.cc
@@ -19,15 +19,15 @@ template <typename T, int Rank>
 struct EigenPad<Eigen::DefaultDevice, T, Rank> {
   using Array = std::array<std::pair<int64_t, int64_t>, Rank>;
   using Array32Bit = std::array<std::pair<int, int>, Rank>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
   using InType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
-  using OutType = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using OutType =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   using OutType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
 
   static void Eval(const Eigen::DefaultDevice& dev,

--- a/paddle/phi/kernels/funcs/eigen/pad.cu
+++ b/paddle/phi/kernels/funcs/eigen/pad.cu
@@ -20,15 +20,15 @@ template <typename T, int Rank>
 struct EigenPad<Eigen::GpuDevice, T, Rank> {
   using Array = std::array<std::pair<int64_t, int64_t>, Rank>;
   using Array32Bit = std::array<std::pair<int, int>, Rank>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
   using InType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
-  using OutType = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using OutType =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   using OutType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
 
   static void Eval(const Eigen::GpuDevice& dev,

--- a/paddle/phi/kernels/funcs/eigen/reverse.cc
+++ b/paddle/phi/kernels/funcs/eigen/reverse.cc
@@ -18,10 +18,10 @@ namespace phi::funcs {
 template <typename T, int Rank>
 struct EigenReverse<Eigen::DefaultDevice, T, Rank> {
   using Array = Eigen::DSizes<bool, Rank>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
-  using OutType = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
+  using OutType =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType out,
                    const InType& in,

--- a/paddle/phi/kernels/funcs/eigen/reverse.cu
+++ b/paddle/phi/kernels/funcs/eigen/reverse.cu
@@ -19,10 +19,10 @@ namespace funcs {
 template <typename T, int Rank>
 struct EigenReverse<Eigen::GpuDevice, T, Rank> {
   using Array = Eigen::DSizes<bool, Rank>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
-  using OutType = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
+  using OutType =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType out,
                    const InType& in,

--- a/paddle/phi/kernels/funcs/eigen/scale.cc
+++ b/paddle/phi/kernels/funcs/eigen/scale.cc
@@ -18,10 +18,10 @@ namespace funcs {
 
 template <typename T>
 struct EigenScale<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType out,
                    const InType& in,

--- a/paddle/phi/kernels/funcs/eigen/scale.cu
+++ b/paddle/phi/kernels/funcs/eigen/scale.cu
@@ -18,10 +18,10 @@ namespace funcs {
 
 template <typename T>
 struct EigenScale<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev,
                    OutType out,
                    const InType& in,

--- a/paddle/phi/kernels/funcs/eigen/sign.cc
+++ b/paddle/phi/kernels/funcs/eigen/sign.cc
@@ -18,10 +18,10 @@ namespace phi::funcs {
 
 template <typename T>
 struct EigenSign<Eigen::DefaultDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType out,
                    const InType& in) {
@@ -31,14 +31,10 @@ struct EigenSign<Eigen::DefaultDevice, T> {
 
 template <typename T>
 struct EigenSign<Eigen::DefaultDevice, phi::dtype::complex<T>> {
-  using InType = Eigen::TensorMap<Eigen::Tensor<const phi::dtype::complex<T>,
-                                                1,
-                                                Eigen::RowMajor,
-                                                Eigen::DenseIndex>>;
-  using OutType = Eigen::TensorMap<Eigen::Tensor<phi::dtype::complex<T>,
-                                                 1,
-                                                 Eigen::RowMajor,
-                                                 Eigen::DenseIndex>>;
+  using InType = Eigen::TensorMap<
+      Eigen::Tensor<const phi::dtype::complex<T>, 1, Eigen::RowMajor, int64_t>>;
+  using OutType = Eigen::TensorMap<
+      Eigen::Tensor<phi::dtype::complex<T>, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::DefaultDevice& dev,
                    OutType out,
                    const InType& in) {

--- a/paddle/phi/kernels/funcs/eigen/sign.cu
+++ b/paddle/phi/kernels/funcs/eigen/sign.cu
@@ -19,10 +19,10 @@ namespace funcs {
 
 template <typename T>
 struct EigenSign<Eigen::GpuDevice, T> {
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, 1, Eigen::RowMajor, int64_t>>;
   using OutType =
-      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, Eigen::DenseIndex>>;
+      Eigen::TensorMap<Eigen::Tensor<T, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev, OutType out, const InType& in) {
     out.device(dev) = in.sign();
   }
@@ -30,14 +30,10 @@ struct EigenSign<Eigen::GpuDevice, T> {
 
 template <typename T>
 struct EigenSign<Eigen::GpuDevice, phi::dtype::complex<T>> {
-  using InType = Eigen::TensorMap<Eigen::Tensor<const phi::dtype::complex<T>,
-                                                1,
-                                                Eigen::RowMajor,
-                                                Eigen::DenseIndex>>;
-  using OutType = Eigen::TensorMap<Eigen::Tensor<phi::dtype::complex<T>,
-                                                 1,
-                                                 Eigen::RowMajor,
-                                                 Eigen::DenseIndex>>;
+  using InType = Eigen::TensorMap<
+      Eigen::Tensor<const phi::dtype::complex<T>, 1, Eigen::RowMajor, int64_t>>;
+  using OutType = Eigen::TensorMap<
+      Eigen::Tensor<phi::dtype::complex<T>, 1, Eigen::RowMajor, int64_t>>;
   static void Eval(const Eigen::GpuDevice& dev, OutType out, const InType& in) {
     out.device(dev) = in.unaryExpr(
         [] __host__ __device__(

--- a/paddle/phi/kernels/funcs/eigen/slice.cc
+++ b/paddle/phi/kernels/funcs/eigen/slice.cc
@@ -19,16 +19,16 @@ namespace phi::funcs {
 template <typename T, int Rank>
 struct EigenSlice<Eigen::DefaultDevice, T, Rank> {
   using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
-  using Array32Bit = Eigen::DSizes<int, Rank>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using Array32Bit = Eigen::DSizes<int64_t, Rank>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
   using InType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
-  using OutType = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using OutType =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   using OutType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
 
   static void Eval(const Eigen::DefaultDevice& dev,

--- a/paddle/phi/kernels/funcs/eigen/slice.cc
+++ b/paddle/phi/kernels/funcs/eigen/slice.cc
@@ -18,7 +18,7 @@ namespace phi::funcs {
 
 template <typename T, int Rank>
 struct EigenSlice<Eigen::DefaultDevice, T, Rank> {
-  using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
+  using Array = Eigen::DSizes<int64_t, Rank>;
   using Array32Bit = Eigen::DSizes<int64_t, Rank>;
   using InType =
       Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;

--- a/paddle/phi/kernels/funcs/eigen/slice.cu
+++ b/paddle/phi/kernels/funcs/eigen/slice.cu
@@ -18,7 +18,7 @@ namespace funcs {
 
 template <typename T, int Rank>
 struct EigenSlice<Eigen::GpuDevice, T, Rank> {
-  using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
+  using Array = Eigen::DSizes<int64_t, Rank>;
   using Array32Bit = Eigen::DSizes<int64_t, Rank>;
   using InType =
       Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;

--- a/paddle/phi/kernels/funcs/eigen/slice.cu
+++ b/paddle/phi/kernels/funcs/eigen/slice.cu
@@ -19,16 +19,16 @@ namespace funcs {
 template <typename T, int Rank>
 struct EigenSlice<Eigen::GpuDevice, T, Rank> {
   using Array = Eigen::DSizes<Eigen::DenseIndex, Rank>;
-  using Array32Bit = Eigen::DSizes<int, Rank>;
-  using InType = Eigen::TensorMap<
-      Eigen::Tensor<const T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using Array32Bit = Eigen::DSizes<int64_t, Rank>;
+  using InType =
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>>;
   using InType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<const T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
-  using OutType = Eigen::TensorMap<
-      Eigen::Tensor<T, Rank, Eigen::RowMajor, Eigen::DenseIndex>>;
+  using OutType =
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>>;
   using OutType32BitIndex =
-      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int>,
+      Eigen::TensorMap<Eigen::Tensor<T, Rank, Eigen::RowMajor, int64_t>,
                        Eigen::Aligned>;
 
   static void Eval(const Eigen::GpuDevice& dev,

--- a/paddle/phi/kernels/funcs/padding.h
+++ b/paddle/phi/kernels/funcs/padding.h
@@ -24,11 +24,8 @@ limitations under the License. */
 namespace phi {
 namespace funcs {
 
-template <typename T,
-          size_t D,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenTensor = EigenTensor<T, D, MajorType, IndexType>;
+template <typename T, size_t D, int MajorType = Eigen::RowMajor>
+using EigenTensor = EigenTensor<T, D, MajorType>;
 
 template <typename DeviceContext, typename T, size_t D>
 void PadFunction(const DeviceContext& dev_ctx,

--- a/paddle/phi/kernels/funcs/sequence2batch.h
+++ b/paddle/phi/kernels/funcs/sequence2batch.h
@@ -23,10 +23,8 @@ limitations under the License. */
 namespace phi {
 namespace funcs {
 
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenMatrix = phi::EigenMatrix<T, MajorType, IndexType>;
+template <typename T, int MajorType = Eigen::RowMajor>
+using EigenMatrix = EigenMatrix<T, MajorType>;
 
 template <typename DeviceContext, typename T>
 class CopyMatrixRowsFunctor {

--- a/paddle/phi/kernels/funcs/sequence_pooling.cc
+++ b/paddle/phi/kernels/funcs/sequence_pooling.cc
@@ -23,14 +23,10 @@ limitations under the License. */
 
 namespace phi::funcs {
 
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenVector = phi::EigenVector<T, MajorType, IndexType>;
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenMatrix = phi::EigenMatrix<T, MajorType, IndexType>;
+template <typename T, int MajorType = Eigen::RowMajor>
+using EigenVector = EigenVector<T, MajorType>;
+template <typename T, int MajorType = Eigen::RowMajor>
+using EigenMatrix = EigenMatrix<T, MajorType>;
 
 template <typename T, bool is_test>
 class MaxSeqPoolFunctor {

--- a/paddle/phi/kernels/funcs/slice.h
+++ b/paddle/phi/kernels/funcs/slice.h
@@ -45,9 +45,9 @@ void EigenSliceWrapper(const Context& dev_ctx,
                         "argument must have the same length as input rank."));
   auto eigen_place_ptr = dev_ctx.eigen_device();
   auto eigen_place = *eigen_place_ptr;
-  auto out_t = phi::EigenTensor<T, D>::From(*out, out->dims());
-  auto in_t = phi::EigenTensor<T, D>::From(*in, in->dims());
-  Eigen::DSizes<int, D> offsets_32bit, extents_32bit;
+  auto out_t = EigenTensor<T, D>::From(*out, out->dims());
+  auto in_t = EigenTensor<T, D>::From(*in, in->dims());
+  Eigen::DSizes<int64_t, D> offsets_32bit, extents_32bit;
   for (size_t i = 0; i < D; i++) {
     offsets_32bit[i] = start[i];
     extents_32bit[i] = end[i];
@@ -151,10 +151,8 @@ static void Slice(const Context& dev_ctx,
   out->Resize(out_dims);
   dev_ctx.template Alloc<T>(out);
 
-  auto in_t =
-      EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(*input);
-  auto out_t = EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(
-      *out, out_dims);
+  auto in_t = EigenTensor<T, D, Eigen::RowMajor>::From(*input);
+  auto out_t = EigenTensor<T, D, Eigen::RowMajor>::From(*out, out_dims);
 
   funcs::EigenSlice<std::decay_t<decltype(place)>, T, D>::Eval(
       place, out_t, in_t, offsets, extents);

--- a/paddle/phi/kernels/funcs/slice.h
+++ b/paddle/phi/kernels/funcs/slice.h
@@ -133,8 +133,8 @@ static void Slice(const Context& dev_ctx,
                   const std::vector<int64_t>& axes_vec) {
   auto& place = *dev_ctx.eigen_device();
   auto in_dims = input->dims();
-  auto offsets = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto extents = Eigen::DSizes<Eigen::DenseIndex, D>();
+  auto offsets = Eigen::DSizes<int64_t, D>();
+  auto extents = Eigen::DSizes<int64_t, D>();
   for (size_t i = 0; i < D; ++i) {
     offsets[i] = 0;
     extents[i] = in_dims[i];

--- a/paddle/phi/kernels/funcs/softmax_impl.h
+++ b/paddle/phi/kernels/funcs/softmax_impl.h
@@ -25,10 +25,8 @@ limitations under the License. */
 namespace phi {
 namespace funcs {
 
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenMatrix = phi::EigenMatrix<T, MajorType, IndexType>;
+template <typename T, int MajorType = Eigen::RowMajor>
+using EigenMatrix = EigenMatrix<T, MajorType>;
 
 template <typename T>
 struct ValueClip {

--- a/paddle/phi/kernels/funcs/strided_slice.h
+++ b/paddle/phi/kernels/funcs/strided_slice.h
@@ -183,9 +183,9 @@ void StridedSliceCompute(const Context& dev_ctx,
   auto ends_ = ends.GetData();
   auto strides_ = strides.GetData();
 
-  auto starts_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto ends_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto strides_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
+  auto starts_indices = Eigen::DSizes<int64_t, D>();
+  auto ends_indices = Eigen::DSizes<int64_t, D>();
+  auto strides_indices = Eigen::DSizes<int64_t, D>();
   auto reverse_axis = Eigen::array<bool, D>();
 
   std::vector<int64_t> out_dims_vector(in_dims.size(), -1);
@@ -298,9 +298,9 @@ void StridedSliceCompute(const Context& dev_ctx,
   auto ends_ = ends.GetData();
   auto strides_ = strides.GetData();
 
-  auto starts_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto ends_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto strides_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
+  auto starts_indices = Eigen::DSizes<int64_t, D>();
+  auto ends_indices = Eigen::DSizes<int64_t, D>();
+  auto strides_indices = Eigen::DSizes<int64_t, D>();
   auto reverse_axis = Eigen::array<bool, D>();
 
   std::vector<int64_t> out_dims_vector(in_dims.size(), -1);
@@ -450,9 +450,9 @@ void StridedSliceGradCompute(const Context& dev_ctx,
   auto ends_ = ends.GetData();
   auto strides_ = strides.GetData();
 
-  auto starts_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto ends_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto strides_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
+  auto starts_indices = Eigen::DSizes<int64_t, D>();
+  auto ends_indices = Eigen::DSizes<int64_t, D>();
+  auto strides_indices = Eigen::DSizes<int64_t, D>();
 
   auto reverse_axis = Eigen::array<bool, D>();
   std::vector<int> reverse_vector(starts_.size(), 0);
@@ -535,9 +535,9 @@ void StridedSliceGradCompute(const Context& dev_ctx,
   auto ends_ = ends.GetData();
   auto strides_ = strides.GetData();
 
-  auto starts_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto ends_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto strides_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
+  auto starts_indices = Eigen::DSizes<int64_t, D>();
+  auto ends_indices = Eigen::DSizes<int64_t, D>();
+  auto strides_indices = Eigen::DSizes<int64_t, D>();
 
   auto reverse_axis = Eigen::array<bool, D>();
   std::vector<int> reverse_vector(starts_.size(), 0);

--- a/paddle/phi/kernels/funcs/strided_slice.h
+++ b/paddle/phi/kernels/funcs/strided_slice.h
@@ -260,16 +260,14 @@ void StridedSliceCompute(const Context& dev_ctx,
 
   out->Resize(out_dims);
   dev_ctx.template Alloc<T>(out);
-  auto in_t = EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(x);
-  auto out_t = EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(
-      *out, out_dims);
+  auto in_t = EigenTensor<T, D, Eigen::RowMajor>::From(x);
+  auto out_t = EigenTensor<T, D, Eigen::RowMajor>::From(*out, out_dims);
   if (need_reverse) {
     DenseTensor tmp;
     tmp.Resize(out_dims);
     dev_ctx.template Alloc<T>(&tmp);
 
-    auto tmp_t =
-        EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(tmp);
+    auto tmp_t = EigenTensor<T, D, Eigen::RowMajor>::From(tmp);
     tmp_t.device(place) =
         in_t.stridedSlice(starts_indices, ends_indices, strides_indices);
     out_t.device(place) = tmp_t.reverse(reverse_axis);
@@ -496,18 +494,14 @@ void StridedSliceGradCompute(const Context& dev_ctx,
 
   auto out_grad_dims = out_grad.dims();
 
-  auto in_t =
-      EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(out_grad);
-  auto out_t = EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(
-      *x_grad, out_dims);
+  auto in_t = EigenTensor<T, D, Eigen::RowMajor>::From(out_grad);
+  auto out_t = EigenTensor<T, D, Eigen::RowMajor>::From(*x_grad, out_dims);
   if (need_reverse) {
     DenseTensor reverse_input;
     reverse_input.Resize(out_grad_dims);
     dev_ctx.template Alloc<T>(&reverse_input);
 
-    auto reverse_in_t =
-        EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(
-            reverse_input);
+    auto reverse_in_t = EigenTensor<T, D, Eigen::RowMajor>::From(reverse_input);
 
     reverse_in_t.device(place) = in_t.reverse(reverse_axis);
     out_t.stridedSlice(starts_indices, ends_indices, strides_indices)

--- a/paddle/phi/kernels/funcs/top_k_function_cuda.h
+++ b/paddle/phi/kernels/funcs/top_k_function_cuda.h
@@ -1296,11 +1296,11 @@ bool SortTopk(const phi::GPUContext& dev_ctx,
   auto& dev = *dev_ctx.eigen_device();
   if (k < num_cols) {
     // copy sliced data to output.
-    const Eigen::DSizes<Eigen::DenseIndex, 2> slice_indices{0, 0};
-    const Eigen::DSizes<Eigen::DenseIndex, 2> slice_sizes{num_rows, k};
-    auto e_indices = phi::EigenMatrix<int64_t>::From(*indices_tensor, dim);
-    auto e_tmp_indices = phi::EigenMatrix<int64_t>::From(
-        static_cast<const Tensor>(temp_indices));
+    const Eigen::DSizes<int64_t, 2> slice_indices{0, 0};
+    const Eigen::DSizes<int64_t, 2> slice_sizes{num_rows, k};
+    auto e_indices = EigenMatrix<int64_t>::From(*indices_tensor, dim);
+    auto e_tmp_indices = EigenMatrix<int64_t>::From(
+        static_cast<const DenseTensor>(temp_indices));
 
     std::vector<int> odims = {static_cast<int>(num_rows), static_cast<int>(k)};
     auto dim = common::make_ddim(odims);

--- a/paddle/phi/kernels/gpu/kthvalue_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_kernel.cu
@@ -139,14 +139,14 @@ bool SortKthvalue(const phi::GPUContext& dev_ctx,
   const Eigen::DSizes<int64_t, 2> slice_indices{0, k - 1};
   const Eigen::DSizes<int64_t, 2> slice_sizes{num_rows, 1};
   auto e_indices = EigenMatrix<int64_t>::From(*indices_tensor, dim);
-  auto e_tmp_indices =
-      EigenMatrix<int64_t>::From(static_cast<const DenseTensor>(temp_indices));
+  auto e_tmp_indices = EigenMatrix<int64_t>::From(
+      static_cast<const phi::DenseTensor>(temp_indices));
 
   std::vector<int64_t> odims = {num_rows, 1};
   dim = common::make_ddim(odims);
   auto e_values = EigenMatrix<T>::From(*out_tensor, dim);
   auto e_tmp_values =
-      EigenMatrix<T>::From(static_cast<const DenseTensor>(temp_values));
+      EigenMatrix<T>::From(static_cast<const phi::DenseTensor>(temp_values));
 
   funcs::EigenSlice<std::decay_t<decltype(dev)>, int64_t, 2>::Eval(
       dev, e_indices, e_tmp_indices, slice_indices, slice_sizes);

--- a/paddle/phi/kernels/gpu/kthvalue_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_kernel.cu
@@ -136,8 +136,8 @@ bool SortKthvalue(const phi::GPUContext& dev_ctx,
   }
 #endif
   auto& dev = *dev_ctx.eigen_device();
-  const Eigen::DSizes<Eigen::DenseIndex, 2> slice_indices{0, k - 1};
-  const Eigen::DSizes<Eigen::DenseIndex, 2> slice_sizes{num_rows, 1};
+  const Eigen::DSizes<int64_t, 2> slice_indices{0, k - 1};
+  const Eigen::DSizes<int64_t, 2> slice_sizes{num_rows, 1};
   auto e_indices = EigenMatrix<int64_t>::From(*indices_tensor, dim);
   auto e_tmp_indices =
       EigenMatrix<int64_t>::From(static_cast<const DenseTensor>(temp_indices));

--- a/paddle/phi/kernels/gpu/l1_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/l1_norm_grad_kernel.cu
@@ -42,7 +42,7 @@ void L1NormGradKernel(const Context& dev_ctx,
   auto d_out_eigen = phi::EigenVector<T>::Flatten(out_grad);
   auto dx_eigen = phi::EigenVector<T>::Flatten(*x_grad);
   auto& dev = *dev_ctx.eigen_device();
-  Eigen::DSizes<Eigen::DenseIndex, 1> x_dsize(x.numel());
+  Eigen::DSizes<int64_t, 1> x_dsize(x.numel());
   funcs::EigenL1NormGrad<std::decay_t<decltype(dev)>, T>::Eval(
       dev, dx_eigen, d_out_eigen, x_eigen, x_dsize);
 }

--- a/paddle/phi/kernels/gpu/l1_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/l1_norm_kernel.cu
@@ -42,7 +42,7 @@ void L1NormGradKernel(const Context& dev_ctx,
   auto d_out_eigen = phi::EigenVector<T>::Flatten(out_grad);
   auto dx_eigen = phi::EigenVector<T>::Flatten(*x_grad);
   auto& dev = *dev_ctx.eigen_device();
-  Eigen::DSizes<Eigen::DenseIndex, 1> x_dsize(x.numel());
+  Eigen::DSizes<int64_t, 1> x_dsize(x.numel());
   funcs::EigenL1NormGrad<std::decay_t<decltype(dev)>, T>::Eval(
       dev, dx_eigen, d_out_eigen, x_eigen, x_dsize);
 }

--- a/paddle/phi/kernels/gpudnn/conv_gpudnn_base.h
+++ b/paddle/phi/kernels/gpudnn/conv_gpudnn_base.h
@@ -209,10 +209,8 @@ static void RemovePaddingSlice(const phi::GPUContext& dev_ctx,
     offsets[axes[i]] = start;
   }
 
-  auto in_t =
-      phi::EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(*input);
-  auto out_t = phi::EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(
-      *out, new_out_dims);
+  auto in_t = EigenTensor<T, D, Eigen::RowMajor>::From(*input);
+  auto out_t = EigenTensor<T, D, Eigen::RowMajor>::From(*out, new_out_dims);
 
   funcs::EigenSlice<std::decay_t<decltype(place)>, T, D>::Eval(
       place, out_t, in_t, offsets, extents);

--- a/paddle/phi/kernels/gpudnn/conv_gpudnn_base.h
+++ b/paddle/phi/kernels/gpudnn/conv_gpudnn_base.h
@@ -193,8 +193,8 @@ static void RemovePaddingSlice(const phi::GPUContext& dev_ctx,
   auto& place = *dev_ctx.eigen_device();
   auto in_dims = input->dims();
   auto new_out_dims = out->dims();
-  auto offsets = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto extents = Eigen::DSizes<Eigen::DenseIndex, D>();
+  auto offsets = Eigen::DSizes<int64_t, D>();
+  auto extents = Eigen::DSizes<int64_t, D>();
   for (size_t i = 0; i < D; ++i) {
     offsets[i] = 0;
     extents[i] = new_out_dims[i];

--- a/paddle/phi/kernels/impl/addmm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/addmm_grad_kernel_impl.h
@@ -50,8 +50,8 @@ struct CopyOrScaleFunctor {
 template <typename T, size_t D, int MajorType = Eigen::RowMajor>
 using PhiEigenTensor = EigenTensor<T, D, MajorType>;
 
-using Array1 = Eigen::DSizes<Eigen::DenseIndex, 1>;
-using Array2 = Eigen::DSizes<Eigen::DenseIndex, 2>;
+using Array1 = Eigen::DSizes<int64_t, 1>;
+using Array2 = Eigen::DSizes<int64_t, 2>;
 
 template <typename T, typename Context>
 void AddmmGradKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/impl/addmm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/addmm_grad_kernel_impl.h
@@ -47,11 +47,8 @@ struct CopyOrScaleFunctor {
   int64_t numel_;
 };
 
-template <typename T,
-          size_t D,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using PhiEigenTensor = EigenTensor<T, D, MajorType, IndexType>;
+template <typename T, size_t D, int MajorType = Eigen::RowMajor>
+using PhiEigenTensor = EigenTensor<T, D, MajorType>;
 
 using Array1 = Eigen::DSizes<Eigen::DenseIndex, 1>;
 using Array2 = Eigen::DSizes<Eigen::DenseIndex, 2>;

--- a/paddle/phi/kernels/impl/addmm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/addmm_kernel_impl.h
@@ -28,8 +28,8 @@ namespace phi {
 template <typename T, size_t D, int MajorType = Eigen::RowMajor>
 using PhiEigenTensor = EigenTensor<T, D, MajorType>;
 
-using Array1 = Eigen::DSizes<Eigen::DenseIndex, 1>;
-using Array2 = Eigen::DSizes<Eigen::DenseIndex, 2>;
+using Array1 = Eigen::DSizes<int64_t, 1>;
+using Array2 = Eigen::DSizes<int64_t, 2>;
 
 template <typename T, typename Context>
 void AddmmKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/impl/addmm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/addmm_kernel_impl.h
@@ -25,11 +25,8 @@ limitations under the License. */
 
 namespace phi {
 
-template <typename T,
-          size_t D,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using PhiEigenTensor = EigenTensor<T, D, MajorType, IndexType>;
+template <typename T, size_t D, int MajorType = Eigen::RowMajor>
+using PhiEigenTensor = EigenTensor<T, D, MajorType>;
 
 using Array1 = Eigen::DSizes<Eigen::DenseIndex, 1>;
 using Array2 = Eigen::DSizes<Eigen::DenseIndex, 2>;

--- a/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
@@ -45,11 +45,8 @@ struct BCopyOrScaleFunctor {
   int64_t numel_;
 };
 
-template <typename T,
-          size_t D,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using PhiEigenTensor = EigenTensor<T, D, MajorType, IndexType>;
+template <typename T, size_t D, int MajorType = Eigen::RowMajor>
+using PhiEigenTensor = EigenTensor<T, D, MajorType>;
 
 using Array1 = Eigen::DSizes<Eigen::DenseIndex, 1>;
 using Array2 = Eigen::DSizes<Eigen::DenseIndex, 2>;

--- a/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
@@ -48,9 +48,9 @@ struct BCopyOrScaleFunctor {
 template <typename T, size_t D, int MajorType = Eigen::RowMajor>
 using PhiEigenTensor = EigenTensor<T, D, MajorType>;
 
-using Array1 = Eigen::DSizes<Eigen::DenseIndex, 1>;
-using Array2 = Eigen::DSizes<Eigen::DenseIndex, 2>;
-using Array3 = Eigen::DSizes<Eigen::DenseIndex, 3>;
+using Array1 = Eigen::DSizes<int64_t, 1>;
+using Array2 = Eigen::DSizes<int64_t, 2>;
+using Array3 = Eigen::DSizes<int64_t, 3>;
 
 template <typename T, typename Context>
 void BaddbmmGradKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/impl/baddbmm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/baddbmm_kernel_impl.h
@@ -26,11 +26,8 @@ limitations under the License. */
 
 namespace phi {
 
-template <typename T,
-          size_t D,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using PhiEigenTensor = EigenTensor<T, D, MajorType, IndexType>;
+template <typename T, size_t D, int MajorType = Eigen::RowMajor>
+using PhiEigenTensor = EigenTensor<T, D, MajorType>;
 
 using Array1 = Eigen::DSizes<Eigen::DenseIndex, 1>;
 using Array2 = Eigen::DSizes<Eigen::DenseIndex, 2>;

--- a/paddle/phi/kernels/impl/baddbmm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/baddbmm_kernel_impl.h
@@ -29,9 +29,9 @@ namespace phi {
 template <typename T, size_t D, int MajorType = Eigen::RowMajor>
 using PhiEigenTensor = EigenTensor<T, D, MajorType>;
 
-using Array1 = Eigen::DSizes<Eigen::DenseIndex, 1>;
-using Array2 = Eigen::DSizes<Eigen::DenseIndex, 2>;
-using Array3 = Eigen::DSizes<Eigen::DenseIndex, 3>;
+using Array1 = Eigen::DSizes<int64_t, 1>;
+using Array2 = Eigen::DSizes<int64_t, 2>;
+using Array3 = Eigen::DSizes<int64_t, 3>;
 
 template <typename T, typename Context>
 void BaddbmmKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/impl/broadcast_tensors_kernel_impl.h
+++ b/paddle/phi/kernels/impl/broadcast_tensors_kernel_impl.h
@@ -47,7 +47,7 @@ void ApplyBroadcast(const Context& dev_ctx,
   // 2. Collect new_input_dims_vec. Eigen::broadcast requires same rank for
   // both input and output tensors, so we need to initialize input X with
   // expanded dims: "new_input_dims_vec"
-  Eigen::DSizes<Eigen::DenseIndex, OutRank> bcast_dims;
+  Eigen::DSizes<int64_t, OutRank> bcast_dims;
   std::vector<int64_t> new_input_dims_vec(out_rank);
   for (int i = 0; i < out_rank; i++) {
     int in_axis = in_rank - i - 1;

--- a/paddle/phi/kernels/impl/crop_kernel_impl.h
+++ b/paddle/phi/kernels/impl/crop_kernel_impl.h
@@ -125,8 +125,8 @@ void CropTensorFunction(const Context& dev_ctx,
 
   auto x_tensor = EigenTensor<T, D>::From(x);
   auto out_tensor = EigenTensor<T, D>::From(*out);
-  Eigen::DSizes<Eigen::DenseIndex, D> e_offsets;
-  Eigen::DSizes<Eigen::DenseIndex, D> e_shape;
+  Eigen::DSizes<int64_t, D> e_offsets;
+  Eigen::DSizes<int64_t, D> e_shape;
   for (size_t i = 0; i < D; ++i) {
     e_offsets[i] = offsets_vec[i];
     e_shape[i] = out->dims()[i];

--- a/paddle/phi/kernels/impl/expand_as_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/expand_as_grad_kernel_impl.h
@@ -28,11 +28,11 @@ void ExpandAsBackward(const Context& dev_ctx,
   size_t reduce_size = reduce_dims_vec.size();
   dev_ctx.template Alloc<T>(in_grad);
   auto x_grad = EigenVector<T>::Flatten(*in_grad);
-  Eigen::DSizes<Eigen::DenseIndex, Dims * 2> reshape_dims;
+  Eigen::DSizes<int64_t, Dims * 2> reshape_dims;
   for (size_t i = 0; i < reshape_size; ++i) {
     reshape_dims[i] = reshape_dims_vec[i];
   }
-  Eigen::DSizes<Eigen::DenseIndex, Dims> reduce_dims;
+  Eigen::DSizes<int64_t, Dims> reduce_dims;
   for (size_t i = 0; i < reduce_size; ++i) {
     reduce_dims[i] = reduce_dims_vec[i];
   }

--- a/paddle/phi/kernels/impl/expand_as_kernel_impl.h
+++ b/paddle/phi/kernels/impl/expand_as_kernel_impl.h
@@ -76,7 +76,7 @@ void ExpandAs(const Context& dev_ctx,
       repeat_times[i] = 1;
     }
   }
-  Eigen::DSizes<Eigen::DenseIndex, Rank> bcast_dims;
+  Eigen::DSizes<int64_t, Rank> bcast_dims;
   for (size_t i = 0; i < repeat_times.size(); ++i) {
     bcast_dims[i] = repeat_times[i];
   }

--- a/paddle/phi/kernels/impl/expand_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/expand_grad_kernel_impl.h
@@ -42,11 +42,11 @@ void ExpandBackward(const Context& dev_ctx,
     dev_ctx.template Alloc<float>(&in_grad_fp32);
 
     auto x_grad = EigenVector<float>::Flatten(in_grad_fp32);
-    Eigen::DSizes<Eigen::DenseIndex, Dims * 2> reshape_dims;
+    Eigen::DSizes<int64_t, Dims * 2> reshape_dims;
     for (size_t i = 0; i < reshape_size; ++i) {
       reshape_dims[i] = reshape_dims_vec[i];
     }
-    Eigen::DSizes<Eigen::DenseIndex, Dims> reduce_dims;
+    Eigen::DSizes<int64_t, Dims> reduce_dims;
     for (size_t i = 0; i < reduce_size; ++i) {
       reduce_dims[i] = reduce_dims_vec[i];
     }
@@ -64,11 +64,11 @@ void ExpandBackward(const Context& dev_ctx,
     }
   } else {
     auto x_grad = EigenVector<T>::Flatten(*in_grad);
-    Eigen::DSizes<Eigen::DenseIndex, Dims * 2> reshape_dims;
+    Eigen::DSizes<int64_t, Dims * 2> reshape_dims;
     for (size_t i = 0; i < reshape_size; ++i) {
       reshape_dims[i] = reshape_dims_vec[i];
     }
-    Eigen::DSizes<Eigen::DenseIndex, Dims> reduce_dims;
+    Eigen::DSizes<int64_t, Dims> reduce_dims;
     for (size_t i = 0; i < reduce_size; ++i) {
       reduce_dims[i] = reduce_dims_vec[i];
     }

--- a/paddle/phi/kernels/impl/expand_kernel_impl.h
+++ b/paddle/phi/kernels/impl/expand_kernel_impl.h
@@ -77,7 +77,7 @@ void Expand(const Context& dev_ctx,
       repeat_times[i] = 1;
     }
   }
-  Eigen::DSizes<Eigen::DenseIndex, Rank> bcast_dims;
+  Eigen::DSizes<int64_t, Rank> bcast_dims;
   for (size_t i = 0; i < repeat_times.size(); ++i) {
     bcast_dims[i] = repeat_times[i];
   }

--- a/paddle/phi/kernels/impl/legacy_crop_kernel_impl.h
+++ b/paddle/phi/kernels/impl/legacy_crop_kernel_impl.h
@@ -40,8 +40,8 @@ void CropFunction(const Context &dev_ctx,
 
   auto x_tensor = EigenTensor<T, D>::From(*x);
   auto out_tensor = EigenTensor<T, D>::From(*out);
-  Eigen::DSizes<Eigen::DenseIndex, D> e_offsets;
-  Eigen::DSizes<Eigen::DenseIndex, D> e_shape;
+  Eigen::DSizes<int64_t, D> e_offsets;
+  Eigen::DSizes<int64_t, D> e_shape;
   for (size_t i = 0; i < D; ++i) {
     e_offsets[i] = offsets[i];
     e_shape[i] = out->dims()[i];

--- a/paddle/phi/kernels/impl/legacy_expand_kernel_impl.h
+++ b/paddle/phi/kernels/impl/legacy_expand_kernel_impl.h
@@ -40,7 +40,7 @@ void Expand(const Context& dev_ctx,
                         expand_times.size(),
                         static_cast<size_t>(in_dims.size())));
   auto* out0 = out;
-  Eigen::DSizes<Eigen::DenseIndex, Rank> bcast_dims;
+  Eigen::DSizes<int64_t, Rank> bcast_dims;
   for (size_t i = 0; i < expand_times.size(); ++i) {
     bcast_dims[i] = expand_times[i];
   }
@@ -141,11 +141,11 @@ void ExpandBackward(const Context& dev_ctx,
   auto* out0 = in_grad;
   dev_ctx.template Alloc<T>(out0);
   auto x_grad = EigenVector<T>::Flatten(*out0);
-  Eigen::DSizes<Eigen::DenseIndex, Dims * 2> reshape_dims;
+  Eigen::DSizes<int64_t, Dims * 2> reshape_dims;
   for (size_t i = 0; i < reshape_size; ++i) {
     reshape_dims[i] = reshape_dims_vec[i];
   }
-  Eigen::DSizes<Eigen::DenseIndex, Dims> reduce_dims;
+  Eigen::DSizes<int64_t, Dims> reduce_dims;
   for (size_t i = 0; i < reduce_size; ++i) {
     reduce_dims[i] = reduce_dims_vec[i];
   }

--- a/paddle/phi/kernels/impl/lu_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lu_kernel_impl.h
@@ -110,9 +110,9 @@ void SetValueCompute(const Context& dev_ctx,
   // Step 1: Set the value of out at `_index` to zero
   slice_e.device(eigen_place) = slice_e.constant(T(0));
 
-  auto starts_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto ends_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto strides_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
+  auto starts_indices = Eigen::DSizes<int64_t, D>();
+  auto ends_indices = Eigen::DSizes<int64_t, D>();
+  auto strides_indices = Eigen::DSizes<int64_t, D>();
 
   for (size_t i = 0; i < D; ++i) {
     starts_indices[i] = 0;
@@ -298,8 +298,8 @@ void SliceCompute(const Context& dev_ctx,
   out_dims = phi::funcs::GetDecreasedDims(slice_dims, decrease_axis);
 
   // 2.2 Get output
-  auto offsets = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto extents = Eigen::DSizes<Eigen::DenseIndex, D>();
+  auto offsets = Eigen::DSizes<int64_t, D>();
+  auto extents = Eigen::DSizes<int64_t, D>();
 
   for (size_t i = 0; i < D; ++i) {
     offsets[i] = 0;

--- a/paddle/phi/kernels/impl/lu_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lu_kernel_impl.h
@@ -319,7 +319,7 @@ void SliceCompute(const Context& dev_ctx,
   if (in->numel() <= Eigen::NumTraits<int>::highest()) {
     // similar to tf.slice:
     // if element number less than INT_MAX, change the type of index to int
-    Eigen::DSizes<int, D> offsets_32bit, extents_32bit;
+    Eigen::DSizes<int64_t, D> offsets_32bit, extents_32bit;
     for (size_t i = 0; i < D; i++) {
       offsets_32bit[i] = offsets[i];
       extents_32bit[i] = extents[i];

--- a/paddle/phi/kernels/impl/meshgrid_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/meshgrid_grad_kernel_impl.h
@@ -60,12 +60,12 @@ void MeshgridBackward(const Context& dev_ctx,
       }
     }
 
-    Eigen::DSizes<Eigen::DenseIndex, Rank> reduce_dims;
+    Eigen::DSizes<int64_t, Rank> reduce_dims;
     for (int k = 0; k < n; k++) {
       reduce_dims[k] = reduce_dims_vec[k];
     }
 
-    Eigen::DSizes<Eigen::DenseIndex, Rank * 2> reshape_dims;
+    Eigen::DSizes<int64_t, Rank * 2> reshape_dims;
     for (int k = 0; k < n * 2; k++) {
       reshape_dims[k] = reshape_dims_vec[k];
     }

--- a/paddle/phi/kernels/impl/meshgrid_kernel_impl.h
+++ b/paddle/phi/kernels/impl/meshgrid_kernel_impl.h
@@ -62,7 +62,7 @@ void MeshgridForward(const Context& dev_ctx,
     reshape_ins_tensor.Resize(out_dims_reshape);
     DDim out_dims = common::make_ddim(shape);
 
-    Eigen::DSizes<Eigen::DenseIndex, Rank> bcast_dims;
+    Eigen::DSizes<int64_t, Rank> bcast_dims;
     for (int64_t j = 0; j < size; j++) {
       bcast_dims[j] = shape[j];
     }

--- a/paddle/phi/kernels/impl/slice_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/slice_grad_kernel_impl.h
@@ -32,10 +32,8 @@ void LaunchEigenPadding(
     const DDim& out_dims,
     const std::array<std::pair<int64_t, int64_t>, D>& paddings) {
   auto& place = *dev_ctx.eigen_device();
-  auto d_in_t = EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(
-      *d_input, in_dims);
-  auto d_out_t = EigenTensor<T, D, Eigen::RowMajor, Eigen::DenseIndex>::From(
-      *d_out, out_dims);
+  auto d_in_t = EigenTensor<T, D, Eigen::RowMajor>::From(*d_input, in_dims);
+  auto d_out_t = EigenTensor<T, D, Eigen::RowMajor>::From(*d_out, out_dims);
 
   if (d_input->numel() <= Eigen::NumTraits<int>::highest()) {
     // similar to tf.pad:

--- a/paddle/phi/kernels/impl/slice_kernel_impl.h
+++ b/paddle/phi/kernels/impl/slice_kernel_impl.h
@@ -59,8 +59,8 @@ void SliceCompute(const Context& dev_ctx,
   out_dims = funcs::GetDecreasedDims<int64_t>(slice_dims, decrease_axis);
 
   // 2.2 Get output
-  auto offsets = Eigen::DSizes<Eigen::DenseIndex, D>();
-  auto extents = Eigen::DSizes<Eigen::DenseIndex, D>();
+  auto offsets = Eigen::DSizes<int64_t, D>();
+  auto extents = Eigen::DSizes<int64_t, D>();
 
   for (size_t i = 0; i < D; ++i) {
     offsets[i] = 0;

--- a/paddle/phi/kernels/impl/slice_kernel_impl.h
+++ b/paddle/phi/kernels/impl/slice_kernel_impl.h
@@ -80,7 +80,7 @@ void SliceCompute(const Context& dev_ctx,
   if (in->numel() <= Eigen::NumTraits<int>::highest()) {
     // similar to tf.slice:
     // if element number less than INT_MAX, change the type of index to int
-    Eigen::DSizes<int, D> offsets_32bit, extents_32bit;
+    Eigen::DSizes<int64_t, D> offsets_32bit, extents_32bit;
     for (size_t i = 0; i < D; i++) {
       offsets_32bit[i] = offsets[i];
       extents_32bit[i] = extents[i];

--- a/paddle/phi/kernels/impl/tile_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/tile_grad_kernel_impl.h
@@ -43,11 +43,11 @@ void TileBackward(const Context& dev_ctx,
     x_grad_fp32.Resize(x_grad->dims());
     dev_ctx.template Alloc<float>(&x_grad_fp32);
     auto eigen_x_grad = EigenVector<float>::Flatten(x_grad_fp32);
-    Eigen::DSizes<Eigen::DenseIndex, Dims * 2> reshape_dims;
+    Eigen::DSizes<int64_t, Dims * 2> reshape_dims;
     for (size_t i = 0; i < reshape_size; ++i) {
       reshape_dims[i] = reshape_dims_vec[i];
     }
-    Eigen::DSizes<Eigen::DenseIndex, Dims> reduce_dims;
+    Eigen::DSizes<int64_t, Dims> reduce_dims;
     for (size_t i = 0; i < reduce_size; ++i) {
       reduce_dims[i] = reduce_dims_vec[i];
     }
@@ -64,11 +64,11 @@ void TileBackward(const Context& dev_ctx,
     }
   } else {
     auto eigen_x_grad = EigenVector<T>::Flatten(*x_grad);
-    Eigen::DSizes<Eigen::DenseIndex, Dims * 2> reshape_dims;
+    Eigen::DSizes<int64_t, Dims * 2> reshape_dims;
     for (size_t i = 0; i < reshape_size; ++i) {
       reshape_dims[i] = reshape_dims_vec[i];
     }
-    Eigen::DSizes<Eigen::DenseIndex, Dims> reduce_dims;
+    Eigen::DSizes<int64_t, Dims> reduce_dims;
     for (size_t i = 0; i < reduce_size; ++i) {
       reduce_dims[i] = reduce_dims_vec[i];
     }

--- a/paddle/phi/kernels/impl/tile_kernel_impl.h
+++ b/paddle/phi/kernels/impl/tile_kernel_impl.h
@@ -62,7 +62,7 @@ void Tile(const Context& dev_ctx,
     phi::Copy<DeviceContext>(dev_ctx, x, dev_ctx.GetPlace(), false, out);
     return;
   }
-  Eigen::DSizes<Eigen::DenseIndex, Rank> bcast_dims;
+  Eigen::DSizes<int64_t, Rank> bcast_dims;
   for (size_t i = 0; i < repeat_times.size(); ++i) {
     bcast_dims[i] = repeat_times[i];
   }

--- a/paddle/phi/kernels/selected_rows/impl/ftrl_kernel_impl.h
+++ b/paddle/phi/kernels/selected_rows/impl/ftrl_kernel_impl.h
@@ -22,10 +22,8 @@
 namespace phi {
 namespace sr {
 
-template <typename T,
-          int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenVector = phi::EigenVector<T, MajorType, IndexType>;
+template <typename T, int MajorType = Eigen::RowMajor>
+using EigenVector = EigenVector<T, MajorType>;
 
 template <typename T>
 class SparseFTRLFunctor {

--- a/test/legacy_test/test_l1_norm_grad_kernel.py
+++ b/test/legacy_test/test_l1_norm_grad_kernel.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CPU unit test for L1NormGradKernel
+(paddle/phi/kernels/cpu/l1_norm_grad_kernel.cc).
+
+Kernel formula: dX = dout * sign(X)
+  sign(x) = +1 if x > 0, -1 if x < 0, 0 if x == 0
+"""
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class TestL1NormGradKernel(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+        paddle.set_device('cpu')
+
+    def test_basic(self):
+        """dX = dout * sign(X); loss = l1_norm(x), dout = 1."""
+        x_np = np.array([-3.0, 1.0, -2.0, 4.0], dtype='float32')
+
+        x = paddle.to_tensor(x_np, stop_gradient=False)
+        loss = paddle.norm(x, p=1)  # sum(abs(x))
+        loss.backward()
+
+        # expected: sign(x) * 1.0
+        expected = np.sign(x_np).astype('float32')
+        np.testing.assert_allclose(x.grad.numpy(), expected, rtol=1e-6)
+
+    def test_2d_input(self):
+        """2-D input flattened inside the kernel; same formula applies."""
+        x_np = np.array([[1.0, -2.0], [-3.0, 4.0]], dtype='float32')
+
+        x = paddle.to_tensor(x_np, stop_gradient=False)
+        loss = paddle.norm(x, p=1)
+        loss.backward()
+
+        expected = np.sign(x_np).astype('float32')
+        np.testing.assert_allclose(x.grad.numpy(), expected, rtol=1e-6)
+
+    def test_scaled_dout(self):
+        """Wrap l1_norm in a chain to get dout != 1: loss = 3 * l1_norm(x)."""
+        x_np = np.array([-1.0, 2.0, -3.0], dtype='float32')
+
+        x = paddle.to_tensor(x_np, stop_gradient=False)
+        loss = 3.0 * paddle.norm(x, p=1)
+        loss.backward()
+
+        expected = 3.0 * np.sign(x_np).astype('float32')
+        np.testing.assert_allclose(x.grad.numpy(), expected, rtol=1e-6)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/legacy_test/test_lars_momentum_kernel.py
+++ b/test/legacy_test/test_lars_momentum_kernel.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CPU unit test for LarsMomentumKernel (forward).
+(paddle/phi/kernels/cpu/lars_momentum_kernel.cc)
+
+Kernel formulas (rescale_grad=1.0):
+  p_norm   = norm2(p)
+  g_norm   = norm2(g)
+  local_lr = lr * lars_coeff * p_norm / (g_norm + wd * p_norm + eps)
+             (only when wd > 0 AND p_norm > 0 AND g_norm > 0;
+              otherwise local_lr = lr)
+  v_out    = v * mu + local_lr * (g + wd * p)
+  p_out    = p - v_out
+"""
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.incubate.optimizer import LarsMomentumOptimizer
+
+
+def _lars_ref(p, v, g, lr, mu, lars_coeff, wd, eps, rescale_grad=1.0):
+    """NumPy reference implementation of one LARS step."""
+    rg = rescale_grad * g
+    p_norm = np.linalg.norm(p)
+    g_norm = np.linalg.norm(rg)
+    if wd > 0 and p_norm > 0 and g_norm > 0:
+        local_lr = lr * lars_coeff * p_norm / (g_norm + wd * p_norm + eps)
+    else:
+        local_lr = lr
+    v_out = v * mu + local_lr * (rg + wd * p)
+    p_out = p - v_out
+    return p_out.astype(np.float32), v_out.astype(np.float32)
+
+
+def _one_step(p_np, g_np, lr, mu, lars_coeff, wd, eps, rescale_grad=1.0):
+    """
+    Run one LarsMomentumOptimizer step in dygraph mode on CPU.
+    Initial velocity is zero (default).
+    Returns updated param numpy array.
+    """
+    paddle.disable_static()
+    paddle.set_device('cpu')
+
+    param = paddle.create_parameter(
+        shape=p_np.shape,
+        dtype='float32',
+        default_initializer=paddle.nn.initializer.Assign(p_np),
+    )
+    opt = LarsMomentumOptimizer(
+        learning_rate=lr,
+        momentum=mu,
+        lars_coeff=lars_coeff,
+        lars_weight_decay=wd,
+        epsilon=eps,
+        rescale_grad=rescale_grad,
+        parameter_list=[param],
+    )
+    param.grad = paddle.to_tensor(g_np.copy())
+    opt.step()
+    return param.numpy()
+
+
+class TestLarsMomentumKernelCPU(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+        paddle.set_device('cpu')
+
+    def test_basic_lars_step(self):
+        """Standard LARS update; initial velocity = 0."""
+        p_np = np.array([1.0, 2.0, 3.0, 4.0], dtype='float32')
+        g_np = np.array([0.1, 0.2, 0.3, 0.4], dtype='float32')
+        lr, mu, lars_coeff, wd, eps = 0.1, 0.9, 0.001, 0.0001, 1e-4
+
+        p_ref, _ = _lars_ref(
+            p_np, np.zeros_like(p_np), g_np, lr, mu, lars_coeff, wd, eps
+        )
+        p_out = _one_step(p_np, g_np, lr, mu, lars_coeff, wd, eps)
+
+        np.testing.assert_allclose(
+            p_out,
+            p_ref,
+            rtol=1e-5,
+            err_msg=f'p_out mismatch: expected {p_ref}, got {p_out}',
+        )
+
+    def test_zero_weight_decay_uses_raw_lr(self):
+        """
+        When wd=0, local_lr falls back to bare lr (no LARS scaling).
+        v_out = lr * g  (mu=0 for simple verification)
+        p_out = p - lr * g
+        """
+        p_np = np.array([3.0, -1.0, 2.0], dtype='float32')
+        g_np = np.array([0.5, 0.5, 0.5], dtype='float32')
+        lr, mu, lars_coeff, wd, eps = 0.01, 0.0, 0.5, 0.0, 1e-4
+
+        p_ref, _ = _lars_ref(
+            p_np, np.zeros_like(p_np), g_np, lr, mu, lars_coeff, wd, eps
+        )
+        p_out = _one_step(p_np, g_np, lr, mu, lars_coeff, wd, eps)
+
+        np.testing.assert_allclose(p_out, p_ref, rtol=1e-5)
+
+    def test_multi_param_groups(self):
+        """
+        Two separate parameters in one optimizer call.
+        The kernel iterates over op_num; both params must be updated correctly.
+        """
+        paddle.disable_static()
+        paddle.set_device('cpu')
+
+        p1_np = np.array([1.0, 2.0], dtype='float32')
+        g1_np = np.array([0.1, 0.2], dtype='float32')
+        p2_np = np.array([3.0, 4.0, 5.0], dtype='float32')
+        g2_np = np.array([0.3, 0.4, 0.5], dtype='float32')
+
+        lr, mu, lars_coeff, wd, eps = 0.1, 0.9, 0.001, 0.0001, 1e-4
+
+        p1_ref, _ = _lars_ref(
+            p1_np, np.zeros_like(p1_np), g1_np, lr, mu, lars_coeff, wd, eps
+        )
+        p2_ref, _ = _lars_ref(
+            p2_np, np.zeros_like(p2_np), g2_np, lr, mu, lars_coeff, wd, eps
+        )
+
+        param1 = paddle.create_parameter(
+            shape=p1_np.shape,
+            dtype='float32',
+            default_initializer=paddle.nn.initializer.Assign(p1_np),
+        )
+        param2 = paddle.create_parameter(
+            shape=p2_np.shape,
+            dtype='float32',
+            default_initializer=paddle.nn.initializer.Assign(p2_np),
+        )
+        opt = LarsMomentumOptimizer(
+            learning_rate=lr,
+            momentum=mu,
+            lars_coeff=lars_coeff,
+            lars_weight_decay=wd,
+            epsilon=eps,
+            parameter_list=[param1, param2],
+        )
+        param1.grad = paddle.to_tensor(g1_np.copy())
+        param2.grad = paddle.to_tensor(g2_np.copy())
+        opt.step()
+
+        np.testing.assert_allclose(
+            param1.numpy(),
+            p1_ref,
+            rtol=1e-5,
+            err_msg=f'param1: expected {p1_ref}, got {param1.numpy()}',
+        )
+        np.testing.assert_allclose(
+            param2.numpy(),
+            p2_ref,
+            rtol=1e-5,
+            err_msg=f'param2: expected {p2_ref}, got {param2.numpy()}',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/legacy_test/test_set_value_grad_kernel.py
+++ b/test/legacy_test/test_set_value_grad_kernel.py
@@ -1,0 +1,338 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CPU unit tests for SetValueGradImpl.
+
+Covers the four branches inside SetValueGradImpl
+(paddle/phi/kernels/cpu/set_value_grad_kernel.cc):
+
+  Branch 1 - x_grad:
+      out_grad is copied to x_grad, then the slice region is zeroed out.
+
+  Branch 2 - value_grad (same shape, need_reverse=false):
+      When value_grad.dims() == out_dims and step > 0, the gradient is
+      extracted directly via stridedSlice.
+
+  Branch 3 - value_grad (same shape, need_reverse=true):  ** previously uncovered **
+      When step < 0, reverse_vector is set and the stridedSlice result is
+      reversed before being written to value_grad.
+
+  Branch 4 - value_grad (broadcast/reduce):
+      When value_grad.dims() != out_dims, gradient is accumulated across
+      multiple broadcast tiles.
+
+The test chain used throughout:
+    a = x * x
+    a[index] = value * value
+    loss = a.sum()
+    loss.backward()
+
+Using v*v (instead of a direct assignment) makes gradients non-trivial and
+easy to verify analytically:
+    d(loss)/d(x[i]) = 2*x[i]   for i NOT in slice region; 0 inside region
+    d(loss)/d(v[i]) = 2*v[i]   (each v[i] appears once as v[i]^2)
+"""
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class TestSetValueGradXGrad(unittest.TestCase):
+    """
+    Branch 1: x_grad path.
+
+    SetValueGradImpl copies out_grad into x_grad, then zeros the slice region.
+    Expected: x_grad[i] = 2*x[i] outside the slice; 0 inside.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+        paddle.set_device('cpu')
+
+    def test_1d_slice_step1(self):
+        x_np = np.arange(1.0, 7.0, dtype='float32')  # [1,2,3,4,5,6]
+        value_np = np.array([10.0, 10.0], dtype='float32')
+
+        x = paddle.to_tensor(x_np, stop_gradient=False)
+        value = paddle.to_tensor(value_np, stop_gradient=False)
+
+        a = x * x
+        a[1:3] = value  # slice indices 1,2
+        loss = a.sum()
+        loss.backward()
+
+        expected = 2.0 * x_np
+        expected[1:3] = 0.0
+
+        np.testing.assert_allclose(
+            x.grad.numpy(),
+            expected,
+            rtol=1e-6,
+            err_msg=f'x_grad mismatch: expected {expected}, got {x.grad.numpy()}',
+        )
+
+    def test_2d_slice(self):
+        x_np = np.arange(1.0, 13.0, dtype='float32').reshape(3, 4)
+        value_np = np.ones((2, 4), dtype='float32') * 99.0
+
+        x = paddle.to_tensor(x_np, stop_gradient=False)
+        value = paddle.to_tensor(value_np, stop_gradient=False)
+
+        a = x * x
+        a[0:2, :] = value
+        loss = a.sum()
+        loss.backward()
+
+        expected = 2.0 * x_np
+        expected[0:2, :] = 0.0
+
+        np.testing.assert_allclose(
+            x.grad.numpy(),
+            expected,
+            rtol=1e-6,
+        )
+
+
+class TestSetValueGradValueGradSameShape(unittest.TestCase):
+    """
+    Branch 2: value_grad when value_grad.dims() == out_dims and step > 0.
+
+    SetValueGradImpl extracts the gradient via a single stridedSlice and assigns
+    it directly to value_grad (no accumulation, no reverse).
+    Expected: value_grad[i] = 2*v[i].
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+        paddle.set_device('cpu')
+
+    def test_1d_exact_shape(self):
+        x_np = np.arange(1.0, 7.0, dtype='float32')
+        value_np = np.array([10.0, 20.0, 30.0], dtype='float32')
+
+        x = paddle.to_tensor(x_np, stop_gradient=False)
+        value = paddle.to_tensor(value_np, stop_gradient=False)
+
+        a = x * x
+        a[2:5] = value * value  # slice output shape [3] == value shape [3]
+        loss = a.sum()
+        loss.backward()
+
+        expected = 2.0 * value_np
+        np.testing.assert_allclose(
+            value.grad.numpy(),
+            expected,
+            rtol=1e-6,
+        )
+
+    def test_2d_exact_shape(self):
+        x_np = np.arange(1.0, 13.0, dtype='float32').reshape(4, 3)
+        value_np = np.arange(100.0, 106.0, dtype='float32').reshape(2, 3)
+
+        x = paddle.to_tensor(x_np, stop_gradient=False)
+        value = paddle.to_tensor(value_np, stop_gradient=False)
+
+        a = x * x
+        a[1:3, :] = (
+            value * value
+        )  # slice output shape [2,3] == value shape [2,3]
+        loss = a.sum()
+        loss.backward()
+
+        expected = 2.0 * value_np
+        np.testing.assert_allclose(
+            value.grad.numpy(),
+            expected,
+            rtol=1e-5,
+        )
+
+
+class TestSetValueGradNegativeStep(unittest.TestCase):
+    """
+    Branch 3: need_reverse = true (step < 0).
+
+    When any axis has a negative step, reverse_vector is set for that axis and
+    SetValueGradImpl reverses the stridedSlice result before writing to
+    value_grad.  This branch was NOT covered by existing tests.
+
+    The key invariant: value_grad[i] = 2*v[i] regardless of the direction in
+    which v was written into x, because the reverse restores the correspondence
+    between value positions and gradient positions.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+        paddle.set_device('cpu')
+
+    def test_1d_step_neg1(self):
+        """a[5:2:-1] = v => writes a[5],a[4],a[3]; step=-1 triggers need_reverse."""
+        x_np = np.arange(1.0, 7.0, dtype='float32')  # [1,2,3,4,5,6]
+        value_np = np.array([10.0, 20.0, 30.0], dtype='float32')
+
+        x = paddle.to_tensor(x_np, stop_gradient=False)
+        value = paddle.to_tensor(value_np, stop_gradient=False)
+
+        a = x * x
+        a[5:2:-1] = value * value  # fills indices 5,4,3
+        loss = a.sum()
+        loss.backward()
+
+        # x_grad: 2*x everywhere, 0 at indices {3,4,5}
+        expected_x_grad = 2.0 * x_np
+        expected_x_grad[3:6] = 0.0
+
+        # value_grad: 2*v (reverse restores original order)
+        expected_value_grad = 2.0 * value_np
+
+        np.testing.assert_allclose(
+            x.grad.numpy(),
+            expected_x_grad,
+            rtol=1e-6,
+            err_msg=f'x_grad: expected {expected_x_grad}, got {x.grad.numpy()}',
+        )
+        np.testing.assert_allclose(
+            value.grad.numpy(),
+            expected_value_grad,
+            rtol=1e-6,
+            err_msg=f'value_grad: expected {expected_value_grad}, got {value.grad.numpy()}',
+        )
+
+    def test_2d_negative_step_axis0(self):
+        """a[3:0:-1, :] = v => fills rows 3,2,1 in reverse; step=-1 on axis 0."""
+        x_np = np.arange(1.0, 13.0, dtype='float32').reshape(4, 3)
+        value_np = np.arange(10.0, 19.0, dtype='float32').reshape(3, 3)
+
+        x = paddle.to_tensor(x_np, stop_gradient=False)
+        value = paddle.to_tensor(value_np, stop_gradient=False)
+
+        a = x * x
+        a[3:0:-1, :] = value * value  # fills rows 3,2,1
+        loss = a.sum()
+        loss.backward()
+
+        # x_grad: 2*x for row 0 only; 0 for rows 1,2,3
+        expected_x_grad = 2.0 * x_np
+        expected_x_grad[1:4, :] = 0.0
+
+        expected_value_grad = 2.0 * value_np
+
+        np.testing.assert_allclose(
+            x.grad.numpy(),
+            expected_x_grad,
+            rtol=1e-6,
+        )
+        np.testing.assert_allclose(
+            value.grad.numpy(),
+            expected_value_grad,
+            rtol=1e-6,
+        )
+
+    def test_1d_step_neg2(self):
+        """a[::-2] = v => step=-2, hits indices 7,5,3,1."""
+        x_np = np.arange(1.0, 9.0, dtype='float32')  # [1..8], shape [8]
+        value_np = np.array([10.0, 20.0, 30.0, 40.0], dtype='float32')
+
+        x = paddle.to_tensor(x_np, stop_gradient=False)
+        value = paddle.to_tensor(value_np, stop_gradient=False)
+
+        a = x * x
+        a[::-2] = value * value  # fills indices 7,5,3,1
+        loss = a.sum()
+        loss.backward()
+
+        # x_grad=0 at {1,3,5,7}; 2*x elsewhere
+        expected_x_grad = 2.0 * x_np
+        expected_x_grad[[1, 3, 5, 7]] = 0.0
+
+        expected_value_grad = 2.0 * value_np
+
+        np.testing.assert_allclose(
+            x.grad.numpy(),
+            expected_x_grad,
+            rtol=1e-6,
+        )
+        np.testing.assert_allclose(
+            value.grad.numpy(),
+            expected_value_grad,
+            rtol=1e-6,
+        )
+
+
+class TestSetValueGradValueGradBroadcast(unittest.TestCase):
+    """
+    Branch 4: value_grad when value_grad.dims() != out_dims (broadcast/reduce).
+
+    SetValueGradImpl accumulates the gradient from multiple broadcast tiles into
+    value_grad via repeated additions.
+    Expected: value_grad[i] = 2*v[i] * (number of tiles v[i] is broadcast into).
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+        paddle.set_device('cpu')
+
+    def test_scalar_broadcast_into_2d_slice(self):
+        """value shape [1] broadcast into slice shape [2,4] (8 elements)."""
+        x_np = np.arange(1.0, 13.0, dtype='float32').reshape(3, 4)
+        value_np = np.array([5.0], dtype='float32')
+
+        x = paddle.to_tensor(x_np, stop_gradient=False)
+        value = paddle.to_tensor(value_np, stop_gradient=False)
+
+        a = x * x
+        a[0:2, :] = value * value  # slice [2,4], value [1] -> 8 tiles
+        loss = a.sum()
+        loss.backward()
+
+        # d(loss)/d(v[0]) = sum over 8 positions of 2*v[0] = 2*5*8 = 80
+        expected_value_grad = np.array([2.0 * 5.0 * 8.0], dtype='float32')
+
+        np.testing.assert_allclose(
+            value.grad.numpy(),
+            expected_value_grad,
+            rtol=1e-5,
+            err_msg=f'Expected {expected_value_grad}, got {value.grad.numpy()}',
+        )
+
+    def test_row_vector_broadcast(self):
+        """value shape [1,4] broadcast into slice shape [2,4] (2 rows)."""
+        x_np = np.arange(1.0, 13.0, dtype='float32').reshape(3, 4)
+        value_np = np.array([[10.0, 20.0, 30.0, 40.0]], dtype='float32')
+
+        x = paddle.to_tensor(x_np, stop_gradient=False)
+        value = paddle.to_tensor(value_np, stop_gradient=False)
+
+        a = x * x
+        a[0:2, :] = (
+            value * value
+        )  # slice [2,4], value [1,4] -> each v[j] used 2×
+        loss = a.sum()
+        loss.backward()
+
+        # d(loss)/d(v[0,j]) = 2*v[0,j] * 2  (2 rows use the same v[0,j])
+        expected_value_grad = 2.0 * value_np * 2.0
+
+        np.testing.assert_allclose(
+            value.grad.numpy(),
+            expected_value_grad,
+            rtol=1e-5,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
<!-- Describe what you’ve done -->

devPR:https://github.com/PaddlePaddle/Paddle/pull/78390

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否