### PR TITLE
fix matmul 2D w-stride precision problem

### DIFF
--- a/paddle/phi/kernels/stride/matmul_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/matmul_stride_kernel.cu
@@ -185,7 +185,7 @@ void MatmulStrideKernel(const Context &dev_ctx,
                                                              &y_stride,
                                                              &y_axis)) {
     auto y_trans_dims = y_axis.size();
-    if (y_axis.size() > 2 && y_axis[y_trans_dims - 1] == y_trans_dims - 2 &&
+    if (y_axis.size() >= 2 && y_axis[y_trans_dims - 1] == y_trans_dims - 2 &&
         y_axis[y_trans_dims - 2] == y_trans_dims - 1) {
       transpose_y = !transpose_y;
       y_meta.dims = y_shape;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
fix matmul 2D w-stride precision problem
会影响到Hopper下weight 带stride的matmul kernel精度，属于stride机制修复

pcard-91067


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是