### PR TITLE
[XPU][Fix] fused_rms_norm_quant_grad: handle x.stop_gradient=True case

### DIFF
--- a/paddle/phi/kernels/xpu/fused_rms_norm_quant_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/fused_rms_norm_quant_grad_kernel.cc
@@ -143,7 +143,7 @@ void RmsNormQuantGradKernel(const Context& dev_ctx,
       inv_var_data,
       reinterpret_cast<XPUType*>(norm_weight_grad_data),
       reinterpret_cast<XPUType*>(norm_bias_grad_data),
-      false);
+      true);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "rms_layer_norm_grad");
 }
 }  // namespace phi

--- a/paddle/phi/kernels/xpu/fused_rms_norm_quant_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/fused_rms_norm_quant_grad_kernel.cc
@@ -35,7 +35,9 @@ void RmsNormQuantGradKernel(const Context& dev_ctx,
                             DenseTensor* norm_weight_grad,
                             DenseTensor* norm_bias_grad) {
   if (x.numel() == 0) {
-    dev_ctx.template Alloc<T>(x_grad);
+    if (x_grad) {
+      dev_ctx.template Alloc<T>(x_grad);
+    }
     if (norm_weight_grad) {
       Full<T, Context>(dev_ctx, norm_weight_grad->dims(), 0, norm_weight_grad);
     }
@@ -61,8 +63,18 @@ void RmsNormQuantGradKernel(const Context& dev_ctx,
   const float* inv_var_data = inv_var.data<float>();
   const T* out_grad_data = out_grad.data<T>();
 
-  dev_ctx.template Alloc<T>(x_grad);
-  T* x_grad_data = x_grad->data<T>();
+  // Handle x_grad=nullptr case (when x.stop_gradient=True)
+  DenseTensor actual_x_grad;
+  T* x_grad_data = nullptr;
+  if (x_grad) {
+    dev_ctx.template Alloc<T>(x_grad);
+    x_grad_data = x_grad->data<T>();
+  } else {
+    // Create temporary tensor for x_grad since XPU API requires it
+    actual_x_grad.Resize(x.dims());
+    dev_ctx.template Alloc<T>(&actual_x_grad);
+    x_grad_data = actual_x_grad.data<T>();
+  }
 
   T* norm_weight_grad_data = nullptr;
   if (norm_weight_grad) {
@@ -76,8 +88,8 @@ void RmsNormQuantGradKernel(const Context& dev_ctx,
     norm_bias_grad_data = norm_bias_grad->data<T>();
   }
 
-  int32_t rows = 1;
-  int32_t cols = 1;
+  int64_t rows = 1;
+  int64_t cols = 1;
   for (int i = 0; i < begin_norm_axis; i++) {
     rows *= x.dims()[i];
   }

--- a/paddle/phi/kernels/xpu/fused_rms_norm_quant_kernel.cc
+++ b/paddle/phi/kernels/xpu/fused_rms_norm_quant_kernel.cc
@@ -154,7 +154,7 @@ void RmsNormQuantKernel(const Context& dev_ctx,
         reinterpret_cast<const XPUType*>(norm_weight_data),
         reinterpret_cast<const XPUType*>(norm_bias_data),
         inv_var_data,
-        false);
+        true);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "rms_layer_norm");
   } else {
     int r = xpu::rms_layer_norm<XPUType>(
@@ -167,7 +167,7 @@ void RmsNormQuantKernel(const Context& dev_ctx,
         reinterpret_cast<const XPUType*>(norm_weight_data),
         reinterpret_cast<const XPUType*>(norm_bias_data),
         inv_var_data,
-        false);
+        true);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "rms_layer_norm");
   }
 }


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description

修复 XPU `fused_rms_norm_quant` 系列 kernel 的两个问题。

#### 问题一：`x.stop_gradient=True` 时崩溃

**问题现象**：
在 EB5 模型训练中，Pipeline Parallel + Recompute 场景下出现以下错误：
```
ExternalError: rms_layer_norm_grad XDNN Error <1>, XDNN_INVALID_PARAM
```

**根因分析**：
1. Recompute backward 重新执行 forward 时，对 non-leaf tensor 调用 `detach()`
2. Paddle autograd 优化：non-leaf tensor 且 `stop_gradient=True` 时不分配梯度存储
3. 因此 `x_grad` 参数传入 kernel 时为 `nullptr`
4. XPU kernel 未处理 `nullptr`，直接调用 `dev_ctx.Alloc(x_grad)` 导致崩溃

**修复内容**：
- 空 tensor 处理：检查 `x_grad != nullptr` 再分配内存
- `x_grad=nullptr` 处理：创建临时 tensor 供 XPU API 使用（结果会被丢弃）
- 类型修复：`rows`/`cols` 从 `int32_t` 改为 `int64_t`

#### 问题二：`is_rstd` 参数设置错误导致精度损失

**问题现象**：
`paddle.incubate.nn.functional.fused_rms_norm` 与 `paddle_xpu_nn.xpu_rms_norm` 存在精度差距。

**根因分析**：
| 实现 | `is_rstd` 参数 | `inv_var` 存储内容 |
|------|---------------|-------------------|
| paddle_xpu_nn.xpu_rms_norm | `true` | rstd = `1/sqrt(var+eps)` |
| paddle.fused_rms_norm (修复前) | `false` | variance (原始方差) |

`is_rstd=false` 时：
- 前向存储 variance
- 反向需要额外计算 `1/sqrt(var+eps)`
- 在 bf16/fp16 下引入额外精度损失

**修复内容**：
将 forward 和 backward kernel 的 `is_rstd` 参数从 `false` 改为 `true`，使 `inv_var` 存储 rstd：
- 减少反向计算量
- 提高数值精度
- 与 `paddle_xpu_nn.xpu_rms_norm` 实现对齐

#### 测试验证

```python
# Test 1: x.stop_gradient=True
x = paddle.randn([8, 128, 768], dtype='bfloat16')
x.stop_gradient = True
weight = paddle.randn([768], dtype='bfloat16')
out = paddle.incubate.nn.functional.fused_rms_norm(x, weight, None, 1e-6, 2)[0]
loss = out.sum()
loss.backward()  # 修复前崩溃，修复后正常

# Test 2: 精度对比
# 修复后与 paddle_xpu_nn.xpu_rms_norm 结果一致
```

### 是否引起精度变化
是
