### PR TITLE
[0 SIZE] Fix canonical strides for zero-size DenseTensor

### DIFF
--- a/paddle/phi/core/tensor_meta.cc
+++ b/paddle/phi/core/tensor_meta.cc
@@ -21,7 +21,7 @@ COMMON_DECLARE_bool(use_stride_kernel);
 namespace phi {
 
 DDim DenseTensorMeta::calc_strides(const DDim& dims) {
-  if (dims.size() == -1 || product(dims) <= 0) {
+  if (dims.size() == -1 || contain_unknown_dim(dims)) {
     return dims;
   }
 

--- a/paddle/phi/kernels/stride/view_kernel.cc
+++ b/paddle/phi/kernels/stride/view_kernel.cc
@@ -50,10 +50,14 @@ void ViewShapeStridedKernel(const Context& dev_ctx,
     }
   }
   if (numel != 0) {
-    PADDLE_ENFORCE_NE(new_size,
-                      0,
-                      common::errors::Unavailable(
-                          "cannot reshape tensor of 0 elements into shape "));
+    PADDLE_ENFORCE_NE(
+        new_size,
+        0,
+        common::errors::InvalidArgument(
+            "cannot reshape tensor with %d elements into shape %s because "
+            "the target shape has 0 elements",
+            numel,
+            common::make_ddim(dims_copy)));
   }
   if (infer_dim >= 0 && new_size > 0 && numel % new_size == 0) {
     dims_copy[infer_dim] = numel / new_size;

--- a/paddle/phi/kernels/stride/view_kernel.cc
+++ b/paddle/phi/kernels/stride/view_kernel.cc
@@ -49,10 +49,12 @@ void ViewShapeStridedKernel(const Context& dev_ctx,
       PADDLE_THROW(common::errors::OutOfRange("Tensor idx is out of range"));
     }
   }
-  PADDLE_ENFORCE_NE(new_size,
-                    0,
-                    common::errors::Unavailable(
-                        "cannot reshape tensor of 0 elements into shape "));
+  if (numel != 0) {
+    PADDLE_ENFORCE_NE(new_size,
+                      0,
+                      common::errors::Unavailable(
+                          "cannot reshape tensor of 0 elements into shape "));
+  }
   if (infer_dim >= 0 && new_size > 0 && numel % new_size == 0) {
     dims_copy[infer_dim] = numel / new_size;
   }

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -4256,7 +4256,7 @@ def set_(
         if source is None:
             source = paddle.empty([0], dtype=x.dtype)
             shape = [0]
-            stride = [0]
+            stride = source.strides
         else:
             if not isinstance(source, (Variable, core.eager.Tensor)):
                 raise ValueError(

--- a/test/cpp/phi/core/test_dense_tensor.cc
+++ b/test/cpp/phi/core/test_dense_tensor.cc
@@ -195,6 +195,24 @@ TEST(dense_tensor, meta) {
                                       meta_5.valid()));
 }
 
+TEST(dense_tensor, zero_size_strides) {
+  const auto zero_size_dims = common::make_ddim({0, 2048});
+  const auto zero_size_strides = DenseTensorMeta::calc_strides(zero_size_dims);
+  const auto expected_zero_size_strides = common::make_ddim({2048, 1});
+  EXPECT_EQ(zero_size_strides, expected_zero_size_strides);
+
+  DenseTensorMeta zero_size_meta(DataType::FLOAT32, zero_size_dims);
+  EXPECT_EQ(zero_size_meta.strides, expected_zero_size_strides);
+  EXPECT_TRUE(zero_size_meta.is_contiguous());
+
+  const auto reshaped_zero_size_dims = common::make_ddim({0, 512, 4});
+  EXPECT_EQ(DenseTensorMeta::calc_strides(reshaped_zero_size_dims),
+            common::make_ddim({2048, 4, 1}));
+
+  const auto unknown_dims = common::make_ddim({-1, 2048});
+  EXPECT_EQ(DenseTensorMeta::calc_strides(unknown_dims), unknown_dims);
+}
+
 TEST(dense_tensor, def_ctor) {
   DenseTensor tensor_0;
   PADDLE_ENFORCE_EQ(

--- a/test/legacy_test/test_dlpack_basic.py
+++ b/test/legacy_test/test_dlpack_basic.py
@@ -258,6 +258,7 @@ class TestDLPack(unittest.TestCase):
             for place in places:
                 for _ in range(4):
                     x = paddle.zeros([0, 10]).to(device=place)
+                    self.assertEqual(x.strides, [10, 1])
                     dlpack_v1 = paddle.utils.dlpack.to_dlpack(x)
                     dlpack_v2 = x.__dlpack__()
                     y1 = paddle.utils.dlpack.from_dlpack(dlpack_v1)
@@ -266,6 +267,8 @@ class TestDLPack(unittest.TestCase):
                     self.assertEqual(x.data_ptr(), y2.data_ptr())
                     self.assertEqual(str(x.place), str(y1.place))
                     self.assertEqual(str(x.place), str(y2.place))
+                    self.assertEqual(y1.strides, [10, 1])
+                    self.assertEqual(y2.strides, [10, 1])
                     self.assertEqual(y1.shape, [0, 10])
                     self.assertEqual(y2.shape, [0, 10])
                     self.assertEqual(y1.numel().item(), 0)

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -2268,6 +2268,33 @@ class TestEagerTensorStride(unittest.TestCase):
         for i in range(4):
             self.assertEqual(x4d.stride(i), strides_4d[i])
 
+    def test_stride_zero_size_contiguous_view_reshape_and_slice(self):
+        paddle.disable_static()
+
+        x = paddle.zeros([0, 2048], dtype='float32')
+        self.assertEqual(x.stride(), [2048, 1])
+        self.assertEqual(x.get_strides(), [2048, 1])
+        self.assertTrue(x.is_contiguous())
+
+        viewed = x.view([0, 512, 4])
+        self.assertEqual(viewed.stride(), [2048, 4, 1])
+        self.assertEqual(viewed.get_strides(), [2048, 4, 1])
+        self.assertTrue(viewed.is_contiguous())
+
+        reshaped = x.reshape([0, 512, 4])
+        self.assertEqual(reshaped.stride(), [2048, 4, 1])
+        self.assertEqual(reshaped.get_strides(), [2048, 4, 1])
+        self.assertTrue(reshaped.is_contiguous())
+
+        sliced = x[:, ::2]
+        self.assertEqual(sliced.stride(), [2048, 2])
+        self.assertEqual(sliced.get_strides(), [2048, 2])
+        self.assertFalse(sliced.is_contiguous())
+
+        contiguous = sliced.contiguous()
+        self.assertEqual(contiguous.stride(), [1024, 1])
+        self.assertTrue(contiguous.is_contiguous())
+
     def test_stride_different_dtypes(self):
         paddle.disable_static()
 

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -2360,6 +2360,7 @@ class TestDygraphInplaceSet(unittest.TestCase):
 
             x = self.inplace_api_processing(x)
             self.assertEqual(x.inplace_version, 2)
+            self.assertEqual(x.get_strides(), [1])
 
             x = self.inplace_api_processing(x, new_x=new_x)
             self.assertEqual(x.inplace_version, 3)

--- a/test/legacy_test/test_parameter.py
+++ b/test/legacy_test/test_parameter.py
@@ -88,8 +88,7 @@ class ParameterChecks(unittest.TestCase):
                 )
                 self.assertEqual(zero_size_param.shape, shape)
                 self.assertEqual(zero_size_param.data_ptr(), 0)
-                # strides will be same with shape for 0-size tensor in paddle
-                self.assertEqual(zero_size_param.strides, shape)
+                self.assertEqual(zero_size_param.strides, [4, 1])
 
     def func_exception(self):
         b = main_program.global_block()

--- a/test/legacy_test/test_zero_size.py
+++ b/test/legacy_test/test_zero_size.py
@@ -19,6 +19,15 @@ import paddle
 from paddle.framework import core
 
 
+def contiguous_strides(shape):
+    strides = [0] * len(shape)
+    running = 1
+    for i in range(len(shape) - 1, -1, -1):
+        strides[i] = running
+        running *= shape[i]
+    return strides
+
+
 class TestZeroSizeParameter(unittest.TestCase):
     def setUp(self):
         self.places = [
@@ -76,7 +85,7 @@ class TestZeroSizeParameter(unittest.TestCase):
                     )
                     self.assertEqual(
                         model.w.strides,
-                        zero_size_shape,
+                        contiguous_strides(zero_size_shape),
                         msg=f"Check failed at: {parameter_dtype}, {zero_size_shape}",
                     )
                     self.assertEqual(
@@ -144,7 +153,7 @@ class TestZeroSizeForward(unittest.TestCase):
                     )
                     self.assertEqual(
                         y.strides,
-                        zero_size_shape,
+                        contiguous_strides(zero_size_shape),
                         msg=f"Check failed at: {dtype}, {zero_size_shape}",
                     )
                     self.assertEqual(
@@ -197,7 +206,7 @@ class TestZeroSizeForward(unittest.TestCase):
                     )
                     self.assertEqual(
                         y.strides,
-                        zero_size_shape,
+                        contiguous_strides(zero_size_shape),
                         msg=f"Check failed at: {dtype}, {zero_size_shape}",
                     )
                     self.assertEqual(
@@ -271,7 +280,7 @@ class TestZeroSizeBackward(unittest.TestCase):
                     )
                     self.assertEqual(
                         x_grad.strides,
-                        zero_size_shape,
+                        contiguous_strides(zero_size_shape),
                         msg=f"Check failed at: {dtype}, {zero_size_shape}",
                     )
                     self.assertEqual(
@@ -322,7 +331,7 @@ class TestZeroSizeBackward(unittest.TestCase):
                     )
                     self.assertEqual(
                         x_grad.strides,
-                        zero_size_shape,
+                        contiguous_strides(zero_size_shape),
                         msg=f"Check failed at: {dtype}, {zero_size_shape}",
                     )
                     self.assertEqual(
@@ -400,7 +409,7 @@ class TestZeroSizeBackwardWithGradientAccumulation(unittest.TestCase):
                     )
                     self.assertEqual(
                         x_grad.strides,
-                        zero_size_shape,
+                        contiguous_strides(zero_size_shape),
                         msg=f"Check failed at: {dtype}, {zero_size_shape}",
                     )
                     self.assertEqual(
@@ -453,7 +462,7 @@ class TestZeroSizeBackwardWithGradientAccumulation(unittest.TestCase):
                     )
                     self.assertEqual(
                         x_grad.strides,
-                        zero_size_shape,
+                        contiguous_strides(zero_size_shape),
                         msg=f"Check failed at: {dtype}, {zero_size_shape}",
                     )
                     self.assertEqual(


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
修复 zero-size `DenseTensor` 的 canonical stride 元数据。

此前 `phi::DenseTensorMeta::calc_strides` 在 `product(dims) <= 0` 时直接返回 `dims`，导致合法的 0-size Tensor 也把 shape 复用成 stride 元数据。例如，`paddle.zeros([0, 2048]).stride()` 会得到 `[0, 2048]`，而不是 canonical contiguous stride `[2048, 1]`。由于 DLPack 导出会直接共享 Paddle Tensor 的 strides，这个错误元数据也会原样传播到 DLPack。

这个 PR 保持 unknown-dim 场景的原有行为不变，只在框架层为合法的 0-size Tensor 计算 canonical contiguous strides。这样可以同时修正 eager 侧的 stride 表现和 DLPack 互操作。

新增/更新的测试：
- C++：覆盖 `DenseTensorMeta::calc_strides` 在 zero-size 和 unknown dims 下的行为
- eager：覆盖 zero-size `stride()` 以及 `view` / `reshape` / `slice` / `contiguous` 路径
- DLPack：覆盖 zero-size round-trip 的 stride 检查
- 同步更新已有的 zero-size 回归测试，将原先 `strides == shape` 的错误预期改为 canonical contiguous stride

### 是否引起精度变化
否
