### PR TITLE
[CI] Remove invaild `check-bypass` step condition in inference workflow

### DIFF
--- a/.github/workflows/_Inference.yml
+++ b/.github/workflows/_Inference.yml
@@ -152,7 +152,6 @@ jobs:
           '
 
       - name: Upload build.tar.gz
-        if: steps.check-bypass.outputs.can_skip != 'true'
         env:
           home_path: /action-runner
           bos_file: /action-runner/bos_retry/BosClient.py


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->

清理无效语句，并没有 `steps.check-bypass`，只有 `needs.check-bypass` 且在 job 级就已经判断 check-bypass 了

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否