### PR TITLE
[PHI] Fix the problem of size accuracy when using arange/range with different input and output types

### DIFF
--- a/paddle/phi/common/data_type.h
+++ b/paddle/phi/common/data_type.h
@@ -328,6 +328,20 @@ inline DataType StringToDataType(const std::string& dtype) {
   }
 }
 
+inline bool IsFloatingType(const DataType& type) {
+  return (type == DataType::FLOAT16 || type == DataType::BFLOAT16 ||
+          type == DataType::FLOAT32 || type == DataType::FLOAT64 ||
+          type == DataType::FLOAT8_E4M3FN || type == DataType::FLOAT8_E5M2);
+}
+
+inline bool IsIntegerType(const DataType& type) {
+  return (type == DataType::INT8 || type == DataType::INT16 ||
+          type == DataType::INT32 || type == DataType::INT64 ||
+          type == DataType::UINT8 || type == DataType::UINT16 ||
+          type == DataType::UINT32 || type == DataType::UINT64 ||
+          type == DataType::BOOL);
+}
+
 }  // namespace phi
 
 namespace paddle {

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -835,6 +835,57 @@ void FlashAttnV3VarlenInferMeta(const MetaTensor& q,
   softmax_lse->set_dtype(DataType::FLOAT32);
 }
 
+void ArangeTensorInferMetaLegacy(const MetaTensor& start,
+                                 const MetaTensor& end,
+                                 const MetaTensor& step,
+                                 MetaTensor* out) {
+  PADDLE_ENFORCE_EQ(common::product(start.dims()),
+                    1,
+                    common::errors::InvalidArgument(
+                        "The numel of Input(start) should be 1, but got %d",
+                        common::product(start.dims())));
+
+  PADDLE_ENFORCE_EQ(common::product(end.dims()),
+                    1,
+                    common::errors::InvalidArgument(
+                        "The numel of Input(end) should be 1, but got %d",
+                        common::product(end.dims())));
+
+  PADDLE_ENFORCE_EQ(common::product(step.dims()),
+                    1,
+                    common::errors::InvalidArgument(
+                        "The numel of Input(step) should be 1, but got %d",
+                        common::product(step.dims())));
+
+  out->set_dims({-1});
+  out->set_dtype(start.dtype());
+}
+
+void RangeTensorInferMetaLegacy(const MetaTensor& start,
+                                const MetaTensor& end,
+                                const MetaTensor& step,
+                                MetaTensor* out) {
+  PADDLE_ENFORCE_EQ(common::product(start.dims()),
+                    1,
+                    common::errors::InvalidArgument(
+                        "The numel of Input(start) should be 1, but got %d",
+                        common::product(start.dims())));
+
+  PADDLE_ENFORCE_EQ(common::product(end.dims()),
+                    1,
+                    common::errors::InvalidArgument(
+                        "The numel of Input(end) should be 1, but got %d",
+                        common::product(end.dims())));
+
+  PADDLE_ENFORCE_EQ(common::product(step.dims()),
+                    1,
+                    common::errors::InvalidArgument(
+                        "The numel of Input(step) should be 1, but got %d",
+                        common::product(step.dims())));
+
+  out->set_dims({-1});
+  out->set_dtype(start.dtype());
+}
 void ArangeTensorInferMeta(const MetaTensor& start,
                            const MetaTensor& end,
                            const MetaTensor& step,

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -838,6 +838,7 @@ void FlashAttnV3VarlenInferMeta(const MetaTensor& q,
 void ArangeTensorInferMeta(const MetaTensor& start,
                            const MetaTensor& end,
                            const MetaTensor& step,
+                           DataType dtype,
                            MetaTensor* out) {
   PADDLE_ENFORCE_EQ(common::product(start.dims()),
                     1,
@@ -858,12 +859,13 @@ void ArangeTensorInferMeta(const MetaTensor& start,
                         common::product(step.dims())));
 
   out->set_dims({-1});
-  out->set_dtype(start.dtype());
+  out->set_dtype(dtype);
 }
 
 void RangeTensorInferMeta(const MetaTensor& start,
                           const MetaTensor& end,
                           const MetaTensor& step,
+                          DataType dtype,
                           MetaTensor* out) {
   PADDLE_ENFORCE_EQ(common::product(start.dims()),
                     1,
@@ -884,7 +886,7 @@ void RangeTensorInferMeta(const MetaTensor& start,
                         common::product(step.dims())));
 
   out->set_dims({-1});
-  out->set_dtype(start.dtype());
+  out->set_dtype(dtype);
 }
 
 void CollectFpnProposalsInferMeta(

--- a/paddle/phi/infermeta/ternary.h
+++ b/paddle/phi/infermeta/ternary.h
@@ -75,6 +75,16 @@ PADDLE_API void RangeTensorInferMeta(const MetaTensor& start,
                                      DataType dtype,
                                      MetaTensor* out);
 
+PADDLE_API void ArangeTensorInferMetaLegacy(const MetaTensor& start,
+                                            const MetaTensor& end,
+                                            const MetaTensor& step,
+                                            MetaTensor* out);
+
+PADDLE_API void RangeTensorInferMetaLegacy(const MetaTensor& start,
+                                           const MetaTensor& end,
+                                           const MetaTensor& step,
+                                           MetaTensor* out);
+
 PADDLE_API void AssignPosInferMeta(const MetaTensor& x,
                                    const MetaTensor& cum_count,
                                    const MetaTensor& eff_num_len,

--- a/paddle/phi/infermeta/ternary.h
+++ b/paddle/phi/infermeta/ternary.h
@@ -66,11 +66,13 @@ PADDLE_API void AffineChannelInferMeta(const MetaTensor& x,
 PADDLE_API void ArangeTensorInferMeta(const MetaTensor& start,
                                       const MetaTensor& end,
                                       const MetaTensor& step,
+                                      DataType dtype,
                                       MetaTensor* out);
 
 PADDLE_API void RangeTensorInferMeta(const MetaTensor& start,
                                      const MetaTensor& end,
                                      const MetaTensor& step,
+                                     DataType dtype,
                                      MetaTensor* out);
 
 PADDLE_API void AssignPosInferMeta(const MetaTensor& x,

--- a/paddle/phi/kernels/cpu/arange_kernel.cc
+++ b/paddle/phi/kernels/cpu/arange_kernel.cc
@@ -93,14 +93,14 @@ void ArangeKernel(const Context& dev_ctx,
     double sv = start.to<double>();
     double ev = end.to<double>();
     double stv = step.to<double>();
-    funcs::GetSize<double>(sv, ev, stv, &size);
+    funcs::GetSize(sv, ev, stv, &size);
     start_value = static_cast<T>(sv);
     step_value = static_cast<T>(stv);
   } else {
     int64_t sv = start.to<int64_t>();
     int64_t ev = end.to<int64_t>();
     int64_t stv = step.to<int64_t>();
-    funcs::GetSize<double>(sv, ev, stv, &size);
+    funcs::GetSize(sv, ev, stv, &size);
     start_value = static_cast<T>(sv);
     step_value = static_cast<T>(stv);
   }

--- a/paddle/phi/kernels/cpu/arange_kernel.cc
+++ b/paddle/phi/kernels/cpu/arange_kernel.cc
@@ -43,10 +43,39 @@ void ArangeTensorKernel(const Context& dev_ctx,
                         const DenseTensor& end,
                         const DenseTensor& step,
                         DenseTensor* out) {
-  T start_value = start.data<T>()[0];
-  T end_value = end.data<T>()[0];
-  T step_value = step.data<T>()[0];
-  ArangeFunc<T, Context>(dev_ctx, start_value, end_value, step_value, out);
+  int64_t size = 0;
+  T start_value, step_value;
+
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
+
+  Scalar start_scalar(start);
+  Scalar end_scalar(end);
+  Scalar step_scalar(step);
+
+  if (any_float) {
+    double sv = start_scalar.to<double>();
+    double ev = end_scalar.to<double>();
+    double stv = step_scalar.to<double>();
+    funcs::GetSize(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
+  } else {
+    int64_t sv = start_scalar.to<int64_t>();
+    int64_t ev = end_scalar.to<int64_t>();
+    int64_t stv = step_scalar.to<int64_t>();
+    funcs::GetSize(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
+  }
+  out->Resize({size});
+  T* out_data = dev_ctx.template Alloc<T>(out);
+  T value = start_value;
+  for (int64_t i = 0; i < size; ++i) {
+    out_data[i] = value;
+    value += step_value;
+  }
 }
 
 template <typename T, typename Context>
@@ -55,10 +84,33 @@ void ArangeKernel(const Context& dev_ctx,
                   const Scalar& end,
                   const Scalar& step,
                   DenseTensor* out) {
-  T start_value = start.to<T>();
-  T end_value = end.to<T>();
-  T step_value = step.to<T>();
-  ArangeFunc<T, Context>(dev_ctx, start_value, end_value, step_value, out);
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
+  int64_t size = 0;
+  T start_value, step_value;
+  if (any_float) {
+    double sv = start.to<double>();
+    double ev = end.to<double>();
+    double stv = step.to<double>();
+    funcs::GetSize<double>(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
+  } else {
+    int64_t sv = start.to<int64_t>();
+    int64_t ev = end.to<int64_t>();
+    int64_t stv = step.to<int64_t>();
+    funcs::GetSize<double>(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
+  }
+  out->Resize({size});
+  T* out_data = dev_ctx.template Alloc<T>(out);
+  T value = start_value;
+  for (int64_t i = 0; i < size; ++i) {
+    out_data[i] = value;
+    value += step_value;
+  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/arange_kernel.cc
+++ b/paddle/phi/kernels/cpu/arange_kernel.cc
@@ -15,6 +15,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/arange_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/range_function.h"
 
@@ -44,7 +45,7 @@ void ArangeTensorKernel(const Context& dev_ctx,
                         const DenseTensor& step,
                         DenseTensor* out) {
   int64_t size = 0;
-  T start_value, step_value;
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
 
   bool any_float = phi::IsFloatingType(start.dtype()) ||
                    phi::IsFloatingType(end.dtype()) ||
@@ -58,22 +59,21 @@ void ArangeTensorKernel(const Context& dev_ctx,
     double sv = start_scalar.to<double>();
     double ev = end_scalar.to<double>();
     double stv = step_scalar.to<double>();
-    funcs::GetSize(sv, ev, stv, &size);
-    start_value = static_cast<T>(sv);
-    step_value = static_cast<T>(stv);
+    funcs::GetSize<double>(sv, ev, stv, &size);
   } else {
     int64_t sv = start_scalar.to<int64_t>();
     int64_t ev = end_scalar.to<int64_t>();
     int64_t stv = step_scalar.to<int64_t>();
-    funcs::GetSize(sv, ev, stv, &size);
-    start_value = static_cast<T>(sv);
-    step_value = static_cast<T>(stv);
+    funcs::GetSize<int64_t>(sv, ev, stv, &size);
   }
+  MPType start_value = start_scalar.to<MPType>();
+  MPType step_value = step_scalar.to<MPType>();
+
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
-  T value = start_value;
+  MPType value = start_value;
   for (int64_t i = 0; i < size; ++i) {
-    out_data[i] = value;
+    out_data[i] = static_cast<T>(value);
     value += step_value;
   }
 }
@@ -88,27 +88,25 @@ void ArangeKernel(const Context& dev_ctx,
                    phi::IsFloatingType(end.dtype()) ||
                    phi::IsFloatingType(step.dtype());
   int64_t size = 0;
-  T start_value, step_value;
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   if (any_float) {
     double sv = start.to<double>();
     double ev = end.to<double>();
     double stv = step.to<double>();
-    funcs::GetSize(sv, ev, stv, &size);
-    start_value = static_cast<T>(sv);
-    step_value = static_cast<T>(stv);
+    funcs::GetSize<double>(sv, ev, stv, &size);
   } else {
     int64_t sv = start.to<int64_t>();
     int64_t ev = end.to<int64_t>();
     int64_t stv = step.to<int64_t>();
-    funcs::GetSize(sv, ev, stv, &size);
-    start_value = static_cast<T>(sv);
-    step_value = static_cast<T>(stv);
+    funcs::GetSize<int64_t>(sv, ev, stv, &size);
   }
+  MPType start_value = start.to<MPType>();
+  MPType step_value = step.to<MPType>();
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
-  T value = start_value;
+  MPType value = start_value;
   for (int64_t i = 0; i < size; ++i) {
-    out_data[i] = value;
+    out_data[i] = static_cast<T>(value);
     value += step_value;
   }
 }

--- a/paddle/phi/kernels/cpu/range_kernel.cc
+++ b/paddle/phi/kernels/cpu/range_kernel.cc
@@ -46,9 +46,6 @@ void RangeTensorKernel(const Context& dev_ctx,
                        const DenseTensor& end,
                        const DenseTensor& step,
                        DenseTensor* out) {
-  bool any_float = phi::IsFloatingType(start.dtype()) ||
-                   phi::IsFloatingType(end.dtype()) ||
-                   phi::IsFloatingType(step.dtype());
   int64_t size = 0;
   Scalar start_scalar(start);
   Scalar end_scalar(end);

--- a/paddle/phi/kernels/cpu/range_kernel.cc
+++ b/paddle/phi/kernels/cpu/range_kernel.cc
@@ -46,13 +46,45 @@ void RangeTensorKernel(const Context& dev_ctx,
                        const DenseTensor& end,
                        const DenseTensor& step,
                        DenseTensor* out) {
-  T start_value = start.data<T>()[0];
-  T end_value = end.data<T>()[0];
-  T step_value = step.data<T>()[0];
-  if (step_value == static_cast<T>(0)) {
-    PADDLE_THROW(errors::InvalidArgument("step must be nonzero."));
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
+  int64_t size = 0;
+  T start_value, step_value;
+  Scalar start_scalar(start);
+  Scalar end_scalar(end);
+  Scalar step_scalar(step);
+  if (any_float) {
+    // double sv = start.data<double>()[0];
+    // double ev = end.data<double>()[0];
+    // double stv = step.data<double>()[0];
+    double sv = start_scalar.to<double>();
+    double ev = end_scalar.to<double>();
+    double stv = step_scalar.to<double>();
+    funcs::GetSizeForRange(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
+  } else {
+    // int64_t sv = start.data<int64_t>()[0];
+    // int64_t ev = end.data<int64_t>()[0];
+    // int64_t stv = step.data<int64_t>()[0];
+    int64_t sv = start_scalar.to<int64_t>();
+    int64_t ev = end_scalar.to<int64_t>();
+    int64_t stv = step_scalar.to<int64_t>();
+    funcs::GetSizeForRange(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
   }
-  RangeFunc<T, Context>(dev_ctx, start_value, end_value, step_value, out);
+  out->Resize({size});
+  T* out_data = dev_ctx.template Alloc<T>(out);
+  if (size == 0) {
+    return;
+  }
+  T value = start_value;
+  for (int64_t i = 0; i < size; ++i) {
+    out_data[i] = value;
+    value += step_value;
+  }
 }
 
 template <typename T, typename Context>
@@ -61,16 +93,36 @@ void RangeKernel(const Context& dev_ctx,
                  const Scalar& end,
                  const Scalar& step,
                  DenseTensor* out) {
-  T start_value = start.to<T>();
-  T end_value = end.to<T>();
-  T step_value = step.to<T>();
-  if constexpr (std::is_floating_point_v<T>) {
-    if (std::isnan(end_value)) {
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "The end value of range cannot be NaN. Please check your input."));
-    }
+  int64_t size = 0;
+  T start_value, step_value;
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
+  if (any_float) {
+    double sv = start.to<double>();
+    double ev = end.to<double>();
+    double stv = step.to<double>();
+    funcs::GetSizeForRange(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
+  } else {
+    int64_t sv = start.to<int64_t>();
+    int64_t ev = end.to<int64_t>();
+    int64_t stv = step.to<int64_t>();
+    funcs::GetSizeForRange(sv, ev, stv, &size);
+    start_value = static_cast<T>(sv);
+    step_value = static_cast<T>(stv);
   }
-  RangeFunc<T, Context>(dev_ctx, start_value, end_value, step_value, out);
+  out->Resize({size});
+  T* out_data = dev_ctx.template Alloc<T>(out);
+  if (size == 0) {
+    return;
+  }
+  T value = start_value;
+  for (int64_t i = 0; i < size; ++i) {
+    out_data[i] = value;
+    value += step_value;
+  }
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/range_kernel.cc
+++ b/paddle/phi/kernels/cpu/range_kernel.cc
@@ -50,31 +50,15 @@ void RangeTensorKernel(const Context& dev_ctx,
                    phi::IsFloatingType(end.dtype()) ||
                    phi::IsFloatingType(step.dtype());
   int64_t size = 0;
-  T start_value, step_value;
   Scalar start_scalar(start);
   Scalar end_scalar(end);
   Scalar step_scalar(step);
-  if (any_float) {
-    // double sv = start.data<double>()[0];
-    // double ev = end.data<double>()[0];
-    // double stv = step.data<double>()[0];
-    double sv = start_scalar.to<double>();
-    double ev = end_scalar.to<double>();
-    double stv = step_scalar.to<double>();
-    funcs::GetSizeForRange(sv, ev, stv, &size);
-    start_value = static_cast<T>(sv);
-    step_value = static_cast<T>(stv);
-  } else {
-    // int64_t sv = start.data<int64_t>()[0];
-    // int64_t ev = end.data<int64_t>()[0];
-    // int64_t stv = step.data<int64_t>()[0];
-    int64_t sv = start_scalar.to<int64_t>();
-    int64_t ev = end_scalar.to<int64_t>();
-    int64_t stv = step_scalar.to<int64_t>();
-    funcs::GetSizeForRange(sv, ev, stv, &size);
-    start_value = static_cast<T>(sv);
-    step_value = static_cast<T>(stv);
-  }
+  T start_value = start_scalar.to<T>();
+  T end_value = end_scalar.to<T>();
+  T step_value = step_scalar.to<T>();
+
+  funcs::GetSizeForRange(start_value, end_value, step_value, &size);
+
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
   if (size == 0) {
@@ -94,25 +78,10 @@ void RangeKernel(const Context& dev_ctx,
                  const Scalar& step,
                  DenseTensor* out) {
   int64_t size = 0;
-  T start_value, step_value;
-  bool any_float = phi::IsFloatingType(start.dtype()) ||
-                   phi::IsFloatingType(end.dtype()) ||
-                   phi::IsFloatingType(step.dtype());
-  if (any_float) {
-    double sv = start.to<double>();
-    double ev = end.to<double>();
-    double stv = step.to<double>();
-    funcs::GetSizeForRange(sv, ev, stv, &size);
-    start_value = static_cast<T>(sv);
-    step_value = static_cast<T>(stv);
-  } else {
-    int64_t sv = start.to<int64_t>();
-    int64_t ev = end.to<int64_t>();
-    int64_t stv = step.to<int64_t>();
-    funcs::GetSizeForRange(sv, ev, stv, &size);
-    start_value = static_cast<T>(sv);
-    step_value = static_cast<T>(stv);
-  }
+  T start_value = start.to<T>();
+  T end_value = end.to<T>();
+  T step_value = step.to<T>();
+  funcs::GetSizeForRange(start_value, end_value, step_value, &size);
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
   if (size == 0) {

--- a/paddle/phi/kernels/cpu/range_kernel.cc
+++ b/paddle/phi/kernels/cpu/range_kernel.cc
@@ -15,6 +15,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/range_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/range_function.h"
 
@@ -47,12 +48,13 @@ void RangeTensorKernel(const Context& dev_ctx,
                        const DenseTensor& step,
                        DenseTensor* out) {
   int64_t size = 0;
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   Scalar start_scalar(start);
   Scalar end_scalar(end);
   Scalar step_scalar(step);
-  T start_value = start_scalar.to<T>();
-  T end_value = end_scalar.to<T>();
-  T step_value = step_scalar.to<T>();
+  MPType start_value = start_scalar.to<MPType>();
+  MPType end_value = end_scalar.to<MPType>();
+  MPType step_value = step_scalar.to<MPType>();
 
   funcs::GetSizeForRange(start_value, end_value, step_value, &size);
 
@@ -61,9 +63,9 @@ void RangeTensorKernel(const Context& dev_ctx,
   if (size == 0) {
     return;
   }
-  T value = start_value;
+  MPType value = start_value;
   for (int64_t i = 0; i < size; ++i) {
-    out_data[i] = value;
+    out_data[i] = static_cast<T>(value);
     value += step_value;
   }
 }
@@ -75,18 +77,19 @@ void RangeKernel(const Context& dev_ctx,
                  const Scalar& step,
                  DenseTensor* out) {
   int64_t size = 0;
-  T start_value = start.to<T>();
-  T end_value = end.to<T>();
-  T step_value = step.to<T>();
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  MPType start_value = start.to<MPType>();
+  MPType end_value = end.to<MPType>();
+  MPType step_value = step.to<MPType>();
   funcs::GetSizeForRange(start_value, end_value, step_value, &size);
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
   if (size == 0) {
     return;
   }
-  T value = start_value;
+  MPType value = start_value;
   for (int64_t i = 0; i < size; ++i) {
-    out_data[i] = value;
+    out_data[i] = static_cast<T>(value);
     value += step_value;
   }
 }

--- a/paddle/phi/kernels/funcs/range_function.h
+++ b/paddle/phi/kernels/funcs/range_function.h
@@ -73,25 +73,22 @@ void GetSizeForRange(T start, T end, T step, int64_t* size) {
   if constexpr (std::is_same_v<T, phi::bfloat16> ||
                 std::is_same_v<T, phi::float16>) {
     PADDLE_ENFORCE_EQ(
-        phi::dtype::isfinite(start) && phi::dtype::isfinite(end) &&
-            phi::dtype::isfinite(step),
+        phi::dtype::isfinite(start) && phi::dtype::isfinite(end),
         true,
         common::errors::InvalidArgument(
             "The start, end and step of range op should be finite "
-            "numbers, but received start=%f, end=%f, step=%f.",
+            "numbers, but received start=%f, end=%f.",
             static_cast<double>(start),
-            static_cast<double>(end),
-            static_cast<double>(step)));
+            static_cast<double>(end)));
   } else if constexpr (std::is_floating_point_v<T>) {
     PADDLE_ENFORCE_EQ(
-        std::isfinite(start) && std::isfinite(end) && std::isfinite(step),
+        std::isfinite(start) && std::isfinite(end),
         true,
         common::errors::InvalidArgument(
             "The start, end and step of range op should be finite "
-            "numbers, but received start=%f, end=%f, step=%f.",
+            "numbers, but received start=%f, end=%f.",
             static_cast<double>(start),
-            static_cast<double>(end),
-            static_cast<double>(step)));
+            static_cast<double>(end)));
   }
 
   if (start < end) {

--- a/paddle/phi/kernels/funcs/range_function.h
+++ b/paddle/phi/kernels/funcs/range_function.h
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 #pragma once
-#include <iomanip>
+#include <cmath>
+#include <type_traits>
 #include "paddle/phi/core/enforce.h"
 
 namespace phi {

--- a/paddle/phi/kernels/funcs/range_function.h
+++ b/paddle/phi/kernels/funcs/range_function.h
@@ -69,8 +69,6 @@ void GetSizeForRange(T start, T end, T step, int64_t* size) {
       step,
       0,
       common::errors::InvalidArgument("The step of range op should not be 0."));
-  PADDLE_THROW(common::errors::Fatal(
-      "[CI_PATH_TEST] GetSizeForRange reached after step check (line 67)"));
 
   if constexpr (std::is_same_v<T, phi::bfloat16> ||
                 std::is_same_v<T, phi::float16>) {
@@ -82,8 +80,6 @@ void GetSizeForRange(T start, T end, T step, int64_t* size) {
             "numbers, but received start=%f, end=%f.",
             static_cast<double>(start),
             static_cast<double>(end)));
-    PADDLE_THROW(common::errors::Fatal(
-        "[CI_PATH_TEST] GetSizeForRange reached bf16/fp16 branch"));
   } else if constexpr (std::is_floating_point_v<T>) {
     PADDLE_ENFORCE_EQ(
         std::isfinite(start) && std::isfinite(end),
@@ -93,13 +89,9 @@ void GetSizeForRange(T start, T end, T step, int64_t* size) {
             "numbers, but received start=%f, end=%f.",
             static_cast<double>(start),
             static_cast<double>(end)));
-    PADDLE_THROW(common::errors::Fatal(
-        "[CI_PATH_TEST] GetSizeForRange reached floating-point branch "));
   }
   // Closed interval [start, end], so we add 1
   *size = static_cast<int64_t>(((end - start) / step) + 1);
-  PADDLE_THROW(common::errors::Fatal(
-      "[CI_PATH_TEST] GetSizeForRange reached final size calc (line 112)"));
 }
 
 }  // namespace funcs

--- a/paddle/phi/kernels/funcs/range_function.h
+++ b/paddle/phi/kernels/funcs/range_function.h
@@ -69,6 +69,8 @@ void GetSizeForRange(T start, T end, T step, int64_t* size) {
       step,
       0,
       common::errors::InvalidArgument("The step of range op should not be 0."));
+  PADDLE_THROW(common::errors::Fatal(
+      "[CI_PATH_TEST] GetSizeForRange reached after step check (line 67)"));
 
   if constexpr (std::is_same_v<T, phi::bfloat16> ||
                 std::is_same_v<T, phi::float16>) {
@@ -80,6 +82,8 @@ void GetSizeForRange(T start, T end, T step, int64_t* size) {
             "numbers, but received start=%f, end=%f.",
             static_cast<double>(start),
             static_cast<double>(end)));
+    PADDLE_THROW(common::errors::Fatal(
+        "[CI_PATH_TEST] GetSizeForRange reached bf16/fp16 branch"));
   } else if constexpr (std::is_floating_point_v<T>) {
     PADDLE_ENFORCE_EQ(
         std::isfinite(start) && std::isfinite(end),
@@ -89,24 +93,13 @@ void GetSizeForRange(T start, T end, T step, int64_t* size) {
             "numbers, but received start=%f, end=%f.",
             static_cast<double>(start),
             static_cast<double>(end)));
+    PADDLE_THROW(common::errors::Fatal(
+        "[CI_PATH_TEST] GetSizeForRange reached floating-point branch "));
   }
-
-  if (start < end) {
-    if (step < 0) {
-      *size = 0;
-      return;
-    }
-  }
-
-  if (start > end) {
-    if (step > 0) {
-      *size = 0;
-      return;
-    }
-  }
-
   // Closed interval [start, end], so we add 1
   *size = static_cast<int64_t>(((end - start) / step) + 1);
+  PADDLE_THROW(common::errors::Fatal(
+      "[CI_PATH_TEST] GetSizeForRange reached final size calc (line 112)"));
 }
 
 }  // namespace funcs

--- a/paddle/phi/kernels/funcs/range_function.h
+++ b/paddle/phi/kernels/funcs/range_function.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <iomanip>
 #include "paddle/phi/core/enforce.h"
 
 namespace phi {

--- a/paddle/phi/kernels/funcs/range_function.h
+++ b/paddle/phi/kernels/funcs/range_function.h
@@ -61,5 +61,55 @@ void GetSize(T start, T end, T step, int64_t* size) {
               : std::ceil(std::abs((end - start) / step));
 }
 
+template <typename T>
+void GetSizeForRange(T start, T end, T step, int64_t* size) {
+  // For range op: closed interval [start, end]
+  PADDLE_ENFORCE_NE(
+      step,
+      0,
+      common::errors::InvalidArgument("The step of range op should not be 0."));
+
+  if constexpr (std::is_same_v<T, phi::bfloat16> ||
+                std::is_same_v<T, phi::float16>) {
+    PADDLE_ENFORCE_EQ(
+        phi::dtype::isfinite(start) && phi::dtype::isfinite(end) &&
+            phi::dtype::isfinite(step),
+        true,
+        common::errors::InvalidArgument(
+            "The start, end and step of range op should be finite "
+            "numbers, but received start=%f, end=%f, step=%f.",
+            static_cast<double>(start),
+            static_cast<double>(end),
+            static_cast<double>(step)));
+  } else if constexpr (std::is_floating_point_v<T>) {
+    PADDLE_ENFORCE_EQ(
+        std::isfinite(start) && std::isfinite(end) && std::isfinite(step),
+        true,
+        common::errors::InvalidArgument(
+            "The start, end and step of range op should be finite "
+            "numbers, but received start=%f, end=%f, step=%f.",
+            static_cast<double>(start),
+            static_cast<double>(end),
+            static_cast<double>(step)));
+  }
+
+  if (start < end) {
+    if (step < 0) {
+      *size = 0;
+      return;
+    }
+  }
+
+  if (start > end) {
+    if (step > 0) {
+      *size = 0;
+      return;
+    }
+  }
+
+  // Closed interval [start, end], so we add 1
+  *size = static_cast<int64_t>(((end - start) / step) + 1);
+}
+
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/arange_kernel.cu
+++ b/paddle/phi/kernels/gpu/arange_kernel.cu
@@ -43,42 +43,22 @@ void ArangeTensorKernel(const Context& dev_ctx,
                    phi::IsFloatingType(step.dtype());
   int64_t size = 0;
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  MPType start_value, step_value;
+  Scalar start_scalar(start);
+  Scalar end_scalar(end);
+  Scalar step_scalar(step);
   if (any_float) {
-    double sv, ev, stv;
-    PD_VISIT_ALL_TYPES(
-        start.dtype(), "GetStart", ([&] {
-          sv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, start));
-        }));
-    PD_VISIT_ALL_TYPES(
-        end.dtype(), "GetEnd", ([&] {
-          ev = static_cast<double>(GetValue<data_t, Context>(dev_ctx, end));
-        }));
-    PD_VISIT_ALL_TYPES(
-        step.dtype(), "GetStep", ([&] {
-          stv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, step));
-        }));
+    double sv = start_scalar.to<double>();
+    double ev = end_scalar.to<double>();
+    double stv = step_scalar.to<double>();
     funcs::GetSize<double>(sv, ev, stv, &size);
-    start_value = static_cast<MPType>(sv);
-    step_value = static_cast<MPType>(stv);
   } else {
-    int64_t sv, ev, stv;
-    PD_VISIT_ALL_TYPES(
-        start.dtype(), "GetStart", ([&] {
-          sv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, start));
-        }));
-    PD_VISIT_ALL_TYPES(
-        end.dtype(), "GetEnd", ([&] {
-          ev = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, end));
-        }));
-    PD_VISIT_ALL_TYPES(
-        step.dtype(), "GetStep", ([&] {
-          stv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, step));
-        }));
+    int64_t sv = start_scalar.to<int64_t>();
+    int64_t ev = end_scalar.to<int64_t>();
+    int64_t stv = step_scalar.to<int64_t>();
     funcs::GetSize<int64_t>(sv, ev, stv, &size);
-    start_value = static_cast<MPType>(sv);
-    step_value = static_cast<MPType>(stv);
   }
+  MPType start_value = start_scalar.to<MPType>();
+  MPType step_value = step_scalar.to<MPType>();
 
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
@@ -89,7 +69,7 @@ void ArangeTensorKernel(const Context& dev_ctx,
     return;
   }
   int64_t grid = (size + block - 1) / block;
-  Range<MT, T>
+  Range<MPType, T>
       <<<grid, block, 0, stream>>>(start_value, step_value, size, out_data);
 }
 

--- a/paddle/phi/kernels/gpu/arange_kernel.cu
+++ b/paddle/phi/kernels/gpu/arange_kernel.cu
@@ -20,6 +20,7 @@
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/core/visit_type.h"
 #include "paddle/phi/kernels/funcs/range_function.h"
 
 namespace phi {
@@ -37,13 +38,48 @@ void ArangeTensorKernel(const Context& dev_ctx,
                         const DenseTensor& end,
                         const DenseTensor& step,
                         DenseTensor* out) {
-  using MT = typename MPTypeTrait<T>::Type;
-  MT start_value = static_cast<MT>(GetValue<T, Context>(dev_ctx, start));
-  MT end_value = static_cast<MT>(GetValue<T, Context>(dev_ctx, end));
-  MT step_value = static_cast<MT>(GetValue<T, Context>(dev_ctx, step));
-
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
   int64_t size = 0;
-  funcs::GetSize(start_value, end_value, step_value, &size);
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  MPType start_value, step_value;
+  if (any_float) {
+    double sv, ev, stv;
+    PD_VISIT_ALL_TYPES(
+        start.dtype(), "GetStart", ([&] {
+          sv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, start));
+        }));
+    PD_VISIT_ALL_TYPES(
+        end.dtype(), "GetEnd", ([&] {
+          ev = static_cast<double>(GetValue<data_t, Context>(dev_ctx, end));
+        }));
+    PD_VISIT_ALL_TYPES(
+        step.dtype(), "GetStep", ([&] {
+          stv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, step));
+        }));
+    funcs::GetSize<double>(sv, ev, stv, &size);
+    start_value = static_cast<MPType>(sv);
+    step_value = static_cast<MPType>(stv);
+  } else {
+    int64_t sv, ev, stv;
+    PD_VISIT_ALL_TYPES(
+        start.dtype(), "GetStart", ([&] {
+          sv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, start));
+        }));
+    PD_VISIT_ALL_TYPES(
+        end.dtype(), "GetEnd", ([&] {
+          ev = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, end));
+        }));
+    PD_VISIT_ALL_TYPES(
+        step.dtype(), "GetStep", ([&] {
+          stv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, step));
+        }));
+    funcs::GetSize<int64_t>(sv, ev, stv, &size);
+    start_value = static_cast<MPType>(sv);
+    step_value = static_cast<MPType>(stv);
+  }
+
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
 
