### PR TITLE
[XPU] fix float32 matmul precision: use FC_FLOAT default instead of FC_TF32 on XRE5

### DIFF
--- a/paddle/phi/kernels/xpu/xpu_api_wrapper.h
+++ b/paddle/phi/kernels/xpu/xpu_api_wrapper.h
@@ -64,7 +64,10 @@ inline XPUFCCalcType FCCalcType() {
       {"XPU_PADDLE_FC_INT32_WITH_LL", XPUFCCalcType::FC_INT32_WITH_LL},
   };
 #ifdef PADDLE_WITH_XPU_XRE5
-  auto default_calc_type = XPUFCCalcType::FC_TF32;
+  // Use full float32 accumulation by default for better precision, matching
+  // the GPU default (FLAGS_cublas_allow_tf32=false). Users who need TF32
+  // performance can set env var XPU_PADDLE_FC_TF32.
+  auto default_calc_type = XPUFCCalcType::FC_FLOAT;
 #else
   auto default_calc_type = XPUFCCalcType::FC_INT16;
 #endif


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
在 XPU XRE5 硬件上，`FCCalcType<float>()` 原来默认使用 `FC_TF32`（TensorFloat-32，仅 10 位尾数精度）。在矩阵 K 维度较大时（如 K=4096），TF32 的截断误差会累积，导致 `paddle.matmul` 的 XPU 结果与 GPU 结果之间的最大绝对误差超过阈值（实测 `max_abs_diff=0.0139818 > atol=0.01`）。

GPU 侧默认关闭 TF32（`FLAGS_cublas_allow_tf32=false`），使用完整 float32 精度。本 PR 将 XRE5 上的默认计算类型从 `FC_TF32` 改为 `FC_FLOAT`，使 XPU 与 GPU 精度行为保持一致。

需要 TF32 性能的用户仍可通过设置环境变量 `XPU_PADDLE_FC_TF32` 来启用。

**修复前：** `max_abs_diff=0.0139818` → 精度检查失败
**修复后：** `max_abs_diff=0.000133514` → 精度检查通过（精度提升约 100 倍）

### 是否引起精度变化
否，不影响GPU精度。XPU float32 矩阵乘法精度与 GPU 保持一致，max_abs_diff 从 ~0.014 降至 ~0.00013。
