### PR TITLE
[CI] Clean inactive reviewer routing to avoid pinging inactive developers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,18 +31,18 @@ paddle/fluid/prim/api/api.yaml @xiaoguoguo626807 @JiabinYang @zhangbo9674
 paddle/fluid/prim/api/composite_backward/composite_backward_api.h @xiaoguoguo626807 @JiabinYang
 paddle/fluid/prim/api/composite_backward/composite_double_backward_api.h @xiaoguoguo626807 @JiabinYang
 paddle/fluid/prim/api/manual_prim/prim_manual_api.h @xiaoguoguo626807 @JiabinYang
-paddle/phi/api/include/tensor.h @zhangbo9674 @zyfncg @YuanRisheng
-paddle/phi/core/attribute.h @zhangbo9674 @zyfncg @YuanRisheng
-paddle/phi/core/dense_tensor.h @zhangbo9674 @zyfncg @YuanRisheng
-paddle/phi/core/device_context.h @zhangbo9674 @zyfncg @YuanRisheng
-paddle/phi/core/infermeta_utils.h @zhangbo9674 @zyfncg @YuanRisheng
-paddle/phi/core/kernel_context.h @zhangbo9674 @zyfncg @YuanRisheng
-paddle/phi/core/kernel_factory.h @zhangbo9674 @zyfncg @YuanRisheng
-paddle/phi/core/kernel_registry.h @zhangbo9674 @zyfncg @YuanRisheng
-paddle/phi/core/kernel_utils.h @zhangbo9674 @zyfncg @YuanRisheng
-paddle/phi/core/meta_tensor.h @zhangbo9674 @zyfncg @YuanRisheng
-paddle/phi/core/tensor_base.h @zhangbo9674 @zyfncg @YuanRisheng
-paddle/phi/core/tensor_meta.h @zhangbo9674 @zyfncg @YuanRisheng
+paddle/phi/api/include/tensor.h @zhangbo9674
+paddle/phi/core/attribute.h @zhangbo9674
+paddle/phi/core/dense_tensor.h @zhangbo9674
+paddle/phi/core/device_context.h @zhangbo9674
+paddle/phi/core/infermeta_utils.h @zhangbo9674
+paddle/phi/core/kernel_context.h @zhangbo9674
+paddle/phi/core/kernel_factory.h @zhangbo9674
+paddle/phi/core/kernel_registry.h @zhangbo9674
+paddle/phi/core/kernel_utils.h @zhangbo9674
+paddle/phi/core/meta_tensor.h @zhangbo9674
+paddle/phi/core/tensor_base.h @zhangbo9674
+paddle/phi/core/tensor_meta.h @zhangbo9674
 paddle/phi/infermeta/spmd_rules @LiYuRio @ForFishes @From00
 paddle/scripts/paddle_build.bat @zhwesky2010 @wanghuancoder
 paddle/scripts/paddle_build.sh @risemeup1 @zhangbo9674 @XieYunshen

--- a/.github/workflows/check-bypass.yml
+++ b/.github/workflows/check-bypass.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
     env:
-      CI_TEAM_MEMBERS: '["swgu98", "risemeup1" , "XieYunshen", "luotao1", "ooooo-create", "SigureMo"]'
+      CI_TEAM_MEMBERS: '["swgu98", "risemeup1" , "XieYunshen", "luotao1", "SigureMo"]'
     outputs:
       can-skip: ${{ steps.check-bypass.outputs.can-skip }}
     timeout-minutes: 3

