### PR TITLE
[0 SIZE] Add zero-size input validation for variable_length_memory_ef…

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/variable_length_memory_efficient_attention_kernel.cu
+++ b/paddle/phi/kernels/fusion/cutlass/variable_length_memory_efficient_attention_kernel.cu
@@ -32,6 +32,9 @@ void MultiHeadAttentionVariableForwardKernel(
     DenseTensor* output) {
   dev_ctx.template Alloc<T>(output);
   if (output->numel() == 0) return;
+  // If seq_lens or kv_seq_lens is a 0-size tensor, no valid sequence lengths
+  // are provided, so there is nothing to compute.
+  if (seq_lens.numel() == 0 || kv_seq_lens.numel() == 0) return;
 
   Params params{};
   // [B, N, S, H]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism
### PR Types
Bug fixes

### Description
devPR:https://github.com/PaddlePaddle/Paddle/pull/78446
[Cherry-pick]修复 `variable_length_memory_efficient_attention` 算子在 `seq_lens` 或 `kv_seq_lens` 为 0-size 张量时触发非法 CUDA 内存访问的问题（CUDA error 700: illegal memory access）。

**问题根因**

原有的防护检查仅针对 `output` 是否为 0-size：

```cpp
if (output->numel() == 0) return;
```

但当 `seq_lens` 的 shape 为 `[0, 1]`（numel=0）而 `query` shape 为 `[1, 1, 31, 64]` 时，`output` 的 numel 不为零，检查不会触发。此时 `seq_lens.data<int>()` 返回无效指针，CUDA kernel 访问该指针导致崩溃。

**修复方案**

**`paddle/phi/kernels/fusion/cutlass/variable_length_memory_efficient_attention_kernel.cu`**
- 新增对 `seq_lens` 和 `kv_seq_lens` 的 0-size 检查：若任意一个为 0-size 张量则提前返回，无需执行 kernel。

**复现用例**

```python
import paddle
query       = paddle.randn([1, 1, 31, 64], dtype="float16")
key         = paddle.randn([1, 1, 31, 64], dtype="float16")
value       = paddle.randn([1, 1, 31, 64], dtype="float16")
seq_lens    = paddle.zeros([0, 1], dtype="int32")   # 0-size tensor
kv_seq_lens = paddle.ones([1, 1], dtype="int32")
mask        = paddle.randn([1, 1, 50, 50], dtype="float16")
# 修复前：CUDA error 700 (illegal memory access)
# 修复后：正常返回
out = paddle.incubate.nn.functional.variable_length_memory_efficient_attention(
    query, key, value, seq_lens, kv_seq_lens, mask=mask, scale=0.125)
```

### 是否引起精度变化
否