### PR TITLE
[Compat] Use public enable_compat in torch proxy tests

### DIFF
--- a/test/compat/test_torch_proxy.py
+++ b/test/compat/test_torch_proxy.py
@@ -32,11 +32,11 @@ def use_torch_inside_inner_function():
 
 
 class TestTorchProxy(unittest.TestCase):
-    def test_enable_torch_proxy(self):
+    def test_enable_compat(self):
         with self.assertRaises(ModuleNotFoundError):
             import torch
 
-        paddle.compat.enable_torch_proxy()
+        paddle.enable_compat()
         import torch
 
         self.assertIs(torch.sin, paddle.sin)
@@ -115,9 +115,7 @@ class TestTorchProxyLocalEnabledModule(unittest.TestCase):
         with self.assertRaises(ModuleNotFoundError):
             import torch_proxy_local_enabled_module
 
-        paddle.compat.enable_torch_proxy(
-            scope="torch_proxy_local_enabled_module"
-        )
+        paddle.enable_compat(scope="torch_proxy_local_enabled_module")
         with self.assertRaises(ModuleNotFoundError):
             import torch  # noqa: F401
 


### PR DESCRIPTION
### PR Category

User Experience

### PR Types

Improvements

### Description

follow-up of #76823。

这个 PR 做了一个最小清理：

- 将 `test/compat/test_torch_proxy.py` 中 2 处 `paddle.compat.enable_torch_proxy` 调用替换为公开 API `paddle.enable_compat`
- 将对应测试名同步为 `test_enable_compat`

额外检查了一遍仓库内文档/示例/兼容层说明：

- 代码搜索后，仓库内该旧 API 的实际使用点只剩上述 2 处测试调用
- `python/paddle/compat/proxy.py` 中相关示例已经使用 `paddle.enable_compat`，无需额外同步

### Test

- `rg -n "paddle\.compat\.enable_torch_proxy|paddle\.enable_compat" test/compat/test_torch_proxy.py python/paddle`
- `prek run --files test/compat/test_torch_proxy.py`
- `python3 -m py_compile test/compat/test_torch_proxy.py`
- `python3 -m unittest discover -s test/compat -p 'test_torch_proxy.py'`  
  当前本地环境缺少 `numpy`，未能完整执行该测试

### 是否引起精度变化

否
