### PR TITLE
[PAA] Align tanhshrink and gelu precision with PyTorch

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -4943,10 +4943,16 @@ struct CudaSoftShrinkGradFunctor : public BaseActivationFunctor<T> {
 template <typename T>
 struct CudaTanhShrinkFunctor : public BaseActivationFunctor<T> {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  bool compatible = false;
 
   // tanhshrink(x) = x - tanh(x)
   __device__ __forceinline__ T operator()(const T arg_x) const {
     MPType x = static_cast<MPType>(arg_x);
+    if (compatible) {
+      // Match PyTorch: tanh truncated to native dtype T before subtraction
+      T tanh_val = static_cast<T>(tanh(x));
+      return static_cast<T>(x - static_cast<MPType>(tanh_val));
+    }
     return static_cast<T>(x - tanh(x));
   }
 };
@@ -4954,12 +4960,83 @@ struct CudaTanhShrinkFunctor : public BaseActivationFunctor<T> {
 template <typename T>
 struct CudaTanhShrinkGradFunctor : public BaseActivationFunctor<T> {
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  bool compatible = false;
 
   // dx = dout * tanh(x)^2
+  // PyTorch decomposes tanhshrink as x - tanh(x), so backward is:
+  //   tanh_grad_input = -grad * (1 - tanh_out_T * tanh_out_T)
+  //   dx = grad + tanh_grad_input
+  // PyTorch's tanh backward for fp16/bf16 computes out*out in native dtype
+  // using __hmul (not promoted to fp32). We must use explicit __half ops
+  // to avoid implicit float promotion through operator float().
   __device__ __forceinline__ T operator()(const T arg_dout,
                                           const T arg_x) const {
     MPType dout = static_cast<MPType>(arg_dout);
     MPType x = static_cast<MPType>(arg_x);
+    if (compatible) {
+      // Match PyTorch decomposed backward for tanhshrink = x - tanh(x):
+      //   tanh_grad = grad * (1 - tanh_out^2)  -- CudaTanhGradFunctor pattern
+      //   dx = grad - tanh_grad
+      // tanh output is stored at native dtype T.
+      T tanh_val = static_cast<T>(tanh(x));
+      if constexpr (std::is_same<T, phi::float16>::value) {
+        // Match PyTorch: tanh backward computes in native fp16 (scalar_t),
+        // using __hmul for multiplication. Each intermediate truncated to fp16.
+        // PyTorch's tanh_backward: a * (scalar_t{1.} - b * b)
+        // NVCC may fuse __hsub(one, __hmul(t,t)) into HFMA2, but PyTorch
+        // does NOT fuse these for fp16. Use volatile to prevent FMA fusion
+        // for the t_sq computation, matching PyTorch's non-fused behavior.
+        __half t_half = __float2half_rn(static_cast<float>(tanh_val));
+        volatile __half t_sq_half = __hmul(t_half, t_half);
+        __half one_half = __float2half_rn(1.0f);
+        __half one_minus_t_sq = __hsub(one_half, t_sq_half);
+        __half dout_half = __float2half_rn(static_cast<float>(arg_dout));
+        volatile __half tanh_grad_half = __hmul(dout_half, one_minus_t_sq);
+        __half result_half = __hsub(dout_half, tanh_grad_half);
+        return static_cast<T>(__half2float(result_half));
+      } else if constexpr (std::is_same<T, phi::dtype::bfloat16>::value) {
+        // Match PyTorch: tanh backward computes in native bf16 (scalar_t),
+        // not promoted to opmath_t. Compute each step at T precision.
+        T one = static_cast<T>(1.0f);
+        T t_sq = static_cast<T>(static_cast<float>(tanh_val) *
+                                static_cast<float>(tanh_val));
+        T one_minus_t_sq =
+            static_cast<T>(static_cast<float>(one) - static_cast<float>(t_sq));
+        T tanh_grad = static_cast<T>(static_cast<float>(arg_dout) *
+                                     static_cast<float>(one_minus_t_sq));
+        return static_cast<T>(static_cast<float>(arg_dout) -
+                              static_cast<float>(tanh_grad));
+      } else if constexpr (std::is_same<T, float>::value) {
+        // For float32: T == MPType == float.
+        // PyTorch decomposes tanhshrink backward into two SEPARATE kernels:
+        //   Kernel 1 (tanh_backward): (-dout) * (1.0f - t*t)
+        //   Kernel 2 (add): dout + tanh_backward_result
+        // Within Kernel 1, NVCC fuses (1.0f - t*t) into fma(-t, t, 1),
+        // so we ALLOW FMA here. The multiply dout*one_minus_t_sq is a
+        // separate fmul instruction in PyTorch's kernel.
+        // Between kernels, no FMA fusion occurs (global memory barrier).
+        //
+        // Bug: volatile on tanh_grad does NOT prevent NVCC from fusing
+        // dout * one_minus_t_sq and dout - tanh_grad into a single
+        // fmaf(-dout, one_minus_t_sq, dout). This causes 1-ULP errors
+        // when dout != 1.0 (e.g., .mean() backward where dout = 1/N).
+        // Fix: use __fmul_rn to force a non-FMA rounded multiply,
+        // which emits a mul.rn.f32 instruction that NVCC cannot fuse.
+        float t = static_cast<float>(tanh_val);
+        float one_minus_t_sq = 1.0f - t * t;  // FMA allowed: fma(-t,t,1)
+        float tanh_grad = __fmul_rn(dout, one_minus_t_sq);  // non-FMA mul
+        return dout - tanh_grad;
+      } else {
+        // For float64: T == MPType == double.
+        // Same decomposition as float32. NVCC fuses (1 - t*t) via FMA.
+        // Use __dmul_rn to prevent FMA fusion of multiply+subtract,
+        // matching PyTorch's separate-kernel behavior.
+        double t = static_cast<double>(tanh_val);
+        double one_minus_t_sq = 1.0 - t * t;  // FMA allowed: fma(-t,t,1)
+        double tanh_grad = __dmul_rn(dout, one_minus_t_sq);  // non-FMA mul
+        return dout - tanh_grad;
+      }
+    }
     return static_cast<T>(dout * tanh(x) * tanh(x));
   }
 

--- a/paddle/phi/kernels/gpu/activation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_grad_kernel.cu
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/kernels/activation_grad_kernel.h"
+#include "paddle/common/flags.h"
 
 #include "glog/logging.h"
 
@@ -23,6 +24,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
 #include "paddle/phi/kernels/impl/activation_grad_impl.h"
 
+COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
 namespace phi {
 
 template <typename T, typename Context, typename Functor>
@@ -239,7 +241,17 @@ DEFINE_GPU_ACTIVATION_GRAD_KERNEL_DEPX(Cosh, CudaCoshGradFunctor);
 DEFINE_GPU_ACTIVATION_GRAD_KERNEL_DEPX(Asinh, CudaAsinhGradFunctor);
 DEFINE_GPU_ACTIVATION_GRAD_KERNEL_DEPX(Acosh, CudaAcoshGradFunctor);
 DEFINE_GPU_ACTIVATION_GRAD_KERNEL_DEPX(Atanh, CudaAtanhGradFunctor);
-DEFINE_GPU_ACTIVATION_GRAD_KERNEL_DEPX(TanhShrink, CudaTanhShrinkGradFunctor);
+// TanhShrinkGrad: custom kernel to support FLAGS_use_accuracy_compatible_kernel
+template <typename T, typename Context>
+void TanhShrinkGradKernel(const Context& dev_ctx,
+                          const DenseTensor& x,
+                          const DenseTensor& dout,
+                          DenseTensor* dx) {
+  funcs::CudaTanhShrinkGradFunctor<T> functor;
+  functor.compatible = FLAGS_use_accuracy_compatible_kernel;
+  ActivationGradGPUImpl<T, Context, funcs::CudaTanhShrinkGradFunctor<T>>(
+      dev_ctx, &x, nullptr, &dout, dx, functor);
+}
 DEFINE_GPU_ACTIVATION_GRAD_KERNEL_DEPX(Square, CudaSquareGradFunctor);
 
 DEFINE_GPU_ACTIVATION_GRAD_KERNEL_DEPOUT(Exp, CudaExpGradFunctor);

--- a/paddle/phi/kernels/gpu/activation_kernel.cu
+++ b/paddle/phi/kernels/gpu/activation_kernel.cu
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/kernels/activation_kernel.h"
+#include "paddle/common/flags.h"
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
@@ -22,6 +23,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/impl/activation_grad_impl.h"
 #include "paddle/phi/kernels/impl/activation_impl.h"
 
+COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
 namespace phi {
 
 template <typename T, typename Context, typename Functor>
@@ -132,7 +134,16 @@ DEFINE_GPU_ACTIVATION_KERNEL(Acosh, CudaAcoshFunctor)
 DEFINE_GPU_ACTIVATION_KERNEL(Atanh, CudaAtanhFunctor)
 DEFINE_GPU_ACTIVATION_KERNEL(Relu, CudaReluFunctor)
 DEFINE_GPU_ACTIVATION_KERNEL(Tanh, CudaTanhFunctor)
-DEFINE_GPU_ACTIVATION_KERNEL(TanhShrink, CudaTanhShrinkFunctor)
+// TanhShrink: custom kernel to support FLAGS_use_accuracy_compatible_kernel
+template <typename T, typename Context>
+void TanhShrinkKernel(const Context& dev_ctx,
+                      const DenseTensor& x,
+                      DenseTensor* out) {
+  funcs::CudaTanhShrinkFunctor<T> functor;
+  functor.compatible = FLAGS_use_accuracy_compatible_kernel;
+  ActivationGPUImpl<T, Context, funcs::CudaTanhShrinkFunctor<T>>(
+      dev_ctx, x, out, functor);
+}
 DEFINE_GPU_ACTIVATION_KERNEL(Silu, CudaSiluFunctor)
 DEFINE_GPU_ACTIVATION_KERNEL(Reciprocal, CudaReciprocalFunctor)
 DEFINE_GPU_ACTIVATION_KERNEL(Square, CudaSquareFunctor)

--- a/paddle/phi/kernels/gpu/gelu_funcs.h
+++ b/paddle/phi/kernels/gpu/gelu_funcs.h
@@ -41,31 +41,46 @@ static __device__ __forceinline__ float FP32FastTanh(float x) {
 
 template <typename T, bool FastMode>
 static __device__ __forceinline__ T GeluFwd(T x) {
+  constexpr float kBeta = 0.7978845608f;  // M_SQRT2 * M_2_SQRTPI * 0.5
+  constexpr float kKappa = 0.044715f;
   const float cast_x = static_cast<float>(x);
-  auto tanh_out = FP32FastTanh<FastMode>(0.79788456f * cast_x *
-                                         (1.0f + 0.044715f * cast_x * cast_x));
-  return static_cast<T>(cast_x * 0.5f * (1.0f + tanh_out));
+  auto x_cube = cast_x * cast_x * cast_x;
+  auto inner = kBeta * (cast_x + kKappa * x_cube);
+  auto tanh_out = FP32FastTanh<FastMode>(inner);
+  return static_cast<T>(0.5f * cast_x * (1.0f + tanh_out));
 }
 
 #ifdef PADDLE_WITH_HIP
 template <bool FastMode>
 static __device__ __forceinline__ __half GeluFwdHalf(__half x) {
+  constexpr float kBeta = 0.7978845608f;
+  constexpr float kKappa = 0.044715f;
   const float cast_x = __half2float(x);
-  auto tanh_out = FP32FastTanh<FastMode>(0.79788456f * cast_x *
-                                         (1.0f + 0.044715f * cast_x * cast_x));
-  return __float2half(cast_x * 0.5f * (1.0f + tanh_out));
+  auto x_cube = cast_x * cast_x * cast_x;
+  auto inner = kBeta * (cast_x + kKappa * x_cube);
+  auto tanh_out = FP32FastTanh<FastMode>(inner);
+  return __float2half(0.5f * cast_x * (1.0f + tanh_out));
 }
 #endif
 
 template <bool FastMode>
 static __device__ __forceinline__ float FP32GeluBwd(float x, float y_g) {
-  auto tanh_out =
-      FP32FastTanh<FastMode>(0.79788456f * x * (1.0f + 0.044715f * x * x));
-  auto tmp = 0.5f * x *
-                 ((1.0f - tanh_out * tanh_out) *
-                  (0.79788456f + 0.1070322243f * x * x)) +
-             0.5f * (1.0f + tanh_out);
-  return tmp * y_g;
+  constexpr float kBeta = 0.7978845608f;  // M_SQRT2 * M_2_SQRTPI * 0.5
+  constexpr float kKappa = 0.044715f;
+  auto x_sq = x * x;
+  auto x_cube = x_sq * x;
+  auto inner = kBeta * (x + kKappa * x_cube);
+  auto tanh_inner = FP32FastTanh<FastMode>(inner);
+
+  auto left = 0.5f * x;
+  auto right = 1.0f + tanh_inner;
+
+  auto left_derivative = 0.5f * right;
+  auto tanh_derivative = 1.0f - tanh_inner * tanh_inner;
+  auto inner_derivative = kBeta * (1.0f + 3.0f * kKappa * x_sq);
+  auto right_derivative = left * tanh_derivative * inner_derivative;
+
+  return y_g * (left_derivative + right_derivative);
 }
 
 template <int VecSize, bool FastMode>

--- a/paddle/phi/kernels/gpu/gelu_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/gelu_grad_kernel.cu
@@ -22,6 +22,7 @@
 #include "paddle/phi/kernels/gpu/gelu_funcs.h"
 
 COMMON_DECLARE_bool(use_fast_math);
+COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
 
 namespace phi {
 
@@ -31,17 +32,23 @@ struct GeluWithApproximateGradFunctor {
   inline HOSTDEVICE T operator()(T arg_x, T arg_dout) {
     MPType x = static_cast<MPType>(arg_x);
     MPType dout = static_cast<MPType>(arg_dout);
-    MPType one = static_cast<MPType>(1);
-    MPType half = static_cast<MPType>(0.5);
-    MPType kAlpha = M_SQRT2 * M_2_SQRTPI * static_cast<MPType>(0.5);
-    MPType kBeta = static_cast<MPType>(GELU_CONSTANT);
-    auto x_seq = x * x;
-    auto cube_x = x * x * x;
-    auto tanh_out = tanh(kAlpha * ((kBeta * cube_x) + x));
-    auto ans = half * (one + tanh_out) +
-               half * x * (one - tanh_out * tanh_out) *
-                   (kAlpha * (one + static_cast<MPType>(3) * kBeta * x_seq));
-    return static_cast<T>(ans * dout);
+    MPType kBeta = M_SQRT2 * M_2_SQRTPI * static_cast<MPType>(0.5);
+    MPType kKappa = static_cast<MPType>(GELU_CONSTANT);
+    auto x_sq = x * x;
+    auto x_cube = x_sq * x;
+    auto inner = kBeta * (x + kKappa * x_cube);
+    auto tanh_inner = tanh(inner);
+
+    auto left = static_cast<MPType>(0.5) * x;
+    auto right = static_cast<MPType>(1) + tanh_inner;
+
+    auto left_derivative = static_cast<MPType>(0.5) * right;
+    auto tanh_derivative = static_cast<MPType>(1) - tanh_inner * tanh_inner;
+    auto inner_derivative = kBeta * (static_cast<MPType>(1) +
+                                     static_cast<MPType>(3) * kKappa * x_sq);
+    auto right_derivative = left * tanh_derivative * inner_derivative;
+
+    return static_cast<T>(dout * (left_derivative + right_derivative));
   }
 };
 
@@ -73,7 +80,8 @@ void GeluGradKernel(const Context& dev_ctx,
   std::vector<DenseTensor*> outs = {x_grad};
   if (approximate) {
 #if defined(__NVCC__) || defined(__HIPCC__)
-    if (std::is_same<T, dtype::float16>::value) {
+    if (std::is_same<T, dtype::float16>::value &&
+        !FLAGS_use_accuracy_compatible_kernel) {
       size_t n = x.numel();
       const auto* x_ptr = reinterpret_cast<const __half*>(x.data<T>());
       const auto* y_g_ptr = reinterpret_cast<const __half*>(out_grad.data<T>());

--- a/paddle/phi/kernels/gpu/gelu_kernel.cu
+++ b/paddle/phi/kernels/gpu/gelu_kernel.cu
@@ -26,6 +26,7 @@
 // clang-format on
 
 COMMON_DECLARE_bool(use_fast_math);
+COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
 
 namespace phi {
 
@@ -70,7 +71,8 @@ void GeluKernel(const Context& dev_ctx,
   std::vector<DenseTensor*> outs = {out};
   if (approximate) {
 #if defined(__NVCC__) || defined(__HIPCC__)
-    if (std::is_same<T, dtype::float16>::value) {
+    if (std::is_same<T, dtype::float16>::value &&
+        !FLAGS_use_accuracy_compatible_kernel) {
       size_t n = x.numel();
       const auto* in_ptr = reinterpret_cast<const __half*>(x.data<T>());
       auto* out_ptr = reinterpret_cast<__half*>(out->data<T>());


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Improvements

### Description
将 master 分支上 tanhshrink 和 gelu 算子的精度对齐改动 cherry-pick 到 release/3.3 分支。

#### 主要改动
- **tanhshrink forward/backward**：在 `FLAGS_use_accuracy_compatible_kernel` 开启时，GPU kernel 按 PyTorch 的分解路径计算，针对 fp16/bf16/fp32/fp64 分别处理精度截断和 FMA 融合行为，实现与 PyTorch 的 bit-level 对齐。
- **gelu forward/backward**：在兼容模式下调整中间计算精度和舍入行为，匹配 PyTorch 的 gelu 实现。

devPR:https://github.com/PaddlePaddle/Paddle/pull/78241

### 是否引起精度变化
是