### PR TITLE
CI修复无法显示DCUbuild日志

### DIFF
--- a/.github/workflows/_Linux-DCU.yml
+++ b/.github/workflows/_Linux-DCU.yml
@@ -143,6 +143,8 @@ jobs:
           echo "Pull upstream develop or target branch"
           git pull upstream $BRANCH --no-edit
           git submodule update
+          echo "[CI] step finished"
+          sleep 1
           '
 
       - name: Run build
@@ -158,6 +160,8 @@ jobs:
           rm -rf `find . -name "*.a"`
           rm -rf `find . -name "*.o"`
           exit $EXCODE
+          echo "[CI] step finished"
+          sleep 1
           '
 
       - name: Upload build.tar.gz and paddle_whl to bos
@@ -182,6 +186,8 @@ jobs:
           echo "Uploading paddle_whl"
           cp /paddle/dist/${{ env.paddle_whl }} .
           python ${{ env.bos_file }} ${{ env.paddle_whl }} paddle-github-action/PR/dcu/${{ env.PR_ID }}/${{ env.COMMIT_ID }}
+          echo "[CI] step finished"
+          sleep 1
           '
 
       - name: Terminate and delete the container
@@ -283,6 +289,8 @@ jobs:
           wget -q --tries=5 --no-proxy https://paddle-github-action.bj.bcebos.com/PR/dcu/${PR_ID}/${COMMIT_ID}/build.tar.gz --no-check-certificate
           tar --use-compress-program="pzstd" -xf build.tar.gz --strip-components=1
           rm build.tar.gz
+          echo "[CI] step finished"
+          sleep 1
           '
 
       - name: Run test
@@ -296,6 +304,8 @@ jobs:
           tar -zxf hyhal-Z100.tar.gz -C /opt
           source /opt/dtk-24.04.1/env.sh
           bash -x ${ci_scripts}/dcu_test.sh
+          echo "[CI] step finished"
+          sleep 1
           '
 
       - name: Terminate and delete the container

--- a/.github/workflows/_Linux-DCU.yml
+++ b/.github/workflows/_Linux-DCU.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Download paddle.tar.gz and update test branch
         timeout-minutes: 30
         run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -c '
+          docker exec ${{ env.container_name }} /bin/bash -c '
           ulimit -n 102400
           rm -rf * .[^.]*
           set -e
@@ -143,8 +143,6 @@ jobs:
           echo "Pull upstream develop or target branch"
           git pull upstream $BRANCH --no-edit
           git submodule update
-          echo "[CI] step finished"
-          sleep 1
           '
 
       - name: Run build
@@ -152,7 +150,7 @@ jobs:
           work_dir: ${{ github.workspace }}
           PADDLE_ROOT: ${{ github.workspace }}
         run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -c '
+          docker exec ${{ env.container_name }} /bin/bash -c '
           source /opt/dtk-24.04.1/env.sh
           bash ${ci_scripts}/run_setup.sh bdist_wheel
           EXCODE=$?
@@ -160,8 +158,6 @@ jobs:
           rm -rf `find . -name "*.a"`
           rm -rf `find . -name "*.o"`
           exit $EXCODE
-          echo "[CI] step finished"
-          sleep 1
           '
 
       - name: Upload build.tar.gz and paddle_whl to bos
@@ -172,7 +168,7 @@ jobs:
           bos_file: ${{ github.workspace }}/../bos/BosClient.py
           paddle_whl: paddlepaddle_dcu-0.0.0-cp310-cp310-linux_x86_64.whl
         run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -c '
+          docker exec ${{ env.container_name }} /bin/bash -c '
           if [ ! -f "${{ env.bos_file }}" ]; then
             wget -q --no-proxy -O ${{ env.home_path }}/bos_new.tar.gz https://xly-devops.bj.bcebos.com/home/bos_new.tar.gz --no-check-certificate
             mkdir ${{ env.home_path }}/bos
