### PR TITLE
Fix the problem of size accuracy when using arange/range with differe…

### DIFF
--- a/paddle/phi/common/data_type.h
+++ b/paddle/phi/common/data_type.h
@@ -328,6 +328,20 @@ inline DataType StringToDataType(const std::string& dtype) {
   }
 }
 
+inline bool IsFloatingType(const DataType& type) {
+  return (type == DataType::FLOAT16 || type == DataType::BFLOAT16 ||
+          type == DataType::FLOAT32 || type == DataType::FLOAT64 ||
+          type == DataType::FLOAT8_E4M3FN || type == DataType::FLOAT8_E5M2);
+}
+
+inline bool IsIntegerType(const DataType& type) {
+  return (type == DataType::INT8 || type == DataType::INT16 ||
+          type == DataType::INT32 || type == DataType::INT64 ||
+          type == DataType::UINT8 || type == DataType::UINT16 ||
+          type == DataType::UINT32 || type == DataType::UINT64 ||
+          type == DataType::BOOL);
+}
+
 }  // namespace phi
 
 namespace paddle {

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -838,6 +838,7 @@ void FlashAttnV3VarlenInferMeta(const MetaTensor& q,
 void ArangeTensorInferMeta(const MetaTensor& start,
                            const MetaTensor& end,
                            const MetaTensor& step,
+                           DataType dtype,
                            MetaTensor* out) {
   PADDLE_ENFORCE_EQ(common::product(start.dims()),
                     1,
@@ -858,12 +859,13 @@ void ArangeTensorInferMeta(const MetaTensor& start,
                         common::product(step.dims())));
 
   out->set_dims({-1});
-  out->set_dtype(start.dtype());
+  out->set_dtype(dtype);
 }
 
 void RangeTensorInferMeta(const MetaTensor& start,
                           const MetaTensor& end,
                           const MetaTensor& step,
+                          DataType dtype,
                           MetaTensor* out) {
   PADDLE_ENFORCE_EQ(common::product(start.dims()),
                     1,
@@ -884,7 +886,7 @@ void RangeTensorInferMeta(const MetaTensor& start,
                         common::product(step.dims())));
 
   out->set_dims({-1});
-  out->set_dtype(start.dtype());
+  out->set_dtype(dtype);
 }
 
 void CollectFpnProposalsInferMeta(

--- a/paddle/phi/infermeta/ternary.h
+++ b/paddle/phi/infermeta/ternary.h
@@ -66,11 +66,13 @@ PADDLE_API void AffineChannelInferMeta(const MetaTensor& x,
 PADDLE_API void ArangeTensorInferMeta(const MetaTensor& start,
                                       const MetaTensor& end,
                                       const MetaTensor& step,
+                                      DataType dtype,
                                       MetaTensor* out);
 
 PADDLE_API void RangeTensorInferMeta(const MetaTensor& start,
                                      const MetaTensor& end,
                                      const MetaTensor& step,
+                                     DataType dtype,
                                      MetaTensor* out);
 
 PADDLE_API void AssignPosInferMeta(const MetaTensor& x,

--- a/paddle/phi/kernels/cpu/arange_kernel.cc
+++ b/paddle/phi/kernels/cpu/arange_kernel.cc
@@ -43,10 +43,39 @@ void ArangeTensorKernel(const Context& dev_ctx,
                         const DenseTensor& end,
                         const DenseTensor& step,
                         DenseTensor* out) {
-  T start_value = start.data<T>()[0];
-  T end_value = end.data<T>()[0];
-  T step_value = step.data<T>()[0];
-  ArangeFunc<T, Context>(dev_ctx, start_value, end_value, step_value, out);
+  int64_t size = 0;
+  T start_value, step_value;
+
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
+
+  Scalar start_scalar(start);
+  Scalar end_scalar(end);
+  Scalar step_scalar(step);
+
+  if (any_float) {
+    double sv = start_scalar.to<double>();
+    double ev = end_scalar.to<double>();
+    double stv = step_scalar.to<double>();
+    funcs::GetSize(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
+  } else {
+    int64_t sv = start_scalar.to<int64_t>();
+    int64_t ev = end_scalar.to<int64_t>();
+    int64_t stv = step_scalar.to<int64_t>();
+    funcs::GetSize(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
+  }
+  out->Resize({size});
+  T* out_data = dev_ctx.template Alloc<T>(out);
+  T value = start_value;
+  for (int64_t i = 0; i < size; ++i) {
+    out_data[i] = value;
+    value += step_value;
+  }
 }
 
 template <typename T, typename Context>
@@ -55,10 +84,33 @@ void ArangeKernel(const Context& dev_ctx,
                   const Scalar& end,
                   const Scalar& step,
                   DenseTensor* out) {
-  T start_value = start.to<T>();
-  T end_value = end.to<T>();
-  T step_value = step.to<T>();
-  ArangeFunc<T, Context>(dev_ctx, start_value, end_value, step_value, out);
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
+  int64_t size = 0;
+  T start_value, step_value;
+  if (any_float) {
+    double sv = start.to<double>();
+    double ev = end.to<double>();
+    double stv = step.to<double>();
+    funcs::GetSize<double>(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
+  } else {
+    int64_t sv = start.to<int64_t>();
+    int64_t ev = end.to<int64_t>();
+    int64_t stv = step.to<int64_t>();
+    funcs::GetSize<double>(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
+  }
+  out->Resize({size});
+  T* out_data = dev_ctx.template Alloc<T>(out);
+  T value = start_value;
+  for (int64_t i = 0; i < size; ++i) {
+    out_data[i] = value;
+    value += step_value;
+  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/range_kernel.cc
+++ b/paddle/phi/kernels/cpu/range_kernel.cc
@@ -46,13 +46,45 @@ void RangeTensorKernel(const Context& dev_ctx,
                        const DenseTensor& end,
                        const DenseTensor& step,
                        DenseTensor* out) {
-  T start_value = start.data<T>()[0];
-  T end_value = end.data<T>()[0];
-  T step_value = step.data<T>()[0];
-  if (step_value == static_cast<T>(0)) {
-    PADDLE_THROW(errors::InvalidArgument("step must be nonzero."));
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
+  int64_t size = 0;
+  T start_value, step_value;
+  Scalar start_scalar(start);
+  Scalar end_scalar(end);
+  Scalar step_scalar(step);
+  if (any_float) {
+    // double sv = start.data<double>()[0];
+    // double ev = end.data<double>()[0];
+    // double stv = step.data<double>()[0];
+    double sv = start_scalar.to<double>();
+    double ev = end_scalar.to<double>();
+    double stv = step_scalar.to<double>();
+    funcs::GetSizeForRange(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
+  } else {
+    // int64_t sv = start.data<int64_t>()[0];
+    // int64_t ev = end.data<int64_t>()[0];
+    // int64_t stv = step.data<int64_t>()[0];
+    int64_t sv = start_scalar.to<int64_t>();
+    int64_t ev = end_scalar.to<int64_t>();
+    int64_t stv = step_scalar.to<int64_t>();
+    funcs::GetSizeForRange(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
   }
-  RangeFunc<T, Context>(dev_ctx, start_value, end_value, step_value, out);
+  out->Resize({size});
+  T* out_data = dev_ctx.template Alloc<T>(out);
+  if (size == 0) {
+    return;
+  }
+  T value = start_value;
+  for (int64_t i = 0; i < size; ++i) {
+    out_data[i] = value;
+    value += step_value;
+  }
 }
 
 template <typename T, typename Context>
@@ -61,16 +93,36 @@ void RangeKernel(const Context& dev_ctx,
                  const Scalar& end,
                  const Scalar& step,
                  DenseTensor* out) {
-  T start_value = start.to<T>();
-  T end_value = end.to<T>();
-  T step_value = step.to<T>();
-  if constexpr (std::is_floating_point_v<T>) {
-    if (std::isnan(end_value)) {
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "The end value of range cannot be NaN. Please check your input."));
-    }
+  int64_t size = 0;
+  T start_value, step_value;
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
+  if (any_float) {
+    double sv = start.to<double>();
+    double ev = end.to<double>();
+    double stv = step.to<double>();
+    funcs::GetSizeForRange(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
+  } else {
+    int64_t sv = start.to<int64_t>();
+    int64_t ev = end.to<int64_t>();
+    int64_t stv = step.to<int64_t>();
+    funcs::GetSizeForRange(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
   }
-  RangeFunc<T, Context>(dev_ctx, start_value, end_value, step_value, out);
+  out->Resize({size});
+  T* out_data = dev_ctx.template Alloc<T>(out);
+  if (size == 0) {
+    return;
+  }
+  T value = start_value;
+  for (int64_t i = 0; i < size; ++i) {
+    out_data[i] = value;
+    value += step_value;
+  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/range_function.h
+++ b/paddle/phi/kernels/funcs/range_function.h
@@ -61,5 +61,55 @@ void GetSize(T start, T end, T step, int64_t* size) {
               : std::ceil(std::abs((end - start) / step));
 }
 
+template <typename T>
+void GetSizeForRange(T start, T end, T step, int64_t* size) {
+  // For range op: closed interval [start, end]
+  PADDLE_ENFORCE_NE(
+      step,
+      0,
+      common::errors::InvalidArgument("The step of range op should not be 0."));
+
+  if constexpr (std::is_same_v<T, phi::bfloat16> ||
+                std::is_same_v<T, phi::float16>) {
+    PADDLE_ENFORCE_EQ(
+        phi::dtype::isfinite(start) && phi::dtype::isfinite(end) &&
+            phi::dtype::isfinite(step),
+        true,
+        common::errors::InvalidArgument(
+            "The start, end and step of range op should be finite "
+            "numbers, but received start=%f, end=%f, step=%f.",
+            static_cast<double>(start),
+            static_cast<double>(end),
+            static_cast<double>(step)));
+  } else if constexpr (std::is_floating_point_v<T>) {
+    PADDLE_ENFORCE_EQ(
+        std::isfinite(start) && std::isfinite(end) && std::isfinite(step),
+        true,
+        common::errors::InvalidArgument(
+            "The start, end and step of range op should be finite "
+            "numbers, but received start=%f, end=%f, step=%f.",
+            static_cast<double>(start),
+            static_cast<double>(end),
+            static_cast<double>(step)));
+  }
+
+  if (start < end) {
+    if (step < 0) {
+      *size = 0;
+      return;
+    }
+  }
+
+  if (start > end) {
+    if (step > 0) {
+      *size = 0;
+      return;
+    }
+  }
+
+  // Closed interval [start, end], so we add 1
+  *size = static_cast<int64_t>(((end - start) / step) + 1);
+}
+
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/arange_kernel.cu
+++ b/paddle/phi/kernels/gpu/arange_kernel.cu
@@ -20,6 +20,7 @@
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/core/visit_type.h"
 #include "paddle/phi/kernels/funcs/range_function.h"
 
 namespace phi {
@@ -37,14 +38,48 @@ void ArangeTensorKernel(const Context& dev_ctx,
                         const DenseTensor& end,
                         const DenseTensor& step,
                         DenseTensor* out) {
-  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  MPType start_value =
-      static_cast<MPType>(GetValue<T, Context>(dev_ctx, start));
-  MPType end_value = static_cast<MPType>(GetValue<T, Context>(dev_ctx, end));
-  MPType step_value = static_cast<MPType>(GetValue<T, Context>(dev_ctx, step));
-
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
   int64_t size = 0;
-  funcs::GetSize(start_value, end_value, step_value, &size);
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  MPType start_value, step_value;
+  if (any_float) {
+    double sv, ev, stv;
+    PD_VISIT_ALL_TYPES(
+        start.dtype(), "GetStart", ([&] {
+          sv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, start));
+        }));
+    PD_VISIT_ALL_TYPES(
+        end.dtype(), "GetEnd", ([&] {
+          ev = static_cast<double>(GetValue<data_t, Context>(dev_ctx, end));
+        }));
+    PD_VISIT_ALL_TYPES(
+        step.dtype(), "GetStep", ([&] {
+          stv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, step));
+        }));
+    funcs::GetSize<double>(sv, ev, stv, &size);
+    start_value = static_cast<MPType>(sv);
+    step_value = static_cast<MPType>(stv);
+  } else {
+    int64_t sv, ev, stv;
+    PD_VISIT_ALL_TYPES(
+        start.dtype(), "GetStart", ([&] {
+          sv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, start));
+        }));
+    PD_VISIT_ALL_TYPES(
+        end.dtype(), "GetEnd", ([&] {
+          ev = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, end));
+        }));
+    PD_VISIT_ALL_TYPES(
+        step.dtype(), "GetStep", ([&] {
+          stv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, step));
+        }));
+    funcs::GetSize<int64_t>(sv, ev, stv, &size);
+    start_value = static_cast<MPType>(sv);
+    step_value = static_cast<MPType>(stv);
+  }
+
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
 
@@ -89,11 +124,35 @@ void ArangeKernel(const Context& dev_ctx,
                   const Scalar& end,
                   const Scalar& step,
                   DenseTensor* out) {
-  T start_value = start.to<T>();
-  T end_value = end.to<T>();
-  T step_value = step.to<T>();
-  ArangeNullaryKernel<T, Context>(
-      dev_ctx, start_value, end_value, step_value, out);
+  bool is_floating = phi::IsFloatingType(start.dtype()) ||
+                     phi::IsFloatingType(end.dtype()) ||
+                     phi::IsFloatingType(step.dtype());
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  int64_t size = 0;
+  if (is_floating) {
+    double sv = start.to<double>();
+    double ev = end.to<double>();
+    double stv = step.to<double>();
+    funcs::GetSize<double>(sv, ev, stv, &size);
+  } else {
+    int64_t sv = start.to<int64_t>();
+    int64_t ev = end.to<int64_t>();
+    int64_t stv = step.to<int64_t>();
+    funcs::GetSize<int64_t>(sv, ev, stv, &size);
+  }
+  MPType start_value = start.to<MPType>();
+  MPType step_value = step.to<MPType>();
+  out->Resize({size});
+  T* out_data = dev_ctx.template Alloc<T>(out);
+
+  auto stream = dev_ctx.stream();
+  int64_t block = std::min(size, static_cast<int64_t>(256));
+  if (block == 0) {
+    return;
+  }
+  int64_t grid = (size + block - 1) / block;
+  Range<MPType, T>
+      <<<grid, block, 0, stream>>>(start_value, step_value, size, out_data);
 }
 
 template decltype(ArangeNullaryKernel<int64_t, GPUContext>) ArangeNullaryKernel;

--- a/paddle/phi/kernels/gpu/range_kernel.cu
+++ b/paddle/phi/kernels/gpu/range_kernel.cu
@@ -20,6 +20,7 @@
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/core/visit_type.h"
 #include "paddle/phi/kernels/funcs/range_function.h"
 
 namespace phi {
@@ -37,16 +38,48 @@ void RangeTensorKernel(const Context& dev_ctx,
                        const DenseTensor& end,
                        const DenseTensor& step,
                        DenseTensor* out) {
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
+  int64_t size = 0;
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  MPType start_value =
-      static_cast<MPType>(GetValue<T, Context>(dev_ctx, start));
-  MPType end_value = static_cast<MPType>(GetValue<T, Context>(dev_ctx, end));
-  MPType step_value = static_cast<MPType>(GetValue<T, Context>(dev_ctx, step));
-  if (step_value == static_cast<MPType>(0)) {
-    PADDLE_THROW(common::errors::InvalidArgument("step must be nonzero."));
+  MPType start_value, step_value;
+  if (any_float) {
+    double sv, ev, stv;
+    PD_VISIT_ALL_TYPES(
+        start.dtype(), "GetStart", ([&] {
+          sv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, start));
+        }));
+    PD_VISIT_ALL_TYPES(
+        end.dtype(), "GetEnd", ([&] {
+          ev = static_cast<double>(GetValue<data_t, Context>(dev_ctx, end));
+        }));
+    PD_VISIT_ALL_TYPES(
+        step.dtype(), "GetStep", ([&] {
+          stv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, step));
+        }));
+    funcs::GetSize<int64_t>(sv, ev, stv, &size);
+    start_value = static_cast<MPType>(sv);
+    step_value = static_cast<MPType>(stv);
+  } else {
+    int64_t sv, ev, stv;
+    PD_VISIT_ALL_TYPES(
+        start.dtype(), "GetStart", ([&] {
+          sv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, start));
+        }));
+    PD_VISIT_ALL_TYPES(
+        end.dtype(), "GetEnd", ([&] {
+          ev = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, end));
+        }));
+    PD_VISIT_ALL_TYPES(
+        step.dtype(), "GetStep", ([&] {
+          stv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, step));
+        }));
+    funcs::GetSizeForRange<int64_t>(sv, ev, stv, &size);
+    start_value = static_cast<MPType>(sv);
+    step_value = static_cast<MPType>(stv);
   }
-  int64_t size =
-      static_cast<int64_t>(((end_value - start_value) / step_value) + 1);
+
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
 
@@ -108,25 +141,40 @@ void RangeKernel(const Context& dev_ctx,
                  const Scalar& end,
                  const Scalar& step,
                  DenseTensor* out) {
-  T start_value = start.to<T>();
-  T end_value = end.to<T>();
-  T step_value = step.to<T>();
-  if constexpr (std::is_same_v<T, float>) {
-    if (std::isnan(end_value)) {
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "The end value of range cannot be NaN. Please check your input."));
-    }
-  } else if constexpr (std::is_same_v<T, double>) {
-    if (std::isnan(end_value)) {
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "The end value of range cannot be NaN. Please check your input."));
-    }
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
+  int64_t size = 0;
+  if (any_float) {
+    double sv, ev, stv;
+    sv = start.to<double>();
+    ev = end.to<double>();
+    stv = step.to<double>();
+    funcs::GetSize<int64_t>(sv, ev, stv, &size);
+  } else {
+    int64_t sv, ev, stv;
+    sv = start.to<int64_t>();
+    ev = end.to<int64_t>();
+    stv = step.to<int64_t>();
+    funcs::GetSizeForRange<int64_t>(sv, ev, stv, &size);
   }
