### PR TITLE
Remove no delay_scale_loss branch in pipeline parallel

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/dualpipev.py
+++ b/python/paddle/distributed/fleet/meta_parallel/dualpipev.py
@@ -130,14 +130,9 @@ class DualPipeVParallel(PipelineParallel):
         loss_fn_node = None
         if not self.overlapped_forward_backward:
             loss_tensor = self._layers._loss_fn[0](logits, labels)
-            with paddle.amp.auto_cast(enable=False):
-                if self.accumulate_steps > 1 and not self._delay_scale_loss:
-                    loss_tensor = loss_tensor / self.accumulate_steps
         else:
             loss_fn_node = self._layers._loss_fn[0].build_schedule_node()
             loss_fn_node.labels = labels
-            if self.accumulate_steps > 1 and not self._delay_scale_loss:
-                loss_fn_node.scale_loss_factor = self.accumulate_steps
             loss_tensor = loss_fn_node.forward(logits)
         self._store_forward_loss(phase, loss_tensor, loss_fn_node)
 
@@ -311,8 +306,6 @@ class DualPipeVParallel(PipelineParallel):
                 0
             ].build_schedule_node()
             forward_loss_fn_node.labels = forward_labels
-            if self.accumulate_steps > 1 and not self._delay_scale_loss:
-                forward_loss_fn_node.scale_loss_factor = self.accumulate_steps
         else:
             forward_loss_fn_node = None
 
@@ -681,8 +674,7 @@ class DualPipeVParallel(PipelineParallel):
             )
             for loss in self.loss_tensors:
                 loss_sum_tensor += loss.detach().astype("float32")
