### PR TITLE
[CI] Enable XPU-only PR CI skip for non-XPU hardware jobs

### DIFF
--- a/.github/workflows/CI-Build.yml
+++ b/.github/workflows/CI-Build.yml
@@ -56,6 +56,7 @@ jobs:
     name: PR-CI-Inference
     uses: ./.github/workflows/_Inference.yml
     needs: [clone, build-docker]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       docker_inference_image: ${{ needs.build-docker.outputs.docker_build_image }}
       clone-can-skip: ${{ needs.clone.outputs.can-skip }}
@@ -80,6 +81,7 @@ jobs:
     name: CE-Framework
     uses: ./.github/workflows/_CE-Framework.yml
     needs: [clone, build-docker, build]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       can-skip: ${{ needs.build.outputs.can-skip == 'true' || needs.clone.outputs.can-skip == 'true' }}
       docker_build_image: ${{ needs.build-docker.outputs.docker_build_image }}
@@ -88,6 +90,7 @@ jobs:
     name: CE-CINN-Framework
     uses: ./.github/workflows/_CE-CINN-Framework.yml
     needs: [clone, build-docker, build]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       can-skip: ${{ needs.build.outputs.can-skip == 'true' || needs.clone.outputs.can-skip == 'true' }}
       docker_build_image: ${{ needs.build-docker.outputs.docker_build_image }}
@@ -96,6 +99,7 @@ jobs:
     name: Api-Benchmark
     uses: ./.github/workflows/_Api-Benchmark.yml
     needs: [clone, build-docker, build]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       can-skip: ${{ needs.build.outputs.can-skip == 'true' || needs.clone.outputs.can-skip == 'true' }}
       docker_build_image: ${{ needs.build-docker.outputs.docker_build_image }}
@@ -112,6 +116,7 @@ jobs:
     name: Model-Benchmark
     uses: ./.github/workflows/_Model-Benchmark.yml
     needs: [clone, build-docker, build]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       can-skip: ${{ needs.build.outputs.can-skip == 'true' || needs.clone.outputs.can-skip == 'true' }}
       docker_build_image: ${{ needs.build-docker.outputs.docker_build_image }}
@@ -120,6 +125,7 @@ jobs:
     name: Doc-Preview
     uses: ./.github/workflows/_Doc-Preview.yml
     needs: [clone, build-docker, build]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       can-skip: ${{ needs.build.outputs.can-skip == 'true' || needs.clone.outputs.can-skip == 'true' }}
       docker_doc_image: ${{ needs.build-docker.outputs.docker_doc_image }}
@@ -128,6 +134,7 @@ jobs:
     name: Slice
     uses: ./.github/workflows/_Slice.yml
     needs: [clone, build-docker, build]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       can-skip: ${{ needs.build.outputs.can-skip == 'true' || needs.clone.outputs.can-skip == 'true' }}
       docker_build_image: ${{ needs.build-docker.outputs.docker_build_image }}