-  if (step_value == static_cast<T>(0)) {
-    PADDLE_THROW(common::errors::InvalidArgument("step must be nonzero."));
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  MPType start_value = start.to<MPType>();
+  MPType step_value = step.to<MPType>();
+  out->Resize({size});
+  T* out_data = dev_ctx.template Alloc<T>(out);
+  if (size == 0) {
+    return;
   }
-  RangeNullaryKernel<T, Context>(
-      dev_ctx, start_value, end_value, step_value, out);
+
+  auto stream = dev_ctx.stream();
+  int64_t block = std::min(size, static_cast<int64_t>(256));
+  if (block == 0) {
+    return;
+  }
+  int64_t grid = (size + block - 1) / block;
+  Range<MPType, T>
+      <<<grid, block, 0, stream>>>(start_value, step_value, size, out_data);
 }
 
 template decltype(RangeNullaryKernel<int64_t, GPUContext>) RangeNullaryKernel;

--- a/paddle/phi/kernels/xpu/arange_kernel.cc
+++ b/paddle/phi/kernels/xpu/arange_kernel.cc
@@ -26,15 +26,48 @@ void ArangeTensorKernel(const Context& dev_ctx,
                         const DenseTensor& end,
                         const DenseTensor& step,
                         DenseTensor* out) {
-  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  using XPUType = typename XPUTypeTrait<T>::Type;
-  MPType start_value =
-      static_cast<MPType>(GetValue<T, Context>(dev_ctx, start));
-  MPType end_value = static_cast<MPType>(GetValue<T, Context>(dev_ctx, end));
-  MPType step_value = static_cast<MPType>(GetValue<T, Context>(dev_ctx, step));
-
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
   int64_t size = 0;
-  funcs::GetSize(start_value, end_value, step_value, &size);
+  using XPUType = typename XPUTypeTrait<T>::Type;
+  XPUType start_value, step_value;
+  if (any_float) {
+    double sv, ev, stv;
+    PD_VISIT_ALL_TYPES(
+        start.dtype(), "GetStart", ([&] {
+          sv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, start));
+        }));
+    PD_VISIT_ALL_TYPES(
+        end.dtype(), "GetEnd", ([&] {
+          ev = static_cast<double>(GetValue<data_t, Context>(dev_ctx, end));
+        }));
+    PD_VISIT_ALL_TYPES(
+        step.dtype(), "GetStep", ([&] {
+          stv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, step));
+        }));
+    funcs::GetSize<double>(sv, ev, stv, &size);
+    start_value = static_cast<XPUType>(sv);
+    step_value = static_cast<XPUType>(stv);
+  } else {
+    int64_t sv, ev, stv;
+    PD_VISIT_ALL_TYPES(
+        start.dtype(), "GetStart", ([&] {
+          sv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, start));
+        }));
+    PD_VISIT_ALL_TYPES(
+        end.dtype(), "GetEnd", ([&] {
+          ev = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, end));
+        }));
+    PD_VISIT_ALL_TYPES(
+        step.dtype(), "GetStep", ([&] {
+          stv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, step));
+        }));
+    funcs::GetSize<int64_t>(sv, ev, stv, &size);
+    start_value = static_cast<XPUType>(sv);
+    step_value = static_cast<XPUType>(stv);
+  }
+  int64_t size = 0;
   if (size == 0) {
     out->Resize({0});
     dev_ctx.template Alloc<T>(out);
@@ -44,11 +77,8 @@ void ArangeTensorKernel(const Context& dev_ctx,
   XPUType* out_data =
       reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(out));
 
-  int ret = xpu::range(dev_ctx.x_context(),
-                       out_data,
-                       static_cast<XPUType>(start_value),
-                       static_cast<XPUType>(step_value),
-                       size);
+  int ret =
+      xpu::range(dev_ctx.x_context(), out_data, start_value, step_value, size);
   PADDLE_ENFORCE_XDNN_SUCCESS(ret, "range");
 }
 

