### PR TITLE
[CodeStyle] Configure yamlfmt line endings

### DIFF
--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,3 +1,4 @@
+line_ending: lf
 formatter:
   indent: 2
   type: basic


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Devs

### Description
本 PR 为 `.yamlfmt` 显式配置 `line_ending: lf`，避免 Windows 环境下 `yamlfmt` 默认输出 CRLF，与 `remove-crlf` hook 反复产生行尾改动。

背景：`yamlfmt` 在 Windows 上默认 `line_ending` 为 `crlf`，会把已由 `remove-crlf` 转成 LF 的 YAML 文件重新写回 CRLF。本配置将 yamlfmt 的输出行尾固定为 LF，使其与现有 `remove-crlf` hook 保持一致。

验证：
- `yamlfmt -print_conf` 确认 `line_ending` 和 `formatter.line_ending` 均为 `lf`
- `prek`

### 是否引起精度变化
否