@@ -88,11 +124,35 @@ void ArangeKernel(const Context& dev_ctx,
                   const Scalar& end,
                   const Scalar& step,
                   DenseTensor* out) {
-  T start_value = start.to<T>();
-  T end_value = end.to<T>();
-  T step_value = step.to<T>();
-  ArangeNullaryKernel<T, Context>(
-      dev_ctx, start_value, end_value, step_value, out);
+  bool is_floating = phi::IsFloatingType(start.dtype()) ||
+                     phi::IsFloatingType(end.dtype()) ||
+                     phi::IsFloatingType(step.dtype());
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  int64_t size = 0;
+  if (is_floating) {
+    double sv = start.to<double>();
+    double ev = end.to<double>();
+    double stv = step.to<double>();
+    funcs::GetSize<double>(sv, ev, stv, &size);
+  } else {
+    int64_t sv = start.to<int64_t>();
+    int64_t ev = end.to<int64_t>();
+    int64_t stv = step.to<int64_t>();
+    funcs::GetSize<int64_t>(sv, ev, stv, &size);
+  }
+  MPType start_value = start.to<MPType>();
+  MPType step_value = step.to<MPType>();
+  out->Resize({size});
+  T* out_data = dev_ctx.template Alloc<T>(out);
+
+  auto stream = dev_ctx.stream();
+  int64_t block = std::min(size, static_cast<int64_t>(256));
+  if (block == 0) {
+    return;
+  }
+  int64_t grid = (size + block - 1) / block;
+  Range<MPType, T>
+      <<<grid, block, 0, stream>>>(start_value, step_value, size, out_data);
 }
 
 template decltype(ArangeNullaryKernel<int64_t, GPUContext>) ArangeNullaryKernel;