-            if self._delay_scale_loss:
-                loss_sum_tensor /= self.accumulate_steps
+            loss_sum_tensor /= self.accumulate_steps
 
         paddle.distributed.all_reduce(
             loss_sum_tensor, group=self.pp_group, sync_op=True

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -309,9 +309,7 @@ class NoPipelineParallel(MetaParallelBase):
         self.accumulate_steps = self._strategy.pipeline_configs[
             "accumulate_steps"
         ]
-        self._delay_scale_loss = self._strategy.hybrid_configs[
-            "pp_configs"
-        ].delay_scale_loss
+
         self._dp_comm_overlap = False
         self._sharding_comm_overlap = False
 
@@ -384,13 +382,12 @@ class NoPipelineParallel(MetaParallelBase):
         return data
 
     def _optimizer_step(self):
-        if self._delay_scale_loss:
-            for p in self._layers.parameters():
-                if hasattr(p, "main_grad") and p.main_grad is not None:
-                    assert p.grad is None
-                    p.main_grad = p.main_grad.scale(1.0 / self.accumulate_steps)
-                elif p.grad is not None:
-                    p.grad = p.grad.scale(1.0 / self.accumulate_steps)
+        for p in self._layers.parameters():
+            if hasattr(p, "main_grad") and p.main_grad is not None:
+                assert p.grad is None
+                p.main_grad = p.main_grad.scale(1.0 / self.accumulate_steps)
+            elif p.grad is not None:
+                p.grad = p.grad.scale(1.0 / self.accumulate_steps)
 
         if self.scaler:
             self.scaler.step(self.optimizer)
@@ -446,9 +443,7 @@ class NoPipelineParallel(MetaParallelBase):
                 assert isinstance(loss_tensor, paddle.Tensor), (
                     "Currently, loss_fn should obtain Paddle.Tensor dtype"
                 )
-                with paddle.amp.auto_cast(enable=False):
-                    if self.accumulate_steps > 1 and not self._delay_scale_loss:
-                        loss_tensor = loss_tensor / self.accumulate_steps
+
                 if self.total_loss is None:
                     self.total_loss = []
                 # when self.total_loss length is less than idx, append a new tensor
@@ -480,10 +475,7 @@ class NoPipelineParallel(MetaParallelBase):
                     tmp = paddle.zeros_like(self.total_loss[idx][0])
                     for loss in self.total_loss[idx]:
                         tmp += loss.detach()
-                    if not self._delay_scale_loss:
-                        losses.append(tmp)
-                    else:
-                        losses.append(tmp / self.accumulate_steps)
+                    losses.append(tmp / self.accumulate_steps)
                 else:
                     losses.append(self.total_loss[idx].detach())
         return losses[0] if len(losses) == 1 else losses
@@ -561,9 +553,7 @@ class NoPipelineParallel(MetaParallelBase):
                 assert isinstance(loss_tensor, paddle.Tensor), (
                     "Currently, loss_fn should obtain Paddle.Tensor dtype"
                 )
-                with paddle.amp.auto_cast(enable=False):
-                    if self.accumulate_steps > 1 and not self._delay_scale_loss:
-                        loss_tensor = loss_tensor / self.accumulate_steps
+
                 if self.total_loss is None:
                     self.total_loss = []
                 # when self.total_loss length is less than idx, append a new tensor
@@ -588,10 +578,7 @@ class NoPipelineParallel(MetaParallelBase):
                 tmp = paddle.zeros_like(self.total_loss[idx][0])
                 for loss in self.total_loss[idx]:
                     tmp += loss.detach()
-                if not self._delay_scale_loss:
-                    losses.append(tmp)
-                else:
-                    losses.append(tmp / self.accumulate_steps)
+                losses.append(tmp / self.accumulate_steps)
             else:
                 losses.append(self.total_loss[idx].detach())
         return losses[0] if len(losses) == 1 else losses
@@ -649,9 +636,6 @@ class PipelineParallel(MetaParallelBase):
         self._real_pp_world_size = self.num_stages
         self._real_pp_rank = self.stage_id
 
-        self._delay_scale_loss = self._strategy.hybrid_configs[
-            "pp_configs"
-        ].delay_scale_loss
         # TODO(PP Dev): support dp_comm_overlap without use_main_grad training.
         # This combination will trigger inplace check error during `reshape_` in function `_split_tensors`.
         self._dp_comm_overlap = self._strategy.hybrid_configs[
@@ -1512,28 +1496,12 @@ class PipelineParallel(MetaParallelBase):
                     if overlap_schedule_mode:
                         loss_fn_node = loss_fn.build_schedule_node()
                         loss_fn_node.labels = labels
-                        if (
-                            self.accumulate_steps > 1
-                            and not self._delay_scale_loss
-                        ):
-                            loss_fn_node.scale_loss_factor = (
-                                self.accumulate_steps
-                            )
                         loss_tensor = loss_fn_node.forward(output_tensor)
                     else:
                         loss_tensor = loss_fn(output_tensor, labels)
                         assert isinstance(loss_tensor, paddle.Tensor), (
                             "Currently, loss_fn should obtain Paddle.Tensor dtype"
                         )
-
-                        with paddle.amp.auto_cast(enable=False):
-                            if (
-                                self.accumulate_steps > 1
-                                and not self._delay_scale_loss
-                            ):
-                                loss_tensor = (
-                                    loss_tensor / self.accumulate_steps
-                                )
 
                     if self.total_loss is None:
                         self.total_loss = []
@@ -1737,10 +1705,7 @@ class PipelineParallel(MetaParallelBase):
                     tmp = paddle.zeros_like(self.total_loss[idx][0])
                     for loss in self.total_loss[idx]:
                         tmp += loss.detach()
-                    if not self._delay_scale_loss:
-                        losses.append(tmp)
-                    else:
-                        losses.append(tmp / self.accumulate_steps)
+                    losses.append(tmp / self.accumulate_steps)
                 else:
                     losses.append(self.total_loss[idx].detach())
 
@@ -1790,13 +1755,12 @@ class PipelineParallel(MetaParallelBase):
         return losses[0] if len(losses) == 1 else losses
 
     def _optimizer_step(self):
-        if self._delay_scale_loss:
-            for p in self._layers.parameters():
-                if hasattr(p, "main_grad") and p.main_grad is not None:
-                    assert p.grad is None
-                    p.main_grad = p.main_grad.scale(1.0 / self.accumulate_steps)
-                elif p.grad is not None:
-                    p.grad = p.grad.scale(1.0 / self.accumulate_steps)
+        for p in self._layers.parameters():
+            if hasattr(p, "main_grad") and p.main_grad is not None:
+                assert p.grad is None
+                p.main_grad = p.main_grad.scale(1.0 / self.accumulate_steps)
+            elif p.grad is not None:
+                p.grad = p.grad.scale(1.0 / self.accumulate_steps)
 
         if self.scaler:
             self.scaler.step(self.optimizer)
@@ -2330,10 +2294,6 @@ class PipelineParallelWithInterleave(PipelineParallel):
                     0
                 ].build_schedule_node()
                 forward_loss_fn_node.labels = labels
-                if self.accumulate_steps > 1 and not self._delay_scale_loss:
-                    forward_loss_fn_node.scale_loss_factor = (
-                        self.accumulate_steps
-                    )
             else:
                 forward_loss_fn_node = None
 

--- a/test/collective/fleet/hybrid_parallel_pp_layers.py
+++ b/test/collective/fleet/hybrid_parallel_pp_layers.py
@@ -210,7 +210,6 @@ class TestPipeLayerAPI(unittest.TestCase):
         pipe_model.train_batch(data, optimizer, lr_scheduler)
         pipe_model.eval_batch(data, optimizer)
 
-        pipe_model._delay_scale_loss = True
         pipe_model.train_batch(data, optimizer)
         pipe_model.eval_batch(data, optimizer)
         pipe_model.is_pipeline_last_stage()

--- a/test/collective/fleet/hybrid_parallel_pp_return_micro_batch_loss.py
+++ b/test/collective/fleet/hybrid_parallel_pp_return_micro_batch_loss.py
@@ -22,6 +22,9 @@ import paddle.distributed as dist
 from paddle import nn
 from paddle.distributed import fleet
 from paddle.distributed.fleet.meta_parallel import LayerDesc, PipelineLayer
+from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+    NoPipelineParallel,
+)
 from paddle.nn import Layer
 
 
