### PR TITLE
[CodeStyle] Bump `ast-grep` to `v0.42.1` and `typos` to `v1.45.0`

### DIFF
--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install pre-commit==2.17.0
-          pip install ast-grep-cli==0.40.0 # This version should be consistent with the one in .pre-commit-config.yaml
+          pip install ast-grep-cli==0.42.1 # This version should be consistent with the one in .pre-commit-config.yaml
 
       - name: Run ast-grep unit tests
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
             test/dygraph_to_static/test_error.py
           )$
   - repo: https://github.com/PFCCLab/ast-grep-pre-commit-mirror
-    rev: v0.40.0.1
+    rev: v0.42.1
     hooks:
       - id: ast-grep
   - repo: local
@@ -55,7 +55,7 @@ repos:
             paddle/cinn/utils/registry.h
           )$
   - repo: https://github.com/PFCCLab/typos-pre-commit-mirror.git
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: typos
         args: [--force-exclude]

--- a/_typos.toml
+++ b/_typos.toml
@@ -51,3 +51,6 @@ tood = 'tood'
 UNEXPECT = 'UNEXPECT'
 unpacket = "unpacket"
 vaccum = 'vaccum'
+
+[default.extend-identifiers]
+NPY_ARRAY_WRITEABLE_ = "NPY_ARRAY_WRITEABLE_"

--- a/paddle/phi/kernels/fusion/cutlass/cutlass_extensions/gemm/threadblock/dp_mma_multistage_finegrained.h
+++ b/paddle/phi/kernels/fusion/cutlass/cutlass_extensions/gemm/threadblock/dp_mma_multistage_finegrained.h
@@ -80,7 +80,7 @@ template <
     //  MaskedTileIterator)
     typename IteratorA_,
     /// Iterates over tiles of A operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorA_,
     /// Cache operation for operand A
     cutlass::arch::CacheOperation::Kind CacheOpA,
@@ -89,7 +89,7 @@ template <
     //  MaskedTileIterator)
     typename IteratorB_,
     /// Iterates over tiles of B operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorB_,
     /// Cache operation for operand B
     cutlass::arch::CacheOperation::Kind CacheOpB,

--- a/paddle/phi/kernels/fusion/cutlass/cutlass_extensions/gemm/threadblock/dp_mma_multistage_percol.h
+++ b/paddle/phi/kernels/fusion/cutlass/cutlass_extensions/gemm/threadblock/dp_mma_multistage_percol.h
@@ -79,7 +79,7 @@ template <
     //  MaskedTileIterator)
     typename IteratorA_,
     /// Iterates over tiles of A operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorA_,
     /// Cache operation for operand A
     cutlass::arch::CacheOperation::Kind CacheOpA,
@@ -88,7 +88,7 @@ template <
     //  MaskedTileIterator)
     typename IteratorB_,
     /// Iterates over tiles of B operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorB_,
     /// Cache operation for operand B
     cutlass::arch::CacheOperation::Kind CacheOpB,

--- a/paddle/phi/kernels/fusion/cutlass/cutlass_extensions/gemm/threadblock/dq_mma_multistage.h
+++ b/paddle/phi/kernels/fusion/cutlass/cutlass_extensions/gemm/threadblock/dq_mma_multistage.h
@@ -65,7 +65,7 @@ template <
     //  MaskedTileIterator)
     typename IteratorA_,
     /// Iterates over tiles of A operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorA_,
     /// Cache operation for operand A
     cutlass::arch::CacheOperation::Kind CacheOpA,
@@ -74,7 +74,7 @@ template <
     //  MaskedTileIterator)
     typename IteratorB_,
     /// Iterates over tiles of B operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorB_,
     /// Cache operation for operand B
     cutlass::arch::CacheOperation::Kind CacheOpB,

