### PR TITLE
[SOT][3.14] Update the internal function to use `PyObject_GC_Track` replace `_PyObject_GC_TRACK`

### DIFF
--- a/.github/workflows/_SOT.yml
+++ b/.github/workflows/_SOT.yml
@@ -37,7 +37,7 @@ jobs:
     needs: [check-bypass]
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' && inputs.clone-can-skip != 'true' }}
     runs-on:
-      group: SOT-314-debug
+      group: GZ_BD-CPU
     timeout-minutes: 120
 
     steps:

--- a/.github/workflows/_SOT.yml
+++ b/.github/workflows/_SOT.yml
@@ -37,7 +37,7 @@ jobs:
     needs: [check-bypass]
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' && inputs.clone-can-skip != 'true' }}
     runs-on:
-      group: GZ_BD-CPU
+      group: SOT-314-debug
     timeout-minutes: 120
 
     steps:

--- a/ci/run_sot_test.sh
+++ b/ci/run_sot_test.sh
@@ -48,7 +48,7 @@ function run_sot_test() {
         run_and_check "Uninstalling numpy for Python 3.14..." \
             $PYTHON_WITH_SPECIFY_VERSION -m pip uninstall -y "numpy"
         run_and_check "Installing numpy>=2.3.5 for Python 3.14..." \
-            $PYTHON_WITH_SPECIFY_VERSION -m pip install "numpy>=2.3.5"
+            $PYTHON_WITH_SPECIFY_VERSION -m pip install --force-reinstall --no-cache-dir "numpy>=2.3.5"
     fi
 
     # cd to sot test dir

--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_14.c
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_14.c
@@ -18,6 +18,7 @@ limitations under the License. */
 
 #include <internal/pycore_code.h>
 #include <internal/pycore_frame.h>
+#include <internal/pycore_genobject.h>
 #define Py_BUILD_CORE       // internal/pycore_opcode.h need this macro
 #define NEED_OPCODE_TABLES  // To get _PyOpcode_Caches and _PyOpcode_Deopt
 
@@ -141,7 +142,7 @@ static void Internal_take_ownership(PyFrameObject *f,
     PyErr_SetRaisedException(exc);
   }
   if (!_PyObject_GC_IS_TRACKED((PyObject *)f)) {
-    _PyObject_GC_TRACK((PyObject *)f);
+    PyObject_GC_Track((PyObject *)f);
   }
   Py_END_CRITICAL_SECTION();
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

* 修复 debug 模式下 `_PyGen_GetGeneratorFromFrame` 内部函数编译错误
* 修复 `_PyObject_GC_TRACK` 内部函数因为宏展开导致的更多内部函数使用，报错: `undefined symbol: _Py_TriggerGC`。 改用公开的 api `PyObject_GC_Track`


#### 相关链接
* https://github.com/python/cpython/blob/v3.14.0/Include/objimpl.h#L168-L171
* https://github.com/python/cpython/blob/v3.14.0/Include/internal/pycore_gc.h#L209-L222


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否