### PR TITLE
[release/3.3][ZeroSize] fix fused_rotary_position_embedding crash when k/v have zero num_heads

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/fused_rope_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_rope_kernel.cu
@@ -154,7 +154,7 @@ void FusedRopeKernel(const Context& dev_ctx,
 
   // K
   int k_num_heads = -1;
-  if (k) {
+  if (k && k->numel() > 0) {
     k_num_heads = k->dims()[2];
     auto k_batch_size = time_major ? k->dims()[1] : k->dims()[0];
     PADDLE_ENFORCE_LE(
@@ -205,7 +205,7 @@ void FusedRopeKernel(const Context& dev_ctx,
   }
 
   // V
-  if (v) {
+  if (v && v->numel() > 0) {
     auto v_num_heads = v->dims()[2];
     // Multi Query Attention (MQA) or Group Query Attention (GQA)
     if (k_num_heads != -1) {

--- a/paddle/phi/kernels/fusion/gpu/fused_rope_utils.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_rope_utils.h
@@ -278,6 +278,7 @@ void FusedRopeKernelLauncher(const T* src,
                              const int64_t batch_size,
                              const int64_t numel,
                              gpuStream_t stream) {
+  if (numel <= 0) return;
   const int64_t warps_per_block = h < 16 ? 4 : 8;
   dim3 grid(seq_len, batch_size);
   dim3 block(32, warps_per_block);  // 32 threads per warp

--- a/test/legacy_test/test_fused_rotary_position_embedding.py
+++ b/test/legacy_test/test_fused_rotary_position_embedding.py
@@ -790,5 +790,178 @@ class TestFusedRotaryPositionEmbeddingZeroSize(unittest.TestCase):
         self._test_forward_backward()
 
 
+@unittest.skipIf(
+    not (core.is_compiled_with_cuda() or is_custom_device())
+    and not paddle.is_compiled_with_rocm(),
+    "core is not compiled with CUDA or ROCM ",
+)
+class TestFusedRotaryPositionEmbeddingZeroNumHeads(unittest.TestCase):
+    """Test fused_rotary_position_embedding with k or v tensors that have
+    zero num_heads (e.g. shape [batch, seq, 0, head_dim]).
+
+    Regression test for a bug where:
+      1. The MQA/GQA validation `num_heads % v_num_heads == 0` caused a
+         SIGFPE (integer division by zero) when v_num_heads == 0.
+      2. FusedRopeKernelLauncher launched CUDA kernels for zero-element
+         tensors even when numel == 0.
+    """
+
+    def setUp(self):
+        self.dtype = "float32"
+        self.batch_size = 1
+        self.seq_len = 8
+        self.num_heads_q = 4
+        self.head_dim = 8
+        self.sin_cos_shape = [1, self.seq_len, 1, self.head_dim]
+
+    def _make_tensor(self, shape, requires_grad=True):
+        t = paddle.randn(shape, dtype=self.dtype)
+        t.stop_gradient = not requires_grad
+        return t
+
+    def _make_sin_cos(self):
+        sin = paddle.sin(paddle.randn(self.sin_cos_shape, dtype=self.dtype))
+        cos = paddle.cos(paddle.randn(self.sin_cos_shape, dtype=self.dtype))
+        return sin, cos
+
+    def _run_forward_backward(self, q, k, v, sin, cos, **kwargs):
+        """Run forward + backward; return outputs and check no crash."""
+        out_q, out_k, out_v = fused_rotary_position_embedding(
+            q, k, v, sin=sin, cos=cos, **kwargs
+        )
+        # Build loss from initialized, non-empty outputs
+        loss_terms = []
+        for out in [out_q, out_k, out_v]:
+            if out is not None and out._is_initialized() and out.numel() > 0:
+                loss_terms.append(out.sum())
+        if loss_terms:
+            sum(loss_terms).backward()
+        return out_q, out_k, out_v
+
+    def test_v_zero_num_heads(self):
+        """v with 0 num_heads should not crash (original bug scenario)."""
+        q_shape = [
+            self.batch_size,
+            self.seq_len,
+            self.num_heads_q,
+            self.head_dim,
+        ]
+        kv_shape = [self.batch_size, self.seq_len, 0, self.head_dim]
+        q = self._make_tensor(q_shape)
+        k = self._make_tensor(kv_shape)
+        v = self._make_tensor(kv_shape)
+        sin, cos = self._make_sin_cos()
+
+        out_q, out_k, out_v = self._run_forward_backward(
+            q, k, v, sin, cos, use_neox_rotary_style=False
+        )
+        self.assertEqual(list(out_q.shape), q_shape)
+        self.assertEqual(list(out_k.shape), kv_shape)
+        self.assertEqual(list(out_v.shape), kv_shape)
+
+    def test_k_zero_num_heads(self):
+        """k with 0 num_heads should not crash."""
+        q_shape = [
+            self.batch_size,
+            self.seq_len,
+            self.num_heads_q,
+            self.head_dim,
+        ]
+        k_shape = [self.batch_size, self.seq_len, 0, self.head_dim]
+        q = self._make_tensor(q_shape)
+        k = self._make_tensor(k_shape)
+        sin, cos = self._make_sin_cos()
+
+        out_q, out_k, out_v = self._run_forward_backward(
+            q, k, None, sin, cos, use_neox_rotary_style=False
+        )
+        self.assertEqual(list(out_q.shape), q_shape)
+        self.assertEqual(list(out_k.shape), k_shape)
+
+    def test_kv_zero_num_heads(self):
+        """Both k and v with 0 num_heads should not crash."""
+        q_shape = [
+            self.batch_size,
+            self.seq_len,
+            self.num_heads_q,
+            self.head_dim,
+        ]
+        kv_shape = [self.batch_size, self.seq_len, 0, self.head_dim]
+        q = self._make_tensor(q_shape)
+        k = self._make_tensor(kv_shape)
+        v = self._make_tensor(kv_shape)
+        sin, cos = self._make_sin_cos()
+
+        out_q, out_k, out_v = self._run_forward_backward(
+            q, k, v, sin, cos, use_neox_rotary_style=False
+        )
+        self.assertEqual(list(out_q.shape), q_shape)
+        self.assertEqual(list(out_k.shape), kv_shape)
+        self.assertEqual(list(out_v.shape), kv_shape)
+
+    def test_v_zero_num_heads_neox_style(self):
+        """v with 0 num_heads, neox rotary style, should not crash."""
+        q_shape = [
+            self.batch_size,
+            self.seq_len,
+            self.num_heads_q,
+            self.head_dim,
+        ]
+        kv_shape = [self.batch_size, self.seq_len, 0, self.head_dim]
+        q = self._make_tensor(q_shape)
+        k = self._make_tensor(kv_shape)
+        v = self._make_tensor(kv_shape)
+        sin, cos = self._make_sin_cos()
+
+        out_q, out_k, out_v = self._run_forward_backward(
+            q, k, v, sin, cos, use_neox_rotary_style=True
+        )
+        self.assertEqual(list(out_q.shape), q_shape)
+        self.assertEqual(list(out_k.shape), kv_shape)
+        self.assertEqual(list(out_v.shape), kv_shape)
+
+    def test_v_zero_num_heads_time_major(self):
+        """v with 0 num_heads, time_major=True, should not crash."""
+        # time_major: [seq_len, batch_size, num_heads, head_dim]
+        q_shape = [
+            self.seq_len,
+            self.batch_size,
+            self.num_heads_q,
+            self.head_dim,
+        ]
+        kv_shape = [self.seq_len, self.batch_size, 0, self.head_dim]
+        q = self._make_tensor(q_shape)
+        k = self._make_tensor(kv_shape)
+        v = self._make_tensor(kv_shape)
+        sin, cos = self._make_sin_cos()
+
+        out_q, out_k, out_v = self._run_forward_backward(
+            q, k, v, sin, cos, use_neox_rotary_style=False, time_major=True
+        )
+        self.assertEqual(list(out_q.shape), q_shape)
+        self.assertEqual(list(out_k.shape), kv_shape)
+        self.assertEqual(list(out_v.shape), kv_shape)
+
+    def test_q_grad_shape_with_zero_kv(self):
+        """Backward pass gradient shape for q should be correct when k/v have 0 heads."""
+        q_shape = [
+            self.batch_size,
+            self.seq_len,
+            self.num_heads_q,
+            self.head_dim,
+        ]
+        kv_shape = [self.batch_size, self.seq_len, 0, self.head_dim]
+        q = self._make_tensor(q_shape)
+        k = self._make_tensor(kv_shape)
+        v = self._make_tensor(kv_shape)
+        sin, cos = self._make_sin_cos()
+
+        out_q, out_k, out_v = fused_rotary_position_embedding(
+            q, k, v, sin=sin, cos=cos, use_neox_rotary_style=False
+        )
+        out_q.sum().backward()
+        self.assertEqual(list(q.grad.shape), q_shape)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

#### 问题背景

当 `paddle.incubate.nn.functional.fused_rotary_position_embedding` 的输入 `k` 或 `v` 张量的 `num_heads` 维度为 0 时（如 shape 为 `[batch, seq, 0, head_dim]`），会触发 **SIGFPE（整数除零）** 或非法 CUDA kernel 启动，导致进程崩溃。

复现命令：
```
FLAGS_check_cuda_error=1 FLAGS_use_system_allocator=1 python engineV2.py --paddle_only=True \
  --api_config='paddle.incubate.nn.functional.fused_rotary_position_embedding(
    Tensor([1, 8, 4, 8],"float32"), None,
    Tensor([1, 8, 0, 8],"float32"),
    Tensor([1, 8, 1, 8],"float32"), Tensor([1, 8, 1, 8],"float32"),
    position_ids=None, use_neox_rotary_style=False, time_major=False, )'
```

#### 根因分析

两处 Bug：

**Bug 1（`fused_rope_kernel.cu`）**：`if (k)` / `if (v)` 只检查了 optional 张量是否存在，但没有排除 numel=0 的情况。当 `v_num_heads == 0` 时，MQA/GQA 合法性校验 `num_heads % v_num_heads == 0` 触发整数除零（SIGFPE）。

**Bug 2（`fused_rope_utils.h`）**：`FusedRopeKernelLauncher` 在 `numel == 0` 时仍然以非零 grid 尺寸启动 CUDA kernel，导致非法访问。

#### 修复方案

- `fused_rope_kernel.cu`：将 `if (k)` / `if (v)` 改为 `if (k && k->numel() > 0)` / `if (v && v->numel() > 0)`，跳过对零元素张量的所有校验和 kernel 启动。
- `fused_rope_utils.h`：在 `FusedRopeKernelLauncher` 开头添加 `if (numel <= 0) return;` 守卫。

注：`fused_rope_grad_kernel.cu` 已有正确的 `if (dk && dk->numel() > 0)` 模式，无需修改。

#### 新增单测

在 `TestFusedRotaryPositionEmbeddingZeroNumHeads` 类中新增 6 个测试用例，覆盖：
- `v` 的 `num_heads` 为 0（原始 bug 场景）
- `k` 的 `num_heads` 为 0
- `k` 和 `v` 的 `num_heads` 同时为 0
- neox rotary style 下的零 `num_heads`
- `time_major=True` 下的零 `num_heads`
- 反向传播梯度 shape 正确性验证

### 是否引起精度变化
否

---

Cherry-pick of #78253 (authored by @DanielSun11) to `release/3.3`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78253 <!-- For pass CI -->