@@ -186,8 +182,6 @@ jobs:
           echo "Uploading paddle_whl"
           cp /paddle/dist/${{ env.paddle_whl }} .
           python ${{ env.bos_file }} ${{ env.paddle_whl }} paddle-github-action/PR/dcu/${{ env.PR_ID }}/${{ env.COMMIT_ID }}
-          echo "[CI] step finished"
-          sleep 1
           '
 
       - name: Terminate and delete the container
@@ -284,18 +278,16 @@ jobs:
 
       - name: Download build.tar.gz
         run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -c '
+          docker exec ${{ env.container_name }} /bin/bash -c '
           rm -rf ./*
           wget -q --tries=5 --no-proxy https://paddle-github-action.bj.bcebos.com/PR/dcu/${PR_ID}/${COMMIT_ID}/build.tar.gz --no-check-certificate
           tar --use-compress-program="pzstd" -xf build.tar.gz --strip-components=1
           rm build.tar.gz
-          echo "[CI] step finished"
-          sleep 1
           '
 
       - name: Run test
         run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -c '
+          docker exec ${{ env.container_name }} /bin/bash -c '
           export PATH=/usr/local/bin:${PATH}
           ln -sf $(which python3.10) /usr/local/bin/python
           ln -sf $(which pip3.10) /usr/local/bin/pip
@@ -304,14 +296,12 @@ jobs:
           tar -zxf hyhal-Z100.tar.gz -C /opt
           source /opt/dtk-24.04.1/env.sh
           bash -x ${ci_scripts}/dcu_test.sh
-          echo "[CI] step finished"
-          sleep 1
           '
 
       - name: Terminate and delete the container
         if: always()
         run: |
-          docker exec -t ${{ env.container_name }} /bin/bash -c '
+          docker exec ${{ env.container_name }} /bin/bash -c '
           rm -rf * .[^.]*
           '
           docker stop ${container_name}

--- a/ci/run_setup.sh
+++ b/ci/run_setup.sh
@@ -300,8 +300,7 @@ EOF
               ${PYTHON_EXECUTABLE} setup.py $1 --plat-name=macosx_10_9_x86_64;build_error=$?
 	    fi
         else
-            ${PYTHON_EXECUTABLE} setup.py $1 2>&1 | grep -v -E "^\[[0-9]+/[0-9]+\]"
-            build_error=${PIPESTATUS[0]}
+            ${PYTHON_EXECUTABLE} setup.py $1;build_error=$?
         fi
     else
         if [ "$SYSTEM" == "Darwin" ]; then
@@ -311,8 +310,7 @@ EOF
               python3 setup.py $1 --plat-name=macosx_10_9_x86_64;build_error=$?
 	    fi
         else
-            python setup.py $1 2>&1 | grep -v -E "^\[[0-9]+/[0-9]+\]"
-            build_error=${PIPESTATUS[0]}
+            python setup.py $1;build_error=$?
         fi
     fi
 

--- a/ci/run_setup.sh
+++ b/ci/run_setup.sh
@@ -300,7 +300,8 @@ EOF
               ${PYTHON_EXECUTABLE} setup.py $1 --plat-name=macosx_10_9_x86_64;build_error=$?
 	    fi
         else
-            ${PYTHON_EXECUTABLE} setup.py $1;build_error=$?
+            ${PYTHON_EXECUTABLE} setup.py $1 2>&1 | grep -v -E "^\[[0-9]+/[0-9]+\]"
+            build_error=${PIPESTATUS[0]}
         fi
     else
         if [ "$SYSTEM" == "Darwin" ]; then
@@ -310,7 +311,8 @@ EOF
               python3 setup.py $1 --plat-name=macosx_10_9_x86_64;build_error=$?
 	    fi
         else
-            python setup.py $1;build_error=$?
+            python setup.py $1 2>&1 | grep -v -E "^\[[0-9]+/[0-9]+\]"
+            build_error=${PIPESTATUS[0]}
         fi
     fi
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Linux-DCU build环节总是无法显示日志信息，导致用户无法查看报错详情，推测可能是因为日志过长或者过快导致github ui无法加载，过滤一些数字开头的cmake编译进度日志

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否