--- a/paddle/phi/kernels/gpu/range_kernel.cu
+++ b/paddle/phi/kernels/gpu/range_kernel.cu
@@ -14,12 +14,16 @@
 
 #include "paddle/phi/kernels/range_kernel.h"
 
+#include <type_traits>
+
 #include "paddle/common/errors.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/amp_type_traits.h"
+#include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/core/visit_type.h"
 #include "paddle/phi/kernels/funcs/range_function.h"
 
 namespace phi {
@@ -37,15 +41,48 @@ void RangeTensorKernel(const Context& dev_ctx,
                        const DenseTensor& end,
                        const DenseTensor& step,
                        DenseTensor* out) {
-  using MT = typename MPTypeTrait<T>::Type;
-  MT start_value = static_cast<MT>(GetValue<T, Context>(dev_ctx, start));
-  MT end_value = static_cast<MT>(GetValue<T, Context>(dev_ctx, end));
-  MT step_value = static_cast<MT>(GetValue<T, Context>(dev_ctx, step));
-  if (step_value == static_cast<MT>(0)) {
-    PADDLE_THROW(common::errors::InvalidArgument("step must be nonzero."));
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
+  int64_t size = 0;
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  MPType start_value, step_value;
+  if (any_float) {
+    double sv, ev, stv;
+    PD_VISIT_ALL_TYPES(
+        start.dtype(), "GetStart", ([&] {
+          sv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, start));
+        }));
+    PD_VISIT_ALL_TYPES(
+        end.dtype(), "GetEnd", ([&] {
+          ev = static_cast<double>(GetValue<data_t, Context>(dev_ctx, end));
+        }));
+    PD_VISIT_ALL_TYPES(
+        step.dtype(), "GetStep", ([&] {
+          stv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, step));
+        }));
+    funcs::GetSizeForRange<double>(sv, ev, stv, &size);
+    start_value = static_cast<MPType>(sv);
+    step_value = static_cast<MPType>(stv);
+  } else {
+    int64_t sv, ev, stv;
+    PD_VISIT_ALL_TYPES(
+        start.dtype(), "GetStart", ([&] {
+          sv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, start));
+        }));
+    PD_VISIT_ALL_TYPES(
+        end.dtype(), "GetEnd", ([&] {
+          ev = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, end));
+        }));
+    PD_VISIT_ALL_TYPES(
+        step.dtype(), "GetStep", ([&] {
+          stv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, step));
+        }));
+    funcs::GetSizeForRange<int64_t>(sv, ev, stv, &size);
+    start_value = static_cast<MPType>(sv);
+    step_value = static_cast<MPType>(stv);
   }
