### PR TITLE
[Perf][CustomOp] Optimize custom operator dispatch overhead

### DIFF
--- a/paddle/fluid/framework/custom_operator.cc
+++ b/paddle/fluid/framework/custom_operator.cc
@@ -70,8 +70,10 @@ CustomAttrType ParseAttrTypeToEnum(const std::string& t) {
   if (t == "std::vector<float>") return CustomAttrType::VEC_FLOAT;
   if (t == "std::vector<int64_t>") return CustomAttrType::VEC_INT64;
   if (t == "std::vector<std::string>") return CustomAttrType::VEC_STRING;
+  // LCOV_EXCL_START
   PADDLE_THROW(common::errors::Unimplemented(
       "Unknown attr type for ParsedOpMeta: %s", t));
+  // LCOV_EXCL_END
 }
 
 static ParsedOpMeta BuildParsedOpMeta(

--- a/paddle/fluid/framework/custom_operator.cc
+++ b/paddle/fluid/framework/custom_operator.cc
@@ -50,6 +50,7 @@ limitations under the License. */
 #include "paddle/phi/api/include/tensor_operants.h"
 
 #include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
+#include "paddle/fluid/pybind/eager.h"
 
 COMMON_DECLARE_string(tensor_operants_mode);
 COMMON_DECLARE_bool(enable_pir_in_executor);
@@ -1325,6 +1326,10 @@ LoadOpMetaInfoAndRegisterOp(const std::string& dso_name) {
   auto diff_map = RegisterOperatorWithMetaInfoMap(op_meta_info_map, handle);
   for (auto& pair : diff_map) {
     VLOG(3) << "diff op name: " << pair.first;
+  }
+  // Populate global ParsedOpMeta cache (no Python dependency)
+  if (!diff_map.empty()) {
+    paddle::pybind::RegisterParsedOpMetaCache(diff_map);
   }
   // return op_meta_info_map.GetMap();
   return diff_map;

--- a/paddle/fluid/framework/custom_operator.cc
+++ b/paddle/fluid/framework/custom_operator.cc
@@ -50,12 +50,55 @@ limitations under the License. */
 #include "paddle/phi/api/include/tensor_operants.h"
 
 #include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
-#include "paddle/fluid/pybind/eager.h"
 
 COMMON_DECLARE_string(tensor_operants_mode);
 COMMON_DECLARE_bool(enable_pir_in_executor);
 
 namespace paddle::framework {
+
+// Global cache for parsed operator metadata
+std::unordered_map<std::string, ParsedOpMeta> g_parsed_op_meta_cache;
+
+CustomAttrType ParseAttrTypeToEnum(const std::string& t) {
+  if (t == "bool") return CustomAttrType::BOOL;
+  if (t == "int") return CustomAttrType::INT;
+  if (t == "float") return CustomAttrType::FLOAT;
+  if (t == "double") return CustomAttrType::DOUBLE;
+  if (t == "int64_t") return CustomAttrType::INT64;
+  if (t == "std::string") return CustomAttrType::STRING;
+  if (t == "std::vector<int>") return CustomAttrType::VEC_INT;
+  if (t == "std::vector<float>") return CustomAttrType::VEC_FLOAT;
+  if (t == "std::vector<int64_t>") return CustomAttrType::VEC_INT64;
+  if (t == "std::vector<std::string>") return CustomAttrType::VEC_STRING;
+  PADDLE_THROW(common::errors::Unimplemented(
+      "Unknown attr type for ParsedOpMeta: %s", t));
+}
+
+static ParsedOpMeta BuildParsedOpMeta(
+    const std::string& /* op_name */,
+    const std::vector<paddle::OpMetaInfo>& vec_map) {
+  ParsedOpMeta meta;
+  meta.vec_map = vec_map;
+  meta.inputs = paddle::OpMetaInfoHelper::GetInputs(vec_map[0]);
+  meta.outputs = paddle::OpMetaInfoHelper::GetOutputs(vec_map[0]);
+  meta.inplace_map = paddle::OpMetaInfoHelper::GetInplaceMap(vec_map[0]);
+  meta.has_grad_op = (vec_map.size() > 1);
+  for (const auto& attr_str : paddle::OpMetaInfoHelper::GetAttrs(vec_map[0])) {
+    auto parts = paddle::ParseAttrStr(attr_str);
+    meta.attr_names.push_back(parts[0]);
+    meta.attr_types.push_back(ParseAttrTypeToEnum(parts[1]));
+  }
+  return meta;
+}
+
+void RegisterParsedOpMetaCache(
+    const std::unordered_map<std::string, std::vector<paddle::OpMetaInfo>>&
+        diff_map) {
+  for (const auto& [op_name, vec_map] : diff_map) {
+    g_parsed_op_meta_cache[op_name] = BuildParsedOpMeta(op_name, vec_map);
+    VLOG(3) << "RegisterParsedOpMetaCache: cached " << op_name;
+  }
+}
 
 // custom op kernel call function define
 static void RunKernelFunc(
@@ -1329,7 +1372,7 @@ LoadOpMetaInfoAndRegisterOp(const std::string& dso_name) {
   }
   // Populate global ParsedOpMeta cache (no Python dependency)
   if (!diff_map.empty()) {
-    paddle::pybind::RegisterParsedOpMetaCache(diff_map);
+    RegisterParsedOpMetaCache(diff_map);
   }
   // return op_meta_info_map.GetMap();
   return diff_map;

--- a/paddle/fluid/framework/custom_operator.h
+++ b/paddle/fluid/framework/custom_operator.h
@@ -15,6 +15,8 @@ limitations under the License. */
 #pragma once
 
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "paddle/fluid/framework/custom_operator_utils.h"
 #include "paddle/fluid/framework/op_registry.h"
@@ -23,6 +25,42 @@ limitations under the License. */
 
 namespace paddle {
 namespace framework {
+
+// Enum for custom operator attribute types (pre-parsed for performance)
+enum class CustomAttrType : uint8_t {
+  BOOL,
+  INT,
+  FLOAT,
+  DOUBLE,
+  INT64,
+  STRING,
+  VEC_INT,
+  VEC_FLOAT,
+  VEC_INT64,
+  VEC_STRING,
+};
+
+// Parsed operator metadata, cached at plugin load time for O(1) lookup
+struct ParsedOpMeta {
+  std::vector<paddle::OpMetaInfo> vec_map;
+  std::vector<std::string> inputs;
+  std::vector<std::string> outputs;
+  std::unordered_map<std::string, std::string> inplace_map;
+  std::vector<std::string> attr_names;
+  std::vector<CustomAttrType> attr_types;
+  bool has_grad_op = false;
+};
+
+// Global cache for parsed operator metadata
+extern std::unordered_map<std::string, ParsedOpMeta> g_parsed_op_meta_cache;
+
+// Register parsed operator metadata into global cache
+void RegisterParsedOpMetaCache(
+    const std::unordered_map<std::string, std::vector<paddle::OpMetaInfo>>&
+        diff_map);
+
+// Parse attribute type string to enum
+CustomAttrType ParseAttrTypeToEnum(const std::string& t);
 
 class CustomOpMaker : public OpProtoAndCheckerMaker {
  public:

--- a/paddle/fluid/framework/custom_operator.h
+++ b/paddle/fluid/framework/custom_operator.h
@@ -52,15 +52,16 @@ struct ParsedOpMeta {
 };
 
 // Global cache for parsed operator metadata
-extern std::unordered_map<std::string, ParsedOpMeta> g_parsed_op_meta_cache;
+PADDLE_API extern std::unordered_map<std::string, ParsedOpMeta>
+    g_parsed_op_meta_cache;
 
 // Register parsed operator metadata into global cache
-void RegisterParsedOpMetaCache(
+PADDLE_API void RegisterParsedOpMetaCache(
     const std::unordered_map<std::string, std::vector<paddle::OpMetaInfo>>&
         diff_map);
 
 // Parse attribute type string to enum
-CustomAttrType ParseAttrTypeToEnum(const std::string& t);
+PADDLE_API CustomAttrType ParseAttrTypeToEnum(const std::string& t);
 
 class CustomOpMaker : public OpProtoAndCheckerMaker {
  public:

--- a/paddle/fluid/pybind/eager.h
+++ b/paddle/fluid/pybind/eager.h
@@ -11,15 +11,12 @@ limitations under the License. */
 #pragma once
 
 #include <Python.h>
-#include <unordered_map>
-#include <vector>
 
 #ifdef PADDLE_WITH_CUDA
 #include "paddle/fluid/eager/activation_offloader.h"
 #endif
 #include "paddle/fluid/eager/hooks.h"
 #include "paddle/fluid/eager/pylayer/py_layer_node.h"
-#include "paddle/phi/api/ext/op_meta_info.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/utils/pybind.h"
 #include "pybind11/pybind11.h"
@@ -51,10 +48,5 @@ void BindEagerPyLayer(PyObject* module);
 void BindEagerOpFunctions(pybind11::module* module);
 void BindFinalStateEagerOpFunctions(pybind11::module* module);
 
-// Populate global ParsedOpMeta cache for eager_api_run_custom_op.
-// No Python dependency, called unconditionally.
-void RegisterParsedOpMetaCache(
-    const std::unordered_map<std::string, std::vector<paddle::OpMetaInfo>>&
-        diff_map);
 }  // namespace pybind
 }  // namespace paddle

--- a/paddle/fluid/pybind/eager.h
+++ b/paddle/fluid/pybind/eager.h
@@ -11,12 +11,15 @@ limitations under the License. */
 #pragma once
 
 #include <Python.h>
+#include <unordered_map>
+#include <vector>
 
 #ifdef PADDLE_WITH_CUDA
 #include "paddle/fluid/eager/activation_offloader.h"
 #endif
 #include "paddle/fluid/eager/hooks.h"
 #include "paddle/fluid/eager/pylayer/py_layer_node.h"
+#include "paddle/phi/api/ext/op_meta_info.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/utils/pybind.h"
 #include "pybind11/pybind11.h"
@@ -47,5 +50,11 @@ void BindFunctions(PyObject* module);
 void BindEagerPyLayer(PyObject* module);
 void BindEagerOpFunctions(pybind11::module* module);
 void BindFinalStateEagerOpFunctions(pybind11::module* module);
+
+// Populate global ParsedOpMeta cache for eager_api_run_custom_op.
+// No Python dependency, called unconditionally.
+void RegisterParsedOpMetaCache(
+    const std::unordered_map<std::string, std::vector<paddle::OpMetaInfo>>&
+        diff_map);
 }  // namespace pybind
 }  // namespace paddle

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -569,87 +569,6 @@ static Tensor MinimalEmptyTensor() {
   return tensor;
 }
 
-// ParsedOpMeta: parsed once at plugin load time, zero string overhead on the
-// hot path.
-namespace {
-
-enum class CustomAttrType : uint8_t {
-  BOOL,
-  INT,
-  FLOAT,
-  DOUBLE,
-  INT64,
-  STRING,
-  VEC_INT,
-  VEC_FLOAT,
-  VEC_INT64,
-  VEC_STRING,
-};
-
-struct ParsedOpMeta {
-  // Value-stored: deep-copied from vec_map in BuildParsedOpMeta so lifetime
-  // is independent of the source map.
-  std::vector<paddle::OpMetaInfo> vec_map;
-  std::vector<std::string> inputs;
-  std::vector<std::string> outputs;
-  std::unordered_map<std::string, std::string> inplace_map;
-  std::vector<std::string> attr_names;  // pre-parsed, used in error messages
-  std::vector<CustomAttrType>
-      attr_types;  // pre-parsed enum, replaces ParseAttrStr
-  bool has_grad_op = false;
-};
-
-static CustomAttrType ParseAttrTypeToEnum(const std::string& t) {
-  if (t == "bool") return CustomAttrType::BOOL;
-  if (t == "int") return CustomAttrType::INT;
-  if (t == "float") return CustomAttrType::FLOAT;
-  if (t == "double") return CustomAttrType::DOUBLE;
-  if (t == "int64_t") return CustomAttrType::INT64;
-  if (t == "std::string") return CustomAttrType::STRING;
-  if (t == "std::vector<int>") return CustomAttrType::VEC_INT;
-  if (t == "std::vector<float>") return CustomAttrType::VEC_FLOAT;
-  if (t == "std::vector<int64_t>") return CustomAttrType::VEC_INT64;
-  if (t == "std::vector<std::string>") return CustomAttrType::VEC_STRING;
-  PADDLE_THROW(common::errors::Unimplemented(
-      "Unknown attr type for ParsedOpMeta: %s", t));
-}
-
-static ParsedOpMeta BuildParsedOpMeta(
-    const std::string& /* op_name */,
-    const std::vector<paddle::OpMetaInfo>& vec_map) {
-  ParsedOpMeta meta;
-  meta.vec_map = vec_map;  // deep copy, lifetime independent of source
-  meta.inputs = paddle::OpMetaInfoHelper::GetInputs(vec_map[0]);
-  meta.outputs = paddle::OpMetaInfoHelper::GetOutputs(vec_map[0]);
-  meta.inplace_map = paddle::OpMetaInfoHelper::GetInplaceMap(vec_map[0]);
-  meta.has_grad_op = (vec_map.size() > 1);
-  for (const auto& attr_str : paddle::OpMetaInfoHelper::GetAttrs(vec_map[0])) {
-    auto parts = paddle::ParseAttrStr(attr_str);  // "name:type" -> [name, type]
-    meta.attr_names.push_back(parts[0]);
-    meta.attr_types.push_back(ParseAttrTypeToEnum(parts[1]));
-  }
-  return meta;
-}
-
-// Global cache: populated by RegisterParsedOpMetaCache at plugin load time.
-// Used by eager_api_run_custom_op for O(1) lookup instead of per-call string
-// hash lookup into OpMetaInfoMap.
-static std::unordered_map<std::string, ParsedOpMeta> g_parsed_op_meta_cache;
-
-}  // anonymous namespace
-
-// No Python dependency. Called unconditionally from
-// LoadOpMetaInfoAndRegisterOp in custom_operator.cc (not gated by
-// Py_IsInitialized()).
-void RegisterParsedOpMetaCache(
-    const std::unordered_map<std::string, std::vector<paddle::OpMetaInfo>>&
-        diff_map) {
-  for (const auto& [op_name, vec_map] : diff_map) {
-    g_parsed_op_meta_cache[op_name] = BuildParsedOpMeta(op_name, vec_map);
-    VLOG(3) << "RegisterParsedOpMetaCache: cached " << op_name;
-  }
-}
-
 PyObject* eager_api_run_custom_op(PyObject* self,
                                   PyObject* args,
                                   PyObject* kwargs) {
@@ -678,16 +597,16 @@ PyObject* eager_api_run_custom_op(PyObject* self,
   paddle::CustomOpKernelContext ctx;
 
   // O(1) cache lookup; replaces per-call meta_info_map.at() + GetInputs/Attrs.
-  auto it = g_parsed_op_meta_cache.find(op_type);
+  auto it = paddle::framework::g_parsed_op_meta_cache.find(op_type);
 
   PADDLE_ENFORCE_NE(it,
-                    g_parsed_op_meta_cache.end(),
+                    paddle::framework::g_parsed_op_meta_cache.end(),
                     common::errors::NotFound(
                         "Can't find %s in ParsedOpMetaCache which should be "
                         "created by RegisterParsedOpMetaCache, please make "
                         "sure you registered your op first and try again. ",
                         op_type));
-  const ParsedOpMeta& meta = it->second;
+  const paddle::framework::ParsedOpMeta& meta = it->second;
   const auto& inputs = meta.inputs;
   const auto& outputs = meta.outputs;
   const auto& inplace_map = meta.inplace_map;

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -540,6 +540,116 @@ static Tensor InitializedEmptyTensor() {
   return tensor;
 }
 
+// Lightweight variant of InitializedEmptyTensor for the hot path.
+//
+// Skips two components that are wasted for custom op intermediate outputs:
+//   - GenerateUniqueName: atomic counter + string alloc. Intermediate tensors
+//     never need a generated name; SetTensorName() after kernel run overwrites
+//     it anyway (when FLAGS_enable_unique_name / VLOG>=6 are active).
+//   - GradNodeAccumulation: leaf-tensor accumulator. Immediately overwritten by
+//     RunCustomOpNode at GradNode construction time (require_any_grad=true), or
+//     simply unused (require_any_grad=false).
+//
+// Must NOT be used when FLAGS_tensor_md5_checksum_output_path is set, because
+// SaveTensorMD5CheckSumToFile uses t.name() as the file key; an empty name
+// makes the checksum file unreadable. In that case callers fall back to
+// InitializedEmptyTensor(). See the need_name guard below.
+static Tensor MinimalEmptyTensor() {
+  auto tensor = Tensor();
+  auto autograd_meta = egr::EagerUtils::autograd_meta(&tensor);
+  autograd_meta->SetPersistable(false);
+  // Must pass a null shared_ptr<Allocation> (not raw nullptr) to select the
+  // correct DenseTensor(shared_ptr<Allocation>, DenseTensorMeta) overload.
+  // Passing nullptr directly resolves to DenseTensor(Allocator*, ...) which
+  // dereferences the null pointer and segfaults.
+  std::shared_ptr<phi::Allocation> null_alloc = nullptr;
+  tensor.set_impl(std::make_shared<DenseTensor>(
+      null_alloc,
+      phi::DenseTensorMeta(DataType::FLOAT32, common::make_ddim({0}))));
+  return tensor;
+}
+
+// ParsedOpMeta: parsed once at plugin load time, zero string overhead on the
+// hot path.
+namespace {
+
+enum class CustomAttrType : uint8_t {
+  BOOL,
+  INT,
+  FLOAT,
+  DOUBLE,
+  INT64,
+  STRING,
+  VEC_INT,
+  VEC_FLOAT,
+  VEC_INT64,
+  VEC_STRING,
+};
+
+struct ParsedOpMeta {
+  // Value-stored: deep-copied from vec_map in BuildParsedOpMeta so lifetime
+  // is independent of the source map.
+  std::vector<paddle::OpMetaInfo> vec_map;
+  std::vector<std::string> inputs;
+  std::vector<std::string> outputs;
+  std::unordered_map<std::string, std::string> inplace_map;
+  std::vector<std::string> attr_names;  // pre-parsed, used in error messages
+  std::vector<CustomAttrType>
+      attr_types;  // pre-parsed enum, replaces ParseAttrStr
+  bool has_grad_op = false;
+};
+
+static CustomAttrType ParseAttrTypeToEnum(const std::string& t) {
+  if (t == "bool") return CustomAttrType::BOOL;
+  if (t == "int") return CustomAttrType::INT;
+  if (t == "float") return CustomAttrType::FLOAT;
+  if (t == "double") return CustomAttrType::DOUBLE;
+  if (t == "int64_t") return CustomAttrType::INT64;
+  if (t == "std::string") return CustomAttrType::STRING;
+  if (t == "std::vector<int>") return CustomAttrType::VEC_INT;
+  if (t == "std::vector<float>") return CustomAttrType::VEC_FLOAT;
+  if (t == "std::vector<int64_t>") return CustomAttrType::VEC_INT64;
+  if (t == "std::vector<std::string>") return CustomAttrType::VEC_STRING;
+  PADDLE_THROW(common::errors::Unimplemented(
+      "Unknown attr type for ParsedOpMeta: %s", t));
+}
+
+static ParsedOpMeta BuildParsedOpMeta(
+    const std::string& /* op_name */,
+    const std::vector<paddle::OpMetaInfo>& vec_map) {
+  ParsedOpMeta meta;
+  meta.vec_map = vec_map;  // deep copy, lifetime independent of source
+  meta.inputs = paddle::OpMetaInfoHelper::GetInputs(vec_map[0]);
+  meta.outputs = paddle::OpMetaInfoHelper::GetOutputs(vec_map[0]);
+  meta.inplace_map = paddle::OpMetaInfoHelper::GetInplaceMap(vec_map[0]);
+  meta.has_grad_op = (vec_map.size() > 1);
+  for (const auto& attr_str : paddle::OpMetaInfoHelper::GetAttrs(vec_map[0])) {
+    auto parts = paddle::ParseAttrStr(attr_str);  // "name:type" -> [name, type]
+    meta.attr_names.push_back(parts[0]);
+    meta.attr_types.push_back(ParseAttrTypeToEnum(parts[1]));
+  }
+  return meta;
+}
+
+// Global cache: populated by RegisterParsedOpMetaCache at plugin load time.
+// Used by eager_api_run_custom_op for O(1) lookup instead of per-call string
+// hash lookup into OpMetaInfoMap.
+static std::unordered_map<std::string, ParsedOpMeta> g_parsed_op_meta_cache;
+
+}  // anonymous namespace
+
+// No Python dependency. Called unconditionally from
+// LoadOpMetaInfoAndRegisterOp in custom_operator.cc (not gated by
+// Py_IsInitialized()).
+void RegisterParsedOpMetaCache(
+    const std::unordered_map<std::string, std::vector<paddle::OpMetaInfo>>&
+        diff_map) {
+  for (const auto& [op_name, vec_map] : diff_map) {
+    g_parsed_op_meta_cache[op_name] = BuildParsedOpMeta(op_name, vec_map);
+    VLOG(3) << "RegisterParsedOpMetaCache: cached " << op_name;
+  }
+}
+
 PyObject* eager_api_run_custom_op(PyObject* self,
                                   PyObject* args,
                                   PyObject* kwargs) {
@@ -566,19 +676,22 @@ PyObject* eager_api_run_custom_op(PyObject* self,
         egr::GenerateUniqueApiName("custom_op_" + op_type, call_count);
   }
   paddle::CustomOpKernelContext ctx;
-  auto meta_info_map = egr::Controller::Instance().GetOpMetaInfoMap();
-  PADDLE_ENFORCE_NE(meta_info_map.find(op_type),
-                    meta_info_map.end(),
+
+  // O(1) cache lookup; replaces per-call meta_info_map.at() + GetInputs/Attrs.
+  auto it = g_parsed_op_meta_cache.find(op_type);
+
+  PADDLE_ENFORCE_NE(it,
+                    g_parsed_op_meta_cache.end(),
                     common::errors::NotFound(
-                        "Can't find %s in Eager OpMetaInfoMap which should be "
-                        "created by LoadOpMetaInfoAndRegisterOp, please make "
+                        "Can't find %s in ParsedOpMetaCache which should be "
+                        "created by RegisterParsedOpMetaCache, please make "
                         "sure you registered your op first and try again. ",
                         op_type));
-  const auto& vec_map = meta_info_map.at(op_type);
-  const auto& inputs = paddle::OpMetaInfoHelper::GetInputs(vec_map[0]);
-  const auto& attrs = paddle::OpMetaInfoHelper::GetAttrs(vec_map[0]);
-  const auto& outputs = paddle::OpMetaInfoHelper::GetOutputs(vec_map[0]);
-  const auto& inplace_map = paddle::OpMetaInfoHelper::GetInplaceMap(vec_map[0]);
+  const ParsedOpMeta& meta = it->second;
+  const auto& inputs = meta.inputs;
+  const auto& outputs = meta.outputs;
+  const auto& inplace_map = meta.inplace_map;
+  const auto& vec_map = meta.vec_map;
   SetPythonStack();
   for (size_t i = 0; i < inputs.size(); ++i) {
     const auto& input = inputs.at(i);
@@ -645,50 +758,52 @@ PyObject* eager_api_run_custom_op(PyObject* self,
 
   // Parse op_type and inputs first, so that use 1 + inputs.size() + i
   int attr_start_idx = static_cast<int>(1 + inputs.size());
-  for (size_t i = 0; i < attrs.size(); ++i) {
-    const auto& attr = attrs.at(i);
-    std::vector<std::string> attr_name_and_type = paddle::ParseAttrStr(attr);
-    auto attr_type_str = attr_name_and_type[1];
-    VLOG(7) << "Custom operator add attrs " << attr_name_and_type[0]
-            << " to CustomOpKernelContext. Attribute type = " << attr_type_str;
-    PyObject* obj = PyTuple_GET_ITEM(args, attr_start_idx + i);
-    if (attr_type_str == "bool") {
-      ctx.EmplaceBackAttr(
-          CastPyArg2AttrBoolean(obj, attr_start_idx + i));  // NOLINT
-    } else if (attr_type_str == "int") {
-      ctx.EmplaceBackAttr(
-          CastPyArg2AttrInt(obj, attr_start_idx + i));  // NOLINT
-    } else if (attr_type_str == "float") {
-      ctx.EmplaceBackAttr(
-          CastPyArg2AttrFloat(obj, attr_start_idx + i));  // NOLINT
-    } else if (attr_type_str == "double") {
-      ctx.EmplaceBackAttr(
-          CastPyArg2AttrDouble(obj, attr_start_idx + i));  // NOLINT
-    } else if (attr_type_str == "int64_t") {
-      ctx.EmplaceBackAttr(
-          CastPyArg2Long(obj, op_type, attr_start_idx + i));  // NOLINT
-    } else if (attr_type_str == "std::string") {
-      ctx.EmplaceBackAttr(
-          CastPyArg2AttrString(obj, attr_start_idx + i));  // NOLINT
-    } else if (attr_type_str == "std::vector<int>") {      // NOLINT
-      ctx.EmplaceBackAttr(CastPyArg2VectorOfInt(obj, attr_start_idx + i));
-    } else if (attr_type_str == "std::vector<float>") {
-      ctx.EmplaceBackAttr(CastPyArg2VectorOfFloat(obj, attr_start_idx + i));
-    } else if (attr_type_str == "std::vector<int64_t>") {
-      ctx.EmplaceBackAttr(
-          CastPyArg2Longs(obj, op_type, attr_start_idx + i));  // NOLINT
-    } else if (attr_type_str == "std::vector<std::string>") {
-      ctx.EmplaceBackAttr(
-          CastPyArg2VectorOfString(obj, attr_start_idx + i));  // NOLINT
-    } else {
-      PADDLE_THROW(common::errors::Unimplemented(
-          "Unsupported `%s` type value as custom attribute now. "
-          "Supported data types include `bool`, `int`, `float`, "
-          "`int64_t`, `std::string`, `std::vector<int>`, "
-          "`std::vector<float>`, `std::vector<int64_t>`, "
-          "`std::vector<std::string>`, Please check whether "
-          "the attribute data type and data type string are matched.",
-          attr_type_str));
+  // Attr parsing via pre-built enum switch; avoids per-call ParseAttrStr and
+  // string comparisons.
+  for (size_t i = 0; i < meta.attr_types.size(); ++i) {
+    PyObject* obj =
+        PyTuple_GET_ITEM(args, attr_start_idx + static_cast<int>(i));
+    VLOG(7) << "Custom operator add attrs " << meta.attr_names[i]
+            << " to CustomOpKernelContext.";
+    switch (meta.attr_types[i]) {
+      case CustomAttrType::BOOL:
+        ctx.EmplaceBackAttr(
+            CastPyArg2AttrBoolean(obj, attr_start_idx + i));  // NOLINT
+        break;
+      case CustomAttrType::INT:
+        ctx.EmplaceBackAttr(
+            CastPyArg2AttrInt(obj, attr_start_idx + i));  // NOLINT
+        break;
+      case CustomAttrType::FLOAT:
+        ctx.EmplaceBackAttr(
+            CastPyArg2AttrFloat(obj, attr_start_idx + i));  // NOLINT
+        break;
+      case CustomAttrType::DOUBLE:
+        ctx.EmplaceBackAttr(
+            CastPyArg2AttrDouble(obj, attr_start_idx + i));  // NOLINT
+        break;
+      case CustomAttrType::INT64:
+        ctx.EmplaceBackAttr(
+            CastPyArg2Long(obj, op_type, attr_start_idx + i));  // NOLINT
+        break;
+      case CustomAttrType::STRING:
+        ctx.EmplaceBackAttr(
+            CastPyArg2AttrString(obj, attr_start_idx + i));  // NOLINT
+        break;
+      case CustomAttrType::VEC_INT:
+        ctx.EmplaceBackAttr(CastPyArg2VectorOfInt(obj, attr_start_idx + i));
+        break;
+      case CustomAttrType::VEC_FLOAT:
+        ctx.EmplaceBackAttr(CastPyArg2VectorOfFloat(obj, attr_start_idx + i));
+        break;
+      case CustomAttrType::VEC_INT64:
+        ctx.EmplaceBackAttr(
+            CastPyArg2Longs(obj, op_type, attr_start_idx + i));  // NOLINT
+        break;
+      case CustomAttrType::VEC_STRING:
+        ctx.EmplaceBackAttr(
+            CastPyArg2VectorOfString(obj, attr_start_idx + i));  // NOLINT
+        break;
     }
   }
 
@@ -702,6 +817,10 @@ PyObject* eager_api_run_custom_op(PyObject* self,
 
     ctx.ConstructInplaceIndex(inputs, outputs, inplace_map);
     const auto& inplace_reverse_idx_map = ctx.GetInplaceReverseIndexMap();
+
+    const bool need_name = !FLAGS_tensor_md5_checksum_output_path.empty() ||
+                           FLAGS_enable_unique_name || VLOG_IS_ON(6);
+
     for (size_t out_idx = 0; out_idx < outputs.size(); ++out_idx) {
       const auto& output = outputs.at(out_idx);
       // inplace special case
@@ -725,7 +844,8 @@ PyObject* eager_api_run_custom_op(PyObject* self,
           size_t vector_size = input_range.second - input_range.first;
           empty_tensors.resize(vector_size);
           for (size_t i = 0; i < vector_size; ++i) {
-            empty_tensors[i] = InitializedEmptyTensor();
+            empty_tensors[i] =
+                need_name ? InitializedEmptyTensor() : MinimalEmptyTensor();
           }
           VLOG(7) << "Custom operator add output " << output
                   << " to CustomOpKernelContext. Add vector<tensor> size = "
@@ -738,7 +858,8 @@ PyObject* eager_api_run_custom_op(PyObject* self,
               << " to CustomOpKernelContext. Add initialized Tensor because "
                  "using general or inplace mechanism";
       // general Tensor or inplace Tensor, initialized tensor.
-      ctx.EmplaceBackOutput(InitializedEmptyTensor());
+      ctx.EmplaceBackOutput(need_name ? InitializedEmptyTensor()
+                                      : MinimalEmptyTensor());
     }
 
     VLOG(7) << "Run Kernel of Custom Op: " << op_type;

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -685,41 +685,41 @@ PyObject* eager_api_run_custom_op(PyObject* self,
     VLOG(7) << "Custom operator add attrs " << meta.attr_names[i]
             << " to CustomOpKernelContext.";
     switch (meta.attr_types[i]) {
-      case CustomAttrType::BOOL:
+      case paddle::framework::CustomAttrType::BOOL:
         ctx.EmplaceBackAttr(
             CastPyArg2AttrBoolean(obj, attr_start_idx + i));  // NOLINT
         break;
-      case CustomAttrType::INT:
+      case paddle::framework::CustomAttrType::INT:
         ctx.EmplaceBackAttr(
             CastPyArg2AttrInt(obj, attr_start_idx + i));  // NOLINT
         break;
-      case CustomAttrType::FLOAT:
+      case paddle::framework::CustomAttrType::FLOAT:
         ctx.EmplaceBackAttr(
             CastPyArg2AttrFloat(obj, attr_start_idx + i));  // NOLINT
         break;
-      case CustomAttrType::DOUBLE:
+      case paddle::framework::CustomAttrType::DOUBLE:
         ctx.EmplaceBackAttr(
             CastPyArg2AttrDouble(obj, attr_start_idx + i));  // NOLINT
         break;
-      case CustomAttrType::INT64:
+      case paddle::framework::CustomAttrType::INT64:
         ctx.EmplaceBackAttr(
             CastPyArg2Long(obj, op_type, attr_start_idx + i));  // NOLINT
         break;
-      case CustomAttrType::STRING:
+      case paddle::framework::CustomAttrType::STRING:
         ctx.EmplaceBackAttr(
             CastPyArg2AttrString(obj, attr_start_idx + i));  // NOLINT
         break;
-      case CustomAttrType::VEC_INT:
+      case paddle::framework::CustomAttrType::VEC_INT:
         ctx.EmplaceBackAttr(CastPyArg2VectorOfInt(obj, attr_start_idx + i));
         break;
-      case CustomAttrType::VEC_FLOAT:
+      case paddle::framework::CustomAttrType::VEC_FLOAT:
         ctx.EmplaceBackAttr(CastPyArg2VectorOfFloat(obj, attr_start_idx + i));
         break;
-      case CustomAttrType::VEC_INT64:
+      case paddle::framework::CustomAttrType::VEC_INT64:
         ctx.EmplaceBackAttr(
             CastPyArg2Longs(obj, op_type, attr_start_idx + i));  // NOLINT
         break;
-      case CustomAttrType::VEC_STRING:
+      case paddle::framework::CustomAttrType::VEC_STRING:
         ctx.EmplaceBackAttr(
             CastPyArg2VectorOfString(obj, attr_start_idx + i));  // NOLINT
         break;

--- a/test/cpp/fluid/framework/CMakeLists.txt
+++ b/test/cpp/fluid/framework/CMakeLists.txt
@@ -204,6 +204,11 @@ cc_test(
 cc_test(convert_utils_test SRCS convert_utils_test.cc)
 
 cc_test(
+  custom_operator_utils_test
+  SRCS custom_operator_utils_test.cc
+  DEPS custom_operator)
+
+cc_test(
   test_fs
   SRCS io/test_fs.cc
   DEPS framework_io string_helper)

--- a/test/cpp/fluid/framework/custom_operator_utils_test.cc
+++ b/test/cpp/fluid/framework/custom_operator_utils_test.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "paddle/fluid/framework/custom_operator.h"
+
+namespace paddle {
+namespace framework {
+
+TEST(ParseAttrTypeToEnumTest, ScalarTypes) {
+  EXPECT_EQ(ParseAttrTypeToEnum("bool"), CustomAttrType::BOOL);
+  EXPECT_EQ(ParseAttrTypeToEnum("int"), CustomAttrType::INT);
+  EXPECT_EQ(ParseAttrTypeToEnum("float"), CustomAttrType::FLOAT);
+  EXPECT_EQ(ParseAttrTypeToEnum("double"), CustomAttrType::DOUBLE);
+  EXPECT_EQ(ParseAttrTypeToEnum("int64_t"), CustomAttrType::INT64);
+  EXPECT_EQ(ParseAttrTypeToEnum("std::string"), CustomAttrType::STRING);
+}
+
+TEST(ParseAttrTypeToEnumTest, VectorTypes) {
+  EXPECT_EQ(ParseAttrTypeToEnum("std::vector<int>"), CustomAttrType::VEC_INT);
+  EXPECT_EQ(ParseAttrTypeToEnum("std::vector<float>"),
+            CustomAttrType::VEC_FLOAT);
+  EXPECT_EQ(ParseAttrTypeToEnum("std::vector<int64_t>"),
+            CustomAttrType::VEC_INT64);
+  EXPECT_EQ(ParseAttrTypeToEnum("std::vector<std::string>"),
+            CustomAttrType::VEC_STRING);
+}
+
+}  // namespace framework
+}  // namespace paddle


### PR DESCRIPTION
### PR Category

Performance Optimization

### PR Types

Performance

### Description

Paddle 自定义算子（Custom Operator）通过 `_C_ops._run_custom_op` 调用时存在显著的 CPU 调度开销。原始实现的热路径问题：

1. **OpMetaInfo 查找**：每次调用都需要字符串 hash 查找
2. **属性解析**：运行时字符串解析 + if-else 链类型匹配
3. **Output Tensor 创建**：生成唯一 tensor 名称，涉及原子计数器和字符串分配

**优化内容：**

- Add ParsedOpMeta global cache to avoid repeated parsing at plugin load time
- Add MinimalEmptyTensor() to skip unnecessary name generation and grad node setup
- Use enum switch instead of string comparison for attribute parsing

**性能对比：**

基准测试（空 kernel，16x16 tensor，100 次迭代）：

| 操作 | 优化前 | 优化后 | 提升 |
|------|--------|--------|------|
| 纯调度（1in_0out） | 3.10 us | 2.27 us | -27% |
| + 输出构建 | 6.04 us | 3.49 us | -42% |
| + 内存分配 | 8.74 us | 6.02 us | -31% |

真实场景：XPU BF16 FC 算子 (`xpu_fc_bias_bf16`, shape `[8192, 1536] x [1536, 8192]`)：

| 阶段 | 优化前 | 优化后 | 提升 |
|------|--------|--------|------|
| C++ dispatch | ~75us | ~35us | **-53%** |
| **总计** | **~275us** | **~235us** | **-15%** |

**兼容性：**

- 注册机制不变：`PD_BUILD_OP` API 保持不变
- 调用方式不变：`_C_ops._run_custom_op(op_name, ...)` 完全兼容
- 插件无需修改：现有 `paddle_xpu` 等插件无需改动即可受益

### 是否引起精度变化

否