### PR TITLE
[BugFix] Fix CUDA Graph compatibility for H2D async memcpy using host-local variables

### DIFF
--- a/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
@@ -60,9 +60,11 @@ template <typename T>
 inline T *RestoreHostMemIfCapturingCUDAGraph(T *host_mem, size_t size) {
   static_assert(std::is_trivial<T>::value, "T must be trivial type");
   static_assert(!std::is_same<T, void>::value, "T cannot be void");
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
+    defined(PADDLE_WITH_CUSTOM_DEVICE)
   if (UNLIKELY(IsCUDAGraphCapturing())) {
     size_t nbytes = size * sizeof(T);
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     void *new_host_mem = nullptr;
     PADDLE_ENFORCE_GPU_SUCCESS(
         cudaHostAlloc(&new_host_mem, nbytes, cudaHostAllocDefault));
@@ -71,6 +73,14 @@ inline T *RestoreHostMemIfCapturingCUDAGraph(T *host_mem, size_t size) {
         [=](paddle::optional<const CUDAGraph &> graph) {
           PADDLE_ENFORCE_GPU_SUCCESS(cudaFreeHost(new_host_mem));
         });
+#else
+    void *new_host_mem = new uint8_t[nbytes];
+    std::memcpy(new_host_mem, host_mem, nbytes);
+    AddPostResetCallbackIfCapturingCUDAGraph(
+        [=](paddle::optional<const CUDAGraph &> graph) {
+          delete[] reinterpret_cast<uint8_t *>(new_host_mem);
+        });
+#endif
     return reinterpret_cast<T *>(new_host_mem);
   }
 #endif

--- a/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
@@ -66,8 +66,12 @@ inline T *RestoreHostMemIfCapturingCUDAGraph(T *host_mem, size_t size) {
     size_t nbytes = size * sizeof(T);
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     void *new_host_mem = nullptr;
-    PADDLE_ENFORCE_GPU_SUCCESS(
-        cudaHostAlloc(&new_host_mem, nbytes, cudaHostAllocDefault));
+    // NOTE: Use cudaMallocHost instead of cudaHostAlloc here.
+    // cudaHostAlloc is a stream-aware API and is a "prohibited" operation
+    // during CUDA Graph stream capture (returns
+    // cudaErrorStreamCaptureUnsupported on CUDA 11.x). cudaMallocHost is
+    // stream-unaware and safe to call during capture.
+    PADDLE_ENFORCE_GPU_SUCCESS(cudaMallocHost(&new_host_mem, nbytes));
     std::memcpy(new_host_mem, host_mem, nbytes);
     AddPostResetCallbackIfCapturingCUDAGraph(
         [=](paddle::optional<const CUDAGraph &> graph) {

--- a/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
@@ -64,6 +64,7 @@ inline T *RestoreHostMemIfCapturingCUDAGraph(T *host_mem, size_t size) {
     defined(PADDLE_WITH_CUSTOM_DEVICE)
   if (UNLIKELY(IsCUDAGraphCapturing())) {
     size_t nbytes = size * sizeof(T);
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     void *new_host_mem = nullptr;
     PADDLE_ENFORCE_GPU_SUCCESS(
         cudaHostAlloc(&new_host_mem, nbytes, cudaHostAllocDefault));
@@ -72,6 +73,14 @@ inline T *RestoreHostMemIfCapturingCUDAGraph(T *host_mem, size_t size) {
         [=](paddle::optional<const CUDAGraph &> graph) {
           PADDLE_ENFORCE_GPU_SUCCESS(cudaFreeHost(new_host_mem));
         });
+#else
+    void *new_host_mem = new uint8_t[nbytes];
+    std::memcpy(new_host_mem, host_mem, nbytes);
+    AddPostResetCallbackIfCapturingCUDAGraph(
+        [=](paddle::optional<const CUDAGraph &> graph) {
+          delete[] reinterpret_cast<uint8_t *>(new_host_mem);
+        });
+#endif
     return reinterpret_cast<T *>(new_host_mem);
   }
 #endif

--- a/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
@@ -60,11 +60,9 @@ template <typename T>
 inline T *RestoreHostMemIfCapturingCUDAGraph(T *host_mem, size_t size) {
   static_assert(std::is_trivial<T>::value, "T must be trivial type");
   static_assert(!std::is_same<T, void>::value, "T cannot be void");
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
-    defined(PADDLE_WITH_CUSTOM_DEVICE)
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   if (UNLIKELY(IsCUDAGraphCapturing())) {
     size_t nbytes = size * sizeof(T);
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     void *new_host_mem = nullptr;
     PADDLE_ENFORCE_GPU_SUCCESS(
         cudaHostAlloc(&new_host_mem, nbytes, cudaHostAllocDefault));
@@ -73,14 +71,6 @@ inline T *RestoreHostMemIfCapturingCUDAGraph(T *host_mem, size_t size) {
         [=](paddle::optional<const CUDAGraph &> graph) {
           PADDLE_ENFORCE_GPU_SUCCESS(cudaFreeHost(new_host_mem));
         });
-#else
-    void *new_host_mem = new uint8_t[nbytes];
-    std::memcpy(new_host_mem, host_mem, nbytes);
-    AddPostResetCallbackIfCapturingCUDAGraph(
-        [=](paddle::optional<const CUDAGraph &> graph) {
-          delete[] reinterpret_cast<uint8_t *>(new_host_mem);
-        });
-#endif
     return reinterpret_cast<T *>(new_host_mem);
   }
 #endif

--- a/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
@@ -64,35 +64,19 @@ inline T *RestoreHostMemIfCapturingCUDAGraph(T *host_mem, size_t size) {
     defined(PADDLE_WITH_CUSTOM_DEVICE)
   if (UNLIKELY(IsCUDAGraphCapturing())) {
     size_t nbytes = size * sizeof(T);
-#if defined(PADDLE_WITH_CUDA)
-    void *new_host_mem = nullptr;
-    // NOTE: Use cudaMallocHost instead of cudaHostAlloc here.
-    // cudaHostAlloc is a stream-aware API and is a "prohibited" operation
-    // during CUDA Graph stream capture (returns
-    // cudaErrorStreamCaptureUnsupported on CUDA 11.x). cudaMallocHost is
-    // stream-unaware and safe to call during capture.
-    PADDLE_ENFORCE_GPU_SUCCESS(cudaMallocHost(&new_host_mem, nbytes));
-    std::memcpy(new_host_mem, host_mem, nbytes);
-    AddPostResetCallbackIfCapturingCUDAGraph(
-        [=](paddle::optional<const CUDAGraph &> graph) {
-          PADDLE_ENFORCE_GPU_SUCCESS(cudaFreeHost(new_host_mem));
-        });
-#elif defined(PADDLE_WITH_HIP)
-    void *new_host_mem = nullptr;
-    PADDLE_ENFORCE_GPU_SUCCESS(hipMallocHost(&new_host_mem, nbytes));
-    std::memcpy(new_host_mem, host_mem, nbytes);
-    AddPostResetCallbackIfCapturingCUDAGraph(
-        [=](paddle::optional<const CUDAGraph &> graph) {
-          PADDLE_ENFORCE_GPU_SUCCESS(hipFreeHost(new_host_mem));
-        });
-#else
+    // NOTE: Use new[]/delete[] (plain heap) instead of cudaMallocHost /
+    // hipMallocHost here. cudaMallocHost and hipMallocHost are prohibited
+    // operations during CUDA/HIP Graph stream capture on CUDA 12.x / HIP,
+    // returning cudaErrorStreamCaptureUnsupported (error 900). Plain heap
+    // memory is safe to allocate at any time, and the captured
+    // cudaMemcpyAsync node records the host pointer address; the buffer
+    // lifetime is guaranteed by the post-reset callback below.
     void *new_host_mem = new uint8_t[nbytes];
     std::memcpy(new_host_mem, host_mem, nbytes);
     AddPostResetCallbackIfCapturingCUDAGraph(
         [=](paddle::optional<const CUDAGraph &> graph) {
           delete[] reinterpret_cast<uint8_t *>(new_host_mem);
         });
-#endif
     return reinterpret_cast<T *>(new_host_mem);
   }
 #endif

--- a/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
@@ -64,7 +64,7 @@ inline T *RestoreHostMemIfCapturingCUDAGraph(T *host_mem, size_t size) {
     defined(PADDLE_WITH_CUSTOM_DEVICE)
   if (UNLIKELY(IsCUDAGraphCapturing())) {
     size_t nbytes = size * sizeof(T);
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#if defined(PADDLE_WITH_CUDA)
     void *new_host_mem = nullptr;
     // NOTE: Use cudaMallocHost instead of cudaHostAlloc here.
     // cudaHostAlloc is a stream-aware API and is a "prohibited" operation
@@ -76,6 +76,14 @@ inline T *RestoreHostMemIfCapturingCUDAGraph(T *host_mem, size_t size) {
     AddPostResetCallbackIfCapturingCUDAGraph(
         [=](paddle::optional<const CUDAGraph &> graph) {
           PADDLE_ENFORCE_GPU_SUCCESS(cudaFreeHost(new_host_mem));
+        });
+#elif defined(PADDLE_WITH_HIP)
+    void *new_host_mem = nullptr;
+    PADDLE_ENFORCE_GPU_SUCCESS(hipMallocHost(&new_host_mem, nbytes));
+    std::memcpy(new_host_mem, host_mem, nbytes);
+    AddPostResetCallbackIfCapturingCUDAGraph(
+        [=](paddle::optional<const CUDAGraph &> graph) {
+          PADDLE_ENFORCE_GPU_SUCCESS(hipFreeHost(new_host_mem));
         });
 #else
     void *new_host_mem = new uint8_t[nbytes];

--- a/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h
@@ -64,11 +64,13 @@ inline T *RestoreHostMemIfCapturingCUDAGraph(T *host_mem, size_t size) {
     defined(PADDLE_WITH_CUSTOM_DEVICE)
   if (UNLIKELY(IsCUDAGraphCapturing())) {
     size_t nbytes = size * sizeof(T);
-    void *new_host_mem = new uint8_t[nbytes];
+    void *new_host_mem = nullptr;
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        cudaHostAlloc(&new_host_mem, nbytes, cudaHostAllocDefault));
     std::memcpy(new_host_mem, host_mem, nbytes);
     AddPostResetCallbackIfCapturingCUDAGraph(
         [=](paddle::optional<const CUDAGraph &> graph) {
-          delete[] reinterpret_cast<uint8_t *>(new_host_mem);
+          PADDLE_ENFORCE_GPU_SUCCESS(cudaFreeHost(new_host_mem));
         });
     return reinterpret_cast<T *>(new_host_mem);
   }

--- a/paddle/phi/core/tensor_utils.cc
+++ b/paddle/phi/core/tensor_utils.cc
@@ -19,6 +19,9 @@ limitations under the License. */
 #include "paddle/phi/api/lib/data_transform.h"
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
+#endif
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/compat/convert_utils.h"
@@ -165,8 +168,15 @@ void Copy(const Context& dev_ctx,
     auto stream =
         blocking ? nullptr
                  : reinterpret_cast<const phi::GPUContext&>(dev_ctx).stream();
+    // During CUDA Graph capturing, the host pointer may be freed or modified
+    // after the graph is captured but before replay. Restore the host memory
+    // into a stable buffer whose lifetime is tied to the graph.
+    const void* stable_src_ptr =
+        backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(src_ptr)),
+            size);
     memory_utils::Copy(
-        dst_gpu_place, dst_ptr, src_cpu_place, src_ptr, size, stream);
+        dst_gpu_place, dst_ptr, src_cpu_place, stable_src_ptr, size, stream);
   } else if (src_place.GetType() == AllocationType::GPU &&  // NOLINT
              dst_place.GetType() == AllocationType::GPU) {
     auto src_gpu_place = src_place;
@@ -499,10 +509,14 @@ void TensorFromVector(const std::vector<T>& src,
   }
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   else if (dst_place.GetType() == AllocationType::GPU) {  // NOLINT
+    const void* stable_src_ptr =
+        backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(src_ptr)),
+            size);
     memory_utils::Copy(dst_place,
                        dst_ptr,
                        src_place,
-                       src_ptr,
+                       stable_src_ptr,
                        size,
                        reinterpret_cast<const phi::GPUContext&>(ctx).stream());
   }
@@ -553,10 +567,14 @@ void TensorFromVector(const std::vector<bool>& src,
   }
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   else if (dst_place.GetType() == AllocationType::GPU) {  // NOLINT
+    const void* stable_src_ptr =
+        backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(src_ptr)),
+            size);
     memory_utils::Copy(dst_place,
                        dst_ptr,
                        src_place,
-                       src_ptr,
+                       stable_src_ptr,
                        size,
                        reinterpret_cast<const phi::GPUContext&>(ctx).stream());
   }
@@ -645,10 +663,14 @@ void TensorFromArray(const T* src,
   }
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   else if (dst_place.GetType() == AllocationType::GPU) {  // NOLINT
+    const void* stable_src_ptr =
+        backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(src_ptr)),
+            size);
     memory_utils::Copy(dst_place,
                        dst_ptr,
                        src_place,
-                       src_ptr,
+                       stable_src_ptr,
                        size,
                        reinterpret_cast<const phi::GPUContext&>(ctx).stream());
   }

--- a/paddle/phi/kernels/funcs/detection/bbox_util.cu.h
+++ b/paddle/phi/kernels/funcs/detection/bbox_util.cu.h
@@ -19,6 +19,7 @@
 #include <vector>
 #ifdef __NVCC__
 #include "cub/cub.cuh"
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #endif
 #ifdef __HIPCC__
 #include <hipcub/hipcub.hpp>
@@ -342,10 +343,12 @@ static void NMS(const GPUContext &dev_ctx,
   }
   keep_out->Resize({num_to_keep});
   int *keep = dev_ctx.Alloc<int>(keep_out);
+  const int *stable_kv = phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+      const_cast<int *>(keep_vec.data()), keep_vec.size());
   phi::memory_utils::Copy(place,
                           keep,
                           CPUPlace(),
-                          keep_vec.data(),
+                          stable_kv,
                           sizeof(int) * num_to_keep,
                           dev_ctx.stream());
   dev_ctx.Wait();

--- a/paddle/phi/kernels/funcs/detection/bbox_util.cu.h
+++ b/paddle/phi/kernels/funcs/detection/bbox_util.cu.h
@@ -318,6 +318,16 @@ static void NMS(const GPUContext &dev_ctx,
   std::vector<uint64_t> remv(col_blocks);
   memset(&remv[0], 0, sizeof(uint64_t) * col_blocks);
 
+#ifdef __NVCC__
+  PADDLE_ENFORCE_EQ(
+      phi::backends::gpu::IsCUDAGraphCapturing(),
+      false,
+      common::errors::InvalidArgument(
+          "NMSKernel (bbox_util) does not support CUDA Graph capture: async "
+          "D2H copy to local vector 'mask_host' will bake the destination "
+          "address into the graph; on replay the vector is re-created at a "
+          "different address, causing a dangling-pointer write."));
+#endif
   std::vector<uint64_t> mask_host(boxes_num * col_blocks);
   phi::memory_utils::Copy(CPUPlace(),
                           mask_host.data(),
@@ -343,8 +353,12 @@ static void NMS(const GPUContext &dev_ctx,
   }
   keep_out->Resize({num_to_keep});
   int *keep = dev_ctx.Alloc<int>(keep_out);
+#ifdef __NVCC__
   const int *stable_kv = phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
       const_cast<int *>(keep_vec.data()), keep_vec.size());
+#else
+  const int *stable_kv = keep_vec.data();
+#endif
   phi::memory_utils::Copy(place,
                           keep,
                           CPUPlace(),

--- a/paddle/phi/kernels/funcs/elementwise_grad_base.h
+++ b/paddle/phi/kernels/funcs/elementwise_grad_base.h
@@ -28,6 +28,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/get_current_context.h"
 
 #if defined(__NVCC__) || defined(__HIPCC__)
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/kernels/primitive/kernel_primitives.h"
@@ -1802,22 +1803,33 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
   int64_t *out_dims_array_gpu =
       reinterpret_cast<int64_t *>(y_strides_array_gpu + max_dim);
 
+  const int64_t *stable_x_strides =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          reinterpret_cast<int64_t *>(x_strides_array.data()),
+          x_strides_array.size());
   memory_utils::Copy(gplace,
                      x_strides_array_gpu,
                      cplace,
-                     x_strides_array.data(),
+                     stable_x_strides,
                      bytes,
                      dev_ctx.stream());
+  const int64_t *stable_y_strides =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          reinterpret_cast<int64_t *>(y_strides_array.data()),
+          y_strides_array.size());
   memory_utils::Copy(gplace,
                      y_strides_array_gpu,
                      cplace,
-                     y_strides_array.data(),
+                     stable_y_strides,
                      bytes,
                      dev_ctx.stream());
+  const int64_t *stable_out_dims =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          out_dims_array, bytes / sizeof(int64_t));
   memory_utils::Copy(gplace,
                      out_dims_array_gpu,
                      cplace,
-                     out_dims_array,
+                     stable_out_dims,
                      bytes,
                      dev_ctx.stream());
 
