### PR TITLE
[Distributed] Replace `os.system` with `os.kill` in `launch/main.py`

### DIFF
--- a/python/paddle/distributed/launch/main.py
+++ b/python/paddle/distributed/launch/main.py
@@ -1228,7 +1228,7 @@ def launch() -> None:
             auto_tuner.add_cfg(cur_cfg)
 
             # per task launch interval
-            self_pid = str(os.getpid())
+            self_pid = os.getpid()
             if paddle.device.is_compiled_with_custom_device('npu'):
                 processes = os.popen(
                     "fuser -v /dev/davinci* |awk '{for(i=1;i<=NF;i++) print $i;}'"
@@ -1241,7 +1241,8 @@ def launch() -> None:
                 processes = os.popen(
                     "fuser -v /dev/nvidia* |awk '{for(i=1;i<=NF;i++) print $i;}'"
                 ).readlines()
-            launch_utils.cleanup_processes(processes, self_pid)
+            pids_to_kill = launch_utils.filter_pids(processes, self_pid)
+            launch_utils.terminate_processes(pids_to_kill)
             time.sleep(3)
             end_time = time.time()
 

--- a/python/paddle/distributed/launch/main.py
+++ b/python/paddle/distributed/launch/main.py
@@ -1241,9 +1241,15 @@ def launch() -> None:
                     "fuser -v /dev/nvidia* |awk '{for(i=1;i<=NF;i++) print $i;}'"
                 ).readlines()
             for process in processes:
-                pid = str(process.strip())
-                if pid != self_pid:
-                    os.system("kill -9 " + pid)
+                pid = process.strip()
+                # Skip empty lines, non-numeric tokens, and the current process.
+                if not pid or not pid.isdigit() or pid == self_pid:
+                    continue
+                try:
+                    os.kill(int(pid), 9)
+                except (ProcessLookupError, PermissionError):
+                    # Target exited or no permission; match prior os.system behavior (no abort).
+                    pass
             time.sleep(3)
             end_time = time.time()
 

--- a/python/paddle/distributed/launch/main.py
+++ b/python/paddle/distributed/launch/main.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import paddle
 from paddle.distributed.launch.context import Context
-from paddle.distributed.utils.launch_utils import terminate_other_processes
+from paddle.distributed.utils import launch_utils
 
 ctx = None
 
@@ -1241,7 +1241,8 @@ def launch() -> None:
                 processes = os.popen(
                     "fuser -v /dev/nvidia* |awk '{for(i=1;i<=NF;i++) print $i;}'"
                 ).readlines()
-            terminate_other_processes(processes, self_pid)
+            pids_to_kill = launch_utils.filter_pids(processes, self_pid)
+            launch_utils.terminate_processes(pids_to_kill)
             time.sleep(3)
             end_time = time.time()
 

--- a/python/paddle/distributed/launch/main.py
+++ b/python/paddle/distributed/launch/main.py
@@ -1241,8 +1241,7 @@ def launch() -> None:
                 processes = os.popen(
                     "fuser -v /dev/nvidia* |awk '{for(i=1;i<=NF;i++) print $i;}'"
                 ).readlines()
-            pids_to_kill = launch_utils.filter_pids(processes, self_pid)
-            launch_utils.terminate_processes(pids_to_kill)
+            launch_utils.cleanup_processes(processes, self_pid)
             time.sleep(3)
             end_time = time.time()
 

--- a/python/paddle/distributed/launch/main.py
+++ b/python/paddle/distributed/launch/main.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import paddle
 from paddle.distributed.launch.context import Context
+from paddle.distributed.utils.launch_utils import terminate_other_processes
 
 ctx = None
 
@@ -1240,16 +1241,7 @@ def launch() -> None:
                 processes = os.popen(
                     "fuser -v /dev/nvidia* |awk '{for(i=1;i<=NF;i++) print $i;}'"
                 ).readlines()
