### PR TITLE
[Cpp API Compatibility] Fix `as_strided` to align `resize_`

### DIFF
--- a/paddle/phi/api/include/compat/ATen/ops/as_strided.h
+++ b/paddle/phi/api/include/compat/ATen/ops/as_strided.h
@@ -29,6 +29,9 @@ inline at::Tensor Tensor::as_strided(
     at::IntArrayRef size,
     at::IntArrayRef stride,
     ::std::optional<int64_t> storage_offset) const {
+  // Materialize the compat StorageHolderView before creating the view so
+  // aliasing tensors share one StorageImpl and observe later resize_ growth.
+  (void)this->storage();
   auto src_impl = tensor_.impl();
   auto* src_tensor =
       std::dynamic_pointer_cast<phi::DenseTensor>(src_impl).get();
@@ -67,6 +70,9 @@ inline const at::Tensor& Tensor::as_strided_(
     at::IntArrayRef size,
     at::IntArrayRef stride,
     ::std::optional<int64_t> storage_offset) const {
+  // Keep inplace metadata-only view rewrites attached to the same compat
+  // storage as the original tensor.
+  (void)this->storage();
   auto src_impl = tensor_.impl();
   auto* src_tensor =
       std::dynamic_pointer_cast<phi::DenseTensor>(src_impl).get();

--- a/test/cpp/compat/c10_storage_test.cc
+++ b/test/cpp/compat/c10_storage_test.cc
@@ -17,6 +17,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/EmptyTensor.h>
 #include <ATen/native/cuda/Resize.h>
+#include <ATen/ops/as_strided.h>
 #include <ATen/ops/tensor.h>
 #include <c10/core/ScalarType.h>
 #include <c10/core/SymInt.h>
@@ -976,6 +977,19 @@ TEST(StorageTest, CopiedTensorWrappersShareStorageImpl) {
   ASSERT_EQ(tensor.storage().get_impl(), alias.storage().get_impl());
   ASSERT_EQ(alias.data_ptr(), new_alloc->ptr())
       << "Copied TensorBase wrappers must observe shared storage mutations";
+}
+
+TEST(StorageTest, AsStridedViewSharesStorageImplWithBaseTensor) {
+  at::Tensor base = at::tensor({1, 2, 3, 4}, at::kInt);
+  at::Tensor view = base.as_strided({3}, {1}, 1);
+
+  ASSERT_EQ(base.storage().get_impl(), view.storage().get_impl());
+
+  view.resize_({4});
+
+  ASSERT_EQ(view.data_ptr<int>(), base.data_ptr<int>() + 1)
+      << "Growing an as_strided view must update the shared compat storage "
+         "visible from the base tensor";
 }
 
 TEST(StorageTest, AliasWrapperDoesNotIncreaseTensorOwnedStorageCount) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure


### PR Types
Bug fixes


### Description
修复 `as_strided` 接口来对齐 `resize_` 的行为


### 是否引起精度变化
否
