### PR TITLE
[release/3.4] Add the check of API names in `check_nan_or_inf`, so that the checks …

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -104,6 +104,19 @@ PHI_DEFINE_EXPORTED_int32(
 
 /**
  * Operator related FLAG
+ * Name: FLAGS_check_nan_inf_blacklist
+ * Since Version:
+ * Value Range: string, default=""
+ * Example: FLAGS_check_nan_inf_blacklist="op1,op2,op3"
+ * Note: Blacklist of ops to skip when checking NAN/INF
+ */
+PHI_DEFINE_EXPORTED_string(
+    check_nan_inf_blacklist,
+    "",
+    "Blacklist of ops to skip when checking NAN/INF, split by ','");
+
+/**
+ * Operator related FLAG
  * Name: FLAGS_check_nan_inf
  * Since Version: 0.13.0
  * Value Range: bool, default=false

--- a/paddle/fluid/eager/nan_inf_utils.cc
+++ b/paddle/fluid/eager/nan_inf_utils.cc
@@ -23,6 +23,7 @@
 #include "paddle/phi/core/distributed/auto_parallel/dist_tensor.h"
 #include "paddle/phi/core/selected_rows.h"
 
+COMMON_DECLARE_string(check_nan_inf_blacklist);
 COMMON_DECLARE_int32(check_nan_inf_level);
 namespace egr {
 
@@ -82,6 +83,27 @@ bool CheckOp(const std::string& api_name) {
 }
 
 void CheckTensorHasNanOrInf(const std::string& api_name, const Tensor& tensor) {
+  if (api_name == "empty") {
+    VLOG(4) << "Current op is \"empty\", skip nan inf check.";
+    return;
+  }
+
+  if (api_name == "empty_like") {
+    VLOG(4) << "Current op is \"empty_like\", skip nan inf check.";
+    return;
+  }
+
+  if (!FLAGS_check_nan_inf_blacklist.empty()) {
+    std::stringstream blacklist_ss(FLAGS_check_nan_inf_blacklist);
+    std::string blacklisted_op;
+    while (std::getline(blacklist_ss, blacklisted_op, ',')) {
+      if (api_name == blacklisted_op) {
+        VLOG(4) << "Current op is in blacklist, skip nan inf check: "
+                << api_name;
+        return;
+      }
+    }
+  }
   auto op_name = phi::TransToFluidOpName(api_name);
   if (tensor.initialized() && CheckOp(op_name)) {
     auto& tensor_name = tensor.name();

--- a/test/cpp/eager/task_tests/nan_inf_utils_test.cc
+++ b/test/cpp/eager/task_tests/nan_inf_utils_test.cc
@@ -16,9 +16,12 @@
 
 #include <iostream>
 #include <limits>
+#include <ostream>
+#include <string>
 #include <tuple>
 
 #include "gtest/gtest.h"
+#include "paddle/common/flags.h"
 #include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/phi/api/include/api.h"
@@ -28,8 +31,11 @@
 PD_DECLARE_KERNEL(full, CPU, ALL_LAYOUT);
 PD_DECLARE_KERNEL(strings_empty, CPU, ALL_LAYOUT);
 
+COMMON_DECLARE_string(check_nan_inf_blacklist);
+
 namespace egr {
 
+using paddle_flags::FLAGS_check_nan_inf_blacklist;
 #define CHECK_NAN_INF(tensors)                                               \
   {                                                                          \
     bool caught_exception = false;                                           \
@@ -55,6 +61,63 @@ namespace egr {
     }                                                                        \
     EXPECT_FALSE(caught_exception);                                          \
   }
+
+#define CHECK_APINAME_SKIP(api_name, tensor)            \
+  {                                                     \
+    bool caught_exception = false;                      \
+    try {                                               \
+      CheckTensorHasNanOrInf(api_name, tensor);         \
+    } catch (paddle::platform::EnforceNotMet & error) { \
+      caught_exception = true;                          \
+    }                                                   \
+    EXPECT_FALSE(caught_exception);                     \
+  }
+
+#define CHECK_APINAME_NO_SKIP(api_name, tensor)         \
+  {                                                     \
+    bool caught_exception = false;                      \
+    try {                                               \
+      CheckTensorHasNanOrInf(api_name, tensor);         \
+    } catch (paddle::platform::EnforceNotMet & error) { \
+      caught_exception = true;                          \
+    }                                                   \
+    EXPECT_TRUE(caught_exception);                      \
+  }
+
+TEST(NanInfUtils, BlacklistSkipCheck) {
+  auto nan_tensor = paddle::experimental::full(
+      {3, 4}, std::numeric_limits<double>::quiet_NaN(), phi::DataType::FLOAT64);
+
+  FLAGS_check_nan_inf_blacklist = "";
+  CHECK_APINAME_SKIP("empty", nan_tensor);
+
+  // Test that "empty_like" always skips regardless of blacklist
+  FLAGS_check_nan_inf_blacklist = "";
+  CHECK_APINAME_SKIP("empty_like", nan_tensor);
+
+  // Test with empty blacklist (default behavior)
+  FLAGS_check_nan_inf_blacklist = "";
+  CHECK_APINAME_NO_SKIP("some_op", nan_tensor);
+
+  // Test with single op in blacklist
+  FLAGS_check_nan_inf_blacklist = "single_op";
+  CHECK_APINAME_SKIP("single_op", nan_tensor);
+  CHECK_APINAME_NO_SKIP("other_op", nan_tensor);
+
+  // Even when blacklist is set, these should still skip
+  CHECK_APINAME_SKIP("empty", nan_tensor);
+  CHECK_APINAME_SKIP("empty_like", nan_tensor);
+
+  // blacklist="op1,op2,op3" and op is in blacklist
+  FLAGS_check_nan_inf_blacklist = "op1,op2,op3";
+  CHECK_APINAME_SKIP("op1", nan_tensor);
+  CHECK_APINAME_SKIP("op2", nan_tensor);
+  CHECK_APINAME_SKIP("op3", nan_tensor);
+  // not in blacklist, should perform nan_or_inf check
+  CHECK_APINAME_NO_SKIP("op4", nan_tensor);
+
+  FLAGS_check_nan_inf_blacklist = "";
+}
 
 TEST(NanInfUtils, Functions) {
   // test all methods


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
新增了FLAGS_check_nan_inf_blacklist变量，在`eager/nan_inf_utils.cc`的`CheckTensorHasNanOrInf`中在检查tensor前先对api_name进行判断，如果api_name满足(1)是”empty”(2)是“empty_like“(3)在FLAGS_check_nan_inf_blacklist黑名单中，就跳过对tensor的检查

### 是否引起精度变化
 否 


---

Cherry-pick of #78816 (authored by @omoYang) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78816 <!-- For pass CI -->