### PR TITLE
[API Compatibility] Support function call for `paddle.Tensor.type`

### DIFF
--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -133,9 +133,20 @@ class TensorSize(int):
         return shape[dim]
 
 
-class TensorType:
+class TensorType(core.VarDesc.VarType):
     tensor: Tensor
     _value_: core.VarDesc.VarType
+
+    def __new__(cls, tensor):
+        obj = super().__new__(cls, int(core.VarDesc.VarType.DENSE_TENSOR))
+        return obj
+
+    def __init__(self, tensor):
+        core.VarDesc.VarType.__init__(
+            self, int(core.VarDesc.VarType.DENSE_TENSOR)
+        )
+        self._value_ = core.VarDesc.VarType.DENSE_TENSOR
+        self.tensor = tensor
 
     def __repr__(self):
         return repr(self._value_)
@@ -143,19 +154,16 @@ class TensorType:
     def __str__(self):
         return str(self._value_)
 
-    def __new__(cls, tensor):
-        instance = super().__new__(cls)
-        instance._value_ = core.VarDesc.VarType.DENSE_TENSOR
-        instance.tensor = tensor
-        return instance
-
     def __call__(self, dtype=None, blocking=None):
         if dtype is None:
             return self
         return self.tensor.astype(dtype)
 
     def __eq__(self, other):
-        return self._value_ == other
+        try:
+            return int(self._value_) == int(other)
+        except Exception:
+            return self._value_ == other
 
 
 def monkey_patch_math_tensor():

--- a/python/paddle/base/dygraph/math_op_patch.py
+++ b/python/paddle/base/dygraph/math_op_patch.py
@@ -133,6 +133,31 @@ class TensorSize(int):
         return shape[dim]
 
 
+class TensorType:
+    tensor: Tensor
+    _value_: core.VarDesc.VarType
+
+    def __repr__(self):
+        return repr(self._value_)
+
+    def __str__(self):
+        return str(self._value_)
+
+    def __new__(cls, tensor):
+        instance = super().__new__(cls)
+        instance._value_ = core.VarDesc.VarType.DENSE_TENSOR
+        instance.tensor = tensor
+        return instance
+
+    def __call__(self, dtype=None, blocking=None):
+        if dtype is None:
+            return self
+        return self.tensor.astype(dtype)
+
+    def __eq__(self, other):
+        return self._value_ == other
+
+
 def monkey_patch_math_tensor():
     """
     Similar to monkey_patch_variable.
@@ -172,6 +197,10 @@ def monkey_patch_math_tensor():
             return self
 
         return _C_ops.cast(self, dtype)
+
+    @property
+    def _type_(self: Tensor) -> core.VarDesc.VarType:
+        return TensorType(self)
 
     def byte(self: Tensor) -> Tensor:
         # since paddle don't support float to uint8, so we need to convert it to int8 first
@@ -622,6 +651,7 @@ def monkey_patch_math_tensor():
         ('astype', astype),
         ('byte', byte),
         ('uint8', byte),
+        ('type', _type_),
         ('type_as', type_as),
         ('dim', dim),
         ('ndimension', ndimension),

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -676,6 +676,17 @@ class TestEagerTensor(unittest.TestCase):
         var = paddle.to_tensor(self.array)
         self.assertTrue(isinstance(str(var), str))
 
+    def test_tensor_type(self):
+        var = paddle.to_tensor(self.array)
+        type_attr = var.type
+        type_method_call = var.type()
+        astype_method_call = var.type("float16")
+        astype_ref = var.astype("float16")
+        self.assertEqual(type_attr, type_method_call)
+        np.testing.assert_array_equal(
+            astype_method_call.numpy(), astype_ref.numpy()
+        )
+
     def test_element_size(self):
         with base.dygraph.guard():
             x = paddle.to_tensor(1, dtype="bool")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
New features


### Description
<!-- Describe what you’ve done -->
- Support `paddle.Tensor.type()` as an alias for attribute `paddle.Tensor.type`
- Add alias `paddle.Tensor.type(dtype)` for `paddle.Tensor.astype(dtype)`
- Add arg `blocking` for compatibility (ignored)
- Add test

**Used AI Studio**


### 是否引起精度变化
否
