### PR TITLE
[Operator Mechanism] fix(erfinv): return NaN for out-of-domain inputs

### DIFF
--- a/paddle/phi/kernels/cpu/erfinv_kernel.cc
+++ b/paddle/phi/kernels/cpu/erfinv_kernel.cc
@@ -18,6 +18,8 @@
 
 #include "paddle/phi/kernels/erfinv_kernel.h"
 
+#include <limits>
+
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
@@ -36,7 +38,14 @@ void ErfinvKernel(const Context& dev_ctx,
   auto& place = *dev_ctx.eigen_device();
   constexpr T half = static_cast<T>(0.5);
   constexpr T half_sqrt = static_cast<T>(M_SQRT1_2);
-  eigen_out.device(place) = (eigen_in * half + half).ndtri() * half_sqrt;
+  constexpr T one = static_cast<T>(1);
+  const T nan_val = std::numeric_limits<T>::quiet_NaN();
+  // erfinv is only defined on [-1, 1]; align with PyTorch/scipy by returning
+  // NaN for |x| > 1 (boundary +/-1 still yields +/-inf through ndtri).
+  eigen_out.device(place) =
+      (eigen_in.abs() > eigen_in.constant(one))
+          .select(eigen_in.constant(nan_val),
+                  (eigen_in * half + half).ndtri() * half_sqrt);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/erfinv_kernel.cu
+++ b/paddle/phi/kernels/gpu/erfinv_kernel.cu
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/erfinv_kernel.h"
+
+#include <limits>
+
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
@@ -21,12 +24,22 @@ namespace phi {
 
 template <typename T>
 struct ErfinvFunctor {
-  HOSTDEVICE inline T operator()(const T x) const { return erfinv(x); }
+  HOSTDEVICE inline T operator()(const T x) const {
+    // erfinv is only defined on [-1, 1]; align with PyTorch/scipy by
+    // returning NaN for |x| > 1 (CUDA erfinv returns +/-inf otherwise).
+    if (x > static_cast<T>(1) || x < static_cast<T>(-1)) {
+      return std::numeric_limits<T>::quiet_NaN();
+    }
+    return erfinv(x);
+  }
 };
 template <>
 struct ErfinvFunctor<float16> {
   HOSTDEVICE inline float16 operator()(const float16 x) const {
     auto x_ = static_cast<float>(x);
+    if (x_ > 1.0f || x_ < -1.0f) {
+      return static_cast<float16>(std::numeric_limits<float>::quiet_NaN());
+    }
     return static_cast<float16>(erfinv(x_));
   }
 };
@@ -35,6 +48,9 @@ template <>
 struct ErfinvFunctor<bfloat16> {
   HOSTDEVICE inline bfloat16 operator()(const bfloat16 x) const {
     auto x_ = static_cast<float>(x);
+    if (x_ > 1.0f || x_ < -1.0f) {
+      return static_cast<bfloat16>(std::numeric_limits<float>::quiet_NaN());
+    }
     return static_cast<bfloat16>(erfinv(x_));
   }
 };

--- a/test/legacy_test/test_erfinv_op.py
+++ b/test/legacy_test/test_erfinv_op.py
@@ -166,5 +166,44 @@ class TestErfinvBF16Op(OpTest):
         self.check_grad_with_place(place, ['X'], 'Out', check_pir=True)
 
 
+class TestErfinvOutOfDomainNaN(unittest.TestCase):
+    """|x| > 1 must return NaN to match PyTorch / scipy; +/-1 stays +/-inf.
+
+    Covers issues #78106 / #78107 / #78121.
+    """
+
+    def _run(self, place, dtype):
+        paddle.disable_static(place)
+        x_np = np.asarray(
+            [-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, np.nan], dtype=dtype
+        )
+        out = paddle.erfinv(paddle.to_tensor(x_np)).numpy()
+
+        # |x| > 1 -> NaN
+        self.assertTrue(np.isnan(out[0]))  # -1.5
+        self.assertTrue(np.isnan(out[6]))  # +1.5
+        # +/-1 -> +/-inf (not NaN)
+        self.assertTrue(np.isneginf(out[1]))
+        self.assertTrue(np.isposinf(out[5]))
+        # In-domain values stay finite
+        for idx in (2, 3, 4):
+            self.assertTrue(np.isfinite(out[idx]))
+        # NaN input propagates as NaN
+        self.assertTrue(np.isnan(out[7]))
+        paddle.enable_static()
+
+    def test_dygraph_cpu(self):
+        for dtype in ('float32', 'float64'):
+            self._run(paddle.CPUPlace(), dtype)
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda(),
+        'core is not compiled with CUDA',
+    )
+    def test_dygraph_gpu(self):
+        for dtype in ('float32', 'float64'):
+            self._run(paddle.CUDAPlace(0), dtype)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

修复 `paddle.erfinv` 在越界输入（`|x| > 1`）时返回 `±inf` 而非 `NaN`、与 PyTorch / `scipy.special.erfinv` / 数学定义不一致的问题。

#### 背景

- `erfinv` 的数学定义域为 `(-1, 1)`，`±1` 处为 `±∞`。
- 当前 CPU 实现经 Eigen 的 `ndtri`：对 `p ≤ 0` 返回 `-inf`、`p ≥ 1` 返回 `+inf`，因此 `x < -1` 得到 `-inf`，`x > 1` 得到 `+inf`。
- GPU 实现直接调用 CUDA 设备端 `erfinv(x)`，越界同样返回 `±inf`。
- PyTorch / scipy 对 `|x| > 1` 统一返回 `NaN`，这一差异导致 paddle↔torch 的算子等价迁移校验在三个 issue 中被判定失败。

关联 Issue：
- Fixes #78121
- Fixes #78107
- Fixes #78106

#### 改动

- `paddle/phi/kernels/cpu/erfinv_kernel.cc`：在 Eigen 表达式上加一层 `(|x| > 1).select(NaN, computed)` 掩码。
- `paddle/phi/kernels/gpu/erfinv_kernel.cu`：`ErfinvFunctor<T>` 及 `float16` / `bfloat16` 特化在 `x > 1 || x < -1` 时早退返回 `NaN`，其余路径保持原 `erfinv(x)` 调用。
- `test/legacy_test/test_erfinv_op.py`：新增 `TestErfinvOutOfDomainNaN`，覆盖双向越界 → NaN、边界 `±1` → `±inf`、NaN 输入 → NaN 的不变式。

反向 kernel 未变动：前向输出 `NaN` 时，`dx = sqrt(π)/2 · dy · exp(y²)` 自然传播 `NaN`。

#### 行为变化

| 输入 | 修复前 | 修复后 | PyTorch / scipy |
| --- | --- | --- | --- |
| `\|x\| < 1` | 正常 | 正常（不变） | 正常 |
| `x = ±1` | `±inf` | `±inf`（不变） | `±inf` |
| `\|x\| > 1` | `±inf` | `NaN` | `NaN` |
| `x = NaN` | `NaN` | `NaN` | `NaN` |

#### 验证

- Python 语义仿真：用 `scipy.stats.norm.ppf` 模拟 Eigen `ndtri` + `select` 掩码路径，三个 issue 输入全部通过。
- 独立 Eigen 3.4.0 + g++ 编译测试：与 kernel 完全相同的表达式，三个 issue 输入下所有 `|x| > 1` 样本均得到 NaN，定义域内与 `±1` 行为保持不变。
- 本地无完整 Paddle 构建环境，GPU 分支逻辑平凡，其正确性由 CI 的 CUDA 构建与既有 `test_erfinv_op.py` 回归覆盖。

### 是否引起精度变化

否。仅在原本就落在数学定义域外（`|x| > 1`）且行为未定义的输入上，由 `±inf` 改为 `NaN`；定义域内与 `±1` 处输出完全不变，不影响任何合法输入下的模型精度。
