### PR TITLE
[Feature] Add masked_scatter C++ kernel for CPU and GPU

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -30,6 +30,7 @@ limitations under the License. */
 #include "paddle/phi/core/utils/data_type.h"
 #include "paddle/phi/infermeta/binary.h"
 #include "paddle/phi/infermeta/nullary.h"
+#include "paddle/phi/kernels/funcs/common_infer_shape_functions.h"
 #include "paddle/phi/kernels/funcs/common_shape.h"
 #include "paddle/phi/kernels/funcs/concat_funcs.h"
 
@@ -6437,6 +6438,17 @@ void MultiheadMatmulInferMeta(const MetaTensor& input,
   out->set_dims(input.dims());
   out->set_dtype(input.dtype());
   out->share_lod(input);
+}
+
+void MaskedScatterInferMeta(const MetaTensor& x,
+                            const MetaTensor& mask,
+                            const MetaTensor& value,
+                            MetaTensor* out) {
+  auto x_dims = x.dims();
+  auto mask_dims = mask.dims();
+  auto expanded_dims = funcs::BroadcastTwoDims(x_dims, mask_dims, -1);
+  out->set_dims(expanded_dims);
+  out->set_dtype(x.dtype());
 }
 
 void MaskedMultiheadAttentionInferMeta(const MetaTensor& x,

--- a/paddle/phi/infermeta/multiary.h
+++ b/paddle/phi/infermeta/multiary.h
@@ -1314,6 +1314,11 @@ PADDLE_API void MultiheadMatmulInferMeta(const MetaTensor& input,
                                          const int head_number,
                                          MetaTensor* out);
 
+PADDLE_API void MaskedScatterInferMeta(const MetaTensor& x,
+                                       const MetaTensor& mask,
+                                       const MetaTensor& value,
+                                       MetaTensor* out);
+
 PADDLE_API void MaskedMultiheadAttentionInferMeta(
     const MetaTensor& x,
     const MetaTensor& cache_kv,

--- a/paddle/phi/kernels/cpu/masked_scatter_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/masked_scatter_grad_kernel.cc
@@ -60,7 +60,7 @@ void MaskedScatterGradKernel(const Context& dev_ctx,
   int64_t total = out_grad.numel();
 
   if (x_grad) {
-    dev_ctx.template HostAlloc<T>(x_grad);
+    dev_ctx.template Alloc<T>(x_grad);
     auto* x_grad_data = x_grad->data<T>();
     for (int64_t i = 0; i < total; i++) {
       x_grad_data[i] = mask_data[i] ? static_cast<T>(0) : out_grad_data[i];
@@ -68,7 +68,7 @@ void MaskedScatterGradKernel(const Context& dev_ctx,
   }
 
   if (value_grad) {
-    dev_ctx.template HostAlloc<T>(value_grad);
+    dev_ctx.template Alloc<T>(value_grad);
     auto* value_grad_data = value_grad->data<T>();
     int64_t value_numel = value_grad->numel();
     std::memset(value_grad_data, 0, value_numel * sizeof(T));

--- a/paddle/phi/kernels/cpu/masked_scatter_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/masked_scatter_grad_kernel.cc
@@ -1,0 +1,92 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/masked_scatter_grad_kernel.h"
+
+#include <cstring>
+
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/expand_kernel.h"
+#include "paddle/phi/kernels/funcs/common_infer_shape_functions.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void MaskedScatterGradKernel(const Context& dev_ctx,
+                             const DenseTensor& mask,
+                             const DenseTensor& value,
+                             const DenseTensor& out_grad,
+                             DenseTensor* x_grad,
+                             DenseTensor* value_grad) {
+  auto out_grad_dims = out_grad.dims();
+  auto mask_dims = mask.dims();
+  auto expanded_size =
+      vectorize(funcs::BroadcastTwoDims(out_grad_dims, mask_dims, -1));
+  DDim expanded_dims = make_ddim(expanded_size);
+
+  DenseTensor mask_expand;
+  if (mask_dims != expanded_dims) {
+    ExpandKernel<bool, Context>(
+        dev_ctx, mask, IntArray(expanded_size), &mask_expand);
+  } else {
+    mask_expand = mask;
+  }
+
+  auto* mask_data = mask_expand.data<bool>();
+  auto* out_grad_data = out_grad.data<T>();
+  int64_t total = out_grad.numel();
+
+  if (x_grad) {
+    dev_ctx.template HostAlloc<T>(x_grad);
+    auto* x_grad_data = x_grad->data<T>();
+    for (int64_t i = 0; i < total; i++) {
+      x_grad_data[i] = mask_data[i] ? static_cast<T>(0) : out_grad_data[i];
+    }
+  }
+
+  if (value_grad) {
+    dev_ctx.template HostAlloc<T>(value_grad);
+    auto* value_grad_data = value_grad->data<T>();
+    int64_t value_numel = value_grad->numel();
+    std::memset(value_grad_data, 0, value_numel * sizeof(T));
+
+    int64_t count = 0;
+    for (int64_t i = 0; i < total; i++) {
+      if (mask_data[i]) {
+        if (count < value_numel) {
+          value_grad_data[count] = out_grad_data[i];
+        }
+        count++;
+      }
+    }
+  }
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(masked_scatter_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::MaskedScatterGradKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   int16_t,
+                   int8_t,
+                   uint8_t,
+                   phi::float16,
+                   phi::bfloat16) {
+  kernel->InputAt(0).SetDataType(phi::DataType::BOOL);
+}

--- a/paddle/phi/kernels/cpu/masked_scatter_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/masked_scatter_grad_kernel.cc
@@ -20,11 +20,14 @@
 #include "paddle/phi/kernels/expand_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/common_infer_shape_functions.h"
+#include "paddle/phi/kernels/funcs/elementwise_base.h"
+#include "paddle/phi/kernels/reduce_sum_kernel.h"
 
 namespace phi {
 
 template <typename T, typename Context>
 void MaskedScatterGradKernel(const Context& dev_ctx,
+                             const DenseTensor& x,
                              const DenseTensor& mask,
                              const DenseTensor& value,
                              const DenseTensor& out_grad,
@@ -60,10 +63,32 @@ void MaskedScatterGradKernel(const Context& dev_ctx,
   int64_t total = out_grad.numel();
 
   if (x_grad) {
-    dev_ctx.template Alloc<T>(x_grad);
-    auto* x_grad_data = x_grad->data<T>();
-    for (int64_t i = 0; i < total; i++) {
-      x_grad_data[i] = mask_data[i] ? static_cast<T>(0) : out_grad_data[i];
+    auto x_grad_dims = x_grad->dims();
+    if (x_grad_dims == out_grad_dims) {
+      // No broadcast happened, compute directly into x_grad.
+      dev_ctx.template Alloc<T>(x_grad);
+      auto* x_grad_data = x_grad->data<T>();
+      for (int64_t i = 0; i < total; i++) {
+        x_grad_data[i] = mask_data[i] ? static_cast<T>(0) : out_grad_data[i];
+      }
+    } else {
+      // Broadcast happened: compute at broadcast shape, then reduce-sum.
+      DenseTensor x_grad_broadcast;
+      x_grad_broadcast.Resize(expanded_dims);
+      dev_ctx.template Alloc<T>(&x_grad_broadcast);
+      auto* x_grad_broadcast_data = x_grad_broadcast.data<T>();
+      for (int64_t i = 0; i < total; i++) {
+        x_grad_broadcast_data[i] =
+            mask_data[i] ? static_cast<T>(0) : out_grad_data[i];
+      }
+      std::vector<int> reduce_dims =
+          funcs::GetReduceDim(x_grad_dims, expanded_dims, -1);
+      phi::SumKernel<T, Context>(dev_ctx,
+                                 x_grad_broadcast,
+                                 reduce_dims,
+                                 x_grad_broadcast.dtype(),
+                                 false,
+                                 x_grad);
     }
   }
 
@@ -100,5 +125,5 @@ PD_REGISTER_KERNEL(masked_scatter_grad,
                    uint8_t,
                    phi::float16,
                    phi::bfloat16) {
-  kernel->InputAt(0).SetDataType(phi::DataType::BOOL);
+  kernel->InputAt(1).SetDataType(phi::DataType::BOOL);
 }

--- a/paddle/phi/kernels/cpu/masked_scatter_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/masked_scatter_grad_kernel.cc
@@ -18,6 +18,7 @@
 
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/expand_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/common_infer_shape_functions.h"
 
 namespace phi {
@@ -29,6 +30,17 @@ void MaskedScatterGradKernel(const Context& dev_ctx,
                              const DenseTensor& out_grad,
                              DenseTensor* x_grad,
                              DenseTensor* value_grad) {
+  if (out_grad.numel() == 0 || mask.numel() == 0) {
+    if (x_grad) {
+      phi::Full<T, Context>(dev_ctx, x_grad->dims(), static_cast<T>(0), x_grad);
+    }
+    if (value_grad) {
+      phi::Full<T, Context>(
+          dev_ctx, value_grad->dims(), static_cast<T>(0), value_grad);
+    }
+    return;
+  }
+
   auto out_grad_dims = out_grad.dims();
   auto mask_dims = mask.dims();
   auto expanded_size =

--- a/paddle/phi/kernels/cpu/masked_scatter_kernel.cc
+++ b/paddle/phi/kernels/cpu/masked_scatter_kernel.cc
@@ -54,7 +54,7 @@ void MaskedScatterKernel(const Context& dev_ctx,
   }
 
   out->Resize(expanded_dims);
-  auto* out_data = dev_ctx.template HostAlloc<T>(out);
+  auto* out_data = dev_ctx.template Alloc<T>(out);
   auto* x_data = x_expand.data<T>();
   auto* mask_data = mask_expand.data<bool>();
   auto* value_data = value.data<T>();

--- a/paddle/phi/kernels/cpu/masked_scatter_kernel.cc
+++ b/paddle/phi/kernels/cpu/masked_scatter_kernel.cc
@@ -1,0 +1,99 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/masked_scatter_kernel.h"
+
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/expand_kernel.h"
+#include "paddle/phi/kernels/funcs/common_infer_shape_functions.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void MaskedScatterKernel(const Context& dev_ctx,
+                         const DenseTensor& x,
+                         const DenseTensor& mask,
+                         const DenseTensor& value,
+                         DenseTensor* out) {
+  if (x.numel() == 0 || mask.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
+
+  auto x_dims = x.dims();
+  auto mask_dims = mask.dims();
+  auto expanded_size =
+      vectorize(funcs::BroadcastTwoDims(x_dims, mask_dims, -1));
+  DDim expanded_dims = make_ddim(expanded_size);
+
+  DenseTensor mask_expand;
+  DenseTensor x_expand;
+
+  if (mask_dims != expanded_dims) {
+    ExpandKernel<bool, Context>(
+        dev_ctx, mask, IntArray(expanded_size), &mask_expand);
+  } else {
+    mask_expand = mask;
+  }
+
+  if (x_dims != expanded_dims) {
+    ExpandKernel<T, Context>(dev_ctx, x, IntArray(expanded_size), &x_expand);
+  } else {
+    x_expand = x;
+  }
+
+  out->Resize(expanded_dims);
+  auto* out_data = dev_ctx.template HostAlloc<T>(out);
+  auto* x_data = x_expand.data<T>();
+  auto* mask_data = mask_expand.data<bool>();
+  auto* value_data = value.data<T>();
+  int64_t total = x_expand.numel();
+  int64_t value_numel = value.numel();
+
+  int64_t count = 0;
+  for (int64_t i = 0; i < total; i++) {
+    if (mask_data[i]) {
+      PADDLE_ENFORCE_LT(
+          count,
+          value_numel,
+          common::errors::InvalidArgument(
+              "Number of True values in mask (%d) exceeds the number of "
+              "elements in value (%d).",
+              count + 1,
+              value_numel));
+      out_data[i] = value_data[count];
+      count++;
+    } else {
+      out_data[i] = x_data[i];
+    }
+  }
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(masked_scatter,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::MaskedScatterKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   int16_t,
+                   int8_t,
+                   uint8_t,
+                   phi::float16,
+                   phi::bfloat16) {
+  kernel->InputAt(1).SetDataType(phi::DataType::BOOL);
+}

--- a/paddle/phi/kernels/gpu/masked_scatter_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_scatter_grad_kernel.cu
@@ -25,6 +25,13 @@
 
 namespace phi {
 
+__global__ void BoolToInt64GradKernel(const bool* in, int64_t* out, int64_t n) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    out[idx] = static_cast<int64_t>(in[idx]);
+  }
+}
+
 template <typename T>
 __global__ void MaskedScatterGradXKernel(const T* out_grad_data,
                                          const bool* mask_data,
@@ -94,14 +101,23 @@ void MaskedScatterGradKernel(const Context& dev_ctx,
     Full<T, Context>(
         dev_ctx, value_grad->dims(), static_cast<T>(0), value_grad);
 
-    // Compute prefix sum of mask for scatter index using CUB directly
-    // on bool mask (avoids extra bool->int64 transform kernel)
+    // Compute prefix sum of mask for scatter index.
+    // Convert bool mask to int64 first for hipcub compatibility on DCU/ROCm.
     DenseTensor prefix_sum;
     prefix_sum.Resize(mask_expand.dims());
     dev_ctx.template Alloc<int64_t>(&prefix_sum);
     auto* prefix_sum_data = prefix_sum.data<int64_t>();
 
     {
+      // Cast bool -> int64
+      auto mask_int64_alloc =
+          phi::memory_utils::Alloc(dev_ctx.GetPlace(), total * sizeof(int64_t));
+      int64_t* mask_int64_data = static_cast<int64_t*>(mask_int64_alloc->ptr());
+      int block = 256;
+      int grid = static_cast<int>((total + block - 1) / block);
+      BoolToInt64GradKernel<<<grid, block, 0, stream>>>(
+          mask_data, mask_int64_data, total);
+
       void* temp_storage = nullptr;
       size_t temp_storage_bytes = 0;
       phi::Allocator::AllocationPtr allocation;
@@ -109,7 +125,7 @@ void MaskedScatterGradKernel(const Context& dev_ctx,
         PADDLE_ENFORCE_GPU_SUCCESS(
             cub::DeviceScan::ExclusiveSum(temp_storage,
                                           temp_storage_bytes,
-                                          mask_data,
+                                          mask_int64_data,
                                           prefix_sum_data,
                                           static_cast<int>(total),
                                           stream));

--- a/paddle/phi/kernels/gpu/masked_scatter_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_scatter_grad_kernel.cu
@@ -68,6 +68,17 @@ void MaskedScatterGradKernel(const Context& dev_ctx,
                              const DenseTensor& out_grad,
                              DenseTensor* x_grad,
                              DenseTensor* value_grad) {
+  if (out_grad.numel() == 0 || mask.numel() == 0) {
+    if (x_grad) {
+      phi::Full<T, Context>(dev_ctx, x_grad->dims(), static_cast<T>(0), x_grad);
+    }
+    if (value_grad) {
+      phi::Full<T, Context>(
+          dev_ctx, value_grad->dims(), static_cast<T>(0), value_grad);
+    }
+    return;
+  }
+
   auto out_grad_dims = out_grad.dims();
   auto mask_dims = mask.dims();
   auto expanded_size =

--- a/paddle/phi/kernels/gpu/masked_scatter_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_scatter_grad_kernel.cu
@@ -22,6 +22,8 @@
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/common_infer_shape_functions.h"
 #include "paddle/phi/kernels/funcs/cub.h"
+#include "paddle/phi/kernels/funcs/elementwise_base.h"
+#include "paddle/phi/kernels/reduce_sum_kernel.h"
 
 namespace phi {
 
@@ -63,6 +65,7 @@ __global__ void MaskedScatterGradValueKernel(const T* out_grad_data,
 
 template <typename T, typename Context>
 void MaskedScatterGradKernel(const Context& dev_ctx,
+                             const DenseTensor& x,
                              const DenseTensor& mask,
                              const DenseTensor& value,
                              const DenseTensor& out_grad,
@@ -99,11 +102,32 @@ void MaskedScatterGradKernel(const Context& dev_ctx,
 
   // Compute x_grad
   if (x_grad) {
-    dev_ctx.template Alloc<T>(x_grad);
+    auto x_grad_dims = x_grad->dims();
     auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, total);
-    MaskedScatterGradXKernel<T>
-        <<<config.block_per_grid, config.thread_per_block, 0, stream>>>(
-            out_grad.data<T>(), mask_data, total, x_grad->data<T>());
+
+    if (x_grad_dims == out_grad_dims) {
+      // No broadcast happened, compute directly into x_grad.
+      dev_ctx.template Alloc<T>(x_grad);
+      MaskedScatterGradXKernel<T>
+          <<<config.block_per_grid, config.thread_per_block, 0, stream>>>(
+              out_grad.data<T>(), mask_data, total, x_grad->data<T>());
+    } else {
+      // Broadcast happened: compute at broadcast shape, then reduce-sum.
+      DenseTensor x_grad_broadcast;
+      x_grad_broadcast.Resize(expanded_dims);
+      dev_ctx.template Alloc<T>(&x_grad_broadcast);
+      MaskedScatterGradXKernel<T>
+          <<<config.block_per_grid, config.thread_per_block, 0, stream>>>(
+              out_grad.data<T>(), mask_data, total, x_grad_broadcast.data<T>());
+      std::vector<int> reduce_dims =
+          funcs::GetReduceDim(x_grad_dims, expanded_dims, -1);
+      phi::SumKernel<T, Context>(dev_ctx,
+                                 x_grad_broadcast,
+                                 reduce_dims,
+                                 x_grad_broadcast.dtype(),
+                                 false,
+                                 x_grad);
+    }
   }
 
   // Compute value_grad
@@ -175,5 +199,5 @@ PD_REGISTER_KERNEL(masked_scatter_grad,
                    uint8_t,
                    phi::float16,
                    phi::bfloat16) {
-  kernel->InputAt(0).SetDataType(phi::DataType::BOOL);
+  kernel->InputAt(1).SetDataType(phi::DataType::BOOL);
 }

--- a/paddle/phi/kernels/gpu/masked_scatter_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_scatter_grad_kernel.cu
@@ -1,0 +1,152 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/masked_scatter_grad_kernel.h"
+
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_launch_config.h"
+#include "paddle/phi/common/memory_utils.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/expand_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/funcs/common_infer_shape_functions.h"
+#include "paddle/phi/kernels/funcs/cub.h"
+
+namespace phi {
+
+template <typename T>
+__global__ void MaskedScatterGradXKernel(const T* out_grad_data,
+                                         const bool* mask_data,
+                                         const int64_t total,
+                                         T* x_grad_data) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= total) return;
+
+  x_grad_data[idx] = mask_data[idx] ? static_cast<T>(0) : out_grad_data[idx];
+}
+
+template <typename T>
+__global__ void MaskedScatterGradValueKernel(const T* out_grad_data,
+                                             const bool* mask_data,
+                                             const int64_t* prefix_sum_data,
+                                             const int64_t total,
+                                             const int64_t value_numel,
+                                             T* value_grad_data) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= total) return;
+
+  if (mask_data[idx]) {
+    int64_t value_idx = prefix_sum_data[idx];
+    if (value_idx < value_numel) {
+      value_grad_data[value_idx] = out_grad_data[idx];
+    }
+  }
+}
+
+template <typename T, typename Context>
+void MaskedScatterGradKernel(const Context& dev_ctx,
+                             const DenseTensor& mask,
+                             const DenseTensor& value,
+                             const DenseTensor& out_grad,
+                             DenseTensor* x_grad,
+                             DenseTensor* value_grad) {
+  auto out_grad_dims = out_grad.dims();
+  auto mask_dims = mask.dims();
+  auto expanded_size =
+      vectorize(funcs::BroadcastTwoDims(out_grad_dims, mask_dims, -1));
+  DDim expanded_dims = make_ddim(expanded_size);
+
+  DenseTensor mask_expand;
+  if (mask_dims != expanded_dims) {
+    ExpandKernel<bool, Context>(
+        dev_ctx, mask, IntArray(expanded_size), &mask_expand);
+  } else {
+    mask_expand = mask;
+  }
+
+  int64_t total = out_grad.numel();
+  auto stream = dev_ctx.stream();
+  auto* mask_data = mask_expand.data<bool>();
+
+  // Compute x_grad
+  if (x_grad) {
+    dev_ctx.template Alloc<T>(x_grad);
+    auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, total);
+    MaskedScatterGradXKernel<T>
+        <<<config.block_per_grid, config.thread_per_block, 0, stream>>>(
+            out_grad.data<T>(), mask_data, total, x_grad->data<T>());
+  }
+
+  // Compute value_grad
+  if (value_grad) {
+    int64_t value_numel = value_grad->numel();
+    Full<T, Context>(
+        dev_ctx, value_grad->dims(), static_cast<T>(0), value_grad);
+
+    // Compute prefix sum of mask for scatter index using CUB directly
+    // on bool mask (avoids extra bool->int64 transform kernel)
+    DenseTensor prefix_sum;
+    prefix_sum.Resize(mask_expand.dims());
+    dev_ctx.template Alloc<int64_t>(&prefix_sum);
+    auto* prefix_sum_data = prefix_sum.data<int64_t>();
+
+    {
+      void* temp_storage = nullptr;
+      size_t temp_storage_bytes = 0;
+      phi::Allocator::AllocationPtr allocation;
+      for (int i = 0; i < 2; ++i) {
+        PADDLE_ENFORCE_GPU_SUCCESS(
+            cub::DeviceScan::ExclusiveSum(temp_storage,
+                                          temp_storage_bytes,
+                                          mask_data,
+                                          prefix_sum_data,
+                                          static_cast<int>(total),
+                                          stream));
+        if (i == 0 && temp_storage_bytes > 0) {
+          allocation =
+              phi::memory_utils::Alloc(dev_ctx.GetPlace(), temp_storage_bytes);
+          temp_storage = allocation->ptr();
+        }
+      }
+    }
+
+    auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, total);
+    MaskedScatterGradValueKernel<T>
+        <<<config.block_per_grid, config.thread_per_block, 0, stream>>>(
+            out_grad.data<T>(),
+            mask_data,
+            prefix_sum_data,
+            total,
+            value_numel,
+            value_grad->data<T>());
+  }
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(masked_scatter_grad,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::MaskedScatterGradKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   int16_t,
+                   int8_t,
+                   uint8_t,
+                   phi::float16,
+                   phi::bfloat16) {
+  kernel->InputAt(0).SetDataType(phi::DataType::BOOL);
+}

--- a/paddle/phi/kernels/gpu/masked_scatter_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_scatter_kernel.cu
@@ -1,0 +1,150 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/masked_scatter_kernel.h"
+
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_launch_config.h"
+#include "paddle/phi/common/memory_utils.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/expand_kernel.h"
+#include "paddle/phi/kernels/funcs/common_infer_shape_functions.h"
+#include "paddle/phi/kernels/funcs/cub.h"
+
+namespace phi {
+
+// CUB-based mask exclusive sum: directly scans bool input to int64 output
+// in a single pass, matching PyTorch's at::cuda::cub::mask_exclusive_sum.
+static void MaskExclusiveSum(const bool* mask_data,
+                             int64_t* prefix_sum_data,
+                             int64_t n,
+                             const phi::Place& place,
+                             gpuStream_t stream) {
+  void* temp_storage = nullptr;
+  size_t temp_storage_bytes = 0;
+  phi::Allocator::AllocationPtr allocation;
+
+  // First call to get temp storage size, second call to run the scan
+  for (int i = 0; i < 2; ++i) {
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        cub::DeviceScan::ExclusiveSum(temp_storage,
+                                      temp_storage_bytes,
+                                      mask_data,
+                                      prefix_sum_data,
+                                      static_cast<int>(n),
+                                      stream));
+    if (i == 0 && temp_storage_bytes > 0) {
+      allocation = phi::memory_utils::Alloc(place, temp_storage_bytes);
+      temp_storage = allocation->ptr();
+    }
+  }
+}
+
+template <typename T>
+__global__ void MaskedScatterCUDAKernel(const T* x_data,
+                                        const bool* mask_data,
+                                        const T* value_data,
+                                        const int64_t* prefix_sum_data,
+                                        const int64_t total,
+                                        T* out_data) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= total) return;
+
+  if (mask_data[idx]) {
+    out_data[idx] = value_data[prefix_sum_data[idx]];
+  } else {
+    out_data[idx] = x_data[idx];
+  }
+}
+
+template <typename T, typename Context>
+void MaskedScatterKernel(const Context& dev_ctx,
+                         const DenseTensor& x,
+                         const DenseTensor& mask,
+                         const DenseTensor& value,
+                         DenseTensor* out) {
+  if (x.numel() == 0 || mask.numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
+
+  auto x_dims = x.dims();
+  auto mask_dims = mask.dims();
+  auto expanded_size =
+      vectorize(funcs::BroadcastTwoDims(x_dims, mask_dims, -1));
+  DDim expanded_dims = make_ddim(expanded_size);
+
+  DenseTensor mask_expand;
+  DenseTensor x_expand;
+
+  if (mask_dims != expanded_dims) {
+    ExpandKernel<bool, Context>(
+        dev_ctx, mask, IntArray(expanded_size), &mask_expand);
+  } else {
+    mask_expand = mask;
+  }
+
+  if (x_dims != expanded_dims) {
+    ExpandKernel<T, Context>(dev_ctx, x, IntArray(expanded_size), &x_expand);
+  } else {
+    x_expand = x;
+  }
+
+  out->Resize(expanded_dims);
+  dev_ctx.template Alloc<T>(out);
+
+  int64_t total = x_expand.numel();
+  auto stream = dev_ctx.stream();
+  auto* mask_bool_data = mask_expand.data<bool>();
+
+  // Use CUB ExclusiveSum directly on bool mask -> int64 prefix sum
+  // This avoids the extra bool->int64 transform kernel that the old
+  // thrust-based implementation required (matching PyTorch's approach).
+  DenseTensor prefix_sum;
+  prefix_sum.Resize(mask_expand.dims());
+  dev_ctx.template Alloc<int64_t>(&prefix_sum);
+  auto* prefix_sum_data = prefix_sum.data<int64_t>();
+
+  MaskExclusiveSum(
+      mask_bool_data, prefix_sum_data, total, dev_ctx.GetPlace(), stream);
+
+  // Launch masked scatter kernel
+  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, total);
+  MaskedScatterCUDAKernel<T>
+      <<<config.block_per_grid, config.thread_per_block, 0, stream>>>(
+          x_expand.data<T>(),
+          mask_bool_data,
+          value.data<T>(),
+          prefix_sum_data,
+          total,
+          out->data<T>());
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(masked_scatter,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::MaskedScatterKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   int16_t,
+                   int8_t,
+                   uint8_t,
+                   phi::float16,
+                   phi::bfloat16) {
+  kernel->InputAt(1).SetDataType(phi::DataType::BOOL);
+}

--- a/paddle/phi/kernels/gpu/masked_scatter_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_scatter_kernel.cu
@@ -24,13 +24,29 @@
 
 namespace phi {
 
-// CUB-based mask exclusive sum: directly scans bool input to int64 output
-// in a single pass, matching PyTorch's at::cuda::cub::mask_exclusive_sum.
+__global__ void BoolToInt64Kernel(const bool* in, int64_t* out, int64_t n) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    out[idx] = static_cast<int64_t>(in[idx]);
+  }
+}
+
+// Mask exclusive sum: converts bool mask to int64, then runs CUB ExclusiveSum.
+// hipcub on ROCm/DCU does not reliably handle mismatched input (bool*) and
+// output (int64_t*) types in ExclusiveSum, so we cast explicitly.
 static void MaskExclusiveSum(const bool* mask_data,
                              int64_t* prefix_sum_data,
                              int64_t n,
                              const phi::Place& place,
                              gpuStream_t stream) {
+  // Convert bool mask to int64 for CUB compatibility
+  auto mask_int64_alloc = phi::memory_utils::Alloc(place, n * sizeof(int64_t));
+  int64_t* mask_int64_data = static_cast<int64_t*>(mask_int64_alloc->ptr());
+
+  int block = 256;
+  int grid = static_cast<int>((n + block - 1) / block);
+  BoolToInt64Kernel<<<grid, block, 0, stream>>>(mask_data, mask_int64_data, n);
+
   void* temp_storage = nullptr;
   size_t temp_storage_bytes = 0;
   phi::Allocator::AllocationPtr allocation;
@@ -40,7 +56,7 @@ static void MaskExclusiveSum(const bool* mask_data,
     PADDLE_ENFORCE_GPU_SUCCESS(
         cub::DeviceScan::ExclusiveSum(temp_storage,
                                       temp_storage_bytes,
-                                      mask_data,
+                                      mask_int64_data,
                                       prefix_sum_data,
                                       static_cast<int>(n),
                                       stream));
@@ -124,9 +140,7 @@ void MaskedScatterKernel(const Context& dev_ctx,
   auto stream = dev_ctx.stream();
   auto* mask_bool_data = mask_expand.data<bool>();
 
-  // Use CUB ExclusiveSum directly on bool mask -> int64 prefix sum
-  // This avoids the extra bool->int64 transform kernel that the old
-  // thrust-based implementation required (matching PyTorch's approach).
+  // Compute exclusive prefix sum of the bool mask -> int64 prefix sum.
   DenseTensor prefix_sum;
   prefix_sum.Resize(mask_expand.dims());
   dev_ctx.template Alloc<int64_t>(&prefix_sum);

--- a/paddle/phi/kernels/gpu/masked_scatter_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_scatter_kernel.cu
@@ -51,6 +51,22 @@ static void MaskExclusiveSum(const bool* mask_data,
   }
 }
 
+// Asynchronously check that the number of `1` elements present in the mask
+// must be <= the number of elements available in `source`.
+// This mirrors PyTorch's masked_scatter_size_check kernel: a single-thread
+// kernel that avoids any D2H memcpy and stream synchronization.
+__global__ void MaskedScatterSizeCheck(const int64_t* mask_exclusive_sum,
+                                       const bool* mask,
+                                       int64_t srcSize) {
+  // Convert exclusive sum to inclusive sum
+  const auto totalElements = *mask_exclusive_sum + static_cast<int64_t>(*mask);
+  PADDLE_ENFORCE(totalElements <= srcSize,
+                 "The number of True elements in mask (%ld) exceeds "
+                 "the number of elements in source (%ld).",
+                 totalElements,
+                 srcSize);
+}
+
 template <typename T>
 __global__ void MaskedScatterCUDAKernel(const T* x_data,
                                         const bool* mask_data,
@@ -118,6 +134,11 @@ void MaskedScatterKernel(const Context& dev_ctx,
 
   MaskExclusiveSum(
       mask_bool_data, prefix_sum_data, total, dev_ctx.GetPlace(), stream);
+
+  // Asynchronously check that the number of `1` elements present in the mask
+  // must be <= the number of elements available in `source`.
+  MaskedScatterSizeCheck<<<1, 1, 0, stream>>>(
+      &prefix_sum_data[total - 1], &mask_bool_data[total - 1], value.numel());
 
   // Launch masked scatter kernel
   auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, total);

--- a/paddle/phi/kernels/masked_scatter_grad_kernel.h
+++ b/paddle/phi/kernels/masked_scatter_grad_kernel.h
@@ -20,6 +20,7 @@ namespace phi {
 
 template <typename T, typename Context>
 void MaskedScatterGradKernel(const Context& dev_ctx,
+                             const DenseTensor& x,
                              const DenseTensor& mask,
                              const DenseTensor& value,
                              const DenseTensor& out_grad,

--- a/paddle/phi/kernels/masked_scatter_grad_kernel.h
+++ b/paddle/phi/kernels/masked_scatter_grad_kernel.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void MaskedScatterGradKernel(const Context& dev_ctx,
+                             const DenseTensor& mask,
+                             const DenseTensor& value,
+                             const DenseTensor& out_grad,
+                             DenseTensor* x_grad,
+                             DenseTensor* value_grad);
+
+}  // namespace phi

--- a/paddle/phi/kernels/masked_scatter_kernel.h
+++ b/paddle/phi/kernels/masked_scatter_kernel.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void MaskedScatterKernel(const Context& dev_ctx,
+                         const DenseTensor& x,
+                         const DenseTensor& mask,
+                         const DenseTensor& value,
+                         DenseTensor* out);
+
+}  // namespace phi

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2337,15 +2337,15 @@
 
 - backward_op : masked_scatter_grad
   forward : masked_scatter (Tensor x, Tensor mask, Tensor value) -> Tensor(out)
-  args : (Tensor mask, Tensor value, Tensor out_grad)
+  args : (Tensor x, Tensor mask, Tensor value, Tensor out_grad)
   output : Tensor(x_grad), Tensor(value_grad)
   infer_meta :
     func : GeneralBinaryGradInferMeta
-    param : [out_grad, value]
+    param : [x, value]
   kernel :
     func : masked_scatter_grad
     data_type : out_grad
-  no_need_buffer : value
+  no_need_buffer : x, value
 
 - backward_op : masked_select_double_grad
   forward: masked_select_grad (Tensor x, Tensor mask, Tensor grad_out) -> Tensor(grad_x)

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -2335,6 +2335,18 @@
   no_need_buffer : x, value
   backward: masked_fill_double_grad
 
+- backward_op : masked_scatter_grad
+  forward : masked_scatter (Tensor x, Tensor mask, Tensor value) -> Tensor(out)
+  args : (Tensor mask, Tensor value, Tensor out_grad)
+  output : Tensor(x_grad), Tensor(value_grad)
+  infer_meta :
+    func : GeneralBinaryGradInferMeta
+    param : [out_grad, value]
+  kernel :
+    func : masked_scatter_grad
+    data_type : out_grad
+  no_need_buffer : value
+
 - backward_op : masked_select_double_grad
   forward: masked_select_grad (Tensor x, Tensor mask, Tensor grad_out) -> Tensor(grad_x)
   args : (Tensor mask, Tensor grad_x_grad)

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -3569,6 +3569,17 @@
   interfaces : paddle::dialect::InferSymbolicShapeInterface
   traits : paddle::dialect::ForwardOnlyTrait
 
+- op : masked_scatter
+  args : (Tensor x, Tensor mask, Tensor value)
+  output : Tensor (out)
+  inplace: (x -> out)
+  infer_meta :
+    func : MaskedScatterInferMeta
+  kernel :
+    func : masked_scatter
+    data_type : x
+  backward : masked_scatter_grad
+
 - op : masked_select
   args : (Tensor x, Tensor mask)
   output : Tensor (out)

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -5666,23 +5666,26 @@ def masked_scatter(
              [-0.31660911,  0.04793844]])
 
     """
-    if mask.dtype != paddle.bool:
-        mask = paddle.cast(mask, 'bool')
+    # make sure the dtype of x and value is the same
+    assert x.dtype == value.dtype, (
+        f'x and value must have the same dtype, but got x dtype is {x.dtype}, value dtype is {value.dtype}'
+    )
+    assert mask.dtype == paddle.bool
 
     if paddle.is_compiled_with_cuda() and in_dynamic_or_pir_mode():
         return _C_ops.masked_scatter(x, mask, value)
-    else:
-        zeros_like_x = paddle.zeros_like(x, dtype=int)
-        mask = paddle.add(paddle.cast(mask, dtype="int"), zeros_like_x)
-        mask_prefix = paddle.clip(mask.cumsum() - 1, min=0)
-        if in_dynamic_mode() and mask_prefix.numel() != 0:
-            assert mask_prefix[-1] <= value.numel(), (
-                f'mask true nums must be <= value size, but got mask true nums is {mask_prefix[-1].item()}, value size is {value.numel().item()}'
-            )
 
-        value = value.flatten()[mask_prefix].reshape(mask.shape)
-        mask = paddle.logical_not(mask.astype(bool))
-        return paddle.where(mask, x, value)
+    zeros_like_x = paddle.zeros_like(x, dtype=int)
+    mask = paddle.add(paddle.cast(mask, dtype="int"), zeros_like_x)
+    mask_prefix = paddle.clip(mask.cumsum() - 1, min=0)
+    if in_dynamic_mode() and mask_prefix.numel() != 0:
+        assert mask_prefix[-1] <= value.numel(), (
+            f'mask true nums must be <= value size, but got mask true nums is {mask_prefix[-1].item()}, value size is {value.numel().item()}'
+        )
+
+    value = value.flatten()[mask_prefix].reshape(mask.shape)
+    mask = paddle.logical_not(mask.astype(bool))
+    return paddle.where(mask, x, value)
 
 
 @inplace_apis_in_dygraph_only
@@ -5693,10 +5696,26 @@ def masked_scatter_(
     Inplace version of ``masked_scatter`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_masked_scatter`.
     """
-    if mask.dtype != paddle.bool:
-        mask = paddle.cast(mask, 'bool')
+    # make sure the dtype of x and value is the same
+    assert x.dtype == value.dtype, (
+        f'x and value must have the same dtype, but got x dtype is {x.dtype}, value dtype is {value.dtype}'
+    )
+    assert mask.dtype == paddle.bool
 
-    return _C_ops.masked_scatter_(x, mask, value)
+    if paddle.is_compiled_with_cuda() and in_dynamic_or_pir_mode():
+        return _C_ops.masked_scatter_(x, mask, value)
+
+    zeros_like_x = paddle.zeros_like(x, dtype=int)
+    mask = paddle.add(paddle.cast(mask, dtype="int"), zeros_like_x)
+    mask_prefix = paddle.clip(mask.cumsum() - 1, min=0)
+    assert mask_prefix[-1] <= value.numel(), (
+        f'mask true nums must be <= value size, but got mask true nums is {mask_prefix[-1].item()}, value size is {value.numel().item()}'
+    )
+
+    value = value.flatten()[mask_prefix].reshape(mask.shape)
+    mask = paddle.logical_not(mask.astype(bool))
+    out = paddle.where_(mask, x, value)
+    return out
 
 
 @inplace_apis_in_dygraph_only

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -5666,23 +5666,23 @@ def masked_scatter(
              [-0.31660911,  0.04793844]])
 
     """
-    # make sure the dtype of x and value is the same
-    assert x.dtype == value.dtype, (
-        f'x and value must have the same dtype, but got x dtype is {x.dtype}, value dtype is {value.dtype}'
-    )
-    assert mask.dtype == paddle.bool
+    if mask.dtype != paddle.bool:
+        mask = paddle.cast(mask, 'bool')
 
-    zeros_like_x = paddle.zeros_like(x, dtype=int)
-    mask = paddle.add(paddle.cast(mask, dtype="int"), zeros_like_x)
-    mask_prefix = paddle.clip(mask.cumsum() - 1, min=0)
-    if in_dynamic_mode() and mask_prefix.numel() != 0:
-        assert mask_prefix[-1] <= value.numel(), (
-            f'mask true nums must be <= value size, but got mask true nums is {mask_prefix[-1].item()}, value size is {value.numel().item()}'
-        )
+    if paddle.is_compiled_with_cuda() and in_dynamic_or_pir_mode():
+        return _C_ops.masked_scatter(x, mask, value)
+    else:
+        zeros_like_x = paddle.zeros_like(x, dtype=int)
+        mask = paddle.add(paddle.cast(mask, dtype="int"), zeros_like_x)
+        mask_prefix = paddle.clip(mask.cumsum() - 1, min=0)
+        if in_dynamic_mode() and mask_prefix.numel() != 0:
+            assert mask_prefix[-1] <= value.numel(), (
+                f'mask true nums must be <= value size, but got mask true nums is {mask_prefix[-1].item()}, value size is {value.numel().item()}'
+            )
 
-    value = value.flatten()[mask_prefix].reshape(mask.shape)
-    mask = paddle.logical_not(mask.astype(bool))
-    return paddle.where(mask, x, value)
+        value = value.flatten()[mask_prefix].reshape(mask.shape)
+        mask = paddle.logical_not(mask.astype(bool))
+        return paddle.where(mask, x, value)
 
 
 @inplace_apis_in_dygraph_only
@@ -5693,21 +5693,10 @@ def masked_scatter_(
     Inplace version of ``masked_scatter`` API, the output Tensor will be inplaced with input ``x``.
     Please refer to :ref:`api_paddle_masked_scatter`.
     """
-    assert x.dtype == value.dtype, (
-        f'x and value must have the same dtype, but got x dtype is {x.dtype}, value dtype is {value.dtype}'
-    )
-    assert mask.dtype == paddle.bool
-    zeros_like_x = paddle.zeros_like(x, dtype=int)
-    mask = paddle.add(paddle.cast(mask, dtype="int"), zeros_like_x)
-    mask_prefix = paddle.clip(mask.cumsum() - 1, min=0)
-    assert mask_prefix[-1] <= value.numel(), (
-        f'mask true nums must be <= value size, but got mask true nums is {mask_prefix[-1].item()}, value size is {value.numel().item()}'
-    )
+    if mask.dtype != paddle.bool:
+        mask = paddle.cast(mask, 'bool')
 
-    value = value.flatten()[mask_prefix].reshape(mask.shape)
-    mask = paddle.logical_not(mask.astype(bool))
-    out = paddle.where_(mask, x, value)
-    return out
+    return _C_ops.masked_scatter_(x, mask, value)
 
 
 @inplace_apis_in_dygraph_only

--- a/test/legacy_test/test_masked_scatter.py
+++ b/test/legacy_test/test_masked_scatter.py
@@ -71,7 +71,24 @@ class TestMaskedScatterError(unittest.TestCase):
         with np.testing.assert_raises(AssertionError):
             paddle.masked_scatter(x, mask, value)
 
+    @unittest.skipIf(
+        core.is_compiled_with_cuda(),
+        "core is compiled with CUDA",
+    )
     def test_numel_error(self):
+        paddle.disable_static()
+        self.value_np = np.random.randn(5, 5).astype(self.dtype)
+        x = paddle.to_tensor(self.x_np, dtype=self.dtype)
+        mask = paddle.to_tensor(self.mask_np).astype('bool')
+        value = paddle.to_tensor(self.value_np, dtype=self.dtype)
+        with np.testing.assert_raises(AssertionError):
+            paddle.masked_scatter(x, mask, value)
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda(),
+        "core is not compiled with CUDA",
+    )
+    def test_numel_error_cuda(self):
         # The size check kernel uses asm("trap;") which fatally corrupts the
         # CUDA context.  Run in a subprocess so the parent stays healthy.
         code = """

--- a/test/legacy_test/test_masked_scatter.py
+++ b/test/legacy_test/test_masked_scatter.py
@@ -116,7 +116,10 @@ paddle.device.cuda.synchronize()
         combined = (proc.stdout + proc.stderr).lower()
         self.assertTrue(
             "number of true elements in mask" in combined
-            or "cuda error" in combined,
+            or "cuda error" in combined
+            or "hip error" in combined
+            or "device-side assert" in combined
+            or "abort" in combined,
             f"Expected masked_scatter size-check error, got:\n{combined}",
         )
 

--- a/test/legacy_test/test_masked_scatter.py
+++ b/test/legacy_test/test_masked_scatter.py
@@ -464,6 +464,14 @@ class TestMaskedScatterCPUBroadcast2(TestMaskedScatterCPU):
 
 class TestMaskedScatterCPUBroadcast3(TestMaskedScatterCPU):
     def init(self):
+        self.x_shape = (120,)
+        self.mask_shape = (300, 120)
+        self.dtype = "float32"
+        self.value_shape = (300, 300)
+
+
+class TestMaskedScatterCPUBroadcast4(TestMaskedScatterCPU):
+    def init(self):
         self.x_shape = (300, 40)
         self.mask_shape = (40,)
         self.dtype = "float32"

--- a/test/legacy_test/test_masked_scatter.py
+++ b/test/legacy_test/test_masked_scatter.py
@@ -417,11 +417,7 @@ class TestMaskedScatterCPU(TestMaskedScatterAPI):
         result = paddle.masked_scatter(x, mask, value)
         loss = paddle.sum(result)
         loss.backward()
-        # x.grad has the broadcast shape (x broadcasted with mask)
-        broadcast_shape = list(
-            np.broadcast_shapes(self.x_np.shape, self.mask_np.shape)
-        )
-        self.assertEqual(list(x.grad.shape), broadcast_shape)
+        self.assertEqual(list(x.grad.shape), list(self.x_np.shape))
         self.assertEqual(list(value.grad.shape), list(self.value_np.shape))
         paddle.enable_static()
 
@@ -467,14 +463,6 @@ class TestMaskedScatterCPUBroadcast2(TestMaskedScatterCPU):
 
 
 class TestMaskedScatterCPUBroadcast3(TestMaskedScatterCPU):
-    def init(self):
-        self.x_shape = (120,)
-        self.mask_shape = (300, 120)
-        self.dtype = "float32"
-        self.value_shape = (300, 300)
-
-
-class TestMaskedScatterCPUBroadcast4(TestMaskedScatterCPU):
     def init(self):
         self.x_shape = (300, 40)
         self.mask_shape = (40,)

--- a/test/legacy_test/test_masked_scatter.py
+++ b/test/legacy_test/test_masked_scatter.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import subprocess
+import sys
 import unittest
 
 import numpy as np
@@ -70,13 +72,36 @@ class TestMaskedScatterError(unittest.TestCase):
             paddle.masked_scatter(x, mask, value)
 
     def test_numel_error(self):
-        paddle.disable_static()
-        self.value_np = np.random.randn(5, 5).astype(self.dtype)
-        x = paddle.to_tensor(self.x_np, dtype=self.dtype)
-        mask = paddle.to_tensor(self.mask_np).astype('bool')
-        value = paddle.to_tensor(self.value_np, dtype=self.dtype)
-        with np.testing.assert_raises(AssertionError):
-            paddle.masked_scatter(x, mask, value)
+        # The size check kernel uses asm("trap;") which fatally corrupts the
+        # CUDA context.  Run in a subprocess so the parent stays healthy.
+        code = """
+import numpy as np
+import paddle
+paddle.disable_static()
+x_np = np.random.random((50, 3)).astype("float32")
+mask_np = np.ones((50, 3), dtype="bool")
+value_np = np.random.randn(5, 5).astype("float32")
+x = paddle.to_tensor(x_np)
+mask = paddle.to_tensor(mask_np)
+value = paddle.to_tensor(value_np)
+out = paddle.masked_scatter(x, mask, value)
+# Force synchronization so the device-side trap error surfaces.
+paddle.device.cuda.synchronize()
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        # Device-side printf may go to stdout; the OSError traceback is
+        # on stderr.  Check both for the kernel error message.
+        combined = (proc.stdout + proc.stderr).lower()
+        self.assertTrue(
+            "number of true elements in mask" in combined
+            or "cuda error" in combined,
+            f"Expected masked_scatter size-check error, got:\n{combined}",
+        )
 
 
 class TestMaskedScatterAPI(unittest.TestCase):

--- a/test/legacy_test/test_masked_scatter.py
+++ b/test/legacy_test/test_masked_scatter.py
@@ -362,6 +362,126 @@ class TestMaskedScatterBF16APIBroadcast2(TestMaskedScatterBF16):
         self.value_shape = (300, 300)
 
 
+class TestMaskedScatterCPU(TestMaskedScatterAPI):
+    """Explicitly run masked_scatter tests on CPUPlace to guarantee CPU
+    coverage regardless of whether the build includes CUDA."""
+
+    def test_static_graph(self):
+        paddle.enable_static()
+        startup_program = base.Program()
+        train_program = base.Program()
+        with base.program_guard(startup_program, train_program):
+            x = paddle.static.data(
+                name='x', dtype=self.dtype, shape=self.x_shape
+            )
+            mask = paddle.static.data(
+                name='mask', dtype='bool', shape=self.mask_shape
+            )
+            value = paddle.static.data(
+                name='value', dtype=self.dtype, shape=self.value_np.shape
+            )
+            out = paddle.masked_scatter(x, mask, value)
+
+            place = core.CPUPlace()
+            exe = base.Executor(place)
+            res = exe.run(
+                base.default_main_program(),
+                feed={
+                    'x': self.x_np,
+                    'mask': self.mask_np,
+                    'value': self.value_np,
+                },
+                fetch_list=[out],
+            )
+            np.testing.assert_allclose(
+                res[0], self.out_np, atol=1e-5, rtol=1e-5
+            )
+            paddle.disable_static()
+
+    def test_dygraph(self):
+        paddle.disable_static(paddle.CPUPlace())
+        x = paddle.to_tensor(self.x_np, dtype=self.dtype)
+        mask = paddle.to_tensor(self.mask_np).astype('bool')
+        value = paddle.to_tensor(self.value_np, dtype=self.dtype)
+        result = paddle.masked_scatter(x, mask, value)
+        np.testing.assert_allclose(self.out_np, result.numpy(), rtol=1e-05)
+        paddle.enable_static()
+
+    def test_dygraph_grad(self):
+        paddle.disable_static(paddle.CPUPlace())
+        x = paddle.to_tensor(self.x_np, dtype=self.dtype)
+        x.stop_gradient = False
+        mask = paddle.to_tensor(self.mask_np).astype('bool')
+        value = paddle.to_tensor(self.value_np, dtype=self.dtype)
+        value.stop_gradient = False
+        result = paddle.masked_scatter(x, mask, value)
+        loss = paddle.sum(result)
+        loss.backward()
+        # x.grad has the broadcast shape (x broadcasted with mask)
+        broadcast_shape = list(
+            np.broadcast_shapes(self.x_np.shape, self.mask_np.shape)
+        )
+        self.assertEqual(list(x.grad.shape), broadcast_shape)
+        self.assertEqual(list(value.grad.shape), list(self.value_np.shape))
+        paddle.enable_static()
+
+
+class TestMaskedScatterCPU1(TestMaskedScatterCPU):
+    def init(self):
+        self.x_shape = (6, 8, 9, 18)
+        self.mask_shape = self.x_shape
+        self.dtype = "float32"
+        self.value_shape = (300, 300)
+
+
+class TestMaskedScatterCPU2(TestMaskedScatterCPU):
+    def init(self):
+        self.x_shape = (168,)
+        self.mask_shape = self.x_shape
+        self.dtype = "float32"
+        self.value_shape = (300, 300)
+
+
+class TestMaskedScatterCPUFloat64(TestMaskedScatterCPU):
+    def init(self):
+        self.x_shape = (50, 3)
+        self.mask_shape = self.x_shape
+        self.dtype = "float64"
+        self.value_shape = (300, 300)
+
+
+class TestMaskedScatterCPUBroadcast(TestMaskedScatterCPU):
+    def init(self):
+        self.x_shape = (3, 40)
+        self.mask_shape = (3, 1)
+        self.dtype = "float32"
+        self.value_shape = (300, 300)
+
+
+class TestMaskedScatterCPUBroadcast2(TestMaskedScatterCPU):
+    def init(self):
+        self.x_shape = (3, 3)
+        self.mask_shape = (1, 3)
+        self.dtype = "float32"
+        self.value_shape = (300, 300)
+
+
+class TestMaskedScatterCPUBroadcast3(TestMaskedScatterCPU):
+    def init(self):
+        self.x_shape = (120,)
+        self.mask_shape = (300, 120)
+        self.dtype = "float32"
+        self.value_shape = (300, 300)
+
+
+class TestMaskedScatterCPUBroadcast4(TestMaskedScatterCPU):
+    def init(self):
+        self.x_shape = (300, 40)
+        self.mask_shape = (40,)
+        self.dtype = "float32"
+        self.value_shape = (300, 300)
+
+
 class TestMaskedScatterAPI_ZeroSize(unittest.TestCase):
     def setUp(self):
         self.init()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Performance

### Description

This PR adds native C++ kernels (CPU & GPU) for `masked_scatter` and `masked_scatter_grad`, replacing the previous pure-Python composite implementation with a high-performance operator.

### Motivation

The existing `paddle.masked_scatter` was implemented purely in Python using composite operations (`cumsum`, `where`, `flatten`, etc.), which has significant overhead for large tensors. This PR adds dedicated C++ forward and backward kernels for both CPU and GPU to improve performance.

### Modifications

- **InferMeta**: Added `MaskedScatterInferMeta` in `paddle/phi/infermeta/multiary.cc/.h`
- **CPU kernels**:
  - `paddle/phi/kernels/cpu/masked_scatter_kernel.cc` (forward)
  - `paddle/phi/kernels/cpu/masked_scatter_grad_kernel.cc` (backward)
- **GPU kernels**:
  - `paddle/phi/kernels/gpu/masked_scatter_kernel.cu` (forward)
  - `paddle/phi/kernels/gpu/masked_scatter_grad_kernel.cu` (backward)
- **Kernel headers**:
  - `paddle/phi/kernels/masked_scatter_kernel.h`
  - `paddle/phi/kernels/masked_scatter_grad_kernel.h`
- **YAML registration**: Added op config in `ops.yaml` and `backward.yaml`
- **Python API**: Updated `python/paddle/tensor/manipulation.py` to dispatch to the C++ kernel when CUDA is available, with fallback to the original composite implementation

### Key Design

- Forward kernel: Uses prefix-sum on the boolean mask to map each `True` position to the corresponding index in the flattened `value` tensor.
- Backward kernel: Computes gradients for both `x` (masked fill with zeros) and `value` (gather gradients from `out_grad` at mask positions).
- Supports inplace operation (`masked_scatter_`).

### 性能对比
#### 前向：
<img width="2128" height="798" alt="image" src="https://github.com/user-attachments/assets/0fc5ad59-0fdd-4f45-9d70-01c2d132bad0" />

#### 反向：
<img width="2320" height="698" alt="image" src="https://github.com/user-attachments/assets/e09ab4d9-ec2a-4d71-8023-c05f9a3f6753" />


### 是否引起精度变化
否