@@ -241,6 +244,367 @@ class TestDistPPTraining(unittest.TestCase):
                     rtol=1e-6,
                     atol=1e-6,
                 )
+
+
+class TestDistPPTrainingDelayScaleLoss(TestDistPPTraining):
+    """Test that explicitly setting delay_scale_loss=True in pp_configs
+    (backward compat) still produces correct results after the unification."""
+
+    def setUp(self):
+        strategy = fleet.DistributedStrategy()
+        self.model_parallel_size = 1
+        self.data_parallel_size = 1
+        self.pipeline_parallel_size = 2
+        strategy.hybrid_configs = {
+            "dp_degree": self.data_parallel_size,
+            "mp_degree": self.model_parallel_size,
+            "pp_degree": self.pipeline_parallel_size,
+            "pp_configs": {
+                "delay_scale_loss": True,
+            },
+        }
+        strategy.pipeline_configs = {
+            "accumulate_steps": batch_size // micro_batch_size,
+            "micro_batch_size": micro_batch_size,
+        }
+        fleet.init(is_collective=True, strategy=strategy)
+
+    def test_pp_model_backward(self):
+        super().test_pp_model_backward()
+
+
+class TestDistPPTrainingMicroBatchLossValues(unittest.TestCase):
+    """Verify that return_micro_batch_loss=True returns raw unscaled
+    per-micro-batch loss values, and that each one matches the reference
+    model's loss computed on the corresponding micro batch slice."""
+
+    def setUp(self):
+        strategy = fleet.DistributedStrategy()
+        self.model_parallel_size = 1
+        self.data_parallel_size = 1
+        self.pipeline_parallel_size = 2
+        strategy.hybrid_configs = {
+            "dp_degree": self.data_parallel_size,
+            "mp_degree": self.model_parallel_size,
+            "pp_degree": self.pipeline_parallel_size,
+        }
+        strategy.pipeline_configs = {
+            "accumulate_steps": batch_size // micro_batch_size,
+            "micro_batch_size": micro_batch_size,
+        }
+        fleet.init(is_collective=True, strategy=strategy)
+
+    def test_micro_batch_loss_unscaled(self):
+        hcg = fleet.get_hybrid_communicate_group()
+        dp_id = hcg.get_data_parallel_rank()
+        pp_id = hcg.get_stage_id()
+        rank_id = dist.get_rank()
+        set_random_seed(2048, dp_id, rank_id)
+
+        accumulate_steps = batch_size // micro_batch_size
+
+        # construct reference model
+        model_a = SimpleNet()
+
+        # construct pipeline model
+        model_b = SimpleNetPipe(topology=hcg.topology())
+        scheduler_b = paddle.optimizer.lr.PiecewiseDecay(
+            boundaries=[2, 3, 4], values=[0.01, 0.02, 0.03, 0.04], verbose=True
+        )
+        optimizer_b = paddle.optimizer.SGD(
+            learning_rate=scheduler_b, parameters=model_b.parameters()
+        )
+        model_b = fleet.distributed_model(model_b)
+        optimizer_b = fleet.distributed_optimizer(optimizer_b)
+
+        param_len = len(model_a.parameters())
+        parameters = [p.numpy() for p in model_a.parameters()]
+
+        model_b_params = model_b.parameters()
+        if pp_id == 0:
+            model_b_params[0].set_value(parameters[2])
+        else:
+            model_b_params[0].set_value(parameters[0])
+            model_b_params[1].set_value(parameters[1])
+
+        x1_data = np.random.randint(0, vocab_size, size=[batch_size, 1])
+        x2_data = np.random.randint(0, vocab_size, size=[batch_size, 1])
+        y1_data = np.random.randint(0, hidden_size, size=[batch_size, 1])
+
+        x1 = paddle.to_tensor(x1_data, dtype="int64")
+        x2 = paddle.to_tensor(x2_data, dtype="float32")
+        y1 = paddle.to_tensor(y1_data, dtype="float32")
+        x1.stop_gradient = True
+        x2.stop_gradient = True
+        y1.stop_gradient = True
+
+        loss_fn_idx = 0
+        loss_b = model_b.train_batch(
+            [(x1, x2), (y1,)],
+            optimizer_b,
+            scheduler_b,
+            loss_fn_idx=loss_fn_idx,
+            return_micro_batch_loss=True,
+        )
+
+        # Compute per-micro-batch reference losses
+        for mb_idx in range(accumulate_steps):
+            start = mb_idx * micro_batch_size
+            end = start + micro_batch_size
+            mb_x1 = x1[start:end]
+            mb_x2 = x2[start:end]
+            mb_y1 = y1[start:end]
+            ref_losses = model_a(mb_x1, mb_x2, mb_y1)
+
+            for fn_idx in range(2):
+                # Each micro batch loss should be unscaled and match reference
+                np.testing.assert_allclose(
+                    ref_losses[fn_idx].numpy(),
+                    loss_b[fn_idx][mb_idx].numpy(),
+                    rtol=1e-6,
+                    atol=1e-6,
+                    err_msg=(
+                        f"Micro batch {mb_idx} loss_fn {fn_idx} mismatch: "
+                        f"expected raw unscaled loss"
+                    ),
+                )
+
+
+class TestNoPipelineParallelTraining(unittest.TestCase):
+    """Test NoPipelineParallel (single-stage pipeline) path.
+    Verifies that train_batch and eval_batch return correct loss values
+    after the delay_scale_loss unification."""
+
+    def setUp(self):
+        strategy = fleet.DistributedStrategy()
+        self.model_parallel_size = 1
+        self.data_parallel_size = 1
+        self.pipeline_parallel_size = 2
+        strategy.hybrid_configs = {
+            "dp_degree": self.data_parallel_size,
+            "mp_degree": self.model_parallel_size,
+            "pp_degree": self.pipeline_parallel_size,
+        }
+        strategy.pipeline_configs = {
+            "accumulate_steps": batch_size // micro_batch_size,
+            "micro_batch_size": micro_batch_size,
+        }
+        fleet.init(is_collective=True, strategy=strategy)
+
+    def test_no_pipeline_train_loss(self):
+        """Verify NoPipelineParallel.train_batch returns correct average loss."""
+        hcg = fleet.get_hybrid_communicate_group()
+        dp_id = hcg.get_data_parallel_rank()
+        rank_id = dist.get_rank()
+        set_random_seed(4096, dp_id, rank_id)
+
+        strategy = fleet.fleet._user_defined_strategy
+
+        # Build single-stage pipeline model (all layers on one device)
+        pipe_model = SimpleNetPipe(num_stages=1)
+        no_pp_model = NoPipelineParallel(pipe_model, strategy, hcg)
+
+        # Build reference model with same parameters
+        model_a = SimpleNet()
+        params_a = [p.numpy() for p in model_a.parameters()]
+
+        # Sync parameters: NoPipelineParallel has all params on one stage
+        # SimpleNetPipe layer order: EmbeddingNet, MatmulNet, BiasNet
+        # params: [embedding_weight, softmax_weight, softmax_bias]
+        # SimpleNet params: [embedding_weight, softmax_weight, softmax_bias]
+        no_pp_params = no_pp_model.parameters()
+        for i, p in enumerate(no_pp_params):
+            p.set_value(params_a[i])
+
+        scheduler_a = paddle.optimizer.lr.PiecewiseDecay(
+            boundaries=[2, 3, 4], values=[0.01, 0.02, 0.03, 0.04], verbose=True
+        )
+        optimizer_a = paddle.optimizer.SGD(
+            learning_rate=scheduler_a, parameters=model_a.parameters()
+        )
+        scheduler_b = paddle.optimizer.lr.PiecewiseDecay(
+            boundaries=[2, 3, 4], values=[0.01, 0.02, 0.03, 0.04], verbose=True
+        )
+        optimizer_b = paddle.optimizer.SGD(
+            learning_rate=scheduler_b, parameters=no_pp_model.parameters()
+        )
+
+        for _ in range(3):
+            x1_data = np.random.randint(0, vocab_size, size=[batch_size, 1])
+            x2_data = np.random.randint(0, vocab_size, size=[batch_size, 1])
+            y1_data = np.random.randint(0, hidden_size, size=[batch_size, 1])
+
+            x1 = paddle.to_tensor(x1_data, dtype="int64")
+            x2 = paddle.to_tensor(x2_data, dtype="float32")
+            y1 = paddle.to_tensor(y1_data, dtype="float32")
+            x1.stop_gradient = True
+            x2.stop_gradient = True
+            y1.stop_gradient = True
+
+            # Reference model: forward + backward + step
+            loss_a = model_a(x1, x2, y1)
+            loss_a[0].backward()
+            optimizer_a.step()
+            optimizer_a.clear_grad()
+            scheduler_a.step()
+
+            # NoPipelineParallel model: train_batch
+            loss_b = no_pp_model.train_batch(
+                [(x1, x2), (y1,)], optimizer_b, scheduler_b
+            )
+
+            print("no_pp loss:", loss_a[0].numpy(), loss_b.numpy())
+            np.testing.assert_allclose(
+                loss_a[0].numpy(), loss_b.numpy(), rtol=1e-6, atol=1e-6
+            )
+
+    def test_no_pipeline_eval_loss(self):
+        """Verify NoPipelineParallel.eval_batch returns correct average loss."""
+        hcg = fleet.get_hybrid_communicate_group()
+        dp_id = hcg.get_data_parallel_rank()
+        rank_id = dist.get_rank()
+        set_random_seed(5120, dp_id, rank_id)
+
+        strategy = fleet.fleet._user_defined_strategy
+
+        pipe_model = SimpleNetPipe(num_stages=1)
+        no_pp_model = NoPipelineParallel(pipe_model, strategy, hcg)
+
+        model_a = SimpleNet()
+        params_a = [p.numpy() for p in model_a.parameters()]
+        no_pp_params = no_pp_model.parameters()
+        for i, p in enumerate(no_pp_params):
+            p.set_value(params_a[i])
+
+        optimizer_b = paddle.optimizer.SGD(
+            learning_rate=0.01, parameters=no_pp_model.parameters()
+        )
+
+        x1_data = np.random.randint(0, vocab_size, size=[batch_size, 1])
+        x2_data = np.random.randint(0, vocab_size, size=[batch_size, 1])
+        y1_data = np.random.randint(0, hidden_size, size=[batch_size, 1])
+
+        x1 = paddle.to_tensor(x1_data, dtype="int64")
+        x2 = paddle.to_tensor(x2_data, dtype="float32")
+        y1 = paddle.to_tensor(y1_data, dtype="float32")
+        x1.stop_gradient = True
+        x2.stop_gradient = True
+        y1.stop_gradient = True
+
+        # Reference: compute full batch loss
+        loss_a = model_a(x1, x2, y1)
+
+        # NoPipelineParallel: eval_batch
+        loss_b = no_pp_model.eval_batch([(x1, x2), (y1,)], compute_loss=True)
+
+        print("no_pp eval loss:", loss_a[0].numpy(), loss_b.numpy())
+        np.testing.assert_allclose(
+            loss_a[0].numpy(), loss_b.numpy(), rtol=1e-6, atol=1e-6
+        )
+
+    def test_no_pipeline_return_micro_batch_loss(self):
+        """Verify NoPipelineParallel.train_batch with return_micro_batch_loss
+        returns raw unscaled per-micro-batch values."""
+        hcg = fleet.get_hybrid_communicate_group()
+        dp_id = hcg.get_data_parallel_rank()
+        rank_id = dist.get_rank()
+        set_random_seed(6144, dp_id, rank_id)
+
+        strategy = fleet.fleet._user_defined_strategy
+        accumulate_steps = batch_size // micro_batch_size
+
+        pipe_model = SimpleNetPipe(num_stages=1)
+        no_pp_model = NoPipelineParallel(pipe_model, strategy, hcg)
+
+        model_a = SimpleNet()
+        params_a = [p.numpy() for p in model_a.parameters()]
+        no_pp_params = no_pp_model.parameters()
+        for i, p in enumerate(no_pp_params):
+            p.set_value(params_a[i])
+
+        scheduler_b = paddle.optimizer.lr.PiecewiseDecay(
+            boundaries=[2, 3, 4], values=[0.01, 0.02, 0.03, 0.04], verbose=True
+        )
+        optimizer_b = paddle.optimizer.SGD(
+            learning_rate=scheduler_b, parameters=no_pp_model.parameters()
+        )
+
+        x1_data = np.random.randint(0, vocab_size, size=[batch_size, 1])
+        x2_data = np.random.randint(0, vocab_size, size=[batch_size, 1])
+        y1_data = np.random.randint(0, hidden_size, size=[batch_size, 1])
+
+        x1 = paddle.to_tensor(x1_data, dtype="int64")
+        x2 = paddle.to_tensor(x2_data, dtype="float32")
+        y1 = paddle.to_tensor(y1_data, dtype="float32")
+        x1.stop_gradient = True
+        x2.stop_gradient = True
+        y1.stop_gradient = True
+
+        loss_b = no_pp_model.train_batch(
+            [(x1, x2), (y1,)],
+            optimizer_b,
+            scheduler_b,
+            return_micro_batch_loss=True,
+        )
+
+        # Verify each micro batch loss matches reference
+        for mb_idx in range(accumulate_steps):
+            start = mb_idx * micro_batch_size
+            end = start + micro_batch_size
+            ref_losses = model_a(x1[start:end], x2[start:end], y1[start:end])
+            for fn_idx in range(2):
+                np.testing.assert_allclose(
+                    ref_losses[fn_idx].numpy(),
+                    loss_b[fn_idx][mb_idx].numpy(),
+                    rtol=1e-6,
+                    atol=1e-6,
+                )
+
+
+class TestDistPPEvalBatch(TestDistPPTraining):
+    """Test PipelineParallel.eval_batch returns correct average loss."""
+
+    def test_pp_eval_batch(self):
+        hcg = fleet.get_hybrid_communicate_group()
+        dp_id = hcg.get_data_parallel_rank()
+        pp_id = hcg.get_stage_id()
+        rank_id = dist.get_rank()
+        set_random_seed(7168, dp_id, rank_id)
+
+        model_a = SimpleNet()
+        model_b = SimpleNetPipe(topology=hcg.topology())
+        optimizer_b = paddle.optimizer.SGD(
+            learning_rate=0.01, parameters=model_b.parameters()
+        )
+        model_b = fleet.distributed_model(model_b)
+        optimizer_b = fleet.distributed_optimizer(optimizer_b)
+
+        params_a = [p.numpy() for p in model_a.parameters()]
+        model_b_params = model_b.parameters()
+        if pp_id == 0:
+            model_b_params[0].set_value(params_a[2])
+        else:
+            model_b_params[0].set_value(params_a[0])
+            model_b_params[1].set_value(params_a[1])
+
+        x1_data = np.random.randint(0, vocab_size, size=[batch_size, 1])
+        x2_data = np.random.randint(0, vocab_size, size=[batch_size, 1])
+        y1_data = np.random.randint(0, hidden_size, size=[batch_size, 1])
+
+        x1 = paddle.to_tensor(x1_data, dtype="int64")
+        x2 = paddle.to_tensor(x2_data, dtype="float32")
+        y1 = paddle.to_tensor(y1_data, dtype="float32")
+        x1.stop_gradient = True
+        x2.stop_gradient = True
+        y1.stop_gradient = True
+
+        loss_a = model_a(x1, x2, y1)
+        loss_b = model_b.eval_batch([(x1, x2), (y1,)], compute_loss=True)
+
+        print("eval loss:", loss_a[0].numpy(), loss_b.numpy())
+        np.testing.assert_allclose(
+            loss_a[0].numpy(), loss_b.numpy(), rtol=1e-6, atol=1e-6
+        )
 
 
 if __name__ == "__main__":