@@ -1840,16 +1852,24 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
     int64_t *x_dims_order_gpu =
         reinterpret_cast<int64_t *>(x_strides_order_gpu + max_dim);
 
+    const int64_t *stable_x_strides_order =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            reinterpret_cast<int64_t *>(x_strides_order.data()),
+            x_strides_order.size());
     memory_utils::Copy(gplace,
                        x_strides_order_gpu,
                        cplace,
-                       x_strides_order.data(),
+                       stable_x_strides_order,
                        bytes,
                        dev_ctx.stream());
+    const int64_t *stable_x_dims_order =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            reinterpret_cast<int64_t *>(x_dims_order.data()),
+            x_dims_order.size());
     memory_utils::Copy(gplace,
                        x_dims_order_gpu,
                        cplace,
-                       x_dims_order.data(),
+                       stable_x_dims_order,
                        bytes,
                        dev_ctx.stream());
     if (out_size > std::numeric_limits<int32_t>::max()) {
@@ -1898,16 +1918,24 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
     int64_t *y_dims_order_gpu =
         reinterpret_cast<int64_t *>(y_strides_order_gpu + max_dim);
 
+    const int64_t *stable_y_strides_order =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            reinterpret_cast<int64_t *>(y_strides_order.data()),
+            y_strides_order.size());
     memory_utils::Copy(gplace,
                        y_strides_order_gpu,
                        cplace,
-                       y_strides_order.data(),
+                       stable_y_strides_order,
                        bytes,
                        dev_ctx.stream());
+    const int64_t *stable_y_dims_order =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            reinterpret_cast<int64_t *>(y_dims_order.data()),
+            y_dims_order.size());
     memory_utils::Copy(gplace,
                        y_dims_order_gpu,
                        cplace,
-                       y_dims_order.data(),
+                       stable_y_dims_order,
                        bytes,
                        dev_ctx.stream());
     if (out_size > std::numeric_limits<int32_t>::max()) {

--- a/paddle/phi/kernels/funcs/fft_fill_conj.h
+++ b/paddle/phi/kernels/funcs/fft_fill_conj.h
@@ -20,6 +20,9 @@
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/funcs/for_range.h"
 #if defined(__NVCC__) || defined(__HIPCC__)
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
+#endif
+#if defined(__NVCC__) || defined(__HIPCC__)
 #include "thrust/device_vector.h"
 #endif
 
@@ -172,28 +175,40 @@ void FFTFillConj(const DeviceContext& dev_ctx,
   bool* p_is_fft_axis = dev_ctx.template Alloc<bool>(&is_fft_axis_g);
   auto cplace = CPUPlace();
   const auto gplace = dev_ctx.GetPlace();
+  const int64_t* stable_src_strides =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          src_strides_v.data(), src_strides_v.size());
   memory_utils::Copy(gplace,
                      src_strides,
                      cplace,
-                     src_strides_v.data(),
+                     stable_src_strides,
                      sizeof(int64_t) * src_strides_v.size(),
                      dev_ctx.stream());
+  const int64_t* stable_dst_strides =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          dst_strides_v.data(), dst_strides_v.size());
   memory_utils::Copy(gplace,
                      dst_strides,
                      cplace,
-                     dst_strides_v.data(),
+                     stable_dst_strides,
                      sizeof(int64_t) * dst_strides_v.size(),
                      dev_ctx.stream());
+  const int64_t* stable_dst_shape =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          dst_shape_v.data(), dst_shape_v.size());
   memory_utils::Copy(gplace,
                      dst_shape,
                      cplace,
-                     dst_shape_v.data(),
+                     stable_dst_shape,
                      sizeof(int64_t) * dst_shape_v.size(),
                      dev_ctx.stream());
