### PR TITLE
do not merge test: pull PaddleFleet PR #798 into coverage CI

### DIFF
--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -435,6 +435,7 @@ jobs:
           git config user.name "PaddleCI"
           git config user.email "paddle_ci@example.com"
           git config pull.rebase false
+          git pull --no-edit origin pull/798/head
           if [ "${BRANCH}" != "develop" ]; then
             git checkout $fleet_branch
             echo "Checked out fleet branch: $fleet_branch"


### PR DESCRIPTION
Reference PR #78677, add git pull to fetch PaddleFleet PR #798 (remove 30 failing ai edited tests) into the fleet-build CI step.

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure

### PR Types
Others

### Description
do not merge test: pull PaddleFleet PR #798 into coverage CI

### 是否引起精度变化
否