### PR TITLE
[XPU] Fix fused_rotary_position_embedding precision: skip zero-numel k/v tensor

### DIFF
--- a/paddle/phi/kernels/fusion/xpu/fused_rope_utils.h
+++ b/paddle/phi/kernels/fusion/xpu/fused_rope_utils.h
@@ -282,7 +282,10 @@ void XPUFusedRotaryEveryTwo(const Context& dev_ctx,
     single_func_name = "rotary_embedding_everytwo_unary_freqs_grad";
     fusion_func_name = "rotary_embedding_everytwo_binary_freqs_grad";
   }
-  if (!in_k) {
+  // Check k/v numel > 0, matching GPU's guard (k && k->numel() > 0), to
+  // avoid passing a zero-element tensor pointer to the XPU library which
+  // causes undefined behavior and overflow outputs.
+  if (!in_k || in_k->numel() == 0) {
     int ret = everytwo_func(dev_ctx.x_context(),
                             reinterpret_cast<const XPUType*>(in_q.data()),
                             nullptr,
@@ -310,7 +313,7 @@ void XPUFusedRotaryEveryTwo(const Context& dev_ctx,
                             10000.0f);
     PADDLE_ENFORCE_XDNN_SUCCESS(ret, fusion_func_name);
   }
-  if (in_v) {
+  if (in_v && in_v->numel() > 0) {
     int64_t num_heads_v = in_v->dims()[2];
     int ret = everytwo_func(dev_ctx.x_context(),
                             reinterpret_cast<const XPUType*>(in_v->data()),
@@ -352,7 +355,10 @@ void XPUFusedRotaryHalf(const Context& dev_ctx,
     fusion_func_name = "xpu::rotary_embedding_half_binary_freqs_grad";
   }
 
-  if (!in_k) {
+  // Check k/v numel > 0, matching GPU's guard (k && k->numel() > 0), to
+  // avoid passing a zero-element tensor pointer to the XPU library which
+  // causes undefined behavior and overflow outputs.
+  if (!in_k || in_k->numel() == 0) {
     int ret = half_func(dev_ctx.x_context(),
                         reinterpret_cast<const XPUType*>(in_q.data()),
                         nullptr,
@@ -389,7 +395,7 @@ void XPUFusedRotaryHalf(const Context& dev_ctx,
     PADDLE_ENFORCE_XDNN_SUCCESS(ret, fusion_func_name);
   }
 
-  if (in_v) {
+  if (in_v && in_v->numel() > 0) {
     int64_t num_heads_v = in_v->dims()[2];
     int ret = half_func(dev_ctx.x_context(),
                         reinterpret_cast<const XPUType*>(in_v->data()),


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

#### 问题背景

`paddle.incubate.nn.functional.fused_rotary_position_embedding` 在 XPU 上出现严重精度问题，XPU 与 GPU 输出的 `max_abs_diff` 高达 `2.28754e+37`（接近 float32 最大值），输出为溢出/垃圾值。

#### 根本原因

XPU 实现（`XPUFusedRotaryEveryTwo` 和 `XPUFusedRotaryHalf`）通过 `!in_k` 判断 k 是否存在（检查 optional 是否有值），但未检查 `in_k->numel() > 0`。

当 k 张量形状为 `[0, seq_len, heads, dim]`（numel=0）时，optional 非空（有值），但底层数据指针指向零元素张量。XPU 库函数 `rotary_embedding_everytwo/half` 收到一个悬空指针，产生未定义行为，导致输出溢出。

GPU 实现已正确处理此情况：`if (k && k->numel() > 0)`，当 numel=0 时跳过 k/v 的处理。

#### 修复方案

在 `XPUFusedRotaryEveryTwo` 和 `XPUFusedRotaryHalf` 中，将判断条件从：

```cpp
if (!in_k) { ... }   // 仅检查 optional 是否有值
if (in_v) { ... }
```

改为：

```cpp
if (!in_k || in_k->numel() == 0) { ... }  // 与 GPU 保持一致
if (in_v && in_v->numel() > 0) { ... }
```

#### 验证结果

| 指标 | 修复前 | 修复后 |
|------|--------|--------|
| forward max_abs_diff | 2.28754e+37 | 1.59e-28 |
| forward 精度检查 | **FAILED** | **PASSED** |
| backward max_abs_diff | — | 1.32e-28 |
| backward 精度检查 | — | **PASSED** |

### 是否引起精度变化

否，不影响GPU精度。修正了 XPU 在 k/v 为零元素张量时的精度问题，使其与 GPU 输出对齐。对于正常（非零元素）输入，行为不变。