--- a/test/collective/fleet/hybrid_parallel_pp_return_micro_batch_loss.py
+++ b/test/collective/fleet/hybrid_parallel_pp_return_micro_batch_loss.py
@@ -391,6 +391,21 @@ class TestNoPipelineParallelTraining(unittest.TestCase):
         }
         fleet.init(is_collective=True, strategy=strategy)
 
+    @staticmethod
+    def _sync_params_by_shape(src_model, dst_model):
+        """Sync parameters from src_model to dst_model by matching shapes.
+
+        SimpleNet and SimpleNetPipe have identical parameters but in different
+        order.  Match them by shape to avoid index-order mismatches.
+        """
+        src_params = {tuple(p.shape): p.numpy() for p in src_model.parameters()}
+        for p in dst_model.parameters():
+            key = tuple(p.shape)
+            assert key in src_params, (
+                f"No matching param with shape {key} in source model"
+            )
+            p.set_value(src_params.pop(key))
+
     def test_no_pipeline_train_loss(self):
         """Verify NoPipelineParallel.train_batch returns correct average loss."""
         hcg = fleet.get_hybrid_communicate_group()
@@ -406,15 +421,10 @@ class TestNoPipelineParallelTraining(unittest.TestCase):
 
         # Build reference model with same parameters
         model_a = SimpleNet()
