### PR TITLE
[API Compatibility] fix default device.id

### DIFF
--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -8393,7 +8393,7 @@ def _get_paddle_place(place):
         if place == "gpu_pinned":
             return core.CUDAPinnedPlace()
         elif place == "gpu" or place == "dcu":
-            return core.CUDAPlace(0)
+            return _current_expected_place_()
         else:
             place_info_list = place.split(":", 1)
             device_id = place_info_list[1]

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -8393,7 +8393,10 @@ def _get_paddle_place(place):
         if place == "gpu_pinned":
             return core.CUDAPinnedPlace()
         elif place == "gpu" or place == "dcu":
-            return _current_expected_place_()
+            if isinstance(_current_expected_place_(), core.CUDAPlace):
+                return _current_expected_place_()
+            else:
+                return core.CUDAPlace(0)
         else:
             place_info_list = place.split(":", 1)
             device_id = place_info_list[1]

--- a/test/legacy_test/test_device.py
+++ b/test/legacy_test/test_device.py
@@ -118,26 +118,33 @@ class TestImperativeDeviceManage(unittest.TestCase):
 class TestGetPaddlePlaceAdaptiveGPU(unittest.TestCase):
     """Test that _get_paddle_place('gpu'/'cuda') respects the globally set device ID."""
 
+    def setUp(self):
+        paddle.disable_static()
+
     def test_empty_device_cuda_follows_set_device(self):
         """paddle.empty(device='cuda') should be placed on the device
         selected by paddle.device.set_device('cuda:1'), not always GPU 0."""
-        if not core.is_compiled_with_cuda() or core.get_cuda_device_count() < 2:
+        if not core.is_compiled_with_cuda():
+            return
+        if core.get_cuda_device_count() < 2:
             return
         paddle.device.set_device('cuda:1')
         a = paddle.empty(1, device='cuda')
-        device_str = str(a.device)
+        place_str = str(a.place)
         # restore default
         paddle.device.set_device('cuda:0')
         self.assertIn(
             '1',
-            device_str,
-            msg=f"Expected tensor on GPU 1 but got place: {device_str}",
+            place_str,
+            msg=f"Expected tensor on GPU 1 but got place: {place_str}",
         )
 
     def test_empty_device_gpu_follows_set_device_cpu(self):
-        """paddle.empty(device='gpu') should also respect set_device('gpu:1')."""
-        if not core.is_compiled_with_cuda() or core.get_cuda_device_count() < 1:
-            self.skipTest("Requires at least 1 GPU devices")
+        """paddle.empty(device='gpu') should also respect set_device('gpu:0')."""
+        if not core.is_compiled_with_cuda():
+            return
+        if core.get_cuda_device_count() < 1:
+            return
         paddle.device.set_device('gpu:0')
         a = paddle.empty(1, device='gpu')
         self.assertTrue(a.place.is_gpu_place())

--- a/test/legacy_test/test_device.py
+++ b/test/legacy_test/test_device.py
@@ -115,5 +115,40 @@ class TestImperativeDeviceManage(unittest.TestCase):
                 self.assertEqual(device, get_device(True))
 
 
+class TestGetPaddlePlaceAdaptiveGPU(unittest.TestCase):
+    """Test that _get_paddle_place('gpu'/'cuda') respects the globally set device ID."""
+
+    def test_empty_device_cuda_follows_set_device(self):
+        """paddle.empty(device='cuda') should be placed on the device
+        selected by paddle.device.set_device('cuda:1'), not always GPU 0."""
+        if not core.is_compiled_with_cuda() or core.get_cuda_device_count() < 2:
+            return
+        paddle.device.set_device('cuda:1')
+        a = paddle.empty(1, device='cuda')
+        device_str = str(a.device)
+        # restore default
+        paddle.device.set_device('cuda:0')
+        self.assertIn(
+            '1',
+            device_str,
+            msg=f"Expected tensor on GPU 1 but got place: {device_str}",
+        )
+
+    def test_empty_device_gpu_follows_set_device(self):
+        """paddle.empty(device='gpu') should also respect set_device('gpu:1')."""
+        if not core.is_compiled_with_cuda() or core.get_cuda_device_count() < 2:
+            self.skipTest("Requires at least 2 GPU devices")
+        paddle.device.set_device('gpu:1')
+        a = paddle.empty(1, device='gpu')
+        device_str = str(a.device)
+        # restore default
+        paddle.device.set_device('gpu:0')
+        self.assertIn(
+            '1',
+            device_str,
+            msg=f"Expected tensor on GPU 1 but got place: {device_str}",
+        )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_device.py
+++ b/test/legacy_test/test_device.py
@@ -149,6 +149,39 @@ class TestGetPaddlePlaceAdaptiveGPU(unittest.TestCase):
             msg=f"Expected tensor on GPU 1 but got place: {device_str}",
         )
 
