### PR TITLE
Fix memory read OOB in WeightOnlyLinearGradKernel for zero-size weight

### DIFF
--- a/paddle/phi/kernels/funcs/weight_dequant_functor.h
+++ b/paddle/phi/kernels/funcs/weight_dequant_functor.h
@@ -373,6 +373,10 @@ void WeightDequantize(const Context& dev_ctx,
   // TODO(large-tensor): downstream functors may still use int
   int64_t k = x.dims()[1];
 
+  if (n == 0 || k == 0) {
+    return;
+  }
+
   dim3 block(512);
   dim3 grid(n / 32);
   auto stream = dev_ctx.stream();

--- a/paddle/phi/kernels/gpu/weight_only_linear_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/weight_only_linear_grad_kernel.cu
@@ -54,7 +54,7 @@ void WeightOnlyLinearGradKernel(const Context& dev_ctx,
   int64_t k = weight.dims()[1];
 
   dev_ctx.template Alloc<T>(x_grad);
-  if (x_grad->numel() == 0 || out_grad.numel() == 0) {
+  if (x_grad->numel() == 0 || out_grad.numel() == 0 || weight.numel() == 0) {
     Full<T, Context>(dev_ctx, x_grad->dims(), 0, x_grad);
     return;
   }

--- a/test/quantization/test_weight_only_linear.py
+++ b/test/quantization/test_weight_only_linear.py
@@ -1020,5 +1020,80 @@ class WeightOnlyLinear_stream_k_TestCase(unittest.TestCase):
         test_weightonly_linear_backward(self)
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "quantized_matmul requires CUDA_ARCH >= 8",
+)
+class WeightOnlyLinearZeroSizeWeightTestCase(unittest.TestCase):
+    """Test weight_only_linear with zero-size weight tensor (first dim = 0).
+
+    When weight has shape [0, k], the grad kernel (WeightOnlyLinearGradKernel)
+    must skip the WeightDequantize call to avoid launching CUDA kernels that
+    read from the empty weight buffer.
+    """
+
+    def _run_zero_weight_forward_and_grad(
+        self, dtype, weight_dtype, bias, in_features, out_features
+    ):
+        """Helper: forward + backward with weight.shape[0] == 0 must not crash."""
+        x = paddle.randn([2, 1, in_features], dtype=dtype)
+        x.stop_gradient = False
+
+        weight = paddle.zeros([0, in_features], dtype='int8')
+        weight_scale = paddle.randn([out_features], dtype=dtype)
+        bias_tensor = (
+            paddle.randn([out_features], dtype=dtype) if bias else None
+        )
+
+        out = Q.weight_only_linear(
+            x,
+            weight,
+            bias=bias_tensor,
+            weight_scale=weight_scale,
+            weight_dtype=weight_dtype,
+        )
+
+        # output should be all zeros since weight is empty
+        np.testing.assert_equal(
+            out.numpy(),
+            np.zeros(
+                out.shape,
+                dtype=np.float16 if dtype == 'float16' else np.float32,
+            ),
+        )
+
+        # backward should not crash
+        if out.numel() > 0:
+            paddle.grad(
+                [out],
+                [x],
+                grad_outputs=[paddle.ones_like(out)],
+                allow_unused=True,
+            )
+
+    def test_zero_weight_int8_fp16_with_bias(self):
+        self._run_zero_weight_forward_and_grad('float16', 'int8', True, 64, 192)
+
+    def test_zero_weight_int8_fp16_no_bias(self):
+        self._run_zero_weight_forward_and_grad(
+            'float16', 'int8', False, 512, 512
+        )
+
+    def test_zero_weight_int4_fp16_with_bias(self):
+        self._run_zero_weight_forward_and_grad('float16', 'int4', True, 64, 256)
+
+    def test_zero_weight_int8_fp16_large(self):
+        self._run_zero_weight_forward_and_grad(
+            'float16', 'int8', False, 768, 2304
+        )
+
+    def test_zero_weight_int8_fp16_3d_input(self):
+        """Specifically mirrors the original bug report shape."""
+        self._run_zero_weight_forward_and_grad(
+            'float16', 'int8', True, 128, 288
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category

<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

当权重张量的形状为 [0, k] 时，反向核函数（WeightOnlyLinearGradKernel）缺少对空权重的检查，导致 WeightDequantize 启动 CUDA 内核时从空的权重缓冲区读取数据，进而引发 compute-sanitizer 检测到无效的全局内存读取。
前向核函数已有此保护（`weight.numel() == 0`），但梯度核函数仅检查了 `x_grad` 和 `out_grad`。此次提交：

1. 在梯度核函数的早期返回条件中添加了 `weight.numel() == 0`。
2. 在 WeightDequantize 中增加了防御性检查 `n == 0 || k == 0`，防止在数据为空时启动内核。
3. 添加了覆盖 int8/int4 零尺寸权重、有无偏置的单元测试。

pcard-73145

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否