### PR TITLE
[FIX Blackwell release3.3] layer_norm backward

### DIFF
--- a/paddle/phi/kernels/gpu/layer_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_kernel.cu
@@ -700,8 +700,9 @@ void LayerNormKernel(const Context& dev_ctx,
     case LayerNormKernelVariant::GENERIC:
     default:
 #ifdef PADDLE_WITH_CUDA
-      if (FLAGS_use_accuracy_compatible_kernel ||
-          (!isPowerOfTwo(feature_size) && feature_size > 1024)) {
+      if ((x_dtype == scale_bias_dtype) &&
+          (FLAGS_use_accuracy_compatible_kernel ||
+           (!isPowerOfTwo(feature_size) && feature_size > 1024))) {
         LayerNormFwdCompatKernel<T, Context>(
             dev_ctx,
             x_data,

--- a/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
+++ b/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
@@ -1794,15 +1794,15 @@ template <typename T,
           unsigned int rows_per_block_y,
           bool partial_reduction,
           bool aligned_grid>
-__global__ void GammaBetaBackwardCUDAKernelTemplate(
-    int64_t M,
-    int64_t N,
-    const T* __restrict__ dY,
-    const T* __restrict__ X,
-    const T_ACC* __restrict__ mean,
-    const T_ACC* __restrict__ rstd,
-    T* __restrict__ dgamma,
-    T* __restrict__ dbeta) {
+__global__ void __launch_bounds__(block_dim_x* block_dim_y)
+    GammaBetaBackwardCUDAKernelTemplate(int64_t M,
+                                        int64_t N,
+                                        const T* __restrict__ dY,
+                                        const T* __restrict__ X,
+                                        const T_ACC* __restrict__ mean,
+                                        const T_ACC* __restrict__ rstd,
+                                        T* __restrict__ dgamma,
+                                        T* __restrict__ dbeta) {
   constexpr int rows_per_thread_y = rows_per_block_y / block_dim_y;
   static_assert(rows_per_thread_y <= kWarpSize);
 
@@ -2189,15 +2189,26 @@ void LayerNormBwdCompatKernel(
             dgamma_data,
             dbeta_data,
             stream);
-      } else {
-        // Use block_dim_y=16 (512 threads/block) instead of 32 (1024) to
-        // avoid "too many resources requested for launch" on architectures
-        // with higher per-thread register usage (e.g. Blackwell / SM 100).
+      } else if (M < 256) {
         ConfigureAndLaunchGammaBetaBackwardKernel<T,
                                                   T_ACC,
                                                   block_dim_x,
                                                   16,
                                                   128>(dY_data,
+                                                       X_data,
+                                                       mean_data,
+                                                       rstd_data,
+                                                       M,
+                                                       N,
+                                                       dgamma_data,
+                                                       dbeta_data,
+                                                       stream);
+      } else {
+        ConfigureAndLaunchGammaBetaBackwardKernel<T,
+                                                  T_ACC,
+                                                  block_dim_x,
+                                                  32,
+                                                  256>(dY_data,
                                                        X_data,
                                                        mean_data,
                                                        rstd_data,

--- a/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
+++ b/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
@@ -2189,26 +2189,15 @@ void LayerNormBwdCompatKernel(
             dgamma_data,
             dbeta_data,
             stream);
-      } else if (M < 256) {
+      } else {
+        // Use block_dim_y=16 (512 threads/block) instead of 32 (1024) to
+        // avoid "too many resources requested for launch" on architectures
+        // with higher per-thread register usage (e.g. Blackwell / SM 100).
         ConfigureAndLaunchGammaBetaBackwardKernel<T,
                                                   T_ACC,
                                                   block_dim_x,
                                                   16,
                                                   128>(dY_data,
-                                                       X_data,
-                                                       mean_data,
-                                                       rstd_data,
-                                                       M,
-                                                       N,
-                                                       dgamma_data,
-                                                       dbeta_data,
-                                                       stream);
-      } else {
-        ConfigureAndLaunchGammaBetaBackwardKernel<T,
-                                                  T_ACC,
-                                                  block_dim_x,
-                                                  32,
-                                                  256>(dY_data,
                                                        X_data,
                                                        mean_data,
                                                        rstd_data,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
devPR:https://github.com/PaddlePaddle/Paddle/pull/78782

根因：GammaBetaBackwardCUDAKernelTemplate 使用 block_dim_x=32, block_dim_y=32 =1024线程/block。在Blackwell (SM 100)架构上，编译器为每个线程生成了更多的寄存器，导致 1024 线程 × 寄存器数/线程 超出了SM的寄存器文件容量。Kernel完全没有执行（"too many resources requested for launch"），输出buffer保留了未初始化的脏数据（Inf/NaN）。H卡(Hopper SM 90)上同样的kernel没有问题，因为寄存器使用量更低。

修复：给GammaBetaBackwardCUDAKernelTemplate加上__launch_bounds__(block_dim_x* block_dim_y)

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否