### PR TITLE
Fix segment_pool float16 initial value issue

### DIFF
--- a/paddle/phi/kernels/funcs/segment_pooling.cu
+++ b/paddle/phi/kernels/funcs/segment_pooling.cu
@@ -102,7 +102,8 @@ __global__ void SegmentMeanKernel(const Index* segment_ids,
         for (Index interval_id = last_segment_id + 1;
              interval_id < current_segment_id;
              ++interval_id) {
-          *(output + interval_id * inner_dim_size + segment_offset) = T(0);
+          *(output + interval_id * inner_dim_size + segment_offset) =
+              pool.initial();
         }
 
         if (j > 0) {
@@ -158,7 +159,8 @@ __global__ void __launch_bounds__(1024, 1) SegmentOpsKernel(
         for (Index interval_id = last_segment_id + 1;
              interval_id < current_segment_id;
              ++interval_id) {
-          *(output + interval_id * inner_dim_size + segment_offset) = T(0);
+          *(output + interval_id * inner_dim_size + segment_offset) =
+              pool.initial();
         }
         // don't update result when j=0
         if (j > 0) {
@@ -243,25 +245,30 @@ class ArrangeHelper {
   const T input_total_size;
   const T input_length_size;
   const T output_length_size;
-  T inner_dim_size;
-  T total_stripe_count;
+  int64_t inner_dim_size;
+  int64_t total_stripe_count;
   const T DimTileSize = 8;
 
   ArrangeHelper(T a, T b, T c)
       : input_total_size(a), input_length_size(b), output_length_size(c) {
     T input_outer_dim_num_stripe =
         (input_length_size + DimTileSize - 1) / DimTileSize;
-    inner_dim_size = input_total_size / input_length_size;
-    total_stripe_count = inner_dim_size * input_outer_dim_num_stripe;
+    inner_dim_size = static_cast<int64_t>(input_total_size) /
+                     static_cast<int64_t>(input_length_size);
+    total_stripe_count =
+        inner_dim_size * static_cast<int64_t>(input_outer_dim_num_stripe);
   }
 
   DEVICE inline void calculate(T stripe_index,
                                T* segment_offset,
                                T* dim_index_base,
                                T* actual_height) {
-    *segment_offset = stripe_index % inner_dim_size;
-    *dim_index_base = stripe_index / inner_dim_size * DimTileSize;
-    *actual_height = min(DimTileSize, input_length_size - *dim_index_base);
+    *segment_offset = static_cast<T>(stripe_index % inner_dim_size);
+    *dim_index_base = static_cast<T>(static_cast<int64_t>(stripe_index) /
+                                     inner_dim_size * DimTileSize);
+    *actual_height = min(static_cast<int64_t>(DimTileSize),
+                         static_cast<int64_t>(input_length_size) -
+                             static_cast<int64_t>(*dim_index_base));
   }
 };
 

--- a/paddle/phi/kernels/funcs/segment_pooling.cu
+++ b/paddle/phi/kernels/funcs/segment_pooling.cu
@@ -210,7 +210,7 @@ __global__ void SegmentIndexGradKernel(const Index* segment_ids,
 template <class T>
 class MaxPool {
  public:
-  DEVICE inline T initial() { return static_cast<T>(-FLT_MAX); }
+  DEVICE inline T initial() { return std::numeric_limits<T>::lowest(); }
   DEVICE inline void compute(const T& x, T* y) { *y = *y > x ? *y : x; }
   DEVICE inline T atomic(T* address, const T val) {
     return phi::CudaAtomicMax(address, val);
@@ -220,7 +220,7 @@ class MaxPool {
 template <class T>
 class MinPool {
  public:
-  DEVICE inline T initial() { return static_cast<T>(FLT_MAX); }
+  DEVICE inline T initial() { return std::numeric_limits<T>::max(); }
   DEVICE inline void compute(const T& x, T* y) { *y = *y < x ? *y : x; }
   DEVICE inline T atomic(T* address, const T val) {
     return phi::CudaAtomicMin(address, val);

--- a/paddle/phi/kernels/impl/segment_pool_kernel_impl.h
+++ b/paddle/phi/kernels/impl/segment_pool_kernel_impl.h
@@ -19,6 +19,7 @@
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/segment_pooling.h"
+#include <limits>
 
 namespace phi {
 
@@ -94,9 +95,9 @@ void SegmentKernelLaunchHelper(const Context& dev_ctx,
 
     T init_value = static_cast<T>(0);
     if (pooltype == "MAX") {
-      init_value = static_cast<T>(-FLT_MAX);
+      init_value = std::numeric_limits<T>::lowest();
     } else if (pooltype == "MIN") {
-      init_value = static_cast<T>(FLT_MAX);
+      init_value = std::numeric_limits<T>::max();
     }
     funcs::SetConstant<Context, T> setconst;
     setconst(dev_ctx, out, static_cast<T>(init_value));


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Use std::numeric_limits<T>::lowest() and std::numeric_limits<T>::max() instead of FLT_MAX/-FLT_MAX for type-safe initialization in MaxPool and MinPool classes. This ensures correct behavior for float16 and other half-precision types.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是