### PR TITLE
Fix 0-size tensor handling in flashmask_attention

### DIFF
--- a/paddle/phi/kernels/gpu/flash_attn_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_kernel.cu
@@ -730,6 +730,24 @@ void FlashMaskKernel(const Context& dev_ctx,
                      DenseTensor* softmax,
                      DenseTensor* softmax_lse,
                      DenseTensor* seed_offset) {
+  // Handle 0-size tensors: return zeros without calling CUDA kernel
+  // to avoid invalid memory access
+  if (q.numel() == 0 || k.numel() == 0 || v.numel() == 0) {
+    if (out) {
+      Full<T, Context>(dev_ctx, out->dims(), 0, out);
+    }
+    if (softmax) {
+      Full<T, Context>(dev_ctx, softmax->dims(), 0, softmax);
+    }
+    if (softmax_lse) {
+      Full<T, Context>(dev_ctx, softmax_lse->dims(), 0, softmax_lse);
+    }
+    if (seed_offset) {
+      Full<T, Context>(dev_ctx, seed_offset->dims(), 0, seed_offset);
+    }
+    return;
+  }
+
   FlashAttnBaseKernel<T, Context>(dev_ctx,
                                   q,
                                   k,

--- a/paddle/phi/kernels/gpu/flash_attn_v3_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_v3_kernel.cu
@@ -2272,6 +2272,21 @@ void FlashMaskV2Kernel(const Context &dev_ctx,
                        DenseTensor *out,
                        DenseTensor *softmax_lse) {
 #ifdef PADDLE_WITH_FLASHATTN_V3
+  // Handle 0-size tensors: return zeros without calling CUDA kernel
+  // to avoid invalid memory access
+  if (q.numel() == 0 || k.numel() == 0 || v.numel() == 0) {
+    if (out) {
+      funcs::SetConstant<Context, T> set_zero;
+      set_zero(dev_ctx, out, T{0});
+    }
+    if (softmax_lse) {
+      funcs::SetConstant<Context, float> set_infinity;
+      set_infinity(
+          dev_ctx, softmax_lse, std::numeric_limits<float>::infinity());
+    }
+    return;
+  }
+
   DenseTensor out_accum;
   DenseTensor softmax_lse_accum;
   FlashMaskV2BaseKernel<T, Context>(dev_ctx,

--- a/paddle/phi/kernels/xpu/flash_attn_kernel.cc
+++ b/paddle/phi/kernels/xpu/flash_attn_kernel.cc
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/flash_attn_kernel.h"
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/slice_kernel.h"
 #include "paddle/phi/kernels/xpu/flash_attn_utils.h"
 #include "xfa/flash_api.h"
@@ -158,6 +159,27 @@ void FlashAttnKernelBase(const Context& dev_ctx,
                          DenseTensor* softmax,
                          DenseTensor* softmax_lse,
                          DenseTensor* seed_offset) {
+  // Handle 0-size tensors: return zeros without calling XPU kernel
+  // to avoid invalid memory access
+  if (q.numel() == 0 || k.numel() == 0 || v.numel() == 0) {
+    if (out) {
+      Full<T, Context>(dev_ctx, out->dims(), 0, out);
+    }
+    if (softmax) {
+      Full<T, Context>(dev_ctx, softmax->dims(), 0, softmax);
+    }
+    if (softmax_lse) {
+      std::vector<int64_t> softmax_lse_dims = {
+          batch_size, num_heads, max_seqlen_q_.to<int64_t>()};
+      softmax_lse->Resize(phi::make_ddim(softmax_lse_dims));
+      Full<float, Context>(dev_ctx, softmax_lse->dims(), 0, softmax_lse);
+    }
+    if (seed_offset) {
+      Full<int64_t, Context>(dev_ctx, seed_offset->dims(), 0, seed_offset);
+    }
+    return;
+  }
+
   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
   float real_scale = scale == 0.0f ? 1.0f / std::sqrt(head_size) : scale;
   float real_dropout = is_test ? 0.0f : dropout;
@@ -498,6 +520,24 @@ void FlashMaskKernel(const Context& dev_ctx,
   if (return_softmax == true) {
     PADDLE_THROW(
         common::errors::Unimplemented("return_softmax should be false"));
+  }
+
+  // Handle 0-size tensors: return zeros without calling XPU kernel
+  // to avoid invalid memory access
+  if (q.numel() == 0 || k.numel() == 0 || v.numel() == 0) {
+    if (out) {
+      Full<T, Context>(dev_ctx, out->dims(), 0, out);
+    }
+    if (softmax) {
+      Full<T, Context>(dev_ctx, softmax->dims(), 0, softmax);
+    }
+    if (softmax_lse) {
+      Full<float, Context>(dev_ctx, softmax_lse->dims(), 0, softmax_lse);
+    }
+    if (seed_offset) {
+      Full<int64_t, Context>(dev_ctx, seed_offset->dims(), 0, seed_offset);
+    }
+    return;
   }
 
   // q, k, v [batch_size, seq_len, num_heads, head_dim]

--- a/test/legacy_test/test_flashmask.py
+++ b/test/legacy_test/test_flashmask.py
@@ -409,10 +409,18 @@ class TestFlashMaskAttentionZeroSize(unittest.TestCase):
         """Helper method to run a single test case."""
         paddle.disable_static()
 
-        q = paddle.randn(q_shape, dtype=self.dtype, place=self.place)
-        k = paddle.randn(k_shape, dtype=self.dtype, place=self.place)
-        v = paddle.randn(v_shape, dtype=self.dtype, place=self.place)
-        startend = paddle.ones(startend_shape, dtype="int32", place=self.place)
+        q = paddle.to_tensor(
+            np.random.randn(*q_shape).astype(self.dtype), place=self.place
+        )
+        k = paddle.to_tensor(
+            np.random.randn(*k_shape).astype(self.dtype), place=self.place
+        )
+        v = paddle.to_tensor(
+            np.random.randn(*v_shape).astype(self.dtype), place=self.place
+        )
+        startend = paddle.to_tensor(
+            np.ones(startend_shape, dtype="int32"), place=self.place
+        )
 
         result = flashmask_attention(
             q,
@@ -422,8 +430,17 @@ class TestFlashMaskAttentionZeroSize(unittest.TestCase):
             causal=causal,
         )
 
-        # Verify result shape matches query shape
-        self.assertEqual(list(result.shape), list(q.shape))
+        # According to FlashAttnInferMeta:
+        # - Output shape is based on q.shape
+        # - head_dim uses v's head_dim
+        # - If batch is 0 (q.batch=0 or k.batch=0 or v.batch=0), output batch is 0
+        expected_shape = list(q.shape)
+        expected_shape[3] = v_shape[3]  # head_dim from v
+        if q_shape[0] == 0 or k_shape[0] == 0 or v_shape[0] == 0:
+            expected_shape[0] = 0  # batch is 0
+
+        # Verify result shape
+        self.assertEqual(list(result.shape), expected_shape)
         # Verify result is all zeros
         self.assertTrue(paddle.all(result == 0).item())
 

--- a/test/legacy_test/test_flashmask.py
+++ b/test/legacy_test/test_flashmask.py
@@ -388,5 +388,108 @@ class TestFlashMaskAttentionFP16API6(TestFlashMaskAttentionAPI):
         self.mask_func = gen_global_slide_window_mask
 
 
+@unittest.skipIf(
+    not is_flashattn_supported(),
+    "core is not compiled with CUDA and cuda version need larger than or equal to 11.4"
+    "and device's compute capability must be 7.5 or 8.x",
+)
+class TestFlashMaskAttentionZeroSize(unittest.TestCase):
+    """Test flashmask_attention with 0-size tensors.
+
+    When any input tensor has a dimension of size 0, the function should
+    return a zero tensor with the same shape as query without calling
+    the CUDA kernel to avoid invalid memory access.
+    """
+
+    def setUp(self):
+        self.place = get_device_place()
+        self.dtype = 'float16'
+
+    def _run_test(self, q_shape, k_shape, v_shape, startend_shape, causal=True):
+        """Helper method to run a single test case."""
+        paddle.disable_static()
+
+        q = paddle.randn(q_shape, dtype=self.dtype, place=self.place)
+        k = paddle.randn(k_shape, dtype=self.dtype, place=self.place)
+        v = paddle.randn(v_shape, dtype=self.dtype, place=self.place)
+        startend = paddle.ones(startend_shape, dtype="int32", place=self.place)
+
+        result = flashmask_attention(
+            q,
+            k,
+            v,
+            startend_row_indices=startend,
+            causal=causal,
+        )
+
+        # Verify result shape matches query shape
+        self.assertEqual(list(result.shape), list(q.shape))
+        # Verify result is all zeros
+        self.assertTrue(paddle.all(result == 0).item())
+
+    def test_query_zero_seqlen(self):
+        """Test when query sequence length is 0."""
+        self._run_test(
+            q_shape=[1, 128, 8, 96],
+            k_shape=[1, 128, 8, 96],
+            v_shape=[1, 0, 8, 96],  # query seqlen = 0
+            startend_shape=[1, 1, 128, 1],
+        )
+
+    def test_key_zero_seqlen(self):
+        """Test when key sequence length is 0."""
+        self._run_test(
+            q_shape=[1, 128, 8, 96],
+            k_shape=[1, 0, 8, 96],  # key seqlen = 0
+            v_shape=[1, 0, 8, 96],  # value must have same seqlen as key
+            startend_shape=[1, 1, 0, 1],
+        )
+
+    def test_key_zero_head_dim(self):
+        """Test when key head_dim is 0."""
+        self._run_test(
+            q_shape=[1, 128, 8, 96],
+            k_shape=[1, 128, 8, 0],  # key head_dim = 0
+            v_shape=[1, 128, 8, 96],
+            startend_shape=[1, 1, 128, 1],
+        )
+
+    def test_value_zero_batch(self):
+        """Test when value batch size is 0."""
+        self._run_test(
+            q_shape=[1, 128, 8, 96],
+            k_shape=[1, 128, 8, 96],
+            v_shape=[0, 128, 8, 96],  # value batch = 0
+            startend_shape=[1, 1, 128, 1],
+        )
+
+    def test_value_zero_seqlen(self):
+        """Test when value sequence length is 0."""
+        self._run_test(
+            q_shape=[1, 128, 8, 96],
+            k_shape=[1, 128, 8, 96],
+            v_shape=[1, 0, 8, 96],  # value seqlen = 0
+            startend_shape=[1, 1, 128, 1],
+        )
+
+    def test_value_zero_head_dim(self):
+        """Test when value head_dim is 0."""
+        self._run_test(
+            q_shape=[1, 128, 8, 96],
+            k_shape=[1, 128, 8, 96],
+            v_shape=[1, 128, 8, 0],  # value head_dim = 0
+            startend_shape=[1, 1, 128, 1],
+        )
+
+    def test_all_zero_batch(self):
+        """Test when all tensors have batch size 0."""
+        self._run_test(
+            q_shape=[0, 128, 8, 96],
+            k_shape=[0, 128, 8, 96],
+            v_shape=[0, 128, 8, 96],
+            startend_shape=[0, 1, 128, 1],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/xpu/test_flashmask_attention_op_xpu.py
+++ b/test/xpu/test_flashmask_attention_op_xpu.py
@@ -315,5 +315,158 @@ class TestFlashAttentionAPI(unittest.TestCase):
         )
 
 
+@unittest.skipIf(
+    core.is_compiled_with_xpu()
+    and core.get_xpu_device_version(0) < core.XPUVersion.XPU3,
+    "run test when xpu's compute capability >= xpu3.",
+)
+class TestFlashMaskAttentionZeroSize(unittest.TestCase):
+    """Test flashmask_attention with 0-size tensors on XPU.
+
+    When any input tensor has a dimension of size 0, the function should
+    return a zero tensor with the same shape as query without calling
+    the XPU kernel to avoid invalid memory access.
+    """
+
+    def setUp(self):
+        self.place = paddle.XPUPlace(0)
+        self.dtype = 'float16'
+
+    def _run_test(self, q_shape, k_shape, v_shape, startend_shape, causal=True):
+        """Helper method to run a single test case."""
+        paddle.disable_static()
+
+        # Create tensors using paddle.to_tensor with place parameter
+        q = paddle.to_tensor(
+            np.random.randn(*q_shape).astype(self.dtype), place=self.place
+        )
+        k = paddle.to_tensor(
+            np.random.randn(*k_shape).astype(self.dtype), place=self.place
+        )
+        v = paddle.to_tensor(
+            np.random.randn(*v_shape).astype(self.dtype), place=self.place
+        )
+        startend = paddle.to_tensor(
+            np.ones(startend_shape, dtype="int32"), place=self.place
+        )
+
+        result = flashmask_attention(
+            q,
+            k,
+            v,
+            startend_row_indices=startend,
+            causal=causal,
+        )
+
+        # According to FlashAttnInferMeta:
+        # - Output shape is based on q.shape
+        # - head_dim uses v's head_dim
+        # - If batch is 0 (q.batch=0 or k.batch=0 or v.batch=0), output batch is 0
+        expected_shape = list(q.shape)
+        expected_shape[3] = v_shape[3]  # head_dim from v
+        if q_shape[0] == 0 or k_shape[0] == 0 or v_shape[0] == 0:
+            expected_shape[0] = 0  # batch is 0
+
+        # Verify result shape
+        self.assertEqual(list(result.shape), expected_shape)
+        # Verify result is all zeros
+        self.assertTrue(paddle.all(result == 0).item())
+
+    def test_query_zero_seqlen(self):
+        """Test when query sequence length is 0."""
+        self._run_test(
+            q_shape=[1, 128, 8, 96],
+            k_shape=[1, 128, 8, 96],
+            v_shape=[1, 0, 8, 96],  # query seqlen = 0
+            startend_shape=[1, 1, 128, 1],
+        )
+
+    def test_key_zero_seqlen(self):
+        """Test when key sequence length is 0."""
+        self._run_test(
+            q_shape=[1, 128, 8, 96],
+            k_shape=[1, 0, 8, 96],  # key seqlen = 0
+            v_shape=[1, 0, 8, 96],  # value must have same seqlen as key
+            startend_shape=[1, 1, 0, 1],
+        )
+
+    def test_key_zero_head_dim(self):
+        """Test when key head_dim is 0."""
+        # Since k.numel() = 0, the kernel returns zeros.
+        # Output shape uses value's head_dim: [1, 128, 8, 96]
+        paddle.disable_static()
+        q = paddle.to_tensor(
+            np.random.randn(1, 128, 8, 96).astype(self.dtype), place=self.place
+        )
+        k = paddle.to_tensor(
+            np.random.randn(1, 128, 8, 0).astype(self.dtype), place=self.place
+        )
+        v = paddle.to_tensor(
+            np.random.randn(1, 128, 8, 96).astype(self.dtype), place=self.place
+        )
+        startend = paddle.to_tensor(
+            np.ones([1, 1, 128, 1], dtype="int32"), place=self.place
+        )
+        result = flashmask_attention(
+            q, k, v, startend_row_indices=startend, causal=True
+        )
+        # Output shape uses value's head_dim: [1, 128, 8, 96]
+        expected_shape = [1, 128, 8, 96]
+        self.assertEqual(list(result.shape), expected_shape)
+        self.assertTrue(paddle.all(result == 0).item())
+
+    def test_value_zero_batch(self):
+        """Test when value batch size is 0."""
+        self._run_test(
+            q_shape=[1, 128, 8, 96],
+            k_shape=[1, 128, 8, 96],
+            v_shape=[0, 128, 8, 96],  # value batch = 0
+            startend_shape=[1, 1, 128, 1],
+        )
+
+    def test_value_zero_seqlen(self):
+        """Test when value sequence length is 0."""
+        self._run_test(
+            q_shape=[1, 128, 8, 96],
+            k_shape=[1, 128, 8, 96],
+            v_shape=[1, 0, 8, 96],  # value seqlen = 0
+            startend_shape=[1, 1, 128, 1],
+        )
+
+    def test_value_zero_head_dim(self):
+        """Test when value head_dim is 0."""
+        # Since v.numel() = 0, kernel returns zeros.
+        # Output shape uses value's head_dim: [1, 128, 8, 0]
+        paddle.disable_static()
+        q = paddle.to_tensor(
+            np.random.randn(1, 128, 8, 96).astype(self.dtype), place=self.place
+        )
+        k = paddle.to_tensor(
+            np.random.randn(1, 128, 8, 96).astype(self.dtype), place=self.place
+        )
+        v = paddle.to_tensor(
+            np.random.randn(1, 128, 8, 0).astype(self.dtype), place=self.place
+        )
+        startend = paddle.to_tensor(
+            np.ones([1, 1, 128, 1], dtype="int32"), place=self.place
+        )
+        result = flashmask_attention(
+            q, k, v, startend_row_indices=startend, causal=True
+        )
+        # Output shape uses value's head_dim: [1, 128, 8, 0]
+        expected_shape = [1, 128, 8, 0]
+        self.assertEqual(list(result.shape), expected_shape)
+        self.assertTrue(paddle.all(result == 0).item())
+
+    def test_all_zero_batch(self):
+        """Test when all tensors have batch size 0."""
+        self._run_test(
+            q_shape=[0, 128, 8, 96],
+            k_shape=[0, 128, 8, 96],
+            v_shape=[0, 128, 8, 96],
+            startend_shape=[0, 1, 128, 1],
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix invalid memory access in flashmask_attention when any input tensor has a dimension of size 0. The CUDA kernel should not be called for 0-size tensors to avoid out-of-bounds memory access.

Changes:
- Add 0-size check in flashmask_attention before calling CUDA kernel
- When any input has numel() == 0, return a zero tensor with query shape
- Also handle return_softmax_lse and return_seed_offset for 0-size case
- Add TestFlashMaskAttentionZeroSize test class with 6 test cases

Fixes compute-sanitizer errors for cases like:
- query.seqlen=0
- key.seqlen=0
- key.head_dim=0
- value.batch=0
- value.seqlen=0
- value.head_dim=0

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否