### PR TITLE
[Build] deduplicate data_feed Python proto generation

### DIFF
--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -334,7 +334,7 @@ cc_library(
 
 if(WITH_PYTHON)
   py_proto_compile(framework_py_proto SRCS framework.proto data_feed.proto)
-  py_proto_compile(trainer_py_proto SRCS trainer_desc.proto data_feed.proto)
+  py_proto_compile(trainer_py_proto SRCS trainer_desc.proto)
   py_proto_compile(distributed_strategy_py_proto SRCS
                    distributed_strategy.proto)
   py_proto_compile(pass_desc_py_proto SRCS pass_desc.proto)

--- a/python/paddle/base/trainer_desc.py
+++ b/python/paddle/base/trainer_desc.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 """Definition of trainers."""
 
-import os
-import sys
-
 __all__ = []
 
 
@@ -31,15 +28,7 @@ class TrainerDesc:
         with open(proto_file, 'r') as f:
             text_format.Parse(f.read(), self.proto_desc)
         '''
-        # Workaround for relative import in protobuf under python3
-        # TODO: should be fixed
-        cur_path = os.path.dirname(__file__)
-        if cur_path not in sys.path:
-            sys.path.append(cur_path)
-        if cur_path + "/proto" not in sys.path:
-            sys.path.append(cur_path + "/proto")
-
-        from proto import trainer_desc_pb2
+        from .proto import trainer_desc_pb2
 
         self.proto_desc = trainer_desc_pb2.TrainerDesc()
         import multiprocessing as mp


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Others

### Description

😺 在 #78713 的 `coverage test` 流水线的单测 `test_deprecated_decorator` 和 `test_trainer_desc` 一直挂，顾让 codex 来帮忙分析一下，由于没有实际环境和产物并没有分析出合理原因，后来重跑 `coverage clone` 通过，但是 codex 对代码提出了修改建议，觉得有道理就提交上来了

🤖 本 PR 去掉了 `data_feed.proto` 在 Python proto 构建中的重复声明，让 `data_feed_pb2.py` 只由一个 CMake target 生成（😺 `py_proto_compile` 的 SRCS 之后的参数，是根据 `xxx.proto` 生成 `xxx_pb2.py` 文件）；同时将 `python/paddle/base/trainer_desc.py` 中的 `trainer_desc_pb2` 导入改为包内导入，简化 Python 侧 proto 加载路径。

#### 验证
- `prek`
- `./.venv/bin/python -m py_compile python/paddle/base/trainer_desc.py`

### 是否引起精度变化
否
