### PR TITLE
fix(ci): preload inference test data to avoid download failures

### DIFF
--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -189,6 +189,7 @@ jobs:
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-12.9/compat
           source ${{ github.workspace }}/../../../proxy
           bash ${ci_scripts}/cmake-predownload.sh
+          bash ${ci_scripts}/cmake_preload_data_file.sh
           pip install -r python/requirements.txt
           mkdir -p build && cd build
           ccache -z

--- a/ci/cmake_preload_data_file.sh
+++ b/ci/cmake_preload_data_file.sh
@@ -14,15 +14,47 @@
 
 set -e
 
-echo "=== preload data file from CFS_DIR  ==="
+echo "=== preload data file from CFS_DIR ==="
 
 BASE_SRC=${CFS_DIR}/preload_file
 BASE_DST=/paddle/build/third_party/inference_demo
 
 declare -A FILE_MAP=(
+  ["word2vec.inference.model.tar.gz"]="word2vec"
+  ["image_classification_resnet.inference.model.tgz"]="image_classification_resnet"
+
+  ########################
+  # Quant1
+  ########################
+  ["ResNet50_qat_model.tar.gz"]="quant/ResNet50_quant"
+  ["ResNet101_qat_model.tar.gz"]="quant/ResNet101_quant"
+  ["GoogleNet_qat_model.tar.gz"]="quant/GoogleNet_quant"
+  ["MobileNetV1_qat_model.tar.gz"]="quant/MobileNetV1_quant"
+  ["MobileNetV2_qat_model.tar.gz"]="quant/MobileNetV2_quant"
+  ["VGG16_qat_model.tar.gz"]="quant/VGG16_quant"
+  ["VGG19_qat_model.tar.gz"]="quant/VGG19_quant"
+
+  ########################
+  # Quant2
+  ########################
   ["ResNet50_qat_perf.tar.gz"]="quant/ResNet50_quant2"
+  ["ResNet50_qat_range.tar.gz"]="quant/ResNet50_quant2_range"
+  ["ResNet50_qat_channelwise.tar.gz"]="quant/ResNet50_quant2_channelwise"
+  ["MobileNet_qat_perf.tar.gz"]="quant/MobileNetV1_quant2"
+
+  ########################
+  # NLP
+  ########################
   ["Ernie_dataset.tar.gz"]="Ernie_dataset"
+  ["ernie_qat.tar.gz"]="quant/Ernie_quant2"
+  ["ernie_fp32_model.tar.gz"]="quant/Ernie_float"
+
+  ########################
+  # LSTM
+  ########################
+  ["lstm_quant.tar.gz"]="quant/lstm_quant_test"
   ["quant_lstm_input_data.tar.gz"]="quant/lstm_quant2_int8"
+  ["lstm_fp32_model.tar.gz"]="quant/lstm_quant2_int8"
 )
 
 for file in "${!FILE_MAP[@]}"; do
@@ -38,3 +70,5 @@ for file in "${!FILE_MAP[@]}"; do
         echo "[MISS] ${src} not found"
     fi
 done
+
+echo "=== preload finished ==="

--- a/ci/cmake_preload_data_file.sh
+++ b/ci/cmake_preload_data_file.sh
@@ -1,0 +1,40 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+echo "=== preload data file from CACHE_DIR  ==="
+
+BASE_SRC=${CACHE_DIR}/preload_file
+BASE_DST=/paddle/build/third_party/inference_demo
+
+declare -A FILE_MAP=(
+  ["ResNet50_qat_perf.tar.gz"]="quant/ResNet50_quant2"
+  ["Ernie_dataset.tar.gz"]="Ernie_dataset"
+  ["quant_lstm_input_data.tar.gz"]="quant/lstm_quant2_int8"
+)
+
+for file in "${!FILE_MAP[@]}"; do
+    src="${BASE_SRC}/${file}"
+    dst="${BASE_DST}/${FILE_MAP[$file]}"
+
+    mkdir -p "${dst}"
+
+    if [ -f "${src}" ]; then
+        echo "[HIT] copy ${src} -> ${dst}"
+        cp -f "${src}" "${dst}/"
+    else
+        echo "[MISS] ${src} not found"
+    fi
+done

--- a/ci/cmake_preload_data_file.sh
+++ b/ci/cmake_preload_data_file.sh
@@ -16,7 +16,7 @@ set -e
 
 echo "=== preload data file from CACHE_DIR  ==="
 
-BASE_SRC=${CACHE_DIR}/preload_file
+BASE_SRC=${CFS_DIR}/preload_file
 BASE_DST=/paddle/build/third_party/inference_demo
 
 declare -A FILE_MAP=(

--- a/ci/cmake_preload_data_file.sh
+++ b/ci/cmake_preload_data_file.sh
@@ -14,7 +14,7 @@
 
 set -e
 
-echo "=== preload data file from CACHE_DIR  ==="
+echo "=== preload data file from CFS_DIR  ==="
 
 BASE_SRC=${CFS_DIR}/preload_file
 BASE_DST=/paddle/build/third_party/inference_demo


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
已将文件缓存到cfs，新增脚本执行copy命令，提前将文件copy到对应目录避免因下载失败而导致cmake执行失败

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否