### PR TITLE
[XPU] fix pinned memory auto transform

### DIFF
--- a/paddle/phi/api/lib/data_transform.h
+++ b/paddle/phi/api/lib/data_transform.h
@@ -181,8 +181,9 @@ inline bool NeedTransformPlace(const phi::Place& src_place,
               phi::TransToPhiBackend(src_place) !=
                   (target != Backend::GPUDNN ? target : Backend::GPU));
 #elif defined(PADDLE_WITH_XPU)
-  bool ret = target != Backend::ALL_BACKEND &&
-             phi::TransToPhiBackend(src_place) != target;
+  bool ret = src_place.GetType() == AllocationType::XPUPINNED ||
+             (target != Backend::ALL_BACKEND &&
+              phi::TransToPhiBackend(src_place) != target);
 #elif defined(PADDLE_WITH_IPU)
   bool ret = target != Backend::ALL_BACKEND &&
              phi::TransToPhiBackend(src_place) != target;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
XPU does not transform  data from XPUPINNED to XPU automatically. The PR fix this.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否