### PR TITLE
[Compat] Update DispatchKey usage to `c10::DispatchKey` and replace dispatch_key_to_string with `c10::toString`

### DIFF
--- a/paddle/phi/api/include/compat/torch/library.cpp
+++ b/paddle/phi/api/include/compat/torch/library.cpp
@@ -238,7 +238,7 @@ void OperatorRegistry::register_implementation(
   auto& op = get_or_create_operator(qualified_name);
   op.implementations[key] = std::move(func);
   VLOG(3) << "Registered implementation: " << qualified_name << " for "
-          << dispatch_key_to_string(key);
+          << c10::toString(key);
 }
 
 OperatorRegistration* OperatorRegistry::find_operator(
@@ -257,7 +257,7 @@ void OperatorRegistry::print_all_operators() const {
     }
     oss << "  Implementations: ";
     for (const auto& [key, impl] : op.implementations) {
-      oss << dispatch_key_to_string(key) << " ";
+      oss << c10::toString(key) << " ";
     }
     oss << std::endl;
   }
@@ -280,7 +280,7 @@ Library::Library(Kind kind,
   oss << "Created Library: kind=" << kind_to_string(kind)
       << ", namespace=" << ns;
   if (dispatch_key) {
-    oss << ", dispatch_key=" << dispatch_key_to_string(*dispatch_key);
+    oss << ", dispatch_key=" << c10::toString(*dispatch_key);
   }
   VLOG(3) << oss.str() << std::endl;
 }
@@ -309,7 +309,7 @@ void Library::print_info() const {
   std::ostringstream oss;
   oss << "Library Info: " << kind_to_string(kind_) << ", namespace=" << ns_;
   if (dispatch_key_) {
-    oss << ", dispatch_key=" << dispatch_key_to_string(*dispatch_key_);
+    oss << ", dispatch_key=" << c10::toString(*dispatch_key_);
   }
   std::cout << oss.str() << std::endl;
 }