-        params_a = [p.numpy() for p in model_a.parameters()]
 
-        # Sync parameters: NoPipelineParallel has all params on one stage
-        # SimpleNetPipe layer order: EmbeddingNet, MatmulNet, BiasNet
-        # params: [embedding_weight, softmax_weight, softmax_bias]
-        # SimpleNet params: [embedding_weight, softmax_weight, softmax_bias]
-        no_pp_params = no_pp_model.parameters()
-        for i, p in enumerate(no_pp_params):
-            p.set_value(params_a[i])
+        # Sync parameters by shape: SimpleNet and SimpleNetPipe have the same
+        # set of parameter shapes but enumerate them in different order.
+        self._sync_params_by_shape(model_a, no_pp_model)
 
         scheduler_a = paddle.optimizer.lr.PiecewiseDecay(
             boundaries=[2, 3, 4], values=[0.01, 0.02, 0.03, 0.04], verbose=True
@@ -453,9 +463,10 @@ class TestNoPipelineParallelTraining(unittest.TestCase):
                 [(x1, x2), (y1,)], optimizer_b, scheduler_b
             )
 
-            print("no_pp loss:", loss_a[0].numpy(), loss_b.numpy())
+            # train_batch returns a list when there are multiple loss functions
+            print("no_pp loss:", loss_a[0].numpy(), loss_b[0].numpy())
             np.testing.assert_allclose(
-                loss_a[0].numpy(), loss_b.numpy(), rtol=1e-6, atol=1e-6
+                loss_a[0].numpy(), loss_b[0].numpy(), rtol=1e-6, atol=1e-6
             )
 
     def test_no_pipeline_eval_loss(self):
