### PR TITLE
[Dosc] Add missing docstring for some `nn.functional` apis

### DIFF
--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -47,7 +47,7 @@ def add_doc_and_signature(func_name: str, docstr: str, func_def: str) -> None:
     Add docstr for function (paddle.*) and method (paddle.Tensor.*) if method exists
     """
     python_api_sig = _parse_function_signature(func_name, func_def)
-    for module in [paddle, paddle.Tensor]:
+    for module in [paddle, paddle.Tensor, paddle.nn.functional]:
         if hasattr(module, func_name):
             func = getattr(module, func_name)
             if inspect.isfunction(func):
@@ -4054,6 +4054,11 @@ add_doc_and_signature(
 
     Returns:
         Tensor: The output tensor, it's data type is bool.
+
+    Examples:
+        .. code-block:: pycon
+
+            >>> import paddle
 
             >>> x = paddle.to_tensor([10000., 1e-07])
             >>> y = paddle.to_tensor([10000.1, 1e-08])


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Docs 

### Description
<!-- Describe what you’ve done -->
fix missing docstring for nn.functional apis
find in https://github.com/PaddlePaddle/docs/pull/7873#pullrequestreview-3957715089

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否