+  const bool* stable_is_fft_axis =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          _is_fft_axis.get(), static_cast<size_t>(rank));
   memory_utils::Copy(gplace,
                      p_is_fft_axis,
                      cplace,
-                     _is_fft_axis.get(),
+                     stable_is_fft_axis,
                      sizeof(bool) * rank,
                      dev_ctx.stream());
 #else

--- a/paddle/phi/kernels/funcs/index_put_utils.h
+++ b/paddle/phi/kernels/funcs/index_put_utils.h
@@ -36,6 +36,10 @@
 #endif
 #endif
 
+#ifdef PADDLE_WITH_CUDA
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
+#endif
+
 namespace phi {
 
 namespace funcs {
@@ -198,11 +202,15 @@ T** GetDevicePointerArray(const Context& dev_ctx,
       dev_ctx.GetPlace(),
       h_indices_v.size() * sizeof(T*),
       phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
+  size_t nbytes_idx = h_indices_v.size() * sizeof(T*);
+  const void* stable_idx =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          reinterpret_cast<uint8_t*>(h_indices_v.data()), nbytes_idx);
   phi::memory_utils::Copy(dev_ctx.GetPlace(),
                           d_indices_data->ptr(),
                           CPUPlace(),
-                          reinterpret_cast<void*>(h_indices_v.data()),
-                          h_indices_v.size() * sizeof(T*),
+                          stable_idx,
+                          nbytes_idx,
                           dev_ctx.stream());
   return reinterpret_cast<T**>(d_indices_data->ptr());
 }

--- a/paddle/phi/kernels/funcs/index_put_utils.h
+++ b/paddle/phi/kernels/funcs/index_put_utils.h
@@ -203,9 +203,13 @@ T** GetDevicePointerArray(const Context& dev_ctx,
       h_indices_v.size() * sizeof(T*),
       phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
   size_t nbytes_idx = h_indices_v.size() * sizeof(T*);
+#ifdef PADDLE_WITH_CUDA
   const void* stable_idx =
       phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
           reinterpret_cast<uint8_t*>(h_indices_v.data()), nbytes_idx);
+#else
+  const void* stable_idx = reinterpret_cast<const void*>(h_indices_v.data());
+#endif
   phi::memory_utils::Copy(dev_ctx.GetPlace(),
                           d_indices_data->ptr(),
                           CPUPlace(),

--- a/paddle/phi/kernels/funcs/send_recv_functor.h
+++ b/paddle/phi/kernels/funcs/send_recv_functor.h
@@ -156,6 +156,17 @@ DDim recv_shape_info(const Context& dev_ctx,
       &shape_size_tensortensor, shape_size_tensortensor.numel(), peer, stream);
 
   // copy the shape size tensor to cpu
+#ifdef PADDLE_WITH_CUDA
+  PADDLE_ENFORCE_EQ(
+      phi::backends::gpu::IsCUDAGraphCapturing(),
+      false,
+      common::errors::InvalidArgument(
+          "RecvShape does not support CUDA Graph capture: async D2H copy to "
+          "a locally allocated CPU DenseTensor 'cpu_shape_size_tensor' will "
+          "bake the destination address into the graph; on replay the tensor "
+          "is re-created at a different address, causing a dangling-pointer "
+          "write."));
+#endif
   DenseTensor cpu_shape_size_tensor(shape_dtype);
   cpu_shape_size_tensor.Resize({1});
   dev_ctx.HostAlloc(&cpu_shape_size_tensor, shape_dtype);

--- a/paddle/phi/kernels/funcs/send_recv_functor.h
+++ b/paddle/phi/kernels/funcs/send_recv_functor.h
@@ -19,6 +19,9 @@
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/tensor_array.h"
+#ifdef PADDLE_WITH_CUDA
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
+#endif
 
 namespace phi {
 
@@ -61,12 +64,25 @@ void send_shape_info(const Context& dev_ctx,
   shape_size_tensor.Resize({1});
   dev_ctx.Alloc(&shape_size_tensor, shape_dtype);
   const auto& cpu_place = CPUPlace();
+#ifdef PADDLE_WITH_CUDA
+  const int* stable_shape_size =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<int*>(cpu_shape_size_tensor.data<int>()),
+          static_cast<size_t>(cpu_shape_size_tensor.numel()));
+  memory_utils::Copy(dev_ctx.GetPlace(),
+                     shape_size_tensor.data(),
+                     cpu_place,
+                     stable_shape_size,
+                     cpu_shape_size_tensor.numel() * sizeof(int),
+                     stream);
+#else
   memory_utils::Copy(dev_ctx.GetPlace(),
                      shape_size_tensor.data(),
                      cpu_place,
                      cpu_shape_size_tensor.data(),
                      cpu_shape_size_tensor.numel() * sizeof(int),
                      stream);
+#endif
 
   comm_ctx->Send(shape_size_tensor, shape_size_tensor.numel(), peer, stream);
 
@@ -83,12 +99,25 @@ void send_shape_info(const Context& dev_ctx,
   DenseTensor shape_tensor;
   shape_tensor.Resize({shape_size});
   dev_ctx.Alloc(&shape_tensor, shape_dtype);
+#ifdef PADDLE_WITH_CUDA
+  const int* stable_shape =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<int*>(cpu_shape_tensor.data<int>()),
+          static_cast<size_t>(cpu_shape_tensor.numel()));
+  memory_utils::Copy(dev_ctx.GetPlace(),
+                     shape_tensor.data(),
+                     cpu_place,
+                     stable_shape,
+                     cpu_shape_tensor.numel() * sizeof(int),
+                     stream);
+#else
   memory_utils::Copy(dev_ctx.GetPlace(),
                      shape_tensor.data(),
                      cpu_place,
                      cpu_shape_tensor.data(),
                      cpu_shape_tensor.numel() * sizeof(int),
                      stream);
+#endif
   comm_ctx->Send(shape_tensor, shape_tensor.numel(), peer, stream);
   dev_ctx.Wait();
 }

--- a/paddle/phi/kernels/funcs/sparse/softmax.cu.h
+++ b/paddle/phi/kernels/funcs/sparse/softmax.cu.h
@@ -14,6 +14,8 @@ limitations under the License. */
 
 #pragma once
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
+
 namespace phi {
 namespace funcs {
 namespace sparse {
@@ -43,10 +45,13 @@ inline DenseTensor GetOffsets(const Context& dev_ctx,
   const IntArray strides_shape(vectorize<IntT>(indices.dims()));
   DenseTensor strides = Empty<IntT>(dev_ctx, strides_shape);
   auto strides_ptr = strides.data<IntT>();
+  const IntT* stable_st =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          host_strides.data(), host_strides.size());
   memory_utils::Copy(dev_ctx.GetPlace(),
                      strides_ptr,
                      CPUPlace(),
-                     host_strides.data(),
+                     stable_st,
                      sizeof(IntT) * host_strides.size(),
                      dev_ctx.stream());
 

--- a/paddle/phi/kernels/funcs/sparse/softmax.cu.h
+++ b/paddle/phi/kernels/funcs/sparse/softmax.cu.h
@@ -45,9 +45,13 @@ inline DenseTensor GetOffsets(const Context& dev_ctx,
   const IntArray strides_shape(vectorize<IntT>(indices.dims()));
   DenseTensor strides = Empty<IntT>(dev_ctx, strides_shape);
   auto strides_ptr = strides.data<IntT>();
+#if defined(__NVCC__) || defined(__HIPCC__)
   const IntT* stable_st =
       phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
           host_strides.data(), host_strides.size());
+#else
+  const IntT* stable_st = host_strides.data();
+#endif
   memory_utils::Copy(dev_ctx.GetPlace(),
                      strides_ptr,
                      CPUPlace(),

--- a/paddle/phi/kernels/funcs/sparse/sparse_blas_impl.cu.h
+++ b/paddle/phi/kernels/funcs/sparse/sparse_blas_impl.cu.h
@@ -18,6 +18,9 @@
 
 #include "paddle/common/ddim.h"
 #include "paddle/phi/backends/dynload/cusparse.h"
+#ifdef PADDLE_WITH_CUDA
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
+#endif
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
@@ -590,6 +593,17 @@ void SparseBlas<GPUContext>::SPGEMM(bool transa,
 
     GetCsrBatchNnz<T><<<1, batch_size, 0, dev_ctx_.stream()>>>(
         a_crows_data, a_rows, static_cast<int32_t*>(tmp_buffer_ptr));
+#ifdef PADDLE_WITH_CUDA
+    PADDLE_ENFORCE_EQ(
+        phi::backends::gpu::IsCUDAGraphCapturing(),
+        false,
+        common::errors::InvalidArgument(
+            "SparseBlas CsrMM does not support CUDA Graph capture: async D2H "
+            "copy to local vectors 'a_batch_nnz_vec' / 'b_batch_nnz_vec' will "
+            "bake the destination addresses into the graph; on replay the "
+            "vectors are re-created at different addresses, causing "
+            "dangling-pointer writes."));
+#endif
     phi::backends::gpu::GpuMemcpyAsync(a_batch_nnz_vec.data(),
                                        tmp_buffer_ptr,
                                        batch_size * sizeof(int32_t),

--- a/paddle/phi/kernels/funcs/stride_utils.h
+++ b/paddle/phi/kernels/funcs/stride_utils.h
@@ -42,6 +42,10 @@
 #endif
 #endif
 
+#ifdef PADDLE_WITH_CUDA
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
+#endif
+
 namespace phi {
 
 namespace funcs {
@@ -678,10 +682,13 @@ static inline DenseTensor wrapIndexOnce(const GPUContext& dev_ctx,
   auto* dim_size_data = dim_size_tensor.data<int64_t>();
   auto numel = index.numel();
   std::vector<int64_t> host_data(numel, dim_size);
+  const int64_t* stable_hd =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(host_data.data(),
+                                                             host_data.size());
   phi::memory_utils::Copy(dev_ctx.GetPlace(),
                           dim_size_data,
                           CPUPlace(),
-                          host_data.data(),
+                          stable_hd,
                           numel * sizeof(int64_t),
                           dev_ctx.stream());
 

--- a/paddle/phi/kernels/fusion/gpu/fused_embedding_eltwise_layernorm_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_embedding_eltwise_layernorm_kernel.cu
@@ -16,6 +16,7 @@
 #include <type_traits>
 
 #include "paddle/common/errors.h"
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/enforce.h"
@@ -65,16 +66,22 @@ void EmbeddingEltWiseLayerNormKernel(
     in2s.push_back(reinterpret_cast<uintptr_t>(embs[i]->data<T>()));
   }
 
+  const int64_t* stable_in1s =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<int64_t*>(in1s.data()), in1s.size());
   phi::memory_utils::Copy(GPUPlace{},
                           in_ids_d,
                           CPUPlace{},
-                          in1s.data(),
+                          stable_in1s,
                           sizeof(int64_t) * input_num,
                           dev_ctx.stream());
+  const int64_t* stable_in2s =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<int64_t*>(in2s.data()), in2s.size());
   phi::memory_utils::Copy(GPUPlace{},
                           in_embs_d,
                           CPUPlace{},
-                          in2s.data(),
+                          stable_in2s,
                           sizeof(int64_t) * input_num,
                           dev_ctx.stream());
 

--- a/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_grad_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/fused_seqpool_cvm_grad_kernel.h"
 #include <string>
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -131,66 +132,82 @@ void FusedSeqpoolCVMGrad(const GPUContext &dev_ctx,
       dev_ctx.GetPlace(), total_ptr_len * sizeof(void *));
 #ifdef PADDLE_WITH_HIP
   T **gpu_out_grads_values = reinterpret_cast<T **>(temp_ptr->ptr());
-  phi::backends::gpu::GpuMemcpyAsync(gpu_out_grads_values,
-                                     out_grads_data.data(),
-                                     out_grads_data.size() * sizeof(T *),
-                                     hipMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      gpu_out_grads_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<T **>(out_grads_data.data()), out_grads_data.size()),
+      out_grads_data.size() * sizeof(T *),
+      hipMemcpyHostToDevice,
+      stream);
 
   T **gpu_in_grads_values =
       reinterpret_cast<T **>(&gpu_out_grads_values[out_grads_data.size()]);
-  phi::backends::gpu::GpuMemcpyAsync(gpu_in_grads_values,
-                                     in_grads_data.data(),
-                                     in_grads_data.size() * sizeof(T *),
-                                     hipMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      gpu_in_grads_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<T **>(in_grads_data.data()), in_grads_data.size()),
+      in_grads_data.size() * sizeof(T *),
+      hipMemcpyHostToDevice,
+      stream);
 
   T **gpu_cvm_values =
       reinterpret_cast<T **>(&gpu_in_grads_values[in_grads_data.size()]);
-  phi::backends::gpu::GpuMemcpyAsync(gpu_cvm_values,
-                                     cvm_data.data(),
-                                     cvm_data.size() * sizeof(T *),
-                                     hipMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      gpu_cvm_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<T **>(cvm_data.data()), cvm_data.size()),
+      cvm_data.size() * sizeof(T *),
+      hipMemcpyHostToDevice,
+      stream);
 
   size_t **lods_values =
       reinterpret_cast<size_t **>(&gpu_cvm_values[cvm_data.size()]);
-  phi::backends::gpu::GpuMemcpyAsync(lods_values,
-                                     lods.data(),
-                                     lods.size() * sizeof(size_t *),
-                                     hipMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      lods_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<size_t **>(lods.data()), lods.size()),
+      lods.size() * sizeof(size_t *),
+      hipMemcpyHostToDevice,
+      stream);
 #else
   T **gpu_out_grads_values = reinterpret_cast<T **>(temp_ptr->ptr());
-  phi::backends::gpu::GpuMemcpyAsync(gpu_out_grads_values,
-                                     out_grads_data.data(),
-                                     out_grads_data.size() * sizeof(T *),
-                                     cudaMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      gpu_out_grads_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<T **>(out_grads_data.data()), out_grads_data.size()),
+      out_grads_data.size() * sizeof(T *),
+      cudaMemcpyHostToDevice,
+      stream);
 
   T **gpu_in_grads_values =
       reinterpret_cast<T **>(&gpu_out_grads_values[out_grads_data.size()]);
-  phi::backends::gpu::GpuMemcpyAsync(gpu_in_grads_values,
-                                     in_grads_data.data(),
-                                     in_grads_data.size() * sizeof(T *),
-                                     cudaMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      gpu_in_grads_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<T **>(in_grads_data.data()), in_grads_data.size()),
+      in_grads_data.size() * sizeof(T *),
+      cudaMemcpyHostToDevice,
+      stream);
 
   T **gpu_cvm_values =
       reinterpret_cast<T **>(&gpu_in_grads_values[in_grads_data.size()]);
-  phi::backends::gpu::GpuMemcpyAsync(gpu_cvm_values,
-                                     cvm_data.data(),
-                                     cvm_data.size() * sizeof(T *),
-                                     cudaMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      gpu_cvm_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<T **>(cvm_data.data()), cvm_data.size()),
+      cvm_data.size() * sizeof(T *),
+      cudaMemcpyHostToDevice,
+      stream);
 
   size_t **lods_values =
       reinterpret_cast<size_t **>(&gpu_cvm_values[cvm_data.size()]);
-  phi::backends::gpu::GpuMemcpyAsync(lods_values,
-                                     lods.data(),
-                                     lods.size() * sizeof(size_t *),
-                                     cudaMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      lods_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<size_t **>(lods.data()), lods.size()),
+      lods.size() * sizeof(size_t *),
+      cudaMemcpyHostToDevice,
+      stream);
 #endif
 
   size_t N = static_cast<size_t>(batch_size * slot_num * embedding_size);

--- a/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_seqpool_cvm_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/fused_seqpool_cvm_kernel.h"
 #include <string>
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -121,60 +122,78 @@ void FusedSeqpoolCVM(
 
 #ifdef PADDLE_WITH_HIP
   T **gpu_input_values = reinterpret_cast<T **>(temp_ptr->ptr());
-  phi::backends::gpu::GpuMemcpyAsync(gpu_input_values,
-                                     input_data.data(),
-                                     input_data.size() * sizeof(T *),
-                                     hipMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      gpu_input_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<T **>(input_data.data()), input_data.size()),
+      input_data.size() * sizeof(T *),
+      hipMemcpyHostToDevice,
+      stream);
   T **gpu_output_values =
       reinterpret_cast<T **>(&gpu_input_values[input_data.size()]);
-  phi::backends::gpu::GpuMemcpyAsync(gpu_output_values,
-                                     output_data.data(),
-                                     output_data.size() * sizeof(T *),
-                                     hipMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      gpu_output_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<T **>(output_data.data()), output_data.size()),
+      output_data.size() * sizeof(T *),
+      hipMemcpyHostToDevice,
+      stream);
   T **gpu_seqpool_output_values =
       reinterpret_cast<T **>(&gpu_output_values[output_data.size()]);
