### PR TITLE
[Allocator] guard VMM best fit v2 with CUDA macro

### DIFF
--- a/paddle/phi/core/memory/allocation/vmm_auto_growth_best_fit_allocator_v2.cc
+++ b/paddle/phi/core/memory/allocation/vmm_auto_growth_best_fit_allocator_v2.cc
@@ -14,6 +14,8 @@
 
 #include "paddle/phi/core/memory/allocation/vmm_auto_growth_best_fit_allocator_v2.h"
 
+#if defined(PADDLE_WITH_CUDA)
+
 #include <algorithm>
 #include <iterator>
 
@@ -336,3 +338,5 @@ void VMMAutoGrowthBestFitAllocatorV2::TryMerge(BlockListIt it) {
 }  // namespace allocation
 }  // namespace memory
 }  // namespace paddle
+
+#endif

--- a/paddle/phi/core/memory/allocation/vmm_auto_growth_best_fit_allocator_v2.h
+++ b/paddle/phi/core/memory/allocation/vmm_auto_growth_best_fit_allocator_v2.h
@@ -24,6 +24,8 @@
 #include "paddle/phi/core/memory/allocation/spin_lock.h"
 #include "paddle/phi/core/memory/allocation/vmm_allocator_v2_types.h"
 
+#if defined(PADDLE_WITH_CUDA)
+
 namespace paddle {
 namespace memory {
 namespace allocation {
@@ -85,3 +87,5 @@ class VMMAutoGrowthBestFitAllocatorV2 : public Allocator {
 }  // namespace allocation
 }  // namespace memory
 }  // namespace paddle
+
+#endif


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] --> Performance Optimization


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] --> Bug fixes


### Description
<!-- Describe what you’ve done -->
 guard VMM best fit v2 with CUDA macro

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]--> 否 
