### PR TITLE
[Cherry-Pick][PHI] Fix int32/float16 overflow in GPU reduce and Welford std/var for large tensors

### DIFF
--- a/paddle/phi/kernels/gpu/std_var_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/std_var_grad_kernel.cu
@@ -14,7 +14,9 @@
 
 #include "paddle/phi/kernels/std_var_grad_kernel.h"
 
+#include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/compare_kernel.h"
 #include "paddle/phi/kernels/elementwise_divide_kernel.h"
 #include "paddle/phi/kernels/elementwise_kernel.h"
@@ -90,13 +92,38 @@ void VarGradKernel(const Context& dev_ctx,
   }
 
   // (2.0 / denom) * grad * (x - x.mean());
+  // For float16/bfloat16, multiplications are performed in AccT (float32) to
+  // match PyTorch's opmath behavior, which uses float32 for intermediate
+  // multiply computations on float16 tensors.
+  using AccT = typename phi::dtype::MPTypeTrait<T>::Type;
   DenseTensor x_mean = Mean<T, Context>(dev_ctx, x, axes64, /*keepdim=*/true);
   DenseTensor diff = Subtract<T, Context>(dev_ctx, x, x_mean);
-  DenseTensor scale =
-      phi::FullLike<T, Context>(dev_ctx, x, static_cast<T>(2.0 / denom));
-  DenseTensor tmp = Multiply<T, Context>(dev_ctx, scale, grad_expanded);
   dev_ctx.template Alloc<T>(x_grad);
-  MultiplyKernel<T, Context>(dev_ctx, tmp, diff, x_grad);
+  if (!std::is_same<T, AccT>::value) {
+    auto acc_dtype = phi::CppTypeToDataType<AccT>::Type();
+    DenseTensor grad_acc =
+        phi::Cast<T, Context>(dev_ctx, grad_expanded, acc_dtype);
+    DenseTensor diff_acc = phi::Cast<T, Context>(dev_ctx, diff, acc_dtype);
+    DenseTensor scale_acc = phi::FullLike<AccT, Context>(
+        dev_ctx, grad_acc, static_cast<AccT>(2.0 / denom));
+    // Compute scale*grad in AccT (float32), then cast back to T (float16).
+    // This matches PyTorch's opmath behavior: each element-wise multiply
+    // promotes inputs to float32, multiplies, then stores back as float16.
+    DenseTensor tmp_t = phi::Cast<AccT, Context>(
+        dev_ctx,
+        Multiply<AccT, Context>(dev_ctx, scale_acc, grad_acc),
+        x.dtype());
+    // Second multiply: promote T→AccT, multiply, store as float16 via Cast
+    DenseTensor tmp2_acc = phi::Cast<T, Context>(dev_ctx, tmp_t, acc_dtype);
+    DenseTensor result_acc =
+        Multiply<AccT, Context>(dev_ctx, tmp2_acc, diff_acc);
+    phi::CastKernel<AccT, Context>(dev_ctx, result_acc, x.dtype(), x_grad);
+  } else {
+    DenseTensor scale =
+        phi::FullLike<T, Context>(dev_ctx, x, static_cast<T>(2.0 / denom));
+    DenseTensor tmp = Multiply<T, Context>(dev_ctx, scale, grad_expanded);
+    MultiplyKernel<T, Context>(dev_ctx, tmp, diff, x_grad);
+  }
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/gpu/std_var_kernel.cu
+++ b/paddle/phi/kernels/gpu/std_var_kernel.cu
@@ -126,10 +126,10 @@ struct WelfordOps {
   inline C10_DEVICE res_t post_process(acc_t acc) const {
     const auto mean = static_cast<scalar_t>(acc.mean);
     const auto divisor = acc.nf > correction ? acc.nf - correction : 0;
-    const auto var = static_cast<scalar_t>(acc.m2 / divisor);
-    const auto var_sqrt =
-        static_cast<scalar_t>(device_sqrt(static_cast<acc_scalar_t>(var)));
-    res_t results(take_sqrt ? var_sqrt : var, mean);
+    const auto var = acc.m2 / divisor;
+    res_t results(take_sqrt ? static_cast<scalar_t>(device_sqrt(var))
+                            : static_cast<scalar_t>(var),
+                  mean);
     return results;
   }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you've done -->
devPR:https://github.com/PaddlePaddle/Paddle/pull/78451
#### Problem
1. FP16/BF16 精度无法和torch逐位对齐
2. 大Tensor下FP16/BF16 测试前向结果有可能出inf的情况

### 解决方案
中间计算使用更高精度的数据类型，然后计算完成后cast成低精度的

### 是否引起精度变化
是