### PR TITLE
Fix layer norm backward 33 v2

### DIFF
--- a/paddle/phi/kernels/gpu/layer_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_kernel.cu
@@ -700,8 +700,9 @@ void LayerNormKernel(const Context& dev_ctx,
     case LayerNormKernelVariant::GENERIC:
     default:
 #ifdef PADDLE_WITH_CUDA
-      if (FLAGS_use_accuracy_compatible_kernel ||
-          (!isPowerOfTwo(feature_size) && feature_size > 1024)) {
+      if ((x_dtype == scale_bias_dtype) &&
+          (FLAGS_use_accuracy_compatible_kernel ||
+           (!isPowerOfTwo(feature_size) && feature_size > 1024))) {
         LayerNormFwdCompatKernel<T, Context>(
             dev_ctx,
             x_data,

--- a/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
+++ b/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
@@ -1794,15 +1794,15 @@ template <typename T,
           unsigned int rows_per_block_y,
           bool partial_reduction,
           bool aligned_grid>
-__global__ void GammaBetaBackwardCUDAKernelTemplate(
-    int64_t M,
-    int64_t N,
-    const T* __restrict__ dY,
-    const T* __restrict__ X,
-    const T_ACC* __restrict__ mean,
-    const T_ACC* __restrict__ rstd,
-    T* __restrict__ dgamma,
-    T* __restrict__ dbeta) {
+__global__ void __launch_bounds__(block_dim_x* block_dim_y)
+    GammaBetaBackwardCUDAKernelTemplate(int64_t M,
+                                        int64_t N,
+                                        const T* __restrict__ dY,
+                                        const T* __restrict__ X,
+                                        const T_ACC* __restrict__ mean,
+                                        const T_ACC* __restrict__ rstd,
+                                        T* __restrict__ dgamma,
+                                        T* __restrict__ dbeta) {
   constexpr int rows_per_thread_y = rows_per_block_y / block_dim_y;
   static_assert(rows_per_thread_y <= kWarpSize);
 
@@ -2189,15 +2189,26 @@ void LayerNormBwdCompatKernel(
             dgamma_data,
             dbeta_data,
             stream);
-      } else {
-        // Use block_dim_y=16 (512 threads/block) instead of 32 (1024) to
-        // avoid "too many resources requested for launch" on architectures
-        // with higher per-thread register usage (e.g. Blackwell / SM 100).
+      } else if (M < 256) {
         ConfigureAndLaunchGammaBetaBackwardKernel<T,
                                                   T_ACC,
                                                   block_dim_x,
                                                   16,
                                                   128>(dY_data,
+                                                       X_data,
+                                                       mean_data,
+                                                       rstd_data,
+                                                       M,
+                                                       N,
+                                                       dgamma_data,
+                                                       dbeta_data,
+                                                       stream);
+      } else {
+        ConfigureAndLaunchGammaBetaBackwardKernel<T,
+                                                  T_ACC,
+                                                  block_dim_x,
+                                                  32,
+                                                  256>(dY_data,
                                                        X_data,
                                                        mean_data,
                                                        rstd_data,

--- a/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
+++ b/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
@@ -430,6 +430,11 @@ void launch_vectorized_rms_norm_kernel_driver(int N,
   vectorized_rms_norm_kernel<T, T_ACC, kVecSize>
       <<<blocks, threads, nshared, stream>>>(
           N, eps, X_data, scale_data, rstd_data, Y_data);
+#ifdef PADDLE_WITH_HIP
+  PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
 }
 
 struct WelfordDataLN {
@@ -709,6 +714,11 @@ void launch_vectorized_layer_norm_kernel_driver(int N,
   vectorized_layer_norm_kernel<T, T_ACC, kVecSize>
       <<<blocks, threads, nshared, stream>>>(
           N, eps, X_data, gamma_data, beta_data, mean_data, var_data, Y_data);
+#ifdef PADDLE_WITH_HIP
+  PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
 }
 
 template <typename T, typename Context>
@@ -723,6 +733,11 @@ void LayerNormFwdCompatKernel(
     T* y_data,
     typename phi::dtype::MPTypeTrait<T>::Type* mean_data,
     typename phi::dtype::MPTypeTrait<T>::Type* var_data) {
+#ifdef PADDLE_WITH_HIP
+  PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
   using T_ACC = typename phi::dtype::MPTypeTrait<T>::Type;
 
   if (rows == 0 || cols == 0) {
@@ -763,7 +778,11 @@ void LayerNormFwdCompatKernel(
     LayerNormRowwiseMomentsCUDAKernel<T, T_ACC>
         <<<rows, kCUDABlockReduceNumThreads, 0, stream>>>(
             cols, static_cast<T_ACC>(epsilon), x_data, mean_data, var_data);
-
+#ifdef PADDLE_WITH_HIP
+    PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+    PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     LayerNormForwardCUDAKernel<T, T_ACC>
         <<<rows, kCUDANumThreads, 0, stream>>>(cols,
                                                x_data,
@@ -773,6 +792,11 @@ void LayerNormFwdCompatKernel(
                                                gamma_data,
                                                beta_data,
                                                y_data);
+#ifdef PADDLE_WITH_HIP
+    PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+    PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
   }
 }
 
@@ -1184,6 +1208,11 @@ void ConfigureAndLaunchScaleBackwardKernel(const T* dY_data,
                                       true>
           <<<blocks, threads, shmem_sz, cuda_stream>>>(
               M, N, dY_data, X_data, rstd_data, dscale_data);
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     } else {
       ScaleBackwardCUDAKernelTemplate<T,
                                       T_ACC,
@@ -1194,6 +1223,11 @@ void ConfigureAndLaunchScaleBackwardKernel(const T* dY_data,
                                       false>
           <<<blocks, threads, shmem_sz, cuda_stream>>>(
               M, N, dY_data, X_data, rstd_data, dscale_data);
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     }
   } else {
     if (aligned_grid) {
@@ -1206,6 +1240,11 @@ void ConfigureAndLaunchScaleBackwardKernel(const T* dY_data,
                                       true>
           <<<blocks, threads, shmem_sz, cuda_stream>>>(
               M, N, dY_data, X_data, rstd_data, dscale_data);
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     } else {
       ScaleBackwardCUDAKernelTemplate<T,
                                       T_ACC,
@@ -1216,6 +1255,11 @@ void ConfigureAndLaunchScaleBackwardKernel(const T* dY_data,
                                       false>
           <<<blocks, threads, shmem_sz, cuda_stream>>>(
               M, N, dY_data, X_data, rstd_data, dscale_data);
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     }
   }
 }
@@ -1232,7 +1276,12 @@ void RMSNormFwdKernel(const Context& dev_ctx,
                       double epsilon,
                       DenseTensor* y,
                       DenseTensor* invvar) {
-  using T_ACC = typename phi::dtype::MPTypeTrait<T>::Type;
+#ifdef PADDLE_WITH_HIP
+  PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
+  using T_ACC = typename dtype::MPTypeTrait<T>::Type;
 
   if (x.numel() == 0) {
     dev_ctx.template Alloc<T>(y);
@@ -1313,9 +1362,19 @@ void RMSNormFwdKernel(const Context& dev_ctx,
     RowwiseMomentsCUDAKernel<T, T_ACC>
         <<<rows, kCUDABlockReduceNumThreads, 0, stream>>>(
             cols, static_cast<T_ACC>(epsilon), x_data, rstd_data);
+#ifdef PADDLE_WITH_HIP
+    PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+    PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
 
     RMSNormForwardCUDAKernel<T, T_ACC><<<rows, kCUDANumThreads, 0, stream>>>(
         cols, x_data, rstd_data, scale_data, y_data);
+#ifdef PADDLE_WITH_HIP
+    PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+    PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
   }
 }
 
@@ -1329,7 +1388,12 @@ void RMSNormBwdKernel(const Context& dev_ctx,
                       double epsilon,
                       DenseTensor* dX,
                       DenseTensor* dscale) {
-  using T_ACC = typename phi::dtype::MPTypeTrait<T>::Type;
+#ifdef PADDLE_WITH_HIP
+  PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
+  using T_ACC = typename dtype::MPTypeTrait<T>::Type;
 
   if (X.numel() == 0) {
     if (dX) {
@@ -1396,14 +1460,29 @@ void RMSNormBwdKernel(const Context& dev_ctx,
       rms_norm_grad_input_kernel_vectorized<T, T_ACC, 8>
           <<<blocks, num_threads, nshared, stream>>>(
               dY_data, X_data, invvar_data, scale_data, dX_data, N);
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     } else if (is_supported_type && bAlignedBuffers && bVectorSizeMultiple) {
       rms_norm_grad_input_kernel_vectorized<T, T_ACC, kVecSize>
           <<<blocks, num_threads, nshared, stream>>>(
               dY_data, X_data, invvar_data, scale_data, dX_data, N);
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     } else {
       rms_norm_grad_input_kernel<T, T_ACC>
           <<<blocks, num_threads, nshared, stream>>>(
               dY_data, X_data, invvar_data, scale_data, dX_data, N);
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     }
   }
 
@@ -1437,6 +1516,11 @@ void RMSNormBwdKernel(const Context& dev_ctx,
                                         true,
                                         true><<<blocks, threads, 0, stream>>>(
             M, N, dY_data, X_data, invvar_data, dscale_blocks_ptr);
+#ifdef PADDLE_WITH_HIP
+        PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+        PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
       } else {
         ScaleBackwardCUDAKernelTemplate<T,
                                         T_ACC,
@@ -1446,6 +1530,11 @@ void RMSNormBwdKernel(const Context& dev_ctx,
                                         true,
                                         false><<<blocks, threads, 0, stream>>>(
             M, N, dY_data, X_data, invvar_data, dscale_blocks_ptr);
+#ifdef PADDLE_WITH_HIP
+        PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+        PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
       }
 
       // Sum reduction along blocks.y dimension to get final dscale
@@ -1943,6 +2032,11 @@ void ConfigureAndLaunchGammaBetaBackwardKernel(const T* dY_data,
                                                        rstd_data,
                                                        dgamma_data,
                                                        dbeta_data);
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     } else {
       GammaBetaBackwardCUDAKernelTemplate<T,
                                           T_ACC,
@@ -1959,6 +2053,11 @@ void ConfigureAndLaunchGammaBetaBackwardKernel(const T* dY_data,
                                                        rstd_data,
                                                        dgamma_data,
                                                        dbeta_data);
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     }
   } else {
     if (aligned_grid) {
@@ -1977,6 +2076,11 @@ void ConfigureAndLaunchGammaBetaBackwardKernel(const T* dY_data,
                                                        rstd_data,
                                                        dgamma_data,
                                                        dbeta_data);
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     } else {
       GammaBetaBackwardCUDAKernelTemplate<T,
                                           T_ACC,
@@ -1993,6 +2097,11 @@ void ConfigureAndLaunchGammaBetaBackwardKernel(const T* dY_data,
                                                        rstd_data,
                                                        dgamma_data,
                                                        dbeta_data);
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     }
   }
 }
@@ -2011,6 +2120,11 @@ void LayerNormBwdCompatKernel(
     double epsilon,
     int64_t rows,
     int64_t cols) {
+#ifdef PADDLE_WITH_HIP
+  PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
   using T_ACC = typename phi::dtype::MPTypeTrait<T>::Type;
   if (rows == 0 || cols == 0) return;
   auto stream = dev_ctx.stream();
@@ -2028,6 +2142,11 @@ void LayerNormBwdCompatKernel(
     int64_t num_blocks = (M + kBlockSize - 1) / kBlockSize;
     VarToRstdKernel<T_ACC><<<num_blocks, kBlockSize, 0, stream>>>(
         var_data, static_cast<T_ACC>(epsilon), rstd_data, M);
+#ifdef PADDLE_WITH_HIP
+    PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+    PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
   }
 
   // Step 2: Compute dX using vectorized or non-vectorized kernel
@@ -2059,6 +2178,11 @@ void LayerNormBwdCompatKernel(
       layer_norm_grad_input_kernel_vectorized<T, T_ACC, kVecSize>
           <<<blocks, num_threads, nshared, stream>>>(
               dY_data, X_data, mean_data, rstd_data, gamma_data, dX_data, N);
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
     } else {
       layer_norm_grad_input_kernel<T, T_ACC>
           <<<blocks, num_threads, nshared, stream>>>(
@@ -2112,6 +2236,11 @@ void LayerNormBwdCompatKernel(
                                              rstd_data,
                                              dgamma_blocks_ptr,
                                              dbeta_blocks_ptr);
+#ifdef PADDLE_WITH_HIP
+        PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+        PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
       } else {
         GammaBetaBackwardCUDAKernelTemplate<T,
                                             T_ACC,
@@ -2128,6 +2257,11 @@ void LayerNormBwdCompatKernel(
                                              rstd_data,
                                              dgamma_blocks_ptr,
                                              dbeta_blocks_ptr);
+#ifdef PADDLE_WITH_HIP
+        PADDLE_ENFORCE_GPU_SUCCESS(hipGetLastError());
+#else
+        PADDLE_ENFORCE_GPU_SUCCESS(cudaGetLastError());
+#endif
       }
 
       // Sum reduction along blocks.y dimension to get final dgamma/dbeta.

--- a/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
+++ b/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
@@ -2189,26 +2189,15 @@ void LayerNormBwdCompatKernel(
             dgamma_data,
             dbeta_data,
             stream);
-      } else if (M < 256) {
+      } else {
+        // Use block_dim_y=16 (512 threads/block) instead of 32 (1024) to
+        // avoid "too many resources requested for launch" on architectures
+        // with higher per-thread register usage (e.g. Blackwell / SM 100).
         ConfigureAndLaunchGammaBetaBackwardKernel<T,
                                                   T_ACC,
                                                   block_dim_x,
                                                   16,
                                                   128>(dY_data,
-                                                       X_data,
-                                                       mean_data,
-                                                       rstd_data,
-                                                       M,
-                                                       N,
-                                                       dgamma_data,
-                                                       dbeta_data,
-                                                       stream);
-      } else {
-        ConfigureAndLaunchGammaBetaBackwardKernel<T,
-                                                  T_ACC,
-                                                  block_dim_x,
-                                                  32,
-                                                  256>(dY_data,
                                                        X_data,
                                                        mean_data,
                                                        rstd_data,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
devPR:https://github.com/PaddlePaddle/Paddle/pull/78794
revert 掉 revert的代码，并加上修改GammaBetaBackwardCUDAKernelTemplate的修改。

根因：GammaBetaBackwardCUDAKernelTemplate 使用 block_dim_x=32, block_dim_y=32 =1024线程/block。在Blackwell (SM 100)架构上，编译器为每个线程生成了更多的寄存器，导致 1024 线程 × 寄存器数/线程 超出了SM的寄存器文件容量。Kernel完全没有执行（"too many resources requested for launch"），输出buffer保留了未初始化的脏数据（Inf/NaN）。H卡(Hopper SM 90)上同样的kernel没有问题，因为寄存器使用量更低。

修复：给GammaBetaBackwardCUDAKernelTemplate加上__launch_bounds__(block_dim_x* block_dim_y)

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否