### PR TITLE
[Cpp API Compatibility] Fix `resize_` with storage alignment

### DIFF
--- a/paddle/phi/api/include/compat/ATen/ops/resize.h
+++ b/paddle/phi/api/include/compat/ATen/ops/resize.h
@@ -98,7 +98,7 @@ inline const at::Tensor& Tensor::resize_(
 
   // Sync through the compat Storage path first so the DenseTensor holder is a
   // live StorageHolderView backed by shared StorageImpl.
-  auto& storage = const_cast<c10::Storage&>(this->storage());
+  auto storage = this->storage();
   const auto old_holder = dense_tensor->Holder();
   TORCH_CHECK(old_holder != nullptr,
               "resize_ cannot grow a tensor without allocated storage");

--- a/paddle/phi/api/include/compat/ATen/ops/resize.h
+++ b/paddle/phi/api/include/compat/ATen/ops/resize.h
@@ -24,6 +24,7 @@
 #include "paddle/phi/api/include/api.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/ddim.h"
+#include "paddle/phi/core/memory/malloc.h"
 
 namespace at {
 
@@ -49,11 +50,24 @@ inline int64_t ResizeCheckedNumel(at::IntArrayRef size) {
   return numel;
 }
 
+inline size_t ResizeCheckedStorageBytes(int64_t numel,
+                                        size_t itemsize,
+                                        size_t storage_offset_bytes) {
+  const auto numel_size = static_cast<size_t>(numel);
+  TORCH_CHECK(
+      itemsize == 0 || numel_size <= (std::numeric_limits<size_t>::max() -
+                                      storage_offset_bytes) /
+                                         itemsize,
+      "resize_ size is too large in bytes");
+  return storage_offset_bytes + numel_size * itemsize;
+}
+
 }  // namespace detail
 
 // resize_ - operate on the underlying DenseTensor directly so we preserve
-// storage semantics across shrink/grow round-trips and only reallocate when
-// the requested shape exceeds the current storage capacity.
+// storage semantics across shrink/grow round-trips. When growth exceeds the
+// current capacity, expand the shared storage itself so aliasing views keep
+// their storage offset and existing storage contents stay intact.
 inline const at::Tensor& Tensor::resize_(
     at::IntArrayRef size,
     ::std::optional<at::MemoryFormat> memory_format) const {
@@ -72,35 +86,33 @@ inline const at::Tensor& Tensor::resize_(
               "resize_ is not allowed on an undefined tensor");
 
   const size_t itemsize = phi::SizeOf(dense_tensor->dtype());
-  const size_t old_numel = static_cast<size_t>(tensor_.numel());
-  const size_t new_numel_size = static_cast<size_t>(new_numel);
-  const size_t required_bytes = new_numel_size * itemsize;
-  const size_t available_bytes =
-      dense_tensor->Holder() == nullptr
-          ? 0
-          : dense_tensor->Holder()->size() - dense_tensor->meta().offset;
+  const size_t new_storage_bytes = detail::ResizeCheckedStorageBytes(
+      new_numel, itemsize, dense_tensor->meta().offset);
+  const size_t current_storage_bytes =
+      dense_tensor->Holder() == nullptr ? 0 : dense_tensor->Holder()->size();
 
-  if (required_bytes <= available_bytes || new_numel == 0) {
+  if (new_storage_bytes <= current_storage_bytes || new_numel == 0) {
     dense_tensor->Resize(dims);
     return *this;
   }
 
+  // Sync through the compat Storage path first so the DenseTensor holder is a
+  // live StorageHolderView backed by shared StorageImpl.
+  auto& storage = const_cast<c10::Storage&>(this->storage());
   const auto old_holder = dense_tensor->Holder();
   TORCH_CHECK(old_holder != nullptr,
               "resize_ cannot grow a tensor without allocated storage");
-  const size_t old_offset = dense_tensor->meta().offset;
-  const size_t copy_bytes = std::min(old_numel, new_numel_size) * itemsize;
   const phi::Place place = old_holder->place();
-  const void* old_data =
-      old_holder == nullptr
-          ? nullptr
-          : reinterpret_cast<const uint8_t*>(old_holder->ptr()) + old_offset;
-
-  dense_tensor->ResizeAndAllocate(phi::make_ddim(dims));
-  void* new_data = dense_tensor->data();
-  if (copy_bytes > 0 && old_data != nullptr && old_data != new_data) {
-    phi::memory_utils::Copy(place, new_data, place, old_data, copy_bytes);
+  auto new_holder = paddle::memory::AllocShared(place, new_storage_bytes);
+  TORCH_CHECK(new_holder != nullptr, "resize_ failed to allocate storage");
+  const size_t copy_bytes = std::min(old_holder->size(), new_storage_bytes);
+  if (copy_bytes > 0 && old_holder->ptr() != nullptr &&
+      old_holder->ptr() != new_holder->ptr()) {
+    phi::memory_utils::Copy(
+        place, new_holder->ptr(), place, old_holder->ptr(), copy_bytes);
   }
+  storage.set_data_ptr_noswap(std::move(new_holder));
+  dense_tensor->Resize(phi::make_ddim(dims));
   return *this;
 }
 

--- a/paddle/phi/api/include/compat/ATen/ops/slice.h
+++ b/paddle/phi/api/include/compat/ATen/ops/slice.h
@@ -23,6 +23,9 @@ inline at::Tensor slice(const at::Tensor& self,
                         ::std::optional<int64_t> start = ::std::nullopt,
                         ::std::optional<int64_t> end = ::std::nullopt,
                         int64_t step = 1) {
+  // Materialize the compat StorageHolderView before creating the slice so the
+  // base tensor and its views observe the same shared storage during resize_.
+  (void)self.storage();
   return paddle::experimental::slice(
       self._PD_GetInner(),
       {dim},

--- a/test/cpp/compat/ATen_resize_test.cc
+++ b/test/cpp/compat/ATen_resize_test.cc
@@ -14,6 +14,7 @@
 
 #include <ATen/Functions.h>
 #include <ATen/core/TensorBody.h>
+#include <ATen/ops/as_strided.h>
 #include <ATen/ops/resize.h>
 #include <ATen/ops/tensor.h>
 #include <c10/core/ScalarType.h>
@@ -257,14 +258,15 @@ TEST(TensorResizeTest, ResizeChain) {
   ASSERT_EQ(t.sizes()[1], 4);
 }
 
-// Test that resizing a slice with shared storage copies data from the start of
-// the storage, not from the slice's offset, to preserve the original slice data
-// and storage semantics
+// Test that resizing a view with shared storage copies data from the start of
+// the storage, not from the view's offset, to preserve the original data and
+// storage semantics.
 TEST(TensorResizeTest, ResizeSliceSharedStorageCopiesFromStorageStart) {
   // ta = [1, 2, 3, 4], tb = [2, 3, 4]
-  // tb shares storage with ta.
+  // Build tb through as_strided so it is a view with a non-zero storage
+  // offset even when backend slice kernels materialize copies.
   at::Tensor ta = at::tensor({1, 2, 3, 4}, at::kInt);
-  at::Tensor tb = ta.slice(0, 1, 4);
+  at::Tensor tb = ta.as_strided({3}, {1}, 1);
 
   tb.resize_(4);
 

--- a/test/cpp/compat/ATen_resize_test.cc
+++ b/test/cpp/compat/ATen_resize_test.cc
@@ -277,9 +277,10 @@ TEST(TensorResizeTest, ResizeSliceSharedStorageCopiesFromStorageStart) {
   ASSERT_EQ(ta[2].item<int>(), 3);
   ASSERT_EQ(ta[3].item<int>(), 4);
 
-  // tb should preserve the expected sequence after resize.
+  // PyTorch only preserves the pre-existing prefix here. The newly exposed
+  // tail element after resize_ is uninitialized and should not be asserted.
   ASSERT_EQ(tb[0].item<int>(), 2);
   ASSERT_EQ(tb[1].item<int>(), 3);
   ASSERT_EQ(tb[2].item<int>(), 4);
-  ASSERT_EQ(tb[3].item<int>(), 4);
+  ASSERT_EQ(tb.numel(), 4);
 }

--- a/test/cpp/compat/ATen_resize_test.cc
+++ b/test/cpp/compat/ATen_resize_test.cc
@@ -256,3 +256,19 @@ TEST(TensorResizeTest, ResizeChain) {
   ASSERT_EQ(t.sizes()[0], 3);
   ASSERT_EQ(t.sizes()[1], 4);
 }
+
+// Test that resizing a slice with shared storage copies data from the start of
+// the storage, not from the slice's offset, to preserve the original slice data
+// and storage semantics
+TEST(TensorResizeTest, ResizeSliceSharedStorageCopiesFromStorageStart) {
+  // ta = [1, 2, 3, 4], tb = [2, 3, 4]
+  // tb shares storage with ta.
+  at::Tensor ta = at::tensor({1, 2, 3, 4}, at::kInt);
+  at::Tensor tb = ta.slice(0, 1, 4);
+
+  tb.resize_(4);
+
+  // After resize, tb[0] and ta[1] must point to the exact same address.
+  ASSERT_EQ(tb.data_ptr<int>(), ta.data_ptr<int>() + 1);
+  // Data should be copied from storage[0], so ta[0] is unchanged.
+}

--- a/test/cpp/compat/ATen_resize_test.cc
+++ b/test/cpp/compat/ATen_resize_test.cc
@@ -270,5 +270,16 @@ TEST(TensorResizeTest, ResizeSliceSharedStorageCopiesFromStorageStart) {
 
   // After resize, tb[0] and ta[1] must point to the exact same address.
   ASSERT_EQ(tb.data_ptr<int>(), ta.data_ptr<int>() + 1);
-  // Data should be copied from storage[0], so ta[0] is unchanged.
+
+  // The original storage contents should remain unchanged.
+  ASSERT_EQ(ta[0].item<int>(), 1);
+  ASSERT_EQ(ta[1].item<int>(), 2);
+  ASSERT_EQ(ta[2].item<int>(), 3);
+  ASSERT_EQ(ta[3].item<int>(), 4);
+
+  // tb should preserve the expected sequence after resize.
+  ASSERT_EQ(tb[0].item<int>(), 2);
+  ASSERT_EQ(tb[1].item<int>(), 3);
+  ASSERT_EQ(tb[2].item<int>(), 4);
+  ASSERT_EQ(tb[3].item<int>(), 4);
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure


### PR Types
Bug fixes


### Description
根据报告的 `resize_` 接口兼容差异添加测试


### 是否引起精度变化
否
