### PR TITLE
[common] Add support for `std::optional` in error messages

### DIFF
--- a/paddle/common/exception.h
+++ b/paddle/common/exception.h
@@ -15,6 +15,7 @@ limitations under the License. */
 #pragma once
 
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -63,6 +64,15 @@ class ErrorMessage {
   template <typename T>
   void build_string(const T& t) {
     oss << t;
+  }
+
+  template <typename T>
+  void build_string(const std::optional<T>& t) {
+    if (t.has_value()) {
+      build_string(*t);
+    } else {
+      oss << "nullopt";
+    }
   }
 
   template <typename T, typename... Args>

--- a/paddle/common/exception.h
+++ b/paddle/common/exception.h
@@ -14,9 +14,16 @@ limitations under the License. */
 
 #pragma once
 
+#if defined(_MSVC_LANG)
+#define PD_CPLUSPLUS _MSVC_LANG
+#else
+#define PD_CPLUSPLUS __cplusplus
+#endif
+
 #include <iostream>
-#if __cplusplus >= 201703L
+#if PD_CPLUSPLUS >= 201703L
 #include <optional>
+#define PD_HAS_STD_OPTIONAL 1
 #endif
 #include <sstream>
 #include <string>
@@ -68,7 +75,7 @@ class ErrorMessage {
     oss << t;
   }
 
-#if __cplusplus >= 201703L
+#ifdef PD_HAS_STD_OPTIONAL
   template <typename T>
   void build_string(const std::optional<T>& t) {
     if (t.has_value()) {
@@ -109,5 +116,10 @@ class ErrorMessage {
     throw ::common::PD_Exception(                                       \
         __message__, __FILE__, __LINE__, "An error occurred.");         \
   } while (0)
+
+#ifdef PD_HAS_STD_OPTIONAL
+#undef PD_HAS_STD_OPTIONAL
+#endif
+#undef PD_CPLUSPLUS
 
 }  // namespace common

--- a/paddle/common/exception.h
+++ b/paddle/common/exception.h
@@ -15,7 +15,9 @@ limitations under the License. */
 #pragma once
 
 #include <iostream>
+#if __cplusplus >= 201703L
 #include <optional>
+#endif
 #include <sstream>
 #include <string>
 
@@ -66,6 +68,7 @@ class ErrorMessage {
     oss << t;
   }
 
+#if __cplusplus >= 201703L
   template <typename T>
   void build_string(const std::optional<T>& t) {
     if (t.has_value()) {
@@ -74,6 +77,7 @@ class ErrorMessage {
       oss << "nullopt";
     }
   }
+#endif
 
   template <typename T, typename... Args>
   void build_string(const T& t, const Args&... args) {

--- a/test/cpp/utils/CMakeLists.txt
+++ b/test/cpp/utils/CMakeLists.txt
@@ -8,6 +8,7 @@ paddle_test(array_ref_test SRCS array_ref_test.cc)
 paddle_test(small_vector_test SRCS small_vector_test.cc)
 paddle_test(variant_test SRCS variant_test.cc)
 paddle_test(span_test SRCS span_test.cc)
+paddle_test(exception_test SRCS exception_test.cc)
 
 if(WITH_ONNXRUNTIME AND WIN32)
   # Copy onnxruntime for some c++ test in Windows, since the test will

--- a/test/cpp/utils/exception_test.cc
+++ b/test/cpp/utils/exception_test.cc
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/common/exception.h"
+
+#include <optional>
+#include <string>
+
+#include "gtest/gtest.h"
+
+TEST(error_message_test, optional_with_value) {
+  std::optional<int> value = 42;
+  std::string msg = common::ErrorMessage("value=", value).to_string();
+  EXPECT_EQ(msg, "value=42");
+}
+
+TEST(error_message_test, optional_without_value) {
+  std::optional<int> value = std::nullopt;
+  std::string msg = common::ErrorMessage("value=", value).to_string();
+  EXPECT_EQ(msg, "value=nullopt");
+}
+
+TEST(pd_check_test, condition_true_no_throw) {
+  EXPECT_NO_THROW(PD_CHECK(true, "should not throw"));
+}
+
+TEST(pd_check_test, condition_false_throws) {
+  EXPECT_THROW(PD_CHECK(false, "bad value"), ::common::PD_Exception);
+}
+
+TEST(pd_check_test, exception_message_contains_custom_msg) {
+  try {
+    PD_CHECK(1 == 2, "expected 1==2 but got mismatch");
+    FAIL() << "expected PD_Exception to be thrown";
+  } catch (const ::common::PD_Exception& e) {
+    EXPECT_NE(std::string(e.what()).find("expected 1==2 but got mismatch"),
+              std::string::npos);
+  }
+}
+
+TEST(pd_check_test, condition_false_with_optional_in_message) {
+  std::optional<int> opt = std::nullopt;
+  try {
+    PD_CHECK(opt.has_value(), "opt is ", opt);
+    FAIL() << "expected PD_Exception to be thrown";
+  } catch (const ::common::PD_Exception& e) {
+    EXPECT_NE(std::string(e.what()).find("opt is nullopt"), std::string::npos);
+  }
+}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
在减少 paddlecodec diff 时发现，`PD_CHECK` 不支持 `std::optional` 相关输出

## 相关链接
* https://github.com/PFCCLab/paddlecodec/pull/3

cc: @ShigureNyako  

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否