### PR TITLE
[API Compatibility] Add kwarg `force` and warning message for `Tensor.numpy`

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -155,6 +155,13 @@ static PyObject* tensor_method_numpy(TensorObject* self,
                                      PyObject* args,
                                      PyObject* kwargs) {
   EAGER_TRY
+  if (kwargs) {
+    PyObject* arg = PyDict_GetItemString(kwargs, "force");
+    if (arg && arg == Py_False) {
+      LOG(WARNING) << "Warning: Currently paddle.Tensor.numpy() only supports "
+                      "force conversion i.e. t.detach().cpu().numpy().";
+    }
+  }
   auto& api = pybind11::detail::npy_api::get();
   if (!self->tensor.impl()) {
     Py_intptr_t py_dims[phi::DDim::kMaxRank];     // NOLINT

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -1940,7 +1940,7 @@ class Variable(metaclass=VariableMetaClass):
         return output
 
     @fake_interface_only
-    def numpy(self):
+    def numpy(self, *, force=True):
         """
         **Notes**:
             **This API is ONLY available in Dygraph mode**

--- a/python/paddle/pir/math_op_patch.py
+++ b/python/paddle/pir/math_op_patch.py
@@ -1391,7 +1391,7 @@ def monkey_patch_value():
         return res
 
     @fake_interface_only
-    def numpy(self):
+    def numpy(self, *, force=True):
         """
         **Notes**:
             **This API is ONLY available in Dygraph mode**

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -1159,6 +1159,9 @@ class TestEagerTensor(unittest.TestCase):
         with base.dygraph.guard():
             var = paddle.to_tensor(self.array)
             np.testing.assert_array_equal(var.numpy(), var.numpy(False))
+            np.testing.assert_array_equal(
+                var.numpy(force=True), var.numpy(force=False)
+            )
 
     def test_tensor_as_np(self):
         with base.dygraph.guard():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Add kwarg `force` for `paddle.Tensor.numpy()`
- Add warning message for unsupported `force=False` in C++ api
- Add test

**Used AI Studio**


### 是否引起精度变化
否
