### PR TITLE
[API Compatibility] Support torch-style positional arg for `paddle.Tensor.fill_diagonal_`

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -30,6 +30,7 @@ from paddle.utils.decorator_utils import (
     ParamAliasDecorator,
     VariableArgsDecorator,
     expand_decorator,
+    fill_diagonal_inplace_decorator,
     index_add_decorator,
     index_fill_decorator,
     param_one_alias,
@@ -1196,8 +1197,26 @@ def zero_(x: Tensor) -> Tensor:
     return _C_ops.fill_(x, 0.0)
 
 
+@overload
+def fill_diagonal_(
+    x: Tensor,
+    value: float,
+    offset: int = 0,
+    wrap: bool = False,
+    name: str | None = None,
+) -> Tensor: ...
+
+
+@overload
+def fill_diagonal_(
+    x: Tensor,
+    fill_value: float,
+    wrap: bool = False,
+) -> Tensor: ...
+
+
 @dygraph_only
-@param_one_alias(["value", "fill_value"])
+@fill_diagonal_inplace_decorator()
 def fill_diagonal_(
     x: Tensor,
     value: float,
@@ -1232,7 +1251,7 @@ def fill_diagonal_(
             [[1.0, 2.0, 2.0], [2.0, 1.0, 2.0], [2.0, 2.0, 1.0], [2.0, 2.0, 2.0]]
 
             >>> # Use 'fill_value' alias (PyTorch compatible)
-            >>> x.fill_diagonal_(fill_value=0.0)  # type: ignore
+            >>> x.fill_diagonal_(fill_value=0.0)
             >>> print(x.tolist())
             [[0.0, 2.0, 2.0], [2.0, 0.0, 2.0], [2.0, 2.0, 0.0], [2.0, 2.0, 2.0]]
     """

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -1190,3 +1190,41 @@ def batch_sampler_decorator() -> Callable[
         return wrapper
 
     return decorator
+
+
+def fill_diagonal_inplace_decorator() -> Callable[
+    [Callable[_InputT, _RetT]], Callable[_InputT, _RetT]
+]:
+    """
+    Usage Example:
+    PyTorch: torch.Tensor.fill_diagonal_(fill_value, wrap=False)
+    Paddle: paddle.Tensor.fill_diagonal_(value, offset, wrap)
+    """
+
+    def decorator(func: Callable[_InputT, _RetT]) -> Callable[_InputT, _RetT]:
+        @functools.wraps(func)
+        def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
+            if "fill_value" in kwargs:
+                if "value" not in kwargs:
+                    kwargs["value"] = kwargs.pop("fill_value")
+                else:
+                    raise ValueError(
+                        "Cannot specify both 'value' and its alias 'fill_value'."
+                    )
+
+            # args[0] is x (tensor)
+            # args[1] is fill_value
+            # args[2] is wrap, use torch signature
+            if len(args) >= 3 and isinstance(args[2], bool):
+                kwargs["wrap"] = args[2]
+                if len(args) > 3:
+                    raise TypeError(
+                        "fill_diagonal_() received too many arguments"
+                    )
+                args = (args[0], args[1])
+            return func(*args, **kwargs)
+
+        wrapper.__signature__ = inspect.signature(func)
+        return wrapper
+
+    return decorator

--- a/test/legacy_test/test_tensor_fill_diagonal_.py
+++ b/test/legacy_test/test_tensor_fill_diagonal_.py
@@ -308,8 +308,22 @@ class TestFillDiagonalAlias(unittest.TestCase):
         """
         x = paddle.zeros([3, 3], dtype='float32')
         # Expect TypeError or ValueError when both arguments are provided
-        with self.assertRaises((ValueError, TypeError)):
+        with self.assertRaises(ValueError):
             x.fill_diagonal_(value=1.0, fill_value=2.0)
+
+    def test_positional_args(self):
+        x = paddle.zeros([4, 4], dtype='float32')
+        x.fill_diagonal_(5.0, False)
+        x_np = x.numpy()
+        for i in range(4):
+            self.assertEqual(x_np[i, i], 5.0)
+        np.fill_diagonal(x_np, 0)
+        self.assertTrue(np.all(x_np == 0))
+
+    def test_too_many_positional_args(self):
+        x = paddle.zeros([3, 3], dtype='float32')
+        with self.assertRaises(TypeError):
+            x.fill_diagonal_(1.0, False, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Add decorator to handle positional arg order
- Move param alias logic into decorator
- Add overload signature
- Add test


### 是否引起精度变化
否
