### PR TITLE
[Cpp API Compatibility] Align indexless CUDA compat ops with current device

### DIFF
--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -142,7 +142,7 @@ class Tensor : public TensorBase {
       PaddlePlace place(phi::AllocationType::CPU);
       return tensor_.copy_to(place, true);
     } else if (b == c10::Backend::CUDA) {
-      PaddlePlace place(phi::AllocationType::GPU);
+      auto place = paddle::DefaultGPUPlace();
       return tensor_.copy_to(place, true);
     } else if (b == c10::Backend::XPU) {
       PaddlePlace place(phi::AllocationType::XPU);
@@ -163,7 +163,7 @@ class Tensor : public TensorBase {
 
   Tensor cuda() const {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-    PaddlePlace place(phi::AllocationType::GPU);
+    auto place = paddle::DefaultGPUPlace();
     return tensor_.copy_to(place, true);
 #elif defined(PADDLE_WITH_XPU)
     return tensor_.copy_to(paddle::DefaultXPUPlace(), true);

--- a/paddle/phi/api/include/compat/ATen/cuda/EmptyTensor.cpp
+++ b/paddle/phi/api/include/compat/ATen/cuda/EmptyTensor.cpp
@@ -29,14 +29,18 @@ at::Tensor empty_cuda(IntArrayRef size,
   return paddle::experimental::empty(
       size._PD_ToPaddleIntArray(),
       compat::_PD_AtenScalarTypeToPhiDataType(dtype),
-      phi::GPUPlace());
+      device_opt && device_opt->has_index() ? phi::GPUPlace(device_opt->index())
+                                            : paddle::DefaultGPUPlace());
 }
 
 at::Tensor empty_cuda(IntArrayRef size, const TensorOptions &options) {
+  auto place = options.has_device() && options.device().has_index()
+                   ? phi::GPUPlace(options.device().index())
+                   : paddle::DefaultGPUPlace();
   return paddle::experimental::empty(
       size._PD_ToPaddleIntArray(),
       compat::_PD_AtenScalarTypeToPhiDataType(options.dtype_opt().value()),
-      phi::GPUPlace());
+      place);
 }
 
 }  // namespace at::detail

