### PR TITLE
[Inference] Remove std::filesystem to fix ARM64 SIGSEGV

### DIFF
--- a/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.h"
+
 #include <fstream>
+
 #include "paddle/fluid/framework/new_executor/instruction/instruction_util.h"
 #include "paddle/fluid/inference/analysis/helper.h"
 #include "paddle/fluid/pir/serialize_deserialize/include/interface.h"

--- a/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.h"
 #include <fstream>
 #include "paddle/fluid/framework/new_executor/instruction/instruction_util.h"
-#include "paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.h"
 #include "paddle/fluid/inference/analysis/helper.h"
 #include "paddle/fluid/pir/serialize_deserialize/include/interface.h"
 #include "paddle/fluid/platform/profiler/supplement_tracing.h"

--- a/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
+++ b/paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <filesystem>
-
+#include <fstream>
 #include "paddle/fluid/framework/new_executor/instruction/instruction_util.h"
 #include "paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.h"
 #include "paddle/fluid/inference/analysis/helper.h"
@@ -211,8 +210,10 @@ TensorRTEngineInstruction::TensorRTEngineInstruction(
   try {
     engine_data = ReadBinaryFileToString(engine_serialized_path);
   } catch (const std::exception &e) {
-    std::filesystem::path path(engine_serialized_path);
-    std::string filename = path.filename().string();
+    size_t last_slash = engine_serialized_path.find_last_of("/\\");
+    std::string filename = (last_slash == std::string::npos)
+                               ? engine_serialized_path
+                               : engine_serialized_path.substr(last_slash + 1);
     std::string file_root = FLAGS_trt_engine_serialized_path;
     engine_data = ReadBinaryFileToString(file_root + '/' + filename);
   }

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -14,8 +14,6 @@
 
 #include "paddle/fluid/inference/api/analysis_predictor.h"
 
-#include <glog/logging.h>
-
 #include <algorithm>
 #include <cstdlib>
 #include <fstream>
@@ -24,6 +22,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <glog/logging.h>
 
 #include "paddle/common/enforce.h"
 #include "paddle/common/errors.h"
@@ -63,6 +63,7 @@
 #include "paddle/phi/common/backend.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/place.h"
+#include "paddle/phi/core/generator.h"
 #include "paddle/phi/core/memory/memcpy.h"
 #include "paddle/phi/core/platform/cpu_helper.h"
 #include "paddle/phi/core/platform/device/gpu/gpu_info.h"
@@ -70,8 +71,6 @@
 #include "paddle/phi/core/platform/device_context.h"
 #include "paddle/phi/core/platform/profiler.h"
 #include "paddle/phi/core/tensor_utils.h"
-
-#include "paddle/phi/core/generator.h"
 #include "paddle/phi/kernels/funcs/data_type_transform.h"
 #include "paddle/utils/string/split.h"
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -470,7 +470,7 @@ bool AnalysisPredictor::Init(
     std::string model_dir = config_.model_dir();
     load_pir_model_ = false;
     std::string model_json_path = model_dir + "/__model__.json";
-    if (FileExists(model_json_path)) {
+    if (paddle::inference::IsFileExists(model_json_path)) {
       load_pir_model_ = true;
       config_.SetProgFile(model_json_path);
     }
@@ -491,7 +491,8 @@ bool AnalysisPredictor::Init(
     }
     std::string optimized_params =
         optimized_model_path + "/" + "_optimized.pdiparams";
-    if (FileExists(optimized_model) && FileExists(optimized_params)) {
+    if (paddle::inference::IsFileExists(optimized_model) &&
+        paddle::inference::IsFileExists(optimized_params)) {
       config_.SetModel(optimized_model, optimized_params);
       if (config_.new_ir_enabled()) {
         load_pir_model_ = true;
@@ -1375,7 +1376,7 @@ bool AnalysisPredictor::SaveOrLoadPirParameters(bool for_save) {
       }
 
     } else {
-      if (FileExists(config_.params_file())) {
+      if (paddle::inference::IsFileExists(config_.params_file())) {
         pir::LoadCombineFunction(config_.params_file(),
                                  filter_param_names,
                                  &tensor_out,

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -14,6 +14,8 @@
 
 #include "paddle/fluid/inference/api/analysis_predictor.h"
 
+#include <glog/logging.h>
+
 #include <algorithm>
 #include <cstdlib>
 #include <fstream>
@@ -22,8 +24,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <glog/logging.h>
 
 #include "paddle/common/enforce.h"
 #include "paddle/common/errors.h"

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <set>
@@ -470,13 +469,10 @@ bool AnalysisPredictor::Init(
   } else if (!config_.model_dir().empty()) {
     std::string model_dir = config_.model_dir();
     load_pir_model_ = false;
-    for (const auto &entry : std::filesystem::directory_iterator(model_dir)) {
-      if (entry.is_regular_file() &&
-          entry.path().filename() == "__model__.json") {
-        load_pir_model_ = true;
-        config_.SetProgFile(config_.model_dir() + "/__model__.json");
-        break;
-      }
+    std::string model_json_path = model_dir + "/__model__.json";
+    if (FileExists(model_json_path)) {
+      load_pir_model_ = true;
+      config_.SetProgFile(model_json_path);
     }
   }
   if (load_pir_model_) {
@@ -1379,7 +1375,7 @@ bool AnalysisPredictor::SaveOrLoadPirParameters(bool for_save) {
       }
 
     } else {
-      if (std::filesystem::exists(config_.params_file())) {
+      if (FileExists(config_.params_file())) {
         pir::LoadCombineFunction(config_.params_file(),
                                  filter_param_names,
                                  &tensor_out,

--- a/paddle/fluid/pir/serialize_deserialize/src/version_compat.cc
+++ b/paddle/fluid/pir/serialize_deserialize/src/version_compat.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string>
 #include "paddle/fluid/pir/serialize_deserialize/include/version_compat.h"
+#include <string>
 
 #include "paddle/fluid/pir/serialize_deserialize/include/patch_util.h"
 namespace pir {

--- a/paddle/fluid/pir/serialize_deserialize/src/version_compat.cc
+++ b/paddle/fluid/pir/serialize_deserialize/src/version_compat.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/pir/serialize_deserialize/include/version_compat.h"
+
 #include <string>
 
 #include "paddle/fluid/pir/serialize_deserialize/include/patch_util.h"

--- a/paddle/fluid/pir/serialize_deserialize/src/version_compat.cc
+++ b/paddle/fluid/pir/serialize_deserialize/src/version_compat.cc
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
 #include "paddle/fluid/pir/serialize_deserialize/include/version_compat.h"
-#include <filesystem>
+
 #include "paddle/fluid/pir/serialize_deserialize/include/patch_util.h"
 namespace pir {
 
@@ -25,11 +26,13 @@ void PatchBuilder::BuildPatch(uint64_t pir_version,
     std::string file_path = "";
     std::string file_name = std::to_string(v % max_version);
     if (!path.empty()) {
-      std::filesystem::path p(path.c_str());
-      std::filesystem::path patch_path = p / file_name;
-      patch_path += ".yaml";
+      std::string patch_path = path;
+      if (patch_path.back() != '/' && patch_path.back() != '\\') {
+        patch_path += "/";
+      }
+      patch_path += file_name + ".yaml";
       VLOG(8) << "Patch file: " << patch_path;
-      file_path = patch_path.string();
+      file_path = patch_path;
     }
     patch_json = YamlParser(file_name, file_path);
     VLOG(8) << "Build version " << v << " patch: " << patch_json;

--- a/test/cpp/pir/serialize_deserialize/save_load_version_compat_test.cc
+++ b/test/cpp/pir/serialize_deserialize/save_load_version_compat_test.cc
@@ -14,7 +14,6 @@
 
 #include <gtest/gtest.h>
 #include <stdio.h>
-#include <filesystem>
 #include <iostream>
 #include <map>
 #include <sstream>
@@ -68,9 +67,9 @@ TEST(save_load_version_compat, op_patch_test) {
   const uint64_t pir_version = 0;
   pir::PatchBuilder builder(pir_version);
   builder.SetFileVersion(1);
-  std::filesystem::path patch_path("patch");
+  std::string patch_path = "patch";
   VLOG(8) << "Patch path: " << patch_path;
-  builder.BuildPatch(2, 2, patch_path.string());
+  builder.BuildPatch(2, 2, patch_path);
 }
 
 bool ReadModuleForTest(const std::string &file_path,
@@ -86,9 +85,9 @@ bool ReadModuleForTest(const std::string &file_path,
         data.at(BASE_CODE).at(PIRVERSION).template get<uint64_t>();
     if (file_version != pir_version) {
       builder.SetFileVersion(file_version);
-      std::filesystem::path patch_path("patch");
+      std::string patch_path = "patch";
       VLOG(8) << "Patch path: " << patch_path;
-      builder.BuildPatch(2, 2, patch_path.string());
+      builder.BuildPatch(2, 2, patch_path);
     }
   } else {
     PADDLE_THROW(::common::errors::InvalidArgument("Invalid model file: %s.",

--- a/test/cpp/pir/serialize_deserialize/save_load_version_compat_test.cc
+++ b/test/cpp/pir/serialize_deserialize/save_load_version_compat_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+
 #include <stdio.h>
 #include <iostream>
 #include <map>
@@ -21,6 +22,7 @@
 #include <vector>
 
 #include "paddle/common/enforce.h"
+#include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_dialect.h"
 #include "paddle/fluid/pir/dialect/operator/ir/op_type.h"
 #include "paddle/fluid/pir/dialect/operator/utils/utils.h"
@@ -28,8 +30,6 @@
 #include "paddle/fluid/pir/serialize_deserialize/include/ir_deserialize.h"
 #include "paddle/fluid/pir/serialize_deserialize/include/version_compat.h"
 #include "paddle/phi/common/port.h"
-
-#include "paddle/fluid/pir/dialect/operator/ir/op_attribute.h"
 #include "paddle/phi/core/tensor_meta.h"
 #include "paddle/pir/include/core/block.h"
 #include "paddle/pir/include/core/builder.h"


### PR DESCRIPTION
### PR Category
Inference

### PR Types
Bug fixes

### Description
This PR resolves a recurring SIGSEGV (Segmentation Fault) observed in `AnalysisPredictor` and the PIR serialization layer on **Linux ARM64** (specifically within Docker environments on Apple Silicon M1/M2/M3).

**Root Cause:**
The crash was identified as an ABI/thread-safety instability in `std::filesystem` within the `libstdc++` implementation on aarch64. The destructor of `std::filesystem::path` would intermittently trigger a segmentation fault during predictor initialization or PIR model loading in Paddle 3.x.

**Solution:**
Removed all dependencies on the `std::filesystem` library in core inference and serialization paths, replacing them with more stable alternatives:
1.  **Path Management:** Replaced `std::filesystem::path` and its operators (like `/`) with standard `std::string` manipulation.
2.  **File Existence:** Switched from `std::filesystem::exists` to Paddle's internal `paddle::inference::IsFileExists` utility, which is robust and handles UTF-8 on Windows.
3.  **Directory Scanning:** Replaced `directory_iterator` with a targeted check for specific required files (e.g., `__model__.json`), ensuring safer initialization.

**Files Modified:**
- `paddle/fluid/inference/api/analysis_predictor.cc`: Eliminated filesystem usage in PIR model detection and parameter loading.
- `paddle/fluid/framework/new_executor/instruction/tensorrt_engine_instruction.cc`: Refactored filename extraction logic.
- `paddle/fluid/pir/serialize_deserialize/src/version_compat.cc`: Refactored path joining logic for patch building.
- `test/cpp/pir/serialize_deserialize/save_load_version_compat_test.cc`: Updated unit tests to maintain cross-platform stability.

**Verification:**
- **Reproduction:** Confirmed the crash in a Linux ARM64 container using official `paddlepaddle 3.2.2`.
- **Logic Validation:** Verified the replacement string manipulation logic with a targeted C++ smoke test on ARM64 hardware.
- **Compilation:** Verified that the modified files compile correctly using the GNU 14.2.0 toolchain on ARM64.

### 是否引起精度变化
否
