### PR TITLE
[XPU] fix XPU argsort tie-breaking to match GPU sort behavior

### DIFF
--- a/paddle/phi/kernels/xpu/argsort_kernel.cc
+++ b/paddle/phi/kernels/xpu/argsort_kernel.cc
@@ -166,11 +166,8 @@ void ArgsortKernel(const Context& dev_ctx,
                         flip_axes);
     PADDLE_ENFORCE_XDNN_SUCCESS(ret, "flip output");
 
-    ret = xpu::flip(dev_ctx.x_context(),
-                    tmp_idx,
-                    indices_data,
-                    shape_vec,
-                    flip_axes);
+    ret = xpu::flip(
+        dev_ctx.x_context(), tmp_idx, indices_data, shape_vec, flip_axes);
     PADDLE_ENFORCE_XDNN_SUCCESS(ret, "flip indices");
     return;
   }

--- a/paddle/phi/kernels/xpu/argsort_kernel.cc
+++ b/paddle/phi/kernels/xpu/argsort_kernel.cc
@@ -31,16 +31,12 @@ static inline void xpu_argsort(xpu::Context* xpu_ctx,
                                int64_t n,
                                bool descending,
                                bool stable) {
-  int ret;
-  if (stable) {
-    ret = xpu::stable_sort(
-        xpu_ctx, input_data, output_data, indices_data, m, n, descending);
-    PADDLE_ENFORCE_XDNN_SUCCESS(ret, "stable_sort");
-  } else {
-    ret = xpu::sort(
-        xpu_ctx, input_data, output_data, indices_data, m, n, descending);
-    PADDLE_ENFORCE_XDNN_SUCCESS(ret, "sort");
-  }
+  // Always use stable_sort to match GPU's CUB/Thrust behavior which is
+  // effectively stable (preserves original relative order of equal elements).
+  (void)stable;
+  int ret = xpu::stable_sort(
+      xpu_ctx, input_data, output_data, indices_data, m, n, descending);
+  PADDLE_ENFORCE_XDNN_SUCCESS(ret, "stable_sort");
 }
 
 template <typename T>
@@ -111,6 +107,7 @@ void ArgsortKernel(const Context& dev_ctx,
 
   axis = (axis < 0) ? (in_dims.size() + axis) : axis;
   int64_t n = in_dims[axis];
+  auto size = input.numel();
 
   auto input_data = input.data<T>();
   auto output_data = dev_ctx.template Alloc<T>(output);
@@ -129,6 +126,54 @@ void ArgsortKernel(const Context& dev_ctx,
   std::vector<int64_t> data_shape{len_before, n, len_after};
 
   using XPUType = typename XPUTypeTrait<T>::Type;
+
+  // When size == n (the sort axis spans the entire tensor), the GPU kernel uses
+  // Thrust: thrust::sort_by_key (ascending, stable) + reverse. For equal
+  // elements with descending=true, the element with the HIGHER original index
+  // ends up first (because stable ascending put lower-index first, then reverse
+  // flips that). We replicate this behavior with stable ascending + flip.
+  //
+  // For all other shapes (segmented sort path on GPU), GPU uses CUB
+  // DeviceSegmentedRadixSort which sorts in the requested direction stably,
+  // giving the element with the LOWER original index first for ties. We use
+  // stable_sort directly for this case (already done in xpu_argsort above).
+  if (!stable && descending && size == n) {
+    xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+    int64_t len = len_before * n * len_after;
+    XPUType* tmp_out = RAII_GUARD.alloc_l3_or_gm<XPUType>(len);
+    int64_t* tmp_idx = RAII_GUARD.alloc_l3_or_gm<int64_t>(len);
+
+    // Sort ascending stably (mirrors Thrust stable ascending sort)
+    XPUArgsort<XPUType>()(dev_ctx.x_context(),
+                          reinterpret_cast<const XPUType*>(input_data),
+                          tmp_out,
+                          tmp_idx,
+                          data_shape,
+                          permute_vec,
+                          /*descending=*/false,
+                          /*stable=*/true);
+
+    // Flip along the sort axis to convert ascending to descending,
+    // matching GPU's reverse step (higher original index first for ties).
+    std::vector<int64_t> shape_vec;
+    for (int i = 0; i < rank; i++) shape_vec.push_back(in_dims[i]);
+    std::vector<int64_t> flip_axes{axis};
+
+    int ret = xpu::flip(dev_ctx.x_context(),
+                        tmp_out,
+                        reinterpret_cast<XPUType*>(output_data),
+                        shape_vec,
+                        flip_axes);
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, "flip output");
+
+    ret = xpu::flip(dev_ctx.x_context(),
+                    tmp_idx,
+                    indices_data,
+                    shape_vec,
+                    flip_axes);
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, "flip indices");
+    return;
+  }
 
   XPUArgsort<XPUType>()(dev_ctx.x_context(),
                         reinterpret_cast<const XPUType*>(input_data),


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description

修复 XPU 上 `paddle.argsort` 的索引顺序与 GPU 不一致的问题。

**问题根因**

`paddle.argsort` 返回整数索引。当输入中存在相等值时，GPU 与 XPU 的排序算法对并列元素的处理方式不同（tie-breaking），导致输出索引不一致：

- GPU 使用两条不同的排序路径，tie-breaking 行为各异：
  - **1D 路径**（`numel == axis_size`）：Thrust `sort_by_key`（稳定升序）+ 反转，降序时并列元素中**原始索引较大**的在前
  - **多维路径**（分段排序）：CUB `DeviceSegmentedRadixSort`（稳定降序），降序时并列元素中**原始索引较小**的在前
- XPU 原先使用 `xpu::sort`（不稳定），tie-breaking 行为与上述两种 GPU 路径均不一致

**修复方案**

修改 `paddle/phi/kernels/xpu/argsort_kernel.cc`：

1. 将 `xpu_argsort` 改为始终调用 `xpu::stable_sort`（原先 `stable=false` 时调用不稳定的 `xpu::sort`），使多维情形下与 GPU CUB 行为一致（降序并列时原始索引较小的在前）
2. 在 `ArgsortKernel` 中增加 1D 特殊路径：当 `!stable && descending && numel == axis_size` 时，先做稳定升序排序，再沿 sort 轴做 `xpu::flip`，复现 GPU Thrust 升序+反转的行为（降序并列时原始索引较大的在前）

**验证结果**

| 配置 | 修复前 | 修复后 |
|------|--------|--------|
| `Tensor([1, 50304], "float32")` descending | max_abs_diff=43444 ❌ | max_abs_diff=0 ✅ |
| `Tensor([32, 2], "float16")` descending | max_abs_diff=1 ❌ | max_abs_diff=0 ✅ |
| `Tensor([7, 2], "float16")` descending | max_abs_diff=1 ❌ | max_abs_diff=0 ✅ |

前向与反向梯度均通过（max_abs_diff=0）。

### 是否引起精度变化

是。修复了 XPU 上 `argsort`（`stable=False`，`descending=True`）在并列元素时的索引顺序，使其与 GPU 结果一致。对于不含相等元素的输入，行为不变。