### PR TITLE
[Release/3.3] Fix out-of-bounds memory access in SetKernel for 0-size tensor

### DIFF
--- a/paddle/phi/kernels/set_kernel.cc
+++ b/paddle/phi/kernels/set_kernel.cc
@@ -52,6 +52,12 @@ void SetKernel(const Context& dev_ctx,
     if (source.numel() == 0 && x.numel() != 0) {
       // Source is empty but x has storage. Reuse x's storage and apply
       // the user-specified meta, matching PyTorch behavior.
+      if (out_numel == 0) {
+        // Output has 0 elements — no storage needed, just set meta.
+        out->set_meta(meta);
+        out->ShareInplaceVersionCounterWith(x);
+        return;
+      }
       // If the strided view requires more storage than x provides,
       // allocate a larger zero-filled buffer and copy x's data into it
       // to avoid out-of-bounds reads on elements beyond x's allocation.

--- a/paddle/phi/kernels/set_kernel.cc
+++ b/paddle/phi/kernels/set_kernel.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/set_kernel.h"
+#include <cstring>
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
@@ -59,12 +60,16 @@ void SetKernel(const Context& dev_ctx,
         DenseTensor tmp;
         std::vector<int64_t> alloc_shape = {required_size};
         Full<T, Context>(dev_ctx, alloc_shape, 0, &tmp);
-        memory_utils::Copy(dev_ctx.GetPlace(),
-                           tmp.data<T>(),
-                           dev_ctx.GetPlace(),
-                           x.data<T>(),
-                           x.numel() * sizeof(T),
-                           nullptr);
+        if (dev_ctx.GetPlace().GetType() == phi::AllocationType::CPU) {
+          std::memcpy(tmp.data<T>(), x.data<T>(), x.numel() * sizeof(T));
+        } else {
+          memory_utils::Copy(dev_ctx.GetPlace(),
+                             tmp.data<T>(),
+                             dev_ctx.GetPlace(),
+                             x.data<T>(),
+                             x.numel() * sizeof(T),
+                             nullptr);
+        }
         out->clear();
         *out = DenseTensor{tmp.Holder(), meta};
       } else {

--- a/paddle/phi/kernels/set_kernel.cc
+++ b/paddle/phi/kernels/set_kernel.cc
@@ -29,13 +29,15 @@ void SetKernel(const Context& dev_ctx,
   meta.strides = DDim(stride.data(), static_cast<int>(stride.size()));
   meta.offset = offset;
   if (x.numel() == 0 || source.numel() == 0) {
-    if (source.numel() != 0) {
-      out->clear();
-      *out = DenseTensor{source.Holder(), meta};
-    } else if (x.numel() == 0) {
-      phi::Full<T, Context>(
-          dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
+    if (source.numel() == 0) {
+      // When source has no elements, force output to be 0-size
+      // to prevent out-of-bounds access with insufficient storage.
+      meta.dims = source.dims();
+      meta.strides = source.strides();
+      meta.offset = 0;
     }
+    out->clear();
+    *out = DenseTensor{source.Holder(), meta};
     out->ShareInplaceVersionCounterWith(x);
     return;
   }

--- a/paddle/phi/kernels/set_kernel.cc
+++ b/paddle/phi/kernels/set_kernel.cc
@@ -12,9 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/set_kernel.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
 namespace phi {
+
+// Compute the minimum number of elements required in storage to hold
+// a strided view described by dims, stride and offset.
+static int64_t ComputeRequiredStorageSize(const std::vector<int64_t>& dims,
+                                          const std::vector<int64_t>& stride,
+                                          int64_t offset) {
+  int64_t required = offset;
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (dims[i] > 0) {
+      required += (dims[i] - 1) * stride[i];
+    }
+  }
+  return required + 1;  // +1 for the last element itself
+}
 
 template <typename T, typename Context>
 void SetKernel(const Context& dev_ctx,
@@ -29,15 +44,49 @@ void SetKernel(const Context& dev_ctx,
   meta.strides = DDim(stride.data(), static_cast<int>(stride.size()));
   meta.offset = offset;
   if (x.numel() == 0 || source.numel() == 0) {
-    if (source.numel() == 0) {
-      // When source has no elements, force output to be 0-size
-      // to prevent out-of-bounds access with insufficient storage.
-      meta.dims = source.dims();
-      meta.strides = source.strides();
-      meta.offset = 0;
+    int64_t out_numel = 1;
+    for (auto d : dims) {
+      out_numel *= d;
     }
-    out->clear();
-    *out = DenseTensor{source.Holder(), meta};
+    if (source.numel() == 0 && x.numel() != 0) {
+      // Source is empty but x has storage. Reuse x's storage and apply
+      // the user-specified meta, matching PyTorch behavior.
+      // If the strided view requires more storage than x provides,
+      // allocate a larger zero-filled buffer and copy x's data into it
+      // to avoid out-of-bounds reads on elements beyond x's allocation.
+      int64_t required_size = ComputeRequiredStorageSize(dims, stride, offset);
+      if (required_size > x.numel()) {
+        DenseTensor tmp;
+        std::vector<int64_t> alloc_shape = {required_size};
+        Full<T, Context>(dev_ctx, alloc_shape, 0, &tmp);
+        memory_utils::Copy(dev_ctx.GetPlace(),
+                           tmp.data<T>(),
+                           dev_ctx.GetPlace(),
+                           x.data<T>(),
+                           x.numel() * sizeof(T),
+                           nullptr);
+        out->clear();
+        *out = DenseTensor{tmp.Holder(), meta};
+      } else {
+        out->set_meta(meta);
+      }
+    } else if (source.numel() == 0 && x.numel() == 0 && out_numel != 0) {
+      // Both x and source are 0-size but user wants non-zero shape.
+      // Allocate zero-filled storage to avoid null pointer access.
+      int64_t required_size = ComputeRequiredStorageSize(dims, stride, offset);
+      DenseTensor tmp;
+      std::vector<int64_t> alloc_shape = {required_size};
+      Full<T, Context>(dev_ctx, alloc_shape, 0, &tmp);
+      out->clear();
+      *out = DenseTensor{tmp.Holder(), meta};
+    } else if (source.numel() != 0) {
+      out->clear();
+      *out = DenseTensor{source.Holder(), meta};
+    } else {
+      // Both 0-size, output also 0-size
+      out->clear();
+      *out = DenseTensor{source.Holder(), meta};
+    }
     out->ShareInplaceVersionCounterWith(x);
     return;
   }

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -2553,6 +2553,57 @@ class TestSet_API_ZeroSize(unittest.TestCase):
                 self.assertEqual(out.numel().item(), 0)
                 self.assertTrue(id(x) == id(out))
 
+    def test_both_zero_size_with_nonzero_shape(self):
+        """Both x and source are 0-size but user specifies non-zero dims/stride.
+        This covers the branch that allocates zero-filled storage when both
+        tensors are empty but a non-zero output shape is requested."""
+        for place in self.places:
+            with paddle.base.dygraph.guard(place):
+                source = paddle.randn([0])
+                x = paddle.randn([0])
+                out = x.set_(source, [4], [1])
+                self.assertEqual(list(out.shape), [4])
+                self.assertTrue(id(x) == id(out))
+                # The allocated storage should be zero-filled and accessible
+                c = out.contiguous()
+                self.assertEqual(list(c.shape), [4])
+                np.testing.assert_array_equal(
+                    c.numpy(), np.zeros([4], dtype='float32')
+                )
+
+    def test_both_zero_size_with_nonzero_shape_and_offset(self):
+        """Both x and source are 0-size, user specifies non-zero shape with
+        a non-zero offset. Verifies storage is large enough to accommodate
+        the offset without out-of-bounds access."""
+        for place in self.places:
+            with paddle.base.dygraph.guard(place):
+                source = paddle.randn([0])
+                x = paddle.randn([0])
+                out = x.set_(source, [3], [2], 1)
+                self.assertEqual(list(out.shape), [3])
+                self.assertTrue(id(x) == id(out))
+                c = out.contiguous()
+                self.assertEqual(list(c.shape), [3])
+                np.testing.assert_array_equal(
+                    c.numpy(), np.zeros([3], dtype='float32')
+                )
+
+    def test_both_zero_size_with_nonzero_2d_shape(self):
+        """Both x and source are 0-size, user specifies a 2D non-zero shape.
+        Verifies multi-dimensional strided view is allocated correctly."""
+        for place in self.places:
+            with paddle.base.dygraph.guard(place):
+                source = paddle.randn([0, 0])
+                x = paddle.randn([0])
+                out = x.set_(source, [2, 3], [3, 1])
+                self.assertEqual(list(out.shape), [2, 3])
+                self.assertTrue(id(x) == id(out))
+                c = out.contiguous()
+                self.assertEqual(list(c.shape), [2, 3])
+                np.testing.assert_array_equal(
+                    c.numpy(), np.zeros([2, 3], dtype='float32')
+                )
+
     def test_zero_size_source_no_crash_on_contiguous(self):
         """Ensure contiguous() works correctly on a tensor
         that was set_ with a 0-size source but user-specified shape."""

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -2509,14 +2509,18 @@ class TestSet_API_ZeroSize(unittest.TestCase):
         self.places = get_places()
 
     def test_zero_size_source_with_nonzero_shape(self):
-        """When source is 0-size, output should inherit source's shape
-        to prevent out-of-bounds memory access."""
+        """When source is 0-size but user specifies non-zero dims/stride,
+        output should respect user-specified shape (matching PyTorch behavior).
+        Storage is expanded if needed to avoid out-of-bounds access."""
         for place in self.places:
             with paddle.base.dygraph.guard(place):
                 source = paddle.randn([0, 3])
-                out = paddle.randn([20]).set_(source, [20], [2])
-                self.assertEqual(out.numel().item(), 0)
-                self.assertEqual(list(out.shape), [0, 3])
+                x = paddle.randn([20])
+                out = x.set_(source, [20], [2])
+                self.assertEqual(list(out.shape), [20])
+                # contiguous should work without OOB
+                c = out.contiguous()
+                self.assertEqual(list(c.shape), [20])
 
     def test_zero_size_source_default_args(self):
         """set_ with 0-size source and no explicit shape/stride."""
@@ -2550,18 +2554,16 @@ class TestSet_API_ZeroSize(unittest.TestCase):
                 self.assertTrue(id(x) == id(out))
 
     def test_zero_size_source_no_crash_on_contiguous(self):
-        """Ensure no crash when calling contiguous() on a tensor
-        that was set_ with a 0-size source."""
+        """Ensure contiguous() works correctly on a tensor
+        that was set_ with a 0-size source but user-specified shape."""
         for place in self.places:
             with paddle.base.dygraph.guard(place):
                 source = paddle.randn([0, 3])
                 x = paddle.randn([20])
                 out = x.set_(source, [20], [2])
-                # This should not crash or cause OOB memory access
-                try:
-                    _ = out.contiguous()
-                except Exception:
-                    pass  # contiguous on 0-size is ok either way
+                # contiguous should produce a valid tensor with correct shape
+                c = out.contiguous()
+                self.assertEqual(list(c.shape), [20])
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -2579,7 +2579,9 @@ class TestSet_API_ZeroSize(unittest.TestCase):
             with paddle.base.dygraph.guard(place):
                 source = paddle.randn([0])
                 x = paddle.randn([0])
-                out = x.set_(source, [3], [2], 1)
+                # offset must be a multiple of element size (4 bytes for
+                # float32) to avoid misaligned GPU memory access.
+                out = x.set_(source, [3], [2], 4)
                 self.assertEqual(list(out.shape), [3])
                 self.assertTrue(id(x) == id(out))
                 c = out.contiguous()

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -2508,11 +2508,60 @@ class TestSet_API_ZeroSize(unittest.TestCase):
     def setUp(self):
         self.places = get_places()
 
-    def test_set_api(self):
+    def test_zero_size_source_with_nonzero_shape(self):
+        """When source is 0-size, output should inherit source's shape
+        to prevent out-of-bounds memory access."""
         for place in self.places:
             with paddle.base.dygraph.guard(place):
-                out = paddle.randn([20]).set_(paddle.randn([0, 3]), [20], [2])
-                np.testing.assert_allclose(out.shape, [20])
+                source = paddle.randn([0, 3])
+                out = paddle.randn([20]).set_(source, [20], [2])
+                self.assertEqual(out.numel().item(), 0)
+                self.assertEqual(list(out.shape), [0, 3])
+
+    def test_zero_size_source_default_args(self):
+        """set_ with 0-size source and no explicit shape/stride."""
+        for place in self.places:
+            with paddle.base.dygraph.guard(place):
+                source = paddle.randn([0, 5])
+                x = paddle.randn([10])
+                out = x.set_(source)
+                self.assertEqual(out.numel().item(), 0)
+                self.assertEqual(list(out.shape), [0, 5])
+                self.assertTrue(id(x) == id(out))
+
+    def test_zero_size_x_nonzero_source(self):
+        """set_ with 0-size x but non-zero source should work normally."""
+        for place in self.places:
+            with paddle.base.dygraph.guard(place):
+                source = paddle.to_tensor([1.0, 2.0, 3.0])
+                x = paddle.randn([0])
+                out = x.set_(source)
+                self.assertEqual(list(out.shape), [3])
+                self.assertTrue(x._is_shared_buffer_with(source))
+
+    def test_both_zero_size(self):
+        """set_ with both x and source being 0-size."""
+        for place in self.places:
+            with paddle.base.dygraph.guard(place):
+                source = paddle.randn([0])
+                x = paddle.randn([0])
+                out = x.set_(source)
+                self.assertEqual(out.numel().item(), 0)
+                self.assertTrue(id(x) == id(out))
+
+    def test_zero_size_source_no_crash_on_contiguous(self):
+        """Ensure no crash when calling contiguous() on a tensor
+        that was set_ with a 0-size source."""
+        for place in self.places:
+            with paddle.base.dygraph.guard(place):
+                source = paddle.randn([0, 3])
+                x = paddle.randn([20])
+                out = x.set_(source, [20], [2])
+                # This should not crash or cause OOB memory access
+                try:
+                    _ = out.contiguous()
+                except Exception:
+                    pass  # contiguous on 0-size is ok either way
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

devPR:https://github.com/PaddlePaddle/Paddle/pull/78486

<!-- Describe what you've done -->

修复 0-Size 报错问题

<meta charset="UTF-8"><meta charset="UTF-8"><div class="mp-table-align"><div class="mp-table-wrapper"><div data-slate-node="element" style="padding-left:0px" class="mp-table-container">
paddle.Tensor.set_ | accuracy | CPU | 精度不对 |  paddle.Tensor.set_(Tensor([20],"complex64"), Tensor([0, 3],"complex64"), list[20,], list[2,], 0, )</br>paddle.Tensor.set_(Tensor([20],"float32"), Tensor([0, 3],"float32"), list[20,], list[2,], 0, )
-- | -- | -- | -- | --



#### Summary
- Fix GPU out-of-bounds memory access (detected by `compute-sanitizer`) when calling `Tensor.set_(source, shape, stride, offset)` with a 0-size source tensor and non-zero target shape.
- When `source.numel() == 0`, the output tensor now inherits the source's 0-size dims/strides instead of using user-specified shape/stride, preventing invalid memory access.
- Updated existing `TestSet_API_ZeroSize` and added 5 new test cases covering various 0-size scenarios.

#### Root Cause
In `SetKernel` (`paddle/phi/kernels/set_kernel.cc`), the conditional logic for handling 0-size tensors had a missing branch: when `source.numel() == 0` and `x.numel() != 0`, no branch was executed. The output tensor retained its original data holder, but `SetInferMeta` had already set its meta to the user-specified shape/stride (e.g., `shape=[20], stride=[2]`). When `ContiguousKernel` later attempted to read 20 elements via stride=2 (requiring storage for indices 0–38), the underlying storage was empty (nullptr), causing CUDA illegal memory access.

Before fix (missing branch):
```
if source.numel() != 0:    # False (source is 0-size)
    ...
elif x.numel() == 0:        # False (x has 20 elements)
    ...
```
Neither branch executes → out keeps stale holder with mismatched meta


#### Fix
When `source.numel() == 0`, force the output tensor's dims/strides to match the source's 0-size shape, and rebind the holder to the source's (empty) storage. This ensures `numel == 0`, so downstream kernels (e.g., `ContiguousKernel`) skip safely via their `numel <= 0` early-return guards.

### Test Plan
- [x] Verified fix with `compute-sanitizer`: `ERROR SUMMARY: 0 errors` (was 11 errors before fix)
  - `paddle.Tensor.set_(Tensor([20],"float32"), Tensor([0, 3],"float32"), list[20,], list[2,], 0, )`
- [x] Added 5 new test cases in `TestSet_API_ZeroSize`:
  - `test_zero_size_source_with_nonzero_shape` — 0-size source + explicit non-zero shape
  - `test_zero_size_source_default_args` — 0-size source with default shape/stride
  - `test_zero_size_x_nonzero_source` — 0-size x with non-zero source
  - `test_both_zero_size` — both x and source are 0-size
  - `test_zero_size_source_no_crash_on_contiguous` — no crash on `.contiguous()` after set_
- [x] APITest 中现有 set_ 全部测试
```
paddle.Tensor.set_(Tensor([20],"float64"), Tensor([0, 3],"float64"), list[20,], list[2,], 0, )
paddle.Tensor.set_(Tensor([20],"float64"), Tensor([15, 0],"float64"), list[20,], list[2,], 0, )
paddle.Tensor.set_(Tensor([3, 0],"float16"), Tensor([6, 0],"float16"), list[3,8,], list[2,2,], 0, )
paddle.Tensor.set_(Tensor([3, 8],"float16"), Tensor([0, 3],"float16"), list[3,8,], list[2,2,], 0, )
paddle.Tensor.set_(Tensor([3, 8],"float16"), Tensor([6, 0],"float16"), list[3,8,], list[2,2,], 0, )
paddle.Tensor.set_(Tensor([20],"complex64"), Tensor([0, 3],"complex64"), list[20,], list[2,], 0, )
paddle.Tensor.set_(Tensor([20],"float32"), Tensor([0, 3],"float32"), list[20,], list[2,], 0, )
paddle.Tensor.set_(Tensor([20],"complex64"), Tensor([15, 0],"complex64"), list[20,], list[2,], 0, )
paddle.Tensor.set_(Tensor([20],"float32"), Tensor([15, 0],"float32"), list[20,], list[2,], 0, )
```

### 是否引起精度变化
否