### PR TITLE
[XPU] fix float32 matmul precision on XRE5: use FC_FLOAT instead of FC_TF32 for nn.functional.linear

### DIFF
--- a/paddle/phi/kernels/xpu/xpu_api_wrapper.h
+++ b/paddle/phi/kernels/xpu/xpu_api_wrapper.h
@@ -64,7 +64,11 @@ inline XPUFCCalcType FCCalcType() {
       {"XPU_PADDLE_FC_INT32_WITH_LL", XPUFCCalcType::FC_INT32_WITH_LL},
   };
 #ifdef PADDLE_WITH_XPU_XRE5
-  auto default_calc_type = XPUFCCalcType::FC_TF32;
+  // Use FC_FLOAT (full IEEE float32 accumulation) as default to match GPU
+  // precision. FC_TF32 (10-bit mantissa) causes max_abs_diff ~0.013-0.023 for
+  // large matrices (K>=4096), exceeding the atol=0.01 threshold vs GPU.
+  // Users who prefer TF32 throughput can opt in with XPU_PADDLE_FC_TF32=1.
+  auto default_calc_type = XPUFCCalcType::FC_FLOAT;
 #else
   auto default_calc_type = XPUFCCalcType::FC_INT16;
 #endif


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description

#### 问题背景

在 XRE5 硬件上（`PADDLE_WITH_XPU_XRE5`），`paddle.nn.functional.linear` 对 float32 输入的精度与 GPU 存在偏差，在大矩阵（K≥4096）场景下 `max_abs_diff` 超过 0.01 容差。

根本原因：`paddle/phi/kernels/xpu/xpu_api_wrapper.h` 中的 `FCCalcType<float>()` 在 XRE5 路径下默认使用 `FC_TF32`（TFloat32，尾数仅 10 位），而 GPU 侧 cuBLAS SGEMM 使用标准 IEEE float32（23 位尾数）。K=4096 的矩阵乘法累积了足够多的截断误差，导致精度差超过测试阈值（atol=0.01）。

测试的 25 个 `paddle.nn.functional.linear` 配置中，3 个 float32 大矩阵配置失败：

| 配置 | max_abs_diff（修复前） |
|------|----------------------|
| x=[1,4096,11008], w=[11008,4096], float32 | 0.0227776 |
| x=[1,4096,4096], w=[4096,22016], float32 | 0.0136099 |
| x=[1,4096,4096], w=[4096,4096], float32 | 0.0127937 |

#### 修复内容

将 XRE5 下 float32 FC 默认计算类型由 `FC_TF32` 改为 `FC_FLOAT`（完整 IEEE float32 累加），与 GPU 精度对齐。

需要 TF32 吞吐量的用户可通过环境变量 `XPU_PADDLE_FC_TF32=1` 按需启用。

#### 修复后验证

全部 25 个配置通过，原先失败的 3 个精度大幅提升：

| 配置 | max_abs_diff（修复后） |
|------|----------------------|
| x=[1,4096,11008], w=[11008,4096], float32 | 0.000111 |
| x=[1,4096,4096], w=[4096,22016], float32 | 0.000374 |
| x=[1,4096,4096], w=[4096,4096], float32 | ~0.000374 |

float16、bfloat16 等其他数据类型的 `FCCalcType` 特化不受影响。

### 是否引起精度变化

是。XRE5 上 float32 matmul（及依赖 matmul 的 linear、fc 等算子）的精度将提升，与 GPU（cuBLAS SGEMM）更接近。性能可能略有下降（TF32 → float32），可通过 `XPU_PADDLE_FC_TF32=1` 恢复原行为。