### PR TITLE
[CI] Add approval gate for `.agents/skills` changes

### DIFF
--- a/.agents/skills/paddle-pull-request/SKILL.md
+++ b/.agents/skills/paddle-pull-request/SKILL.md
@@ -7,8 +7,6 @@ description: |
 
 # Paddle 仓库 PR 创建与更新
 
-<!-- temporary verification for .agents/skills approval gate -->
-
 ## 流程
 
 ### 1. 检查分支状态

--- a/.agents/skills/paddle-pull-request/SKILL.md
+++ b/.agents/skills/paddle-pull-request/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
 # Paddle 仓库 PR 创建与更新
 
+<!-- temporary verification for .agents/skills approval gate -->
+
 ## 流程
 
 ### 1. 检查分支状态

--- a/ci/check_approval.sh
+++ b/ci/check_approval.sh
@@ -289,6 +289,12 @@ if [ "${HAS_MODIFIED_PADDLE_DISTRIBUTED}" != "" ] && [ "${PR_ID}" != "" ]; then
     check_approval 1 From00 ForFishes gongweibao sneaxiy
 fi
 
+HAS_MODIFIED_AGENTS_SKILLS=`git diff --name-only upstream/$BRANCH | grep "^\\.agents/skills/" || true`
+if [ "${HAS_MODIFIED_AGENTS_SKILLS}" != "" ] && [ "${PR_ID}" != "" ]; then
+    echo_line="You must have one RD (zrr1999, SigureMo, ShigureNyako) approval for file changes in .agents/skills.\n"
+    check_approval 1 zrr1999 SigureMo ShigureNyako
+fi
+
 ALL_PADDLE_ENFORCE=`git diff -U0 upstream/$BRANCH -- . ':!.agents/skills/' |grep "^+" |grep -zoE "PADDLE_ENFORCE\(.[^,\);]+.[^;]*\);\s" || true`
 if [ "${ALL_PADDLE_ENFORCE}" != "" ] && [ "${PR_ID}" != "" ]; then
     echo_line="PADDLE_ENFORCE is not recommended. Please use PADDLE_ENFORCE_EQ/NE/GT/GE/LT/LE or PADDLE_ENFORCE_NOT_NULL or PADDLE_ENFORCE_GPU_SUCCESS instead, see [ https://github.com/PaddlePaddle/Paddle/wiki/PADDLE_ENFORCE-Rewriting-Specification ] for details.\nYou must have one RD (luotao1 (Recommend) or zhangbo9674) approval for the usage (either add or delete) of PADDLE_ENFORCE.\n${ALL_PADDLE_ENFORCE}\n"


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Devs

### Description
This PR adds a focused approval gate in `ci/check_approval.sh` for changes under `.agents/skills`.

If a PR modifies files in `.agents/skills`, the approval check now requires at least one approval from `zrr1999`, `SigureMo`, or `ShigureNyako`.

The change is intentionally minimal and only touches the existing approval script.

@SigureMo PTAL

### 是否引起精度变化
否
