### PR TITLE
[CMake] Fix Windows build failure with `WITH_ONEMKL` due to lowercase win32 variable

### DIFF
--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -353,7 +353,7 @@ if(WITH_GPU OR WITH_ROCM)
 endif()
 
 if(MKL_FOUND AND WITH_ONEMKL)
-  if(win32)
+  if(WIN32)
     target_include_directories(phi PRIVATE ${MKL_INCLUDE})
   else()
     target_include_directories(phi_core PRIVATE ${MKL_INCLUDE})


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
修复 #77689 中报告的 Windows 构建失败问题。

**问题原因：**
paddle/phi/CMakeLists.txt 中使用了小写的 `win32`，而 CMake 内置平台变量应为大写 `WIN32`。这导致条件判断始终为 false，Windows 构建时错误地对不存在的 `phi_core` 目标调用 `target_include_directories`。

**修复内容：**
```cmake
# 修改前
if(win32)

# 修改后
if(WIN32)
```

**影响范围：**
修复 Windows 平台使用 WITH_ONEMKL=ON 构建时的 CMake 配置错误，使 Intel oneMKL 加速的 FFT 计算功能可以正常编译。

Fixes: #77689

### 是否引起精度变化
否