--- a/paddle/phi/kernels/fusion/cutlass/cutlass_extensions/gemm/threadblock/dq_mma_pipelined.h
+++ b/paddle/phi/kernels/fusion/cutlass/cutlass_extensions/gemm/threadblock/dq_mma_pipelined.h
@@ -68,14 +68,14 @@ template <
     //  MaskedTileIterator)
     typename IteratorA_,
     /// Iterates over tiles of A operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorA_,
     /// Iterates over tiles of B operand in global memory
     //  (concept: ReadableTileIterator | ForwardTileIterator |
     //  MaskedTileIterator)
     typename IteratorB_,
     /// Iterates over tiles of B operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorB_,
     /// Data type for the scales
     typename IteratorScale_,

--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/gemm/custom_mma_multistage.h
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/gemm/custom_mma_multistage.h
@@ -83,7 +83,7 @@ template <
     //  MaskedTileIterator)
     typename IteratorA_,
     /// Iterates over tiles of A operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorA_,
     /// Cache operation for operand A
     cutlass::arch::CacheOperation::Kind CacheOpA,
@@ -92,7 +92,7 @@ template <
     //  MaskedTileIterator)
     typename IteratorB_,
     /// Iterates over tiles of B operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorB_,
     /// Cache operation for operand B
     cutlass::arch::CacheOperation::Kind CacheOpB,

--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/gemm/custom_mma_pipelined.h
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/gemm/custom_mma_pipelined.h
@@ -83,14 +83,14 @@ template <
     //  MaskedTileIterator)
     typename IteratorA_,
     /// Iterates over tiles of A operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorA_,
     /// Iterates over tiles of B operand in global memory
     //  (concept: ReadableTileIterator | ForwardTileIterator |
     //  MaskedTileIterator)
     typename IteratorB_,
     /// Iterates over tiles of B operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorB_,
     /// Data type of accumulator matrix
     typename ElementC_,

--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/gemm/mma_from_smem.h
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/gemm/mma_from_smem.h
@@ -359,7 +359,7 @@ template <
     //  MaskedTileIterator)
     typename IteratorB_,
     /// Iterates over tiles of B operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorB_,
     /// Data type of accumulator matrix
     typename ElementC_,
@@ -710,7 +710,7 @@ template <
     //  MaskedTileIterator)
     typename IteratorB1_,
     /// Iterates over tiles of B operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorB1_,
     /// Cache operation for operand B
     cutlass::arch::CacheOperation::Kind CacheOpB1,
@@ -1348,14 +1348,14 @@ template <
     //  MaskedTileIterator)
     typename IteratorA_,
     /// Iterates over tiles of A operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorA_,
     /// Iterates over tiles of B operand in global memory
     //  (concept: ReadableTileIterator | ForwardTileIterator |
     //  MaskedTileIterator)
     typename IteratorB_,
     /// Iterates over tiles of B operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorB_,
     /// Data type of accumulator matrix
     typename ElementC_,
@@ -1433,7 +1433,7 @@ template <
     //  MaskedTileIterator)
     typename IteratorA_,
     /// Iterates over tiles of A operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorA_,
     /// Cache operation for operand A
     cutlass::arch::CacheOperation::Kind CacheOpA,
@@ -1442,7 +1442,7 @@ template <
     //  MaskedTileIterator)
     typename IteratorB_,
     /// Iterates over tiles of B operand in shared memory
-    /// (concept: WriteableTileIterator | RandomAccessTileIterator)
+    /// (concept: WritableTileIterator | RandomAccessTileIterator)
     typename SmemIteratorB_,
     /// Cache operation for operand B
     cutlass::arch::CacheOperation::Kind CacheOpB,

