### PR TITLE
fix(transpose): validate perm length in strided kernel

### DIFF
--- a/paddle/phi/kernels/stride/transpose_kernel.cc
+++ b/paddle/phi/kernels/stride/transpose_kernel.cc
@@ -32,6 +32,14 @@ void TransposeStridedKernel(const Context& dev_ctx,
         "be called, something wrong has happened!"));
   }
   size_t x_rank = x.dims().size();
+  PADDLE_ENFORCE_EQ(
+      axis.size(),
+      x_rank,
+      common::errors::InvalidArgument(
+          "The size of axis should be equal to the input tensor's rank, "
+          "but received axis size is %d and input rank is %d.",
+          axis.size(),
+          x_rank));
   std::vector<int> formatted_axis = axis;
   for (size_t i = 0; i < axis.size(); i++) {
     if (axis[i] < 0) {

--- a/test/legacy_test/test_transpose_op.py
+++ b/test/legacy_test/test_transpose_op.py
@@ -573,6 +573,24 @@ class TestTransposeOpError(unittest.TestCase):
             self.assertRaises(ValueError, test_each_elem_value_check)
 
 
+class TestTransposeDygraphStridedPermLenError(unittest.TestCase):
+    # Regression test for Issue #78756: when FLAGS_use_stride_kernel is on,
+    # eager paddle.transpose silently accepted perm with length != rank.
+    def test_perm_length_mismatch_raises(self):
+        paddle.disable_static()
+        paddle.set_device("cpu")
+        orig_flag = paddle.get_flags(["FLAGS_use_stride_kernel"])[
+            "FLAGS_use_stride_kernel"
+        ]
+        try:
+            paddle.set_flags({"FLAGS_use_stride_kernel": True})
+            x = paddle.arange(24, dtype="float32").reshape([2, 3, 4])
+            with self.assertRaises(ValueError):
+                paddle.transpose(x, [0, 1])
+        finally:
+            paddle.set_flags({"FLAGS_use_stride_kernel": orig_flag})
+
+
 class TestTransposeApi(unittest.TestCase):
     def test_static_out(self):
         paddle.enable_static()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

**Problem**

`paddle.transpose` in eager mode silently accepts an invalid `perm` whose length is less than the input tensor's rank when `FLAGS_use_stride_kernel=True`, returning a wrong-shaped tensor. The non-strided `TransposeKernel` rejects this via Eigen's `arity(dims) == D` check, so the eager strided path diverges from the static/compiled path.

Reproduction (from Issue #78756):

```python
import paddle
paddle.disable_static()
paddle.set_device("cpu")
paddle.set_flags({"FLAGS_use_stride_kernel": True})

x = paddle.arange(24, dtype="float32").reshape([2, 3, 4])
paddle.transpose(x, [0, 1])   # should raise; currently returns a tensor
```

**Root cause**

`paddle/phi/kernels/stride/transpose_kernel.cc::TransposeStridedKernel` never validates that `axis.size() == x.dims().size()`. `TransposeInferMeta` intentionally uses `GE` (not `EQ`) to support the `squeeze2 + transpose2` fusion pass, so the length check has to live in the kernel. The non-strided kernel gets the check implicitly through Eigen; the strided kernel does not.

**Fix**

Add an explicit `PADDLE_ENFORCE_EQ(axis.size(), x.dims().size(), ...)` at the entry of `TransposeStridedKernel`, mirroring the semantics of the non-strided path.

**Regression test**

`test/legacy_test/test_transpose_op.py::TestTransposeDygraphStridedPermLenError` runs in dygraph mode with `FLAGS_use_stride_kernel=True` and asserts `ValueError` on `perm=[0, 1]` for a 3-D tensor; restores the flag in `finally`.

Fixes #78756

### 是否引起精度变化
否
