### PR TITLE
[Performance] Optimize index_fill GPU kernel and Python API

### DIFF
--- a/paddle/phi/kernels/gpu/index_fill_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_fill_kernel.cu
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/index_fill_kernel.h"
+#include <climits>
+
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/common/data_type.h"
@@ -20,7 +21,7 @@
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
-#include "paddle/phi/kernels/funcs/index_fill_util.h"
+#include "paddle/phi/kernels/index_fill_kernel.h"
 
 namespace phi {
 
@@ -42,46 +43,77 @@ namespace phi {
 //
 //   Total threads = outer_size * index_size * inner_size
 //   (one thread per element that needs to be filled)
-template <typename T>
+//
+// IndexT: int32_t when numel <= INT32_MAX (faster mod/div on GPU),
+//         int64_t otherwise.
+// IndT:   matches index tensor dtype (int32_t or int64_t), avoids a
+//         CastToInt64 kernel launch when the user supplies int32 indices.
+template <typename T, typename IndexT, typename IndT>
 __global__ void IndexFillCudaKernel(const T* x,
-                                    const int64_t* index,
-                                    const int64_t index_size,
+                                    const IndT* index,
+                                    const IndexT index_size,
                                     const int dim,
-                                    const int64_t outer_size,
+                                    const IndexT outer_size,
                                     const int64_t dim_size,
-                                    const int64_t inner_size,
+                                    const IndexT inner_size,
                                     const T fill_value,
                                     T* out) {
-  int64_t idx =
-      static_cast<int64_t>(threadIdx.x) +
-      static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x);
-  int64_t total = index_size * outer_size * inner_size;
+  IndexT idx =
+      static_cast<IndexT>(threadIdx.x) +
+      static_cast<IndexT>(blockIdx.x) * static_cast<IndexT>(blockDim.x);
+  IndexT total = index_size * outer_size * inner_size;
   if (idx >= total) return;
 
   // Decompose the flat thread index into the three logical coordinates.
   // The iteration order is: outer (slowest) → index → inner (fastest).
-  int64_t inner_idx = idx % inner_size;
-  int64_t temp = idx / inner_size;
-  int64_t index_idx = temp % index_size;
-  int64_t outer_idx = temp / index_size;
+  IndexT inner_idx = idx % inner_size;
+  IndexT temp = idx / inner_size;
+  IndexT index_idx = temp % index_size;
+  IndexT outer_idx = temp / index_size;
 
   // Look up the actual position along the target dimension from the index
-  // tensor.
-  int64_t dim_idx = index[index_idx];
+  // tensor. Widen to int64 for the bounds check against dim_size.
+  int64_t dim_idx = static_cast<int64_t>(index[index_idx]);
   if (dim_idx < 0) dim_idx += dim_size;  // support negative indexing
 
   if (dim_idx < 0 || dim_idx >= dim_size) return;  // out-of-bounds guard
 
   // Convert the 3D logical coordinate back to a flat memory offset.
-  int64_t offset =
-      outer_idx * dim_size * inner_size + dim_idx * inner_size + inner_idx;
+  IndexT offset = outer_idx * static_cast<IndexT>(dim_size) * inner_size +
+                  static_cast<IndexT>(dim_idx) * inner_size + inner_idx;
 
   out[offset] = fill_value;
 }
 
 // Host-side launch function: computes the three-segment sizes and launches
-// the CUDA kernel.
-template <typename T, typename Context>
+// the CUDA kernel with the appropriate index types (IndexT, IndT).
+template <typename T, typename Context, typename IndexT, typename IndT>
+void LaunchIndexFillCudaKernelImpl(const Context& dev_ctx,
+                                   const T* x_data,
+                                   const IndT* index_data,
+                                   IndexT index_size,
+                                   int dim,
+                                   IndexT outer_size,
+                                   int64_t dim_size,
+                                   IndexT inner_size,
+                                   T fill_value,
+                                   T* out_data) {
+  IndexT numel = outer_size * index_size * inner_size;
+  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
+  IndexFillCudaKernel<T, IndexT, IndT>
+      <<<config.block_per_grid, config.thread_per_block, 0, dev_ctx.stream()>>>(
+          x_data,
+          index_data,
+          index_size,
+          dim,
+          outer_size,
+          dim_size,
+          inner_size,
+          fill_value,
+          out_data);
+}
+
+template <typename T, typename Context, typename IndT>
 void LaunchIndexFillCudaKernel(const Context& dev_ctx,
                                const DenseTensor& x,
                                int dim,
@@ -100,7 +132,7 @@ void LaunchIndexFillCudaKernel(const Context& dev_ctx,
     Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
   }
 
-  auto* index_data = index.data<int64_t>();
+  const IndT* index_data = index.data<IndT>();
   int64_t index_size = index.numel();
 
   if (index_size == 0) {
@@ -126,21 +158,35 @@ void LaunchIndexFillCudaKernel(const Context& dev_ctx,
     inner_size *= x_dims[i];
   }
 
-  // Each thread handles one (outer, index_element, inner) triple.
-  int64_t numel = outer_size * index_size * inner_size;
+  // Select int32 index arithmetic when the total work fits in 32 bits —
+  // GPU mod/div on 32-bit integers is significantly faster than on 64-bit.
+  const int64_t numel = x.numel();
+  constexpr int64_t kInt32Max = static_cast<int64_t>(INT32_MAX);
 
-  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
-  IndexFillCudaKernel<T>
-      <<<config.block_per_grid, config.thread_per_block, 0, dev_ctx.stream()>>>(
-          x_data,
-          index_data,
-          index_size,
-          dim,
-          outer_size,
-          dim_size,
-          inner_size,
-          fill_value,
-          out_data);
+  if (numel <= kInt32Max) {
+    LaunchIndexFillCudaKernelImpl<T, Context, int32_t, IndT>(
+        dev_ctx,
+        x_data,
+        index_data,
+        static_cast<int32_t>(index_size),
+        dim,
+        static_cast<int32_t>(outer_size),
+        dim_size,
+        static_cast<int32_t>(inner_size),
+        fill_value,
+        out_data);
+  } else {
+    LaunchIndexFillCudaKernelImpl<T, Context, int64_t, IndT>(dev_ctx,
+                                                             x_data,
+                                                             index_data,
+                                                             index_size,
+                                                             dim,
+                                                             outer_size,
+                                                             dim_size,
+                                                             inner_size,
+                                                             fill_value,
+                                                             out_data);
+  }
 }
 
 // Top-level kernel entry: validates inputs and dispatches to the launcher.
@@ -194,36 +240,18 @@ void IndexFillKernel(const Context& dev_ctx,
     return;
   }
 
-  // The kernel requires int64 indices. If the user passes int32 indices,
-  // cast them to int64 via a lightweight GPU kernel (CastToInt64Kernel).
-  DenseTensor index_int64;
-  const DenseTensor* ptr_index = nullptr;
-
+  // Dispatch directly on index dtype — no cast kernel needed.
   if (index.dtype() == phi::DataType::INT32) {
-    index_int64.Resize(index.dims());
-    dev_ctx.template Alloc<int64_t>(&index_int64);
-
-    int64_t index_numel = index.numel();
-    auto config =
-        phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, index_numel);
-
-    phi::funcs::CastToInt64Kernel<int32_t><<<config.block_per_grid,
-                                             config.thread_per_block,
-                                             0,
-                                             dev_ctx.stream()>>>(
-        index.data<int32_t>(), index_int64.data<int64_t>(), index_numel);
-
-    ptr_index = &index_int64;
+    LaunchIndexFillCudaKernel<T, Context, int32_t>(
+        dev_ctx, x, real_dim, index, value, out);
   } else if (index.dtype() == phi::DataType::INT64) {
-    ptr_index = &index;
+    LaunchIndexFillCudaKernel<T, Context, int64_t>(
+        dev_ctx, x, real_dim, index, value, out);
   } else {
     PADDLE_THROW(common::errors::InvalidArgument(
         "The dtype of index must be int32 or int64, but received %s.",
         phi::DataTypeToString(index.dtype())));
   }
-
-  LaunchIndexFillCudaKernel<T, Context>(
-      dev_ctx, x, real_dim, *ptr_index, value, out);
 }
 }  // namespace phi
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -8223,16 +8223,19 @@ for name, func in __METHODS.items():
 
 
 def _index_fill_impl(
-    x: Tensor, index: Tensor, axis: int, value: Tensor, inplace: bool
+    x: Tensor,
+    index: Tensor,
+    axis: int,
+    value: bool | complex | Tensor,
+    inplace: bool,
 ) -> Tensor:
     if not isinstance(index, (Variable, paddle.pir.Value)):
         raise ValueError("index must be Tensor")
 
