### PR TITLE
Unify tile_transpose_tactic.cc for #CINN_WITH_CUDA and #CINN_WITH_CUSTOM_DEVICE

### DIFF
--- a/paddle/cinn/ir/group_schedule/tactic/tile_transpose_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_transpose_tactic.cc
@@ -37,9 +37,10 @@ namespace {
  *    loop (~32) for better performance, while transpose prefers a smaller inner
  *    loop (~4) to restrict the shared memory size.
  * 2) All transposes in the graph must have the same permutation, because the
- *    size of the shared memory we need is 32^(n+1), where n is the number of
- *    different permutations. More than one permutation makes it impossible to
- *    allocate such a huge space.
+ *    size of the shared memory we need is T^(n+1) where T is the tile size
+ *    (= warp_size, 32 for CUDA, 64 for some custom devices), and n is the
+ *    number of different permutations. More than one permutation makes it
+ *    impossible to allocate such a huge space.
  *
  *
  * How does this tactic work:
@@ -50,11 +51,12 @@ namespace {
  * The rest `...` are called high_axis, which may contain any permutation, and
  * can be transposed by simple index mapping without impacting performance.
  *
- * Second, we split both src_low_axis and dst_low_axis into {-1, 32}:
- *    src [ ..., d_h, d32, ... s_h, s32 ]
- *    dst [ ..., s_h, s32, ... d_h, d32 ]
+ * Second, we split both src_low_axis and dst_low_axis into {-1, T} where
+ * T = tile_size = warp_size (32 for CUDA, 64 for custom devices, etc.):
+ *    src [ ..., d_h, dT, ... s_h, sT ]
+ *    dst [ ..., s_h, sT, ... d_h, dT ]
  *
- * Third, we create a shared memory of shape [32, 32], and bind (s32, d32) to
+ * Third, we create a shared memory of shape [T, T], and bind (sT, dT) to
  * (thread.y, thread.x) to transpose them in the shared memory. The (s_h, d_h)
  * also become high_axis. We transpose high_axis using (block.y, block.x).
  *    src [ block.x, thread.y, block.y, thread.x ]
@@ -75,7 +77,8 @@ namespace {
  *
  * Notes:
  * 1) For simplicity, the high_axis are actually all bound to block.x.
- * 2) For performance, thread.y is actually composed of 4 loops * 8 threads.
+ * 2) For performance, thread.y is actually composed of (T/8) loops * 8
+ *    threads, where T = tile_size = warp_size.
  * 3) To support multiple transpose inputs, we actually store the transposed
  *    value to a local buffer before later computation, so that all inputs can
  *    reuse the same shared memory.
