### PR TITLE
Fix allocator_facade.h overloaded error when enabling PADDLE_WITH_CUD…

### DIFF
--- a/paddle/phi/core/memory/allocation/allocator_facade.h
+++ b/paddle/phi/core/memory/allocation/allocator_facade.h
@@ -102,7 +102,8 @@ class AllocatorFacade {
   PADDLE_API bool IsStreamSafeCUDAAllocatorUsed();
   PADDLE_API bool IsCUDAMallocAsyncAllocatorUsed();
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#if (defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) && \
+    !defined(PADDLE_WITH_CUSTOM_DEVICE)
   // TODO(zhiqiu): change gpuStream_t to phi::Stream if needed.
   uint64_t Release(const GPUPlace& place, gpuStream_t stream);
   bool RecordStream(std::shared_ptr<Allocation> allocation, gpuStream_t stream);


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
<img width="1458" height="185" alt="032CF94168AF6E539DB7CF2847FCDDC2" src="https://github.com/user-attachments/assets/d1d28761-6842-407c-9ff8-2fbb214fdad5" />
如果在FastDeploy里#include "paddle/phi/core/memory/allocation/allocator_facade.h"，在天数硬件上编译会报错，看了一下编译的log，应该是同时开启了PADDLE_WITH_CUDA和PADDLE_WITH_CUSTOM_DEVIC导致函数重名报错了，在paddle里allocator_facade.h的代码如下：
<img width="828" height="945" alt="4951ADCA75DF7F19481E15D1806925B5" src="https://github.com/user-attachments/assets/d2e285b3-acbf-4d66-8b45-4444d91bd849" />
然后malloc.h里也有类似的代码，通过!defined(PADDLE_WITH_CUSTOM_DEVICE)来避免了这个问题：
<img width="775" height="658" alt="C12D2A9E6947EA8A66FEEF8600326B4C" src="https://github.com/user-attachments/assets/faea1bfe-6762-4c27-a1d2-b83df6bd6e6f" />

所以参考malloc.h，在allocator_facade.h里也加上了!defined(PADDLE_WITH_CUSTOM_DEVICE)

### 是否引起精度变化
否