-    if not isinstance(value, Variable):
-        value = paddle.to_tensor(value, dtype=x.dtype)
-    else:
-        if len(value.shape) > 0:
+    if isinstance(value, (Variable, paddle.pir.Value)):
+        if value.numel() != 1:
             raise ValueError("value must be scalar or 0-D tensor")
+        value = value.item()
 
     x_dim = len(x.shape)
     if not (isinstance(axis, int)) or (axis > x_dim - 1) or axis < -x_dim:
@@ -8255,28 +8258,6 @@ def _index_fill_impl(
     ):
         if 0 in index.shape:
             return x if inplace else x.clone()
-
-        if isinstance(value, (Variable, paddle.pir.Value)):
-            if value.numel() != 1:
-                raise ValueError("value must be scalar or 0-D tensor")
-            value = value.item()
-        if x.dtype in [
-            paddle.int8,
-            paddle.int16,
-            paddle.int32,
-            paddle.int64,
-            paddle.uint8,
-        ]:
-            value = int(value)
-        elif x.dtype == paddle.bool:
-            value = bool(value)
-        elif x.dtype in [
-            paddle.complex64,
-            paddle.complex128,
-        ]:
-            value = complex(value)
-        else:
-            value = float(value)
 
         if inplace:
             return _C_ops.index_fill_(x, index, axis, value)

