### PR TITLE
[Cherry-Pick] fix SharedLayerDesc lose attr is_firstly_shared (#78680)

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/dygraph_sharding_optimizer.py
@@ -1196,6 +1196,11 @@ class DygraphShardingOptimizerV2:
         copy_attr("do_model_average")
         copy_attr("need_clip")
         copy_attr("no_sync")
+        copy_attr("is_firstly_shared")
+
+        assert param.name not in self._slice_params, (
+            f"Duplicate param.name {param.name} appeared, which will caused precision gap and ckpt bug."
+        )
 
         self._slice_params[param.name] = slice_param
         return slice_param

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -755,10 +755,9 @@ class PipelineLayer(nn.Layer):
                         group=comm['group'],
                     )
 
-            for param in comm['layer'].parameters():
-                if param.name in comm[
-                    'weight_attr'
-                ] and self.global_rank != min(comm['ranks']):
+            if self.global_rank != min(comm['ranks']):
+                for weight_attr in comm['weight_attr']:
+                    param = getattr(comm['layer'], weight_attr)
                     param.is_firstly_shared = False
 
     def allreduce_shared_weight_gradients(self):
@@ -1022,11 +1021,11 @@ class PipelineLayer(nn.Layer):
                 flush_into_run_function()
                 if layer.layer_name not in self.shared_layers:
                     self.shared_layers[layer.layer_name] = layer.build_layer()
-                    for param in self.shared_layers[
-                        layer.layer_name
-                    ].parameters():
-                        if param.name in layer.shared_weight_attr:
-                            param.is_firstly_shared = True
+                    for weight_attr in layer.shared_weight_attr:
+                        param = getattr(
+                            self.shared_layers[layer.layer_name], weight_attr
+                        )
+                        param.is_firstly_shared = True
 
                 if layer.forward_func is None:
                     run_function.append(self.shared_layers[layer.layer_name])


### PR DESCRIPTION
### PR Category
Distributed Strategy


### PR Types
Bug fixes


### Description
<!-- Describe what you’ve done -->
devPR:https://github.com/PaddlePaddle/Paddle/pull/78680
SharedLayerDesc给param设置属性is_firstly_shared的分支由于判断条件有问题导致都没有走入，计算global_grad_norm的时候会重复计算shared weight的梯度，导致global_norm偏大

### 是否引起精度变化
如果有grad_clip并且生效了，会引起精度变化
如果没有grad_clip或者clip没有生效，就不会引起精度变化
