### PR TITLE
[XPU] Fix precision for paddle.asinh: add float/float16 kernel and KL3 whitelist

### DIFF
--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -23,6 +23,7 @@ XPUOpMap& get_kl3_ops() {
   // KL3支持的op，通过op_name, data_type, place来索引
   static XPUOpMap s_xpu3_kernels{
       {"acos", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
+      {"asinh", XPUKernelSet({FLOAT32, FLOAT16})},
       {"add_act_xpu", XPUKernelSet({FLOAT32, FLOAT16})},
       {"add_layernorm_xpu", XPUKernelSet({FLOAT32, FLOAT16})},
       {"abs", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},

--- a/paddle/phi/kernels/xpu/activation_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_kernel.cc
@@ -605,6 +605,19 @@ struct XPUAcosFunctor : public funcs::BaseActivationFunctor<T> {
   }
 };
 
+template <typename T>
+struct XPUAsinhFunctor : public funcs::BaseActivationFunctor<T> {
+  using XPUType = typename XPUTypeTrait<T>::Type;
+  template <typename Context>
+  void operator()(const Context& dev_ctx,
+                  const DenseTensor& x,
+                  DenseTensor* out) const {
+    int ret = xpu_activation_func<Context, T, XPUType>(
+        dev_ctx, x, out, xpu::asinh<XPUType>);
+    PADDLE_ENFORCE_XDNN_SUCCESS(ret, "asinh");
+  }
+};
+
 DEFINE_XPU_ACTIVATION_KERNEL(Exp, XPUExpFunctor)
 DEFINE_XPU_ACTIVATION_KERNEL(Floor, XPUFloorFunctor)
 DEFINE_XPU_ACTIVATION_KERNEL(Ceil, XPUCeilFunctor)
@@ -621,6 +634,7 @@ DEFINE_XPU_ACTIVATION_KERNEL(Cos, XPUCosFunctor)
 DEFINE_XPU_ACTIVATION_KERNEL(Rsqrt, XPURsqrtFunctor)
 DEFINE_XPU_ACTIVATION_KERNEL(Tan, XPUTanFunctor)
 DEFINE_XPU_ACTIVATION_KERNEL(Acos, XPUAcosFunctor)
+DEFINE_XPU_ACTIVATION_KERNEL(Asinh, XPUAsinhFunctor)
 
 DEFINE_XPU_ACTIVATION_KERNEL_WITH_ONE_ATTRS(Mish, XPUMishFunctor, threshold)
 DEFINE_XPU_ACTIVATION_KERNEL_WITH_ONE_DOUBLE_ATTRS(LeakyRelu,
@@ -776,6 +790,9 @@ PD_REGISTER_KERNEL(acos,
                    float,
                    phi::float16,
                    phi::bfloat16) {}
+
+PD_REGISTER_KERNEL(
+    asinh, XPU, ALL_LAYOUT, phi::AsinhKernel, float, phi::float16) {}
 
 #define PD_REGISTER_ACTIVATION_KERNEL(name, func) \
   PD_REGISTER_KERNEL(name, XPU, ALL_LAYOUT, phi::func, float) {}


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

#### 问题背景

`paddle.asinh` 在 XPU 设备上使用 `float16` 输入时报错：

```
(NotFound) The kernel with key (XPU, Undefined(AnyLayout), float16) of kernel 'asinh' is not registered and fail to fallback to CPU one.
```

根因是 XPU 的 `activation_kernel.cc` 中完全没有注册 `asinh` 算子的任何 kernel，同时 `xpu3_op_list.cc` 中也缺少对应的白名单条目——尽管 XPU 底层库（`libxpuapi.so`）已原生支持 `xpu::asinh<float>` 和 `xpu::asinh<float16>`。

#### 修改内容

**`paddle/phi/kernels/xpu/activation_kernel.cc`**
- 新增 `XPUAsinhFunctor<T>`，通过 `xpu_activation_func` 调用 `xpu::asinh<XPUType>`，与 `XPUAcosFunctor` 等已有实现保持一致。
- 添加 `DEFINE_XPU_ACTIVATION_KERNEL(Asinh, XPUAsinhFunctor)` 宏调用。
- 注册 `PD_REGISTER_KERNEL(asinh, XPU, ALL_LAYOUT, phi::AsinhKernel, float, phi::float16)`。
  - 注：不注册 `bfloat16`，因为 XPU 库无该类型的 `asinh` 实例。

**`paddle/phi/backends/xpu/xpu3_op_list.cc`**
- 在 KL3 白名单中新增 `{"asinh", XPUKernelSet({FLOAT32, FLOAT16})}`。

#### 验证

使用 `paddle.asinh(Tensor([8, 16, 32], "float16"))` 在 XPU 上验证：
- XPU float16 输出：`[2.777, 3.467, 4.16]`，与 CPU float32 参考值最大误差 `0.00103`（容忍度 `0.01`），**通过**。
- XPU float32 输出：与 CPU float32 完全一致，最大误差 `0.0`，**通过**。

### 是否引起精度变化
是 — XPU 上 `paddle.asinh` 的 float16 精度对齐 GPU，此前该组合直接报错（无可对比精度）。