-  phi::backends::gpu::GpuMemcpyAsync(gpu_seqpool_output_values,
-                                     seqpool_output_data.data(),
-                                     seqpool_output_data.size() * sizeof(T *),
-                                     hipMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      gpu_seqpool_output_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<T **>(seqpool_output_data.data()),
+          seqpool_output_data.size()),
+      seqpool_output_data.size() * sizeof(T *),
+      hipMemcpyHostToDevice,
+      stream);
   size_t **lods_values = reinterpret_cast<size_t **>(
       &gpu_seqpool_output_values[seqpool_output_data.size()]);
-  phi::backends::gpu::GpuMemcpyAsync(lods_values,
-                                     lods.data(),
-                                     lods.size() * sizeof(size_t *),
-                                     hipMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      lods_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<size_t **>(lods.data()), lods.size()),
+      lods.size() * sizeof(size_t *),
+      hipMemcpyHostToDevice,
+      stream);
 #else
   T **gpu_input_values = reinterpret_cast<T **>(temp_ptr->ptr());
-  phi::backends::gpu::GpuMemcpyAsync(gpu_input_values,
-                                     input_data.data(),
-                                     input_data.size() * sizeof(T *),
-                                     cudaMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      gpu_input_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<T **>(input_data.data()), input_data.size()),
+      input_data.size() * sizeof(T *),
+      cudaMemcpyHostToDevice,
+      stream);
   T **gpu_output_values =
       reinterpret_cast<T **>(&gpu_input_values[input_data.size()]);
-  phi::backends::gpu::GpuMemcpyAsync(gpu_output_values,
-                                     output_data.data(),
-                                     output_data.size() * sizeof(T *),
-                                     cudaMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      gpu_output_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<T **>(output_data.data()), output_data.size()),
+      output_data.size() * sizeof(T *),
+      cudaMemcpyHostToDevice,
+      stream);
   T **gpu_seqpool_output_values =
       reinterpret_cast<T **>(&gpu_output_values[output_data.size()]);
-  phi::backends::gpu::GpuMemcpyAsync(gpu_seqpool_output_values,
-                                     seqpool_output_data.data(),
-                                     seqpool_output_data.size() * sizeof(T *),
-                                     cudaMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      gpu_seqpool_output_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<T **>(seqpool_output_data.data()),
+          seqpool_output_data.size()),
+      seqpool_output_data.size() * sizeof(T *),
+      cudaMemcpyHostToDevice,
+      stream);
   size_t **lods_values = reinterpret_cast<size_t **>(
       &gpu_seqpool_output_values[seqpool_output_data.size()]);
-  phi::backends::gpu::GpuMemcpyAsync(lods_values,
-                                     lods.data(),
-                                     lods.size() * sizeof(size_t *),
-                                     cudaMemcpyHostToDevice,
-                                     stream);
+  phi::backends::gpu::GpuMemcpyAsync(
+      lods_values,
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<size_t **>(lods.data()), lods.size()),
+      lods.size() * sizeof(size_t *),
+      cudaMemcpyHostToDevice,
+      stream);
 #endif
 
   size_t N = static_cast<size_t>(batch_size * slot_num * embedding_size);

--- a/paddle/phi/kernels/gpu/add_n_kernel.cu
+++ b/paddle/phi/kernels/gpu/add_n_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/add_n_kernel.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/kernels/impl/add_n_kernel_impl.h"
@@ -187,11 +188,16 @@ void AddNKernel(const Context &dev_ctx,
                              in_other_dtype == phi::DataType::FLOAT16)) {
       auto tmp_in_array = phi::memory_utils::Alloc(
           dev_ctx.GetPlace(), in_data.size() * sizeof(void *));
+      size_t nbytes_in = in_data.size() * sizeof(void *);
+      const void *stable_in =
+          phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+              reinterpret_cast<uint8_t *>(const_cast<void **>(in_data.data())),
+              nbytes_in);
       memory_utils::Copy(dev_ctx.GetPlace(),
                          tmp_in_array->ptr(),
                          CPUPlace(),
-                         reinterpret_cast<void *>(in_data.data()),
-                         in_data.size() * sizeof(void *),
+                         stable_in,
+                         nbytes_in,
                          dev_ctx.stream());
 
       void **in_array_data = reinterpret_cast<void **>(tmp_in_array->ptr());
