### PR TITLE
[CI] Update Codecov action to v6

### DIFF
--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -388,7 +388,7 @@ jobs:
           '
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           directory: build/coverage_files
           verbose: true


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Devs

### Description
本 PR 根据 #78645 review 的建议，补充检查非 `actions/*` 仓库的 GitHub Action Node runtime 兼容性，并升级需要处理的 Codecov action。

检查结果：
- `PFCCLab/ci-bypass@v2`：JavaScript action，`runs.using: node24`，无需修改。
- `peter-evans/find-comment@v4`：JavaScript action，`runs.using: node24`，无需修改。
- `peter-evans/create-or-update-comment@v5`：JavaScript action，`runs.using: node24`，无需修改。
- `codecov/codecov-action@v5`：composite action，但内部引用 `actions/github-script@v7.0.1`；`codecov/codecov-action@v6.0.0` 已改为内部使用 `actions/github-script@v8.0.0`，因此将 Coverage workflow 中的 Codecov action 升级到 v6。
- 本仓库本地 composite action 已检查：`rerun-workflow` 不使用 Node runtime；`skip-skill` 本身为 composite，内部 `actions/checkout` 已由 #78645 处理。

验证：
- 使用 `gh api` 检查上述第三方 action 的 `action.yml` / `action.yaml` 配置。
- 扫描 `.github` 下外部 action 引用，确认非 `actions/*` 的第三方 action 仅剩上述列表。
- `prek --skip yamlfmt` 通过。当前 Windows 环境下 full `prek` 会受到 #78646 修复的 `.yamlfmt` 行尾问题影响，`remove-crlf` 与 `yamlfmt` 会反复改动 YAML 行尾，因此本 PR 未重复包含 `.yamlfmt` 修复。

### 是否引起精度变化
否