### PR TITLE
Fix Device class to support custom device types

### DIFF
--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -725,7 +725,11 @@ def get_default_device() -> paddle.device:
 
             >>> print(paddle.get_default_device())
     """
-    return paddle.device(get_device().replace("gpu", "cuda"))
+    dev = get_device()
+    # Only replace exact "gpu" device type, not substrings in custom device names
+    if dev.startswith("gpu"):
+        dev = "cuda" + dev[3:]
+    return paddle.device(dev)
 
 
 def set_default_device(device: PlaceLike | int) -> None:
@@ -2136,21 +2140,25 @@ class Device(str):
 
         elif isinstance(type, str):
             t = type.lower()
-            if t not in cls._SUPPORTED_TYPES and ":" not in t:
-                raise ValueError(f"Unsupported device type: {t}")
-            if index is not None:
+            if ":" in t:
+                dev_type, idx = t.split(":")
+                dev_type = dev_type.lower()
+                if (
+                    dev_type not in cls._SUPPORTED_TYPES
+                    and dev_type not in core.get_all_custom_device_type()
+                ):
+                    raise ValueError(f"Unsupported device type: {dev_type}")
+                dev_index = int(idx)
+            elif t in cls._SUPPORTED_TYPES:
                 dev_type = t
-                dev_index = index if t != "cpu" else None
+                dev_index = (
+                    index if (index is not None and t != "cpu") else None
+                )
+            elif t in core.get_all_custom_device_type():
+                dev_type = t
+                dev_index = index
             else:
-                if ":" in t:
-                    dev_type, idx = t.split(":")
-                    dev_type = dev_type.lower()
-                    if dev_type not in cls._SUPPORTED_TYPES:
-                        raise ValueError(f"Unsupported device type: {dev_type}")
-                    dev_index = int(idx)
-                else:
-                    dev_type = t
-                    dev_index = None
+                raise ValueError(f"Unsupported device type: {t}")
 
         elif isinstance(type, int):
             dev_type = "cuda"
@@ -2185,6 +2193,8 @@ class Device(str):
             return core.CUDAPlace(self.index)
         elif self.type == "xpu":
             return core.XPUPlace(self.index)
+        elif self.type in core.get_all_custom_device_type():
+            return core.CustomPlace(self.type, self.index)
         else:
             raise ValueError(f"Unsupported device type: {self.type}")
 

--- a/test/compat/test_device_apis.py
+++ b/test/compat/test_device_apis.py
@@ -758,6 +758,60 @@ class TestDeviceAPIs(unittest.TestCase):
         with self.assertRaises(ValueError):
             paddle.device.max_memory_allocated([1, 2, 3])
 
+    def test_get_default_device_cuda(self):
+        """Test get_default_device with CUDA."""
+        if not core.is_compiled_with_cuda():
+            self.skipTest("CUDA not available")
+        paddle.device.set_device('gpu')
+        dev = paddle.get_default_device()
+        self.assertIsInstance(dev, paddle.device.Device)
+        self.assertEqual(dev.type, 'cuda')
+
+    def test_get_default_device_customdevice(self):
+        """Test get_default_device with custom device."""
+        if not is_custom_device():
+            self.skipTest("Custom device not available")
+        paddle.device.set_device(self.default_custom_device)
+        dev = paddle.get_default_device()
+        self.assertIsInstance(dev, paddle.device.Device)
+        self.assertEqual(dev.type, self.default_custom_device)
+
+    def test_tensor_device_cuda(self):
+        """Test Tensor.device property with CUDA."""
+        if not core.is_compiled_with_cuda():
+            self.skipTest("CUDA not available")
+        paddle.device.set_device('gpu')
+        t = paddle.randn([2, 2])
+        dev = t.device
+        self.assertIsInstance(dev, paddle.device.Device)
+        self.assertEqual(dev.type, 'cuda')
+        self.assertIsNotNone(dev.index)
+        del t
+
+    def test_tensor_device_customdevice(self):
+        """Test Tensor.device property with custom device."""
+        if not is_custom_device():
+            self.skipTest("Custom device not available")
+        paddle.device.set_device(self.default_custom_device)
+        t = paddle.randn([2, 2])
+        dev = t.device
+        self.assertIsInstance(dev, paddle.device.Device)
+        self.assertEqual(dev.type, self.default_custom_device)
+        self.assertIsNotNone(dev.index)
+        del t
+
+    def test_device_class_customdevice(self):
+        """Test Device class with custom device type string and Place conversion."""
+        if not is_custom_device():
+            self.skipTest("Custom device not available")
+        # String construction
+        dev = paddle.device.Device(f'{self.default_custom_device}:0')
+        self.assertEqual(dev.type, self.default_custom_device)
+        self.assertEqual(dev.index, 0)
+        # _to_place round-trip
+        place = dev._to_place()
+        self.assertTrue(place.is_custom_place())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
[Paddle-iluvatar PR] 40
Fix `Device` class to support custom device types (e.g., `iluvatar_gpu`).

Fixes https://github.com/PaddlePaddle/Paddle/issues/78487

#### Problem

Paddle 3.3.0 新增的 `Device` 类（PyTorch 兼容层）没有处理自定义设备类型，导致安装了 `paddle-iluvatar-gpu` 等自定义设备插件的环境中，以下两个 API 报错：

1. **`paddle.get_default_device()`** — `ValueError: Unsupported device type: iluvatar_cuda`
2. **`paddle.Tensor.device`** — `ValueError: Unsupported device type: iluvatar_gpu`

#### Root Cause

1. `get_default_device()` 中使用 `.replace("gpu", "cuda")` 全局替换，会把 `"iluvatar_gpu:0"` 误替换为 `"iluvatar_cuda:0"`，该字符串不在 `_SUPPORTED_TYPES` 中，触发 ValueError。
2. `Device.__new__` 的字符串解析分支只认 `_SUPPORTED_TYPES = {"cpu", "gpu", "cuda", "xpu"}`，自定义设备类型直接被拒绝。
3. `Device._to_place()` 没有 `CustomPlace` 分支，导致自定义设备的所有属性访问（通过 `__getattr__` 委托）均失败。

#### Fix

| 位置 | 修改 |
|------|------|
| `get_default_device()` | 将 `.replace("gpu", "cuda")` 改为 `startswith("gpu")` 精确匹配，避免误伤自定义设备名中的 `gpu` 子串 |
| `Device.__new__` 字符串分支 | 当 `dev_type` 不在 `_SUPPORTED_TYPES` 时，查询 `core.get_all_custom_device_type()` 判断是否为已注册的自定义设备，而非直接报错 |
| `Device._to_place()` | 新增 `elif self.type in core.get_all_custom_device_type()` 分支，返回 `core.CustomPlace(self.type, self.index)` |

#### Tests

在 `test/compat/test_device_apis.py` 中新增 5 个测试方法：

- `test_get_default_device_cuda` — GPU 场景回归
- `test_get_default_device_customdevice` — 自定义设备下 `get_default_device` 正确性
- `test_tensor_device_cuda` — GPU `Tensor.device` 回归
- `test_tensor_device_customdevice` — 自定义设备下 `Tensor.device` 正确性
- `test_device_class_customdevice` — `Device` 字符串构造 + `_to_place()` 往返验证

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否