### PR TITLE
[CI] Add XPU-only PR detection (observe mode)

### DIFF
--- a/.github/workflows/_Clone-linux.yml
+++ b/.github/workflows/_Clone-linux.yml
@@ -19,6 +19,8 @@ on:
         value: ${{ jobs.clone.outputs.can-skip }}
       slice-check:
         value: ${{ jobs.clone.outputs.slice-check }}
+      xpu-only:
+        value: ${{ jobs.clone.outputs.xpu-only }}
 
 permissions: read-all
 
@@ -49,6 +51,7 @@ jobs:
     outputs:
       can-skip: ${{ needs.check-bypass.outputs.can-skip }}
       slice-check: ${{ steps.check-execution.outputs.slice-check }}
+      xpu-only: ${{ steps.xpu-only-check.outputs.xpu-only }}
     runs-on:
       group: HK-Clone
     timeout-minutes: 30
@@ -83,6 +86,18 @@ jobs:
           git branch -d pr
           source ${ci_scripts}/check_execution.sh
           bash ${ci_scripts}/third_party_tag.sh
+
+      - name: Check if XPU-only PR
+        id: xpu-only-check
+        if: ${{ inputs.is_pr == 'true' }}
+        env:
+          DISABLE_HW_CI_SKIP: ${{ vars.DISABLE_HW_CI_SKIP || 'false' }}
+        run: |
+          if bash ci/check_xpu_only.sh; then
+            echo "xpu-only=true" >> $GITHUB_OUTPUT
+          else
+            echo "xpu-only=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Download bos client
         env:

--- a/ci/check_xpu_only.sh
+++ b/ci/check_xpu_only.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+#
+# check_xpu_only.sh - 判断 PR 是否为纯 XPU 改动
+#
+# 当 PR 变更文件全部属于 XPU 专属路径时，其他硬件 CI 可以跳过。
+#
+# Exit codes:
+#   0 = 纯 XPU 改动（其他硬件 CI 可跳过）
+#   1 = 非纯 XPU 改动（所有 CI 照常运行）
+#
+# Safety: 任何异常默认 exit 1（全量运行），绝不错跳。
+#
+
+set -o pipefail
+
+LOG_PREFIX="[xpu-only]"
+
+# =============================================================================
+# 紧急开关：全局禁用跳过
+# =============================================================================
+if [[ "${DISABLE_HW_CI_SKIP:-false}" == "true" ]]; then
+    echo "$LOG_PREFIX Emergency override: DISABLE_HW_CI_SKIP=true, running all CI"
+    exit 1
+fi
+
+# =============================================================================
+# 强制全量运行：commit message 含 test=all
+# =============================================================================
+COMMIT_MSG=$(git log -1 --pretty=%B 2>/dev/null || echo "")
+if echo "$COMMIT_MSG" | grep -qiE 'test[=:] *all'; then
+    echo "$LOG_PREFIX Force full CI: commit message contains test=all"
+    exit 1
+fi
+
+# =============================================================================
+# 获取变更文件
+# =============================================================================
+
+CHANGED_FILES=""
+
+# Method 1: GitHub PR 上下文（对比 base branch）
+if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+    CHANGED_FILES=$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" 2>/dev/null || echo "")
+fi
+
+# Method 2: 对比 develop 分支
+if [[ -z "$CHANGED_FILES" ]]; then
+    CHANGED_FILES=$(git diff --name-only origin/develop...HEAD 2>/dev/null || echo "")
+fi
+
+# Method 3: 对比上一个 commit（兜底）
+if [[ -z "$CHANGED_FILES" ]]; then
+    CHANGED_FILES=$(git diff --name-only HEAD~1 2>/dev/null || echo "")
+fi
+
+# 无法获取变更文件 → 全量运行
+if [[ -z "$CHANGED_FILES" ]]; then
+    echo "$LOG_PREFIX WARN: No changed files detected, defaulting to full CI"
+    exit 1
+fi
+
+TOTAL_FILES=$(echo "$CHANGED_FILES" | wc -l | tr -d ' ')
+echo "$LOG_PREFIX Analyzing $TOTAL_FILES changed files"
+
+# =============================================================================
+# XPU 专属路径定义
+# =============================================================================
+XPU_PATHS=(
+    # phi kernels
+    "paddle/phi/kernels/xpu/"
+    "paddle/phi/kernels/fusion/xpu/"
+    "paddle/phi/kernels/selected_rows/xpu/"
+    "paddle/phi/kernels/sparse/xpu/"
+    "paddle/phi/kernels/legacy/xpu/"
+    # phi backends & device
+    "paddle/phi/backends/xpu/"
+    "paddle/phi/core/platform/device/xpu/"
+    # fluid (旧框架遗留)
+    "paddle/fluid/pir/transforms/xpu/"
+    "paddle/fluid/framework/ir/xpu/"
+    "paddle/fluid/platform/device/xpu/"
+    # python API
+    "python/paddle/device/xpu/"
+    "python/paddle/incubate/xpu/"
+    # tests
+    "test/xpu/"
+    "test/cpp/fluid/framework/ir/xpu/"
+    "test/ir/pir/fused_pass/xpu/"
+    # build & tools
+    "cmake/external/xpu.cmake"
+    "cmake/xpu_kp.cmake"
+    "tools/xpu/"
+)
+
+# =============================================================================
+# 逐文件判断：是否全部属于 XPU 专属路径
+# =============================================================================
+while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+
+    is_xpu=false
+    for path in "${XPU_PATHS[@]}"; do
+        if [[ "$file" == "$path"* ]]; then
+            is_xpu=true
+            break
+        fi
+    done
+
+    if [[ "$is_xpu" == "false" ]]; then
+        echo "$LOG_PREFIX Non-XPU file found: $file"
+        echo "$LOG_PREFIX Result: NOT xpu-only PR, running all CI"
+        exit 1
+    fi
+done <<< "$CHANGED_FILES"
+
+echo "$LOG_PREFIX All $TOTAL_FILES changed files are XPU-specific"
+echo "$LOG_PREFIX Result: XPU-only PR, other hardware CI can be skipped"
+exit 0

