### PR TITLE
[CI] Fix PR template error message not displaying in GitHub Actions

### DIFF
--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -36,24 +36,25 @@ jobs:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ github.base_ref }}
         run: |
-          python3 tools/CheckPRTemplate.py; EXCODE=$?
+          set +e
+          python3 tools/CheckPRTemplate.py
+          EXCODE=$?
+          set -e
           echo "EXCODE: $EXCODE"
           echo "ipipe_log_param_EXCODE: $EXCODE"
-          set +x
           if [[ "$EXCODE" != "0" ]];then
             echo -e "######################################################"
             echo -e "If you encounter a situation where the PR template does not match the error message, please use the following link to update your PR: [  https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/.github/PULL_REQUEST_TEMPLATE.md ]"
-            echo -e "##ReferenceDocumentation: ##"
+            echo -e "## Reference Documentation: ##"
             echo -e "[ https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE ]"
             echo -e "[ https://github.com/PaddlePaddle/Paddle/wiki/paddle_ci_manual ]"
             echo -e "######################################################"
+            exit $EXCODE
           fi
-          [[ $EXCODE -eq 0 ]] && {
-            export method=$method
-            echo $method
-            set +x
-            source ~/.icafe
-            wget -q --no-check-certificate https://paddle-qa.bj.bcebos.com/baidu/cloud/modify_icafe.py
-            set -x
-            python3 modify_icafe.py
-          }
+          export method=$method
+          echo $method
+          set +x
+          source ~/.icafe
+          wget -q --no-check-certificate https://paddle-qa.bj.bcebos.com/baidu/cloud/modify_icafe.py
+          set -x
+          python3 modify_icafe.py


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Improvements

### Description
修复 CheckPRTemplate.yml 工作流中，当 PR 模板检查失败时，错误提示信息无法在 GitHub Actions 日志中显示的问题。

**问题原因：**
原脚本使用 `set +x` 只是关闭命令回显，但 Python 脚本以非零退出码退出时，shell 会立即终止，导致后续的 echo 命令无法执行。

**修复方案：**
1. 使用 `set +e` 禁用错误退出，确保能正确捕获 Python 脚本的退出码
2. 在条件判断内显式打印错误信息后，再使用 `exit $EXCODE` 退出
3. 简化成功路径的逻辑结构

**影响：**
- 当 PR 模板检查失败时，用户现在可以在 GitHub Actions 日志中看到完整的错误提示和参考链接
- 便于用户快速定位和修复 PR 模板问题

### 是否引起精度变化
否