### PR TITLE
[Improvement] Replace yaml.load with yaml.safe_load in metrics.py

### DIFF
--- a/python/paddle/distributed/metric/metrics.py
+++ b/python/paddle/distributed/metric/metrics.py
@@ -34,9 +34,8 @@ def init_metric(
     ignore_rank=False,
     bucket_size=1000000,
 ):
-    yaml_fobj = open(metric_yaml_path)
-
-    content = yaml.load(yaml_fobj, Loader=yaml.FullLoader)
+    with open(metric_yaml_path, 'r', encoding='utf-8') as yaml_fobj:
+        content = yaml.safe_load(yaml_fobj)
 
     print("yaml metric config: \n")
     print(content)


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Improvements

### Description
将 `python/paddle/distributed/metric/metrics.py` 中的 `yaml.load(..., Loader=yaml.FullLoader)` 替换为业内推荐的 `yaml.safe_load(...)`。

**主要收益：**
消除使用 `FullLoader` 带来的潜在任意对象实例化风险，提升对外暴露 API 的代码鲁棒性，保护可能调用此模块的下游业务开发者。此修改属于零成本的代码规范（Clean Code）优化，完全不影响现有核心逻辑。

Fixes #78507 

### 是否引起精度变化
否