### PR TITLE
[release/3.3][CppExtension] Expose `dnn.h` when build with onednn

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1528,7 +1528,7 @@ for f in jit_layer_headers:
     headers += list(find_files(f, '@PADDLE_SOURCE_DIR@/paddle/fluid/jit', recursive=True))
 
 if '${WITH_ONEDNN}' == 'ON':
-    headers += list(find_files('*', '${ONEDNN_INSTALL_DIR}/include')) # mkldnn
+    headers += list(find_files('*', '${ONEDNN_INSTALL_DIR}/include', recursive=True)) # mkldnn
 
 if '${WITH_OPENVINO}' == 'ON':
     headers += list(

--- a/setup.py
+++ b/setup.py
@@ -2322,7 +2322,11 @@ def get_headers():
 
     if env_dict.get("WITH_ONEDNN") == 'ON':
         headers += list(
-            find_files('*', env_dict.get("ONEDNN_INSTALL_DIR") + '/include')
+            find_files(
+                '*',
+                env_dict.get("ONEDNN_INSTALL_DIR") + '/include',
+                recursive=True,
+            )
         )  # mkldnn
 
     if env_dict.get("WITH_OPENVINO") == 'ON':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
暴露头文件dnn.h，及其依赖的头文件

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

---

Cherry-pick of #78513 (authored by @risemeup1) to `release/3.3`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78513 <!-- For pass CI -->