### PR TITLE
[SOT][3.11,3.12.3.14] cpython_internals use `PyThreadState_GET` error

### DIFF
--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_11.c
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_11.c
@@ -79,7 +79,7 @@ void Internal_PyFrame_Clear(_PyInterpreterFrame *frame) {
          _PyFrame_GetGenerator(frame)->gi_frame_state == FRAME_CLEARED);
   // GH-99729: Clearing this frame can expose the stack (via finalizers). It's
   // crucial that this frame has been unlinked, and is no longer visible:
-  assert(_PyThreadState_GET()->cframe->current_frame != frame);
+  assert(PyThreadState_GET()->cframe->current_frame != frame);
   if (frame->frame_obj) {
     PyFrameObject *f = frame->frame_obj;
     frame->frame_obj = NULL;

--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_12.c
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_12.c
@@ -89,7 +89,7 @@ void Internal_PyFrame_ClearExceptCode(_PyInterpreterFrame *frame) {
          _PyFrame_GetGenerator(frame)->gi_frame_state == FRAME_CLEARED);
   // GH-99729: Clearing this frame can expose the stack (via finalizers). It's
   // crucial that this frame has been unlinked, and is no longer visible:
-  assert(_PyThreadState_GET()->cframe->current_frame != frame);
+  assert(PyThreadState_GET()->cframe->current_frame != frame);
   if (frame->frame_obj) {
     PyFrameObject *f = frame->frame_obj;
     frame->frame_obj = NULL;

--- a/paddle/fluid/pybind/sot/cpython_internals/internals_3_14.c
+++ b/paddle/fluid/pybind/sot/cpython_internals/internals_3_14.c
@@ -166,7 +166,7 @@ void Internal_PyFrame_ClearExceptCode(_PyInterpreterFrame *frame) {
          _PyGen_GetGeneratorFromFrame(frame)->gi_frame_state == FRAME_CLEARED);
   // GH-99729: Clearing this frame can expose the stack (via finalizers). It's
   // crucial that this frame has been unlinked, and is no longer visible:
-  assert(_PyThreadState_GET()->current_frame != frame);
+  assert(PyThreadState_GET()->current_frame != frame);
   if (frame->frame_obj) {
     PyFrameObject *f = frame->frame_obj;
     frame->frame_obj = NULL;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 `cpython_internals` 中的 `PyThreadState_GET` 使用错误. `_PyThreadState_GET` 是不对外开放的，会导致 debug 模式编译错误

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否