### PR TITLE
[CI] Skip some workflows on forked repositories

### DIFF
--- a/.github/workflows/Approval.yml
+++ b/.github/workflows/Approval.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   check-bypass:
     name: Check bypass
+    if: ${{ github.repository_owner == 'PaddlePaddle' }}
     uses: ./.github/workflows/check-bypass.yml
     with:
       workflow-name: 'approval'

--- a/.github/workflows/CheckPRTemplate.yml
+++ b/.github/workflows/CheckPRTemplate.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   check-bypass:
     name: Check bypass
+    if: ${{ github.repository_owner == 'PaddlePaddle' }}
     uses: ./.github/workflows/check-bypass.yml
     with:
       workflow-name: 'template'

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -31,6 +31,7 @@ defaults:
 jobs:
   check-skill:
     name: Check file paths
+    if: ${{ github.repository_owner == 'PaddlePaddle' }}
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   cherry-pick:
     if: >
+      github.repository_owner == 'PaddlePaddle' &&
       github.event.pull_request.merged == true &&
       (
         github.event.action == 'labeled' ||

--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   remove-skip-ci-labels:
     name: Remove skip-ci labels on new commits
+    if: ${{ github.repository_owner == 'PaddlePaddle' }}
     runs-on: ubuntu-latest
     steps:
       - name: Get PR labels


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others 

### Description
<!-- Describe what you’ve done -->

- `.github/workflows/Coverage.yml` 流水线需要机器，在第一个 job 进行判断
- `.github/workflows/CheckPRTemplate.yml` 也是需要机器，同样第一个 job 判断跳过
- `.github/workflows/Approval.yml` 作为主仓库的 approve，在 fork 仓库作用不大，也加上了判断

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否