-  int64_t size =
-      static_cast<int64_t>(((end_value - start_value) / step_value) + 1);
+
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
 
@@ -107,25 +144,40 @@ void RangeKernel(const Context& dev_ctx,
                  const Scalar& end,
                  const Scalar& step,
                  DenseTensor* out) {
-  T start_value = start.to<T>();
-  T end_value = end.to<T>();
-  T step_value = step.to<T>();
-  if constexpr (std::is_same_v<T, float>) {
-    if (std::isnan(end_value)) {
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "The end value of range cannot be NaN. Please check your input."));
-    }
-  } else if constexpr (std::is_same_v<T, double>) {
-    if (std::isnan(end_value)) {
-      PADDLE_THROW(common::errors::InvalidArgument(
-          "The end value of range cannot be NaN. Please check your input."));
-    }
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
+  int64_t size = 0;
+  if (any_float) {
+    double sv, ev, stv;
+    sv = start.to<double>();
+    ev = end.to<double>();
+    stv = step.to<double>();
+    funcs::GetSizeForRange<double>(sv, ev, stv, &size);
+  } else {
+    int64_t sv, ev, stv;
+    sv = start.to<int64_t>();
+    ev = end.to<int64_t>();
+    stv = step.to<int64_t>();
+    funcs::GetSizeForRange<int64_t>(sv, ev, stv, &size);
   }
-  if (step_value == static_cast<T>(0)) {
-    PADDLE_THROW(common::errors::InvalidArgument("step must be nonzero."));
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  MPType start_value = start.to<MPType>();
+  MPType step_value = step.to<MPType>();
+  out->Resize({size});
+  T* out_data = dev_ctx.template Alloc<T>(out);
+  if (size == 0) {
+    return;
   }
-  RangeNullaryKernel<T, Context>(
-      dev_ctx, start_value, end_value, step_value, out);
+
+  auto stream = dev_ctx.stream();
+  int64_t block = std::min(size, static_cast<int64_t>(256));
+  if (block == 0) {
+    return;
+  }
+  int64_t grid = (size + block - 1) / block;
+  Range<MPType, T>
+      <<<grid, block, 0, stream>>>(start_value, step_value, size, out_data);
 }
 
 template decltype(RangeNullaryKernel<int64_t, GPUContext>) RangeNullaryKernel;

--- a/paddle/phi/kernels/gpu/range_kernel.cu
+++ b/paddle/phi/kernels/gpu/range_kernel.cu
@@ -43,21 +43,14 @@ void RangeTensorKernel(const Context& dev_ctx,
                        DenseTensor* out) {
   int64_t size = 0;
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  MPType start_value, end_value, step_value;
+  Scalar start_scalar(start);
+  Scalar end_scalar(end);
+  Scalar step_scalar(step);
 
-  PD_VISIT_ALL_TYPES(start.dtype(), "GetStart", ([&] {
-                       start_value = static_cast<MPType>(
-                           GetValue<data_t, Context>(dev_ctx, start));
-                     }));
-  PD_VISIT_ALL_TYPES(end.dtype(), "GetEnd", ([&] {
-                       end_value = static_cast<MPType>(
-                           GetValue<data_t, Context>(dev_ctx, end));
-                     }));
-  PD_VISIT_ALL_TYPES(step.dtype(), "GetStep", ([&] {
-                       step_value = static_cast<MPType>(
-                           GetValue<data_t, Context>(dev_ctx, step));
-                     }));
-  funcs::GetSizeForRange(start_value, end_value, step_value, &size);
+  MPType start_value = start_scalar.to<MPType>();
+  MPType end_value = end_scalar.to<MPType>();
+  MPType step_value = step_scalar.to<MPType>();
+  funcs::GetSizeForRange<MPType>(start_value, end_value, step_value, &size);
 
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
@@ -68,7 +61,7 @@ void RangeTensorKernel(const Context& dev_ctx,
     return;
   }
   int64_t grid = (size + block - 1) / block;
-  Range<MT, T>
+  Range<MPType, T>
       <<<grid, block, 0, stream>>>(start_value, step_value, size, out_data);
 }
 

--- a/paddle/phi/kernels/gpu/range_kernel.cu
+++ b/paddle/phi/kernels/gpu/range_kernel.cu
@@ -41,47 +41,23 @@ void RangeTensorKernel(const Context& dev_ctx,
                        const DenseTensor& end,
                        const DenseTensor& step,
                        DenseTensor* out) {
-  bool any_float = phi::IsFloatingType(start.dtype()) ||
-                   phi::IsFloatingType(end.dtype()) ||
-                   phi::IsFloatingType(step.dtype());
   int64_t size = 0;
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  MPType start_value, step_value;
-  if (any_float) {
-    double sv, ev, stv;
-    PD_VISIT_ALL_TYPES(
-        start.dtype(), "GetStart", ([&] {
-          sv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, start));
-        }));
-    PD_VISIT_ALL_TYPES(
-        end.dtype(), "GetEnd", ([&] {
-          ev = static_cast<double>(GetValue<data_t, Context>(dev_ctx, end));
-        }));
-    PD_VISIT_ALL_TYPES(
-        step.dtype(), "GetStep", ([&] {
-          stv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, step));
-        }));
-    funcs::GetSizeForRange<double>(sv, ev, stv, &size);
-    start_value = static_cast<MPType>(sv);
-    step_value = static_cast<MPType>(stv);
-  } else {
-    int64_t sv, ev, stv;
-    PD_VISIT_ALL_TYPES(
-        start.dtype(), "GetStart", ([&] {
-          sv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, start));
-        }));
-    PD_VISIT_ALL_TYPES(
-        end.dtype(), "GetEnd", ([&] {
-          ev = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, end));
-        }));
-    PD_VISIT_ALL_TYPES(
-        step.dtype(), "GetStep", ([&] {
-          stv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, step));
-        }));
-    funcs::GetSizeForRange<int64_t>(sv, ev, stv, &size);
-    start_value = static_cast<MPType>(sv);
-    step_value = static_cast<MPType>(stv);
-  }
+  MPType start_value, end_value, step_value;
+
+  PD_VISIT_ALL_TYPES(start.dtype(), "GetStart", ([&] {
+                       start_value = static_cast<float>(
+                           GetValue<data_t, Context>(dev_ctx, start));
+                     }));
+  PD_VISIT_ALL_TYPES(
+      end.dtype(), "GetEnd", ([&] {
+        end_value = static_cast<float>(GetValue<data_t, Context>(dev_ctx, end));
+      }));
+  PD_VISIT_ALL_TYPES(step.dtype(), "GetStep", ([&] {
+                       step_value = static_cast<MPType>(
+                           GetValue<data_t, Context>(dev_ctx, step));
+                     }));
+  funcs::GetSizeForRange(start_value, end_value, step_value, &size);
 
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
@@ -144,26 +120,12 @@ void RangeKernel(const Context& dev_ctx,
                  const Scalar& end,
                  const Scalar& step,
                  DenseTensor* out) {
-  bool any_float = phi::IsFloatingType(start.dtype()) ||
-                   phi::IsFloatingType(end.dtype()) ||
-                   phi::IsFloatingType(step.dtype());
   int64_t size = 0;
-  if (any_float) {
-    double sv, ev, stv;
-    sv = start.to<double>();
-    ev = end.to<double>();
-    stv = step.to<double>();
-    funcs::GetSizeForRange<double>(sv, ev, stv, &size);
-  } else {
-    int64_t sv, ev, stv;
-    sv = start.to<int64_t>();
-    ev = end.to<int64_t>();
-    stv = step.to<int64_t>();
-    funcs::GetSizeForRange<int64_t>(sv, ev, stv, &size);
-  }
   using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   MPType start_value = start.to<MPType>();
+  MPType end_value = end.to<MPType>();
   MPType step_value = step.to<MPType>();
+  funcs::GetSizeForRange<MPType>(start_value, end_value, step_value, &size);
   out->Resize({size});
   T* out_data = dev_ctx.template Alloc<T>(out);
   if (size == 0) {

--- a/paddle/phi/kernels/gpu/range_kernel.cu
+++ b/paddle/phi/kernels/gpu/range_kernel.cu
@@ -46,13 +46,13 @@ void RangeTensorKernel(const Context& dev_ctx,
   MPType start_value, end_value, step_value;
 
   PD_VISIT_ALL_TYPES(start.dtype(), "GetStart", ([&] {
-                       start_value = static_cast<float>(
+                       start_value = static_cast<MPType>(
                            GetValue<data_t, Context>(dev_ctx, start));
                      }));
-  PD_VISIT_ALL_TYPES(
-      end.dtype(), "GetEnd", ([&] {
-        end_value = static_cast<float>(GetValue<data_t, Context>(dev_ctx, end));
-      }));
+  PD_VISIT_ALL_TYPES(end.dtype(), "GetEnd", ([&] {
+                       end_value = static_cast<MPType>(
+                           GetValue<data_t, Context>(dev_ctx, end));
+                     }));
   PD_VISIT_ALL_TYPES(step.dtype(), "GetStep", ([&] {
                        step_value = static_cast<MPType>(
                            GetValue<data_t, Context>(dev_ctx, step));

--- a/paddle/phi/kernels/xpu/arange_kernel.cc
+++ b/paddle/phi/kernels/xpu/arange_kernel.cc
@@ -26,15 +26,48 @@ void ArangeTensorKernel(const Context& dev_ctx,
                         const DenseTensor& end,
                         const DenseTensor& step,
                         DenseTensor* out) {
-  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  using XPUType = typename XPUTypeTrait<T>::Type;
-  MPType start_value =
-      static_cast<MPType>(GetValue<T, Context>(dev_ctx, start));
-  MPType end_value = static_cast<MPType>(GetValue<T, Context>(dev_ctx, end));
-  MPType step_value = static_cast<MPType>(GetValue<T, Context>(dev_ctx, step));
-
+  bool any_float = phi::IsFloatingType(start.dtype()) ||
+                   phi::IsFloatingType(end.dtype()) ||
+                   phi::IsFloatingType(step.dtype());
   int64_t size = 0;
-  funcs::GetSize(start_value, end_value, step_value, &size);
+  using XPUType = typename XPUTypeTrait<T>::Type;
+  XPUType start_value, step_value;
+  if (any_float) {
+    double sv, ev, stv;
+    PD_VISIT_ALL_TYPES(
+        start.dtype(), "GetStart", ([&] {
+          sv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, start));
+        }));
+    PD_VISIT_ALL_TYPES(
+        end.dtype(), "GetEnd", ([&] {
+          ev = static_cast<double>(GetValue<data_t, Context>(dev_ctx, end));
+        }));
+    PD_VISIT_ALL_TYPES(
+        step.dtype(), "GetStep", ([&] {
+          stv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, step));
+        }));
+    funcs::GetSize<double>(sv, ev, stv, &size);
+    start_value = static_cast<XPUType>(sv);
+    step_value = static_cast<XPUType>(stv);
+  } else {
+    int64_t sv, ev, stv;
+    PD_VISIT_ALL_TYPES(
+        start.dtype(), "GetStart", ([&] {
+          sv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, start));
+        }));
+    PD_VISIT_ALL_TYPES(
+        end.dtype(), "GetEnd", ([&] {
+          ev = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, end));
+        }));
+    PD_VISIT_ALL_TYPES(
+        step.dtype(), "GetStep", ([&] {
+          stv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, step));
+        }));
+    funcs::GetSize<int64_t>(sv, ev, stv, &size);
+    start_value = static_cast<XPUType>(sv);
+    step_value = static_cast<XPUType>(stv);
+  }
+  int64_t size = 0;
   if (size == 0) {
     out->Resize({0});
     dev_ctx.template Alloc<T>(out);
@@ -44,11 +77,8 @@ void ArangeTensorKernel(const Context& dev_ctx,
   XPUType* out_data =
       reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(out));
 
-  int ret = xpu::range(dev_ctx.x_context(),
-                       out_data,
-                       static_cast<XPUType>(start_value),
-                       static_cast<XPUType>(step_value),
-                       size);
+  int ret =
+      xpu::range(dev_ctx.x_context(), out_data, start_value, step_value, size);
   PADDLE_ENFORCE_XDNN_SUCCESS(ret, "range");
 }
 