--- a/test/legacy_test/test_index_fill.py
+++ b/test/legacy_test/test_index_fill.py
@@ -600,5 +600,135 @@ class TestIndexFillGradInt32IndexAxis1(TestIndexFillGradBase):
         self.axis = 1
 
 
+class TestIndexFillOptimizationCorrectness(unittest.TestCase):
+    """Tests specifically targeting the optimization changes:
+    1. IndexT template (int32 vs int64 based on numel)
+    2. IndT template (int32/int64 index without CastToInt64)
+    3. Python-side value handling (no to_tensor roundtrip)
+    """
+
+    def _run_and_check(self, x_np, index_np, axis, value, dtype_np='float64'):
+        ref = compute_index_fill_ref(x_np, axis, index_np, value)
+        for place in get_all_devices():
+            paddle.device.set_device(place)
+            x_pd = paddle.to_tensor(x_np)
+            idx_pd = paddle.to_tensor(index_np)
+            res = paddle.index_fill(x_pd, idx_pd, axis, value)
+            np.testing.assert_allclose(res.numpy(), ref, rtol=1e-5)
+
+    def test_int32_index_direct_pass(self):
+        """IndT=int32: index with int32 dtype should work without cast."""
+        paddle.disable_static()
+        x_np = np.random.random((8, 10)).astype('float64')
+        index_np = np.array([1, 3, 5], dtype='int32')
+        self._run_and_check(x_np, index_np, axis=0, value=-1.0)
+        paddle.enable_static()
+
+    def test_int64_index_direct_pass(self):
+        """IndT=int64: index with int64 dtype should work directly."""
+        paddle.disable_static()
+        x_np = np.random.random((8, 10)).astype('float64')
+        index_np = np.array([0, 4, 7], dtype='int64')
+        self._run_and_check(x_np, index_np, axis=0, value=2.5)
+        paddle.enable_static()
+
+    def test_small_numel_int32_path(self):
+        """IndexT=int32: small tensor numel fits in int32."""
+        paddle.disable_static()
+        x_np = np.random.random((16, 32, 8)).astype('float64')
+        index_np = np.array([0, 5, 10, 15], dtype='int64')
+        self._run_and_check(x_np, index_np, axis=1, value=-0.5)
+        paddle.enable_static()
+
+    def test_value_python_float(self):
+        """Python float value should pass directly without to_tensor."""
+        paddle.disable_static()
+        x_np = np.random.random((4, 6)).astype('float32')
+        index_np = np.array([1, 3], dtype='int64')
+        self._run_and_check(x_np, index_np, axis=1, value=3.14)
+        paddle.enable_static()
+
+    def test_value_python_int(self):
+        """Python int value should pass directly."""
+        paddle.disable_static()
+        x_np = np.random.randint(0, 100, (5, 8)).astype('int64')
+        index_np = np.array([0, 2, 4], dtype='int64')
+        self._run_and_check(x_np, index_np, axis=0, value=999)
+        paddle.enable_static()
+
+    def test_value_python_bool(self):
+        """Python bool value should work with bool tensor."""
+        paddle.disable_static()
+        x_np = np.random.choice([True, False], size=(4, 6)).astype('bool')
+        index_np = np.array([1, 3], dtype='int64')
+        self._run_and_check(x_np, index_np, axis=0, value=True)
+        paddle.enable_static()
+
+    def test_value_zero_dim_tensor(self):
+        """0-D Tensor value should be extracted via .item()."""
+        paddle.disable_static()
+        for place in get_all_devices():
+            paddle.device.set_device(place)
+            x_np = np.random.random((6, 8)).astype('float64')
+            index_np = np.array([2, 5], dtype='int64')
+            x_pd = paddle.to_tensor(x_np)
+            idx_pd = paddle.to_tensor(index_np)
+            val_pd = paddle.to_tensor(-7.0)
+            res = paddle.index_fill(x_pd, idx_pd, axis=0, value=val_pd)
+            ref = compute_index_fill_ref(x_np, 0, index_np, -7.0)
+            np.testing.assert_allclose(res.numpy(), ref)
+        paddle.enable_static()
+
+    def test_inplace_with_scalar_value(self):
+        """Inplace variant should also work with scalar value."""
+        paddle.disable_static()
+        for place in get_all_devices():
+            paddle.device.set_device(place)
+            x_np = np.random.random((4, 5)).astype('float64')
+            index_np = np.array([0, 3], dtype='int32')
+            x_pd = paddle.to_tensor(x_np)
+            idx_pd = paddle.to_tensor(index_np)
+            paddle.index_fill_(x_pd, idx_pd, axis=1, value=-2.0)
+            ref = compute_index_fill_ref(x_np, 1, index_np, -2.0)
+            np.testing.assert_allclose(x_pd.numpy(), ref)
+        paddle.enable_static()
+
+    def test_int32_index_with_various_dtypes(self):
+        """int32 index with float16/float32/float64/int32/int64 tensors."""
+        paddle.disable_static()
+        index_np = np.array([0, 2], dtype='int32')
+        for dtype in ['float32', 'float64', 'int32', 'int64']:
+            if dtype.startswith('int'):
+                x_np = np.random.randint(0, 50, (5, 4)).astype(dtype)
+            else:
+                x_np = np.random.random((5, 4)).astype(dtype)
+            self._run_and_check(x_np, index_np, axis=0, value=-1)
+        paddle.enable_static()
+
+    def test_negative_axis(self):
+        """Negative axis with optimized kernel."""
+        paddle.disable_static()
+        x_np = np.random.random((3, 4, 5)).astype('float64')
+        index_np = np.array([1, 3], dtype='int64')
+        self._run_and_check(x_np, index_np, axis=-1, value=0.0)
+        paddle.enable_static()
+
+    def test_single_index(self):
+        """Single index element - minimal workload."""
+        paddle.disable_static()
+        x_np = np.random.random((10, 20)).astype('float64')
+        index_np = np.array([5], dtype='int32')
+        self._run_and_check(x_np, index_np, axis=0, value=42.0)
+        paddle.enable_static()
+
+    def test_full_dim_index(self):
+        """Index covers entire dimension."""
+        paddle.disable_static()
+        x_np = np.random.random((4, 6)).astype('float64')
+        index_np = np.arange(6, dtype='int64')
+        self._run_and_check(x_np, index_np, axis=1, value=-1.0)
+        paddle.enable_static()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description

