### PR TITLE
[CodeStyle][yamlfmt] Bump `google-yamlfmt` to version 0.21.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,7 +157,7 @@ repos:
           )$
   # For YAML files
   - repo: https://github.com/PFCCLab/yamlfmt-pre-commit-mirror.git
-    rev: v0.16.0
+    rev: v0.21.0
     hooks:
       - id: yamlfmt
         files: |


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Devs

### Description
将 `.pre-commit-config.yaml` 中 `PFCCLab/yamlfmt-pre-commit-mirror` 的 `rev` 从 `v0.16.0` 升级到 `v0.21.0`。

这次重新评估了此前在 #74069 中阻塞升级的 Linux GLIBC 风险，结论和当时不同：

- 当时触发回退的 `0.17.2` Linux x86_64 wheel 内二进制是 **dynamically linked**，本地检查可见 `GLIBC_2.32` / `GLIBC_2.34` 依赖，和回退 PR 中报错一致。
- 当前目标 `0.21.0` 的 `google_yamlfmt-0.21.0-py3-none-manylinux_2_17_x86_64.whl` 内二进制已变为 **statically linked**，不再暴露同类动态 glibc 符号依赖，因此此前的阻塞条件已经解除。

本 PR 只做版本号升级，不引入额外配置改动。

### Validation
- `pre-commit run yamlfmt --files .pre-commit-config.yaml .yamlfmt`
- `pre-commit run --files .pre-commit-config.yaml .yamlfmt`
- 额外检查 wheel：
  - `pip3 download --no-deps --only-binary=:all: --platform manylinux_2_17_x86_64 --implementation py --python-version 310 --abi none google-yamlfmt==0.21.0`
  - `file wheel/yamlfmt/yamlfmt`

### 是否引起精度变化
否
