### PR TITLE
 update cross_entropy_grad_kernel.cu [phi_ops]

### DIFF
--- a/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
@@ -169,11 +169,6 @@ void CrossEntropyWithSoftmaxGradGPUKernel(const GPUContext& dev_ctx,
                                           int ignore_index,
                                           int axis,
                                           DenseTensor* logits_grad) {
-  PADDLE_ENFORCE_EQ(
-      dev_ctx.GetPlace().GetType(),
-      AllocationType::GPU,
-      common::errors::Unavailable("softmax_with_cross_entropy operator's "
-                                  "CUDA kernel only runs on GPU device."));
   const T* loss_grad_data = loss_grad.data<T>();
   DenseTensor* logit_grad = logits_grad;
 

--- a/paddle/phi/kernels/impl/gammaincc_kernel_impl.h
+++ b/paddle/phi/kernels/impl/gammaincc_kernel_impl.h
@@ -56,8 +56,8 @@ HOSTDEVICE T igam(const T a, const T x) {
 
 template <typename T>
 HOSTDEVICE T igamc(const T a, const T x) {
-  static T big = 4.503599627370496e15;
-  static T biginv = 2.22044604925031308085e-16;
+  static const T big = 4.503599627370496e15;
+  static const T biginv = 2.22044604925031308085e-16;
 
   if ((x <= T{0}) || (a <= T{0})) return (T{1.0});
 

--- a/paddle/phi/kernels/impl/gammaln_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/gammaln_grad_kernel_impl.h
@@ -20,8 +20,8 @@
 namespace phi {
 template <typename T>
 HOSTDEVICE T digamma_positive_domain(T x) {
-  static T c = T{8.5};
-  static T euler_mascheroni = T{0.57721566490153286060};
+  static const T c = T{8.5};
+  static const T euler_mascheroni = T{0.57721566490153286060};
   T r;
   T value;
   T x2;
@@ -54,7 +54,7 @@ HOSTDEVICE T digamma_positive_domain(T x) {
 
 template <typename T>
 HOSTDEVICE T digamma(T x) {
-  static T pi = T{3.14159265358979323846};
+  static const T pi = T{3.14159265358979323846};
 
   if (x == T{0.0}) {
     T inf = std::numeric_limits<T>::infinity();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
来自 https://github.com/PaddlePaddle/PaddleCustomDevice/blob/develop/backends/metax_gpu/patch/paddle.patch 的部分修改
paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu 不用判断place
paddle/phi/kernels/impl/gammaincc_kernel_impl.h paddle/phi/kernels/impl/gammaln_grad_kernel_impl.h 常量增加const修饰符，如果加到static前pre-commit有下图中提示信息，所以加到 static 后
<img width="1422" height="109" alt="image" src="https://github.com/user-attachments/assets/694cc2d0-ea4f-4ef7-8a92-7bf7cccb9de4" />

https://github.com/PaddlePaddle/PaddleCustomDevice/issues/2498

### 是否引起精度变化
否