### PR TITLE
[fix] phi::Full in masked_scatter_grad kernel

### DIFF
--- a/paddle/phi/kernels/cpu/masked_scatter_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/masked_scatter_grad_kernel.cc
@@ -35,11 +35,17 @@ void MaskedScatterGradKernel(const Context& dev_ctx,
                              DenseTensor* value_grad) {
   if (out_grad.numel() == 0 || mask.numel() == 0) {
     if (x_grad) {
-      phi::Full<T, Context>(dev_ctx, x_grad->dims(), static_cast<T>(0), x_grad);
+      phi::Full<T, Context>(dev_ctx,
+                            phi::IntArray(common::vectorize(x_grad->dims())),
+                            static_cast<T>(0),
+                            x_grad);
     }
     if (value_grad) {
       phi::Full<T, Context>(
-          dev_ctx, value_grad->dims(), static_cast<T>(0), value_grad);
+          dev_ctx,
+          phi::IntArray(common::vectorize(value_grad->dims())),
+          static_cast<T>(0),
+          value_grad);
     }
     return;
   }

--- a/paddle/phi/kernels/gpu/masked_scatter_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/masked_scatter_grad_kernel.cu
@@ -73,11 +73,17 @@ void MaskedScatterGradKernel(const Context& dev_ctx,
                              DenseTensor* value_grad) {
   if (out_grad.numel() == 0 || mask.numel() == 0) {
     if (x_grad) {
-      phi::Full<T, Context>(dev_ctx, x_grad->dims(), static_cast<T>(0), x_grad);
+      phi::Full<T, Context>(dev_ctx,
+                            phi::IntArray(common::vectorize(x_grad->dims())),
+                            static_cast<T>(0),
+                            x_grad);
     }
     if (value_grad) {
       phi::Full<T, Context>(
-          dev_ctx, value_grad->dims(), static_cast<T>(0), value_grad);
+          dev_ctx,
+          phi::IntArray(common::vectorize(value_grad->dims())),
+          static_cast<T>(0),
+          value_grad);
     }
     return;
   }
@@ -133,8 +139,10 @@ void MaskedScatterGradKernel(const Context& dev_ctx,
   // Compute value_grad
   if (value_grad) {
     int64_t value_numel = value_grad->numel();
-    Full<T, Context>(
-        dev_ctx, value_grad->dims(), static_cast<T>(0), value_grad);
+    phi::Full<T, Context>(dev_ctx,
+                          phi::IntArray(common::vectorize(value_grad->dims())),
+                          static_cast<T>(0),
+                          value_grad);
 
     // Compute prefix sum of mask for scatter index.
     // Convert bool mask to int64 first for hipcub compatibility on DCU/ROCm.

--- a/test/legacy_test/test_masked_scatter.py
+++ b/test/legacy_test/test_masked_scatter.py
@@ -478,6 +478,30 @@ class TestMaskedScatterCPUBroadcast4(TestMaskedScatterCPU):
         self.value_shape = (300, 300)
 
 
+class TestMaskedScatterCPUZeroSize(TestMaskedScatterCPU):
+    def init(self):
+        self.x_shape = (3, 0)
+        self.mask_shape = self.x_shape
+        self.dtype = "float32"
+        self.value_shape = (300, 300)
+
+
+class TestMaskedScatterCPUZeroSize2(TestMaskedScatterCPU):
+    def init(self):
+        self.x_shape = (0,)
+        self.mask_shape = self.x_shape
+        self.dtype = "float32"
+        self.value_shape = (300, 300)
+
+
+class TestMaskedScatterCPUZeroSize3(TestMaskedScatterCPU):
+    def init(self):
+        self.x_shape = (0, 5, 3)
+        self.mask_shape = self.x_shape
+        self.dtype = "float64"
+        self.value_shape = (300, 300)
+
+
 class TestMaskedScatterAPI_ZeroSize(unittest.TestCase):
     def setUp(self):
         self.init()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
原来的实现在release分支出现了编译报错，现更新phi::Full的实现。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否