### PR TITLE
[XPU] Fix precision for paddle.nn.functional.cross_entropy

### DIFF
--- a/paddle/phi/kernels/xpu/cross_entropy_kernel.cc
+++ b/paddle/phi/kernels/xpu/cross_entropy_kernel.cc
@@ -136,6 +136,8 @@ void CrossEntropyWithSoftmaxKernel(const Context& dev_ctx,
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "softmax");
     }
     // 4. hard_cross_entropy only
+    // Use the caller-supplied ignore_index so that positions with label ==
+    // ignore_index are correctly zeroed out (matches GPU behaviour).
     r = xpu::hard_cross_entropy<XPUType, int>(dev_ctx.x_context(),
                                               softmax_data,
                                               labels_data,
@@ -143,7 +145,7 @@ void CrossEntropyWithSoftmaxKernel(const Context& dev_ctx,
                                               nullptr,
                                               n * d,
                                               t,
-                                              -100);
+                                              ignore_index);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "hard_cross_entropy");
   }
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

**背景与问题**

`paddle.nn.functional.cross_entropy` 在 XPU 上计算结果与 GPU 存在精度差异。具体表现为：当 `ignore_index` 设置为非默认值（例如 `ignore_index=4`）时，XPU 的 forward 输出 `max_abs_diff` 高达 2.80162，远超可接受误差范围。

**根因分析**

`paddle/phi/kernels/xpu/cross_entropy_kernel.cc` 中，`CrossEntropyWithSoftmaxKernel` 调用 `xpu::hard_cross_entropy` 时，`ignore_index` 参数被硬编码为 `-100`（即 Paddle 的默认值），而未使用调用方传入的实际 `ignore_index` 值：

```cpp
// 修复前（有问题）
r = xpu::hard_cross_entropy<XPUType, int>(..., -100);

// 修复后（正确）
r = xpu::hard_cross_entropy<XPUType, int>(..., ignore_index);
```

当用户传入 `ignore_index=4` 时，XPU 仍以 `-100` 作为 ignore 位置判断，导致 `label==4` 的位置未被正确归零，而 GPU 实现会正确处理，从而产生精度差异。

**修复方案**

将 `hard_cross_entropy` 调用中的硬编码 `-100` 替换为函数参数 `ignore_index`，使 XPU 行为与 GPU 保持一致。修改范围极小（1 行），向后兼容（默认值本身为 -100，行为不变）。

**验证结果**

修复后回归测试通过：
- Forward `max_abs_diff`：从 2.80162 降至 2.38419e-07
- Backward `max_abs_diff`：1.43051e-06
- 均在 atol=0.01 误差范围内

### 是否引起精度变化
否，不影响 GPU 精度。修正 XPU 精度使其与 GPU 对齐：当 `ignore_index` 为非默认值时，XPU 的 `cross_entropy` 输出现在能正确将 `label==ignore_index` 位置的 loss 归零，与 GPU 行为一致。