@@ -137,6 +144,7 @@ jobs:
     name: DeepMD-Kit-Test
     uses: ./.github/workflows/_Deepmd-pd-test.yml
     needs: [clone, build-docker, build]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       can-skip: ${{ needs.build.outputs.can-skip == 'true' || needs.clone.outputs.can-skip == 'true' }}
       docker_build_image: ${{ needs.build-docker.outputs.docker_build_image }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,6 +50,7 @@ jobs:
     name: PR-CI-SOT
     uses: ./.github/workflows/_SOT.yml
     needs: [clone, build-docker]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       docker_sot_image: ${{ needs.build-docker.outputs.docker_sot_image }}
       clone-can-skip: ${{ needs.clone.outputs.can-skip }}
@@ -58,6 +59,7 @@ jobs:
     name: Mac-CPU
     uses: ./.github/workflows/_Mac.yml
     needs: clone
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       clone-can-skip: ${{ needs.clone.outputs.can-skip }}
 
@@ -73,6 +75,7 @@ jobs:
     name: Linux-DCU
     uses: ./.github/workflows/_Linux-DCU.yml
     needs: [clone, build-docker]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       docker_dcu_image: ${{ needs.build-docker.outputs.docker_dcu_image }}
       clone-can-skip: ${{ needs.clone.outputs.can-skip }}
@@ -81,6 +84,7 @@ jobs:
     name: Linux-CPU
     uses: ./.github/workflows/_Linux-CPU.yml
     needs: [clone, build-docker]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       docker_cpu_image: ${{ needs.build-docker.outputs.docker_cpu_image }}
       clone-can-skip: ${{ needs.clone.outputs.can-skip }}
@@ -89,6 +93,7 @@ jobs:
     name: Linux-NPU
     uses: ./.github/workflows/_Linux-NPU.yml
     needs: [clone, cpu, build-docker]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       can-skip: ${{ needs.cpu.outputs.can-skip == 'true' || needs.clone.outputs.can-skip == 'true' }}
       docker_npu_image: ${{ needs.build-docker.outputs.docker_npu_image }}
@@ -97,6 +102,7 @@ jobs:
     name: Linux-IXUCA
     uses: ./.github/workflows/_Linux-IXUCA.yml
     needs: [clone]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       can-skip: ${{ needs.clone.outputs.can-skip }}
 
@@ -104,6 +110,7 @@ jobs:
     name: Distribute-stable-build
     uses: ./.github/workflows/_Distribute-stable.yml
     needs: [clone, build-docker]
+    if: ${{ needs.clone.outputs.xpu-only != 'true' }}
     with:
       docker_distribute_image: ${{ needs.build-docker.outputs.docker_distribute_image }}
       clone-can-skip: ${{ needs.clone.outputs.can-skip }}

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -77,7 +77,7 @@ jobs:
   build:
     name: Coverage build
     needs: [clone, build-docker, check-bypass]
-    if: ${{ needs.clone.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' }}
+    if: ${{ needs.clone.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' && needs.clone.outputs.xpu-only != 'true' }}
     runs-on:
       group: GZ_BD-CPU
     timeout-minutes: 120

--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -77,7 +77,7 @@ jobs:
   build:
     name: Coverage build
     needs: [clone, check-bypass]
-    if: ${{ needs.check-bypass.outputs.can-skip != 'true' && needs.clone.outputs.can-skip != 'true' }}
+    if: ${{ needs.check-bypass.outputs.can-skip != 'true' && needs.clone.outputs.can-skip != 'true' && needs.clone.outputs.xpu-only != 'true' }}
     runs-on:
       group: GZ_BD-CPU
     timeout-minutes: 120


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description

Enable the XPU-only CI skip logic introduced in #78431 (observe mode). When a PR **only modifies XPU-specific paths**, non-XPU hardware CI jobs are now skipped to save CI resources.

This is the **Week 3 activation PR** — the second phase of the XPU-only PR CI optimization plan.

**What changed:**
- **CI.yml**: Added `if: needs.clone.outputs.xpu-only != 'true'` to 7 jobs: `sot`, `mac`, `dcu`, `cpu`, `npu`, `ixuca`, `distribute`
- **CI-Build.yml**: Added the same condition to 8 jobs: `inference`, `ce-framework`, `ce-cinn-framework`, `api-benchmark`, `model-benchmark`, `doc-preview`, `slice`, `deepmd-test`
- **Coverage.yml**: Added `&& needs.clone.outputs.xpu-only != 'true'` to the `build` job's `if` condition (cascades to `test` via `needs`)
- **H-Coverage.yml**: Same pattern — added to the `build` job's `if` condition (cascades to `test`, `fleet-build`, `fleet_single_card_test`, `fleet-multi-card_test`)

**What is NOT changed (always run):**
- **XPU CI** (`Linux-XPU`): Always runs — no condition added
- **Linux-build**: Always runs (compilation is the foundation for all CI)
- **Static-Check**: Always runs (code style checks)
- **`_Clone-linux.yml`**: No change needed — already outputs `xpu-only` from #78431

**Week 2 Observation Results:**

| Metric | Target | Actual | Status |
|--------|--------|--------|--------|
| Observed PRs | ≥ 50 | **57** | ✅ |
| False positive rate | 0% | **0%** | ✅ |

- **57 PRs** observed from 2026-03-21 to 2026-03-30
- **1 XPU-only PR** correctly identified: #78394 (10 files, all in `paddle/phi/kernels/xpu/`)
- **4 mixed PRs** correctly classified as non-XPU-only (contained shared headers)
- **52 non-XPU PRs** correctly classified

**Safety Mechanisms (all from #78431):**
1. `!= 'true'` comparison: Missing/empty/error values default to running ALL CI
2. `test=all` in commit message: Forces full CI run
3. `DISABLE_HW_CI_SKIP` repo variable: Global emergency disable (no code merge needed)
4. Conservative fallback: Any error in `check_xpu_only.sh` → exit 1 → all CI runs

**Rollback Plan:**

| Level | Method | Speed |
|-------|--------|-------|
| L1 | Set `DISABLE_HW_CI_SKIP=true` in repo Variables | Seconds (no merge) |
| L2 | Add `test=all` to commit message | Per-PR |
| L3 | Revert this PR | Minutes |

devPR: #78431

### 是否引起精度变化
否