--- a/paddle/phi/api/include/compat/ATen/ops/to.h
+++ b/paddle/phi/api/include/compat/ATen/ops/to.h
@@ -42,7 +42,8 @@ inline at::Tensor Tensor::to(
         place = phi::CPUPlace();
         break;
       case c10::DeviceType::CUDA:
-        place = phi::GPUPlace(dev.has_index() ? dev.index() : 0);
+        place = dev.has_index() ? phi::GPUPlace(dev.index())
+                                : paddle::DefaultGPUPlace();
         break;
       default:
         PD_THROW("Unsupported device type: ", dev.type());

--- a/paddle/phi/api/include/compat/c10/core/Device.h
+++ b/paddle/phi/api/include/compat/c10/core/Device.h
@@ -131,7 +131,7 @@ struct Device final {
       case DeviceType::CPU:
         return phi::CPUPlace();
       case DeviceType::CUDA:
-        return phi::GPUPlace(has_index() ? index_ : 0);
+        return has_index() ? phi::GPUPlace(index_) : paddle::DefaultGPUPlace();
       case DeviceType::XPU:
         return phi::XPUPlace(has_index() ? index_ : 0);
       case DeviceType::IPU:

--- a/paddle/phi/api/include/compat/c10/cuda/CUDAGuard.h
+++ b/paddle/phi/api/include/compat/c10/cuda/CUDAGuard.h
@@ -35,7 +35,8 @@ inline Device current_cuda_device() {
 
 inline Device normalize_cuda_device(Device device) {
   TORCH_CHECK(device.is_cuda(), "Expected a CUDA device, but got ", device);
-  return Device(kCUDA, device.has_index() ? device.index() : 0);
+  return device.has_index() ? Device(kCUDA, device.index())
+                            : current_cuda_device();
 }
 
 }  // namespace detail

--- a/test/cpp/compat/ATen_cuda_test.cc
+++ b/test/cpp/compat/ATen_cuda_test.cc
@@ -21,6 +21,7 @@
 #include <c10/core/DeviceType.h>
 #include <c10/core/ScalarType.h>
 #include <c10/cuda/CUDAFunctions.h>
+#include <c10/cuda/CUDAGuard.h>
 
 #include "ATen/ATen.h"
 #include "gtest/gtest.h"
@@ -89,6 +90,18 @@ TEST(TensorCudaTest, DeviceIsCuda) {
   at::Tensor cuda_t = cpu_t.cuda();
 
   ASSERT_EQ(cuda_t.device().type(), c10::DeviceType::CUDA);
+}
+
+TEST(TensorCudaTest, DefaultCudaUsesCurrentDevice) {
+  if (c10::cuda::device_count() < 2) {
+    GTEST_SKIP() << "requires at least 2 CUDA devices";
+  }
+  c10::cuda::CUDAGuard guard(1);
+  at::Tensor cpu_t = at::tensor({1.0f}, at::kFloat);
+  at::Tensor cuda_t = cpu_t.cuda();
+
+  ASSERT_EQ(cuda_t.device().type(), c10::DeviceType::CUDA);
+  ASSERT_EQ(cuda_t.device().index(), 1);
 }
 
 // is_cuda() / is_cpu() are mutually exclusive.

--- a/test/cpp/compat/ATen_cuda_test.cc
+++ b/test/cpp/compat/ATen_cuda_test.cc
@@ -94,7 +94,7 @@ TEST(TensorCudaTest, DeviceIsCuda) {
 
 TEST(TensorCudaTest, DefaultCudaUsesCurrentDevice) {
   if (c10::cuda::device_count() < 2) {
-    GTEST_SKIP() << "requires at least 2 GPU devices";
+    return;
   }
   c10::cuda::CUDAGuard guard(1);
   at::Tensor cpu_t = at::tensor({1.0f}, at::kFloat);

--- a/test/cpp/compat/ATen_cuda_test.cc
+++ b/test/cpp/compat/ATen_cuda_test.cc
@@ -94,7 +94,7 @@ TEST(TensorCudaTest, DeviceIsCuda) {
 
 TEST(TensorCudaTest, DefaultCudaUsesCurrentDevice) {
   if (c10::cuda::device_count() < 2) {
-    GTEST_SKIP() << "requires at least 2 CUDA devices";
+    GTEST_SKIP() << "requires at least 2 GPU devices";
   }
   c10::cuda::CUDAGuard guard(1);
   at::Tensor cpu_t = at::tensor({1.0f}, at::kFloat);

--- a/test/cpp/compat/ATen_empty_test.cc
+++ b/test/cpp/compat/ATen_empty_test.cc
@@ -15,6 +15,7 @@
 #include <ATen/Functions.h>
 #include <ATen/core/TensorBody.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/EmptyTensor.h>
 #include <ATen/ops/empty.h>
 #include <c10/core/ScalarType.h>
 #include <c10/core/TensorOptions.h>
@@ -123,6 +124,43 @@ TEST(ATenEmptyTest, DefaultCudaDeviceUsesCurrentDevice) {
   c10::cuda::CUDAGuard guard(1);
   at::Tensor t =
       at::empty({8}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+
+  ASSERT_TRUE(t.is_cuda());
+  ASSERT_EQ(t.device().index(), 1);
+}
+
+TEST(ATenEmptyTest, ExplicitCudaDeviceUsesRequestedIndex) {
+  if (c10::cuda::device_count() < 2) {
+    return;
+  }
+  c10::cuda::CUDAGuard guard(0);
+  at::Tensor t = at::empty(
+      {8},
+      at::TensorOptions().dtype(at::kFloat).device(at::Device(at::kCUDA, 1)));
+
+  ASSERT_TRUE(t.is_cuda());
+  ASSERT_EQ(t.device().index(), 1);
+}
+
+TEST(ATenEmptyTest, EmptyCudaHelperDefaultDeviceUsesCurrentDevice) {
+  if (c10::cuda::device_count() < 2) {
+    return;
+  }
+  c10::cuda::CUDAGuard guard(1);
+  at::Tensor t = at::detail::empty_cuda(
+      {8}, at::kFloat, at::Device(at::kCUDA), std::nullopt);
+
+  ASSERT_TRUE(t.is_cuda());
+  ASSERT_EQ(t.device().index(), 1);
+}
+
+TEST(ATenEmptyTest, EmptyCudaHelperExplicitDeviceUsesRequestedIndex) {
+  if (c10::cuda::device_count() < 2) {
+    return;
+  }
+  c10::cuda::CUDAGuard guard(0);
+  at::Tensor t = at::detail::empty_cuda(
+      {8}, at::kFloat, at::Device(at::kCUDA, 1), std::nullopt);
 
   ASSERT_TRUE(t.is_cuda());
   ASSERT_EQ(t.device().index(), 1);

--- a/test/cpp/compat/ATen_empty_test.cc
+++ b/test/cpp/compat/ATen_empty_test.cc
@@ -129,19 +129,6 @@ TEST(ATenEmptyTest, DefaultCudaDeviceUsesCurrentDevice) {
   ASSERT_EQ(t.device().index(), 1);
 }
 
-TEST(ATenEmptyTest, ExplicitCudaDeviceUsesRequestedIndex) {
-  if (c10::cuda::device_count() < 2) {
-    return;
-  }
-  c10::cuda::CUDAGuard guard(0);
-  at::Tensor t = at::empty(
-      {8},
-      at::TensorOptions().dtype(at::kFloat).device(at::Device(at::kCUDA, 1)));
-
-  ASSERT_TRUE(t.is_cuda());
-  ASSERT_EQ(t.device().index(), 1);
-}
-
 TEST(ATenEmptyTest, EmptyCudaHelperDefaultDeviceUsesCurrentDevice) {
   if (c10::cuda::device_count() < 2) {
     return;
@@ -154,18 +141,6 @@ TEST(ATenEmptyTest, EmptyCudaHelperDefaultDeviceUsesCurrentDevice) {
   ASSERT_EQ(t.device().index(), 1);
 }
 
-TEST(ATenEmptyTest, EmptyCudaHelperExplicitDeviceUsesRequestedIndex) {
-  if (c10::cuda::device_count() < 2) {
-    return;
-  }
-  c10::cuda::CUDAGuard guard(0);
-  at::Tensor t = at::detail::empty_cuda(
-      {8}, at::kFloat, at::Device(at::kCUDA, 1), std::nullopt);
-
-  ASSERT_TRUE(t.is_cuda());
-  ASSERT_EQ(t.device().index(), 1);
-}
-
 TEST(ATenEmptyTest, EmptyCudaOptionsHelperDefaultDeviceUsesCurrentDevice) {
   if (c10::cuda::device_count() < 2) {
     return;
@@ -173,19 +148,6 @@ TEST(ATenEmptyTest, EmptyCudaOptionsHelperDefaultDeviceUsesCurrentDevice) {
   c10::cuda::CUDAGuard guard(1);
   at::Tensor t = at::detail::empty_cuda(
       {8}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
-
-  ASSERT_TRUE(t.is_cuda());
-  ASSERT_EQ(t.device().index(), 1);
-}
-
-TEST(ATenEmptyTest, EmptyCudaOptionsHelperExplicitDeviceUsesRequestedIndex) {
-  if (c10::cuda::device_count() < 2) {
-    return;
-  }
-  c10::cuda::CUDAGuard guard(0);
-  at::Tensor t = at::detail::empty_cuda(
-      {8},
-      at::TensorOptions().dtype(at::kFloat).device(at::Device(at::kCUDA, 1)));
 
   ASSERT_TRUE(t.is_cuda());
   ASSERT_EQ(t.device().index(), 1);

--- a/test/cpp/compat/ATen_empty_test.cc
+++ b/test/cpp/compat/ATen_empty_test.cc
@@ -118,7 +118,7 @@ TEST(ATenEmptyTest, PinnedTensorDataPtrNonNull) {
 
 TEST(ATenEmptyTest, DefaultCudaDeviceUsesCurrentDevice) {
   if (c10::cuda::device_count() < 2) {
-    GTEST_SKIP() << "requires at least 2 GPU devices";
+    return;
   }
   c10::cuda::CUDAGuard guard(1);
   at::Tensor t =

--- a/test/cpp/compat/ATen_empty_test.cc
+++ b/test/cpp/compat/ATen_empty_test.cc
@@ -166,4 +166,29 @@ TEST(ATenEmptyTest, EmptyCudaHelperExplicitDeviceUsesRequestedIndex) {
   ASSERT_EQ(t.device().index(), 1);
 }
 
+TEST(ATenEmptyTest, EmptyCudaOptionsHelperDefaultDeviceUsesCurrentDevice) {
+  if (c10::cuda::device_count() < 2) {
+    return;
+  }
+  c10::cuda::CUDAGuard guard(1);
+  at::Tensor t = at::detail::empty_cuda(
+      {8}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+
+  ASSERT_TRUE(t.is_cuda());
+  ASSERT_EQ(t.device().index(), 1);
+}
+
+TEST(ATenEmptyTest, EmptyCudaOptionsHelperExplicitDeviceUsesRequestedIndex) {
+  if (c10::cuda::device_count() < 2) {
+    return;
+  }
+  c10::cuda::CUDAGuard guard(0);
+  at::Tensor t = at::detail::empty_cuda(
+      {8},
+      at::TensorOptions().dtype(at::kFloat).device(at::Device(at::kCUDA, 1)));
+
+  ASSERT_TRUE(t.is_cuda());
+  ASSERT_EQ(t.device().index(), 1);
+}
+
 #endif  // PADDLE_WITH_CUDA || PADDLE_WITH_HIP

--- a/test/cpp/compat/ATen_empty_test.cc
+++ b/test/cpp/compat/ATen_empty_test.cc
@@ -54,6 +54,8 @@ TEST(ATenEmptyTest, ExplicitArgsCpu) {
 // ======================== pin_memory tests ========================
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#include <c10/cuda/CUDAFunctions.h>
+#include <c10/cuda/CUDAGuard.h>
 
 // TensorOptions overload: pin_memory via options
 TEST(ATenEmptyTest, PinMemoryViaTensorOptions) {
@@ -112,6 +114,18 @@ TEST(ATenEmptyTest, PinnedTensorDataPtrNonNull) {
   at::Tensor t = at::empty({32}, opts);
   ASSERT_TRUE(t.is_pinned());
   ASSERT_NE(t.data_ptr(), nullptr);
+}
+
+TEST(ATenEmptyTest, DefaultCudaDeviceUsesCurrentDevice) {
+  if (c10::cuda::device_count() < 2) {
+    GTEST_SKIP() << "requires at least 2 CUDA devices";
+  }
+  c10::cuda::CUDAGuard guard(1);
+  at::Tensor t =
+      at::empty({8}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+
+  ASSERT_TRUE(t.is_cuda());
+  ASSERT_EQ(t.device().index(), 1);
 }
 
 #endif  // PADDLE_WITH_CUDA || PADDLE_WITH_HIP

--- a/test/cpp/compat/ATen_empty_test.cc
+++ b/test/cpp/compat/ATen_empty_test.cc
@@ -118,7 +118,7 @@ TEST(ATenEmptyTest, PinnedTensorDataPtrNonNull) {
 
 TEST(ATenEmptyTest, DefaultCudaDeviceUsesCurrentDevice) {
   if (c10::cuda::device_count() < 2) {
-    GTEST_SKIP() << "requires at least 2 CUDA devices";
+    GTEST_SKIP() << "requires at least 2 GPU devices";
   }
   c10::cuda::CUDAGuard guard(1);
   at::Tensor t =

--- a/test/cpp/compat/ATen_to_test.cc
+++ b/test/cpp/compat/ATen_to_test.cc
@@ -231,7 +231,7 @@ TEST(TensorToTest, ToDevice_GPUToCPU) {
 
 TEST(TensorToTest, ToDeviceWithoutIndexUsesCurrentCudaDevice) {
   if (c10::cuda::device_count() < 2) {
-    GTEST_SKIP() << "requires at least 2 GPU devices";
+    return;
   }
   c10::cuda::CUDAGuard guard(1);
   at::Tensor t = at::tensor({5.0f}, at::kFloat);

--- a/test/cpp/compat/ATen_to_test.cc
+++ b/test/cpp/compat/ATen_to_test.cc
@@ -231,7 +231,7 @@ TEST(TensorToTest, ToDevice_GPUToCPU) {
 
 TEST(TensorToTest, ToDeviceWithoutIndexUsesCurrentCudaDevice) {
   if (c10::cuda::device_count() < 2) {
-    GTEST_SKIP() << "requires at least 2 CUDA devices";
+    GTEST_SKIP() << "requires at least 2 GPU devices";
   }
   c10::cuda::CUDAGuard guard(1);
   at::Tensor t = at::tensor({5.0f}, at::kFloat);

--- a/test/cpp/compat/ATen_to_test.cc
+++ b/test/cpp/compat/ATen_to_test.cc
@@ -228,4 +228,19 @@ TEST(TensorToTest, ToDevice_GPUToCPU) {
   ASSERT_EQ(result.device().type(), c10::DeviceType::CPU);
   ASSERT_NEAR(result.item<float>(), 7.0f, 1e-5f);
 }
+
+TEST(TensorToTest, ToDeviceWithoutIndexUsesCurrentCudaDevice) {
+  if (c10::cuda::device_count() < 2) {
+    GTEST_SKIP() << "requires at least 2 CUDA devices";
+  }
+  c10::cuda::CUDAGuard guard(1);
+  at::Tensor t = at::tensor({5.0f}, at::kFloat);
+  at::Tensor result = t.to(c10::Device(c10::kCUDA),
+                           at::kFloat,
+                           /*non_blocking=*/false,
+                           /*copy=*/false);
+
+  ASSERT_EQ(result.device().type(), c10::DeviceType::CUDA);
+  ASSERT_EQ(result.device().index(), 1);
+}
 #endif

--- a/test/cpp/compat/c10_Device_test.cc
+++ b/test/cpp/compat/c10_Device_test.cc
@@ -112,9 +112,13 @@ TEST(DeviceCompatTest, DeviceParseAndPlaceBranches) {
   EXPECT_EQ(custom.str(), "privateuseone:5");
 
   c10::Device cuda_no_index(c10::DeviceType::CUDA);
-  EXPECT_EQ(cuda_no_index._PD_GetInner().GetType(), phi::AllocationType::GPU);
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-  if (c10::cuda::device_count() >= 2) {
+  auto device_count = c10::cuda::device_count();
+  if (device_count == 0) {
+    GTEST_SKIP() << "requires at least 1 GPU device";
+  }
+  EXPECT_EQ(cuda_no_index._PD_GetInner().GetType(), phi::AllocationType::GPU);
+  if (device_count >= 2) {
     c10::cuda::CUDAGuard guard(1);
     EXPECT_EQ(c10::Device(c10::DeviceType::CUDA)._PD_GetInner().GetDeviceId(),
               1);
@@ -122,6 +126,7 @@ TEST(DeviceCompatTest, DeviceParseAndPlaceBranches) {
     EXPECT_EQ(cuda_no_index._PD_GetInner().GetDeviceId(), 0);
   }
 #else
+  EXPECT_EQ(cuda_no_index._PD_GetInner().GetType(), phi::AllocationType::GPU);
   EXPECT_EQ(cuda_no_index._PD_GetInner().GetDeviceId(), 0);
 #endif
   c10::Device xpu_no_index(c10::DeviceType::XPU);

--- a/test/cpp/compat/c10_Device_test.cc
+++ b/test/cpp/compat/c10_Device_test.cc
@@ -14,6 +14,10 @@
 
 #include <c10/core/Device.h>
 #include <c10/core/DeviceType.h>
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#include <c10/cuda/CUDAFunctions.h>
+#include <c10/cuda/CUDAGuard.h>
+#endif
 
 #include <sstream>
 #include <unordered_map>
@@ -109,7 +113,17 @@ TEST(DeviceCompatTest, DeviceParseAndPlaceBranches) {
 
   c10::Device cuda_no_index(c10::DeviceType::CUDA);
   EXPECT_EQ(cuda_no_index._PD_GetInner().GetType(), phi::AllocationType::GPU);
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  if (c10::cuda::device_count() >= 2) {
+    c10::cuda::CUDAGuard guard(1);
+    EXPECT_EQ(c10::Device(c10::DeviceType::CUDA)._PD_GetInner().GetDeviceId(),
+              1);
+  } else {
+    EXPECT_EQ(cuda_no_index._PD_GetInner().GetDeviceId(), 0);
+  }
+#else
   EXPECT_EQ(cuda_no_index._PD_GetInner().GetDeviceId(), 0);
+#endif
   c10::Device xpu_no_index(c10::DeviceType::XPU);
   EXPECT_EQ(xpu_no_index._PD_GetInner().GetType(), phi::AllocationType::XPU);
   EXPECT_EQ(xpu_no_index._PD_GetInner().GetDeviceId(), 0);

--- a/test/cpp/compat/c10_Device_test.cc
+++ b/test/cpp/compat/c10_Device_test.cc
@@ -115,7 +115,7 @@ TEST(DeviceCompatTest, DeviceParseAndPlaceBranches) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   auto device_count = c10::cuda::device_count();
   if (device_count == 0) {
-    GTEST_SKIP() << "requires at least 1 GPU device";
+    return;
   }
   EXPECT_EQ(cuda_no_index._PD_GetInner().GetType(), phi::AllocationType::GPU);
   if (device_count >= 2) {


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
该 PR 修复 torch C++ 兼容层在未显式指定 CUDA device index 时默认回退到 `gpu:0` 的语义偏差。

在多卡多进程场景下，这会让 indexless `.cuda()`、`to(cuda)`、`empty(device=cuda)` 以及 `CUDAGuard(Device(kCUDA))` 偏离当前 CUDA device，和 PyTorch 的默认行为不一致，也会放大上层兼容代码中的 device 错配问题。

本次改动将这些 compat 入口统一对齐到当前 CUDA device：
- `Tensor::cuda()` / `toBackend(CUDA)`
- `Tensor::to(... device=cuda ...)`
- `c10::Device(kCUDA)._PD_GetInner()`
- `c10::cuda::CUDAGuard` 对无 index device 的归一化
- `empty_cuda` / `TensorOptions.device(at::kCUDA)`

同时补充了 4 个 C++ compat 单测，覆盖无 index CUDA 调用在多卡下应跟随当前 device 的行为，避免后续再次回退到固定 `gpu:0`。

本地验证：
- 已运行 `prek run --files ...` 并通过
- 未在本地做编译和单测回归

本 PR Co author…… 啊不对，完全 authored by @codex（GPT 5.4 xhigh）

### 是否引起精度变化
否
