### PR TITLE
[Docs] Fix docstring assignment for methods in `add_doc_and_signature`

### DIFF
--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -53,7 +53,7 @@ def add_doc_and_signature(func_name: str, docstr: str, func_def: str) -> None:
             if inspect.isfunction(func):
                 func.__doc__ = docstr
             elif inspect.ismethod(func):
-                func.__self__.__doc__ = docstr
+                func.__func__.__doc__ = docstr
             elif inspect.isbuiltin(func):
                 _add_docstr(func, docstr)
     methods_dict = dict(methods_map)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Docs 

### Description
<!-- Describe what you’ve done -->
在 `add_doc_and_signature` 中为方法（method）动态添加文档字符串时，之前的逻辑错误地将其赋值给了 `func.__self__.__doc__`。这会修改绑定实例或类本身的文档字符串，而不是该方法本身的文档字符串

将其更改为 `func.__func__.__doc__` 后，可以正确地定位到底层函数对象，并为其成功设置对应的文档字符串。

cc @SigureMo 

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否