--- a/paddle/phi/kernels/xpu/arange_kernel.cc
+++ b/paddle/phi/kernels/xpu/arange_kernel.cc
@@ -32,38 +32,23 @@ void ArangeTensorKernel(const Context& dev_ctx,
                    phi::IsFloatingType(step.dtype());
   int64_t size = 0;
   using XPUType = typename XPUTypeTrait<T>::Type;
-  XPUType start_value, step_value;
+  Scalar start_scalar(start);
+  Scalar end_scalar(end);
+  Scalar step_scalar(step);
+  XPUType start_value;
+  XPUType step_value;
+
   if (any_float) {
-    double sv, ev, stv;
-    PD_VISIT_ALL_TYPES(
-        start.dtype(), "GetStart", ([&] {
-          sv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, start));
-        }));
-    PD_VISIT_ALL_TYPES(
-        end.dtype(), "GetEnd", ([&] {
-          ev = static_cast<double>(GetValue<data_t, Context>(dev_ctx, end));
-        }));
-    PD_VISIT_ALL_TYPES(
-        step.dtype(), "GetStep", ([&] {
-          stv = static_cast<double>(GetValue<data_t, Context>(dev_ctx, step));
-        }));
+    double sv = start_scalar.to<double>();
+    double ev = end_scalar.to<double>();
+    double stv = step_scalar.to<double>();
     funcs::GetSize<double>(sv, ev, stv, &size);
     start_value = static_cast<XPUType>(sv);
     step_value = static_cast<XPUType>(stv);
   } else {
-    int64_t sv, ev, stv;
-    PD_VISIT_ALL_TYPES(
-        start.dtype(), "GetStart", ([&] {
-          sv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, start));
-        }));
-    PD_VISIT_ALL_TYPES(
-        end.dtype(), "GetEnd", ([&] {
-          ev = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, end));
-        }));
-    PD_VISIT_ALL_TYPES(
-        step.dtype(), "GetStep", ([&] {
-          stv = static_cast<int64_t>(GetValue<data_t, Context>(dev_ctx, step));
-        }));
+    int64_t sv = start_scalar.to<int64_t>();
+    int64_t ev = end_scalar.to<int64_t>();
+    int64_t stv = step_scalar.to<int64_t>();
     funcs::GetSize<int64_t>(sv, ev, stv, &size);
     start_value = static_cast<XPUType>(sv);
     step_value = static_cast<XPUType>(stv);

