### PR TITLE
[Cpp API Compatibility] Fix arange default dtype

### DIFF
--- a/paddle/phi/api/include/compat/ATen/ops/arange.h
+++ b/paddle/phi/api/include/compat/ATen/ops/arange.h
@@ -58,6 +58,12 @@ inline at::ScalarType _PD_ResolveArangeDtype(const at::Scalar& start,
   return c10::get_default_dtype_as_scalartype();
 }
 
+inline paddle::Tensor _PD_MakeArangeScalarTensor(const at::Scalar& scalar,
+                                                 phi::DataType dtype,
+                                                 const phi::Place& place) {
+  return paddle::experimental::full({}, scalar, dtype, place);
+}
+
 }  // namespace detail
 
 inline at::Tensor arange(const at::Scalar& start,
@@ -67,6 +73,7 @@ inline at::Tensor arange(const at::Scalar& start,
   // Match PyTorch: step must be non-zero and consistent with (end - start).
   at::native::arange_check_bounds(start, end, step);
   auto dtype = detail::_PD_ResolveArangeDtype(start, end, step, options);
+  auto pd_dtype = compat::_PD_AtenScalarTypeToPhiDataType(dtype);
   if (options.pinned_memory()) {
     // Pinning memory is only supported for CPU tensors
     if (options.has_device() && !options.device().is_cpu()) {
@@ -76,22 +83,20 @@ inline at::Tensor arange(const at::Scalar& start,
     phi::Place base_place = options._PD_GetPlace();
     phi::Place pinned_place = compat::_PD_GetCreatePinnedPlace(base_place);
     auto dense = paddle::experimental::arange(
-        paddle::experimental::full(
-            {}, start.to<double>(), phi::DataType::FLOAT64),
-        paddle::experimental::full(
-            {}, end.to<double>(), phi::DataType::FLOAT64),
-        paddle::experimental::full(
-            {}, step.to<double>(), phi::DataType::FLOAT64),
-        compat::_PD_AtenScalarTypeToPhiDataType(dtype),
+        detail::_PD_MakeArangeScalarTensor(start, pd_dtype, phi::CPUPlace()),
+        detail::_PD_MakeArangeScalarTensor(end, pd_dtype, phi::CPUPlace()),
+        detail::_PD_MakeArangeScalarTensor(step, pd_dtype, phi::CPUPlace()),
+        pd_dtype,
         phi::CPUPlace());
     return dense.copy_to(pinned_place, /*blocking=*/true);
   }
   return paddle::experimental::arange(
-      paddle::experimental::full(
-          {}, start.to<double>(), phi::DataType::FLOAT64),
-      paddle::experimental::full({}, end.to<double>(), phi::DataType::FLOAT64),
-      paddle::experimental::full({}, step.to<double>(), phi::DataType::FLOAT64),
-      compat::_PD_AtenScalarTypeToPhiDataType(dtype),
+      detail::_PD_MakeArangeScalarTensor(
+          start, pd_dtype, options._PD_GetPlace()),
+      detail::_PD_MakeArangeScalarTensor(end, pd_dtype, options._PD_GetPlace()),
+      detail::_PD_MakeArangeScalarTensor(
+          step, pd_dtype, options._PD_GetPlace()),
+      pd_dtype,
       options._PD_GetPlace());
 }
 

--- a/paddle/phi/api/include/compat/ATen/ops/arange.h
+++ b/paddle/phi/api/include/compat/ATen/ops/arange.h
@@ -25,8 +25,45 @@
 
 namespace at {
 
+namespace detail {
+
+inline bool _PD_IsIntegralArangeScalar(const at::Scalar& scalar) {
+  switch (scalar.dtype()) {
+    case phi::DataType::BOOL:
+    case phi::DataType::UINT8:
+    case phi::DataType::INT8:
+    case phi::DataType::UINT16:
+    case phi::DataType::INT16:
+    case phi::DataType::UINT32:
+    case phi::DataType::INT32:
+    case phi::DataType::UINT64:
+    case phi::DataType::INT64:
+      return true;
+    default:
+      return false;
+  }
+}
+
+inline at::ScalarType _PD_ResolveArangeDtype(const at::Scalar& start,
+                                             const at::Scalar& end,
+                                             const at::Scalar& step,
+                                             const at::TensorOptions& options) {
+  if (options.has_dtype()) {
+    return options.dtype().toScalarType();
+  }
+  if (_PD_IsIntegralArangeScalar(start) && _PD_IsIntegralArangeScalar(end) &&
+      _PD_IsIntegralArangeScalar(step)) {
+    return at::kLong;
+  }
+  return c10::get_default_dtype_as_scalartype();
+}
+
+}  // namespace detail
+
 inline at::Tensor arange(const at::Scalar& end,
                          at::TensorOptions options = {}) {
+  auto dtype =
+      detail::_PD_ResolveArangeDtype(/*start=*/0, end, /*step=*/1, options);
   if (options.pinned_memory()) {
     // Pinning memory is only supported for CPU tensors
     if (options.has_device() && !options.device().is_cpu()) {
@@ -40,7 +77,7 @@ inline at::Tensor arange(const at::Scalar& end,
         paddle::experimental::full(
             {}, end.to<double>(), phi::DataType::FLOAT64),
         paddle::experimental::full({}, 1, phi::DataType::FLOAT64),
-        compat::_PD_AtenScalarTypeToPhiDataType(options.dtype()),
+        compat::_PD_AtenScalarTypeToPhiDataType(dtype),
         phi::CPUPlace());
     return dense.copy_to(pinned_place, /*blocking=*/true);
   }
@@ -48,7 +85,7 @@ inline at::Tensor arange(const at::Scalar& end,
       paddle::experimental::full({}, 0, phi::DataType::FLOAT64),
       paddle::experimental::full({}, end.to<double>(), phi::DataType::FLOAT64),
       paddle::experimental::full({}, 1, phi::DataType::FLOAT64),
-      compat::_PD_AtenScalarTypeToPhiDataType(options.dtype()),
+      compat::_PD_AtenScalarTypeToPhiDataType(dtype),
       options._PD_GetPlace());
 }
 
@@ -57,18 +94,18 @@ inline at::Tensor arange(const at::Scalar& end,
                          ::std::optional<at::Layout> layout,
                          ::std::optional<at::Device> device,
                          ::std::optional<bool> pin_memory) {
-  auto options =
-      at::TensorOptions()
-          .dtype(dtype.value_or(c10::get_default_dtype_as_scalartype()))
-          .layout(layout)
-          .device(device.value_or(at::kCPU))
-          .pinned_memory(pin_memory);
+  auto options = at::TensorOptions()
+                     .dtype(dtype)
+                     .layout(layout)
+                     .device(device)
+                     .pinned_memory(pin_memory);
   return arange(end, options);
 }
 
 inline at::Tensor arange(const at::Scalar& start,
                          const at::Scalar& end,
                          at::TensorOptions options = {}) {
+  auto dtype = detail::_PD_ResolveArangeDtype(start, end, /*step=*/1, options);
   if (options.pinned_memory()) {
     // Pinning memory is only supported for CPU tensors
     if (options.has_device() && !options.device().is_cpu()) {
@@ -83,7 +120,7 @@ inline at::Tensor arange(const at::Scalar& start,
         paddle::experimental::full(
             {}, end.to<double>(), phi::DataType::FLOAT64),
         paddle::experimental::full({}, 1, phi::DataType::FLOAT64),
-        compat::_PD_AtenScalarTypeToPhiDataType(options.dtype()),
+        compat::_PD_AtenScalarTypeToPhiDataType(dtype),
         phi::CPUPlace());
     return dense.copy_to(pinned_place, /*blocking=*/true);
   }
@@ -92,7 +129,7 @@ inline at::Tensor arange(const at::Scalar& start,
           {}, start.to<double>(), phi::DataType::FLOAT64),
       paddle::experimental::full({}, end.to<double>(), phi::DataType::FLOAT64),
       paddle::experimental::full({}, 1, phi::DataType::FLOAT64),
-      compat::_PD_AtenScalarTypeToPhiDataType(options.dtype()),
+      compat::_PD_AtenScalarTypeToPhiDataType(dtype),
       options._PD_GetPlace());
 }
 
@@ -102,12 +139,11 @@ inline at::Tensor arange(const at::Scalar& start,
                          ::std::optional<at::Layout> layout,
                          ::std::optional<at::Device> device,
                          ::std::optional<bool> pin_memory) {
-  auto options =
-      at::TensorOptions()
-          .dtype(dtype.value_or(c10::get_default_dtype_as_scalartype()))
-          .layout(layout)
-          .device(device.value_or(at::kCPU))
-          .pinned_memory(pin_memory);
+  auto options = at::TensorOptions()
+                     .dtype(dtype)
+                     .layout(layout)
+                     .device(device)
+                     .pinned_memory(pin_memory);
   return arange(start, end, options);
 }
 
@@ -117,6 +153,7 @@ inline at::Tensor arange(const at::Scalar& start,
                          at::TensorOptions options = {}) {
   // Match PyTorch: step must be non-zero and consistent with (end - start).
   at::native::arange_check_bounds(start, end, step);
+  auto dtype = detail::_PD_ResolveArangeDtype(start, end, step, options);
   if (options.pinned_memory()) {
     // Pinning memory is only supported for CPU tensors
     if (options.has_device() && !options.device().is_cpu()) {
@@ -132,7 +169,7 @@ inline at::Tensor arange(const at::Scalar& start,
             {}, end.to<double>(), phi::DataType::FLOAT64),
         paddle::experimental::full(
             {}, step.to<double>(), phi::DataType::FLOAT64),
-        compat::_PD_AtenScalarTypeToPhiDataType(options.dtype()),
+        compat::_PD_AtenScalarTypeToPhiDataType(dtype),
         phi::CPUPlace());
     return dense.copy_to(pinned_place, /*blocking=*/true);
   }
@@ -141,7 +178,7 @@ inline at::Tensor arange(const at::Scalar& start,
           {}, start.to<double>(), phi::DataType::FLOAT64),
       paddle::experimental::full({}, end.to<double>(), phi::DataType::FLOAT64),
       paddle::experimental::full({}, step.to<double>(), phi::DataType::FLOAT64),
-      compat::_PD_AtenScalarTypeToPhiDataType(options.dtype()),
+      compat::_PD_AtenScalarTypeToPhiDataType(dtype),
       options._PD_GetPlace());
 }
 
@@ -152,12 +189,11 @@ inline at::Tensor arange(const at::Scalar& start,
                          ::std::optional<at::Layout> layout,
                          ::std::optional<at::Device> device,
                          ::std::optional<bool> pin_memory) {
-  auto options =
-      at::TensorOptions()
-          .dtype(dtype.value_or(c10::get_default_dtype_as_scalartype()))
-          .layout(layout)
-          .device(device.value_or(at::kCPU))
-          .pinned_memory(pin_memory);
+  auto options = at::TensorOptions()
+                     .dtype(dtype)
+                     .layout(layout)
+                     .device(device)
+                     .pinned_memory(pin_memory);
   return arange(start, end, step, options);
 }
 

--- a/paddle/phi/api/include/compat/ATen/ops/arange.h
+++ b/paddle/phi/api/include/compat/ATen/ops/arange.h
@@ -60,93 +60,6 @@ inline at::ScalarType _PD_ResolveArangeDtype(const at::Scalar& start,
 
 }  // namespace detail
 
-inline at::Tensor arange(const at::Scalar& end,
-                         at::TensorOptions options = {}) {
-  auto dtype =
-      detail::_PD_ResolveArangeDtype(/*start=*/0, end, /*step=*/1, options);
-  if (options.pinned_memory()) {
-    // Pinning memory is only supported for CPU tensors
-    if (options.has_device() && !options.device().is_cpu()) {
-      PD_THROW(
-          "pin_memory=true requires device to be CPU, but got non-CPU device");
-    }
-    phi::Place base_place = options._PD_GetPlace();
-    phi::Place pinned_place = compat::_PD_GetCreatePinnedPlace(base_place);
-    auto dense = paddle::experimental::arange(
-        paddle::experimental::full({}, 0, phi::DataType::FLOAT64),
-        paddle::experimental::full(
-            {}, end.to<double>(), phi::DataType::FLOAT64),
-        paddle::experimental::full({}, 1, phi::DataType::FLOAT64),
-        compat::_PD_AtenScalarTypeToPhiDataType(dtype),
-        phi::CPUPlace());
-    return dense.copy_to(pinned_place, /*blocking=*/true);
-  }
-  return paddle::experimental::arange(
-      paddle::experimental::full({}, 0, phi::DataType::FLOAT64),
-      paddle::experimental::full({}, end.to<double>(), phi::DataType::FLOAT64),
-      paddle::experimental::full({}, 1, phi::DataType::FLOAT64),
-      compat::_PD_AtenScalarTypeToPhiDataType(dtype),
-      options._PD_GetPlace());
-}
-
-inline at::Tensor arange(const at::Scalar& end,
-                         ::std::optional<at::ScalarType> dtype,
-                         ::std::optional<at::Layout> layout,
-                         ::std::optional<at::Device> device,
-                         ::std::optional<bool> pin_memory) {
-  auto options = at::TensorOptions()
-                     .dtype(dtype)
-                     .layout(layout)
-                     .device(device)
-                     .pinned_memory(pin_memory);
-  return arange(end, options);
-}
-
-inline at::Tensor arange(const at::Scalar& start,
-                         const at::Scalar& end,
-                         at::TensorOptions options = {}) {
-  auto dtype = detail::_PD_ResolveArangeDtype(start, end, /*step=*/1, options);
-  if (options.pinned_memory()) {
-    // Pinning memory is only supported for CPU tensors
-    if (options.has_device() && !options.device().is_cpu()) {
-      PD_THROW(
-          "pin_memory=true requires device to be CPU, but got non-CPU device");
-    }
-    phi::Place base_place = options._PD_GetPlace();
-    phi::Place pinned_place = compat::_PD_GetCreatePinnedPlace(base_place);
-    auto dense = paddle::experimental::arange(
-        paddle::experimental::full(
-            {}, start.to<double>(), phi::DataType::FLOAT64),
-        paddle::experimental::full(
-            {}, end.to<double>(), phi::DataType::FLOAT64),
-        paddle::experimental::full({}, 1, phi::DataType::FLOAT64),
-        compat::_PD_AtenScalarTypeToPhiDataType(dtype),
-        phi::CPUPlace());
-    return dense.copy_to(pinned_place, /*blocking=*/true);
-  }
-  return paddle::experimental::arange(
-      paddle::experimental::full(
-          {}, start.to<double>(), phi::DataType::FLOAT64),
-      paddle::experimental::full({}, end.to<double>(), phi::DataType::FLOAT64),
-      paddle::experimental::full({}, 1, phi::DataType::FLOAT64),
-      compat::_PD_AtenScalarTypeToPhiDataType(dtype),
-      options._PD_GetPlace());
-}
-
-inline at::Tensor arange(const at::Scalar& start,
-                         const at::Scalar& end,
-                         ::std::optional<at::ScalarType> dtype,
-                         ::std::optional<at::Layout> layout,
-                         ::std::optional<at::Device> device,
-                         ::std::optional<bool> pin_memory) {
-  auto options = at::TensorOptions()
-                     .dtype(dtype)
-                     .layout(layout)
-                     .device(device)
-                     .pinned_memory(pin_memory);
-  return arange(start, end, options);
-}
-
 inline at::Tensor arange(const at::Scalar& start,
                          const at::Scalar& end,
                          const at::Scalar& step,
@@ -180,6 +93,44 @@ inline at::Tensor arange(const at::Scalar& start,
       paddle::experimental::full({}, step.to<double>(), phi::DataType::FLOAT64),
       compat::_PD_AtenScalarTypeToPhiDataType(dtype),
       options._PD_GetPlace());
+}
+
+inline at::Tensor arange(const at::Scalar& end,
+                         at::TensorOptions options = {}) {
+  return arange(/*start=*/0, end, /*step=*/1, options);
+}
+
+inline at::Tensor arange(const at::Scalar& end,
+                         ::std::optional<at::ScalarType> dtype,
+                         ::std::optional<at::Layout> layout,
+                         ::std::optional<at::Device> device,
+                         ::std::optional<bool> pin_memory) {
+  auto options = at::TensorOptions()
+                     .dtype(dtype)
+                     .layout(layout)
+                     .device(device)
+                     .pinned_memory(pin_memory);
+  return arange(/*start=*/0, end, /*step=*/1, options);
+}
+
+inline at::Tensor arange(const at::Scalar& start,
+                         const at::Scalar& end,
+                         at::TensorOptions options = {}) {
+  return arange(start, end, /*step=*/1, options);
+}
+
+inline at::Tensor arange(const at::Scalar& start,
+                         const at::Scalar& end,
+                         ::std::optional<at::ScalarType> dtype,
+                         ::std::optional<at::Layout> layout,
+                         ::std::optional<at::Device> device,
+                         ::std::optional<bool> pin_memory) {
+  auto options = at::TensorOptions()
+                     .dtype(dtype)
+                     .layout(layout)
+                     .device(device)
+                     .pinned_memory(pin_memory);
+  return arange(start, end, /*step=*/1, options);
 }
 
 inline at::Tensor arange(const at::Scalar& start,

--- a/test/cpp/compat/ATen_factory_default_dtype_test.cc
+++ b/test/cpp/compat/ATen_factory_default_dtype_test.cc
@@ -51,19 +51,59 @@ TEST(ATenFactoryDefaultDtypeTest, EmptyNulloptDtypeUsesCurrentDefault) {
   ASSERT_EQ(tensor.sizes(), c10::IntArrayRef({2, 3}));
 }
 
-TEST(ATenFactoryDefaultDtypeTest, ArangeNulloptDtypeUsesCurrentDefault) {
+TEST(ATenFactoryDefaultDtypeTest, ArangeOmittedDtypeUsesLongForIntegralInputs) {
   DefaultDtypeGuard guard(at::kDouble);
 
-  at::Tensor end_only =
+  at::Tensor end_only_default = at::arange(5);
+  at::Tensor start_end_default = at::arange(1, 6);
+  at::Tensor start_end_step_default = at::arange(1, 7, 2);
+  at::Tensor end_only_nullopt =
       at::arange(5, std::nullopt, std::nullopt, at::kCPU, false);
-  at::Tensor start_end =
+  at::Tensor start_end_nullopt =
       at::arange(1, 6, std::nullopt, std::nullopt, at::kCPU, false);
-  at::Tensor start_end_step =
+  at::Tensor start_end_step_nullopt =
       at::arange(1, 7, 2, std::nullopt, std::nullopt, at::kCPU, false);
 
-  ASSERT_EQ(end_only.scalar_type(), at::kDouble);
-  ASSERT_EQ(start_end.scalar_type(), at::kDouble);
-  ASSERT_EQ(start_end_step.scalar_type(), at::kDouble);
+  ASSERT_EQ(end_only_default.scalar_type(), at::kLong);
+  ASSERT_EQ(start_end_default.scalar_type(), at::kLong);
+  ASSERT_EQ(start_end_step_default.scalar_type(), at::kLong);
+  ASSERT_EQ(end_only_nullopt.scalar_type(), at::kLong);
+  ASSERT_EQ(start_end_nullopt.scalar_type(), at::kLong);
+  ASSERT_EQ(start_end_step_nullopt.scalar_type(), at::kLong);
+  ASSERT_EQ(end_only_default.data_ptr<int64_t>()[4], 4);
+  ASSERT_EQ(start_end_default.data_ptr<int64_t>()[0], 1);
+  ASSERT_EQ(start_end_step_default.data_ptr<int64_t>()[2], 5);
+  ASSERT_EQ(end_only_nullopt.data_ptr<int64_t>()[4], 4);
+  ASSERT_EQ(start_end_nullopt.data_ptr<int64_t>()[0], 1);
+  ASSERT_EQ(start_end_step_nullopt.data_ptr<int64_t>()[2], 5);
+}
+
+TEST(ATenFactoryDefaultDtypeTest,
+     ArangeOmittedDtypeUsesCurrentDefaultForFloatingInputs) {
+  DefaultDtypeGuard guard(at::kDouble);
+
+  at::Tensor end_only_default = at::arange(5.0);
+  at::Tensor start_end_default = at::arange(1.0, 6.0);
+  at::Tensor start_end_step_default = at::arange(1.0, 7.0, 2.0);
+  at::Tensor end_only_nullopt =
+      at::arange(5.0, std::nullopt, std::nullopt, at::kCPU, false);
+  at::Tensor start_end_nullopt =
+      at::arange(1.0, 6.0, std::nullopt, std::nullopt, at::kCPU, false);
+  at::Tensor start_end_step_nullopt =
+      at::arange(1.0, 7.0, 2.0, std::nullopt, std::nullopt, at::kCPU, false);
+
+  ASSERT_EQ(end_only_default.scalar_type(), at::kDouble);
+  ASSERT_EQ(start_end_default.scalar_type(), at::kDouble);
+  ASSERT_EQ(start_end_step_default.scalar_type(), at::kDouble);
+  ASSERT_EQ(end_only_nullopt.scalar_type(), at::kDouble);
+  ASSERT_EQ(start_end_nullopt.scalar_type(), at::kDouble);
+  ASSERT_EQ(start_end_step_nullopt.scalar_type(), at::kDouble);
+  ASSERT_DOUBLE_EQ(end_only_default.data_ptr<double>()[4], 4.0);
+  ASSERT_DOUBLE_EQ(start_end_default.data_ptr<double>()[0], 1.0);
+  ASSERT_DOUBLE_EQ(start_end_step_default.data_ptr<double>()[2], 5.0);
+  ASSERT_DOUBLE_EQ(end_only_nullopt.data_ptr<double>()[4], 4.0);
+  ASSERT_DOUBLE_EQ(start_end_nullopt.data_ptr<double>()[0], 1.0);
+  ASSERT_DOUBLE_EQ(start_end_step_nullopt.data_ptr<double>()[2], 5.0);
 }
 
 TEST(ATenFactoryDefaultDtypeTest, FullNulloptDtypeUsesCurrentDefault) {

--- a/test/cpp/compat/ATen_factory_default_dtype_test.cc
+++ b/test/cpp/compat/ATen_factory_default_dtype_test.cc
@@ -79,6 +79,26 @@ TEST(ATenFactoryDefaultDtypeTest, ArangeOmittedDtypeUsesLongForIntegralInputs) {
 }
 
 TEST(ATenFactoryDefaultDtypeTest,
+     ArangeOmittedDtypeKeepsLargeInt64InputsExact) {
+  constexpr int64_t kStart = (1LL << 53) + 1;
+  constexpr int64_t kEnd = kStart + 4;
+
+  at::Tensor by_default = at::arange(kStart, kEnd);
+  at::Tensor by_nullopt =
+      at::arange(kStart, kEnd, std::nullopt, std::nullopt, at::kCPU, false);
+
+  ASSERT_EQ(by_default.scalar_type(), at::kLong);
+  ASSERT_EQ(by_nullopt.scalar_type(), at::kLong);
+  ASSERT_EQ(by_default.numel(), 4);
+  ASSERT_EQ(by_nullopt.numel(), 4);
+
+  for (int64_t i = 0; i < 4; ++i) {
+    ASSERT_EQ(by_default.data_ptr<int64_t>()[i], kStart + i);
+    ASSERT_EQ(by_nullopt.data_ptr<int64_t>()[i], kStart + i);
+  }
+}
+
+TEST(ATenFactoryDefaultDtypeTest,
      ArangeOmittedDtypeUsesCurrentDefaultForFloatingInputs) {
   DefaultDtypeGuard guard(at::kDouble);
 

--- a/test/cpp/compat/ATen_pin_memory_creation_test.cc
+++ b/test/cpp/compat/ATen_pin_memory_creation_test.cc
@@ -123,8 +123,16 @@ TEST(ATenPinMemoryCreationTest, EyePinMemoryWithCUDADeviceErrors) {
                std::exception);
 }
 
-TEST(ATenPinMemoryCreationTest, ArangePinMemory) {
+TEST(ATenPinMemoryCreationTest, ArangePinMemoryOverloads) {
   SKIP_IF_CUDA_RUNTIME_UNAVAILABLE();
+  auto end_only_by_options =
+      at::arange(10, at::TensorOptions().dtype(at::kFloat).pinned_memory(true));
+  AssertPinned(end_only_by_options);
+
+  auto end_only_by_args =
+      at::arange(10, at::kFloat, std::nullopt, at::kCPU, true);
+  AssertPinned(end_only_by_args);
+
   auto by_options = at::arange(
       0, 10, at::TensorOptions().dtype(at::kFloat).pinned_memory(true));
   AssertPinned(by_options);
@@ -132,13 +140,29 @@ TEST(ATenPinMemoryCreationTest, ArangePinMemory) {
   auto by_args = at::arange(0, 10, at::kFloat, std::nullopt, at::kCPU, true);
   AssertPinned(by_args);
 
+  auto step_by_options = at::arange(
+      0, 10, 2, at::TensorOptions().dtype(at::kFloat).pinned_memory(true));
+  AssertPinned(step_by_options);
+
+  auto step_by_args =
+      at::arange(0, 10, 2, at::kFloat, std::nullopt, at::kCPU, true);
+  AssertPinned(step_by_args);
+
   auto no_pin = at::arange(0, 10, at::kFloat, std::nullopt, at::kCPU, false);
   AssertNotPinned(no_pin);
+
+  auto step_no_pin =
+      at::arange(0, 10, 2, at::kFloat, std::nullopt, at::kCPU, false);
+  AssertNotPinned(step_no_pin);
 }
 
 TEST(ATenPinMemoryCreationTest, ArangePinMemoryWithCUDADeviceErrors) {
   SKIP_IF_CUDA_RUNTIME_UNAVAILABLE();
+  ASSERT_THROW(at::arange(10, at::kFloat, std::nullopt, at::kCUDA, true),
+               std::exception);
   ASSERT_THROW(at::arange(0, 10, at::kFloat, std::nullopt, at::kCUDA, true),
+               std::exception);
+  ASSERT_THROW(at::arange(0, 10, 2, at::kFloat, std::nullopt, at::kCUDA, true),
                std::exception);
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure


### PR Types
Bug fixes


### Description
拆分自 https://github.com/PaddlePaddle/Paddle/pull/78484

修复 `at::arange` 在不指定 `dtype` 时创建的 tensor 数据类型不是 `kLong` 的错误，用于 DeepGEMM 的对齐。

#### 变更详情

**问题描述**

| 调用方式 | PyTorch 推断类型 | Paddle 历史行为 |
|----------|------------------|-----------------|
| `arange(5)` | `kLong` (int64) | `kFloat` |
| `arange(2, 7)` | `kLong` | `kFloat` |
| `arange(1, 10, 2)` | `kLong` | `kFloat` |

**修复内容** (`ATen/ops/arange.h`)

实现与 PyTorch 一致的类型推断逻辑：
```cpp
// 当不指定 dtype 时：
// - 整数输入（如 5, 2, 7, 1, 10, 2）→ 推断为 kLong
// - 浮点输入（如 5.0, 0.0, 1.0, 0.1）→ 推断为当前默认浮点 dtype
```

**关键修改：**
- 添加 `is_integral` 类型判断
- 整数输入默认推断为 `kLong` (int64)
- 浮点输入继续跟随当前默认浮点 dtype

**回归测试补充** (`test/cpp/compat/ATen_factory_default_dtype_test.cc`)

- `ArangeNoDtypeInt`：整数输入的 dtype 推断
- `ArangeNoDtypeFloat`：浮点输入的 dtype 推断
- 覆盖直接调用和 `dtype=nullopt` 两种路径

### 对齐效果

| 测试用例 | 修复前 Paddle | 修复后 Paddle | PyTorch |
|----------|---------------|---------------|---------|
| `NoDtypeWithEndInt` | scalar_type=6 (kFloat) | scalar_type=4 (kLong) | scalar_type=4 (kLong) |

### 相关文档

- [PaddleCppAPITest cAlign 分支 Arange 差异](https://github.com/youge325/PaddleCppAPITest/blob/cAlign/doc/ATen/ops/mismatch_api_record.md#arange)


### 是否引起精度变化
否