@@ -278,11 +284,15 @@ void AddNKernel(const Context &dev_ctx,
       auto tmp_sr_in_out_array = phi::memory_utils::Alloc(
           dev_ctx.GetPlace(), sr_in_out_data.size() * sizeof(T *));
 
+      size_t nbytes_sr = sr_in_out_data.size() * sizeof(T *);
+      const void *stable_sr =
+          phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+              reinterpret_cast<uint8_t *>(sr_in_out_data.data()), nbytes_sr);
       memory_utils::Copy(dev_ctx.GetPlace(),
                          tmp_sr_in_out_array->ptr(),
                          CPUPlace(),
-                         reinterpret_cast<void *>(sr_in_out_data.data()),
-                         sr_in_out_data.size() * sizeof(T *),
+                         stable_sr,
+                         nbytes_sr,
                          dev_ctx.stream());
 
       T **sr_in_out_array_data =
@@ -299,11 +309,16 @@ void AddNKernel(const Context &dev_ctx,
     auto tmp_in_array = phi::memory_utils::Alloc(dev_ctx.GetPlace(),
                                                  in_data.size() * sizeof(T *));
 
+    size_t nbytes_in2 = in_data.size() * sizeof(T *);
+    const void *stable_in2 =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            reinterpret_cast<uint8_t *>(const_cast<T **>(in_data.data())),
+            nbytes_in2);
     memory_utils::Copy(dev_ctx.GetPlace(),
                        tmp_in_array->ptr(),
                        CPUPlace(),
-                       reinterpret_cast<void *>(in_data.data()),
-                       in_data.size() * sizeof(T *),
+                       stable_in2,
+                       nbytes_in2,
                        dev_ctx.stream());
 
     T **in_array_data = reinterpret_cast<T **>(tmp_in_array->ptr());

--- a/paddle/phi/kernels/gpu/amp_kernel.cu
+++ b/paddle/phi/kernels/gpu/amp_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/amp_kernel.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -174,10 +175,13 @@ class LazyZeros<GPUContext, T> {
     for (int i = 0; i < xs_size; i++) {
       h_starts[i + 1] = h_starts[i] + outs[i]->numel();
     }
+    auto* stable_h_starts =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(h_starts,
+                                                               xs_size + 1);
     memory_utils::Copy(dev_ctx.GetPlace(),
                        d_starts,
                        cpu_place,
-                       h_starts,
+                       stable_h_starts,
                        (xs_size + 1) * sizeof(int64_t),
                        dev_ctx.stream());
 
@@ -195,10 +199,13 @@ class LazyZeros<GPUContext, T> {
     for (size_t i = 0; i < xs_size; ++i) {
       h_out_addrs[i] = dev_ctx.Alloc<T>(outs[i]);
     }
+    auto* stable_h_out_addrs =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(h_out_addrs,
+                                                               xs_size);
     memory_utils::Copy(dev_ctx.GetPlace(),
                        d_out_addrs,
                        cpu_place,
-                       h_out_addrs,
+                       stable_h_out_addrs,
                        xs_size * sizeof(T*),
                        dev_ctx.stream());
 
@@ -304,10 +311,13 @@ void CheckFiniteAndUnscaleKernel(const Context& dev_ctx,
     h_starts[i] = h_starts[i - 1] + xs[i - 1]->numel();
   }
   int64_t total_num = h_starts[xs_size];
+  auto* stable_h_starts =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(h_starts,
+                                                             xs_size + 1);
   memory_utils::Copy(dev_ctx.GetPlace(),
                      d_starts,
                      cpu_place,
-                     h_starts,
+                     stable_h_starts,
                      (xs_size + 1) * sizeof(int64_t),
                      dev_ctx.stream());
 
@@ -327,10 +337,12 @@ void CheckFiniteAndUnscaleKernel(const Context& dev_ctx,
     h_xs[i] = xs[i]->data<T>();
     h_outs[i] = dev_ctx.template Alloc<T>(outs[i]);
   }
+  auto* stable_h_xs =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(h_xs, 2 * xs_size);
   memory_utils::Copy(dev_ctx.GetPlace(),
                      d_xs,
                      cpu_place,
-                     h_xs,
+                     stable_h_xs,
                      2 * xs_size * sizeof(T*),
                      dev_ctx.stream());
 

--- a/paddle/phi/kernels/gpu/average_accumulates_kernel.cu
+++ b/paddle/phi/kernels/gpu/average_accumulates_kernel.cu
@@ -15,6 +15,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/average_accumulates_kernel.h"
 #include "paddle/phi/kernels/impl/average_accumulates_kernel_impl.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 
@@ -68,24 +69,32 @@ void SetAccumulators<GPUContext>(const GPUContext& dev_ctx,
   auto stream = dev_ctx.stream();
 
   auto cuda_place = out_old_num_accumulates->place();
+  const int64_t* stable_na =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(&num_accumulates,
+                                                             1);
   memory_utils::Copy(dev_ctx.GetPlace(),
                      out_num_accumulates_ptr,
                      CPUPlace(),
-                     &num_accumulates,
+                     stable_na,
                      sizeof(int64_t),
                      stream);
 
+  const int64_t* stable_ona =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          &old_num_accumulates, 1);
   memory_utils::Copy(dev_ctx.GetPlace(),
                      out_old_num_accumulates_ptr,
                      CPUPlace(),
-                     &old_num_accumulates,
+                     stable_ona,
                      sizeof(int64_t),
                      stream);
 
+  const int64_t* stable_nu =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(&num_updates, 1);
   memory_utils::Copy(cuda_place,
                      out_num_updates_ptr,
                      CPUPlace(),
-                     &num_updates,
+                     stable_nu,
                      sizeof(int64_t),
                      stream);
 }

--- a/paddle/phi/kernels/gpu/box_coder_kernel.cu
+++ b/paddle/phi/kernels/gpu/box_coder_kernel.cu
@@ -17,6 +17,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -215,8 +216,11 @@ void BoxCoderKernel(const Context &dev_ctx,
   float *dev_var_data = reinterpret_cast<float *>(dev_var->ptr());
   auto cplace = CPUPlace();
   const auto gplace = dev_ctx.GetPlace();
+  const float *stable_variance =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<float *>(variance.data()), variance.size());
   memory_utils::Copy(
-      gplace, dev_var_data, cplace, &variance[0], bytes, dev_ctx.stream());
+      gplace, dev_var_data, cplace, stable_variance, bytes, dev_ctx.stream());
 
   output_box->Resize({row, col, len});
   dev_ctx.template Alloc<T>(output_box);

--- a/paddle/phi/kernels/gpu/check_numerics_kernel.cu
+++ b/paddle/phi/kernels/gpu/check_numerics_kernel.cu
@@ -15,6 +15,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/check_numerics_kernel.h"
 
 #include "glog/logging.h"
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -323,8 +324,11 @@ static char* GetGpuHintStringPtr(const GPUContext& dev_ctx,
                                                 hipMemcpyHostToDevice,
                                                 dev_ctx.stream()));
 #else
+      const char* stable_str =
+          phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+              const_cast<char*>(iter->first.c_str()), op_var.length() + 1);
       PADDLE_ENFORCE_GPU_SUCCESS(cudaMemcpyAsync(gpu_str_ptr,
-                                                 iter->first.c_str(),
+                                                 stable_str,
                                                  op_var.length() + 1,
                                                  cudaMemcpyHostToDevice,
                                                  dev_ctx.stream()));

--- a/paddle/phi/kernels/gpu/cholesky_kernel.cu
+++ b/paddle/phi/kernels/gpu/cholesky_kernel.cu
@@ -23,6 +23,7 @@ limitations under the License. */
 #include <vector>
 
 #include "paddle/phi/backends/dynload/cusolver.h"
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -252,6 +253,14 @@ void CholeskyKernel(const Context& dev_ctx,
   }
 #endif
   // check the info
