### PR TITLE
[Operator Mechanism] refine erfinv out-of-domain NaN follow-up

### DIFF
--- a/paddle/phi/kernels/gpu/erfinv_kernel.cu
+++ b/paddle/phi/kernels/gpu/erfinv_kernel.cu
@@ -38,7 +38,7 @@ struct ErfinvFunctor<float16> {
   HOSTDEVICE inline float16 operator()(const float16 x) const {
     auto x_ = static_cast<float>(x);
     if (x_ > 1.0f || x_ < -1.0f) {
-      return static_cast<float16>(std::numeric_limits<float>::quiet_NaN());
+      return std::numeric_limits<float16>::quiet_NaN();
     }
     return static_cast<float16>(erfinv(x_));
   }
@@ -49,7 +49,7 @@ struct ErfinvFunctor<bfloat16> {
   HOSTDEVICE inline bfloat16 operator()(const bfloat16 x) const {
     auto x_ = static_cast<float>(x);
     if (x_ > 1.0f || x_ < -1.0f) {
-      return static_cast<bfloat16>(std::numeric_limits<float>::quiet_NaN());
+      return std::numeric_limits<bfloat16>::quiet_NaN();
     }
     return static_cast<bfloat16>(erfinv(x_));
   }

--- a/test/legacy_test/test_erfinv_op.py
+++ b/test/legacy_test/test_erfinv_op.py
@@ -174,23 +174,31 @@ class TestErfinvOutOfDomainNaN(unittest.TestCase):
 
     def _run(self, place, dtype):
         paddle.disable_static(place)
-        x_np = np.asarray(
-            [-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, np.nan], dtype=dtype
-        )
-        out = paddle.erfinv(paddle.to_tensor(x_np)).numpy()
+        try:
+            values = [-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, np.nan]
+            if dtype == 'bfloat16':
+                # NumPy does not support bfloat16; build with float32 first.
+                x_tensor = paddle.to_tensor(
+                    np.asarray(values, dtype='float32')
+                ).astype('bfloat16')
+                out = paddle.erfinv(x_tensor).astype('float32').numpy()
+            else:
+                x_np = np.asarray(values, dtype=dtype)
+                out = paddle.erfinv(paddle.to_tensor(x_np)).numpy()
 
-        # |x| > 1 -> NaN
-        self.assertTrue(np.isnan(out[0]))  # -1.5
-        self.assertTrue(np.isnan(out[6]))  # +1.5
-        # +/-1 -> +/-inf (not NaN)
-        self.assertTrue(np.isneginf(out[1]))
-        self.assertTrue(np.isposinf(out[5]))
-        # In-domain values stay finite
-        for idx in (2, 3, 4):
-            self.assertTrue(np.isfinite(out[idx]))
-        # NaN input propagates as NaN
-        self.assertTrue(np.isnan(out[7]))
-        paddle.enable_static()
+            # |x| > 1 -> NaN
+            self.assertTrue(np.isnan(out[0]))  # -1.5
+            self.assertTrue(np.isnan(out[6]))  # +1.5
+            # +/-1 -> +/-inf (not NaN)
+            self.assertTrue(np.isneginf(out[1]))
+            self.assertTrue(np.isposinf(out[5]))
+            # In-domain values stay finite
+            for idx in (2, 3, 4):
+                self.assertTrue(np.isfinite(out[idx]))
+            # NaN input propagates as NaN
+            self.assertTrue(np.isnan(out[7]))
+        finally:
+            paddle.enable_static()
 
     def test_dygraph_cpu(self):
         for dtype in ('float32', 'float64'):
@@ -201,8 +209,11 @@ class TestErfinvOutOfDomainNaN(unittest.TestCase):
         'core is not compiled with CUDA',
     )
     def test_dygraph_gpu(self):
-        for dtype in ('float32', 'float64'):
-            self._run(paddle.CUDAPlace(0), dtype)
+        place = paddle.CUDAPlace(0)
+        for dtype in ('float32', 'float64', 'float16'):
+            self._run(place, dtype)
+        if core.is_bfloat16_supported(place):
+            self._run(place, 'bfloat16')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Improvements

### Description

#### 背景

本 PR 是 #78802 (`fix(erfinv): return NaN for out-of-domain inputs`) 的 follow-up，针对该 PR 中 Copilot review 给出的 3 条建议进行落实。

#### 主要改动

1. **`paddle/phi/kernels/gpu/erfinv_kernel.cu`**：`float16` / `bfloat16` 特化中，将原来的 `static_cast<T>(std::numeric_limits<float>::quiet_NaN())` 改为直接使用 `std::numeric_limits<float16>::quiet_NaN()` / `std::numeric_limits<bfloat16>::quiet_NaN()`，复用 Paddle 已为 `phi::float16` / `phi::bfloat16` 提供的 `numeric_limits` 特化（见 `paddle/phi/common/float16.h`、`bfloat16.h`），避免 NaN 跨类型转换，风格上也与其他 PHI kernel 一致。

2. **`test/legacy_test/test_erfinv_op.py`**：在 `TestErfinvOutOfDomainNaN._run` 中将动态图测试主体包入 `try / finally`，确保即使断言失败也能恢复 `paddle.enable_static()`，避免全局静态/动态模式状态泄漏污染同文件内后续的静态图 op 测试。

3. **`test/legacy_test/test_erfinv_op.py`**：扩展 GPU 测试用例覆盖 `float16` 与 `bfloat16`（后者在 `core.is_bfloat16_supported(place)` 时才执行），覆盖 #78802 新增的 GPU functor 特化分支，防止后续回归。`bfloat16` 由于 numpy 不支持，先用 `float32` 构造再 `astype('bfloat16')`。

#### 验证

- `pre-commit run --files paddle/phi/kernels/gpu/erfinv_kernel.cu test/legacy_test/test_erfinv_op.py` 全部通过。
- 不修改外部 API、不改变 `[-1, 1]` 域内的数值行为，仅整理 NaN 构造方式与扩展测试覆盖。

### 是否引起精度变化

否