### PR TITLE
[release/3.4][CINN] Make CINN compilable with arm CPU and add missing `nvidia-*` dependencies for arm wheel

### DIFF
--- a/cmake/architecture.cmake
+++ b/cmake/architecture.cmake
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard()
+
+function(paddle_normalize_target_arch out_var)
+  string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _processor)
+  if(_processor STREQUAL "")
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_PROCESSOR}" _processor)
+  endif()
+
+  if(_processor MATCHES "^(x86_64|amd64)$")
+    set(_arch "x86_64")
+  elseif(_processor MATCHES "^(aarch64|arm64)$")
+    set(_arch "aarch64")
+  else()
+    set(_arch "${_processor}")
+  endif()
+
+  set(${out_var}
+      "${_arch}"
+      PARENT_SCOPE)
+endfunction()
+
+function(paddle_get_system_library_arch_dir out_var)
+  paddle_normalize_target_arch(_arch)
+  set(_dir "/usr/lib/${_arch}-linux-gnu")
+  if(EXISTS "${_dir}")
+    set(${out_var}
+        "${_dir}"
+        PARENT_SCOPE)
+  else()
+    set(${out_var}
+        ""
+        PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(paddle_detect_cuda_target_dir out_var)
+  set(_cuda_target_dir "")
+  if(NOT CUDA_TOOLKIT_ROOT_DIR)
+    set(${out_var}
+        "${_cuda_target_dir}"
+        PARENT_SCOPE)
+    return()
+  endif()
+
+  set(_targets_root "${CUDA_TOOLKIT_ROOT_DIR}/targets")
+  paddle_normalize_target_arch(_arch)
+  set(_candidates)
+  if(_arch STREQUAL "aarch64")
+    list(APPEND _candidates "sbsa-linux" "aarch64-linux")
+  elseif(_arch STREQUAL "x86_64")
+    list(APPEND _candidates "x86_64-linux")
+  elseif(NOT _arch STREQUAL "")
+    list(APPEND _candidates "${_arch}-linux")
+  endif()
+
+  foreach(_candidate IN LISTS _candidates)
+    if(EXISTS "${_targets_root}/${_candidate}")
+      set(_cuda_target_dir "${_candidate}")
+      break()
+    endif()
+  endforeach()
+
+  if(_cuda_target_dir STREQUAL "" AND EXISTS "${_targets_root}")
+    file(
+      GLOB _detected_targets
+      LIST_DIRECTORIES true
+      "${_targets_root}/*")
+    list(LENGTH _detected_targets _detected_target_count)
+    if(_detected_target_count EQUAL 1)
+      list(GET _detected_targets 0 _detected_target)
+      get_filename_component(_cuda_target_dir "${_detected_target}" NAME)
+    endif()
+  endif()
+
+  set(${out_var}
+      "${_cuda_target_dir}"
+      PARENT_SCOPE)
+endfunction()
+
+function(paddle_get_llvm_native_target out_var)
+  paddle_normalize_target_arch(_arch)
+  if(_arch STREQUAL "aarch64")
+    set(_llvm_target "AArch64")
+  elseif(_arch STREQUAL "x86_64")
+    set(_llvm_target "X86")
+  else()
+    string(TOUPPER "${_arch}" _llvm_target)
+  endif()
+  set(${out_var}
+      "${_llvm_target}"
+      PARENT_SCOPE)
+endfunction()

--- a/cmake/cinn.cmake
+++ b/cmake/cinn.cmake
@@ -61,6 +61,7 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/cmake/cinn/config.cmake)
        DESTINATION ${CMAKE_BINARY_DIR}/cmake/cinn)
 endif()
 include(${CMAKE_BINARY_DIR}/cmake/cinn/config.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/architecture.cmake)
 
 if(WITH_MKL)
   generate_dummy_static_lib(LIB_NAME "cinn_mklml" GENERATOR "mklml.cmake")
@@ -85,9 +86,14 @@ if(WITH_GPU)
   endif()
   enable_language(CUDA)
   find_package(CUDA REQUIRED)
+  paddle_normalize_target_arch(TARGET_ARCH)
+  paddle_get_system_library_arch_dir(SYSTEM_LIBRARY_ARCH_DIR)
+  paddle_detect_cuda_target_dir(CUDA_TARGET_DIR)
   include_directories(${CUDA_INCLUDE_DIRS})
   include_directories(${CMAKE_SOURCE_DIR}/paddle/cinn/runtime/cuda)
-  include_directories(/usr/lib/x86_64-linux-gnu)
+  if(NOT SYSTEM_LIBRARY_ARCH_DIR STREQUAL "")
+    include_directories(${SYSTEM_LIBRARY_ARCH_DIR})
+  endif()
   set(CUDA_SEPARABLE_COMPILATION ON)
 
   cuda_select_nvcc_arch_flags(ARCH_FLAGS Auto)
@@ -102,16 +108,31 @@ if(WITH_GPU)
             paddle/cinn/common/float8e4m3.h
        DESTINATION $ENV{runtime_include_dir})
 
