### PR TITLE
[release/3.3] Fix rms_norm_grad bug (CUDA Error 701)

### DIFF
--- a/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
+++ b/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
@@ -708,7 +708,6 @@ __device__ __forceinline__ void blockReduceScaleBackwardWithChecks(
     }
   }
 }
-
 template <typename T,
           typename T_ACC,
           unsigned int block_dim_x,
@@ -716,12 +715,13 @@ template <typename T,
           unsigned int rows_per_block_y,
           bool partial_reduction,
           bool aligned_grid>
-__global__ void ScaleBackwardCUDAKernelTemplate(int64_t M,
-                                                int64_t N,
-                                                const T* __restrict__ dY,
-                                                const T* __restrict__ X,
-                                                const T_ACC* __restrict__ rstd,
-                                                T* __restrict__ dscale) {
+__global__ void __launch_bounds__(block_dim_x* block_dim_y)
+    ScaleBackwardCUDAKernelTemplate(int64_t M,
+                                    int64_t N,
+                                    const T* __restrict__ dY,
+                                    const T* __restrict__ X,
+                                    const T_ACC* __restrict__ rstd,
+                                    T* __restrict__ dscale) {
   constexpr int rows_per_thread_y = rows_per_block_y / block_dim_y;
   static_assert(rows_per_thread_y <= kWarpSize);
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ]Operator Mechanism -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 Bug fixes 

### Description
<!-- Describe what you’ve done -->
#### 修复 paddle.nn.functional.rms_norm 反向kernel可能产生CUDA Error 701的问题。
#### 问题产生的原因：
ScaleBackwardCUDAKernelTemplate 这个cuda kernel 内部采用了比较多的unroll, nvcc 会为每个thread分配比较多的寄存器，当block内线程数比较多时有可能在launch时产生 ```CUDA Error700 cudaErrorLaunchOutOfResources```

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

---

Cherry-pick of #78478 (authored by @DanielSun11) to `release/3.3`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78478 <!-- For pass CI -->