@@ -120,10 +123,21 @@ class TileTransposeTactic final : public ScheduleTactic {
   void FuseAndBind(ir::IRSchedule* sch,
                    const std::string& block_id,
                    bool need_sync = false);
+  bool ValidateTileAlignment(ir::IRSchedule* sch);
 
  private:
   ScheduleContext* context_;
   bool can_apply_;
+
+  // Parameterized tile configuration derived from warp_size.
+  // tile_size = warp_size (32 for CUDA, 64 for custom device, etc.)
+  // thread_x = tile_size (one warp/wavefront handles one row)
+  // thread_y = 8 (fixed, controls total thread count)
+  // inner_loop = tile_size / thread_y (serial loop to cover full tile row)
+  int tile_size_;
+  int thread_x_;
+  int thread_y_;
+  int inner_loop_;
 
   // The sub iter space apart from the main iter space.
   std::vector<int> sub_iter_space_;
@@ -342,6 +356,26 @@ void TileTransposeTactic::Init(ScheduleContext* context, ir::IRSchedule* sch) {
   can_apply_ = false;
   if (!FLAGS_cinn_enable_tile_transpose) return;
 
+  // Initialize parameterized tile configuration from warp_size.
+  // tile_size = warp_size: each tile is a tile_size x tile_size square.
+  // thread_x = tile_size: one warp/wavefront covers one full tile row.
+  // thread_y = 8: fixed, balancing thread count and inner loop depth.
+  // inner_loop = tile_size / thread_y: serial iterations per thread in y.
+  //
+  // Currently only warp_size 32 (CUDA) and 64 (some custom devices) are
+  // validated. Other values need dedicated analysis before enabling.
+  int64_t warp_size = context->config.tile_config.warp_size;
+  PADDLE_ENFORCE_EQ(
+      warp_size == 32 || warp_size == 64,
+      true,
+      ::common::errors::InvalidArgument(
+          "TileTransposeTactic only supports warp_size 32 or 64, but got %d.",
+          warp_size));
+  tile_size_ = static_cast<int>(warp_size);
+  thread_x_ = tile_size_;
+  thread_y_ = 8;
+  inner_loop_ = tile_size_ / thread_y_;
+
   ir::Expr module_root = sch->GetModule().GetExprs().front();
   ir::Expr root_block = ir::analyzer::GetRootSBlock(module_root);
   auto* root_node = root_block.As<ir::ScheduleBlockRealize>()
@@ -350,7 +384,9 @@ void TileTransposeTactic::Init(ScheduleContext* context, ir::IRSchedule* sch) {
   if (root_node->attrs.count(kTileMethod) > 0) return;
   if (!context->config.base_info->reduce_axis.empty()) return;
 
-  // There must be at least 8 warps (256 threads) to perform this tactic.
+  // The transpose tactic uses thread_y * thread_x threads per block,
+  // which equals tile_size * 8 = warp_size * 8, i.e. 8 warps/wavefronts.
+  // Require warp_num >= 8 to ensure sufficient parallelism.
   if (context->config.tile_config.warp_num < 8) return;
 
   InitUnconditionalLoads(sch);
@@ -363,6 +399,20 @@ void TileTransposeTactic::Init(ScheduleContext* context, ir::IRSchedule* sch) {
   root_node->attrs[kTileMethod] = TacticName();
 
   InitAxisInfo();
+
+  // For non-standard warp_size (e.g. 64), validate that both src_low and
+  // dst_low axis products are divisible by tile_size. If not, fall back to
+  // 32x32 tile which is universally safe — CINN's Split predicate mechanism
+  // handles non-32-aligned cases reliably on all backends.
+  // For warp_size == 32 (CUDA), skip this check to preserve original behavior.
+  if (tile_size_ > 32 && !ValidateTileAlignment(sch)) {
+    VLOG(4) << "TileTransposeTactic: dimensions not aligned to tile_size="
+            << tile_size_ << ", falling back to 32x32 tile";
+    tile_size_ = 32;
+    thread_x_ = 32;
+    thread_y_ = 8;
+    inner_loop_ = 4;
+  }
 }
 
 void TileTransposeTactic::InitUnconditionalLoads(ir::IRSchedule* sch) {
@@ -471,6 +521,27 @@ void TileTransposeTactic::InitAxisInfo() {
   high_axis_.assign(high_axis.begin(), high_axis.end());
 }
 
+bool TileTransposeTactic::ValidateTileAlignment(ir::IRSchedule* sch) {
+  for (auto& block : sch->GetAllBlocks()) {
+    std::vector<ir::Expr> loops = sch->GetLoops(block);
+    int64_t src_low_prod = GetLoopRangeProduct(loops, src_low_axis_);
+    int64_t dst_low_prod = GetLoopRangeProduct(loops, dst_low_axis_);
+
+    // Dynamic shape or non-divisible by tile_size → fall back to general tactic
+    if (src_low_prod <= 0 || dst_low_prod <= 0) {
+      VLOG(4) << "TileTransposeTactic: dynamic shape detected, skipping";
+      return false;
+    }
+    if (src_low_prod % tile_size_ != 0 || dst_low_prod % tile_size_ != 0) {
+      VLOG(4) << "TileTransposeTactic: src_low_prod=" << src_low_prod
+              << " dst_low_prod=" << dst_low_prod
+              << " not aligned to tile_size=" << tile_size_ << ", skipping";
+      return false;
+    }
+  }
+  return true;
+}
+
 std::vector<int> TileTransposeTactic::GetSrcLowAxis(
     const std::vector<int>& iter_space) {
   std::set<int> src_low_axis{iter_space.back()};
@@ -528,7 +599,11 @@ std::string TileTransposeTactic::CreateCacheBlock(
   ir::Expr cache_block = sch->CacheRead(block, buffer_index, memory_type);
 
   std::string transpose_stage = (memory_type == "shared") ? "write" : "read";
-  sch->Annotate(cache_block, "transpose_stage", transpose_stage);
+  // Encode tile_size into the annotation string to avoid two Annotate calls
+  // (the second Annotate would fail because the first one replaces the block
+  // via IRCopy, making the original cache_block Expr stale).
+  std::string annotation = transpose_stage + ":" + std::to_string(tile_size_);
+  sch->Annotate(cache_block, "transpose_stage", annotation);
 
   // Mark the cache block as a virtual output to prevent inlining. This doesn't
   // affect the actual outputs of the graph.
@@ -552,30 +627,19 @@ void TileTransposeTactic::TileCacheBlock(ir::IRSchedule* sch,
   CanonicalizeLayout(sch, local_cache_block_id);
 
   // Step 3. Do inner-block transpose.
+  //   shared_cache (write shm): src split by {-1, thread_x}, dst split by
+  //     {-1, inner_loop, thread_y}. After reorder and bind, the access pattern
+  //     is shm[threadIdx.x][inner_loop * thread_y + threadIdx.y].
+  //   local_cache (read shm, transposed): src split by
+  //     {-1, inner_loop, thread_y}, dst split by {-1, thread_x}. After reorder
+  //     and bind, the access pattern is
+  //     shm[inner_loop * thread_y + threadIdx.y][threadIdx.x].
   int offset = high_axis_.size();
-#ifdef CINN_WITH_CUSTOM_DEVICE
-  sch->Split(
-      shared_cache_block_id,
-      offset + 1,
-      {-1, static_cast<int>(context_->config.tile_config.warp_size / 8), 8});
-  sch->Split(shared_cache_block_id,
-             offset,
-             {-1, static_cast<int>(context_->config.tile_config.warp_size)});
+  sch->Split(shared_cache_block_id, offset + 1, {-1, inner_loop_, thread_y_});
+  sch->Split(shared_cache_block_id, offset, {-1, thread_x_});
 
-  sch->Split(local_cache_block_id,
-             offset + 1,
-             {-1, static_cast<int>(context_->config.tile_config.warp_size)});
-  sch->Split(
-      local_cache_block_id,
-      offset,
-      {-1, static_cast<int>(context_->config.tile_config.warp_size / 8), 8});
-#else  // CINN_WITH_CUDA
-  sch->Split(shared_cache_block_id, offset + 1, {-1, 4, 8});
-  sch->Split(shared_cache_block_id, offset, {-1, 32});
-
-  sch->Split(local_cache_block_id, offset + 1, {-1, 32});
-  sch->Split(local_cache_block_id, offset, {-1, 4, 8});
-#endif
+  sch->Split(local_cache_block_id, offset + 1, {-1, thread_x_});
+  sch->Split(local_cache_block_id, offset, {-1, inner_loop_, thread_y_});
 
   sch->Reorder(shared_cache_block_id, OffsetVec({0, 2, 3, 4, 1}, offset));
   sch->Reorder(local_cache_block_id, OffsetVec({0, 3, 1, 2, 4}, offset));
@@ -590,18 +654,8 @@ void TileTransposeTactic::TileBlock(ir::IRSchedule* sch,
   CanonicalizeLayout(sch, block_id);
 
   int offset = high_axis_.size();
-#ifdef CINN_WITH_CUSTOM_DEVICE
-  sch->Split(block_id,
-             offset + 1,
-             {-1, static_cast<int>(context_->config.tile_config.warp_size)});
-  sch->Split(
-      block_id,
-      offset,
-      {-1, static_cast<int>(context_->config.tile_config.warp_size / 8), 8});
-#else  // CINN_WITH_CUDA
-  sch->Split(block_id, offset + 1, {-1, 32});
-  sch->Split(block_id, offset, {-1, 4, 8});
-#endif
+  sch->Split(block_id, offset + 1, {-1, thread_x_});
+  sch->Split(block_id, offset, {-1, inner_loop_, thread_y_});
 
   sch->Reorder(block_id, OffsetVec({0, 3, 1, 2, 4}, offset));
 

--- a/paddle/cinn/optim/reindex_transpose_buffer_pass.cc
+++ b/paddle/cinn/optim/reindex_transpose_buffer_pass.cc
@@ -33,14 +33,33 @@ using ir::stmt::Store;
 
 namespace {
 
-std::set<ir::Buffer> CollectTransposeBuffers(const BlockRef& body) {
+struct TransposeBufferInfo {
   std::set<ir::Buffer> buffers;
+  int tile_size = 32;  // default to 32 (CUDA) for backward compatibility
+};
+
+TransposeBufferInfo CollectTransposeBuffers(const BlockRef& body) {
+  TransposeBufferInfo info;
 
   const auto VisitFn = [&](const StmtRef& stmt) {
     if (!stmt.isa<Schedule>()) return;
     Schedule schedule = stmt.as<Schedule>();
     auto attr_it = schedule->attrs().find("transpose_stage");
     if (attr_it == schedule->attrs().end()) return;
+
+    // The transpose_stage annotation has format "write:tile_size" or
+    // "read:tile_size" (e.g. "write:64", "read:32"). Parse stage and
+    // tile_size from this single annotation.
+    std::string annotation = std::get<std::string>(attr_it->second);
+    std::string stage;
+    size_t colon_pos = annotation.find(':');
+    if (colon_pos != std::string::npos) {
+      stage = annotation.substr(0, colon_pos);
+      info.tile_size = std::stoi(annotation.substr(colon_pos + 1));
+    } else {
+      // Backward compatibility: old format "write" / "read" without tile_size
+      stage = annotation;
+    }
 
     StmtRef store = schedule->body()->stmts().front();
     PADDLE_ENFORCE(
@@ -54,14 +73,14 @@ std::set<ir::Buffer> CollectTransposeBuffers(const BlockRef& body) {
         ::common::errors::PreconditionNotMet(
             "The store value of transpose buffer must be a pure Load."));
 
-    if (attr_it->second == ir::attr_t(std::string("write"))) {
+    if (stage == "write") {
       ir::Buffer buffer = store_stmt->tensor().as_tensor()->buffer;
-      buffers.insert(buffer);
+      info.buffers.insert(buffer);
     }
   };
 
   ir::stmt::Visit(body, VisitFn, [](auto) {});
-  return buffers;
+  return info;
 }
 
 void ReplaceTransposeBuffersWithUnionBuffer(
@@ -78,8 +97,8 @@ void ReplaceTransposeBuffersWithUnionBuffer(
 }
 
 struct TransposeBufferIndicesMutator : public ir::stmt::StmtMutator<> {
-  explicit TransposeBufferIndicesMutator(ir::Buffer union_buffer)
-      : union_buffer_(union_buffer) {}
+  explicit TransposeBufferIndicesMutator(ir::Buffer union_buffer, int tile_size)
+      : union_buffer_(union_buffer), tile_size_(tile_size) {}
 
   void operator()(BlockRef block) { VisitBlock(block); }
 
@@ -95,12 +114,17 @@ struct TransposeBufferIndicesMutator : public ir::stmt::StmtMutator<> {
     StmtRef store = stmt->body()->stmts().front();
     Store store_stmt = store.as<Store>();
 
-    // Note: we currently use constant tiling configs for transpose, i.e.
-    // inner_loop = 4, blockDim.y = 8, blockDim.x = 32. Therefore, the shape
-    // and indices of the transpose buffer are also fixed.
-    std::vector<ir::Expr> shape = {ir::Expr(32), ir::Expr(32)};
+    // Note: the shape of the transpose shared memory tile is
+    // [tile_size, tile_size], where tile_size = warp_size (32 for CUDA,
+    // 64 for some custom devices). The tile_size is encoded in the
+    // "transpose_stage" annotation as "write:tile_size" or "read:tile_size".
+    std::vector<ir::Expr> shape = {ir::Expr(tile_size_), ir::Expr(tile_size_)};
 
-    if (attr_it->second == ir::attr_t(std::string("write"))) {
+    // Parse the stage from annotation (format: "write:64" or "read:32")
+    std::string annotation = std::get<std::string>(attr_it->second);
+    std::string stage = annotation.substr(0, annotation.find(':'));
+
+    if (stage == "write") {
       // at buffer write stage, re-index the store buffer
       store_stmt->set_indices({GetIndexY(), GetIndexX() ^ GetIndexY()});
       ir::Expr new_tensor = ir::ir_utils::IRCopy(store_stmt->tensor());
@@ -151,6 +175,7 @@ struct TransposeBufferIndicesMutator : public ir::stmt::StmtMutator<> {
  private:
   ir::Buffer union_buffer_;
   ir::Var inner_loop_var_;
+  int tile_size_;
 };
 
 }  // namespace
@@ -160,28 +185,31 @@ LogicalResult ReindexTransposeBufferPass::Run(ir::LoweredFunc func) {
 
   // Step 1. Collect all transpose buffers in the function, also verify that the
   // transpose buffers are used properly.
-  std::set<ir::Buffer> transpose_buffers = CollectTransposeBuffers(body);
-  if (transpose_buffers.empty()) {
+  TransposeBufferInfo info = CollectTransposeBuffers(body);
+  if (info.buffers.empty()) {
     return LogicalResult::success();
   }
 
+  int tile_size = info.tile_size;
+
   // Step 2. Create a union buffer to replace all transpose buffers.
   // The union buffer's size is the size of the largest data type among the
-  // transpose buffers multiplied by 1024 (the block size).
+  // transpose buffers multiplied by tile_size * tile_size (the tile area).
   int max_dtype_bytes = 0;
-  for (auto& buffer : transpose_buffers) {
+  for (auto& buffer : info.buffers) {
     max_dtype_bytes = std::max(max_dtype_bytes, buffer->dtype.bytes());
   }
 
-  ir::Buffer union_buffer = ir::_Buffer_::Make(
-      "transpose_union_shm", {ir::Expr(max_dtype_bytes * 1024)});
+  ir::Buffer union_buffer =
+      ir::_Buffer_::Make("transpose_union_shm",
+                         {ir::Expr(max_dtype_bytes * tile_size * tile_size)});
   union_buffer->dtype = common::UInt(8);
   union_buffer->memory_type = ir::MemoryType::GPUShared;
 
-  ReplaceTransposeBuffersWithUnionBuffer(func, transpose_buffers, union_buffer);
+  ReplaceTransposeBuffersWithUnionBuffer(func, info.buffers, union_buffer);
 
   // Step 3. Swizzle the load & store indices of transpose buffers.
-  TransposeBufferIndicesMutator mutator(union_buffer);
+  TransposeBufferIndicesMutator mutator(union_buffer, tile_size);
   mutator(body);
 
   return LogicalResult::success();

--- a/paddle/cinn/optim/reindex_transpose_buffer_pass.h
+++ b/paddle/cinn/optim/reindex_transpose_buffer_pass.h
@@ -31,8 +31,9 @@ namespace optim {
  *       Store :  shm[y, x ^ y]
  *       Load  :  shm[x, y ^ x]
  *    So that we transpose shm[y][x] to shm[x][y], while neither the store nor
- *    the load cause bank conflict (because both `x ^ y` and `y ^ x` produce 32
- *    unique values within a warp of 32 threads).
+ *    the load cause bank conflict (because both `x ^ y` and `y ^ x` produce T
+ *    unique values within a warp/wavefront of T threads, where T = tile_size =
+ *    warp_size).
  *
  * 2. Replace multiple individual transpose buffers for each transpose with a
  *    single union buffer to save shared memory. This is valid because transpose


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
CINN


### PR Types
Bug fixes

### Description
修复tile_transpose_tactic.cc在CUSTOM_DEVICE上的BUG memory violtion(0x4): memory access offset is negative, out of bounds, or misaligned in kernel，统一tile_transpose_tactic.cc 在#CINN_WITH_CUDA和#CINN_WITH_CUSTOM_DEVICE条件编译下的逻辑

场景 | warp_size | 维度对齐情况 | tile 大小 | 说明
-- | -- | -- | -- | --
CUDA | 32 | 任意 | 32×32 | 完全保持原有行为，不加对齐检查
Custom Device | 64 | 对齐 64 | 64×64 | 最优路径，无 predicate
Custom Device | 64 | 对齐 32 但不对齐 64 | 32×32 | 退回保守方案
Custom Device | 64 | 不对齐 32 | 32×32 | 与 CUDA 同理，靠 CINN predicate 保护

同时修改了reindex_transpose_buffer_pass.cc从annotation中获取tile_size

Pcard-90680

### 是否引起精度变化
否