-            for process in processes:
-                pid = process.strip()
-                # Skip empty lines, non-numeric tokens, and the current process.
-                if not pid or not pid.isdigit() or pid == self_pid:
-                    continue
-                try:
-                    os.kill(int(pid), 9)
-                except (ProcessLookupError, PermissionError):
-                    # Target exited or no permission; match prior os.system behavior (no abort).
-                    pass
+            terminate_other_processes(processes, self_pid)
             time.sleep(3)
             end_time = time.time()
 

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -20,7 +20,6 @@ import subprocess
 import sys
 import time
 from contextlib import closing
-from typing import List
 
 from paddle.distributed.fleet.launch_utils import get_backend_by_compile_flag
 from paddle.utils import strtobool
@@ -555,7 +554,7 @@ def _print_arguments(args):
     print("------------------------------------------------")
 
 
-def terminate_other_processes(processes: List[str], self_pid: str) -> None:
+def terminate_other_processes(processes: list[str], self_pid: str) -> None:
     for process in processes:
         pid = process.strip()
         # Skip empty lines, non-numeric tokens, and the current process.

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
 import copy
 import os
-import signal
 import socket
 import subprocess
 import sys
 import time
 from contextlib import closing
+from typing import Sequence
 
 from paddle.distributed.fleet.launch_utils import get_backend_by_compile_flag
 from paddle.utils import strtobool
@@ -556,14 +554,28 @@ def _print_arguments(args):
     print("------------------------------------------------")
 
 
-def terminate_other_processes(processes: list[str], self_pid: str) -> None:
-    for process in processes:
-        pid = process.strip()
-        # Skip empty lines, non-numeric tokens, and the current process.
-        if not pid or not pid.isdigit() or pid == self_pid:
-            continue
+def filter_pids(processes: list[str], self_pid: str) -> list[int]:
+    """Filter valid PIDs from a list of strings, excluding the current self_pid."""
+    return [
+        int(pid.strip())
+        for pid in processes
+        if pid.strip().isdigit() and pid.strip() != self_pid
+    ]
+
+
+def terminate_processes(processes: Sequence[int]) -> bool:
+    """
+    Terminate a list of processes by their PIDs.
+    Returns True if all processes were successfully terminated (or already dead).
+    Returns False if any process failed to terminate due to permissions or other errors.
+    """
+    success = True
+    for pid in processes:
         try:
-            os.kill(int(pid), 9)
-        except (ProcessLookupError, PermissionError):
-            # Target exited or no permission; match prior os.system behavior (no abort).
+            os.kill(pid, 9)
+        except ProcessLookupError:
+            # Target already exited.
             pass
+        except PermissionError:
+            success = False
+    return success

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -14,12 +14,13 @@
 
 import copy
 import os
+import signal
 import socket
 import subprocess
 import sys
 import time
+from collections.abc import Sequence
 from contextlib import closing
-from typing import Sequence
 
 from paddle.distributed.fleet.launch_utils import get_backend_by_compile_flag
 from paddle.utils import strtobool

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import time
 from contextlib import closing
+from typing import List
 
 from paddle.distributed.fleet.launch_utils import get_backend_by_compile_flag
 from paddle.utils import strtobool
@@ -552,3 +553,16 @@ def _print_arguments(args):
     for arg, value in sorted(vars(args).items()):
         print(f"{arg}: {value}")
     print("------------------------------------------------")
+
+
+def terminate_other_processes(processes: List[str], self_pid: str) -> None:
+    for process in processes:
+        pid = process.strip()
+        # Skip empty lines, non-numeric tokens, and the current process.
+        if not pid or not pid.isdigit() or pid == self_pid:
+            continue
+        try:
+            os.kill(int(pid), 9)
+        except (ProcessLookupError, PermissionError):
+            # Target exited or no permission; match prior os.system behavior (no abort).
+            pass

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -555,19 +555,16 @@ def _print_arguments(args):
     print("------------------------------------------------")
 
 