--- a/paddle/phi/kernels/xpu/arange_kernel.cc
+++ b/paddle/phi/kernels/xpu/arange_kernel.cc
@@ -16,6 +16,7 @@ limitations under the License. */
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/visit_type.h"
 #include "paddle/phi/kernels/funcs/range_function.h"
 
 namespace phi {
@@ -67,7 +68,6 @@ void ArangeTensorKernel(const Context& dev_ctx,
     start_value = static_cast<XPUType>(sv);
     step_value = static_cast<XPUType>(stv);
   }
-  int64_t size = 0;
   if (size == 0) {
     out->Resize({0});
     dev_ctx.template Alloc<T>(out);

--- a/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
@@ -24,14 +24,14 @@
   output : Tensor(out)
   infer_meta :
     func : ArangeTensorInferMeta
-    param : [start, end, step]
+    param : [start, end, step, dtype]
   kernel :
     func : arange_tensor
     param : [start, end, step]
     data_type : dtype
     backend : place
-  data_transform :
-    support_trans_dtype : start, end, step
+  # data_transform :
+  #   support_trans_dtype : start, end, step
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : assign
@@ -316,14 +316,14 @@
   output : Tensor(out)
   infer_meta :
     func : RangeTensorInferMeta
-    param : [start, end, step]
+    param : [start, end, step, dtype]
   kernel :
     func : range_tensor
     param : [start, end, step]
     data_type : dtype
     backend : place
-  data_transform :
-    support_trans_dtype : start, end, step
+  # data_transform :
+  #   support_trans_dtype : start, end, step
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : remainder

--- a/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
@@ -30,8 +30,6 @@
     param : [start, end, step]
     data_type : dtype
     backend : place
-  # data_transform :
-  #   support_trans_dtype : start, end, step
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : assign
@@ -322,8 +320,6 @@
     param : [start, end, step]
     data_type : dtype
     backend : place
-  # data_transform :
-  #   support_trans_dtype : start, end, step
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : remainder

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -41,10 +41,11 @@
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : arange
-  args : (Tensor start, Tensor end, Tensor step)
+  args : (Tensor start, Tensor end, Tensor step, DataType dtype)
   output : Tensor(out)
   infer_meta :
     func : ArangeTensorInferMeta
+    param : [start, end, step, dtype]
   kernel :
     func : arange_tensor
   data_transform :
@@ -897,10 +898,11 @@
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : range_v2
-  args : (Tensor start, Tensor end, Tensor step)
+  args : (Tensor start, Tensor end, Tensor step, DataType dtype)
   output : Tensor(out)
   infer_meta :
     func : RangeTensorInferMeta
+    param : [start, end, step, dtype]
   kernel :
     func : range_tensor
   data_transform :

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -41,11 +41,10 @@
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : arange
-  args : (Tensor start, Tensor end, Tensor step, DataType dtype)
+  args : (Tensor start, Tensor end, Tensor step)
   output : Tensor(out)
   infer_meta :
-    func : ArangeTensorInferMeta
-    param : [start, end, step, dtype]
+    func : ArangeTensorInferMetaLegacy
   kernel :
     func : arange_tensor
   data_transform :
@@ -898,11 +897,10 @@
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : range_v2
-  args : (Tensor start, Tensor end, Tensor step, DataType dtype)
+  args : (Tensor start, Tensor end, Tensor step)
   output : Tensor(out)
   infer_meta :
-    func : RangeTensorInferMeta
-    param : [start, end, step, dtype]
+    func : RangeTensorInferMetaLegacy
   kernel :
     func : range_tensor
   data_transform :

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -718,9 +718,13 @@ def convert_range(*args):
     # the scalar case also be convert as a `Full` OP output.
     # So we add an `Assign` OP after the Tensor input to **mark** it as a variable, which can avoid confusing
     # it with the scalar case.
+    is_full_op_output = lambda x: (
+        isinstance(x, (Variable, Value))
+        and x.get_defining_op()
+        and x.get_defining_op().name() == "pd_op.full"
+    )
     args = [
-        paddle.assign(arg) if isinstance(arg, (Variable, Value)) else arg
-        for arg in args
+        paddle.assign(arg) if is_full_op_output(arg) else arg for arg in args
     ]
     if has_variable:
         if len(args) == 1:

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -702,8 +702,22 @@ def convert_enumerate(*args):
 
 def convert_range(*args):
     has_variable = any(isinstance(x, (Variable, Value)) for x in args)
-    # NOTE(SigureMo): Add an `assign` op after a Tensor argument to avoid confusing it with the scalar case in `arange`;
-    # otherwise, the full op result would be passed to the `ArangeOp` creation stage.
+    # NOTE(SigureMo): Add an `Assign` OP after the Tensor input to mark it as a variable, which can
+    # avoid confusing it with the scalar case in `arange` API.
+    # For example:
+    # ```python
+    # l = []
+    # for i in range(n):
+    #    l.append(i)
+    # ```
+    # - If `n` is a scalar (e.g., `n=10`), we expect to create an `ArangeOp` with a fixed output shape [10].
+    # - If `n` is a Tensor (e.g., `n=full([], 10, "int32")`), we expect to create an `ArangeOp` with a dynamic
+    # output shape [-1]. To ensure the python level and graph level all recognize this is data-dependent control
+    # flow.
+    # However, we can't distinguish the scalar case and the Tensor case when creating the `ArangeOp`. Because
+    # the scalar case also be convert as a `Full` OP output.
+    # So we add an `Assign` OP after the Tensor input to **mark** it as a variable, which can avoid confusing
+    # it with the scalar case.
     args = [
         paddle.assign(arg) if isinstance(arg, (Variable, Value)) else arg
         for arg in args

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -719,7 +719,7 @@ def convert_range(*args):
     # So we add an `Assign` OP after the Tensor input to **mark** it as a variable, which can avoid confusing
     # it with the scalar case.
     is_full_op_output = lambda x: (
-        isinstance(x, (Variable, Value))
+        isinstance(x, Value)
         and x.get_defining_op()
         and x.get_defining_op().name() == "pd_op.full"
     )

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -702,6 +702,12 @@ def convert_enumerate(*args):
 
 def convert_range(*args):
     has_variable = any(isinstance(x, (Variable, Value)) for x in args)
+    # NOTE(SigureMo): Add an `assign` op after a Tensor argument to avoid confusing it with the scalar case in `arange`;
+    # otherwise, the full op result would be passed to the `ArangeOp` creation stage.
+    args = [
+        paddle.assign(arg) if isinstance(arg, (Variable, Value)) else arg
+        for arg in args
+    ]
     if has_variable:
         if len(args) == 1:
             return paddle.arange(0, args[0], 1, "int64")

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2458,7 +2458,6 @@ def arange(
             type='range',
             inputs={'Start': start, 'End': end, 'Step': step},
             outputs={'Out': out},
-            attrs={'dtype': dtype},
         )
         out.stop_gradient = True
         if out_shape is not None:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -2414,10 +2414,6 @@ def arange(
 
     if not isinstance(step, (Variable, paddle.pir.Value)):
         with device_guard("cpu"):
-            if not np.isfinite(step):
-                raise ValueError(
-                    f"The value of end must be finite, but received: {end}."
-                )
             step_dtype = np.array(step).dtype
             step = fill_constant([1], step_dtype, step, force_cpu=True)
     else:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -20,7 +20,7 @@ import numbers
 import os
 import re
 import warnings
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
@@ -2314,20 +2314,19 @@ def arange(
         end = start
         start = 0
 
+    is_all_integer = True
     if dtype is None:
+        # Check if start/end/step contain floating point values
         for val in [start, end, step]:
             if isinstance(val, (Variable, paddle.pir.Value)):
                 if not paddle.is_integer(val):
-                    dtype = paddle.get_default_dtype()
+                    is_all_integer = False
                     break
-                else:
-                    dtype = 'int64'
             else:
-                if not isinstance(val, np.integer) and not isinstance(val, int):
-                    dtype = paddle.get_default_dtype()
+                if isinstance(val, (float, np.floating)):
+                    is_all_integer = False
                     break
-                else:
-                    dtype = 'int64'
+        dtype = 'int64' if is_all_integer else paddle.get_default_dtype()
 
     out_shape = None
     is_value_input = (
@@ -2391,13 +2390,13 @@ def arange(
                 raise ValueError(
                     f"The value of start must be finite, but received: {start}."
                 )
-            start = fill_constant([1], dtype, start, force_cpu=True)
-    elif start.dtype != dtype:
+            start_dtype = np.array(start).dtype
+            start = fill_constant([1], start_dtype, start, force_cpu=True)
+    else:
         if in_dynamic_mode() and not paddle.isfinite(start):
             raise ValueError(
                 f"The value of start must be finite, but received: {start}."
             )
-        start = paddle.cast(start, dtype)
 
     if not isinstance(end, (Variable, paddle.pir.Value)):
         with device_guard("cpu"):
@@ -2405,19 +2404,27 @@ def arange(
                 raise ValueError(
                     f"The value of end must be finite, but received: {end}."
                 )
-            end = fill_constant([1], dtype, end, force_cpu=True)
-    elif end.dtype != dtype:
+            end_dtype = np.array(end).dtype
+            end = fill_constant([1], end_dtype, end, force_cpu=True)
+    else:
         if in_dynamic_mode() and not paddle.isfinite(end):
             raise ValueError(
                 f"The value of end must be finite, but received: {end}."
             )
-        end = paddle.cast(end, dtype)
 
     if not isinstance(step, (Variable, paddle.pir.Value)):
         with device_guard("cpu"):
-            step = fill_constant([1], dtype, step, force_cpu=True)
-    elif step.dtype != dtype:
-        step = paddle.cast(step, dtype)
+            if not np.isfinite(step):
+                raise ValueError(
+                    f"The value of end must be finite, but received: {end}."
+                )
+            step_dtype = np.array(step).dtype
+            step = fill_constant([1], step_dtype, step, force_cpu=True)
+    else:
+        if in_dynamic_mode() and not paddle.isfinite(step):
+            raise ValueError(
+                f"The value of step must be finite, but received: {step}."
+            )
 
     if in_dynamic_or_pir_mode():
         tensor = _C_ops.arange(
@@ -2451,6 +2458,7 @@ def arange(
             type='range',
             inputs={'Start': start, 'End': end, 'Step': step},
             outputs={'Out': out},
+            attrs={'dtype': dtype},
         )
         out.stop_gradient = True
         if out_shape is not None:
@@ -2579,21 +2587,18 @@ def range(
 
     if not isinstance(start, (Variable, paddle.pir.Value)):
         with device_guard("cpu"):
-            start = fill_constant([1], dtype, start, force_cpu=True)
-    elif start.dtype != dtype:
-        start = paddle.cast(start, dtype)
+            start_dtype = np.array(start).dtype
+            start = fill_constant([1], start_dtype, start, force_cpu=True)
 
     if not isinstance(end, (Variable, paddle.pir.Value)):
         with device_guard("cpu"):
-            end = fill_constant([1], dtype, end, force_cpu=True)
-    elif end.dtype != dtype:
-        end = paddle.cast(end, dtype)
+            end_dtype = np.array(end).dtype
+            end = fill_constant([1], end_dtype, end, force_cpu=True)
 
     if not isinstance(step, (Variable, paddle.pir.Value)):
         with device_guard("cpu"):
-            step = fill_constant([1], dtype, step, force_cpu=True)
-    elif step.dtype != dtype:
-        step = paddle.cast(step, dtype)
+            step_dtype = np.array(step).dtype
+            step = fill_constant([1], step_dtype, step, force_cpu=True)
 
     tensor = _C_ops.range_v2(
         start,

--- a/test/legacy_test/test_range_and_arange.py
+++ b/test/legacy_test/test_range_and_arange.py
@@ -331,55 +331,61 @@ class TestRangeV2LegacyInferMeta(unittest.TestCase):
 
     def test_range_v2_legacy(self):
         paddle.enable_static()
-        test_cases = [
-            (0, 5, 1),
-            (2, 7, 2),
-            (0, 1, 0.1),
-            (10, 1, -2),
-            (-1, -10, -2),
-        ]
-        for start_val, end_val, step_val in test_cases:
-            with (
-                paddle.pir_utils.OldIrGuard(),
-                program_guard(Program(), Program()),
-            ):
-                start = paddle.static.data(
-                    name='start', shape=[1], dtype='float32'
-                )
-                end = paddle.static.data(name='end', shape=[1], dtype='float32')
-                step = paddle.static.data(
-                    name='step', shape=[1], dtype='float32'
-                )
+        try:
+            test_cases = [
+                (0, 5, 1),
+                (2, 7, 2),
+                (0, 1, 0.1),
+                (10, 1, -2),
+                (-1, -10, -2),
+            ]
+            for start_val, end_val, step_val in test_cases:
+                with (
+                    paddle.pir_utils.OldIrGuard(),
+                    program_guard(Program(), Program()),
+                ):
+                    start = paddle.static.data(
+                        name='start', shape=[1], dtype='float32'
+                    )
+                    end = paddle.static.data(
+                        name='end', shape=[1], dtype='float32'
+                    )
+                    step = paddle.static.data(
+                        name='step', shape=[1], dtype='float32'
+                    )
 
-                helper = LayerHelper('range_v2')
-                out = helper.create_variable_for_type_inference(dtype='float32')
-                helper.append_op(
-                    type='range_v2',
-                    inputs={'Start': start, 'End': end, 'Step': step},
-                    outputs={'Out': out},
-                )
-                self.assertEqual(out.shape, (-1,))
+                    helper = LayerHelper('range_v2')
+                    out = helper.create_variable_for_type_inference(
+                        dtype='float32'
+                    )
+                    helper.append_op(
+                        type='range_v2',
+                        inputs={'Start': start, 'End': end, 'Step': step},
+                        outputs={'Out': out},
+                    )
+                    self.assertEqual(out.shape, (-1,))
 
-                exe = paddle.static.Executor(paddle.CPUPlace())
-                (result,) = exe.run(
-                    feed={
-                        'start': np.array([start_val], dtype='float32'),
-                        'end': np.array([end_val], dtype='float32'),
-                        'step': np.array([step_val], dtype='float32'),
-                    },
-                    fetch_list=[out],
-                )
-                expected = self.range_manual(
-                    start_val, end_val, step_val, 'float32'
-                )
-                np.testing.assert_allclose(
-                    result,
-                    expected,
-                    rtol=1e-6,
-                    atol=1e-6,
-                    err_msg=f"[FAILED] range_v2({start_val},{end_val},{step_val})",
-                )
-        paddle.disable_static()
+                    exe = paddle.static.Executor(paddle.CPUPlace())
+                    (result,) = exe.run(
+                        feed={
+                            'start': np.array([start_val], dtype='float32'),
+                            'end': np.array([end_val], dtype='float32'),
+                            'step': np.array([step_val], dtype='float32'),
+                        },
+                        fetch_list=[out],
+                    )
+                    expected = self.range_manual(
+                        start_val, end_val, step_val, 'float32'
+                    )
+                    np.testing.assert_allclose(
+                        result,
+                        expected,
+                        rtol=1e-6,
+                        atol=1e-6,
+                        err_msg=f"[FAILED] range_v2({start_val},{end_val},{step_val})",
+                    )
+        finally:
+            paddle.disable_static()
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_range_and_arange.py
+++ b/test/legacy_test/test_range_and_arange.py
@@ -129,6 +129,7 @@ class TestTensorCreation(unittest.TestCase):
         ):
             with dygraph_guard():
                 for start, end, step in [
+                    (0, 0, 1),
                     (0, 5, 1),
                     (2, 7, 2),
                     (5, None, 1),

--- a/test/legacy_test/test_range_and_arange.py
+++ b/test/legacy_test/test_range_and_arange.py
@@ -19,7 +19,8 @@ from op_test import get_device, get_device_place, is_custom_device
 from utils import dygraph_guard
 
 import paddle
-from paddle.static import InputSpec
+from paddle.base.layer_helper import LayerHelper
+from paddle.static import InputSpec, Program, program_guard
 
 
 class TestTensorCreation(unittest.TestCase):
@@ -305,6 +306,79 @@ class TestCreationOut(unittest.TestCase):
         self.assertEqual(t.data_ptr(), y.data_ptr())
         self.assertEqual(y.stop_gradient, False)
         self.assertEqual(t.stop_gradient, False)
+
+
+class TestRangeV2LegacyInferMeta(unittest.TestCase):
+    """
+    Test that RangeTensorInferMetaLegacy is triggered via legacy static graph path.
+    - TestTensorCreation.test_range (above) calls paddle.range() in
+      dynamic graph mode, which triggers RangeTensorInferMeta (with dtype param).
+    - NO existing test triggers RangeTensorInferMetaLegacy (no dtype param),
+      because paddle.range() has no old static graph fallback like
+      paddle.arange() does (which falls back to append_op(type='range')
+      → mapped to the 'arange' op, not 'range_v2').
+    - To trigger RangeTensorInferMetaLegacy, we use append_op(type='range_v2')
+      under static graph mode).
+    """
+
+    def range_manual(self, start, end, step, dtype):
+        size_ = int(np.abs(np.trunc((end - start) / step))) + 1
+        out = np.empty([size_], dtype=dtype)
+        for i in range(size_):
+            out[i] = start + i * step
+        return out
+
+    def test_range_v2_legacy(self):
+        paddle.enable_static()
+        test_cases = [
+            (0, 5, 1),
+            (2, 7, 2),
+            (0, 1, 0.1),
+            (10, 1, -2),
+            (-1, -10, -2),
+        ]
+        for start_val, end_val, step_val in test_cases:
+            with (
+                paddle.pir_utils.OldIrGuard(),
+                program_guard(Program(), Program()),
+            ):
+                start = paddle.static.data(
+                    name='start', shape=[1], dtype='float32'
+                )
+                end = paddle.static.data(name='end', shape=[1], dtype='float32')
+                step = paddle.static.data(
+                    name='step', shape=[1], dtype='float32'
+                )
+
+                helper = LayerHelper('range_v2')
+                out = helper.create_variable_for_type_inference(dtype='float32')
+                helper.append_op(
+                    type='range_v2',
+                    inputs={'Start': start, 'End': end, 'Step': step},
+                    outputs={'Out': out},
+                )
+                self.assertEqual(out.shape, (-1,))
+
+                exe = paddle.static.Executor(paddle.CPUPlace())
+                (result,) = exe.run(
+                    feed={
+                        'start': np.array([start_val], dtype='float32'),
+                        'end': np.array([end_val], dtype='float32'),
+                        'step': np.array([step_val], dtype='float32'),
+                    },
+                    fetch_list=[out],
+                )
+                expected = self.range_manual(
+                    start_val, end_val, step_val, 'float32'
+                )
+                np.testing.assert_allclose(
+                    result,
+                    expected,
+                    rtol=1e-6,
+                    atol=1e-6,
+                    err_msg=f"[FAILED] range_v2({start_val},{end_val},{step_val})",
+                )
+        paddle.disable_static()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
修复了由于输入和输出强制类型统一导致的`paddle.arange()` 和`paddle.range()` 中shape计算的精度问题

**Kernels** (in `paddle/phi/keners/` directory)
- 修改了shape计算时start、end、step的类型，使用高精度double/int64计算输出的shape，如果输入中有浮点数，用double计算；如果输入中全是整数就用int64计算(including files `gpu/arange_kernels.cu`, `gpu/range_kernels.cu`, `cpu/arange_kernels.cc`, `cpu/range_kernels.cc` and `xpu/arange_kenerls.cc` )
- 仿照`arange` 中计算shape的函数`GetSize()` 将`range` 中计算shape的内容封装进了函数`GetSizeForRange()`（`funcs/range_function.h` ）

**Python** (`python/paddle/tensor/creation.py` ):
- 在`arange()` 和`range()` 中取消了将start、end、step构造成为dtype类型的tensor，构造tensor时保留输入原始的类型
- 在`arange()` 中dtype未指定时，根据strat/end/step的类型来决定dtype

**Common** (paddle/phi/common/data_type.h):
- 新增了 `IsFloatingPoint()` 和 `IsInteger()` 来判断类型是否为浮点数或整数

**InferMeta** (`paddle/phi/infermeta/ternary.cc` and `paddle/phi/infermeta/ternary.h`):
- 在`ArangeInferMeta()` 和 `RangeInferMeta()`中新增了DataType dtype参数，取消了将输出类型设置为输入类型
- 将无dtype参数的旧InferMeta函数重命名为`ArangeInferMetaLegacy` 和 `RangeInferMetaLegacy`进行保留

**YAML** (`paddle/phi/ops/yaml/`):
- `inconsistent/dygraph_ops.yaml`: 去除了输入和输出类型的强制统一，
- `legacy/static_ops.yaml`:将InferMeta函数改为`ArangeInferMetaLegacy` 和 `RangeInferMetaLegacy`以支持旧模型


### 是否引起精度变化
是 