### PR TITLE
Fix out-of-bounds access in GraphSendUERecvCUDAKernel

### DIFF
--- a/paddle/phi/kernels/gpu/send_ue_recv_kernel.cu
+++ b/paddle/phi/kernels/gpu/send_ue_recv_kernel.cu
@@ -60,7 +60,16 @@ void GraphSendUERecvOpCUDAKernelLaunchHelper(const Context& dev_ctx,
     memset_size *= dims_[i];
   }
 
-  dev_ctx.template Alloc<T>(out);
+  // For float16/bfloat16 with reduce_op MIN/MAX, CudaAtomicMin/Max uses 4-byte
+  // atomicCAS on 2-byte values. When the total element count is odd, the last
+  // element's 4-byte CAS can read 2 bytes past the allocation boundary.
+  // Request extra padding to avoid this out-of-bounds access.
+  size_t requested_size = 0;
+  if (sizeof(T) == 2 && (memset_size % 2 != 0) &&
+      (reduce_op == "MAX" || reduce_op == "MIN")) {
+    requested_size = (memset_size + 1) * sizeof(T);
+  }
+  dev_ctx.template Alloc<T>(out, requested_size);
   T* out_data = out->data<T>();
   const size_t& memset_bytes = memset_size * sizeof(T);
   funcs::SetConstant<Context, T> constant_functor;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix out-of-bounds memory access in GraphSendUERecvCUDAKernel for float16 with MIN/MAX reduce ops.

#### Root cause:

CudaAtomicMin/CudaAtomicMax for float16 lacks native 2-byte atomic support on GPU, so the implementation uses 4-byte atomicCAS on a 4-byte-aligned uint32_t address containing the target float16 value. When the output tensor has an odd total element count (e.g., shape [3, 3] = 9 elements = 18 bytes), the 4-byte CAS on the last element reads 2 bytes past the allocation boundary.

Example: send_ue_recv(Tensor([3,3], float16), Tensor([4,1], float16), ..., "min") — the last float16 element sits at byte offset 16 in an 18-byte allocation. The 4-byte atomicCAS reads bytes 16–19, exceeding the allocation by 2 bytes.

#### Fix:

Pad the output tensor allocation by 1 extra element when sizeof(T) == 2 (float16/bfloat16), total element count is odd, and reduce_op is MIN or MAX. This ensures the 4-byte atomicCAS always stays within the allocated memory region.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否