-  find_library(CUDASTUB libcuda.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs/
-                                         REQUIRED)
-  find_library(CUBLAS libcublas.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64
-                                         /usr/lib /usr/lib64 REQUIRED)
-  find_library(CUDNN libcudnn.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64 /usr/lib
-                                       /usr/lib64 REQUIRED)
-  find_library(CURAND libcurand.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64
-                                         /usr/lib /usr/lib64 REQUIRED)
-  find_library(CUSOLVER libcusolver.so HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64
-                                             /usr/lib /usr/lib64 REQUIRED)
+  find_library(
+    CUDASTUB libcuda.so
+    HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64/stubs/
+          ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/lib/stubs
+          REQUIRED)
+  find_library(
+    CUBLAS libcublas.so
+    HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64
+          ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/lib /usr/lib
+          /usr/lib64 ${SYSTEM_LIBRARY_ARCH_DIR} REQUIRED)
+  find_library(
+    CUDNN libcudnn.so
+    HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64
+          ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/lib /usr/lib
+          /usr/lib64 ${SYSTEM_LIBRARY_ARCH_DIR} REQUIRED)
+  find_library(
+    CURAND libcurand.so
+    HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64
+          ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/lib /usr/lib
+          /usr/lib64 ${SYSTEM_LIBRARY_ARCH_DIR} REQUIRED)
+  find_library(
+    CUSOLVER libcusolver.so
+    HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64
+          ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/lib /usr/lib
+          /usr/lib64 ${SYSTEM_LIBRARY_ARCH_DIR} REQUIRED)
 endif()
 
 if(WITH_SYCL)
@@ -358,7 +379,11 @@ set(ISL_INCLUDE_DIR "${CMAKE_BINARY_DIR}/third_party/install/isl/include")
 include_directories(${ISL_INCLUDE_DIR})
 
 # Add LLVM
-set(LLVM_INCLUDE_DIR "${CMAKE_BINARY_DIR}/dist/third_party/llvm/include")
+if(DEFINED LLVM_INCLUDE_DIRS)
+  set(LLVM_INCLUDE_DIR "${LLVM_INCLUDE_DIRS}")
+else()
+  set(LLVM_INCLUDE_DIR "${CMAKE_BINARY_DIR}/dist/third_party/llvm/include")
+endif()
 include_directories(${LLVM_INCLUDE_DIR})
 
 ######################################################

--- a/cmake/cinn/core.cmake
+++ b/cmake/cinn/core.cmake
@@ -1,5 +1,14 @@
+include(${PROJECT_SOURCE_DIR}/cmake/architecture.cmake)
+
+paddle_normalize_target_arch(CINN_HOST_ARCH)
+set(CINN_X86_CXX_FLAGS "")
+if(CINN_HOST_ARCH STREQUAL "x86_64")
+  set(CINN_X86_CXX_FLAGS " -mavx -mfma")
+endif()
+
 set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -fPIC -mavx -mfma -Wno-write-strings -Wno-psabi")