@@ -471,10 +482,7 @@ class TestNoPipelineParallelTraining(unittest.TestCase):
         no_pp_model = NoPipelineParallel(pipe_model, strategy, hcg)
 
         model_a = SimpleNet()
-        params_a = [p.numpy() for p in model_a.parameters()]
-        no_pp_params = no_pp_model.parameters()
-        for i, p in enumerate(no_pp_params):
-            p.set_value(params_a[i])
+        self._sync_params_by_shape(model_a, no_pp_model)
 
         optimizer_b = paddle.optimizer.SGD(
             learning_rate=0.01, parameters=no_pp_model.parameters()
@@ -497,9 +505,10 @@ class TestNoPipelineParallelTraining(unittest.TestCase):
         # NoPipelineParallel: eval_batch
         loss_b = no_pp_model.eval_batch([(x1, x2), (y1,)], compute_loss=True)
 
-        print("no_pp eval loss:", loss_a[0].numpy(), loss_b.numpy())
+        # eval_batch returns a list when there are multiple loss functions
+        print("no_pp eval loss:", loss_a[0].numpy(), loss_b[0].numpy())
         np.testing.assert_allclose(
-            loss_a[0].numpy(), loss_b.numpy(), rtol=1e-6, atol=1e-6
+            loss_a[0].numpy(), loss_b[0].numpy(), rtol=1e-6, atol=1e-6
         )
 
     def test_no_pipeline_return_micro_batch_loss(self):
@@ -517,10 +526,7 @@ class TestNoPipelineParallelTraining(unittest.TestCase):
         no_pp_model = NoPipelineParallel(pipe_model, strategy, hcg)
 
         model_a = SimpleNet()
-        params_a = [p.numpy() for p in model_a.parameters()]
-        no_pp_params = no_pp_model.parameters()
-        for i, p in enumerate(no_pp_params):
-            p.set_value(params_a[i])
+        self._sync_params_by_shape(model_a, no_pp_model)
 
         scheduler_b = paddle.optimizer.lr.PiecewiseDecay(
             boundaries=[2, 3, 4], values=[0.01, 0.02, 0.03, 0.04], verbose=True
@@ -601,9 +607,10 @@ class TestDistPPEvalBatch(TestDistPPTraining):
         loss_a = model_a(x1, x2, y1)
         loss_b = model_b.eval_batch([(x1, x2), (y1,)], compute_loss=True)
 
-        print("eval loss:", loss_a[0].numpy(), loss_b.numpy())
+        # eval_batch returns a list when there are multiple loss functions
+        print("eval loss:", loss_a[0].numpy(), loss_b[0].numpy())
         np.testing.assert_allclose(
-            loss_a[0].numpy(), loss_b.numpy(), rtol=1e-6, atol=1e-6
+            loss_a[0].numpy(), loss_b[0].numpy(), rtol=1e-6, atol=1e-6
         )
 
 

--- a/test/collective/fleet/hybrid_parallel_pp_return_micro_batch_loss.py
+++ b/test/collective/fleet/hybrid_parallel_pp_return_micro_batch_loss.py
@@ -231,7 +231,7 @@ class TestDistPPTraining(unittest.TestCase):
 
             for idx in range(2):
                 loss_b_shape = loss_b[idx].shape[0]
-                loss_b_idx = paddle.sum(loss_b[idx])
+                loss_b_idx = paddle.mean(loss_b[idx])
                 np.testing.assert_equal(
                     int(loss_b_shape), int(micro_batch_number)
                 )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Distributed Strategy

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Unify all paths to delay_scale_loss mode: loss is no longer scaled during forward computation, instead gradients are uniformly scaled at optimizer step time.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否