### PR TITLE
[Dy2St] Make `RandomRotation` static comparison deterministic

### DIFF
--- a/test/legacy_test/test_transforms_static.py
+++ b/test/legacy_test/test_transforms_static.py
@@ -156,20 +156,27 @@ class TestRandomCrop_same(TestTransformUnitTestBase):
         self.api = transforms.RandomCrop(self.crop_size)
 
 
+class FixedAngleRandomRotation(transforms.RandomRotation):
+    # Keep the rotation path under test, but bypass separate dy/static RNGs.
+    def __init__(self, angle, **kwargs):
+        self.angle = float(np.float32(angle))
+        super().__init__((self.angle, self.angle), **kwargs)
+
+    def _get_param(self, degrees):
+        del degrees
+        if paddle.in_dynamic_mode():
+            return self.angle
+        return paddle.full([1], self.angle, dtype='float32')
+
+
 class TestRandomRotation(TestTransformUnitTestBase):
     def set_trans_api(self):
-        degree = np.random.uniform(-180, 180)
-        eps = 10e-5
-        degree_tuple = (degree - eps, degree + eps)
-        self.api = transforms.RandomRotation(degree_tuple)
+        self.api = FixedAngleRandomRotation(33.0)
 
 
 class TestRandomRotation_expand_True(TestTransformUnitTestBase):
     def set_trans_api(self):
-        degree = np.random.uniform(-180, 180)
-        eps = 10e-5
-        degree_tuple = (degree - eps, degree + eps)
-        self.api = transforms.RandomRotation(degree_tuple, expand=True, fill=3)
+        self.api = FixedAngleRandomRotation(33.0, expand=True, fill=3)
 
 
 class TestRandomErasing(TestTransformUnitTestBase):


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Not User Facing

### Description
This PR fixes a recurring Mac-CPU CI flake in `test_transforms_static`, observed while validating #78558.

The failing case is `TestRandomRotation_expand_True`, which compares dynamic and static outputs with `np.testing.assert_almost_equal`. The current test tries to make `RandomRotation` effectively deterministic by passing a very narrow degree range, but it still samples the angle from two different RNG paths:

- dynamic mode: `random.uniform(...)`
- static mode: `paddle.uniform(...)`

That means the test is not actually comparing the same rotation angle in the two modes. On macOS this sometimes shows up as a few mismatched edge pixels after `expand=True`, causing the test to fail on one run and pass on rerun.

To fix that, this PR keeps the change scoped to the test file:

- add a local deterministic `FixedAngleRandomRotation` helper in `test/legacy_test/test_transforms_static.py`
- use the exact same fixed angle for both `TestRandomRotation` and `TestRandomRotation_expand_True`

This does not hide a real kernel bug. It makes the test validate the intended contract more accurately: dynamic and static `RandomRotation` should match when given the same input and the same angle.

### 是否引起精度变化
否
