### PR TITLE
Fix float16 out-of-bounds access in GraphSendUERecvCUDAKernel

### DIFF
--- a/paddle/phi/kernels/gpu/send_ue_recv_kernel.cu
+++ b/paddle/phi/kernels/gpu/send_ue_recv_kernel.cu
@@ -60,7 +60,16 @@ void GraphSendUERecvOpCUDAKernelLaunchHelper(const Context& dev_ctx,
     memset_size *= dims_[i];
   }
 
-  dev_ctx.template Alloc<T>(out);
+  // For float16/bfloat16 with reduce_op MIN/MAX, CudaAtomicMin/Max uses 4-byte
+  // atomicCAS on 2-byte values. When the total element count is odd, the last
+  // element's 4-byte CAS can read 2 bytes past the allocation boundary.
+  // Request extra padding to avoid this out-of-bounds access.
+  size_t requested_size = 0;
+  if (sizeof(T) == 2 && (memset_size % 2 != 0) &&
+      (reduce_op == "MAX" || reduce_op == "MIN")) {
+    requested_size = (memset_size + 1) * sizeof(T);
+  }
+  dev_ctx.template Alloc<T>(out, requested_size);
   T* out_data = out->data<T>();
   const size_t& memset_bytes = memset_size * sizeof(T);
   funcs::SetConstant<Context, T> constant_functor;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
devPR:https://github.com/PaddlePaddle/Paddle/pull/78454

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否