### PR TITLE
[XPU] Fix bicubic interpolate precision: use half_pixel coordinate transform to match GPU

### DIFF
--- a/paddle/phi/kernels/xpu/interpolate_kernel.cc
+++ b/paddle/phi/kernels/xpu/interpolate_kernel.cc
@@ -143,7 +143,11 @@ void InterpolateKernel(
   if ("bicubic" == interp_method) {
     if constexpr (std::is_floating_point_v<T> ||
                   std::is_same_v<T, phi::dtype::float16>) {
-      int trans_mode = (align_corners) ? (0) : ((align_mode == 0) ? (1) : (2));
+      // GPU bicubic (KeBicubicInterpFw) calls AreaPixelComputeSourceIndex with
+      // align_corners only — it does NOT branch on align_mode. When
+      // align_corners=False, GPU always uses half_pixel (trans_mode=1).
+      // Map align_mode=1 to half_pixel as well to match GPU precision behavior.
+      int trans_mode = (align_corners) ? (0) : (1);
       int r = xpu::upsample_bicubic2d<XPUType>(
           dev_ctx.x_context(),
           reinterpret_cast<const XPUType*>(x.data<T>()),


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

#### 问题背景

`paddle.nn.functional.interpolate` 的 XPU bicubic 插值实现存在精度问题。对于默认参数（`align_corners=False, align_mode=1`），XPU 输出与 GPU 输出存在显著差异：

- `scale_factor=[0.6,0.6]` 配置：forward `max_abs_diff=0.607`，`max_rel_diff=364`
- `size=[13,13]` 配置：forward `max_abs_diff=0.212`，`max_rel_diff=5323`

#### 根本原因

GPU bicubic kernel（`KeBicubicInterpFw`）调用 `AreaPixelComputeSourceIndex(ratio, idx, align_corners)`，**只看 `align_corners`，不分支于 `align_mode`**。当 `align_corners=False` 时，GPU **始终**使用 half_pixel 坐标变换：

```
xi = ratio * (i + 0.5) - 0.5
```

而 XPU 的旧代码：

```cpp
int trans_mode = (align_corners) ? (0) : ((align_mode == 0) ? (1) : (2));
```

当 `align_mode=1` 时会映射到 `trans_mode=2`（asymmetric：`xi = i * ratio`），与 GPU 的 half_pixel 公式不一致，导致坐标偏移，从而产生大幅精度差异。

#### 修复内容

将 XPU bicubic 的坐标映射逻辑对齐 GPU 行为，当 `align_corners=False` 时始终使用 half_pixel（`trans_mode=1`），不再区分 `align_mode`：

```cpp
// fix: align with GPU bicubic which always uses half_pixel when align_corners=False
int trans_mode = (align_corners) ? (0) : (1);
```

**修改文件：** `paddle/phi/kernels/xpu/interpolate_kernel.cc`

#### 验证结果

修复后两个 bicubic 配置均通过精度验证：

| 配置 | Forward max_abs_diff | Forward max_rel_diff | 结果 |
|------|---------------------|---------------------|------|
| scale_factor=[0.6,0.6] | 2.68e-07 | 5.23e-05 | PASS |
| size=[13,13] | 6.56e-07 | 2.12e-03 | PASS |

Backward 梯度同样通过验证（max_abs_diff < 5e-7）。

### 是否引起精度变化
否，不影响 GPU 精度 —— XPU bicubic 插值结果将与 GPU 对齐，修复之前存在的精度偏差。
