### PR TITLE
[CMake] Suppress AppleClang invalid-specialization on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,6 +615,9 @@ include(third_party
 )# download, build, install third_party, Contains about 20+ dependencies
 
 include(flags) # set paddle compile flags
+if(APPLE)
+  safe_set_cxxflag(CMAKE_CXX_FLAGS "-Wno-invalid-specialization")
+endif()
 include(util) # set unittest and link libs
 include(version) # set PADDLE_VERSION
 include(coveralls) # set code coverage


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
Apple Silicon macOS source builds can fail under newer AppleClang/libc++ because libc++ now marks several standard type traits as `__no_specializations__`, and Paddle still specializes them for `phi::dtype::complex<T>` in `paddle/phi/common/complex.h`.

Before this patch, building with:

```bash
bash compile.sh~ 3.10
```

failed with errors like:

```text
paddle/phi/common/complex.h:690:8: error: 'is_pod' cannot be specialized: Users are not allowed to specialize this standard library entity [-Winvalid-specialization]
paddle/phi/common/complex.h:695:8: error: 'is_floating_point' cannot be specialized: Users are not allowed to specialize this standard library entity [-Winvalid-specialization]
paddle/phi/common/complex.h:699:8: error: 'is_signed' cannot be specialized: Users are not allowed to specialize this standard library entity [-Winvalid-specialization]
paddle/phi/common/complex.h:704:8: error: 'is_unsigned' cannot be specialized: Users are not allowed to specialize this standard library entity [-Winvalid-specialization]
```

This PR adds:

```cmake
if(APPLE)
  safe_set_cxxflag(CMAKE_CXX_FLAGS "-Wno-invalid-specialization")
endif()
```

after `include(flags)`, so the flag is applied only on macOS and only when the compiler actually supports it.

### Validation
- Reproduced on Apple Silicon macOS 26.3 / Xcode 26.4 / AppleClang 21.0.0.21000099 / Python 3.10
- Rebuilt with `bash compile.sh~ 3.10`
- Produced `build_310/python/dist/paddlepaddle-3.4.0.dev20260315-cp310-cp310-macosx_11_0_arm64.whl`
- Installed the wheel and verified `import paddle` plus a small CPU tensor op

### 是否引起精度变化
否
