### PR TITLE
[Cpp API Compatibility] Align resize api

### DIFF
--- a/paddle/phi/api/include/compat/ATen/ops/resize.h
+++ b/paddle/phi/api/include/compat/ATen/ops/resize.h
@@ -16,38 +16,90 @@
 
 #include <ATen/core/Tensor.h>
 #include <c10/core/TensorOptions.h>
+#include <limits>
 #include <optional>
 #include <string_view>
+#include <vector>
 
 #include "paddle/phi/api/include/api.h"
+#include "paddle/phi/common/memory_utils.h"
 
 namespace at {
 
-// resize_ - use reshape for same-numel cases and set_ for storage-changing
-// cases so repeated resize_ calls stay stable.
+namespace detail {
+
+inline int64_t ResizeCheckedNumel(at::IntArrayRef size) {
+  int64_t numel = 1;
+  for (const auto dim : size) {
+    TORCH_CHECK(dim >= 0,
+                "Trying to create tensor with negative dimension ",
+                dim,
+                ": ",
+                size);
+    if (dim == 0) {
+      numel = 0;
+      continue;
+    }
+    TORCH_CHECK(numel <= std::numeric_limits<int64_t>::max() / dim,
+                "resize_ size is too large, possible overflow for size ",
+                size);
+    numel *= dim;
+  }
+  return numel;
+}
+
+}  // namespace detail
+
+// resize_ - operate on the underlying DenseTensor directly so we preserve
+// storage semantics across shrink/grow round-trips and only reallocate when
+// the requested shape exceeds the current storage capacity.
 inline const at::Tensor& Tensor::resize_(
     at::IntArrayRef size,
     ::std::optional<at::MemoryFormat> memory_format) const {
-  if (memory_format.has_value()) {
-    TORCH_CHECK(*memory_format == at::MemoryFormat::Contiguous,
-                "resize_ only supports contiguous memory format, but got ",
-                static_cast<int>(*memory_format));
-  }
+  // Keep old compat behavior for memory_format in this split PR.
+  // TODO(youge325): add real ChannelsLast/ChannelsLast3d restride support
+  // later.
+  (void)memory_format;
 
   std::vector<int64_t> dims(size.begin(), size.end());
-  int64_t new_numel = 1;
-  for (auto dim : dims) {
-    new_numel *= dim;
-  }
+  int64_t new_numel = detail::ResizeCheckedNumel(size);
+  auto dense_tensor =
+      std::dynamic_pointer_cast<phi::DenseTensor>(tensor_.impl());
+  TORCH_CHECK(dense_tensor != nullptr,
+              "resize_ only supports DenseTensor, but got a non-dense tensor");
+  TORCH_CHECK(tensor_.defined(),
+              "resize_ is not allowed on an undefined tensor");
 
-  if (tensor_.numel() == new_numel) {
-    const_cast<Tensor*>(this)->tensor_ =
-        paddle::experimental::reshape(tensor_, phi::IntArray(dims));
+  const size_t itemsize = phi::SizeOf(dense_tensor->dtype());
+  const size_t old_numel = static_cast<size_t>(tensor_.numel());
+  const size_t new_numel_size = static_cast<size_t>(new_numel);
+  const size_t required_bytes = new_numel_size * itemsize;
+  const size_t available_bytes =
+      dense_tensor->Holder() == nullptr
+          ? 0
+          : dense_tensor->Holder()->size() - dense_tensor->offset();
+
+  if (required_bytes <= available_bytes || new_numel == 0) {
+    dense_tensor->Resize(dims);
     return *this;
   }
 
-  auto source = tensor_.copy_to(tensor_.place(), /*blocking=*/true);
-  paddle::experimental::set_(const_cast<Tensor*>(this)->tensor_, source, dims);
+  const auto old_holder = dense_tensor->Holder();
+  TORCH_CHECK(old_holder != nullptr,
+              "resize_ cannot grow a tensor without allocated storage");
+  const size_t old_offset = dense_tensor->offset();
+  const size_t copy_bytes = std::min(old_numel, new_numel_size) * itemsize;
+  const phi::Place place = old_holder->place();
+  const void* old_data =
+      old_holder == nullptr
+          ? nullptr
+          : reinterpret_cast<const uint8_t*>(old_holder->ptr()) + old_offset;
+
+  dense_tensor->Resize(dims);
+  void* new_data = dense_tensor->mutable_data(place, dense_tensor->dtype());
+  if (copy_bytes > 0 && old_data != nullptr && old_data != new_data) {
+    phi::memory_utils::Copy(place, new_data, place, old_data, copy_bytes);
+  }
   return *this;
 }
 

--- a/paddle/phi/api/include/compat/ATen/ops/resize.h
+++ b/paddle/phi/api/include/compat/ATen/ops/resize.h
@@ -23,7 +23,8 @@
 
 namespace at {
 
-// resize_ - in-place resize using Paddle's set_ semantics
+// resize_ - use reshape for same-numel cases and set_ for storage-changing
+// cases so repeated resize_ calls stay stable.
 inline const at::Tensor& Tensor::resize_(
     at::IntArrayRef size,
     ::std::optional<at::MemoryFormat> memory_format) const {
@@ -34,7 +35,19 @@ inline const at::Tensor& Tensor::resize_(
   }
 
   std::vector<int64_t> dims(size.begin(), size.end());
-  paddle::experimental::set_(const_cast<Tensor*>(this)->tensor_, tensor_, dims);
+  int64_t new_numel = 1;
+  for (auto dim : dims) {
+    new_numel *= dim;
+  }
+
+  if (tensor_.numel() == new_numel) {
+    const_cast<Tensor*>(this)->tensor_ =
+        paddle::experimental::reshape(tensor_, phi::IntArray(dims));
+    return *this;
+  }
+
+  auto source = tensor_.copy_to(tensor_.place(), /*blocking=*/true);
+  paddle::experimental::set_(const_cast<Tensor*>(this)->tensor_, source, dims);
   return *this;
 }
 

--- a/paddle/phi/api/include/compat/ATen/ops/resize.h
+++ b/paddle/phi/api/include/compat/ATen/ops/resize.h
@@ -23,13 +23,18 @@
 
 namespace at {
 
-// resize_ - in-place resize using reshape
+// resize_ - in-place resize using Paddle's set_ semantics
 inline const at::Tensor& Tensor::resize_(
     at::IntArrayRef size,
     ::std::optional<at::MemoryFormat> memory_format) const {
-  auto result =
-      paddle::experimental::reshape(tensor_, size._PD_ToPaddleIntArray());
-  const_cast<Tensor*>(this)->tensor_ = result;
+  if (memory_format.has_value()) {
+    TORCH_CHECK(*memory_format == at::MemoryFormat::Contiguous,
+                "resize_ only supports contiguous memory format, but got ",
+                static_cast<int>(*memory_format));
+  }
+
+  std::vector<int64_t> dims(size.begin(), size.end());
+  paddle::experimental::set_(const_cast<Tensor*>(this)->tensor_, tensor_, dims);
   return *this;
 }
 

--- a/test/cpp/compat/ATen_resize_test.cc
+++ b/test/cpp/compat/ATen_resize_test.cc
@@ -24,8 +24,8 @@
 #include "torch/all.h"
 
 // ======================== resize_ tests ========================
-// Note: Paddle's resize_ is implemented via reshape, which requires
-// total element count to remain unchanged.
+// Note: compat resize_ is implemented via Paddle's set_ semantics, so it can
+// resize to a different element count while preserving the existing prefix.
 
 TEST(TensorResizeTest, ResizeBasic) {
   // Create a 2x3 tensor
@@ -107,6 +107,34 @@ TEST(TensorResizeTest, ResizePreservesData) {
   ASSERT_FLOAT_EQ(data[3], 3.0f);
   ASSERT_FLOAT_EQ(data[4], 4.0f);
   ASSERT_FLOAT_EQ(data[5], 5.0f);
+}
+
+TEST(TensorResizeTest, ResizeShrinkDifferentNumel) {
+  at::Tensor t = at::arange(24, at::kFloat).reshape({2, 3, 4});
+
+  t.resize_({4, 5});
+
+  ASSERT_EQ(t.sizes()[0], 4);
+  ASSERT_EQ(t.sizes()[1], 5);
+
+  float* data = t.data_ptr<float>();
+  for (int i = 0; i < 20; ++i) {
+    ASSERT_FLOAT_EQ(data[i], static_cast<float>(i));
+  }
+}
+
+TEST(TensorResizeTest, ResizeGrowDifferentNumelPreservesPrefix) {
+  at::Tensor t = at::arange(6, at::kFloat).reshape({2, 3});
+
+  t.resize_({2, 5});
+
+  ASSERT_EQ(t.sizes()[0], 2);
+  ASSERT_EQ(t.sizes()[1], 5);
+
+  float* data = t.data_ptr<float>();
+  for (int i = 0; i < 6; ++i) {
+    ASSERT_FLOAT_EQ(data[i], static_cast<float>(i));
+  }
 }
 
 TEST(TensorResizeTest, ResizeReturnReference) {

--- a/test/cpp/compat/ATen_resize_test.cc
+++ b/test/cpp/compat/ATen_resize_test.cc
@@ -24,8 +24,8 @@
 #include "torch/all.h"
 
 // ======================== resize_ tests ========================
-// Note: compat resize_ is implemented via Paddle's set_ semantics, so it can
-// resize to a different element count while preserving the existing prefix.
+// Note: compat resize_ uses reshape when numel is unchanged, and falls back to
+// set_ for storage-changing cases so repeated resize_ calls remain stable.
 
 TEST(TensorResizeTest, ResizeBasic) {
   // Create a 2x3 tensor

--- a/test/cpp/compat/ATen_resize_test.cc
+++ b/test/cpp/compat/ATen_resize_test.cc
@@ -19,13 +19,17 @@
 #include <c10/core/ScalarType.h>
 #include <c10/core/TensorOptions.h>
 
+#include <limits>
+#include <vector>
+
 #include "ATen/ATen.h"
 #include "gtest/gtest.h"
 #include "torch/all.h"
 
 // ======================== resize_ tests ========================
-// Note: compat resize_ uses reshape when numel is unchanged, and falls back to
-// set_ for storage-changing cases so repeated resize_ calls remain stable.
+// Note: compat resize_ mutates the underlying DenseTensor directly so
+// shrink/grow round-trips preserve storage semantics without introducing new
+// memory_format hard errors in this split PR.
 
 TEST(TensorResizeTest, ResizeBasic) {
   // Create a 2x3 tensor
@@ -135,6 +139,64 @@ TEST(TensorResizeTest, ResizeGrowDifferentNumelPreservesPrefix) {
   for (int i = 0; i < 6; ++i) {
     ASSERT_FLOAT_EQ(data[i], static_cast<float>(i));
   }
+}
+
+TEST(TensorResizeTest, ResizeShrinkGrowRoundTripPreservesTail) {
+  at::Tensor t = at::arange(24, at::kFloat).reshape({2, 3, 4});
+
+  t.resize_({4, 5});
+  t.resize_({2, 3, 4});
+
+  ASSERT_EQ(t.sizes()[0], 2);
+  ASSERT_EQ(t.sizes()[1], 3);
+  ASSERT_EQ(t.sizes()[2], 4);
+
+  float* data = t.data_ptr<float>();
+  for (int i = 0; i < 24; ++i) {
+    ASSERT_FLOAT_EQ(data[i], static_cast<float>(i));
+  }
+}
+
+TEST(TensorResizeTest, ResizeChannelsLastMemoryFormatDoesNotThrow) {
+  at::Tensor t = at::arange(24, at::kFloat).reshape({1, 2, 3, 4});
+
+  EXPECT_NO_THROW({
+    t.resize_(std::vector<int64_t>{1, 3, 2, 4}, at::MemoryFormat::ChannelsLast);
+  });
+
+  ASSERT_EQ(t.sizes()[0], 1);
+  ASSERT_EQ(t.sizes()[1], 3);
+  ASSERT_EQ(t.sizes()[2], 2);
+  ASSERT_EQ(t.sizes()[3], 4);
+}
+
+TEST(TensorResizeTest, ResizeChannelsLast3dMemoryFormatDoesNotThrow) {
+  at::Tensor t = at::arange(24, at::kFloat).reshape({1, 2, 2, 2, 3});
+
+  EXPECT_NO_THROW({
+    t.resize_(std::vector<int64_t>{1, 2, 2, 3, 2},
+              at::MemoryFormat::ChannelsLast3d);
+  });
+
+  ASSERT_EQ(t.sizes()[0], 1);
+  ASSERT_EQ(t.sizes()[1], 2);
+  ASSERT_EQ(t.sizes()[2], 2);
+  ASSERT_EQ(t.sizes()[3], 3);
+  ASSERT_EQ(t.sizes()[4], 2);
+}
+
+TEST(TensorResizeTest, ResizeRejectsNegativeDimension) {
+  at::Tensor t = at::arange(6, at::kFloat);
+  auto bad_size = std::vector<int64_t>{2, -1};
+
+  EXPECT_THROW(t.resize_(bad_size), std::exception);
+}
+
+TEST(TensorResizeTest, ResizeRejectsNumelOverflow) {
+  at::Tensor t = at::arange(1, at::kFloat);
+  auto huge_size = std::vector<int64_t>{std::numeric_limits<int64_t>::max(), 2};
+
+  EXPECT_THROW(t.resize_(huge_size), std::exception);
 }
 
 TEST(TensorResizeTest, ResizeReturnReference) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure


### PR Types
Bug fixes


### Description
拆分自 https://github.com/PaddlePaddle/Paddle/pull/78484

对齐 `resize_` API，用于 DeepGEMM 等场景中的内存对齐。

#### 变更详情

**变更内容** (`ATen/ops/resize.h`)

支持多种调用方式：
```cpp
// 基础 resize
tensor.resize_(IntArrayRef new_size);

// 带内存格式的 resize
tensor.resize_(IntArrayRef new_size, std::optional<MemoryFormat> memory_format);
```

关键修复：
- 修复 `resize_` 对 `IntArrayRef` 参数的处理
- 正确处理 `memory_format` 参数
- 对齐异常抛出语义

**回归测试补充** (`test/cpp/compat/ATen_resize_test.cc`)

- `ResizeBasic`: 基础 resize 操作
- `ResizeWithMemoryFormat`: 带内存格式的 resize
- `ResizeException`: 异常路径测试

### 相关文档

- [PaddleCppAPITest cAlign 分支](https://github.com/youge325/PaddleCppAPITest/tree/cAlign/doc/ATen/core/mismatch_api_record.md#resize_)


### 是否引起精度变化
否
