### PR TITLE
[CI] Update checkout action to v6

### DIFF
--- a/.github/actions/skip-skill/action.yml
+++ b/.github/actions/skip-skill/action.yml
@@ -33,7 +33,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/CI-Build.yml
+++ b/.github/workflows/CI-Build.yml
@@ -28,7 +28,7 @@ jobs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip || 'false' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run skip check
         id: skip-skill
         uses: ./.github/actions/skip-skill

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -26,7 +26,7 @@ jobs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run skip check
         id: skip-skill
         uses: ./.github/actions/skip-skill

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run skip check
         id: skip-skill
         uses: ./.github/actions/skip-skill
@@ -108,18 +108,18 @@ jobs:
       docker_distribute_image: ${{ needs.build-docker.outputs.docker_distribute_image }}
       clone-can-skip: ${{ needs.clone.outputs.can-skip }}
 
-  # distribute-test:
-  #   name: Distribute-stable-test
-  #   uses: ./.github/workflows/_Distribute-stable-Test.yml
-  #   needs: [clone, build-docker, distribute]
-  #   with:
-  #     docker_distribute_image: ${{ needs.build-docker.outputs.docker_distribute_image }}
-  #     clone-can-skip: ${{ needs.clone.outputs.can-skip }}
+# distribute-test:
+#   name: Distribute-stable-test
+#   uses: ./.github/workflows/_Distribute-stable-Test.yml
+#   needs: [clone, build-docker, distribute]
+#   with:
+#     docker_distribute_image: ${{ needs.build-docker.outputs.docker_distribute_image }}
+#     clone-can-skip: ${{ needs.clone.outputs.can-skip }}
 
-  # distribute-formers:
-  #   name: Distribute-stable-formers
-  #   uses: ./.github/workflows/_Distribute-stable-Formers.yml
-  #   needs: [clone, build-docker, distribute]
-  #   with:
-  #     docker_distribute_image: ${{ needs.build-docker.outputs.docker_distribute_image }}
-  #     clone-can-skip: ${{ needs.clone.outputs.can-skip }}
+# distribute-formers:
+#   name: Distribute-stable-formers
+#   uses: ./.github/workflows/_Distribute-stable-Formers.yml
+#   needs: [clone, build-docker, distribute]
+#   with:
+#     docker_distribute_image: ${{ needs.build-docker.outputs.docker_distribute_image }}
+#     clone-can-skip: ${{ needs.clone.outputs.can-skip }}

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -40,7 +40,7 @@ jobs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip || 'false' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run skip check
         id: skip-skill
         uses: ./.github/actions/skip-skill

--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -42,7 +42,7 @@ jobs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run skip check
         id: skip-skill
         uses: ./.github/actions/skip-skill


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Devs

### Description
本 PR 修复 #78079 合入后新增的 `actions/checkout@v4` 引用，继续保持 GitHub Actions 对 Node 24 的兼容目标。

主要改动：
- 将 `.github/actions/skip-skill/action.yml` 以及 `CI`、`CI-Build`、`CI-Windows`、`Coverage`、`H-Coverage` workflow 中的 `actions/checkout@v4` 升级为 `actions/checkout@v6`。
- 按 `prek`/`yamlfmt` 要求同步规整了 `CI.yml` 中注释块的 YAML 格式。

验证：
- `prek`
- 全仓扫描未再发现 `actions/checkout@v0-v5` 以及 #78079 涉及的其它旧 action 版本。

### 是否引起精度变化
否