### PR TITLE
[CMake] Fix macOS AppleClang invalid-specialization build failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,6 +615,9 @@ include(third_party
 )# download, build, install third_party, Contains about 20+ dependencies
 
 include(flags) # set paddle compile flags
+if(APPLE)
+  safe_set_cxxflag(CMAKE_CXX_FLAGS "-Wno-invalid-specialization")
+endif()
 include(util) # set unittest and link libs
 include(version) # set PADDLE_VERSION
 include(coveralls) # set code coverage


### PR DESCRIPTION
## Summary
- suppress `-Winvalid-specialization` for Apple C++ builds after Paddle's common flags are initialized
- unblock macOS/AppleClang builds that currently fail in `paddle/phi/common/complex.h`

## Test
- reproduced locally on macOS arm64 with `bash compile.sh~ 3.10` in `~/Projects/Paddle`
- `ninja paddle/pir/CMakeFiles/pir.dir/src/core/builder.cc.o paddle/pir/CMakeFiles/pir.dir/src/core/builtin_dialect.cc.o paddle/pir/CMakeFiles/pir.dir/src/core/builtin_op.cc.o`
- `ninja pir`