优化 `paddle.index_fill` 算子的 GPU kernel 性能和 Python API 调用开销，使其与 PyTorch 持平甚至更快。

#### 主要优化点

**1. CUDA Kernel: IndexT 模板参数化（int32/int64 坐标算术）**
- 将 inner_idx、outer_idx、index_idx 等坐标变量的类型从固定 int64_t 改为模板参数 IndexT
- 根据 x.numel() 是否超过 INT32_MAX 自动选择 int32 或 int64
- 小 tensor 场景下 int32 的 % 和 / 运算比 int64 快约 2-4x

**2. CUDA Kernel: IndT 模板参数化（免去 CastToInt64Kernel）**
- 将 index 数组元素类型从固定 int64_t 改为模板参数 IndT
- 当 index.dtype() == INT32 时直接传入 kernel，省去一次额外的 CastToInt64Kernel GPU kernel 启动
- 减少了一次 GPU kernel launch 和一次显存分配

**3. Python API: 移除冗余的 value 转换**
- 删除了 _index_fill_impl 中将标量 value 先转为 paddle.to_tensor(value) 再通过 .item() 转回标量的冗余逻辑
- 优化后：标量 value 直接传入 _C_ops.index_fill，0-D Tensor 通过 .item() 提取

#### 性能测试报告（H800 GPU）