--- a/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
@@ -24,14 +24,14 @@
   output : Tensor(out)
   infer_meta :
     func : ArangeTensorInferMeta
-    param : [start, end, step]
+    param : [start, end, step, dtype]
   kernel :
     func : arange_tensor
     param : [start, end, step]
     data_type : dtype
     backend : place
-  data_transform :
-    support_trans_dtype : start, end, step
+  # data_transform :
+  #   support_trans_dtype : start, end, step
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : assign
@@ -316,14 +316,14 @@
   output : Tensor(out)
   infer_meta :
     func : RangeTensorInferMeta
-    param : [start, end, step]
+    param : [start, end, step, dtype]
   kernel :
     func : range_tensor
     param : [start, end, step]
     data_type : dtype
     backend : place
-  data_transform :
-    support_trans_dtype : start, end, step
+  # data_transform :
+  #   support_trans_dtype : start, end, step
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : remainder

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -41,10 +41,11 @@
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : arange
-  args : (Tensor start, Tensor end, Tensor step)
+  args : (Tensor start, Tensor end, Tensor step, DataType dtype)
   output : Tensor(out)
   infer_meta :
     func : ArangeTensorInferMeta
+    param : [start, end, step, dtype]
   kernel :
     func : arange_tensor
   data_transform :
@@ -897,10 +898,11 @@
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : range_v2
-  args : (Tensor start, Tensor end, Tensor step)
+  args : (Tensor start, Tensor end, Tensor step, DataType dtype)
   output : Tensor(out)
   infer_meta :
     func : RangeTensorInferMeta