+        paddle.device.set_device('cpu')
+        a = paddle.empty(1, device='gpu')
+        device_str = str(a.device)
+        self.assertIn(
+            'cuda:0',
+            device_str,
+            msg=f"Expected tensor on GPU but got place: {device_str}",
+        )
+
+    def test_empty_device_gpu_follows_set_device_cpu(self):
+        """paddle.empty(device='gpu') should also respect set_device('gpu:1')."""
+        if not core.is_compiled_with_cuda() or core.get_cuda_device_count() < 1:
+            self.skipTest("Requires at least 1 GPU devices")
+        paddle.device.set_device('gpu:0')
+        a = paddle.empty(1, device='gpu')
+        device_str = str(a.device)
+        # restore default
+        paddle.device.set_device('gpu:0')
+        self.assertIn(
+            '0',
+            device_str,
+            msg=f"Expected tensor on GPU 1 but got place: {device_str}",
+        )
+
+        paddle.device.set_device('cpu')
+        a = paddle.empty(1, device='gpu')
+        device_str = str(a.device)
+        self.assertIn(
+            'cuda:0',
+            device_str,
+            msg=f"Expected tensor on GPU but got place: {device_str}",
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_device.py
+++ b/test/legacy_test/test_device.py
@@ -134,53 +134,17 @@ class TestGetPaddlePlaceAdaptiveGPU(unittest.TestCase):
             msg=f"Expected tensor on GPU 1 but got place: {device_str}",
         )
 
-    def test_empty_device_gpu_follows_set_device(self):
-        """paddle.empty(device='gpu') should also respect set_device('gpu:1')."""
-        if not core.is_compiled_with_cuda() or core.get_cuda_device_count() < 2:
-            self.skipTest("Requires at least 2 GPU devices")
-        paddle.device.set_device('gpu:1')
-        a = paddle.empty(1, device='gpu')
-        device_str = str(a.device)
-        # restore default
-        paddle.device.set_device('gpu:0')
-        self.assertIn(
-            '1',
-            device_str,
-            msg=f"Expected tensor on GPU 1 but got place: {device_str}",
-        )
-
-        paddle.device.set_device('cpu')
-        a = paddle.empty(1, device='gpu')
-        device_str = str(a.device)
-        self.assertIn(
-            'cuda:0',
-            device_str,
-            msg=f"Expected tensor on GPU but got place: {device_str}",
-        )
-
     def test_empty_device_gpu_follows_set_device_cpu(self):
         """paddle.empty(device='gpu') should also respect set_device('gpu:1')."""
         if not core.is_compiled_with_cuda() or core.get_cuda_device_count() < 1:
             self.skipTest("Requires at least 1 GPU devices")
         paddle.device.set_device('gpu:0')
         a = paddle.empty(1, device='gpu')
-        device_str = str(a.device)
-        # restore default
-        paddle.device.set_device('gpu:0')
-        self.assertIn(
-            '0',
-            device_str,
-            msg=f"Expected tensor on GPU 1 but got place: {device_str}",
-        )
+        self.assertTrue(a.place.is_gpu_place())
 
         paddle.device.set_device('cpu')
         a = paddle.empty(1, device='gpu')
-        device_str = str(a.device)
-        self.assertIn(
-            'cuda:0',
-            device_str,
-            msg=f"Expected tensor on GPU but got place: {device_str}",
-        )
+        self.assertTrue(a.place.is_gpu_place())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 place == "gpu"/"dcu" 时硬编码 CUDAPlace(0) 的问题，改为从 _current_expected_place_() 动态读取当前设备 ID，使 paddle.empty(device='cuda') 等接口能正确响应 set_device('cuda:N') 的设置。新增双卡条件下的单测验证。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
