### PR TITLE
add bf16 support for paddleocr-vl

### DIFF
--- a/paddle/phi/kernels/gpu/layer_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_kernel.cu
@@ -786,8 +786,13 @@ template PADDLE_API void LayerNormKernel<double, GPUContext>(
 
 #ifdef PADDLE_WITH_HIP
 // MIOPEN do not support double
-PD_REGISTER_KERNEL(
-    layer_norm, GPU, ALL_LAYOUT, phi::LayerNormKernel, float, phi::float16) {
+PD_REGISTER_KERNEL(layer_norm,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::LayerNormKernel,
+                   float,
+                   phi::float16,
+                   phi::bfloat16) {
   kernel->OutputAt(1).SetDataType(phi::DataType::UNDEFINED);
   kernel->OutputAt(2).SetDataType(phi::DataType::UNDEFINED);
 }

--- a/test/legacy_test/test_conv2d_op.py
+++ b/test/legacy_test/test_conv2d_op.py
@@ -152,7 +152,11 @@ def conv2d_forward_naive(
 
 def create_test_cudnn_class(parent):
     @unittest.skipIf(
-        not (core.is_compiled_with_cuda() or is_custom_device()),
+        not (
+            core.is_compiled_with_cuda()
+            or core.is_compiled_with_rocm()
+            or is_custom_device()
+        ),
         "core is not compiled with CUDA",
     )
     class TestCUDNNCase(parent):
@@ -171,7 +175,11 @@ def create_test_cudnn_class(parent):
 
 def create_test_cudnn_fp16_class(parent, grad_check=True):
     @unittest.skipIf(
-        not (core.is_compiled_with_cuda() or is_custom_device()),
+        not (
+            core.is_compiled_with_cuda()
+            or core.is_compiled_with_rocm()
+            or is_custom_device()
+        ),
         "core is not compiled with CUDA",
     )
     class TestConv2DCUDNNFp16(parent):
@@ -206,7 +214,11 @@ def create_test_cudnn_fp16_class(parent, grad_check=True):
 
 def create_test_cudnn_bf16_class(parent):
     @unittest.skipIf(
-        not (core.is_compiled_with_cuda() or is_custom_device())
+        not (
+            core.is_compiled_with_cuda()
+            or core.is_compiled_with_rocm()
+            or is_custom_device()
+        )
         or not core.is_bfloat16_supported(get_device_place()),
         "core is not compiled with CUDA and do not support bfloat16",
     )
@@ -273,7 +285,11 @@ def create_test_channel_last_class(parent):
 
 def create_test_cudnn_channel_last_class(parent):
     @unittest.skipIf(
-        not (core.is_compiled_with_cuda() or is_custom_device()),
+        not (
+            core.is_compiled_with_cuda()
+            or core.is_compiled_with_rocm()
+            or is_custom_device()
+        ),
         "core is not compiled with CUDA",
     )
     class TestCudnnChannelLastCase(parent):
@@ -281,7 +297,11 @@ def create_test_cudnn_channel_last_class(parent):
             self.use_cudnn = True
             self.dtype = (
                 np.float32
-                if (core.is_compiled_with_rocm() or is_custom_device())
+                if (
+                    core.is_compiled_with_cuda()
+                    or core.is_compiled_with_rocm()
+                    or is_custom_device()
+                )
                 else np.float64
             )
 
@@ -299,7 +319,11 @@ def create_test_cudnn_channel_last_class(parent):
 
 def create_test_cudnn_channel_last_fp16_class(parent, grad_check=True):
     @unittest.skipIf(
-        not (core.is_compiled_with_cuda() or is_custom_device()),
+        not (
+            core.is_compiled_with_cuda()
+            or core.is_compiled_with_rocm()
+            or is_custom_device()
+        ),
         "core is not compiled with CUDA",
     )
     class TestCudnnChannelLastFp16(parent):
@@ -308,7 +332,11 @@ def create_test_cudnn_channel_last_fp16_class(parent, grad_check=True):
             self.dtype = np.float16
 
         def test_check_output(self):
-            if core.is_compiled_with_cuda() or is_custom_device():
+            if (
+                core.is_compiled_with_cuda()
+                or core.is_compiled_with_rocm()
+                or is_custom_device()
+            ):
                 place = get_device_place()
                 if core.is_float16_supported(place):
                     self.check_output_with_place(place, atol=2e-2)
@@ -363,7 +391,11 @@ def create_test_padding_VALID_class(parent):
 
 def create_test_cudnn_padding_SAME_class(parent):
     @unittest.skipIf(
-        not (core.is_compiled_with_cuda() or is_custom_device()),
+        not (
+            core.is_compiled_with_cuda()
+            or core.is_compiled_with_rocm()
+            or is_custom_device()
+        ),
         "core is not compiled with CUDA",
     )
     class TestCUDNNPaddingSAMECase(parent):
@@ -371,7 +403,11 @@ def create_test_cudnn_padding_SAME_class(parent):
             self.use_cudnn = True
             self.dtype = (
                 np.float32
-                if (core.is_compiled_with_rocm() or is_custom_device())
+                if (
+                    core.is_compiled_with_cuda()
+                    or core.is_compiled_with_rocm()
+                    or is_custom_device()
+                )
                 else np.float64
             )
 
@@ -386,7 +422,11 @@ def create_test_cudnn_padding_SAME_class(parent):
 
 def create_test_cudnn_padding_VALID_class(parent):
     @unittest.skipIf(
-        not (core.is_compiled_with_cuda() or is_custom_device()),
+        not (
+            core.is_compiled_with_cuda()
+            or core.is_compiled_with_rocm()
+            or is_custom_device()
+        ),
         "core is not compiled with CUDA",
     )
     class TestCUDNNPaddingVALIDCase(parent):
@@ -394,7 +434,11 @@ def create_test_cudnn_padding_VALID_class(parent):
             self.use_cudnn = True
             self.dtype = (
                 np.float32
-                if (core.is_compiled_with_rocm() or is_custom_device())
+                if (
+                    core.is_compiled_with_cuda()
+                    or core.is_compiled_with_rocm()
+                    or is_custom_device()
+                )
                 else np.float64
             )
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
1. Added the registration of the bf16 precision for the conv2d forward operator, fixed the corresponding helper function, and the related unit tests passed.
2. Added the registration of the bf16 precision for the layernorm forward operator, and the related unit tests passed.

--- Before:
<img width="3156" height="546" alt="before" src="https://github.com/user-attachments/assets/8333b6fa-6af5-44ef-921b-b42139fab3e2" />

``` bash
<img width="1479" height="256" alt="image" src="https://github.com/user-attachments/assets/3bd9c107-2935-4e0c-9014-d6a97b1ca47e" />
root@asrock-1w300-e4-2b:/opt/PaddleX# paddlex --pipeline PaddleOCR-VL-native.yaml --input /tmp/test_ocr.png
Connectivity check to the model hoster has been skipped because `PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK` is enabled.
Creating model: ('PP-DocLayoutV3', './layout_0116')
Creating model: ('PaddleOCR-VL-1.5-0.9B', './checkpoint-5000')
Loading configuration file checkpoint-5000/config.json
Loading weights file checkpoint-5000/model.safetensors
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
Loaded weights file from disk, setting weights to model.
All model checkpoint weights were used when initializing PaddleOCRVLForConditionalGeneration.

All the weights of PaddleOCRVLForConditionalGeneration were initialized from the model checkpoint at checkpoint-5000.
If your task is similar to the task the model of the checkpoint was trained on, you can already use PaddleOCRVLForConditionalGeneration for predictions without further training.
Loading configuration file checkpoint-5000/generation_config.json
Currently, the 'PaddleOCR-VL-1.5-0.9B' local model only supports batch size of 1. The batch size will be updated to 1.
Pipeline prediction failed
Traceback (most recent call last):
  File "/opt/PaddleX/paddlex/paddlex_cli.py", line 637, in main
    pipeline_predict(
  File "/opt/PaddleX/paddlex/paddlex_cli.py", line 485, in pipeline_predict
    for res in result:
               ^^^^^^
  File "/opt/PaddleX/paddlex/inference/pipelines/_parallel.py", line 139, in predict
    yield from self._pipeline.predict(
  File "/opt/PaddleX/paddlex/inference/pipelines/paddleocr_vl/pipeline.py", line 894, in predict
    raise RuntimeError(
RuntimeError: Exception from the 'vlm' worker: (NotFound) The kernel with key (GPU, Undefined(AnyLayout), bfloat16) of kernel `conv2d` is not registered and fail to fallback to CPU one. Selected wrong DataType `bfloat16`. Paddle support following DataTypes: float64, float32.
  [Hint: Expected kernel_iter != iter->second.end(), but received kernel_iter == iter->second.end().] (at /work/Paddle/paddle/phi/core/kernel_factory.cc:380)

sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
``` 

after:
<img width="3169" height="975" alt="after" src="https://github.com/user-attachments/assets/763d1949-a84c-4677-b27a-58280c2af572" />

``` bash
 Connectivity check to the model hoster has been skipped because `PADDLE_PDX_DISABLE_MODEL_SOURCE_CHECK` is enabled.
Creating model: ('PP-DocLayoutV3', './layout_0116')
Creating model: ('PaddleOCR-VL-1.5-0.9B', './checkpoint-5000')
Loading configuration file checkpoint-5000/config.json
Loading weights file checkpoint-5000/model.safetensors
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
use GQA - num_heads: 16- num_key_value_heads: 2
Loaded weights file from disk, setting weights to model.
All model checkpoint weights were used when initializing PaddleOCRVLForConditionalGeneration.

All the weights of PaddleOCRVLForConditionalGeneration were initialized from the model checkpoint at checkpoint-5000.
If your task is similar to the task the model of the checkpoint was trained on, you can already use PaddleOCRVLForConditionalGeneration for predictions without further training.
Loading configuration file checkpoint-5000/generation_config.json
Currently, the 'PaddleOCR-VL-1.5-0.9B' local model only supports batch size of 1. The batch size will be updated to 1.
{'res': {'input_path': '/tmp/test_ocr.png', 'page_index': None, 'page_count': None, 'width': 896, 'height': 528, 'model_settings': {'use_doc_preprocessor': False, 'use_layout_detection': True, 'use_chart_recognition': False, 'use_seal_recognition': False, 'use_ocr_for_image_block': False, 'format_block_content': False, 'merge_layout_blocks': True, 'markdown_ignore_labels': ['number', 'footnote', 'header', 'header_image', 'footer', 'footer_image', 'aside_text'], 'return_layout_polygon_points': True}, 'layout_det_res': {'input_path': None, 'page_index': None, 'boxes': [{'cls_id': 22, 'label': 'text', 'score': 0.30391931533813477, 'coordinate': [4, 4, 340, 31], 'order': 1, 'polygon_points': array([[  3.8426514,   4.2761917],
       [338.87906  ,   2.2270393],
       [339.03638  ,  27.950848 ],
       [  3.9999695,  30.       ]], dtype=float32)}, {'cls_id': 22, 'label': 'text', 'score': 0.30334219336509705, 'coordinate': [214, 106, 319, 130], 'order': 2, 'polygon_points': array([[214., 106.],
       [318., 106.],
       [318., 129.],
       [214., 129.]], dtype=float32)}, {'cls_id': 22, 'label': 'text', 'score': 0.3251299560070038, 'coordinate': [68, 178, 170, 203], 'order': 3, 'polygon_points': array([[ 67.29294, 181.02385],
       [168.88538, 177.59938],
       [169.65259, 200.36003],
       [ 68.06015, 203.7845 ]], dtype=float32)}, {'cls_id': 22, 'label': 'text', 'score': 0.3090173900127411, 'coordinate': [341, 102, 459, 129], 'order': 4, 'polygon_points': array([[341., 102.],
       [459., 102.],
       [459., 129.],
       [341., 129.]], dtype=float32)}, {'cls_id': 22, 'label': 'text', 'score': 0.3651599884033203, 'coordinate': [342, 172, 470, 199], 'order': 5, 'polygon_points': array([[342., 172.],
       [470., 172.],
       [470., 199.],
       [342., 199.]], dtype=float32)}, {'cls_id': 22, 'label': 'text', 'score': 0.3599250614643097, 'coordinate': [488, 172, 616, 197], 'order': 6, 'polygon_points': array([[488., 172.],
       [616., 172.],
       [616., 197.],
       [488., 197.]], dtype=float32)}, {'cls_id': 22, 'label': 'text', 'score': 0.3172951638698578, 'coordinate': [336, 215, 484, 262], 'order': 7, 'polygon_points': array([[335.45724, 215.45839],
       [482.75192, 213.38379],
       [483.39432, 258.99445],
       [336.09964, 261.06906]], dtype=float32)}]}, 'parsing_res_list': [{'block_label': 'text', 'block_content': 'www.997788.com 中国收藏热线\n\nwww.997788.com 中国收藏热线', 'block_bbox': [4, 4, 340, 31]}, {'block_label': 'text', 'block_content': 'Date: 2024-09-01 00:00:00', 'block_bbox': [214, 106, 319, 130]}, {'block_label': 'text', 'block_content': '1.57 kB??', 'block_bbox': [68, 178, 170, 203]}, {'block_label': 'text', 'block_content': '1.57 kB吾', 'block_bbox': [341, 102, 459, 129]}, {'block_label': 'text', 'block_content': '始发地 FROM \n登机口 GATE', 'block_bbox': [342, 172, 470, 199]}, {'block_label': 'text', 'block_content': '', 'block_bbox': [488, 172, 616, 197]}, {'block_label': 'text', 'block_content': 'TAIYUAN\n身份识别ID NO.\n身份识别ID NO.', 'block_bbox': [336, 215, 484, 262]}]}}
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
