### PR TITLE
[CI] Add note for gcda pre-cleaning risk in coverage_info.sh

### DIFF
--- a/ci/coverage_info.sh
+++ b/ci/coverage_info.sh
@@ -32,6 +32,7 @@ echo "::endgroup::"
 
 cd ${PADDLE_ROOT}/build
 
+# NOTE(ooooo): Known risk: gcda pre-cleaning may delete valid gcda in some cases.
 python ${PADDLE_ROOT}/ci/coverage_gcda_clean.py ${PR_ID} || exit 101
 echo "::group::Run lcov"
 lcov --ignore-errors gcov --capture -d ./ -o coverage.info --rc lcov_branch_coverage=0

--- a/ci/coverage_info.sh
+++ b/ci/coverage_info.sh
@@ -32,7 +32,11 @@ echo "::endgroup::"
 
 cd ${PADDLE_ROOT}/build
 
-# NOTE(ooooo): Known risk: gcda pre-cleaning may delete valid gcda in some cases.
+# NOTE: This gcda pre-cleaning step keeps/removes files by mapping PR
+# changed files to "*.gcda" paths. That is not always correct: for header-only
+# changes, or changes whose coverage is recorded in other translation units,
+# valid gcda may be removed before lcov capture. Keep the current behavior for
+# now because removing this step may increase "lcov/gcov --capture -d" cost.
 python ${PADDLE_ROOT}/ci/coverage_gcda_clean.py ${PR_ID} || exit 101
 echo "::group::Run lcov"
 lcov --ignore-errors gcov --capture -d ./ -o coverage.info --rc lcov_branch_coverage=0


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Not User Facing

### Description
<!-- Describe what you’ve done -->
给 `coverage_gcda_clean` 这一有风险的步骤添加注解，他可能会清理掉一些有效的 `.gcda ` 文件导致覆盖率缺失

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否