### PR TITLE
feat(HIP): register bfloat16 kernels for conv_transpose on ROCm

### DIFF
--- a/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_grad_kernel.cu
@@ -1158,19 +1158,22 @@ PD_REGISTER_KERNEL(conv2d_transpose_grad,
                    ALL_LAYOUT,
                    phi::Conv2dTransposeGradGPUDNNKernel,
                    float,
-                   float16) {}
+                   float16,
+                   phi::bfloat16) {}
 PD_REGISTER_KERNEL(conv2d_transpose_double_grad,
                    GPUDNN,
                    ALL_LAYOUT,
                    phi::Conv2dTransposeDoubleGradGPUDNNKernel,
                    float,
-                   float16) {}
+                   float16,
+                   phi::bfloat16) {}
 PD_REGISTER_KERNEL(conv3d_transpose_grad,
                    GPUDNN,
                    ALL_LAYOUT,
                    phi::Conv3dTransposeGradGPUDNNKernel,
                    float,
-                   float16) {}
+                   float16,
+                   phi::bfloat16) {}
 #else
 #if CUDNN_VERSION_MIN(8, 1, 0)
 PD_REGISTER_KERNEL(conv2d_transpose_grad,

--- a/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_transpose_kernel.cu
@@ -581,13 +581,15 @@ PD_REGISTER_KERNEL(conv2d_transpose,
                    ALL_LAYOUT,
                    phi::Conv2dTransposeGPUDNNKernel,
                    float,
-                   float16) {}
+                   float16,
+                   phi::bfloat16) {}
 PD_REGISTER_KERNEL(conv3d_transpose,
                    GPUDNN,
                    ALL_LAYOUT,
                    phi::Conv3dTransposeGPUDNNKernel,
                    float,
-                   float16) {}
+                   float16,
+                   phi::bfloat16) {}
 #else
 #if CUDNN_VERSION_MIN(8, 1, 0)
 PD_REGISTER_KERNEL(conv2d_transpose,

--- a/test/legacy_test/test_rocm_bf16_conv_transpose.py
+++ b/test/legacy_test/test_rocm_bf16_conv_transpose.py
@@ -30,11 +30,16 @@ class TestRocmBf16ConvTranspose(unittest.TestCase):
         trans_grad = kernels.get("conv2d_transpose_grad", [])
 
         def has_gpu_bf16(items):
-            return any("bfloat16" in x and "place[Place(gpu" in x for x in items)
+            return any(
+                "bfloat16" in x and "place[Place(gpu" in x for x in items
+            )
 
-        self.assertTrue(has_gpu_bf16(trans), msg=f"conv2d_transpose kernels: {trans}")
         self.assertTrue(
-            has_gpu_bf16(trans_grad), msg=f"conv2d_transpose_grad kernels: {trans_grad}"
+            has_gpu_bf16(trans), msg=f"conv2d_transpose kernels: {trans}"
+        )
+        self.assertTrue(
+            has_gpu_bf16(trans_grad),
+            msg=f"conv2d_transpose_grad kernels: {trans_grad}",
         )
 
     def test_conv2d_transpose_bf16_smoke(self):

--- a/test/legacy_test/test_rocm_bf16_conv_transpose.py
+++ b/test/legacy_test/test_rocm_bf16_conv_transpose.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.nn.functional as F
+from paddle.base import core
+
+
+@unittest.skipIf(not paddle.is_compiled_with_rocm(), "ROCm only")
+class TestRocmBf16ConvTranspose(unittest.TestCase):
+    def test_registry_has_gpu_bf16(self):
+        kernels = core._get_all_register_op_kernels("phi")
+        trans = kernels.get("conv2d_transpose", [])
+        trans_grad = kernels.get("conv2d_transpose_grad", [])
+
+        def has_gpu_bf16(items):
+            return any("bfloat16" in x and "place[Place(gpu" in x for x in items)
+
+        self.assertTrue(has_gpu_bf16(trans), msg=f"conv2d_transpose kernels: {trans}")
+        self.assertTrue(
+            has_gpu_bf16(trans_grad), msg=f"conv2d_transpose_grad kernels: {trans_grad}"
+        )
+
+    def test_conv2d_transpose_bf16_smoke(self):
+        paddle.set_device("gpu:0")
+        x = paddle.randn([1, 8, 32, 32], dtype="float32").astype("bfloat16")
+        w = paddle.randn([8, 4, 3, 3], dtype="float32").astype("bfloat16")
+        y = F.conv2d_transpose(x, w, padding=1)
+        self.assertEqual(y.dtype, paddle.bfloat16)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/legacy_test/test_rocm_bf16_conv_transpose.py
+++ b/test/legacy_test/test_rocm_bf16_conv_transpose.py
@@ -19,8 +19,11 @@ import paddle.nn.functional as F
 from paddle.base import core
 
 
-@unittest.skipIf(not paddle.is_compiled_with_rocm(), "ROCm only")
 class TestRocmBf16ConvTranspose(unittest.TestCase):
+    def setUp(self):
+        if not paddle.is_compiled_with_rocm():
+            self.skipTest("ROCm only")
+
     def test_registry_has_gpu_bf16(self):
         kernels = core._get_all_register_op_kernels("phi")
         trans = kernels.get("conv2d_transpose", [])


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
本 PR 用于补齐 current `main` 上 ROCm/HIP 路径中剩余的 transpose-conv BF16 支持缺口。

背景：
- 在官方 AMD Notebook 环境中，已复现 ROCm 下 BF16 conv-family runtime gap：
  - `softmax(bfloat16)` 可以正常运行
  - `conv2d(bfloat16)`、`conv2d_transpose(bfloat16)` 会报 `kernel not registered`
- 结合后续源码核查，`conv2d` 的 BF16 source-side 修复已经在 current `main` 中更早合入
- 因此本 PR 不再扩展到 `conv2d`，而是只针对 current `main` 上剩余的 transpose-conv gap 做修复

本 PR 的改动包括：
1. 在 HIP 路径下为以下算子补充 `phi::bfloat16` 注册：
   - `conv2d_transpose`
   - `conv3d_transpose`
   - `conv2d_transpose_grad`
   - `conv2d_transpose_double_grad`
   - `conv3d_transpose_grad`
2. 新增 ROCm 单测：
   - `test/legacy_test/test_rocm_bf16_conv_transpose.py`
   - 覆盖内容包括：
     - `conv2d_transpose` 与 `conv2d_transpose_grad` 的 GPU BF16 registry 检查
     - `paddle.nn.functional.conv2d_transpose` 的 BF16 forward smoke test

本 PR 的范围刻意保持最小化：
- 仅修复 transpose-conv 相关的剩余 BF16 缺口
- 不回头修改已经在 current `main` 中修复过的 `conv2d`
- 不包含 fused conv、`depthwise_conv2d_transpose` 或更广范围的 conv-family BF16 覆盖

建议验证：
- `python -m pytest test/legacy_test/test_rocm_bf16_conv_transpose.py -v`

### 是否引起精度变化
否

Related to #78719