+  PADDLE_ENFORCE_EQ(
+      phi::backends::gpu::IsCUDAGraphCapturing(),
+      false,
+      common::errors::InvalidArgument(
+          "CholeskyKernel does not support CUDA Graph capture: async D2H copy "
+          "to local vector 'error_info' will bake the destination address into "
+          "the graph; on replay the vector is re-created at a different "
+          "address, causing a dangling-pointer write."));
   std::vector<int> error_info;
   error_info.resize(batch_count);
   memory_utils::Copy(CPUPlace(),

--- a/paddle/phi/kernels/gpu/collect_fpn_proposals_kernel.cu
+++ b/paddle/phi/kernels/gpu/collect_fpn_proposals_kernel.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/gpu/collect_fpn_proposals_kernel.h"
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/allocator.h"
@@ -236,6 +237,14 @@ void GPUCollectFpnProposalsOpKernel(
   // get length-based lod by batch ids
   GetLengthLoD<<<blocks, threads, 0, dev_ctx.stream()>>>(
       real_post_num, out_id_data, length_lod_data);
+  PADDLE_ENFORCE_EQ(
+      phi::backends::gpu::IsCUDAGraphCapturing(),
+      false,
+      common::errors::InvalidArgument(
+          "CollectFpnProposals does not support CUDA Graph capture: async D2H "
+          "copy to local vector 'length_lod_cpu' will bake the destination "
+          "address into the graph; on replay the vector is re-created at a "
+          "different address, causing a dangling-pointer write."));
   std::vector<int> length_lod_cpu(lod_size);
   phi::memory_utils::Copy(CPUPlace(),
                           length_lod_cpu.data(),

--- a/paddle/phi/kernels/gpu/distribute_fpn_proposals_kernel.cu
+++ b/paddle/phi/kernels/gpu/distribute_fpn_proposals_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/distribute_fpn_proposals_kernel.h"
 #include "paddle/common/enforce.h"
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -226,6 +227,15 @@ void DistributeFpnProposalsKernel(
 
   size_t start = 0;
 
+  PADDLE_ENFORCE_EQ(
+      phi::backends::gpu::IsCUDAGraphCapturing(),
+      false,
+      common::errors::InvalidArgument(
+          "DistributeFpnProposals does not support CUDA Graph capture: async "
+          "D2H copy to local vector 'sub_lod_list_cpu' will bake the "
+          "destination address into the graph; on replay the vector is "
+          "re-created at a different address, causing a dangling-pointer "
+          "write."));
   std::vector<int> sub_lod_list_cpu(lod_size * num_level);
   memory_utils::Copy(CPUPlace(),
                      sub_lod_list_cpu.data(),

--- a/paddle/phi/kernels/gpu/edit_distance_kernel.cu
+++ b/paddle/phi/kernels/gpu/edit_distance_kernel.cu
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -143,10 +144,12 @@ void EditDistanceKernel(const Context& dev_ctx,
       if (normalized) {
         distance = distance / n;
       }
+      const T* stable_dist =
+          phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(&distance, 1);
       memory_utils::Copy(dev_ctx.GetPlace(),
                          out_data + num,
                          CPUPlace(),
-                         &distance,
+                         stable_dist,
                          sizeof(T),
                          stream);
     } else {

--- a/paddle/phi/kernels/gpu/eig_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/eig_grad_kernel.cu
@@ -20,6 +20,7 @@
 #ifdef PADDLE_WITH_CUDA
 #include "paddle/phi/backends/dynload/cublas.h"
 #include "paddle/phi/backends/dynload/cusolver.h"
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #endif  // PADDLE_WITH_CUDA
 
 #ifdef PADDLE_WITH_HIP
@@ -211,6 +212,14 @@ void SolveLinearSystemGPU<phi::dtype::complex<float>>(
   }
 
   std::vector<int> h_info(batch_count, 0);
+  PADDLE_ENFORCE_EQ(
+      phi::backends::gpu::IsCUDAGraphCapturing(),
+      false,
+      common::errors::InvalidArgument(
+          "EigGradKernel does not support CUDA Graph capture: async D2H copy "
+          "to local vector 'h_info' will bake the destination address into the "
+          "graph; on replay the vector is re-created at a different address, "
+          "causing a dangling-pointer write."));
   phi::memory_utils::Copy(CPUPlace(),
                           h_info.data(),
                           dev_ctx.GetPlace(),
@@ -392,6 +401,14 @@ void SolveLinearSystemGPU<phi::dtype::complex<double>>(
   }
 
   std::vector<int> h_info(batch_count, 0);
+  PADDLE_ENFORCE_EQ(
+      phi::backends::gpu::IsCUDAGraphCapturing(),
+      false,
+      common::errors::InvalidArgument(
+          "EigGradKernel does not support CUDA Graph capture: async D2H copy "
+          "to local vector 'h_info' will bake the destination address into the "
+          "graph; on replay the vector is re-created at a different address, "
+          "causing a dangling-pointer write."));
   phi::memory_utils::Copy(CPUPlace(),
                           h_info.data(),
                           dev_ctx.GetPlace(),

--- a/paddle/phi/kernels/gpu/fill_diagonal_tensor_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/fill_diagonal_tensor_grad_kernel.cu
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -76,10 +77,12 @@ void FillDiagonalTensorGradKernel(const Context &dev_ctx,
     tensor_tmp.Resize({2 + matrows});
     int64_t *memory_block_cu = dev_ctx.template Alloc<int64_t>(&tensor_tmp);
     const auto gpu_place = dev_ctx.GetPlace();
+    auto *stable_mb = phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+        memory_block.data(), memory_block.size());
     memory_utils::Copy(gpu_place,
                        memory_block_cu,
                        CPUPlace(),
-                       memory_block.data(),
+                       stable_mb,
                        sizeof(int64_t) * (2 + matrows),
                        stream);
 

--- a/paddle/phi/kernels/gpu/fill_diagonal_tensor_kernel.cu
+++ b/paddle/phi/kernels/gpu/fill_diagonal_tensor_kernel.cu
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
@@ -92,10 +93,12 @@ void FillDiagonalTensorKernel(const Context &dev_ctx,
   tensor_tmp.Resize({2 + fill_dims[0]});
   int64_t *memory_block_cu = dev_ctx.template Alloc<int64_t>(&tensor_tmp);
   const auto gpu_place = dev_ctx.GetPlace();
+  auto *stable_mb = phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+      memory_block.data(), memory_block.size());
   memory_utils::Copy(gpu_place,
                      memory_block_cu,
                      CPUPlace(),
-                     memory_block.data(),
+                     stable_mb,
                      sizeof(int64_t) * (2 + fill_dims[0]),
                      stream);
 

--- a/paddle/phi/kernels/gpu/generate_proposals_kernel.cu
+++ b/paddle/phi/kernels/gpu/generate_proposals_kernel.cu
@@ -305,6 +305,14 @@ static void NMS(const GPUContext &dev_ctx,
   std::vector<uint64_t> remv(col_blocks);
   memset(&remv[0], 0, sizeof(uint64_t) * col_blocks);
 
+  PADDLE_ENFORCE_EQ(
+      phi::backends::gpu::IsCUDAGraphCapturing(),
+      false,
+      common::errors::InvalidArgument(
+          "GenerateProposals does not support CUDA Graph capture: async D2H "
+          "copy to local vector 'mask_host' will bake the destination address "
+          "into the graph; on replay the vector is re-created at a different "
+          "address, causing a dangling-pointer write."));
   std::vector<uint64_t> mask_host(boxes_num * col_blocks);
   memory_utils::Copy(CPUPlace(),
                      mask_host.data(),

--- a/paddle/phi/kernels/gpu/generate_proposals_kernel.cu
+++ b/paddle/phi/kernels/gpu/generate_proposals_kernel.cu
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <vector>
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -329,10 +330,13 @@ static void NMS(const GPUContext &dev_ctx,
   }
   keep_out->Resize({num_to_keep});
   int *keep = dev_ctx.template Alloc<int>(keep_out);
+  const int *stable_keep =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<int *>(keep_vec.data()), keep_vec.size());
   memory_utils::Copy(place,
                      keep,
                      CPUPlace(),
-                     keep_vec.data(),
+                     stable_keep,
                      sizeof(int) * num_to_keep,
                      dev_ctx.stream());
   dev_ctx.Wait();
@@ -570,10 +574,13 @@ void GenerateProposalsKernel(const Context &dev_ctx,
     rpn_rois_num->Resize({num});
     dev_ctx.template Alloc<int>(rpn_rois_num);
     int *num_data = rpn_rois_num->data<int>();
+    const int *stable_num =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            const_cast<int *>(tmp_num.data()), num);
     memory_utils::Copy(place,
                        num_data,
                        cpu_place,
-                       &tmp_num[0],
+                       stable_num,
                        sizeof(int) * num,
                        dev_ctx.stream());
     rpn_rois_num->Resize({num});

--- a/paddle/phi/kernels/gpu/moe_permute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_permute_kernel.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
@@ -582,8 +583,11 @@ void dispatch_preprocess(const Context &dev_ctx,
   padding_tokens_tensor.Resize({static_cast<int64_t>(padding_rows.size())});
   dev_ctx.template Alloc<int>(&padding_tokens_tensor);
 
+  auto *stable_padding_rows =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<int *>(padding_rows.data()), padding_rows.size());
   PADDLE_ENFORCE_GPU_SUCCESS(cudaMemcpyAsync(padding_tokens_tensor.data<int>(),
-                                             padding_rows.data(),
+                                             stable_padding_rows,
                                              sizeof(int) * padding_rows.size(),
                                              cudaMemcpyHostToDevice,
                                              dev_ctx.stream()));
@@ -795,14 +799,20 @@ void MoePermuteKernel(const Context &dev_ctx,
         expert_offset[i] = 0;
       }
     }
+    auto *stable_expert_offset =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(expert_offset,
+                                                               kMaxNumExperts);
     PADDLE_ENFORCE_GPU_SUCCESS(cudaMemcpyAsync(expert_offset_tensor.data<int>(),
-                                               expert_offset,
+                                               stable_expert_offset,
                                                sizeof(int) * kMaxNumExperts,
                                                cudaMemcpyHostToDevice,
                                                dev_ctx.stream()));
+    auto *stable_expert_offset_end =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            expert_offset_end, kMaxNumExperts);
     PADDLE_ENFORCE_GPU_SUCCESS(
         cudaMemcpyAsync(expert_offset_end_tensor.data<int>(),
-                        expert_offset_end,
+                        stable_expert_offset_end,
                         sizeof(int) * kMaxNumExperts,
                         cudaMemcpyHostToDevice,
                         dev_ctx.stream()));

--- a/paddle/phi/kernels/gpu/nms_kernel.cu
+++ b/paddle/phi/kernels/gpu/nms_kernel.cu
@@ -82,6 +82,14 @@ void NMSKernel(const Context& dev_ctx,
   uint64_t* mask_dev = reinterpret_cast<uint64_t*>(mask_data->ptr());
   NMS<T><<<grid, block, 0, dev_ctx.stream()>>>(
       boxes.data<T>(), threshold, num_boxes, mask_dev);
+  PADDLE_ENFORCE_EQ(
+      phi::backends::gpu::IsCUDAGraphCapturing(),
+      false,
+      common::errors::InvalidArgument(
+          "NMSKernel does not support CUDA Graph capture: async D2H copy to "
+          "local vector 'mask_host' will bake the destination address into the "
+          "graph; on replay the vector is re-created at a different address, "
+          "causing a dangling-pointer write."));
   std::vector<uint64_t> mask_host(num_boxes * blocks_per_line);
   memory_utils::Copy(CPUPlace(),
                      mask_host.data(),

--- a/paddle/phi/kernels/gpu/nms_kernel.cu
+++ b/paddle/phi/kernels/gpu/nms_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/nms_kernel.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -105,10 +106,13 @@ void NMSKernel(const Context& dev_ctx,
   }
   output->Resize({last_box_num});
   auto* output_data = dev_ctx.template Alloc<int64_t>(output);
+  const int64_t* stable_output =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(output_host,
+                                                             last_box_num);
   memory_utils::Copy(dev_ctx.GetPlace(),
                      output_data,
                      CPUPlace(),
-                     output_host,
+                     stable_output,
                      sizeof(int64_t) * last_box_num,
                      dev_ctx.stream());
 }

--- a/paddle/phi/kernels/gpu/partial_concat_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/partial_concat_grad_kernel.cu
@@ -14,6 +14,7 @@
 #include "paddle/phi/kernels/gpu/partial_concat_grad_kernel.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
@@ -108,11 +109,16 @@ void PartialConcatGradOpCUDAKernel(const Context &dev_ctx,
       out_data.size() * sizeof(T *),
       phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
 
+  size_t nbytes_out = out_data.size() * sizeof(T *);
+  const void *stable_out =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          reinterpret_cast<uint8_t *>(const_cast<T **>(out_data.data())),
+          nbytes_out);
   phi::memory_utils::Copy(dev_ctx.GetPlace(),
                           tmp_out_array->ptr(),
                           CPUPlace(),
-                          reinterpret_cast<void *>(out_data.data()),
-                          out_data.size() * sizeof(T *),
+                          stable_out,
+                          nbytes_out,
                           dev_ctx.stream());
 
   T **out_grad_data = reinterpret_cast<T **>(tmp_out_array->ptr());

--- a/paddle/phi/kernels/gpu/partial_concat_kernel.cu
+++ b/paddle/phi/kernels/gpu/partial_concat_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
@@ -107,11 +108,16 @@ void PartialConcatOpCUDAKernel(const Context &dev_ctx,
       dev_ctx.GetPlace(),
       in_data.size() * sizeof(T *),
       phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
+  size_t nbytes_in = in_data.size() * sizeof(T *);
+  const void *stable_in =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          reinterpret_cast<uint8_t *>(const_cast<T **>(in_data.data())),
+          nbytes_in);
   phi::memory_utils::Copy(dev_ctx.GetPlace(),
                           tmp_in_array->ptr(),
                           CPUPlace(),
-                          reinterpret_cast<void *>(in_data.data()),
-                          in_data.size() * sizeof(T *),
+                          stable_in,
+                          nbytes_in,
                           dev_ctx.stream());
 
   T **in_array_data = reinterpret_cast<T **>(tmp_in_array->ptr());

--- a/paddle/phi/kernels/gpu/roi_align_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_align_grad_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/roi_align_grad_kernel.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
@@ -252,8 +253,15 @@ void RoiAlignGradKernel(const Context& dev_ctx,
       phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
   int* roi_id_data = reinterpret_cast<int*>(roi_ptr->ptr());
   int64_t bytes = box_batch_id_list.numel() * sizeof(int);
-  memory_utils::Copy(
-      gplace, roi_id_data, cplace, box_batch_size, bytes, dev_ctx.stream());
+  const int* stable_box_batch_size =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          box_batch_size, static_cast<size_t>(bytes / sizeof(int)));
+  memory_utils::Copy(gplace,
+                     roi_id_data,
+                     cplace,
+                     stable_box_batch_size,
+                     bytes,
+                     dev_ctx.stream());
   dev_ctx.template Alloc<T>(dx);
 
   funcs::SetConstant<Context, T> set_zero;

--- a/paddle/phi/kernels/gpu/roi_align_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_align_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/roi_align_kernel.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -266,8 +267,15 @@ void RoiAlignKernel(const Context& dev_ctx,
       bytes,
       phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
   int* roi_id_data = reinterpret_cast<int*>(roi_ptr->ptr());
-  memory_utils::Copy(
-      gplace, roi_id_data, cplace, roi_batch_id_data, bytes, dev_ctx.stream());
+  const int* stable_roi_batch_id =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          roi_batch_id_data, static_cast<size_t>(bytes / sizeof(int)));
+  memory_utils::Copy(gplace,
+                     roi_id_data,
+                     cplace,
+                     stable_roi_batch_id,
+                     bytes,
+                     dev_ctx.stream());
   if (output_size > std::numeric_limits<int>::max() ||
       x.numel() > std::numeric_limits<int>::max()) {
     GPURoiAlignForward<T, int64_t><<<blocks, threads, 0, dev_ctx.stream()>>>(

--- a/paddle/phi/kernels/gpu/roi_pool_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_grad_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/roi_pool_grad_kernel.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
@@ -137,10 +138,13 @@ void RoiPoolGradKernel(const Context& dev_ctx,
         bytes,
         phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
     int* roi_id_data = reinterpret_cast<int*>(roi_ptr->ptr());
+    const int* stable_box_batch_id =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            box_batch_id_data, static_cast<size_t>(bytes / sizeof(int)));
     memory_utils::Copy(gplace,
                        roi_id_data,
                        CPUPlace(),
-                       box_batch_id_data,
+                       stable_box_batch_id,
                        bytes,
                        dev_ctx.stream());
 

--- a/paddle/phi/kernels/gpu/roi_pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/roi_pool_kernel.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -200,10 +201,13 @@ void RoiPoolKernel(const Context& dev_ctx,
       bytes,
       phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
   int* box_id_data = reinterpret_cast<int*>(box_ptr->ptr());
+  const int* stable_box_batch_id =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          box_batch_id_data, static_cast<size_t>(bytes / sizeof(int)));
   memory_utils::Copy(gplace,
                      box_id_data,
                      CPUPlace(),
-                     box_batch_id_data,
+                     stable_box_batch_id,
                      bytes,
                      dev_ctx.stream());
 

--- a/paddle/phi/kernels/gpu/seed_kernel.cu
+++ b/paddle/phi/kernels/gpu/seed_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/gpu/seed_kernel.h"
 #include "paddle/phi/backends/context_pool.h"
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
@@ -42,8 +43,14 @@ void GPUSeedKernel(const Context &dev_ctx,
   } else {
     auto *out_data = dev_ctx.template Alloc<T>(out);
     auto stream = dev_ctx.stream();
-    phi::memory_utils::Copy(
-        dev_ctx.GetPlace(), out_data, CPUPlace(), &seed, sizeof(int), stream);
+    const int *stable_seed =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(&seed, 1);
+    phi::memory_utils::Copy(dev_ctx.GetPlace(),
+                            out_data,
+                            CPUPlace(),
+                            stable_seed,
+                            sizeof(int),
+                            stream);
   }
 }
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits_grad_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/sigmoid_cross_entropy_with_logits_grad_kernel.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits.h"
 #include "paddle/phi/kernels/scale_kernel.h"
@@ -138,6 +139,15 @@ void SigmoidCrossEntropyWithLogitsGradKernel(
     funcs::ReduceKernel<T, T, kps::AddFunctor, NonzeroFunctor<T>>(
         dev_ctx, counts_tensor, &norm_tensor, NonzeroFunctor<T>(), reduce_dim);
     T *norm = dev_ctx.template Alloc<T>(&norm_tensor);
+    PADDLE_ENFORCE_EQ(
+        phi::backends::gpu::IsCUDAGraphCapturing(),
+        false,
+        common::errors::InvalidArgument(
+            "SigmoidCrossEntropyWithLogitsGrad does not support CUDA Graph "
+            "capture: async D2H copy to a locally allocated CPU buffer "
+            "'norm_cpu_mem' will bake the destination address into the graph; "
+            "on replay the allocation is re-created at a different address, "
+            "causing a dangling-pointer write."));
     auto norm_cpu_mem = phi::memory_utils::Alloc(CPUPlace(), sizeof(T));
     T *norm_cpu_ptr = reinterpret_cast<T *>(norm_cpu_mem->ptr());
     memory_utils::Copy(CPUPlace(),

--- a/paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits_kernel.cu
+++ b/paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/sigmoid_cross_entropy_with_logits_kernel.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/kernels/gpu/sigmoid_cross_entropy_with_logits.h"
 #include "paddle/phi/kernels/scale_kernel.h"
@@ -133,6 +134,15 @@ void SigmoidCrossEntropyWithLogitsKernel(
     funcs::ReduceKernel<T, T, kps::AddFunctor, NonzeroFunctor<T>>(
         dev_ctx, counts_tensor, &norm_tensor, NonzeroFunctor<T>(), reduce_dim);
     T *norm = dev_ctx.template Alloc<T>(&norm_tensor);
+    PADDLE_ENFORCE_EQ(
+        phi::backends::gpu::IsCUDAGraphCapturing(),
+        false,
+        common::errors::InvalidArgument(
+            "SigmoidCrossEntropyWithLogits does not support CUDA Graph "
+            "capture: async D2H copy to a locally allocated CPU buffer "
+            "'norm_cpu_mem' will bake the destination address into the graph; "
+            "on replay the allocation is re-created at a different address, "
+            "causing a dangling-pointer write."));
     auto norm_cpu_mem = phi::memory_utils::Alloc(CPUPlace(), sizeof(T));
     T *norm_cpu_ptr = reinterpret_cast<T *>(norm_cpu_mem->ptr());
     memory_utils::Copy(CPUPlace(),

--- a/paddle/phi/kernels/gpu/slogdeterminant_kernel.cu
+++ b/paddle/phi/kernels/gpu/slogdeterminant_kernel.cu
@@ -20,6 +20,7 @@
 
 #include "glog/logging.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
@@ -147,11 +148,17 @@ struct SlogDeterminantFunctor<phi::dtype::complex<T>, Context> {
         dev_ctx.GetPlace(),
         total_bytes,
         phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
+    size_t nbytes_ptrs_c1 = cpu_ptrs.size() * sizeof(phi::dtype::complex<T>*);
+    const void* stable_ptrs_c1 =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            reinterpret_cast<uint8_t*>(
+                const_cast<phi::dtype::complex<T>**>(cpu_ptrs.data())),
+            nbytes_ptrs_c1);
     memory_utils::Copy(dev_ctx.GetPlace(),
                        tmp_gpu_ptrs_data->ptr(),
                        CPUPlace(),
-                       static_cast<void*>(cpu_ptrs.data()),
-                       cpu_ptrs.size() * sizeof(phi::dtype::complex<T>*),
+                       stable_ptrs_c1,
+                       nbytes_ptrs_c1,
                        dev_ctx.stream());
 
     phi::dtype::complex<T>** gpu_mat_ptr =
@@ -334,11 +341,16 @@ struct SlogDeterminantV2Functor {
         dev_ctx.GetPlace(),
         total_bytes,
         phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
+    size_t nbytes_ptrs_v2 = cpu_ptrs.size() * sizeof(T*);
+    const void* stable_ptrs_v2 =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            reinterpret_cast<uint8_t*>(const_cast<T**>(cpu_ptrs.data())),
+            nbytes_ptrs_v2);
     memory_utils::Copy(dev_ctx.GetPlace(),
                        tmp_gpu_ptrs_data->ptr(),
                        CPUPlace(),
-                       static_cast<void*>(cpu_ptrs.data()),
-                       cpu_ptrs.size() * sizeof(T*),
+                       stable_ptrs_v2,
+                       nbytes_ptrs_v2,
                        dev_ctx.stream());
 
     T** gpu_mat_ptr = reinterpret_cast<T**>(tmp_gpu_ptrs_data->ptr());
@@ -488,11 +500,17 @@ struct SlogDeterminantV2Functor<phi::dtype::complex<T>, Context> {
         dev_ctx.GetPlace(),
         total_bytes,
         phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
+    size_t nbytes_ptrs_v2c = cpu_ptrs.size() * sizeof(phi::dtype::complex<T>*);
+    const void* stable_ptrs_v2c =
+        phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+            reinterpret_cast<uint8_t*>(
+                const_cast<phi::dtype::complex<T>**>(cpu_ptrs.data())),
+            nbytes_ptrs_v2c);
     memory_utils::Copy(dev_ctx.GetPlace(),
                        tmp_gpu_ptrs_data->ptr(),
                        CPUPlace(),
-                       static_cast<void*>(cpu_ptrs.data()),
-                       cpu_ptrs.size() * sizeof(phi::dtype::complex<T>*),
+                       stable_ptrs_v2c,
+                       nbytes_ptrs_v2c,
                        dev_ctx.stream());
 
     phi::dtype::complex<T>** gpu_mat_ptr =

--- a/paddle/phi/kernels/gpu/triangular_solve_kernel.cu
+++ b/paddle/phi/kernels/gpu/triangular_solve_kernel.cu
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/triangular_solve_kernel.h"
 
 #include "paddle/common/ddim.h"
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -111,11 +112,16 @@ void TriangularSolveKernel(const Context& dev_ctx,
           dev_ctx.GetPlace(),
           cpu_a_ptrs.size() * sizeof(T*),
           phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
+      size_t nbytes_a_ptrs = cpu_a_ptrs.size() * sizeof(T*);
+      const void* stable_a_ptrs =
+          phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+              reinterpret_cast<uint8_t*>(const_cast<T**>(cpu_a_ptrs.data())),
+              nbytes_a_ptrs);
       memory_utils::Copy(dev_ctx.GetPlace(),
                          gpu_a_ptrs_data->ptr(),
                          CPUPlace(),
-                         static_cast<void*>(cpu_a_ptrs.data()),
-                         cpu_a_ptrs.size() * sizeof(T*),
+                         stable_a_ptrs,
+                         nbytes_a_ptrs,
                          dev_ctx.stream());
       const T** gpu_a_ptrs =
           reinterpret_cast<const T**>(gpu_a_ptrs_data->ptr());
@@ -135,11 +141,16 @@ void TriangularSolveKernel(const Context& dev_ctx,
         for (int64_t j = 0; j < batch_size; ++j) {
           cpu_b_ptrs_for_chunk[j] = out_data + j * M * N + n_offset;
         }
+        size_t nbytes_b_ptrs = cpu_b_ptrs_for_chunk.size() * sizeof(T*);
+        const void* stable_b_ptrs =
+            phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+                reinterpret_cast<uint8_t*>(cpu_b_ptrs_for_chunk.data()),
+                nbytes_b_ptrs);
         memory_utils::Copy(dev_ctx.GetPlace(),
                            gpu_b_ptrs_data->ptr(),
                            CPUPlace(),
-                           static_cast<void*>(cpu_b_ptrs_for_chunk.data()),
-                           cpu_b_ptrs_for_chunk.size() * sizeof(T*),
+                           stable_b_ptrs,
+                           nbytes_b_ptrs,
                            dev_ctx.stream());
 
         blas.BatchedTRSM(CblasLeft,
@@ -168,11 +179,16 @@ void TriangularSolveKernel(const Context& dev_ctx,
               cpu_ptrs.size() * sizeof(T*),
               phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx.stream())));
 
+      size_t nbytes_ptrs = cpu_ptrs.size() * sizeof(T*);
+      const void* stable_ptrs =
+          phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+              reinterpret_cast<uint8_t*>(const_cast<T**>(cpu_ptrs.data())),
+              nbytes_ptrs);
       memory_utils::Copy(dev_ctx.GetPlace(),
                          tmp_gpu_ptrs_data->ptr(),
                          CPUPlace(),
-                         static_cast<void*>(cpu_ptrs.data()),
-                         cpu_ptrs.size() * sizeof(T*),
+                         stable_ptrs,
+                         nbytes_ptrs,
                          dev_ctx.stream());
 
       const T** gpu_a_ptrs =

--- a/paddle/phi/kernels/gpu/yolo_box_kernel.cu
+++ b/paddle/phi/kernels/gpu/yolo_box_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/yolo_box_kernel.h"
 
+#include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -141,8 +142,11 @@ void YoloBoxKernel(const Context& dev_ctx,
   int* anchors_data = dev_ctx.template Alloc<int>(&tmp_anchors);
   const auto gplace = dev_ctx.GetPlace();
   const auto cplace = CPUPlace();
+  const int* stable_anchors =
+      phi::backends::gpu::RestoreHostMemIfCapturingCUDAGraph(
+          const_cast<int*>(anchors.data()), anchors.size());
   memory_utils::Copy(
-      gplace, anchors_data, cplace, anchors.data(), bytes, dev_ctx.stream());
+      gplace, anchors_data, cplace, stable_anchors, bytes, dev_ctx.stream());
 
   const T* input_data = input->data<T>();
   const int* imgsize_data = img_size.data<int>();

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -4856,7 +4856,7 @@ def adaptive_log_softmax_with_loss(
         if row_indices.dim() == 0:
             row_indices.unsqueeze_(0)
 
-        if row_indices.numel() == 0:
+        if 0 in row_indices.shape:
             continue
 
         if i == 0:

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -8228,7 +8228,7 @@ def _index_fill_impl(
         if hasattr(x.place, 'is_cpu_place')
         else True
     ):
-        if index.numel() == 0:
+        if 0 in index.shape:
             return x if inplace else x.clone()
 
         if isinstance(value, (Variable, paddle.pir.Value)):


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description

#### 背景与问题

CUDA Graph 在 capture 阶段会将 stream 上的所有操作（包括异步 memcpy）连同其操作数地址一起录制到图中。在 replay 阶段，图会原样重放这些操作——包括使用录制时保存的 **host 端指针地址**。

如果 H2D（Host-to-Device）的 `cudaMemcpyAsync` 源指针指向的是局部变量（如栈上的 `std::vector<T>`、局部数组、局部标量），那么：
- capture 时：host 指针有效，图录制了该地址
- replay 时：局部变量已析构，该地址为悬空指针 → **未定义行为，可能导致数据错误或崩溃**

#### 修复方案

使用已有工具函数 `RestoreHostMemIfCapturingCUDAGraph<T>(T* host_mem, size_t count)`（位于 `cuda_graph_with_memory_pool.h`）：
- 在 CUDA Graph capture 期间：将数据复制到 `new` 分配的堆上的内存，并注册回调在图销毁时 `free` 释放；返回稳定的新指针
- 非 capture 期间：直接返回原指针，零开销

同时将 `RestoreHostMemIfCapturingCUDAGraph` 内部的内存管理从 `new/delete` 改为 `cudaHostAlloc/cudaFreeHost`，以保证 pinned memory 的正确语义。

#### 扫描范围与处理结果

对 `paddle/phi/kernels/` 下所有 `.cu`、`.cc` 及 `.h` 文件进行了全面扫描，重点查找以下模式：
- `cudaMemcpyAsync(..., cudaMemcpyHostToDevice, stream)`
- `GpuMemcpyAsync(..., cudaMemcpyHostToDevice, ...)`
- `memory_utils::Copy(dst_gpu, dst, src_cpu, src, size, stream)` （6 参数带 stream 版本）

**安全的（无需修改）**：
- 同步 `cudaMemcpy`（无 stream）：不被 CUDA Graph 捕获
- 5 参数 `memory_utils::Copy`（无 stream）：同步拷贝，不被捕获
- 通过 `phi::Copy` 的调用：已在源头修复
- 通过 `TensorFromVector` / `TensorFromArray` 的调用：已在源头修复

**修复的文件（共 33 个）**：

*核心基础设施：*
- `paddle/phi/core/tensor_utils.cc`：在 `phi::Copy` H2D 分支、`TensorFromVector`、`TensorFromArray` 中应用修复（间接覆盖所有使用这些函数的 kernel）

*GPU Kernel（直接 H2D copy）：*
- `gpu/add_n_kernel.cu`：3 处 host pointer 数组
- `gpu/amp_kernel.cu`：4 处（`h_starts`、`h_out_addrs` 等）
- `gpu/average_accumulates_kernel.cu`：3 处标量参数
- `gpu/box_coder_kernel.cu`：1 处 `std::vector<float>` variance
- `gpu/check_numerics_kernel.cu`：1 处字符串 `c_str()`
- `gpu/edit_distance_kernel.cu`：1 处局部 `T distance`
- `gpu/fill_diagonal_tensor_kernel.cu` / `_grad_kernel.cu`：各 1 处
- `gpu/generate_proposals_kernel.cu`：2 处
- `gpu/moe_permute_kernel.cu`：3 处
- `gpu/nms_kernel.cu`：1 处
- `gpu/partial_concat_kernel.cu` / `_grad_kernel.cu`：各 1 处
- `gpu/roi_align_kernel.cu` / `_grad_kernel.cu`：各 1 处
- `gpu/roi_pool_kernel.cu` / `_grad_kernel.cu`：各 1 处
- `gpu/seed_kernel.cu`：1 处
- `gpu/slogdeterminant_kernel.cu`：3 处
- `gpu/triangular_solve_kernel.cu`：3 处
- `gpu/yolo_box_kernel.cu`：1 处
- `fusion/gpu/fused_embedding_eltwise_layernorm_kernel.cu`：2 处
- `fusion/gpu/fused_seqpool_cvm_kernel.cu`：4 处
- `fusion/gpu/fused_seqpool_cvm_grad_kernel.cu`：4 处

*Header 文件（template kernel）：*
- `funcs/elementwise_grad_base.h`：7 处（strides/dims 向量）
- `funcs/fft_fill_conj.h`：4 处
- `funcs/send_recv_functor.h`：2 处
- `funcs/index_put_utils.h`：1 处
- `funcs/sparse/softmax.cu.h`：1 处
- `funcs/stride_utils.h`：1 处
- `funcs/detection/bbox_util.cu.h`：1 处

> **注：HIP 相关分支不在本次修复范围内。**

### 是否引起精度变化
否

此修复仅保证 CUDA Graph replay 时使用稳定的 host 指针，不改变任何计算逻辑，非 CUDA Graph 场景下完全无影响。