--- a/paddle/phi/api/include/compat/torch/library.cpp
+++ b/paddle/phi/api/include/compat/torch/library.cpp
@@ -234,7 +234,9 @@ void OperatorRegistry::register_schema(const std::string& qualified_name,
 }
 
 void OperatorRegistry::register_implementation(
-    const std::string& qualified_name, DispatchKey key, CppFunction&& func) {
+    const std::string& qualified_name,
+    c10::DispatchKey key,
+    CppFunction&& func) {
   auto& op = get_or_create_operator(qualified_name);
   op.implementations[key] = std::move(func);
   VLOG(3) << "Registered implementation: " << qualified_name << " for "
@@ -268,7 +270,7 @@ void OperatorRegistry::print_all_operators() const {
 // Library
 Library::Library(Kind kind,
                  const std::string& ns,
-                 std::optional<DispatchKey> dispatch_key,
+                 std::optional<c10::DispatchKey> dispatch_key,
                  const char* file,
                  uint32_t line)
     : kind_(kind),

--- a/paddle/phi/api/include/compat/torch/library.h
+++ b/paddle/phi/api/include/compat/torch/library.h
@@ -731,7 +731,7 @@ class Library {
 
   Library(Kind kind,
           const std::string& ns,
-          std::optional<DispatchKey> dispatch_key = std::nullopt,
+          std::optional<c10::DispatchKey> dispatch_key = std::nullopt,
           const char* file = nullptr,
           uint32_t line = 0);
 
@@ -753,7 +753,7 @@ class Library {
     }
 
     // Register implementation
-    auto dispatch_key = dispatch_key_.value_or(DispatchKey::CPU);
+    auto dispatch_key = dispatch_key_.value_or(c10::DispatchKey::CPU);
     OperatorRegistry::instance().register_implementation(
         qualified_name, dispatch_key, CppFunction(std::forward<Func>(f)));
 
@@ -764,7 +764,7 @@ class Library {
   template <typename Func>
   Library& impl(const std::string& op_name, Func&& f) & {
     auto qualified_name = ns_ + "::" + op_name;
-    auto dispatch_key = dispatch_key_.value_or(DispatchKey::CPU);
+    auto dispatch_key = dispatch_key_.value_or(c10::DispatchKey::CPU);
 
     OperatorRegistry::instance().register_implementation(
         qualified_name, dispatch_key, CppFunction(std::forward<Func>(f)));
@@ -783,7 +783,7 @@ class Library {
  private:
   Kind kind_;
   std::string ns_;
-  std::optional<DispatchKey> dispatch_key_;
+  std::optional<c10::DispatchKey> dispatch_key_;
   const char* file_;
   uint32_t line_;
 
@@ -819,7 +819,7 @@ class TorchLibraryInit {
   TorchLibraryInit(Library::Kind kind,
                    InitFn* fn,
                    const char* ns,
-                   std::optional<DispatchKey> dispatch_key,
+                   std::optional<c10::DispatchKey> dispatch_key,
                    const char* file,
                    uint32_t line) {
     Library lib(kind, ns, dispatch_key, file, line);

--- a/paddle/phi/api/include/compat/torch/library.h
+++ b/paddle/phi/api/include/compat/torch/library.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <c10/core/DispatchKey.h>
 #include <c10/macros/Macros.h>
 #include <functional>
 #include <iostream>
@@ -29,7 +30,6 @@
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
-#include "c10/core/DispatchKey.h"
 #include "paddle/common/macros.h"  // For macro PADDLE_API
 
 namespace torch {

--- a/paddle/phi/api/include/compat/torch/library.h
+++ b/paddle/phi/api/include/compat/torch/library.h
@@ -29,6 +29,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
+#include "c10/core/DispatchKey.h"
 #include "paddle/common/macros.h"  // For macro PADDLE_API
 
 namespace torch {
@@ -658,28 +659,11 @@ class class_ {
   std::string qualified_name_;
 };
 
-enum class DispatchKey {
-  Undefined = 0,
-  CPU,
-  CUDA,
-};
-
-inline std::string dispatch_key_to_string(DispatchKey key) {
-  switch (key) {
-    case DispatchKey::CPU:
-      return "CPU";
-    case DispatchKey::CUDA:
-      return "CUDA";
-    default:
-      return "Undefined";
-  }
-}
-
 // Operator Registration
 struct OperatorRegistration {
   std::string qualified_name;  // namespace::op_name
   std::string schema;
-  std::unordered_map<DispatchKey, CppFunction> implementations;
+  std::unordered_map<c10::DispatchKey, CppFunction> implementations;
 
   OperatorRegistration(const std::string& name,
                        const std::string& schema_str = "")
@@ -696,7 +680,7 @@ class PADDLE_API OperatorRegistry {
                        const std::string& schema);
 
   void register_implementation(const std::string& qualified_name,
-                               DispatchKey key,
+                               c10::DispatchKey key,
                                CppFunction&& func);
 
   bool has_operator(const std::string& qualified_name) const {

--- a/paddle/phi/api/include/compat/torch/library.h
+++ b/paddle/phi/api/include/compat/torch/library.h
@@ -867,7 +867,7 @@ class TorchLibraryInit {
       torch::Library::IMPL,                                          \
       &C10_CONCATENATE(TORCH_LIBRARY_IMPL_init_##ns##_##k##_, uid),  \
       #ns,                                                           \
-      std::make_optional(torch::DispatchKey::k),                     \
+      std::make_optional(c10::DispatchKey::k),                       \
       __FILE__,                                                      \
       __LINE__);                                                     \
   void C10_CONCATENATE(TORCH_LIBRARY_IMPL_init_##ns##_##k##_,        \

--- a/test/cpp/compat/torch_library_test.cc
+++ b/test/cpp/compat/torch_library_test.cc
@@ -111,7 +111,7 @@ TEST(test_torch_library, TestLibraryOperators) {
   auto qualified_name = "example_library::mymuladd";
   auto* op = torch::OperatorRegistry::instance().find_operator(qualified_name);
   ASSERT_NE(op, nullptr);
-  auto impl_it = op->implementations.find(torch::DispatchKey::CPU);
+  auto impl_it = op->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it, op->implementations.end());
   torch::FunctionArgs function_args;
   function_args.add_arg(torch::IValue(at::ones({2, 2}, at::kFloat)));
@@ -207,7 +207,7 @@ TEST(test_torch_library, TestFragmentOperators) {
       torch::OperatorRegistry::instance().find_operator(qualified_name_int_add);
   ASSERT_NE(op_int_add, nullptr);
   auto impl_it_int_add =
-      op_int_add->implementations.find(torch::DispatchKey::CPU);
+      op_int_add->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it_int_add, op_int_add->implementations.end());
   torch::FunctionArgs function_args;
   function_args.add_arg(torch::IValue(3));
@@ -222,7 +222,7 @@ TEST(test_torch_library, TestFragmentOperators) {
       qualified_name_string_concat);
   ASSERT_NE(op_string_concat, nullptr);
   auto impl_it_string_concat =
-      op_string_concat->implementations.find(torch::DispatchKey::CPU);
+      op_string_concat->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it_string_concat, op_string_concat->implementations.end());
   torch::FunctionArgs string_args;
   string_args.add_arg(torch::IValue(std::string("Hello, ")));
@@ -247,7 +247,7 @@ TEST(test_torch_library, TestScalarTypeInput) {
       "example_library_with_scalar_type_input::cast_with_scalar_type";
   auto* op = torch::OperatorRegistry::instance().find_operator(qualified_name);
   ASSERT_NE(op, nullptr);
-  auto impl_it = op->implementations.find(torch::DispatchKey::CPU);
+  auto impl_it = op->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it, op->implementations.end());
   torch::FunctionArgs function_args;
   function_args.add_arg(torch::IValue(at::ones({2, 2}, at::kFloat)));
@@ -268,7 +268,7 @@ TEST(test_torch_library, TestIntConst) {
   auto qualified_name = "example_library_with_int_const::fn_with_int_const";
   auto* op = torch::OperatorRegistry::instance().find_operator(qualified_name);
   ASSERT_NE(op, nullptr);
-  auto impl_it = op->implementations.find(torch::DispatchKey::CPU);
+  auto impl_it = op->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it, op->implementations.end());
   torch::FunctionArgs function_args;
   function_args.add_arg(torch::IValue(3));
@@ -295,7 +295,7 @@ TEST(test_torch_library, TestOptionalInput) {
       "example_library_with_optional_input::fn_with_optional_input";
   auto* op = torch::OperatorRegistry::instance().find_operator(qualified_name);
   ASSERT_NE(op, nullptr);
-  auto impl_it = op->implementations.find(torch::DispatchKey::CPU);
+  auto impl_it = op->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it, op->implementations.end());
 
   // Test with value
@@ -334,7 +334,7 @@ TEST(test_torch_library, TestArrayRefInput) {
       "example_library_with_arrayref_input::fn_with_arrayref_input";
   auto* op = torch::OperatorRegistry::instance().find_operator(qualified_name);
   ASSERT_NE(op, nullptr);
-  auto impl_it = op->implementations.find(torch::DispatchKey::CPU);
+  auto impl_it = op->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it, op->implementations.end());
 
   torch::FunctionArgs function_args;
@@ -369,7 +369,7 @@ TEST(test_torch_library, TestMixOptionalArrayRefInput) {
       "fn_with_mix_optional_arrayref_input";
   auto* op = torch::OperatorRegistry::instance().find_operator(qualified_name);
   ASSERT_NE(op, nullptr);
-  auto impl_it = op->implementations.find(torch::DispatchKey::CPU);
+  auto impl_it = op->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it, op->implementations.end());
 
   // Test with value
@@ -406,7 +406,7 @@ TEST(test_torch_library, TestOptionalTensorConstRefInput) {
       "fn_with_optional_tensor_const_ref_input";
   auto* op = torch::OperatorRegistry::instance().find_operator(qualified_name);
   ASSERT_NE(op, nullptr);
-  auto impl_it = op->implementations.find(torch::DispatchKey::CPU);
+  auto impl_it = op->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it, op->implementations.end());
 
   // Test with value
@@ -465,7 +465,7 @@ TEST(test_torch_library, TestTupleReturn) {
   auto* op_list =
       torch::OperatorRegistry::instance().find_operator(qualified_name_list);
   ASSERT_NE(op_list, nullptr);
-  auto impl_it_list = op_list->implementations.find(torch::DispatchKey::CPU);
+  auto impl_it_list = op_list->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it_list, op_list->implementations.end());
 
   // Create a test tensor [0, 1, 2, 3] with shape [4]
@@ -498,7 +498,7 @@ TEST(test_torch_library, TestTupleReturn) {
   auto* op_tuple =
       torch::OperatorRegistry::instance().find_operator(qualified_name_tuple);
   ASSERT_NE(op_tuple, nullptr);
-  auto impl_it_tuple = op_tuple->implementations.find(torch::DispatchKey::CPU);
+  auto impl_it_tuple = op_tuple->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it_tuple, op_tuple->implementations.end());
 
   torch::FunctionArgs function_args_tuple;
@@ -528,7 +528,7 @@ TEST(test_torch_library, TestTupleReturn) {
       torch::OperatorRegistry::instance().find_operator(qualified_name_tuple_3);
   ASSERT_NE(op_tuple_3, nullptr);
   auto impl_it_tuple_3 =
-      op_tuple_3->implementations.find(torch::DispatchKey::CPU);
+      op_tuple_3->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it_tuple_3, op_tuple_3->implementations.end());
 
   torch::FunctionArgs function_args_tuple_3;
@@ -571,7 +571,7 @@ TEST(test_torch_library, TestConstRefParameterFix) {
       "example_library_const_ref_fix::fn_with_const_ref_param";
   auto* op = torch::OperatorRegistry::instance().find_operator(qualified_name);
   ASSERT_NE(op, nullptr);
-  auto impl_it = op->implementations.find(torch::DispatchKey::CPU);
+  auto impl_it = op->implementations.find(c10::DispatchKey::CPU);
   ASSERT_NE(impl_it, op->implementations.end());
 
   // Test with const reference parameters

--- a/test/cpp/compat/torch_library_test.cc
+++ b/test/cpp/compat/torch_library_test.cc
@@ -15,6 +15,8 @@
 #include <torch/all.h>
 #include <torch/library.h>
 
+#include <sstream>
+
 #include "gtest/gtest.h"
 
 at::Tensor mymuladd_cpu(at::Tensor a, const at::Tensor& b, double c) {
@@ -256,6 +258,47 @@ TEST(test_torch_library, TestScalarTypeInput) {
   ASSERT_TRUE(result.get_value().is_tensor());
   auto result_tensor = result.get_value().to_tensor();
   ASSERT_EQ(result_tensor.dtype(), at::kDouble);
+}
+
+TEST(test_torch_library, TestRegisterImplementationAtRuntime) {
+  auto qualified_name = "runtime_example::runtime_add";
+  auto& registry = torch::OperatorRegistry::instance();
+
+  registry.register_implementation(qualified_name,
+                                   c10::DispatchKey::CPU,
+                                   torch::CppFunction(&generic_add<int>));
+
+  auto* op = registry.find_operator(qualified_name);
+  ASSERT_NE(op, nullptr);
+
+  auto impl_it = op->implementations.find(c10::DispatchKey::CPU);
+  ASSERT_NE(impl_it, op->implementations.end());
+
+  torch::FunctionArgs function_args;
+  function_args.add_arg(torch::IValue(11));
+  function_args.add_arg(torch::IValue(31));
+  auto result = impl_it->second.call_with_args(function_args);
+
+  ASSERT_TRUE(result.get_value().is_int());
+  ASSERT_EQ(result.get_value().to_int(), 42);
+}
+
+TEST(test_torch_library, TestLibraryPrintInfoWithDispatchKey) {
+  torch::Library library(torch::Library::IMPL,
+                         "runtime_library_info",
+                         std::make_optional(c10::DispatchKey::CPU),
+                         __FILE__,
+                         __LINE__);
+
+  std::ostringstream captured_output;
+  auto* original_buffer = std::cout.rdbuf(captured_output.rdbuf());
+  library.print_info();
+  std::cout.rdbuf(original_buffer);
+
+  auto output = captured_output.str();
+  ASSERT_NE(output.find("Library Info: IMPL"), std::string::npos);
+  ASSERT_NE(output.find("namespace=runtime_library_info"), std::string::npos);
+  ASSERT_NE(output.find("dispatch_key="), std::string::npos);
 }
 
 int fn_with_int_const(int const x) { return x + 1; }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
移除 `paddle/phi/api/include/compat/torch/library.h` 下的 `DispatchKey`, 改用 `c10::DispatchKey`

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否