-def filter_pids(processes: list[str], self_pid: str) -> list[int]:
+def filter_pids(processes: Sequence[str], self_pid: int) -> list[int]:
     """Filter valid PIDs from a list of strings, excluding the current self_pid."""
-    return [
-        int(pid.strip())
-        for pid in processes
-        if pid.strip().isdigit() and pid.strip() != self_pid
-    ]
-
-
-def cleanup_processes(processes: list[str], self_pid: str) -> bool:
-    """Filter PIDs then terminate them; returns whether all terminations succeeded."""
-    pids_to_kill = filter_pids(processes, self_pid)
-    return terminate_processes(pids_to_kill)
+    pids_to_kill = []
+    for process in processes:
+        pid_str = process.strip()
+        if pid_str.isdigit():
+            pid_int = int(pid_str)
+            if pid_int != self_pid:
+                pids_to_kill.append(pid_int)
+    return pids_to_kill
 
 
 def terminate_processes(processes: Sequence[int]) -> bool:
@@ -579,7 +576,7 @@ def terminate_processes(processes: Sequence[int]) -> bool:
     success = True
     for pid in processes:
         try:
-            os.kill(pid, 9)
+            os.kill(pid, signal.SIGKILL)
         except ProcessLookupError:
             # Target already exited.
             pass

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -575,7 +575,7 @@ def terminate_processes(processes: Sequence[int]) -> bool:
     Returns True if all processes were successfully terminated (or already dead).
     Returns False if any process failed to terminate due to permissions.
     """
-    sig = getattr(signal, "SIGKILL", signal.SIGTERM)
+    sig = signal.SIGKILL if platform.system() != "Windows" else signal.SIGTERM
     success = True
     for pid in processes:
         try:

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -560,10 +560,12 @@ def filter_pids(processes: Sequence[str], self_pid: int) -> list[int]:
     pids_to_kill = []
     for process in processes:
         pid_str = process.strip()
-        if pid_str.isdigit():
-            pid_int = int(pid_str)
-            if pid_int != self_pid:
-                pids_to_kill.append(pid_int)
+        if not pid_str.isdigit():
+            continue
+        pid_int = int(pid_str)
+        if pid_int == self_pid:
+            continue
+        pids_to_kill.append(pid_int)
     return pids_to_kill
 
 

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -14,6 +14,7 @@
 
 import copy
 import os
+import platform
 import signal
 import socket
 import subprocess

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -563,11 +563,17 @@ def filter_pids(processes: list[str], self_pid: str) -> list[int]:
     ]
 
 
+def cleanup_processes(processes: list[str], self_pid: str) -> bool:
+    """Filter PIDs then terminate them; returns whether all terminations succeeded."""
+    pids_to_kill = filter_pids(processes, self_pid)
+    return terminate_processes(pids_to_kill)
+
+
 def terminate_processes(processes: Sequence[int]) -> bool:
     """
     Terminate a list of processes by their PIDs.
     Returns True if all processes were successfully terminated (or already dead).
-    Returns False if any process failed to terminate due to permissions or other errors.
+    Returns False if any process failed to terminate due to permissions.
     """
     success = True
     for pid in processes:

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import copy
 import os
 import signal

--- a/python/paddle/distributed/utils/launch_utils.py
+++ b/python/paddle/distributed/utils/launch_utils.py
@@ -575,10 +575,11 @@ def terminate_processes(processes: Sequence[int]) -> bool:
     Returns True if all processes were successfully terminated (or already dead).
     Returns False if any process failed to terminate due to permissions.
     """
+    sig = getattr(signal, "SIGKILL", signal.SIGTERM)
     success = True
     for pid in processes:
         try:
-            os.kill(pid, signal.SIGKILL)
+            os.kill(pid, sig)
         except ProcessLookupError:
             # Target already exited.
             pass

--- a/test/legacy_test/test_launch_main_kill.py
+++ b/test/legacy_test/test_launch_main_kill.py
@@ -32,6 +32,7 @@ class TestLaunchMainProcessCleanup(unittest.TestCase):
     def test_terminate_processes_process_lookup(self, mock_kill):
         pids = [12345, 67890]
         mock_kill.side_effect = [None, ProcessLookupError()]
