### PR TITLE
cp mm stride fidx

### DIFF
--- a/paddle/phi/kernels/stride/matmul_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/matmul_stride_kernel.cu
@@ -164,7 +164,7 @@ void MatmulStrideKernel(const Context &dev_ctx,
                                                              &x_stride,
                                                              &x_axis)) {
     auto x_trans_dims = x_axis.size();
-    if (x_axis.size() > 2 && x_axis[x_trans_dims - 1] == x_trans_dims - 2 &&
+    if (x_axis.size() >= 2 && x_axis[x_trans_dims - 1] == x_trans_dims - 2 &&
         x_axis[x_trans_dims - 2] == x_trans_dims - 1) {
       transpose_x = !transpose_x;
       x_meta.dims = x_shape;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
修复matmul stride的一个拦截条件，让2d matmul能正常通过stride kernel

会影响到带stride的matmul的前向精度
devPR:https://github.com/PaddlePaddle/Paddle/pull/78612
pcard-91067

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是