--- a/ci/check_xpu_only.sh
+++ b/ci/check_xpu_only.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # check_xpu_only.sh - 判断 PR 是否为纯 XPU 改动
 #

--- a/ci/check_xpu_only.sh
+++ b/ci/check_xpu_only.sh
@@ -15,15 +15,16 @@
 # limitations under the License.
 
 #
-# check_xpu_only.sh - 判断 PR 是否为纯 XPU 改动
+# check_xpu_only.sh - Determine whether a PR only modifies XPU-specific files
 #
-# 当 PR 变更文件全部属于 XPU 专属路径时，其他硬件 CI 可以跳过。
+# When all changed files in a PR belong to XPU-specific paths,
+# other hardware CI jobs (GPU/DCU/NPU) can be safely skipped.
 #
 # Exit codes:
-#   0 = 纯 XPU 改动（其他硬件 CI 可跳过）
-#   1 = 非纯 XPU 改动（所有 CI 照常运行）
+#   0 = XPU-only changes (other hardware CI can be skipped)
+#   1 = Non-XPU-only changes (all CI should run as usual)
 #
-# Safety: 任何异常默认 exit 1（全量运行），绝不错跳。
+# Safety: Any error defaults to exit 1 (run all CI), never skip by mistake.
 #
 
 set -o pipefail
@@ -31,7 +32,7 @@ set -o pipefail
 LOG_PREFIX="[xpu-only]"
 
 # =============================================================================
-# 紧急开关：全局禁用跳过
+# Emergency kill switch: globally disable CI skipping
 # =============================================================================
 if [[ "${DISABLE_HW_CI_SKIP:-false}" == "true" ]]; then
     echo "$LOG_PREFIX Emergency override: DISABLE_HW_CI_SKIP=true, running all CI"
@@ -39,7 +40,7 @@ if [[ "${DISABLE_HW_CI_SKIP:-false}" == "true" ]]; then
 fi
 
 # =============================================================================