--- a/ci/check_approval.sh
+++ b/ci/check_approval.sh
@@ -90,8 +90,8 @@ CI_OLD_SCRIPTS_COVERAGE=$(git diff --name-only upstream/$BRANCH | grep -E "tools
 CI_OLD_SCRIPTS_TOOLS=$(git diff --name-only upstream/$BRANCH | grep -E "tools" | grep "check_")
 
 if [ -n "$CI_OLD_SCRIPTS_PADDLE_BUILD" ] || [ -n "$CI_OLD_SCRIPTS_COVERAGE" ] || [ -n "$CI_OLD_SCRIPTS_TOOLS" ]; then
-    echo_line="You must have one RD (swgu98, ooooo-create) approval for the old CI scripts.\n"
-    check_approval 1 swgu98 ooooo-create
+    echo_line="You must have one RD (swgu98) approval for the old CI scripts.\n"
+    check_approval 1 swgu98
 fi
 
 HAS_MODIFIED_LINUX_NPU_YML=$(git diff --name-only upstream/$BRANCH | grep ".github/workflows/_Linux-NPU.yml" || true)
@@ -351,8 +351,8 @@ if [ "${HAS_MODIFIED_PY_OR_CPP_FILES}" != "" ] && [ "${PR_ID}" != "" ]; then
         echo_line=${echo_line}${error_lines}"\n"
         echo_line=${echo_line}"You can run following command to fix the errors:\n"
         echo_line=${echo_line}"    python tools/check_code_block_format.py "$(echo ${HAS_MODIFIED_PY_OR_CPP_FILES} | tr "\n" " ")"\n"
-        echo_line=${echo_line}"If you believe this is a false positive, please request one of the RD (sunzhongkai588, SigureMo, ooooo-create) approval for the changes.\n"
-        check_approval 1 sunzhongkai588 SigureMo ooooo-create
+        echo_line=${echo_line}"If you believe this is a false positive, please request one of the RD (sunzhongkai588, SigureMo) approval for the changes.\n"
+        check_approval 1 sunzhongkai588 SigureMo
     fi
 fi
 

--- a/ci/check_approval.sh
+++ b/ci/check_approval.sh
@@ -90,8 +90,8 @@ CI_OLD_SCRIPTS_COVERAGE=$(git diff --name-only upstream/$BRANCH | grep -E "tools
 CI_OLD_SCRIPTS_TOOLS=$(git diff --name-only upstream/$BRANCH | grep -E "tools" | grep "check_")
 
 if [ -n "$CI_OLD_SCRIPTS_PADDLE_BUILD" ] || [ -n "$CI_OLD_SCRIPTS_COVERAGE" ] || [ -n "$CI_OLD_SCRIPTS_TOOLS" ]; then
-    echo_line="You must have one RD (swgu98) approval for the old CI scripts.\n"
-    check_approval 1 swgu98
+    echo_line="You must have one RD (swgu98 or risemeup1) approval for the old CI scripts.\n"
+    check_approval 1 swgu98 risemeup1
 fi
 
 HAS_MODIFIED_LINUX_NPU_YML=$(git diff --name-only upstream/$BRANCH | grep ".github/workflows/_Linux-NPU.yml" || true)

--- a/ci/check_whl_size.sh
+++ b/ci/check_whl_size.sh
@@ -27,12 +27,12 @@ function check_whl_size() {
     whldiffSize=`echo $(($pr_whl_size - $dev_whl_size))`
     if [ ${whldiffSize} -gt 10 ]; then
        approval_line=`curl -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${PR_ID}/reviews?per_page=10000`
-       APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 risemeup1 swgu98 ooooo-create`
+       APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 risemeup1 swgu98`
        echo "current pr ${PR_ID} got approvals: ${APPROVALS}"
        if [ "${APPROVALS}" == "FALSE" ]; then
            echo "=========================================================================================="
            echo "This PR make the release paddlepaddle whl size growth exceeds 10 M."
-           echo "Then you must have one RD (risemeup1 or swgu98 or ooooo-create) approval for this PR\n"
+           echo "Then you must have one RD (risemeup1 or swgu98) approval for this PR\n"
            echo "=========================================================================================="
            exit 6
        fi

--- a/ci/coverage_build_size_approval.sh
+++ b/ci/coverage_build_size_approval.sh
@@ -30,12 +30,12 @@ diff_coverage_build_size=`echo $(($pr_coverage_build_size - $dev_coverage_build_
 set +x
 if [ ${diff_coverage_build_size} -gt 3 ]; then
     approval_line=`curl -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000`
-    APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 swgu98 luotao1 risemeup1 ooooo-create`
+    APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 swgu98 luotao1 risemeup1`
     echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
     if [ "${APPROVALS}" == "FALSE" ]; then
         echo "=========================================================================================="
         echo "This PR make the release paddlepaddle coverage build size growth exceeds 3 G, please explain why your PR exceeds 3G to ext_ppee@baidu.com and in PR description."
-        echo "Then you must have one RD (swgu98 (Recommend) or luotao1 or risemeup1 or ooooo-create) approval for this PR\n"
+        echo "Then you must have one RD (swgu98 (Recommend) or luotao1 or risemeup1) approval for this PR\n"
         echo "=========================================================================================="
         exit 6
     fi

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1138,12 +1138,12 @@ function check_whl_size() {
     whldiffSize=`echo $(($pr_whl_size - $dev_whl_size))`
     if [ ${whldiffSize} -gt 10 ]; then
        approval_line=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000`
-       APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 risemeup1 swgu98 ooooo-create`
+       APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 risemeup1 swgu98`
        echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
        if [ "${APPROVALS}" == "FALSE" ]; then
            echo "=========================================================================================="
            echo "This PR make the release paddlepaddle whl size growth exceeds 10 M."
-           echo "Then you must have one RD (risemeup1 or swgu98 or ooooo-create) approval for this PR\n"
+           echo "Then you must have one RD (risemeup1 or swgu98) approval for this PR\n"
            echo "=========================================================================================="
            exit 6
        fi
@@ -4096,12 +4096,12 @@ function check_coverage_build() {
     set +x
     if [ ${diff_coverage_build_size} -gt 3 ]; then
         approval_line=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000`
-        APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 swgu98 luotao1 risemeup1 ooooo-create`
+        APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 swgu98 luotao1 risemeup1`
         echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
         if [ "${APPROVALS}" == "FALSE" ]; then
             echo "=========================================================================================="
             echo "This PR make the release paddlepaddle coverage build size growth exceeds 3 G, please explain why your PR exceeds 3G to ext_ppee@baidu.com and in PR description."
-            echo "Then you must have one RD (swgu98 (Recommend) or luotao1 or risemeup1 or ooooo-create) approval for this PR\n"
+            echo "Then you must have one RD (swgu98 (Recommend) or luotao1 or risemeup1) approval for this PR\n"
             echo "=========================================================================================="
             exit 6
         fi

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -69,8 +69,8 @@ fi
 
 op_kernel_dtype_spec_diff=`python ${PADDLE_ROOT}/tools/check_op_kernel_same_dtypes.py ${PADDLE_ROOT}/paddle/fluid/OP_KERNEL_DTYPE_DEV.spec  ${PADDLE_ROOT}/paddle/fluid/OP_KERNEL_DTYPE_PR.spec`
 if [ "$op_kernel_dtype_spec_diff" != "" ]; then
-    echo_line="You have added or modified Op Kernel, resulting in inconsistent data types supported by the forward and backward kernels of the same op, such modifications are not allowed in principle. If it is a mismatch, please request one RD (Aurelius84 or zyfncg) review and approve. Including the following kernels:\n${op_kernel_dtype_spec_diff}\n"
-    check_approval 1 Aurelius84 zyfncg
+    echo_line="You have added or modified Op Kernel, resulting in inconsistent data types supported by the forward and backward kernels of the same op, such modifications are not allowed in principle. If it is a mismatch, please request one RD (Aurelius84) review and approve. Including the following kernels:\n${op_kernel_dtype_spec_diff}\n"
+    check_approval 1 Aurelius84
 fi
 
 op_desc_diff=`python ${PADDLE_ROOT}/tools/check_op_desc.py ${PADDLE_ROOT}/paddle/fluid/OP_DESC_DEV.spec  ${PADDLE_ROOT}/paddle/fluid/OP_DESC_PR.spec`

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -63,8 +63,8 @@ fi
 
 op_type_spec_diff=`python ${PADDLE_ROOT}/tools/check_op_register_type.py ${PADDLE_ROOT}/paddle/fluid/OP_TYPE_DEV.spec  ${PADDLE_ROOT}/paddle/fluid/OP_TYPE_PR.spec`
 if [ "$op_type_spec_diff" != "" ]; then
-    echo_line="You must have one RD (Aurelius84 (Recommend) or zhhsplendid)approval for the data_type registration of new operator. More data_type of new operator should be registered in your PR. Please make sure that both float/double (or int/int64_t) have been registered.\n For more details, please click [https://github.com/PaddlePaddle/Paddle/wiki/Data-types-of-generic-Op-must-be-fully-registered].\n"
-    check_approval 1 Aurelius84 zhhsplendid
+    echo_line="You must have one RD (wanghuancoder or SigureMo) approval for the data_type registration of new operator. More data_type of new operator should be registered in your PR. Please make sure that both float/double (or int/int64_t) have been registered.\n For more details, please click [https://github.com/PaddlePaddle/Paddle/wiki/Data-types-of-generic-Op-must-be-fully-registered].\n"
+    check_approval 1 wanghuancoder SigureMo
 fi
 
 op_kernel_dtype_spec_diff=`python ${PADDLE_ROOT}/tools/check_op_kernel_same_dtypes.py ${PADDLE_ROOT}/paddle/fluid/OP_KERNEL_DTYPE_DEV.spec  ${PADDLE_ROOT}/paddle/fluid/OP_KERNEL_DTYPE_PR.spec`

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -69,8 +69,8 @@ fi
 
 op_kernel_dtype_spec_diff=`python ${PADDLE_ROOT}/tools/check_op_kernel_same_dtypes.py ${PADDLE_ROOT}/paddle/fluid/OP_KERNEL_DTYPE_DEV.spec  ${PADDLE_ROOT}/paddle/fluid/OP_KERNEL_DTYPE_PR.spec`
 if [ "$op_kernel_dtype_spec_diff" != "" ]; then
-    echo_line="You have added or modified Op Kernel, resulting in inconsistent data types supported by the forward and backward kernels of the same op, such modifications are not allowed in principle. If it is a mismatch, please request one RD (Aurelius84) review and approve. Including the following kernels:\n${op_kernel_dtype_spec_diff}\n"
-    check_approval 1 Aurelius84
+    echo_line="You have added or modified Op Kernel, resulting in inconsistent data types supported by the forward and backward kernels of the same op, such modifications are not allowed in principle. If it is a mismatch, please request one RD (wanghuancoder or SigureMo) review and approve. Including the following kernels:\n${op_kernel_dtype_spec_diff}\n"
+    check_approval 1 wanghuancoder SigureMo
 fi
 
 op_desc_diff=`python ${PADDLE_ROOT}/tools/check_op_desc.py ${PADDLE_ROOT}/paddle/fluid/OP_DESC_DEV.spec  ${PADDLE_ROOT}/paddle/fluid/OP_DESC_PR.spec`


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Devs

### Description
This PR cleans inactive reviewer routing entries to avoid continuing to ping inactive developers.

It includes the following focused cleanup:
- remove inactive `zyfncg` and `YuanRisheng` from the PHI core/header `CODEOWNERS` entries
- integrate the still-applicable reviewer/approval cleanup from #77653 by removing inactive `ooooo-create` from approval and CI bypass allowlists
- remove inactive `zyfncg` from `tools/check_api_approvals.sh` so op-kernel dtype mismatch approval no longer routes to an inactive reviewer

The goal is to keep CODEOWNERS / approval routing accurate and avoid continuing to disturb inactive developers with automatic review or approval requests.

Note: #77653 also updated `.github/actions/check-bypass/action.yml`, but that file is no longer present in current `develop`; the equivalent current cleanup is applied in `.github/workflows/check-bypass.yml`.

### 是否引起精度变化
否