> Speedup = Torch time / Paddle time（>1 表示 Paddle 更快）

**优化前：**

```
Case                                       Numel Paddle(ms)  Torch(ms)  Speedup
-------------------------------------------------------------------------------
2D [32,32]         idx=16                  1,024      0.129      0.020    0.15x
2D [64,64]         idx=32                  4,096      0.132      0.019    0.14x
2D [128,128]       idx=64                 16,384      0.128      0.019    0.15x
2D [256,256]       idx=128                65,536      0.129      0.019    0.14x
2D [512,512]       idx=256               262,144      0.129      0.019    0.14x
2D [1024,1024]     idx=512             1,048,576      0.133      0.024    0.18x
2D [2048,2048]     idx=1024            4,194,304      0.162      0.053    0.33x
2D [4096,4096]     idx=2048           16,777,216      0.338      0.279    0.82x
2D [8192,8192]     idx=4096           67,108,864      0.984      1.060    1.08x
2D [16384,16384]   idx=8192          268,435,456      3.634      4.231    1.16x
2D [32768,16384]   idx=8192          536,870,912      7.078      8.401    1.19x
2D [128,128]       idx=96                 16,384      0.126      0.018    0.15x
2D [256,256]       idx=192                65,536      0.125      0.018    0.15x
2D [512,512]       idx=384               262,144      0.126      0.019    0.15x
2D [1024,1024]     idx=768             1,048,576      0.133      0.027    0.21x
2D [2048,2048]     idx=1536            4,194,304      0.174      0.072    0.41x
2D [4096,4096]     idx=3072           16,777,216      0.398      0.301    0.76x
2D [8192,8192]     idx=6144           67,108,864      1.222      1.165    0.95x
2D [16384,16384]   idx=12288         268,435,456      4.678      4.640    0.99x
2D [128,128]       idx=115                16,384      0.127      0.018    0.14x
2D [256,256]       idx=230                65,536      0.126      0.018    0.15x
2D [512,512]       idx=460               262,144      0.135      0.020    0.15x
2D [1024,1024]     idx=921             1,048,576      0.145      0.030    0.20x
2D [2048,2048]     idx=1843            4,194,304      0.194      0.076    0.39x
2D [4096,4096]     idx=3686           16,777,216      0.432      0.326    0.76x
2D [8192,8192]     idx=7372           67,108,864      1.367      1.257    0.92x
2D [16384,16384]   idx=14745         268,435,456      5.227      5.057    0.97x
2D [128,128]       idx=128                16,384      0.125      0.018    0.15x
2D [512,512]       idx=512               262,144      0.126      0.020    0.16x
2D [1024,1024]     idx=1024            1,048,576      0.135      0.031    0.23x
2D [4096,4096]     idx=4096           16,777,216      0.427      0.325    0.76x
2D [8192,8192]     idx=8192           67,108,864      1.325      1.262    0.95x
2D [16384,16384]   idx=16384         268,435,456      5.046      5.062    1.00x
2D [4096,4096]     idx=1              16,777,216      0.182      0.070    0.38x
2D [4096,4096]     idx=8              16,777,216      0.183      0.070    0.38x
2D [4096,4096]     idx=64             16,777,216      0.202      0.079    0.39x
2D [4096,4096]     idx=256            16,777,216      0.231      0.122    0.53x
2D [4096,4096]     idx=1024           16,777,216      0.293      0.245    0.84x
2D [4096,4096]     idx=2048           16,777,216      0.335      0.277    0.83x
2D [4096,4096]     idx=3072           16,777,216      0.393      0.301    0.77x
2D [4096,4096]     idx=3686           16,777,216      0.437      0.325    0.74x
2D [4096,4096]     idx=4096           16,777,216      0.472      0.324    0.69x
```