+        expected_sig = getattr(signal, "SIGKILL", signal.SIGTERM)
 
         result = launch_utils.terminate_processes(pids)
 
@@ -39,8 +40,8 @@ class TestLaunchMainProcessCleanup(unittest.TestCase):
         self.assertEqual(mock_kill.call_count, 2)
         mock_kill.assert_has_calls(
             [
-                mock.call(12345, signal.SIGKILL),
-                mock.call(67890, signal.SIGKILL),
+                mock.call(12345, expected_sig),
+                mock.call(67890, expected_sig),
             ],
             any_order=False,
         )
@@ -49,6 +50,7 @@ class TestLaunchMainProcessCleanup(unittest.TestCase):
     def test_terminate_processes_permission_error(self, mock_kill):
         pids = [12345, 67890]
         mock_kill.side_effect = [ProcessLookupError(), PermissionError()]
+        expected_sig = getattr(signal, "SIGKILL", signal.SIGTERM)
 
         result = launch_utils.terminate_processes(pids)
 
@@ -56,8 +58,8 @@ class TestLaunchMainProcessCleanup(unittest.TestCase):
         self.assertEqual(mock_kill.call_count, 2)
         mock_kill.assert_has_calls(
             [
-                mock.call(12345, signal.SIGKILL),
-                mock.call(67890, signal.SIGKILL),
+                mock.call(12345, expected_sig),
+                mock.call(67890, expected_sig),
             ],
             any_order=False,
         )

--- a/test/legacy_test/test_launch_main_kill.py
+++ b/test/legacy_test/test_launch_main_kill.py
@@ -40,7 +40,9 @@ class TestLaunchMainProcessCleanup(unittest.TestCase):
         try:
             launch_utils.terminate_other_processes(processes, self_pid)
         except PermissionError:
-            self.fail("terminate_other_processes should swallow PermissionError")
+            self.fail(
+                "terminate_other_processes should swallow PermissionError"
+            )
         self.assertEqual(mock_kill.call_count, 2)
         mock_kill.assert_has_calls(expected_calls, any_order=False)
 

--- a/test/legacy_test/test_launch_main_kill.py
+++ b/test/legacy_test/test_launch_main_kill.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import platform
 import signal
 import unittest
 from unittest import mock
@@ -32,7 +33,9 @@ class TestLaunchMainProcessCleanup(unittest.TestCase):
     def test_terminate_processes_process_lookup(self, mock_kill):
         pids = [12345, 67890]
         mock_kill.side_effect = [None, ProcessLookupError()]
-        expected_sig = getattr(signal, "SIGKILL", signal.SIGTERM)
+        expected_sig = (
+            signal.SIGKILL if platform.system() != "Windows" else signal.SIGTERM
+        )
 
         result = launch_utils.terminate_processes(pids)
 
@@ -50,7 +53,9 @@ class TestLaunchMainProcessCleanup(unittest.TestCase):
     def test_terminate_processes_permission_error(self, mock_kill):
         pids = [12345, 67890]
         mock_kill.side_effect = [ProcessLookupError(), PermissionError()]
-        expected_sig = getattr(signal, "SIGKILL", signal.SIGTERM)
+        expected_sig = (
+            signal.SIGKILL if platform.system() != "Windows" else signal.SIGTERM
+        )
 
         result = launch_utils.terminate_processes(pids)
 

--- a/test/legacy_test/test_launch_main_kill.py
+++ b/test/legacy_test/test_launch_main_kill.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import signal
 import unittest
 from unittest import mock
 
@@ -19,21 +20,9 @@ from paddle.distributed.utils import launch_utils
 
 
 class TestLaunchMainProcessCleanup(unittest.TestCase):
