### PR TITLE
[SOT][3.13] Fix `internals` `PyThreadState_GET` clerical error

### DIFF
--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_13.c
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_13.c
@@ -146,7 +146,7 @@ void Internal_PyFrame_ClearExceptCode(_PyInterpreterFrame *frame) {
          _PyFrame_GetGenerator(frame)->gi_frame_state == FRAME_CLEARED);
   // GH-99729: Clearing this frame can expose the stack (via finalizers). It's
   // crucial that this frame has been unlinked, and is no longer visible:
-  assert(_PyThreadState_GET()->current_frame != frame);
+  assert(PyThreadState_GET()->current_frame != frame);
   if (frame->frame_obj) {
     PyFrameObject *f = frame->frame_obj;
     frame->frame_obj = NULL;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

debug 模式下编译报错, 单纯是忘记替换了

```bash
/Users/gouzi/Documents/git/Paddle/paddle/fluid/pybind/sot/cpython_internals/internals_3_13.c:149:10: error: call to undeclared function '_PyThreadState_GET'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  149 |   assert(_PyThreadState_GET()->current_frame != frame);
      |          ^
/Users/gouzi/Documents/git/Paddle/paddle/fluid/pybind/sot/cpython_internals/internals_3_13.c:149:10: note: did you mean 'PyThreadState_Get'?
/Users/gouzi/.local/share/uv/python/cpython-3.13.9-macos-aarch64-none/include/python3.13/pystate.h:60:29: note: 'PyThreadState_Get' declared here
   60 | PyAPI_FUNC(PyThreadState *) PyThreadState_Get(void);
      |                             ^
/Users/gouzi/Documents/git/Paddle/paddle/fluid/pybind/sot/cpython_internals/internals_3_13.c:149:32: error: member reference type 'int' is not a pointer
  149 |   assert(_PyThreadState_GET()->current_frame != frame);
      |          ~~~~~~~~~~~~~~~~~~~~  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/assert.h:72:25: note: expanded from macro 'assert'
   72 |     (__builtin_expect(!(e), 0) ? __assert_rtn(__func__, __ASSERT_FILE_NAME, __LINE__, #e) : (void)0)
```

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否