+    param : [start, end, step, dtype]
   kernel :
     func : range_tensor
   data_transform :

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -20,7 +20,7 @@ import numbers
 import os
 import re
 import warnings
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
@@ -2314,20 +2314,19 @@ def arange(
         end = start
         start = 0
 
+    is_all_integer = True
     if dtype is None:
+        # Check if start/end/step contain floating point values
         for val in [start, end, step]:
             if isinstance(val, (Variable, paddle.pir.Value)):
                 if not paddle.is_integer(val):
-                    dtype = paddle.get_default_dtype()
+                    is_all_integer = False
                     break
-                else:
-                    dtype = 'int64'
             else:
-                if not isinstance(val, np.integer) and not isinstance(val, int):
-                    dtype = paddle.get_default_dtype()
+                if isinstance(val, (float, np.floating)):
+                    is_all_integer = False
                     break
-                else:
-                    dtype = 'int64'
+        dtype = 'int64' if is_all_integer else paddle.get_default_dtype()
 
     out_shape = None
     is_value_input = (
@@ -2391,13 +2390,13 @@ def arange(
                 raise ValueError(
                     f"The value of start must be finite, but received: {start}."
                 )
-            start = fill_constant([1], dtype, start, force_cpu=True)
-    elif start.dtype != dtype:
+            start_dtype = np.array(start).dtype
+            start = fill_constant([1], start_dtype, start, force_cpu=True)
+    else:
         if in_dynamic_mode() and not paddle.isfinite(start):
             raise ValueError(
                 f"The value of start must be finite, but received: {start}."
             )
-        start = paddle.cast(start, dtype)
 
     if not isinstance(end, (Variable, paddle.pir.Value)):
         with device_guard("cpu"):
@@ -2405,19 +2404,27 @@ def arange(
                 raise ValueError(
                     f"The value of end must be finite, but received: {end}."
                 )
-            end = fill_constant([1], dtype, end, force_cpu=True)
-    elif end.dtype != dtype:
+            end_dtype = np.array(end).dtype
+            end = fill_constant([1], end_dtype, end, force_cpu=True)
+    else:
         if in_dynamic_mode() and not paddle.isfinite(end):
             raise ValueError(
                 f"The value of end must be finite, but received: {end}."
             )
-        end = paddle.cast(end, dtype)
 
     if not isinstance(step, (Variable, paddle.pir.Value)):
         with device_guard("cpu"):
-            step = fill_constant([1], dtype, step, force_cpu=True)
-    elif step.dtype != dtype:
-        step = paddle.cast(step, dtype)
+            if not np.isfinite(step):
+                raise ValueError(
+                    f"The value of end must be finite, but received: {end}."
+                )
+            step_dtype = np.array(step).dtype
+            step = fill_constant([1], step_dtype, step, force_cpu=True)
+    else:
+        if in_dynamic_mode() and not paddle.isfinite(step):
+            raise ValueError(
+                f"The value of step must be finite, but received: {step}."
+            )
 
     if in_dynamic_or_pir_mode():
         tensor = _C_ops.arange(
@@ -2579,19 +2586,22 @@ def range(
 
     if not isinstance(start, (Variable, paddle.pir.Value)):
         with device_guard("cpu"):
-            start = fill_constant([1], dtype, start, force_cpu=True)
+            start_dtype = np.array(start).dtype
+            start = fill_constant([1], start_dtype, start, force_cpu=True)
     elif start.dtype != dtype:
         start = paddle.cast(start, dtype)
 
     if not isinstance(end, (Variable, paddle.pir.Value)):
         with device_guard("cpu"):
-            end = fill_constant([1], dtype, end, force_cpu=True)
+            end_dtype = np.array(end).dtype
+            end = fill_constant([1], end_dtype, end, force_cpu=True)
     elif end.dtype != dtype:
         end = paddle.cast(end, dtype)
 
     if not isinstance(step, (Variable, paddle.pir.Value)):
         with device_guard("cpu"):
-            step = fill_constant([1], dtype, step, force_cpu=True)
+            step_dtype = np.array(step).dtype
+            step = fill_constant([1], step_dtype, step, force_cpu=True)
     elif step.dtype != dtype:
         step = paddle.cast(step, dtype)
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix the accuracy problem in paddle.arange() and paddle.range() caused by forced type transformation between input and output, which leads to incorrect size calculation.

** Kernels **(`paddle/phi/keners/`, including `gpu/arange_kernels.cu`, `gpu/range_kernels.cu`, `cpu/arange_kernels.cc`, `cpu/range_kernels.cc` and `xpu/arange_kenerls.cc` )
- Modified the type used in shape calculation, and selected appropriate type conversion before computing based on the input: If all the inputs are integers, convert all the input type to int64 to calculate the size. If there are any floating-point values, use double to calculate the shape.

** Tensor ** (`ArangeTensorKernel()` and `RangeTensorKernel()`)
- `gpu/arange_kernels.cu`, `gpu/range_kernels.cu` and `xpu/arange_kenerls.cc`: Use `PD_VISIT_ALL_TYPES` to get the dtype of inputs and get the value from device , instead of relying on output dtype T to read input tensor content.
- `cpu/arange_kernels.cc` and `cpu/range_kernels.cc`:`cpu/range_kernels.cc` Use `DenseTensor.data<DataType>()[0]` to get the input value to computing size, while the type of input value has already finished type conversion in creation.py.

** Scalar ** (`ARangeKernel()` and `RangeKernel()`)
- Use `Scalar.to<DataType>()`  to do the type conversion.

**CUDA Common** (`paddle/phi/kernels/funcs/range_function.h`):
-`GetSizeForRange()`: Add a new function for range kernel size calculation in this file, while also adding NaN and Inf checks for floating-point inputs.


**Python** (`python/paddle/tensor/creation.py`):
- `arange()` and `range()`: Cancel the construction of the input tensor based on the output type and replace with filling the tensor with the corresponding highest precision type based on the input type (integer/float).
- `arange()`: Fix the problem of choosing `dtype` when it is not given. If there is any float type in input, dtype will be default float, or it will be int64.

**Common** (paddle/phi/common/data_type.h):
- Added `IsFloatingPoint()` and IsInteger() functions to determine if a DataType is floating-point or integer type, used in kernel to select appropriate type for size calculation.

**InferMeta** (`paddle/phi/infermeta/ternary.cc` and `paddle/phi/infermeta/ternary.h`):
- `ArangeInferMeta()` and `RangeInferMeta()`: Added dtype parameter support, removed the logic that forces output dtype to match start's type.

**YAML** (`paddle/phi/ops/yaml/`):
- `inconsistent/dygraph_ops.yaml`: Removed forced type casting when calling kernel, allowing input and output to have different types.
- `legacy/static_ops.yaml`: Added `DataType dtype` to arange and range args to support the updated InferMeta.


### 是否引起精度变化
是 