--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/iterators/predicated_tile_access_iterator_residual_last.h
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/iterators/predicated_tile_access_iterator_residual_last.h
@@ -440,7 +440,7 @@ class PredicatedTileAccessIteratorResidualLast<Shape_,
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,
@@ -643,7 +643,7 @@ class PredicatedTileAccessIteratorResidualLast<Shape_,
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,
@@ -844,7 +844,7 @@ class PredicatedTileAccessIteratorResidualLast<Shape_,
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,
@@ -1164,7 +1164,7 @@ class PredicatedTileAccessIteratorResidualLast<Shape_,
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,
@@ -1362,7 +1362,7 @@ class PredicatedTileAccessIteratorResidualLast<Shape_,
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,
@@ -1560,7 +1560,7 @@ class PredicatedTileAccessIteratorResidualLast<Shape_,
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 
@@ -1766,7 +1766,7 @@ class PredicatedTileAccessIteratorResidualLast<
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,

--- a/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/iterators/predicated_tile_iterator_residual_last.h
+++ b/paddle/phi/kernels/fusion/cutlass/memory_efficient_attention/iterators/predicated_tile_iterator_residual_last.h
@@ -79,7 +79,7 @@ namespace threadblock {
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 /// Regular tile iterator using a precomputed control structure to minimize
@@ -174,7 +174,7 @@ class PredicatedTileIteratorResidualLast;
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,
@@ -452,7 +452,7 @@ class PredicatedTileIteratorResidualLast<Shape_,
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,
@@ -663,7 +663,7 @@ class PredicatedTileIteratorResidualLast<Shape_,
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,
@@ -872,7 +872,7 @@ class PredicatedTileIteratorResidualLast<Shape_,
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,
@@ -1142,7 +1142,7 @@ class PredicatedTileIteratorResidualLast<Shape_,
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,
@@ -1348,7 +1348,7 @@ class PredicatedTileIteratorResidualLast<Shape_,
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,
@@ -1554,7 +1554,7 @@ class PredicatedTileIteratorResidualLast<Shape_,
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 
@@ -1763,7 +1763,7 @@ class PredicatedTileIteratorResidualLast<
 ///
 /// Satisfies: ForwardTileIteratorConcept |
 ///            ReadableContiguousTileIteratorConcept |
-///            WriteableContiguousTileIteratorConcept |
+///            WritableContiguousTileIteratorConcept |
 ///            MaskedTileIteratorConcept
 ///
 template <typename Shape_,

--- a/test/legacy_test/test_fused_groupnorm.py
+++ b/test/legacy_test/test_fused_groupnorm.py
@@ -152,7 +152,7 @@ class TestGroupNormNHWC_StaticOp(unittest.TestCase):
         self, x_np, scale_np, bias_np, residual_np, activation, dtype
     ):
         paddle.disable_static()
-        navie_groupnorm_out = naive_residual_biasadd_layer_norm(
+        naive_groupnorm_out = naive_residual_biasadd_layer_norm(
             x_np,
             residual_np,
             scale_np,
@@ -162,7 +162,7 @@ class TestGroupNormNHWC_StaticOp(unittest.TestCase):
             self.data_layout,
             self.activation,
         )
-        navie_residual_out = naive_residual_add(x_np, residual_np)
+        naive_residual_out = naive_residual_add(x_np, residual_np)
         paddle.enable_static()
 
         with (
@@ -205,7 +205,7 @@ class TestGroupNormNHWC_StaticOp(unittest.TestCase):
                 },
                 fetch_list=[outs],
             )
-        return (out_s[0], out_s[1]), navie_groupnorm_out, navie_residual_out
+        return (out_s[0], out_s[1]), naive_groupnorm_out, naive_residual_out
 
     def test_residual_add_groupnorm_fp16(self):
         if not (paddle.is_compiled_with_cuda() or is_custom_device()):


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Others

### Description

Bump `ast-grep` from `v0.40.0` to `v0.42.1` and `typos` from `v1.44.0` to `v1.45.0`.

Main changes:
- update the `ast-grep` and `typos` hook revisions in `.pre-commit-config.yaml`
- keep the CI-installed `ast-grep-cli` version aligned with the hook version
- fix the new typos surfaced by `typos v1.45.0`
- whitelist `NPY_ARRAY_WRITEABLE_` in `_typos.toml` because it is an upstream NumPy API identifier

### 是否引起精度变化

否
