### PR TITLE
[release/3.4] fix: use ThrustAllocator in argsort 1D path to avoid implicit cudaStr…

### DIFF
--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -21,6 +21,7 @@
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/cub.h"
@@ -283,9 +284,13 @@ void PerSort(const GPUContext& dev_ctx,
              bool stable,
              bool descending) {
 #ifdef PADDLE_WITH_CUDA
-  const auto& exec_policy = thrust::cuda::par.on(dev_ctx.stream());
+  phi::memory_utils::ThrustAllocator<cudaStream_t> allocator(dev_ctx.GetPlace(),
+                                                             dev_ctx.stream());
+  const auto& exec_policy = thrust::cuda::par(allocator).on(dev_ctx.stream());
 #else
-  const auto& exec_policy = thrust::hip::par.on(dev_ctx.stream());
+  phi::memory_utils::ThrustAllocator<hipStream_t> allocator(dev_ctx.GetPlace(),
+                                                            dev_ctx.stream());
+  const auto& exec_policy = thrust::hip::par(allocator).on(dev_ctx.stream());
 #endif
   if (stable) {
     if (descending) {
@@ -349,9 +354,13 @@ void ArgsortKernel(const Context& dev_ctx,
     T* out_data = dev_ctx.template Alloc<T>(output);
     int64_t* ids_data = dev_ctx.template Alloc<int64_t>(indices);
 #ifdef PADDLE_WITH_CUDA
-    const auto& exec_policy = thrust::cuda::par.on(dev_ctx.stream());
+    phi::memory_utils::ThrustAllocator<cudaStream_t> allocator(
+        dev_ctx.GetPlace(), dev_ctx.stream());
+    const auto& exec_policy = thrust::cuda::par(allocator).on(dev_ctx.stream());
 #else
-    const auto& exec_policy = thrust::hip::par.on(dev_ctx.stream());
+    phi::memory_utils::ThrustAllocator<hipStream_t> allocator(
+        dev_ctx.GetPlace(), dev_ctx.stream());
+    const auto& exec_policy = thrust::hip::par(allocator).on(dev_ctx.stream());
 #endif
     auto cu_stream = dev_ctx.stream();
     thrust::sequence(exec_policy, ids_data, ids_data + size);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
修复argsort算子在1D case下的低效malloc路径，使其调用框架内存管理机制，避免裸malloc带来的额外同步

pcard-91067


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

---

Cherry-pick of #78726 (authored by @A-nnonymous) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78726 <!-- For pass CI -->