-# 强制全量运行：commit message 含 test=all
+# Force full CI run: commit message contains test=all
 # =============================================================================
 COMMIT_MSG=$(git log -1 --pretty=%B 2>/dev/null || echo "")
 if echo "$COMMIT_MSG" | grep -qiE 'test[=:] *all'; then
@@ -48,27 +49,27 @@ if echo "$COMMIT_MSG" | grep -qiE 'test[=:] *all'; then
 fi
 
 # =============================================================================
-# 获取变更文件
+# Collect changed files
 # =============================================================================
 
 CHANGED_FILES=""
 
-# Method 1: GitHub PR 上下文（对比 base branch）
+# Method 1: GitHub PR context (diff against base branch)
 if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
     CHANGED_FILES=$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" 2>/dev/null || echo "")
 fi
 
-# Method 2: 对比 develop 分支
+# Method 2: Diff against develop branch
 if [[ -z "$CHANGED_FILES" ]]; then
     CHANGED_FILES=$(git diff --name-only origin/develop...HEAD 2>/dev/null || echo "")
 fi
 
-# Method 3: 对比上一个 commit（兜底）
+# Method 3: Diff against previous commit (fallback)
 if [[ -z "$CHANGED_FILES" ]]; then
     CHANGED_FILES=$(git diff --name-only HEAD~1 2>/dev/null || echo "")
 fi
 
-# 无法获取变更文件 → 全量运行
+# Cannot detect changed files -> run all CI
 if [[ -z "$CHANGED_FILES" ]]; then
     echo "$LOG_PREFIX WARN: No changed files detected, defaulting to full CI"
     exit 1
@@ -78,7 +79,7 @@ TOTAL_FILES=$(echo "$CHANGED_FILES" | wc -l | tr -d ' ')
 echo "$LOG_PREFIX Analyzing $TOTAL_FILES changed files"
 
 # =============================================================================
-# XPU 专属路径定义
+# XPU-specific path definitions
 # =============================================================================
 XPU_PATHS=(
     # phi kernels
@@ -90,7 +91,7 @@ XPU_PATHS=(
     # phi backends & device
     "paddle/phi/backends/xpu/"
     "paddle/phi/core/platform/device/xpu/"
-    # fluid (旧框架遗留)
+    # fluid (legacy framework)
     "paddle/fluid/pir/transforms/xpu/"
     "paddle/fluid/framework/ir/xpu/"
     "paddle/fluid/platform/device/xpu/"
@@ -108,7 +109,7 @@ XPU_PATHS=(
 )
 
 # =============================================================================
-# 逐文件判断：是否全部属于 XPU 专属路径
+# Check each file: verify all belong to XPU-specific paths
 # =============================================================================
 while IFS= read -r file; do
     [[ -z "$file" ]] && continue


### PR DESCRIPTION
### PR Category
Execute Infrastructure


### PR Types
New features


### Description
Add XPU-only PR detection to CI pipeline (observe mode only).

When a PR only modifies XPU-specific paths (e.g., `paddle/phi/kernels/xpu/`, `test/xpu/`, `paddle/phi/backends/xpu/`), GPU/DCU/NPU and other hardware CI can be safely skipped to save CI resources.

**This PR adds detection infrastructure only — no CI jobs are actually skipped.**

Changes:
- `ci/check_xpu_only.sh`: New script to detect if all changed files belong to XPU-specific paths (18 paths covered)
- `.github/workflows/_Clone-linux.yml`: Add `xpu-only` output and detection step after PR merge

Safety mechanisms:
- Conservative fallback: any script error defaults to running all CI
- `DISABLE_HW_CI_SKIP` repo variable for emergency global disable
- `test=all` in commit message forces full CI

Pre-merge validation:
- 177 merged PRs from past 4 weeks analyzed, 5 xpu-only PRs correctly identified
- 0 false positives, 39 unit test cases passing

Rollout plan:
1. This PR (observe mode): script runs and logs output, no CI is skipped
2. Follow-up PR: after validating 50+ live PRs with 0% false-positive rate, add if conditions to skip non-XPU CI jobs


### 是否引起精度变化
否