**优化后：**

```
Case                                       Numel Paddle(ms)  Torch(ms)  Speedup
-------------------------------------------------------------------------------
2D [32,32]         idx=16                  1,024      0.021      0.029    1.42x
2D [64,64]         idx=32                  4,096      0.020      0.021    1.04x
2D [128,128]       idx=64                 16,384      0.020      0.021    1.04x
2D [256,256]       idx=128                65,536      0.020      0.020    0.99x
2D [512,512]       idx=256               262,144      0.021      0.020    0.96x
2D [1024,1024]     idx=512             1,048,576      0.025      0.026    1.06x
2D [2048,2048]     idx=1024            4,194,304      0.054      0.058    1.07x
2D [4096,4096]     idx=2048           16,777,216      0.229      0.294    1.28x
2D [8192,8192]     idx=4096           67,108,864      0.865      1.063    1.23x
2D [16384,16384]   idx=8192          268,435,456      3.520      4.243    1.21x
2D [32768,16384]   idx=8192          536,870,912      6.992      8.443    1.21x
2D [128,128]       idx=96                 16,384      0.020      0.020    0.97x
2D [256,256]       idx=192                65,536      0.020      0.020    1.01x
2D [512,512]       idx=384               262,144      0.021      0.021    1.00x
2D [1024,1024]     idx=768             1,048,576      0.028      0.028    1.03x
2D [2048,2048]     idx=1536            4,194,304      0.068      0.069    1.00x
2D [4096,4096]     idx=3072           16,777,216      0.287      0.302    1.05x
2D [8192,8192]     idx=6144           67,108,864      1.106      1.170    1.06x
2D [16384,16384]   idx=12288         268,435,456      4.533      4.661    1.03x
2D [128,128]       idx=115                16,384      0.020      0.020    0.98x
2D [256,256]       idx=230                65,536      0.020      0.020    0.98x
2D [512,512]       idx=460               262,144      0.022      0.022    0.99x
2D [1024,1024]     idx=921             1,048,576      0.030      0.031    1.03x
2D [2048,2048]     idx=1843            4,194,304      0.077      0.077    1.01x
2D [4096,4096]     idx=3686           16,777,216      0.323      0.326    1.01x
2D [8192,8192]     idx=7372           67,108,864      1.243      1.261    1.01x
2D [16384,16384]   idx=14745         268,435,456      5.073      5.064    1.00x
2D [128,128]       idx=128                16,384      0.020      0.020    1.00x
2D [512,512]       idx=512               262,144      0.021      0.022    1.05x
2D [1024,1024]     idx=1024            1,048,576      0.030      0.033    1.10x
2D [4096,4096]     idx=4096           16,777,216      0.315      0.324    1.03x
2D [8192,8192]     idx=8192           67,108,864      1.220      1.271    1.04x
2D [16384,16384]   idx=16384         268,435,456      4.914      5.064    1.03x
2D [4096,4096]     idx=1              16,777,216      0.072      0.070    0.98x
2D [4096,4096]     idx=8              16,777,216      0.073      0.070    0.97x
2D [4096,4096]     idx=64             16,777,216      0.084      0.080    0.95x
2D [4096,4096]     idx=256            16,777,216      0.123      0.122    0.99x
2D [4096,4096]     idx=1024           16,777,216      0.188      0.248    1.31x
2D [4096,4096]     idx=2048           16,777,216      0.229      0.282    1.23x
2D [4096,4096]     idx=3072           16,777,216      0.288      0.303    1.05x
2D [4096,4096]     idx=3686           16,777,216      0.323      0.326    1.01x
2D [4096,4096]     idx=4096           16,777,216      0.315      0.325    1.03x

==============================================================================
  Summary
==============================================================================
Total cases:    42
Average speedup: 1.06x
Median speedup:  1.03x
Max speedup:     1.42x
Min speedup:     0.95x
```

#### 单元测试
- 原有 53 个单测全部通过
- 新增 12 个针对优化路径的正确性测试，覆盖 int32/int64 index 直传、各种 value 类型、inplace 等场景

### 是否引起精度变化
否