+    "${CMAKE_CXX_FLAGS} -fPIC${CINN_X86_CXX_FLAGS} -Wno-write-strings -Wno-psabi"
+)
 
 set(PADDLE_RESOURCE_URL
     "http://paddle-inference-dist.bj.bcebos.com"

--- a/cmake/cinn/external/ginac.cmake
+++ b/cmake/cinn/external/ginac.cmake
@@ -1,21 +1,38 @@
 include(ExternalProject)
+include(${PROJECT_SOURCE_DIR}/cmake/architecture.cmake)
+
+paddle_normalize_target_arch(PADDLE_TARGET_ARCH)
 
 # gmp-6.2.1 https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz
-# cln-1.3.6 https://www.ginac.de/CLN/cln-1.3.6.tar.bz2
+# cln-1.3.6 https://www.ginac.de/CLN/cln-1.3.6.tar.bz2 (default/non-aarch64)
+# cln-1.3.7 https://www.ginac.de/CLN/cln-1.3.7.tar.bz2 (aarch64)
 # ginac-1.8.1 https://www.ginac.de/ginac-1.8.1.tar.bz2
 #  all build with CFLAGS="-fPIC -DPIC" CXXFLAGS="-fPIC -DPIC" --enable-static=yes
 
-set(GINAC_FILE
-    "ginac-1.8.1_cln-1.3.6_gmp-6.2.1.tar.gz"
-    CACHE STRING "" FORCE)
-set(GINAC_DOWNLOAD_URL
-    "https://paddle-inference-dist.bj.bcebos.com/CINN/${GINAC_FILE}")
-set(GINAC_URL_MD5 ebc3e4b7770dd604777ac3f01bfc8b06)
+if(PADDLE_TARGET_ARCH STREQUAL "aarch64")
+  set(GINAC_FILE
+      "ginac-1.8.1_cln-1.3.7_gmp-6.2.1-aarch64.tar.gz"
+      CACHE STRING "" FORCE)
+  set(GINAC_DOWNLOAD_URL
+      "https://paddle-inference-dist.cdn.bcebos.com/CINN/${GINAC_FILE}"
+      CACHE STRING "ARM GiNaC package URL")
+  set(GINAC_URL_MD5
+      "e892414c8eb98153bb04b0877bd07334"
+      CACHE STRING "ARM GiNaC package MD5")
+else()
+  set(GINAC_FILE
+      "ginac-1.8.1_cln-1.3.6_gmp-6.2.1.tar.gz"
+      CACHE STRING "" FORCE)
+  set(GINAC_DOWNLOAD_URL
+      "https://paddle-inference-dist.bj.bcebos.com/CINN/${GINAC_FILE}")
+  set(GINAC_URL_MD5 ebc3e4b7770dd604777ac3f01bfc8b06)
+endif()
 set(GINAC_DOWNLOAD_DIR ${PADDLE_SOURCE_DIR}/third_party/ginac)
 set(GINAC_PREFIX_DIR ${THIRD_PARTY_PATH}/ginac)
 set(GINAC_INSTALL_DIR ${THIRD_PARTY_PATH}/install/ginac)
 
 function(download_ginac)
+  file(MAKE_DIRECTORY "${GINAC_DOWNLOAD_DIR}")
   message(
     STATUS
       "Downloading ${GINAC_DOWNLOAD_URL} to ${GINAC_DOWNLOAD_DIR}/${GINAC_FILE}"
@@ -36,9 +53,8 @@ endfunction()
 
 # Download and check ginac.
 if(EXISTS ${GINAC_DOWNLOAD_DIR}/${GINAC_FILE})
-  file(MD5 ${GINAC_DOWNLOAD_DIR}/${GINAC_FILE} GINAC_MD5)
-  if(NOT GINAC_MD5 STREQUAL GINAC_URL_MD5)
-    # clean build file
+  file(MD5 ${GINAC_DOWNLOAD_DIR}/${GINAC_FILE} GINAC_HASH)
+  if(NOT GINAC_HASH STREQUAL GINAC_URL_MD5)
     file(REMOVE_RECURSE ${GINAC_PREFIX_DIR})
     file(REMOVE_RECURSE ${GINAC_INSTALL_DIR})
     download_ginac()

--- a/cmake/cinn/external/isl.cmake
+++ b/cmake/cinn/external/isl.cmake
@@ -1,4 +1,7 @@
 include(ExternalProject)
+include(${PROJECT_SOURCE_DIR}/cmake/architecture.cmake)
+
+paddle_normalize_target_arch(PADDLE_TARGET_ARCH)
 
 # isl https://github.com/inducer/ISL
 # commit-id 6a1760fe46967cda2a06387793a6b7d4a0876581
@@ -7,17 +10,30 @@ include(ExternalProject)
 # static build
 # CPPFLAGS="-fPIC -DPIC" ./configure --with-gmp-prefix=<gmp-install-path> --with-clang-prefix=<llvm-install-path> --enable-shared=no --enable-static=yes
 
-set(ISL_FILE
-    "isl-6a1760fe.tar.gz"
-    CACHE STRING "" FORCE)
-set(ISL_DOWNLOAD_URL
-    "https://paddle-inference-dist.bj.bcebos.com/CINN/${ISL_FILE}")
-set(ISL_URL_MD5 fff10083fb79d394b8a7b7b2089f6183)
+if(PADDLE_TARGET_ARCH STREQUAL "aarch64")
+  set(ISL_FILE
+      "isl-0.26-aarch64.tar.gz"
+      CACHE STRING "" FORCE)
+  set(ISL_DOWNLOAD_URL
+      "https://paddle-inference-dist.cdn.bcebos.com/CINN/${ISL_FILE}"
+      CACHE STRING "ARM ISL package URL")
+  set(ISL_URL_MD5
+      "092950d5944cbe8163413c740f0c611e"
+      CACHE STRING "ARM ISL package MD5")
+else()
+  set(ISL_FILE
+      "isl-6a1760fe.tar.gz"
+      CACHE STRING "" FORCE)
+  set(ISL_DOWNLOAD_URL
+      "https://paddle-inference-dist.bj.bcebos.com/CINN/${ISL_FILE}")
+  set(ISL_URL_MD5 fff10083fb79d394b8a7b7b2089f6183)
+endif()
 set(ISL_DOWNLOAD_DIR ${PADDLE_SOURCE_DIR}/third_party/isl)
 set(ISL_PREFIX_DIR ${THIRD_PARTY_PATH}/isl)
 set(ISL_INSTALL_DIR ${THIRD_PARTY_PATH}/install/isl)
 
 function(download_isl)
+  file(MAKE_DIRECTORY "${ISL_DOWNLOAD_DIR}")
   message(
     STATUS "Downloading ${ISL_DOWNLOAD_URL} to ${ISL_DOWNLOAD_DIR}/${ISL_FILE}")
   file(
@@ -36,9 +52,8 @@ endfunction()
 
 # Download and check isl.
 if(EXISTS ${ISL_DOWNLOAD_DIR}/${ISL_FILE})
-  file(MD5 ${ISL_DOWNLOAD_DIR}/${ISL_FILE} ISL_MD5)
-  if(NOT ISL_MD5 STREQUAL ISL_URL_MD5)
-    # clean build file
+  file(MD5 ${ISL_DOWNLOAD_DIR}/${ISL_FILE} ISL_HASH)
+  if(NOT ISL_HASH STREQUAL ISL_URL_MD5)
     file(REMOVE_RECURSE ${ISL_PREFIX_DIR})
     file(REMOVE_RECURSE ${ISL_INSTALL_DIR})
     download_isl()

--- a/cmake/cinn/external/llvm.cmake
+++ b/cmake/cinn/external/llvm.cmake
@@ -1,31 +1,39 @@
 include(FetchContent)
-
-# set(LLVM_DOWNLOAD_URL https://paddle-inference-dist.bj.bcebos.com/CINN/llvm11.tar.gz)
-# set(LLVM_MD5 39d32b6be466781dddf5869318dcba53)
-
-set(LLVM_DOWNLOAD_URL
-    https://paddle-inference-dist.bj.bcebos.com/CINN/llvm11-glibc2.17.tar.gz)
-set(LLVM_MD5 33c7d3cc6d370585381e8d90bd7c2198)
+include(${PROJECT_SOURCE_DIR}/cmake/architecture.cmake)
 
 set(FETCHCONTENT_BASE_DIR ${THIRD_PARTY_PATH}/llvm)
 set(FETCHCONTENT_QUIET OFF)
-FetchContent_Declare(
-  external_llvm
-  URL ${LLVM_DOWNLOAD_URL}
-  URL_MD5 ${LLVM_MD5}
-  PREFIX ${THIRD_PARTY_PATH}/llvm SOURCE_DIR ${THIRD_PARTY_PATH}/install/llvm)
+paddle_get_llvm_native_target(PADDLE_LLVM_NATIVE_TARGET)
+paddle_normalize_target_arch(PADDLE_TARGET_ARCH)
+
+if(PADDLE_TARGET_ARCH STREQUAL "aarch64")
+  set(LLVM_DOWNLOAD_URL
+      "https://paddle-inference-dist.cdn.bcebos.com/CINN/llvm11-aarch64-glibc2.17.tar.gz"
+  )
+  set(LLVM_MD5
+      "71c49723bc3e30626da1bd1b866934ce"
+      CACHE STRING "ARM LLVM11 package MD5")
+else()
+  set(LLVM_DOWNLOAD_URL
+      https://paddle-inference-dist.bj.bcebos.com/CINN/llvm11-glibc2.17.tar.gz)
+  set(LLVM_MD5 33c7d3cc6d370585381e8d90bd7c2198)
+endif()
+
 if(NOT LLVM_PATH)
+  FetchContent_Declare(
+    external_llvm
+    URL ${LLVM_DOWNLOAD_URL}
+    URL_MD5 ${LLVM_MD5}
+    PREFIX ${THIRD_PARTY_PATH}/llvm SOURCE_DIR ${THIRD_PARTY_PATH}/install/llvm)
   FetchContent_GetProperties(external_llvm)
   if(NOT external_llvm_POPULATED)
     FetchContent_Populate(external_llvm)
   endif()
   set(LLVM_PATH ${THIRD_PARTY_PATH}/install/llvm)
-  set(LLVM_DIR ${THIRD_PARTY_PATH}/install/llvm/lib/cmake/llvm)
-  set(MLIR_DIR ${THIRD_PARTY_PATH}/install/llvm/lib/cmake/mlir)
-else()
-  set(LLVM_DIR ${LLVM_PATH}/lib/cmake/llvm)
-  set(MLIR_DIR ${LLVM_PATH}/lib/cmake/mlir)
 endif()
+
+set(LLVM_DIR ${LLVM_PATH}/lib/cmake/llvm)
+set(MLIR_DIR ${LLVM_PATH}/lib/cmake/mlir)
 
 if(${CMAKE_CXX_COMPILER} STREQUAL "clang++")
   set(CMAKE_EXE_LINKER_FLAGS
@@ -37,6 +45,9 @@ message(STATUS "set MLIR_DIR: ${MLIR_DIR}")
 find_package(LLVM REQUIRED CONFIG HINTS ${LLVM_DIR})
 find_package(MLIR REQUIRED CONFIG HINTS ${MLIR_DIR})
 find_package(ZLIB REQUIRED)
+
+set(LLVM_CLANG_EXECUTABLE ${LLVM_PATH}/bin/clang++)
+set(LLVM_CONFIG_EXECUTABLE ${LLVM_PATH}/bin/llvm-config)
 
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 include(AddLLVM)
@@ -78,7 +89,7 @@ llvm_map_components_to_libnames(
   Support
   Core
   irreader
-  X86
+  ${PADDLE_LLVM_NATIVE_TARGET}
   executionengine
   orcjit
   mcjit

--- a/cmake/cinn/llvm.cmake
+++ b/cmake/cinn/llvm.cmake
@@ -1,3 +1,5 @@
+include(${PROJECT_SOURCE_DIR}/cmake/architecture.cmake)
+
 if(${CMAKE_CXX_COMPILER} STREQUAL "clang++")
   set(CMAKE_EXE_LINKER_FLAGS
       "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
@@ -8,6 +10,8 @@ message(STATUS "set MLIR_DIR: ${MLIR_DIR}")
 find_package(LLVM REQUIRED CONFIG HINTS ${LLVM_DIR})
 find_package(MLIR REQUIRED CONFIG HINTS ${MLIR_DIR})
 find_package(ZLIB REQUIRED)
+
+paddle_get_llvm_native_target(PADDLE_LLVM_NATIVE_TARGET)
 
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 include(AddLLVM)
@@ -44,7 +48,7 @@ llvm_map_components_to_libnames(
   Support
   Core
   irreader
-  X86
+  ${PADDLE_LLVM_NATIVE_TARGET}
   executionengine
   orcjit
   mcjit

--- a/cmake/cinn/nvtx.cmake
+++ b/cmake/cinn/nvtx.cmake
@@ -5,6 +5,8 @@ if((NOT WITH_GPU)
   return()
 endif()
 
+include(${PROJECT_SOURCE_DIR}/cmake/architecture.cmake)
+
 set(NVTX_ROOT
     "/usr"
     CACHE PATH "NVTX ROOT")
@@ -16,10 +18,8 @@ find_path(
 
 get_filename_component(__libpath_hint ${CUDA_CUDART_LIBRARY} PATH)
 
-set(TARGET_ARCH "x86_64")
-if(NOT ${CMAKE_SYSTEM_PROCESSOR})
-  set(TARGET_ARCH ${CMAKE_SYSTEM_PROCESSOR})
-endif()
+paddle_normalize_target_arch(TARGET_ARCH)
+paddle_detect_cuda_target_dir(CUDA_TARGET_DIR)
 
 list(
   APPEND
@@ -32,7 +32,9 @@ list(
   $ENV{NVTX_ROOT}/lib64
   $ENV{NVTX_ROOT}/lib
   ${CUDA_TOOLKIT_ROOT_DIR}
-  ${CUDA_TOOLKIT_ROOT_DIR}/targets/${TARGET_ARCH}-linux/lib)
+  ${CUDA_TOOLKIT_ROOT_DIR}/targets/${TARGET_ARCH}-linux/lib
+  ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/lib64
+  ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/lib)
 
 find_library(
   CUDA_NVTX_LIB

--- a/cmake/cudnn.cmake
+++ b/cmake/cudnn.cmake
@@ -2,6 +2,8 @@ if(NOT WITH_GPU)
   return()
 endif()
 
+include(${PROJECT_SOURCE_DIR}/cmake/architecture.cmake)
+
 if(WIN32)
   set(CUDNN_ROOT ${CUDA_TOOLKIT_ROOT_DIR})
 else()
@@ -10,16 +12,18 @@ else()
       CACHE PATH "CUDNN ROOT")
 endif()
 
-set(TARGET_ARCH "x86_64")
-if(NOT ${CMAKE_SYSTEM_PROCESSOR})
-  set(TARGET_ARCH ${CMAKE_SYSTEM_PROCESSOR})
-endif()
+paddle_normalize_target_arch(TARGET_ARCH)
+paddle_detect_cuda_target_dir(CUDA_TARGET_DIR)
 
 find_path(
   CUDNN_INCLUDE_DIR cudnn.h
-  PATHS ${CUDNN_ROOT} ${CUDNN_ROOT}/include
-        ${CUDNN_ROOT}/include/${TARGET_ARCH}-linux-gnu $ENV{CUDNN_ROOT}
-        $ENV{CUDNN_ROOT}/include ${CUDA_TOOLKIT_INCLUDE}
+  PATHS ${CUDNN_ROOT}
+        ${CUDNN_ROOT}/include
+        ${CUDNN_ROOT}/include/${TARGET_ARCH}-linux-gnu
+        $ENV{CUDNN_ROOT}
+        $ENV{CUDNN_ROOT}/include
+        ${CUDA_TOOLKIT_INCLUDE}
+        ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/include
   NO_DEFAULT_PATH)
 
 get_filename_component(__libpath_hist ${CUDA_CUDART_LIBRARY} PATH)
@@ -39,7 +43,9 @@ list(
   $ENV{CUDNN_ROOT}/lib/x64
   /usr/lib
   ${CUDA_TOOLKIT_ROOT_DIR}
-  ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64)
+  ${CUDA_TOOLKIT_ROOT_DIR}/lib/x64
+  ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/lib64
+  ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/lib)
 set(CUDNN_LIB_NAME "")
 
 if(LINUX)

--- a/cmake/cupti.cmake
+++ b/cmake/cupti.cmake
@@ -2,6 +2,8 @@ if(NOT WITH_GPU AND NOT WITH_ROCM)
   return()
 endif()
 
+include(${PROJECT_SOURCE_DIR}/cmake/architecture.cmake)
+
 if(WITH_ROCM)
   set(CUPTI_ROOT
       "${ROCM_PATH}/cuda/extras/CUPTI"
@@ -11,6 +13,8 @@ else()
       "/usr"
       CACHE PATH "CUPTI ROOT")
 endif()
+paddle_detect_cuda_target_dir(CUDA_TARGET_DIR)
+
 find_path(
   CUPTI_INCLUDE_DIR cupti.h
   PATHS ${CUPTI_ROOT}
@@ -20,13 +24,16 @@ find_path(
         ${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/include
         ${CUDA_TOOLKIT_ROOT_DIR}/targets/x86_64-linux/include
         ${CUDA_TOOLKIT_ROOT_DIR}/targets/aarch64-linux/include
+        ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/include
   NO_DEFAULT_PATH)
 
 get_filename_component(__libpath_hist ${CUDA_CUDART_LIBRARY} PATH)
 
-set(TARGET_ARCH "x86_64")
-if(NOT ${CMAKE_SYSTEM_PROCESSOR})
-  set(TARGET_ARCH ${CMAKE_SYSTEM_PROCESSOR})
+paddle_normalize_target_arch(TARGET_ARCH)
+if(NOT CUDA_TARGET_DIR STREQUAL "")
+  list(APPEND CUPTI_CHECK_LIBRARY_DIRS
+       ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/lib64
+       ${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/lib)
 endif()
 
 list(
@@ -40,7 +47,6 @@ list(
   $ENV{CUPTI_ROOT}/lib64
   $ENV{CUPTI_ROOT}/lib
   /usr/lib
-  ${CUDA_TOOLKIT_ROOT_DIR}/targets/x86_64-linux/lib64
   ${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI/lib64)
 find_library(
   CUPTI_LIBRARY

--- a/paddle/cinn/backends/CMakeLists.txt
+++ b/paddle/cinn/backends/CMakeLists.txt
@@ -34,7 +34,7 @@ if(WITH_CUSTOM_DEVICE)
   add_subdirectory(custom_device)
 endif()
 
-if(WITH_OPENMP)
+if(WITH_OPENMP AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
   cinn_cc_library(__x86_source_fake_lib SRCS _x86_builtin_source.cc)
 endif()
 add_subdirectory(llvm)

--- a/paddle/cinn/backends/llvm/CMakeLists.txt
+++ b/paddle/cinn/backends/llvm/CMakeLists.txt
@@ -1,11 +1,16 @@
 add_definitions(${LLVM_DEFINITIONS})
 
+set(CINN_RUNTIME_LLVM_FLAGS -std=c++11 -S -emit-llvm -O3)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
+  list(APPEND CINN_RUNTIME_LLVM_FLAGS -mavx2 -masm=intel)
+endif()
+
 # generate cinn_runtime.ll file
 
 add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/paddle/cinn/backends/llvm/cinn_runtime_llvm_ir.h
   COMMAND
-    ${LLVM_PATH}/bin/clang++ -mavx2 -std=c++11 -masm=intel -S -emit-llvm -O3
+    ${LLVM_CLANG_EXECUTABLE} ${CINN_RUNTIME_LLVM_FLAGS}
     ${PROJECT_SOURCE_DIR}/paddle/cinn/runtime/cinn_runtime.cc
     -I${PROJECT_SOURCE_DIR} -o
     ${CMAKE_BINARY_DIR}/paddle/cinn/runtime/cinn_runtime.ll
@@ -13,7 +18,7 @@ add_custom_command(
     ${PYTHON_EXECUTABLE} generate_runtime_llvm_ir.py
     ${CMAKE_BINARY_DIR}/paddle/cinn/runtime/cinn_runtime.ll
     ${CMAKE_BINARY_DIR}/paddle/cinn/backends/llvm/cinn_runtime_llvm_ir.h
-    ${LLVM_PATH}/bin/llvm-config
+    ${LLVM_CONFIG_EXECUTABLE}
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/paddle/cinn/backends/llvm
   DEPENDS ${PROJECT_SOURCE_DIR}/paddle/cinn/runtime/cinn_runtime.cc
           ${PROJECT_SOURCE_DIR}/paddle/cinn/runtime/cinn_runtime.h)

--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -233,7 +233,10 @@ else()
   endif()
 endif()
 
-set(NVTX3_PATH "${CUDA_INCLUDE_DIRS}/../targets/x86_64-linux/include/nvtx3/")
+include(${PROJECT_SOURCE_DIR}/cmake/architecture.cmake)
+paddle_detect_cuda_target_dir(CUDA_TARGET_DIR)
+set(NVTX3_PATH
+    "${CUDA_TOOLKIT_ROOT_DIR}/targets/${CUDA_TARGET_DIR}/include/nvtx3")
 get_filename_component(NVTX3_PATH "${NVTX3_PATH}" ABSOLUTE)
 
 if(EXISTS "${NVTX3_PATH}")

--- a/paddle/pir/include/core/spin_lock.h
+++ b/paddle/pir/include/core/spin_lock.h
@@ -15,8 +15,9 @@
 #pragma once
 
 #include <atomic>
-#if defined(_M_X64) || defined(__x86_64__) || defined(_M_IX86) || \
-    defined(__i386__)
+#if (defined(_M_X64) || defined(__x86_64__) || defined(_M_IX86) || \
+     defined(__i386__)) &&                                         \
+    !(defined(__aarch64__) || defined(__arm64__))
 #define __PADDLE_x86__
 #include <immintrin.h>
 #endif

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -53,11 +53,11 @@ def _preload_nvidia_lib(lib_glob, sub_dirs=None):
     import glob
     import os
 
-    from .version import cuda as cuda_version
+    from .version import cuda_version as _cuda_version
 
     pkg_dir = os.path.dirname(os.path.abspath(__file__))
     nvidia_dir = os.path.join(pkg_dir, '..', 'nvidia')
-    cuda_major = cuda_version().split('.')[0]
+    cuda_major = _cuda_version.split('.')[0]
 
     paths = glob.glob(
         os.path.join(nvidia_dir, f'cu{cuda_major}', 'lib', lib_glob)
@@ -70,13 +70,23 @@ def _preload_nvidia_lib(lib_glob, sub_dirs=None):
 
 
 if __is_metainfo_generated:
+    import builtins
     import platform
 
-    if platform.system() == 'Linux' and platform.machine() == 'x86_64':
+    if platform.system() == 'Linux':
         try:
-            from .version import with_pip_cuda_libraries
+            from .version import (
+                cuda_version as _cuda_version,
+                with_pip_cuda_libraries,
+            )
 
-            if with_pip_cuda_libraries == 'ON':
+            if with_pip_cuda_libraries == 'ON' and (
+                platform.machine() in ('x86_64', 'AMD64')
+                or (
+                    platform.machine() == 'aarch64'
+                    and builtins.float(_cuda_version) >= 13.0
+                )
+            ):
                 _preload_nvidia_lib('libcublasLt.so.*[0-9]', ['cublas'])
                 _preload_nvidia_lib('libcublas.so.*[0-9]', ['cublas'])
         except Exception:
@@ -844,13 +854,22 @@ if is_compiled_with_cinn():
     os.environ['CINN_CONFIG_PATH'] = str(data_file_path)
 
 if __is_metainfo_generated and is_compiled_with_cuda():
+    import builtins
     import os
     import platform
 
+    from .version import cuda_version as _cuda_version, with_pip_cuda_libraries
+
     if (
         platform.system() == 'Linux'
-        and platform.machine() == 'x86_64'
-        and paddle.version.with_pip_cuda_libraries == 'ON'
+        and (
+            platform.machine() in ('x86_64', 'AMD64')
+            or (
+                platform.machine() == 'aarch64'
+                and builtins.float(_cuda_version) >= 13.0
+            )
+        )
+        and with_pip_cuda_libraries == 'ON'
     ):
         package_dir = os.path.dirname(os.path.abspath(__file__))
         nvidia_package_path = package_dir + "/.." + "/nvidia"

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -705,21 +705,21 @@ def get_paddle_extra_install_requirements():
                 "cuda-python==12.9.4; platform_system == 'Linux' and platform_machine == 'x86_64'"
             ),
             "13.0": (
-                "nvidia-cuda-nvrtc==13.0.88; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-cuda-runtime==13.0.88; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-cuda-cupti==13.0.85; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-cudnn-cu13==9.13.0.50; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-cublas==13.0.2.14; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-cufft==12.0.0.61; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-curand==10.4.0.35; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-cusolver==12.0.4.66; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-cusparse==12.6.3.3; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-nccl-cu13==2.28.3; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-nvtx==13.0.85; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-nvjitlink==13.0.88; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "nvidia-cufile==1.15.1.6; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                "cuda-python==13.0.3; platform_system == 'Linux' and platform_machine == 'x86_64'"
+                "nvidia-cuda-nvrtc==13.0.88; platform_system == 'Linux' | "
+                "nvidia-cuda-runtime==13.0.88; platform_system == 'Linux' | "
+                "nvidia-cuda-cupti==13.0.85; platform_system == 'Linux' | "
+                "nvidia-cudnn-cu13==9.15.1.9; platform_system == 'Linux' | "
+                "nvidia-cublas==13.1.0.3; platform_system == 'Linux' | "
+                "nvidia-cufft==12.0.0.61; platform_system == 'Linux' | "
+                "nvidia-curand==10.4.0.35; platform_system == 'Linux' | "
+                "nvidia-cusolver==12.0.4.66; platform_system == 'Linux' | "
+                "nvidia-cusparse==12.6.3.3; platform_system == 'Linux' | "
+                "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "
+                "nvidia-nccl-cu13==2.28.3; platform_system == 'Linux' | "
+                "nvidia-nvtx==13.0.85; platform_system == 'Linux' | "
+                "nvidia-nvjitlink==13.0.88; platform_system == 'Linux' | "
+                "nvidia-cufile==1.15.1.6; platform_system == 'Linux' | "
+                "cuda-python==13.0.3; platform_system == 'Linux'"
             ),
         }
         if '@WITH_CINN@' == 'ON':
@@ -739,7 +739,7 @@ def get_paddle_extra_install_requirements():
                     " | nvidia-cuda-cccl-cu12==12.9.27;platform_system == 'Linux' and platform_machine == 'x86_64' "
             )
             PADDLE_CUDA_INSTALL_REQUIREMENTS["13.0"] += (
-                    " | nvidia-cuda-cccl==13.0.85;platform_system == 'Linux' and platform_machine == 'x86_64' "
+                    " | nvidia-cuda-cccl==13.0.85;platform_system == 'Linux' "
             )
         elif platform.system() == 'Windows':
             PADDLE_CUDA_INSTALL_REQUIREMENTS = {
@@ -790,8 +790,8 @@ def get_paddle_extra_install_requirements():
                 ),
                 "13.0": (
                     "nvidia-cuda-runtime==13.0.88 | "
-                    "nvidia-cudnn-cu13==9.13.0.50 | "
-                    "nvidia-cublas==13.0.2.14 | "
+                    "nvidia-cudnn-cu13==9.15.1.9 | "
+                    "nvidia-cublas==13.1.0.3 | "
                     "nvidia-cufft==12.0.0.61 | "
                     "nvidia-curand==10.4.0.35 | "
                     "nvidia-cusolver==12.0.4.66 | "
@@ -1117,7 +1117,16 @@ if sys.version_info >= (3, 9):
             continue
         setup_requires_tmp+=[setup_requires_i]
     setup_requires = setup_requires_tmp
-    if '@WITH_GPU@' == 'ON' and platform.system() in ('Linux', 'Windows') and platform.machine() in ('x86_64', 'AMD64'):
+    if '@WITH_GPU@' == 'ON' and (
+        (
+            platform.system() == 'Linux'
+            and (
+                platform.machine() == 'x86_64'
+                or float('@CUDA_VERSION@') >= 13.0
+            )
+        )
+        or (platform.system() == 'Windows' and platform.machine() in ('x86_64', 'AMD64'))
+    ):
         paddle_cuda_requires,paddle_tensorrt_requires= get_paddle_extra_install_requirements()
         setup_requires += paddle_cuda_requires
         setup_requires += paddle_tensorrt_requires

--- a/setup.py
+++ b/setup.py
@@ -1204,21 +1204,21 @@ def get_paddle_extra_install_requirements():
                     "cuda-python==12.9.4; platform_system == 'Linux' and platform_machine == 'x86_64'"
                 ),
                 "13.0": (
-                    "nvidia-cuda-nvrtc==13.0.88; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-cuda-runtime==13.0.88; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-cuda-cupti==13.0.85; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-cudnn-cu13==9.13.0.50; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-cublas==13.0.2.14; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-cufft==12.0.0.61; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-curand==10.4.0.35; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-cusolver==12.0.4.66; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-cusparse==12.6.3.3; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-nccl-cu13==2.28.3; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-nvtx==13.0.85; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-nvjitlink==13.0.88; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "nvidia-cufile==1.15.1.6; platform_system == 'Linux' and platform_machine == 'x86_64' | "
-                    "cuda-python==13.0.3; platform_system == 'Linux' and platform_machine == 'x86_64'"
+                    "nvidia-cuda-nvrtc==13.0.88; platform_system == 'Linux' | "
+                    "nvidia-cuda-runtime==13.0.88; platform_system == 'Linux' | "
+                    "nvidia-cuda-cupti==13.0.85; platform_system == 'Linux' | "
+                    "nvidia-cudnn-cu13==9.15.1.9; platform_system == 'Linux' | "
+                    "nvidia-cublas==13.1.0.3; platform_system == 'Linux' | "
+                    "nvidia-cufft==12.0.0.61; platform_system == 'Linux' | "
+                    "nvidia-curand==10.4.0.35; platform_system == 'Linux' | "
+                    "nvidia-cusolver==12.0.4.66; platform_system == 'Linux' | "
+                    "nvidia-cusparse==12.6.3.3; platform_system == 'Linux' | "
+                    "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "
+                    "nvidia-nccl-cu13==2.28.3; platform_system == 'Linux' | "
+                    "nvidia-nvtx==13.0.85; platform_system == 'Linux' | "
+                    "nvidia-nvjitlink==13.0.88; platform_system == 'Linux' | "
+                    "nvidia-cufile==1.15.1.6; platform_system == 'Linux' | "
+                    "cuda-python==13.0.3; platform_system == 'Linux'"
                 ),
             }
             if env_dict.get("WITH_CINN") == "ON":
@@ -1238,7 +1238,7 @@ def get_paddle_extra_install_requirements():
                     " | nvidia-cuda-cccl-cu12==12.9.27;platform_system == 'Linux' and platform_machine == 'x86_64' "
                 )
                 PADDLE_CUDA_INSTALL_REQUIREMENTS["13.0"] += (
-                    " | nvidia-cuda-cccl==13.0.85;platform_system == 'Linux' and platform_machine == 'x86_64' "
+                    " | nvidia-cuda-cccl==13.0.85;platform_system == 'Linux' "
                 )
 
         elif platform.system() == 'Windows':
@@ -1290,8 +1290,8 @@ def get_paddle_extra_install_requirements():
                 ),
                 "13.0": (
                     "nvidia-cuda-runtime==13.0.88 | "
-                    "nvidia-cudnn-cu13==9.13.0.50 | "
-                    "nvidia-cublas==13.0.2.14 | "
+                    "nvidia-cudnn-cu13==9.15.1.9 | "
+                    "nvidia-cublas==13.1.0.3 | "
                     "nvidia-cufft==12.0.0.61 | "
                     "nvidia-curand==10.4.0.35 | "
                     "nvidia-cusolver==12.0.4.66 | "
@@ -2506,13 +2506,17 @@ def get_headers():
 def get_setup_parameters():
     # get setup_requires
     setup_requires = get_setup_requires()
-    if (
-        env_dict.get("WITH_GPU") == 'ON'
-        and platform.system() in ('Linux', 'Windows')
-        and platform.machine()
-        in (
-            'x86_64',
-            'AMD64',
+    if env_dict.get("WITH_GPU") == 'ON' and (
+        (
+            platform.system() == 'Linux'
+            and (
+                platform.machine() == 'x86_64'
+                or float(env_dict.get("CUDA_VERSION")) >= 13.0
+            )
+        )
+        or (
+            platform.system() == 'Windows'
+            and platform.machine() in ('x86_64', 'AMD64')
         )
     ):
         paddle_cuda_requires, paddle_tensorrt_requires = (

--- a/tools/CheckPRTemplate.py
+++ b/tools/CheckPRTemplate.py
@@ -167,7 +167,7 @@ def check_precision_change_approval(body, pr_number, pr_user):
     REQUIRED_APPROVERS = [
         'From00',
         'lugimzzz',
-        'Jiang-Jia-Jun',
+        'yuanlehome',
         'wanghuancoder',
     ]
     REQUIRED_APPROVERS_LOWER = [user.lower() for user in REQUIRED_APPROVERS]


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

使 Paddle 能够在 `WITH_CINN` 下编译、运行，这包含如下几部分

- 添加 `ginac`、`isl`、`llvm` arm64 预编译包版本，并上传 bos，其中 llvm 使用低版本 gcc8 进行编译，确保只包含 glibc2.17 以保证最好的兼容性
- 更新 CUDA 13 下的 `nvidia-*` wheel 包依赖：
   - CUDA 13+ 下不再限定仅 x86 下安装，arm64 也会安装（之前会导致依赖里丢掉这些 nvidia 包，用户在没配置好环境的情况下可能跑不起来）
   - 更新 `nvidia-cudnn-cu13` 到 `9.15.1.9`、`nvidia-cublas` 到 `13.1.0.3`

<sup>This PR is co-authored with @copilot (gpt-5.4)</sup>

### Remaining issues

正是因为之前极度依赖于开发镜像里装了 nvidia 相关依赖，所以 wheel 包缺失 nvidia 依赖才没被发现，但是在没有 wheel 包依赖的情况下，CINN 单测会暴露出默认 nvrtc 编译时找不到系统里 nv 相关头文件的问题，这个问题依然存在，但是对于用户而言，通过装 wheel 包的方式装 nv 相关依赖，该问题就不存在了

后续如果要在 ARM CPU上（也可能是 cu13 的问题，不是 ARM 的问题）跑单测或者开发可以注意下这一点，单独适配下，这个就暂时低优了

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

是

---

Cherry-pick of #78712 (authored by @SigureMo) to `release/3.4`.

本 PR 顺带 cherry-pick 了 #78729，用于调整精度检查 reviewer

devPR:https://github.com/PaddlePaddle/Paddle/pull/78712 <!-- For pass CI -->