### PR TITLE
[CP] No longer perform supplementary checks for the specified GPU architecture

### DIFF
--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -496,7 +496,7 @@ jobs:
     steps:
       - name: Determine the runner
         run: |
-          gpu_id=$(( $(echo $PWD | awk -F'/' '{print $3}' | awk -F'-' '{print $2}') + 3 ))
+          gpu_id=$(( $(echo $PWD | awk -F'/' '{print $3}' | awk -F'-' '{print $2}') - 1 ))
           echo GPU_DEVICES="$gpu_id" >> $GITHUB_ENV
 
       - name: Check docker image and run container

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -473,6 +473,12 @@ def _get_cuda_arch_flags(cflags: list[str] | None = None) -> list[str]:
     _arch_list = os.environ.get("PADDLE_CUDA_ARCH_LIST")
 
     if not _arch_list:
+        if cflags is not None:
+            for flag in cflags:
+                if any(x in flag for x in ['PADDLE_EXTENSION_NAME']):
+                    continue
+                if 'arch' in flag:
+                    return []
         warnings.warn(
             "PADDLE_CUDA_ARCH_LIST are not set, all archs for visible cards are included for compilation. \n"
             "If this is not desired, please set os.environ['PADDLE_CUDA_ARCH_LIST']."

--- a/test/compat/test_cpp_extension_api.py
+++ b/test/compat/test_cpp_extension_api.py
@@ -37,7 +37,7 @@ class TestGetCudaArchFlags(unittest.TestCase):
 
     def test_with_user_cflags(self):
         flags = _get_cuda_arch_flags(cflags=["-arch=sm_90"])
-        self.assertIsInstance(flags, list)
+        self.assertEqual(flags, [])
 
     def test_with_env_hopper(self):
         os.environ["PADDLE_CUDA_ARCH_LIST"] = "Hopper"
@@ -86,6 +86,10 @@ class TestGetCudaArchFlags(unittest.TestCase):
             "Unknown CUDA arch (invalid_arch) or GPU not supported",
             str(context.exception),
         )
+
+    def test_skip_paddle_extension_name_flag(self):
+        flags = _get_cuda_arch_flags(cflags=["-DPADDLE_EXTENSION_NAME=my_ext"])
+        self.assertNotEqual(flags, [])
 
 
 class TestCppExtensionUtils(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
只有自定义算子包里和环境变量里都没有指定架构才会检测显卡架构并补充架构号到编译参数
devPR:https://github.com/PaddlePaddle/Paddle/pull/78732

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否