### PR TITLE
[PHI] Add `vector` and `initializer_list` overloads for `StringTensor::Resize`

### DIFF
--- a/paddle/phi/core/string_tensor.cc
+++ b/paddle/phi/core/string_tensor.cc
@@ -108,6 +108,15 @@ StringTensor& StringTensor::Resize(const DDim& dims) {
   meta_.dims = dims;
   return *this;
 }
+
+StringTensor& Resize(const std::vector<int64_t>& dims) {
+  return common::make_ddim(dims);
+}
+
+StringTensor& Resize(const std::vector<int>& dims) {
+  return common::make_ddim(dims);
+}
+
 // TODO(zhoushunjie): need to remove it for general space
 void StringTensor::init_holder() {
   void* ptr = holder_->ptr();

--- a/paddle/phi/core/string_tensor.cc
+++ b/paddle/phi/core/string_tensor.cc
@@ -110,11 +110,11 @@ StringTensor& StringTensor::Resize(const DDim& dims) {
 }
 
 StringTensor& Resize(const std::vector<int64_t>& dims) {
-  return common::make_ddim(dims);
+  return Resize(common::make_ddim(dims));
 }
 
 StringTensor& Resize(const std::vector<int>& dims) {
-  return common::make_ddim(dims);
+  return Resize(common::make_ddim(dims));
 }
 
 // TODO(zhoushunjie): need to remove it for general space

--- a/paddle/phi/core/string_tensor.cc
+++ b/paddle/phi/core/string_tensor.cc
@@ -110,11 +110,11 @@ StringTensor& StringTensor::Resize(const DDim& dims) {
 }
 
 StringTensor& Resize(const std::vector<int64_t>& dims) {
-  return Resize(common::make_ddim(dims));
+  return Resize(make_ddim(dims));
 }
 
 StringTensor& Resize(const std::vector<int>& dims) {
-  return Resize(common::make_ddim(dims));
+  return Resize(make_ddim(dims));
 }
 
 // TODO(zhoushunjie): need to remove it for general space

--- a/paddle/phi/core/string_tensor.cc
+++ b/paddle/phi/core/string_tensor.cc
@@ -109,6 +109,10 @@ StringTensor& StringTensor::Resize(const DDim& dims) {
   return *this;
 }
 
+StringTensor& StringTensor::Resize(const std::initializer_list<int64_t> dims) {
+  return Resize(make_ddim(dims));
+}
+
 StringTensor& StringTensor::Resize(const std::vector<int64_t>& dims) {
   return Resize(make_ddim(dims));
 }

--- a/paddle/phi/core/string_tensor.cc
+++ b/paddle/phi/core/string_tensor.cc
@@ -109,11 +109,11 @@ StringTensor& StringTensor::Resize(const DDim& dims) {
   return *this;
 }
 
-StringTensor& Resize(const std::vector<int64_t>& dims) {
+StringTensor& StringTensor::Resize(const std::vector<int64_t>& dims) {
   return Resize(make_ddim(dims));
 }
 
-StringTensor& Resize(const std::vector<int>& dims) {
+StringTensor& StringTensor::Resize(const std::vector<int>& dims) {
   return Resize(make_ddim(dims));
 }
 

--- a/paddle/phi/core/string_tensor.h
+++ b/paddle/phi/core/string_tensor.h
@@ -112,6 +112,10 @@ class PADDLE_API StringTensor
 
   StringTensor& Resize(const DDim& dims);
 
+  StringTensor& Resize(const std::vector<int64_t>& dims);
+
+  StringTensor& Resize(const std::vector<int>& dims);
+
   /// \brief Returns the actual storage size occupied by tensor, may be larger
   /// than its shape dims.
   /// \return The actual storage size occupied by tensor.

--- a/paddle/phi/core/string_tensor.h
+++ b/paddle/phi/core/string_tensor.h
@@ -112,6 +112,8 @@ class PADDLE_API StringTensor
 
   StringTensor& Resize(const DDim& dims);
 
+  StringTensor& Resize(const std::initializer_list<int64_t> dims);
+
   StringTensor& Resize(const std::vector<int64_t>& dims);
 
   StringTensor& Resize(const std::vector<int>& dims);

--- a/paddle/phi/kernels/strings/strings_empty_kernel.cc
+++ b/paddle/phi/kernels/strings/strings_empty_kernel.cc
@@ -23,7 +23,7 @@ template <typename Context>
 void EmptyKernel(const Context& dev_ctx,
                  const IntArray& shape,
                  StringTensor* out) {
-  out->Resize(make_ddim(shape.GetData()));
+  out->Resize(shape.GetData());
   dev_ctx.template Alloc<dtype::pstring>(out);
 }
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
StringTensor Resize 增加 std::vector<int64_t> 参数支持

### 是否引起精度变化
否