-    @mock.patch("paddle.distributed.utils.launch_utils.terminate_processes")
-    @mock.patch("paddle.distributed.utils.launch_utils.filter_pids")
-    def test_cleanup_processes(self, mock_filter, mock_terminate):
-        mock_filter.return_value = [123, 456]
-        mock_terminate.return_value = True
-
-        result = launch_utils.cleanup_processes(["123", "456"], "999")
-
-        self.assertTrue(result)
-        mock_filter.assert_called_once_with(["123", "456"], "999")
-        mock_terminate.assert_called_once_with([123, 456])
-
     def test_filter_pids(self):
         processes = [" 123 ", "456", "abc", "", "789"]
-        self_pid = "456"
+        self_pid = 456
 
         result = launch_utils.filter_pids(processes, self_pid)
 
@@ -49,7 +38,11 @@ class TestLaunchMainProcessCleanup(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(mock_kill.call_count, 2)
         mock_kill.assert_has_calls(
-            [mock.call(12345, 9), mock.call(67890, 9)], any_order=False
+            [
+                mock.call(12345, signal.SIGKILL),
+                mock.call(67890, signal.SIGKILL),
+            ],
+            any_order=False,
         )
 
     @mock.patch("paddle.distributed.utils.launch_utils.os.kill")
@@ -62,7 +55,11 @@ class TestLaunchMainProcessCleanup(unittest.TestCase):
         self.assertFalse(result)
         self.assertEqual(mock_kill.call_count, 2)
         mock_kill.assert_has_calls(
-            [mock.call(12345, 9), mock.call(67890, 9)], any_order=False
+            [
+                mock.call(12345, signal.SIGKILL),
+                mock.call(67890, signal.SIGKILL),
+            ],
+            any_order=False,
         )
 
 

--- a/test/legacy_test/test_launch_main_kill.py
+++ b/test/legacy_test/test_launch_main_kill.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from paddle.distributed.utils import launch_utils
+
+
+class TestLaunchMainProcessCleanup(unittest.TestCase):
+    @mock.patch("paddle.distributed.utils.launch_utils.os.kill")
+    def test_terminate_other_processes_swallow_errors(self, mock_kill):
+        processes = ["", "abc", "12345", " 67890 ", "99999"]
+        self_pid = "99999"
+        expected_calls = [mock.call(12345, 9), mock.call(67890, 9)]
+
+        mock_kill.side_effect = ProcessLookupError()
+        try:
+            launch_utils.terminate_other_processes(processes, self_pid)
+        except ProcessLookupError:
+            self.fail(
+                "terminate_other_processes should swallow ProcessLookupError"
+            )
+        self.assertEqual(mock_kill.call_count, 2)
+        mock_kill.assert_has_calls(expected_calls, any_order=False)
+
+        mock_kill.reset_mock()
+        mock_kill.side_effect = PermissionError()
+        try:
+            launch_utils.terminate_other_processes(processes, self_pid)
+        except PermissionError:
+            self.fail("terminate_other_processes should swallow PermissionError")
+        self.assertEqual(mock_kill.call_count, 2)
+        mock_kill.assert_has_calls(expected_calls, any_order=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/legacy_test/test_launch_main_kill.py
+++ b/test/legacy_test/test_launch_main_kill.py
@@ -19,6 +19,18 @@ from paddle.distributed.utils import launch_utils
 
 
 class TestLaunchMainProcessCleanup(unittest.TestCase):
+    @mock.patch("paddle.distributed.utils.launch_utils.terminate_processes")
+    @mock.patch("paddle.distributed.utils.launch_utils.filter_pids")
+    def test_cleanup_processes(self, mock_filter, mock_terminate):
+        mock_filter.return_value = [123, 456]
+        mock_terminate.return_value = True
+
+        result = launch_utils.cleanup_processes(["123", "456"], "999")
+
+        self.assertTrue(result)
+        mock_filter.assert_called_once_with(["123", "456"], "999")
+        mock_terminate.assert_called_once_with([123, 456])
+
     def test_filter_pids(self):
         processes = [" 123 ", "456", "abc", "", "789"]
         self_pid = "456"

--- a/test/legacy_test/test_launch_main_kill.py
+++ b/test/legacy_test/test_launch_main_kill.py
@@ -19,32 +19,39 @@ from paddle.distributed.utils import launch_utils
 
 
 class TestLaunchMainProcessCleanup(unittest.TestCase):
+    def test_filter_pids(self):
+        processes = [" 123 ", "456", "abc", "", "789"]
+        self_pid = "456"
+
+        result = launch_utils.filter_pids(processes, self_pid)
+
+        self.assertEqual(result, [123, 789])
+
     @mock.patch("paddle.distributed.utils.launch_utils.os.kill")
-    def test_terminate_other_processes_swallow_errors(self, mock_kill):
-        processes = ["", "abc", "12345", " 67890 ", "99999"]
-        self_pid = "99999"
-        expected_calls = [mock.call(12345, 9), mock.call(67890, 9)]
+    def test_terminate_processes_process_lookup(self, mock_kill):
+        pids = [12345, 67890]
+        mock_kill.side_effect = [None, ProcessLookupError()]
 
-        mock_kill.side_effect = ProcessLookupError()
-        try:
-            launch_utils.terminate_other_processes(processes, self_pid)
-        except ProcessLookupError:
-            self.fail(
-                "terminate_other_processes should swallow ProcessLookupError"
-            )
-        self.assertEqual(mock_kill.call_count, 2)
-        mock_kill.assert_has_calls(expected_calls, any_order=False)
+        result = launch_utils.terminate_processes(pids)
 
-        mock_kill.reset_mock()
-        mock_kill.side_effect = PermissionError()
-        try:
-            launch_utils.terminate_other_processes(processes, self_pid)
-        except PermissionError:
-            self.fail(
-                "terminate_other_processes should swallow PermissionError"
-            )
+        self.assertTrue(result)
         self.assertEqual(mock_kill.call_count, 2)
-        mock_kill.assert_has_calls(expected_calls, any_order=False)
+        mock_kill.assert_has_calls(
+            [mock.call(12345, 9), mock.call(67890, 9)], any_order=False
+        )
+
+    @mock.patch("paddle.distributed.utils.launch_utils.os.kill")
+    def test_terminate_processes_permission_error(self, mock_kill):
+        pids = [12345, 67890]
+        mock_kill.side_effect = [ProcessLookupError(), PermissionError()]
+
+        result = launch_utils.terminate_processes(pids)
+
+        self.assertFalse(result)
+        self.assertEqual(mock_kill.call_count, 2)
+        mock_kill.assert_has_calls(
+            [mock.call(12345, 9), mock.call(67890, 9)], any_order=False
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Improvements

### Description
将 `python/paddle/distributed/launch/main.py` 中用于清理进程的 `os.system("kill -9 " + pid)` 替换为 Python 原生 API `os.kill(int(pid), 9)`，并增加了更完善的进程状态检测与异常防护机制。

**主要收益与架构考量：**
1. **消除安全隐患（CWE-78）**：弃用 `os.system` 拼接字符串执行 Shell 命令，从根本上防止了潜在的命令注入风险，提升了分布式拉起脚本的安全性。
2. **提升执行性能**：`os.kill` 直接发起底层系统调用，避免了通过 `os.system` 强行 Fork 子进程去执行 `/bin/kill` 命令的不必要系统开销，逻辑更加轻量和 Pythonic。
3. **增强鲁棒性与严格语义对齐**：
   - 原先的 `os.system` 遇到无效 PID 或目标进程已退出时，通常只返回非零退出码，不会中断主程序的 auto-tuner 循环。
   - 本次重构增加了前置的空值与 `.isdigit()` 校验，并对 `os.kill` 可能在竞态条件下引发的 `ProcessLookupError`（目标进程已退出）和 `PermissionError`（无权限）进行了精准捕获与忽略。


### 是否引起精度变化
否