### PR TITLE
[release/3.3] Fix segfault when using advanced indexing on 0-size tensor

### DIFF
--- a/paddle/fluid/pybind/slice_utils.h
+++ b/paddle/fluid/pybind/slice_utils.h
@@ -537,6 +537,15 @@ static void ParseIndex(const paddle::Tensor& tensor,
           }
         } else {
           // int tensor consumes only one dimension of input tensor
+          // Check: if the dimension is valid and has size 0 while the
+          // index tensor has elements, any index is out of bounds.
+          // Skip this check when current_dim >= rank (too many indices),
+          // which is caught later at the end of ParseIndex.
+          if (current_dim < rank && dim_len == 0 && slice_tensor.numel() > 0) {
+            PADDLE_THROW(common::errors::OutOfRange(
+                "index is out of bounds for dimension %d with size 0",
+                static_cast<int>(current_dim)));
+          }
           (*advanced_index_dim)[estimated_dim] = estimated_dim;
           estimated_dim++;
           current_dim++;

--- a/test/indexing/test_getitem_appendix.py
+++ b/test/indexing/test_getitem_appendix.py
@@ -349,6 +349,21 @@ class TestGetItemErrorCase(unittest.TestCase):
         with self.assertRaises(IndexError):
             res = x[0]  # IndexError: (OutOfRange)
 
+    def test_0size_advanced_index(self):
+        # Indexing into a 0-size dimension with non-empty int indices
+        # should raise IndexError, not segfault.
+        x_bool = paddle.empty([0, 5, 4, 3], dtype='bool')
+        with self.assertRaises(IndexError):
+            res = x_bool[[[2, -3, -4], [-1, 2, 5]]]
+        with self.assertRaises(IndexError):
+            res = x_bool[[[2, 3, 4], [1, 2, 5]]]
+
+        x_complex = paddle.empty([0, 5, 4, 3], dtype='complex128')
+        with self.assertRaises(IndexError):
+            res = x_complex[[[2, -3, -4], [-1, 2, 5]]]
+        with self.assertRaises(IndexError):
+            res = x_complex[[[2, 3, 4], [1, 2, 5]]]
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
#### Summary
- Fix a segmentation fault (CPU) / CUDA illegal memory access (GPU) that occurs when using advanced integer indexing (`__getitem__` with list of lists) on a tensor with a 0-size dimension (e.g., shape `[0, 5, 4, 3]`).
- Add a bounds check in `ParseIndex` (`slice_utils.h`): when the indexed dimension has size 0 and the index tensor is non-empty, raise an `OutOfRange` error instead of proceeding to the kernel where an invalid pointer dereference crashes the process.
- This aligns Paddle's behavior with NumPy and PyTorch, which both raise `IndexError` for the same operation.

#### Root Cause
In `ParseIndex` (slice_utils.h), the int tensor advanced indexing branch records the index dimension but does **not** validate that `dim_len > 0`. The `AdvancedIndex` constructor then replaces the 0-size dimension with the index tensor's shape via `restride_src`, making the output `numel` non-zero. The kernel's `out->numel() == 0` early-return guard doesn't trigger, and the kernel dereferences an invalid pointer from the 0-size input tensor, causing the crash.

#### Test plan
- [x] Verified fix with `paddle.zeros([0, 5, 4, 3], dtype='bool')[[[2,-3,-4],[-1,2,5]]]` — now raises `IndexError`
- [x] Verified fix with `paddle.zeros([0, 5, 4, 3], dtype='complex128')[[[2,3,4],[1,2,5]]]` — now raises `IndexError`
- [x] Verified normal advanced indexing still works: `paddle.arange(9).reshape([3,3])[[[0,1],[1,2]]]` — returns correct result
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否


---

Cherry-pick of #78453 (authored by @huangjiyi) to `release/3.3`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78453 <!-- For pass CI -->