### PR TITLE
[Cpp API Compatibility] Align device related APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ third_party/
 *~
 bazel-*
 .humanize
+.codex
 
 build_*
 # clion workspace.

--- a/paddle/phi/api/include/compat/c10/core/Device.cpp
+++ b/paddle/phi/api/include/compat/c10/core/Device.cpp
@@ -74,58 +74,58 @@ DeviceType parse_type(const std::string& device_string) {
               device_string);
 }
 
-enum DeviceStringParsingState { START, INDEX_START, INDEX_REST, ERROR };
+enum DeviceStringParsingState { kStart, kIndexStart, kIndexRest, kError };
 
 Device::Device(const std::string& device_string) : Device(Type::CPU) {
   TORCH_CHECK(!device_string.empty(), "Device string must not be empty");
 
   std::string device_name, device_index_str;
-  DeviceStringParsingState pstate = DeviceStringParsingState::START;
+  DeviceStringParsingState pstate = DeviceStringParsingState::kStart;
 
   for (size_t i = 0;
-       pstate != DeviceStringParsingState::ERROR && i < device_string.size();
+       pstate != DeviceStringParsingState::kError && i < device_string.size();
        ++i) {
     const char ch = device_string.at(i);
     const unsigned char uch = static_cast<unsigned char>(ch);
     switch (pstate) {
-      case DeviceStringParsingState::START:
+      case DeviceStringParsingState::kStart:
         if (ch != ':') {
           if (std::isalpha(uch) || ch == '_') {
             device_name.push_back(ch);
           } else {
-            pstate = DeviceStringParsingState::ERROR;
+            pstate = DeviceStringParsingState::kError;
           }
         } else {
-          pstate = DeviceStringParsingState::INDEX_START;
+          pstate = DeviceStringParsingState::kIndexStart;
         }
         break;
-      case DeviceStringParsingState::INDEX_START:
+      case DeviceStringParsingState::kIndexStart:
         if (std::isdigit(uch)) {
           device_index_str.push_back(ch);
-          pstate = DeviceStringParsingState::INDEX_REST;
+          pstate = DeviceStringParsingState::kIndexRest;
         } else {
-          pstate = DeviceStringParsingState::ERROR;
+          pstate = DeviceStringParsingState::kError;
         }
         break;
-      case DeviceStringParsingState::INDEX_REST:
+      case DeviceStringParsingState::kIndexRest:
         if (device_index_str.at(0) == '0') {
-          pstate = DeviceStringParsingState::ERROR;
+          pstate = DeviceStringParsingState::kError;
           break;
         }
         if (std::isdigit(uch)) {
           device_index_str.push_back(ch);
         } else {
-          pstate = DeviceStringParsingState::ERROR;
+          pstate = DeviceStringParsingState::kError;
         }
         break;
-      case DeviceStringParsingState::ERROR:
+      case DeviceStringParsingState::kError:
         break;
     }
   }
 
   const bool has_error = device_name.empty() ||
-                         pstate == DeviceStringParsingState::ERROR ||
-                         (pstate == DeviceStringParsingState::INDEX_START &&
+                         pstate == DeviceStringParsingState::kError ||
+                         (pstate == DeviceStringParsingState::kIndexStart &&
                           device_index_str.empty());
   TORCH_CHECK(!has_error, "Invalid device string: '", device_string, "'");
 

--- a/paddle/phi/api/include/compat/c10/core/Device.cpp
+++ b/paddle/phi/api/include/compat/c10/core/Device.cpp
@@ -18,7 +18,13 @@
 
 #include <c10/core/Device.h>
 #include <c10/util/Exception.h>
+
+#include <algorithm>
 #include <array>
+#include <cctype>
+#include <exception>
+#include <string>
+
 #include "paddle/common/enforce.h"
 
 namespace c10 {
@@ -45,44 +51,98 @@ const char* DeviceTypeToString(DeviceType type) {
 
 DeviceType parse_type(const std::string& device_string) {
   static const std::array<std::pair<const char*, DeviceType>,
-                          static_cast<size_t>(4)>
+                          static_cast<size_t>(5)>
       types = {{
           {"cpu", DeviceType::CPU},
           {"cuda", DeviceType::CUDA},
           {"ipu", DeviceType::IPU},
           {"xpu", DeviceType::XPU},
+          {"privateuseone", DeviceType::PrivateUse1},
       }};
-  for (const auto& type_pair : types) {
-    if (device_string == type_pair.first) {
-      return type_pair.second;
-    }
+  auto device = std::find_if(
+      types.begin(),
+      types.end(),
+      [&device_string](const std::pair<const char*, DeviceType>& p) {
+        return p.first && p.first == device_string;
+      });
+  if (device != types.end()) {
+    return device->second;
   }
-  PADDLE_THROW(::common::errors::InvalidArgument(
-      "Unknown device type: '%s'. Supported device types are ",
-      "'cpu', 'cuda', 'ipu', and 'xpu'.",
-      device_string));
+  TORCH_CHECK(false,
+              "Expected one of cpu, cuda, ipu, xpu, privateuseone device type "
+              "at start of device string: ",
+              device_string);
 }
+
+enum DeviceStringParsingState { START, INDEX_START, INDEX_REST, ERROR };
 
 Device::Device(const std::string& device_string) : Device(Type::CPU) {
   TORCH_CHECK(!device_string.empty(), "Device string must not be empty");
-  auto colon_pos = device_string.find(':');
-  std::string type_str = colon_pos == std::string::npos
-                             ? device_string
-                             : device_string.substr(0, colon_pos);
-  type_ = parse_type(type_str);
-  index_ = -1;
-  if (colon_pos != std::string::npos) {
-    std::string index_str = device_string.substr(colon_pos + 1);
-    try {
-      index_ = static_cast<DeviceIndex>(std::stoi(index_str));
-    } catch (const std::invalid_argument&) {
-      PADDLE_THROW(::common::errors::InvalidArgument(
-          "Invalid device index: '%s' is not a number.", index_str));
-    } catch (const std::out_of_range&) {
-      PADDLE_THROW(::common::errors::InvalidArgument(
-          "Invalid device index: '%s' is out of range.", index_str));
+
+  std::string device_name, device_index_str;
+  DeviceStringParsingState pstate = DeviceStringParsingState::START;
+
+  for (size_t i = 0;
+       pstate != DeviceStringParsingState::ERROR && i < device_string.size();
+       ++i) {
+    const char ch = device_string.at(i);
+    const unsigned char uch = static_cast<unsigned char>(ch);
+    switch (pstate) {
+      case DeviceStringParsingState::START:
+        if (ch != ':') {
+          if (std::isalpha(uch) || ch == '_') {
+            device_name.push_back(ch);
+          } else {
+            pstate = DeviceStringParsingState::ERROR;
+          }
+        } else {
+          pstate = DeviceStringParsingState::INDEX_START;
+        }
+        break;
+      case DeviceStringParsingState::INDEX_START:
+        if (std::isdigit(uch)) {
+          device_index_str.push_back(ch);
+          pstate = DeviceStringParsingState::INDEX_REST;
+        } else {
+          pstate = DeviceStringParsingState::ERROR;
+        }
+        break;
+      case DeviceStringParsingState::INDEX_REST:
+        if (device_index_str.at(0) == '0') {
+          pstate = DeviceStringParsingState::ERROR;
+          break;
+        }
+        if (std::isdigit(uch)) {
+          device_index_str.push_back(ch);
+        } else {
+          pstate = DeviceStringParsingState::ERROR;
+        }
+        break;
+      case DeviceStringParsingState::ERROR:
+        break;
     }
   }
+
+  const bool has_error = device_name.empty() ||
+                         pstate == DeviceStringParsingState::ERROR ||
+                         (pstate == DeviceStringParsingState::INDEX_START &&
+                          device_index_str.empty());
+  TORCH_CHECK(!has_error, "Invalid device string: '", device_string, "'");
+
+  try {
+    if (!device_index_str.empty()) {
+      index_ = static_cast<DeviceIndex>(std::stoi(device_index_str));
+    }
+  } catch (const std::exception&) {
+    TORCH_CHECK(false,
+                "Could not parse device index '",
+                device_index_str,
+                "' in device string '",
+                device_string,
+                "'");
+  }
+  type_ = parse_type(device_name);
+  validate();
 }
 
 std::string Device::str() const {

--- a/paddle/phi/api/include/compat/c10/core/Device.h
+++ b/paddle/phi/api/include/compat/c10/core/Device.h
@@ -24,7 +24,12 @@ using gpuStream_t = hipStream_t;
 #endif
 
 #include <c10/core/DeviceType.h>
+#include <c10/util/Exception.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <iosfwd>
 #include <string>
 #include <utility>
 
@@ -42,13 +47,19 @@ struct Device final {
         index_(place.GetType() == phi::AllocationType::CPU
                    ? static_cast<DeviceIndex>(-1)
                    : place.GetDeviceId()),
-        custom_device_type_(place.GetDeviceType()) {}
+        custom_device_type_(place.GetDeviceType()) {
+    validate();
+  }
   Device(DeviceType type, DeviceIndex index = -1)
-      : type_(type), index_(index) {}  // NOLINT
+      : type_(type), index_(index) {  // NOLINT
+    validate();
+  }
   Device(DeviceType type, DeviceIndex index, std::string custom_device_type)
       : type_(type),
         index_(index),
-        custom_device_type_(std::move(custom_device_type)) {}  // NOLINT
+        custom_device_type_(std::move(custom_device_type)) {  // NOLINT
+    validate();
+  }
 
   /// Constructs a `Device` from a string description, for convenience.
   /// The string supplied must follow the following schema:
@@ -63,9 +74,50 @@ struct Device final {
 
   DeviceType type() const noexcept { return type_; }
 
+  bool operator!=(const Device& other) const noexcept {
+    return !(*this == other);
+  }
+
+  void set_index(DeviceIndex index) {
+    index_ = index;
+    validate();
+  }
+
   bool is_cuda() const noexcept { return type_ == DeviceType::CUDA; }
 
+  bool is_privateuseone() const noexcept {
+    return type_ == DeviceType::PrivateUse1;
+  }
+
+  bool is_mps() const noexcept { return false; }
+
+  bool is_hip() const noexcept { return false; }
+
+  bool is_ve() const noexcept { return false; }
+
+  bool is_xpu() const noexcept { return type_ == DeviceType::XPU; }
+
+  bool is_ipu() const noexcept { return type_ == DeviceType::IPU; }
+
+  bool is_xla() const noexcept { return false; }
+
+  bool is_mtia() const noexcept { return false; }
+
+  bool is_hpu() const noexcept { return false; }
+
+  bool is_lazy() const noexcept { return false; }
+
+  bool is_vulkan() const noexcept { return false; }
+
+  bool is_metal() const noexcept { return false; }
+
+  bool is_maia() const noexcept { return false; }
+
+  bool is_meta() const noexcept { return false; }
+
   bool is_cpu() const noexcept { return type_ == DeviceType::CPU; }
+
+  bool supports_as_strided() const noexcept { return type_ != DeviceType::IPU; }
 
   std::string str() const;
 
@@ -96,11 +148,36 @@ struct Device final {
   DeviceType type_{DeviceType::CPU};
   DeviceIndex index_{-1};
   std::string custom_device_type_;
+
+  void validate() {
+#ifndef NDEBUG
+    TORCH_INTERNAL_ASSERT(index_ >= -1,
+                          "Device index must be -1 or non-negative, got ",
+                          static_cast<int>(index_));
+    TORCH_INTERNAL_ASSERT(!is_cpu() || index_ <= 0,
+                          "CPU device index must be -1 or zero, got ",
+                          static_cast<int>(index_));
+#endif
+  }
 };
 
 std::ostream& operator<<(std::ostream& stream, const Device& device);
 
 }  // namespace c10
+
+namespace std {
+template <>
+struct hash<c10::Device> {
+  size_t operator()(c10::Device d) const noexcept {
+    static_assert(sizeof(c10::DeviceType) == 1, "DeviceType is not 8-bit");
+    static_assert(sizeof(c10::DeviceIndex) == 1, "DeviceIndex is not 8-bit");
+    uint32_t bits = static_cast<uint32_t>(static_cast<uint8_t>(d.type()))
+                        << 16 |
+                    static_cast<uint32_t>(static_cast<uint8_t>(d.index()));
+    return std::hash<uint32_t>{}(bits);
+  }
+};
+}  // namespace std
 
 namespace at {
 using c10::Device;

--- a/paddle/phi/api/include/compat/c10/core/DeviceType.h
+++ b/paddle/phi/api/include/compat/c10/core/DeviceType.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <ostream>
 
 #include "paddle/phi/common/place.h"
@@ -26,6 +28,7 @@ enum class DeviceType : int8_t {
   XPU = 12,
   IPU = 18,
   CUSTOM = 20,
+  PrivateUse1 = CUSTOM,
 };
 
 constexpr DeviceType kCUDA = DeviceType::CUDA;
@@ -33,6 +36,7 @@ constexpr DeviceType kCPU = DeviceType::CPU;
 constexpr DeviceType kCUSTOM = DeviceType::CUSTOM;
 constexpr DeviceType kXPU = DeviceType::XPU;
 constexpr DeviceType kIPU = DeviceType::IPU;
+constexpr DeviceType kPrivateUse1 = DeviceType::PrivateUse1;
 
 inline phi::AllocationType DeviceTypeToPhi(DeviceType d) {
   switch (d) {
@@ -103,12 +107,22 @@ inline std::ostream& operator<<(std::ostream& os, DeviceType d) {
 
 }  // namespace c10
 
+namespace std {
+template <>
+struct hash<c10::DeviceType> {
+  std::size_t operator()(c10::DeviceType k) const noexcept {
+    return std::hash<int>()(static_cast<int>(k));
+  }
+};
+}  // namespace std
+
 namespace at {
 using c10::DeviceType;
 using c10::kCPU;
 using c10::kCUDA;
 using c10::kCUSTOM;
 using c10::kIPU;
+using c10::kPrivateUse1;
 using c10::kXPU;
 }  // namespace at
 
@@ -118,5 +132,6 @@ using c10::kCPU;
 using c10::kCUDA;
 using c10::kCUSTOM;
 using c10::kIPU;
+using c10::kPrivateUse1;
 using c10::kXPU;
 }  // namespace torch

--- a/paddle/phi/api/include/compat/c10/util/Exception.h
+++ b/paddle/phi/api/include/compat/c10/util/Exception.h
@@ -34,16 +34,16 @@
 namespace c10 {
 #define TORCH_CHECK(COND, ...) PD_CHECK(COND, ##__VA_ARGS__);
 #define TORCH_INTERNAL_ASSERT(COND, ...) PD_CHECK(COND, ##__VA_ARGS__);
-#define TORCH_CHECK_OP(val1, val2, op)                                    \
-  do {                                                                    \
-    auto&& _val1 = (val1);                                                \
-    auto&& _val2 = (val2);                                                \
-    if (!(_val1 op _val2)) {                                              \
-      std::ostringstream _result;                                         \
-      _result << "Expected " #val1 " " #op " " #val2 " (" << _val1 << " " \
-              << #op << " " << _val2 << "), but got false";               \
-      PD_THROW(_result.str());                                            \
-    }                                                                     \
+#define TORCH_CHECK_OP(val1, val2, op)                                  \
+  do {                                                                  \
+    auto&& _val1 = (val1);                                              \
+    auto&& _val2 = (val2);                                              \
+    if (!(_val1 op _val2)) {                                            \
+      std::ostringstream _result;                                       \
+      _result << "Check failed: " #val1 " " #op " " #val2 " (" << _val1 \
+              << " vs. " << _val2 << "). ";                             \
+      PD_THROW(_result.str());                                          \
+    }                                                                   \
   } while (false);
 
 // Check for a given boolean condition.

--- a/test/cpp/compat/c10_Device_test.cc
+++ b/test/cpp/compat/c10_Device_test.cc
@@ -16,6 +16,7 @@
 #include <c10/core/DeviceType.h>
 
 #include <sstream>
+#include <unordered_map>
 
 #include "gtest/gtest.h"
 
@@ -68,6 +69,9 @@ TEST(DeviceTypeCompatTest, DeviceTypeConversionAndStreamOperator) {
   std::ostringstream invalid_os;
   invalid_os << static_cast<c10::DeviceType>(99);
   EXPECT_TRUE(invalid_os.str().empty());
+
+  EXPECT_EQ(c10::DeviceType::PrivateUse1, c10::DeviceType::CUSTOM);
+  EXPECT_EQ(c10::kPrivateUse1, c10::DeviceType::PrivateUse1);
 }
 
 TEST(DeviceCompatTest, DeviceParseAndPlaceBranches) {
@@ -121,4 +125,48 @@ TEST(DeviceCompatTest, DeviceParseAndPlaceBranches) {
   std::ostringstream os;
   os << cuda;
   EXPECT_EQ(os.str(), "cuda:3");
+}
+
+TEST(DeviceCompatTest, DeviceInterfaceParity) {
+  c10::Device cpu(c10::kCPU);
+  c10::Device cuda(c10::kCUDA, 0);
+  c10::Device xpu(c10::kXPU, 1);
+  c10::Device ipu(c10::kIPU, 2);
+  c10::Device privateuse(c10::kPrivateUse1, 4);
+
+  EXPECT_TRUE(cpu.is_cpu());
+  EXPECT_TRUE(cuda.is_cuda());
+  EXPECT_TRUE(xpu.is_xpu());
+  EXPECT_TRUE(ipu.is_ipu());
+  EXPECT_TRUE(privateuse.is_privateuseone());
+  EXPECT_FALSE(privateuse.is_mps());
+  EXPECT_FALSE(privateuse.is_hip());
+  EXPECT_FALSE(privateuse.is_meta());
+  EXPECT_TRUE(cpu.supports_as_strided());
+  EXPECT_FALSE(ipu.supports_as_strided());
+
+  c10::Device cpu_with_index(c10::kCPU);
+  cpu_with_index.set_index(0);
+  EXPECT_EQ(cpu_with_index.index(), 0);
+  EXPECT_EQ(cpu_with_index.str(), "cpu:0");
+
+  c10::Device cuda_with_index(c10::kCUDA);
+  cuda_with_index.set_index(2);
+  EXPECT_EQ(cuda_with_index.index(), 2);
+  EXPECT_EQ(cuda_with_index.str(), "cuda:2");
+
+  EXPECT_NE(cpu, cuda);
+  EXPECT_EQ(cuda, c10::Device(c10::kCUDA, 0));
+  EXPECT_EQ(privateuse.str(), "privateuseone:4");
+  EXPECT_TRUE(c10::Device("privateuseone:7").is_privateuseone());
+
+  EXPECT_THROW(c10::Device("cuda:-1"), ::std::exception);
+  EXPECT_THROW(c10::Device("cuda:01"), ::std::exception);
+  EXPECT_THROW(c10::Device("cuda:1:2"), ::std::exception);
+
+  std::unordered_map<c10::Device, int> device_map;
+  device_map.emplace(c10::Device(c10::kCUDA, 0), 7);
+  device_map.emplace(c10::Device(c10::kCPU), 3);
+  EXPECT_EQ(device_map.at(c10::Device(c10::kCUDA, 0)), 7);
+  EXPECT_EQ(device_map.at(c10::Device(c10::kCPU)), 3);
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure


### PR Types
Improvements


### Description
拆分自 https://github.com/PaddlePaddle/Paddle/pull/78484

Align Device 相关接口，补齐 `c10::Device` 和 `c10::DeviceType` 的 PyTorch C++ API 兼容层。

#### 变更详情

**1. `c10/core/DeviceType.h` 扩展**

- 新增 `DeviceType::PrivateUse1` / `kPrivateUse1` 别名
- 新增 `std::hash<c10::DeviceType>` 特化

**2. `c10/core/Device.h` 接口补齐**

新增以下方法：
```cpp
// 比较运算符
bool operator!=(const Device& other) const noexcept;

// 修改设备索引
void set_index(DeviceIndex index);

// 设备谓词
bool is_privateuseone() const noexcept;
bool is_xpu() const noexcept;
bool is_ipu() const noexcept;
bool is_mps() const noexcept;

// 能力查询
bool supports_as_strided() const noexcept;

// std::hash 支持
struct hash<Device>;
```

**3. `c10/core/Device.cpp` 字符串解析对齐**

- 实现与 PyTorch 一致的严格字符串解析规则
- 支持 `privateuseone` 设备类型
- 正确处理非法格式如 `cuda:-1`、`cuda:01`、`cuda:1:2` 等

**Windows 兼容性处理**：
为规避 Windows 头文件中的 `ERROR` 宏污染，内部状态枚举使用 `kStart/kIndexStart/kIndexRest/kError` 命名（而非 PyTorch 上游的 `START/INDEX_START/INDEX_REST/ERROR`），但对外行为完全一致。

**4. `c10/util/Exception.h` TORCH_CHECK_OP 对齐**

对齐 `TORCH_CHECK_EQ/NE/LT/LE/GT/GE` 等宏的报错前缀格式，使其与 PyTorch 的异常消息格式一致。

### 相关文档

- [PaddleCppAPITest cAlign 分支 Device 差异](https://github.com/youge325/PaddleCppAPITest/blob/cAlign/doc/c10/core/mismatch_api_record.md#device)

### 是否引起精度变化
否
