### PR TITLE
[release/3.4] fix tinyformat

### DIFF
--- a/paddle/phi/kernels/stride/elementwise_grad_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/elementwise_grad_stride_kernel.cu
@@ -38,7 +38,7 @@ COMMON_DECLARE_bool(use_stride_compute_kernel);
 
 namespace phi {
 
-inline void PrepareStridedOut(DenseTensor* out) {
+inline void PrepareStridedOut_elementwise(DenseTensor* out) {
   if (!FLAGS_use_stride_kernel) {
     PADDLE_THROW(common::errors::Fatal(
         "FLAGS_use_stride_kernel is closed. Strided kernel "
@@ -56,7 +56,7 @@ void SumStrideKernel(const Context& dev_ctx,
                      DataType out_dtype,
                      bool keep_dim,
                      DenseTensor* out) {
-  PrepareStridedOut(out);
+  PrepareStridedOut_elementwise(out);
 
   phi::SumKernel<T, Context>(dev_ctx, x, dims, out_dtype, keep_dim, out);
 }

--- a/paddle/phi/kernels/stride/matmul_grad_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/matmul_grad_stride_kernel.cu
@@ -44,7 +44,7 @@ inline bool UseCanonicalizedTransposeGradPath(const Context& dev_ctx) {
 #endif
 }
 
-inline void PrepareStridedOut(DenseTensor* out) {
+inline void PrepareStridedOut_matmul(DenseTensor* out) {
   if (out == nullptr) {
     return;
   }
@@ -175,8 +175,8 @@ void MatmulGradStrideKernel(const Context& dev_ctx,
     if (!out_grad_.meta().is_contiguous()) {
       out_grad_ = Tensor2Contiguous<Context>(dev_ctx, out_grad_);
     }
-    PrepareStridedOut(dx);
-    PrepareStridedOut(dy);
+    PrepareStridedOut_matmul(dx);
+    PrepareStridedOut_matmul(dy);
     phi::MatmulGradKernel<T, Context>(
         dev_ctx, x_, y_, out_grad_, transpose_x, transpose_y, dx, dy);
     return;
@@ -204,14 +204,14 @@ void MatmulGradStrideKernel(const Context& dev_ctx,
     dx_tmp.Resize(x_.dims());
     dx_out = &dx_tmp;
   } else {
-    PrepareStridedOut(dx_out);
+    PrepareStridedOut_matmul(dx_out);
   }
 
   if (dy != nullptr && y_info.applied) {
     dy_tmp.Resize(y_.dims());
     dy_out = &dy_tmp;
   } else {
-    PrepareStridedOut(dy_out);
+    PrepareStridedOut_matmul(dy_out);
   }
 
   phi::MatmulGradKernel<T, Context>(

--- a/paddle/phi/kernels/stride/reduce_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/reduce_stride_kernel.cu
@@ -34,7 +34,7 @@ COMMON_DECLARE_bool(force_stride_compute_contig_out);
 
 namespace phi {
 
-inline void PrepareStridedOut(DenseTensor* out) {
+inline void PrepareStridedOut_reduce(DenseTensor* out) {
   if (!FLAGS_use_stride_kernel) {
     PADDLE_THROW(common::errors::Fatal(
         "FLAGS_use_stride_kernel is closed. Strided kernel "
@@ -51,7 +51,7 @@ void AMaxStrideKernel(const Context& dev_ctx,
                       const std::vector<int64_t>& dims,
                       bool keep_dim,
                       DenseTensor* out) {
-  PrepareStridedOut(out);
+  PrepareStridedOut_reduce(out);
 
   phi::AMaxKernel<T, Context>(dev_ctx, x, dims, keep_dim, out);
 }
@@ -62,7 +62,7 @@ void AMinStrideKernel(const Context& dev_ctx,
                       const std::vector<int64_t>& dims,
                       bool keep_dim,
                       DenseTensor* out) {
-  PrepareStridedOut(out);
+  PrepareStridedOut_reduce(out);
 
   phi::AMinKernel<T, Context>(dev_ctx, x, dims, keep_dim, out);
 }
@@ -73,7 +73,7 @@ void MaxStrideKernel(const Context& dev_ctx,
                      const IntArray& dims,
                      bool keep_dim,
                      DenseTensor* out) {
-  PrepareStridedOut(out);
+  PrepareStridedOut_reduce(out);
 
   phi::MaxKernel<T, Context>(dev_ctx, x, dims, keep_dim, out);
 }
@@ -84,7 +84,7 @@ void MinStrideKernel(const Context& dev_ctx,
                      const IntArray& dims,
                      bool keep_dim,
                      DenseTensor* out) {
-  PrepareStridedOut(out);
+  PrepareStridedOut_reduce(out);
 
   phi::MinKernel<T, Context>(dev_ctx, x, dims, keep_dim, out);
 }
@@ -96,7 +96,7 @@ void ProdStrideKernel(const Context& dev_ctx,
                       bool keep_dim,
                       bool reduce_all,
                       DenseTensor* out) {
-  PrepareStridedOut(out);
+  PrepareStridedOut_reduce(out);
 
   phi::ProdKernel<T, Context>(dev_ctx, x, dims, keep_dim, reduce_all, out);
 }
@@ -107,7 +107,7 @@ void AllStrideKernel(const Context& dev_ctx,
                      const std::vector<int64_t>& dims,
                      bool keep_dim,
                      DenseTensor* out) {
-  PrepareStridedOut(out);
+  PrepareStridedOut_reduce(out);
 
   phi::AllKernel<T, Context>(dev_ctx, x, dims, keep_dim, out);
 }
@@ -118,7 +118,7 @@ void AnyStrideKernel(const Context& dev_ctx,
                      const std::vector<int64_t>& dims,
                      bool keep_dim,
                      DenseTensor* out) {
-  PrepareStridedOut(out);
+  PrepareStridedOut_reduce(out);
 
   phi::AnyKernel<T, Context>(dev_ctx, x, dims, keep_dim, out);
 }
@@ -130,7 +130,7 @@ void SumStrideKernel(const Context& dev_ctx,
                      DataType out_dtype,
                      bool keep_dim,
                      DenseTensor* out) {
-  PrepareStridedOut(out);
+  PrepareStridedOut_reduce(out);
 
   phi::SumKernel<T, Context>(dev_ctx, x, dims, out_dtype, keep_dim, out);
 }
@@ -142,7 +142,7 @@ void NansumStrideKernel(const Context& dev_ctx,
                         DataType out_dtype,
                         bool keep_dim,
                         DenseTensor* out) {
-  PrepareStridedOut(out);
+  PrepareStridedOut_reduce(out);
   phi::NansumKernel<T, Context>(dev_ctx, x, dims, out_dtype, keep_dim, out);
 }
 
@@ -152,7 +152,7 @@ void MeanStrideKernel(const Context& dev_ctx,
                       const IntArray& dims,
                       bool keep_dim,
                       DenseTensor* out) {
-  PrepareStridedOut(out);
+  PrepareStridedOut_reduce(out);
 
   phi::MeanKernel<T, Context>(dev_ctx, x, dims, keep_dim, out);
 }

--- a/paddle/utils/string/printf.h
+++ b/paddle/utils/string/printf.h
@@ -81,7 +81,11 @@ namespace string {
 
 template <typename... Args>
 void Fprintf(std::ostream& out, const char* fmt, const Args&... args) {
-  tinyformat::vformat(out, fmt, tinyformat::makeFormatList(args...));
+  try {
+    tinyformat::vformat(out, fmt, tinyformat::makeFormatList(args...));
+  } catch (const tinyformat::detail::FormatError&) {
+    out << fmt;
+  }
 }
 
 inline std::string Sprintf() { return ""; }
@@ -95,9 +99,13 @@ std::string Sprintf(const Args&... args) {
 
 template <typename... Args>
 std::string Sprintf(const char* fmt, const Args&... args) {
-  std::ostringstream oss;
-  Fprintf(oss, fmt, args...);
-  return oss.str();
+  try {
+    std::ostringstream oss;
+    Fprintf(oss, fmt, args...);
+    return oss.str();
+  } catch (const tinyformat::detail::FormatError&) {
+    return fmt;
+  }
 }
 
 template <typename... Args>

--- a/paddle/utils/string/tinyformat/tinyformat.h
+++ b/paddle/utils/string/tinyformat/tinyformat.h
@@ -119,9 +119,8 @@
 // Additional API information
 // --------------------------
 //
-// Error handling: Define TINYFORMAT_ERROR to customize the error handling for
-// format strings which are unsupported or have the wrong number of format
-// specifiers (calls assert() by default).
+// Error handling: Format errors throw detail::FormatError, which is caught
+// at the public API level to fall back to the raw format string.
 //
 // User defined types: Uses operator<< for user defined types by default.
 // Overload formatValue() for more control.
@@ -139,12 +138,13 @@ namespace paddle {
 namespace string {
 namespace tinyformat {
 
-#ifndef TINYFORMAT_ERROR
-#define TINYFORMAT_ERROR(reason) assert(0 && reason)
-#endif
-
 //------------------------------------------------------------------------------
 namespace detail {
+
+// Exception thrown on format errors instead of crashing via assert.
+// Caught at the public API level to fall back to returning the raw format
+// string, so that a wrong PADDLE_ENFORCE format never causes an abort.
+struct FormatError {};
 
 // Test whether type T1 is convertible to type T2
 template <typename T1, typename T2>
@@ -192,9 +192,7 @@ struct formatValueAsType<T, fmtT, true> {
 template <typename T, bool convertible = is_convertible<T, int>::value>
 struct convertToInt {
   static int invoke(const T & /*value*/) {
-    TINYFORMAT_ERROR(
-        "tinyformat: Cannot convert from argument type to "
-        "integer for use as variable width or precision");
+    throw FormatError();
     return 0;
   }
 };
@@ -579,8 +577,7 @@ inline const char *streamStateFromFormat(std::ostream &out,       // NOLINT
                                          int &argIndex,  // NOLINT
                                          int numFormatters) {
   if (*fmtStart != '%') {
-    TINYFORMAT_ERROR(
-        "tinyformat: Not enough conversion specifiers in format string");
+    throw FormatError();
     return fmtStart;
   }
   // Reset stream state to defaults.
@@ -639,8 +636,7 @@ inline const char *streamStateFromFormat(std::ostream &out,       // NOLINT
     if (argIndex < numFormatters)
       width = formatters[argIndex++].toInt();
     else
-      TINYFORMAT_ERROR(
-          "tinyformat: Not enough arguments to read variable width");
+      throw FormatError();
     if (width < 0) {
       // negative widths correspond to '-' flag set
       out.fill(' ');
@@ -659,8 +655,7 @@ inline const char *streamStateFromFormat(std::ostream &out,       // NOLINT
       if (argIndex < numFormatters)
         precision = formatters[argIndex++].toInt();
       else
-        TINYFORMAT_ERROR(
-            "tinyformat: Not enough arguments to read variable precision");
+        throw FormatError();
     } else {
       if (*c >= '0' && *c <= '9')
         precision = parseIntAndAdvance(c);
@@ -724,9 +719,7 @@ inline const char *streamStateFromFormat(std::ostream &out,       // NOLINT
       break;
     case 'a':
     case 'A':
-      TINYFORMAT_ERROR(
-          "tinyformat: the %a and %A conversion specs "
-          "are not supported");
+      throw FormatError();
       break;
     case 'c':
       // Handled as special case inside formatValue()
@@ -738,12 +731,10 @@ inline const char *streamStateFromFormat(std::ostream &out,       // NOLINT
       break;
     case 'n':
       // Not supported - will cause problems!
-      TINYFORMAT_ERROR("tinyformat: %n conversion spec not supported");
+      throw FormatError();
       break;
     case '\0':
-      TINYFORMAT_ERROR(
-          "tinyformat: Conversion spec incorrectly "
-          "terminated by end of string");
+      throw FormatError();
       return c;
     default:
       break;
@@ -785,7 +776,7 @@ inline void formatImpl(std::ostream &out,
                                                numFormatters);
     if (argIndex >= numFormatters) {
       // Check args remain after reading any variable width/precision
-      TINYFORMAT_ERROR("tinyformat: Not enough format arguments");
+      throw FormatError();
       return;
     }
     const FormatArg &arg = formatters[argIndex];
@@ -811,9 +802,7 @@ inline void formatImpl(std::ostream &out,
 
   // Print remaining part of format string.
   fmt = printFormatStringLiteral(out, fmt);
-  if (fmt != nullptr && *fmt != '\0' && *fmt != 0)
-    TINYFORMAT_ERROR(
-        "tinyformat: Too many conversion specifiers in format string");
+  if (fmt != nullptr && *fmt != '\0' && *fmt != 0) throw FormatError();
 
   // Restore stream state
   out.width(origWidth);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
删除tinyformat里的assert，防止PADDLE_ENFORCE %个数和变量不匹配时，崩溃在assert上而没有提供PADDLE_ENFORCE更有价值的信息。
业务上发生了这种情况。但不可解释的是，assert只在DEBUG编译下才生效，为何发版的包assert会生效暂时没有找到。

通过如下方式复现问题
```
#define TINYFORMAT_ERROR(reason) do { std::cerr << reason ; abort(); } while(0)
```
此后验证本PR，能够有效disable掉assert的崩溃。

但H卡Coverage，test_dygraph_sharding_stage3_for_eager等3个单测会崩溃在PrepareStridedOut中：
```
2026-04-27T12:46:24.0700284Z     70	--------------------------------------
2026-04-27T12:46:24.0700604Z     71	C++ Traceback (most recent call last):
2026-04-27T12:46:24.0700906Z     72	--------------------------------------
2026-04-27T12:46:24.0701655Z     73	0   egr::Backward(std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&, std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&, bool, std::string)
2026-04-27T12:46:24.0703059Z     74	1   egr::RunBackward(std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&, std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&, bool, bool, std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&, bool, std::vector<paddle::Tensor, std::allocator<paddle::Tensor> > const&, std::string)
2026-04-27T12:46:24.0704342Z     75	2   MatmulGradNode::operator()(paddle::small_vector<std::vector<paddle::Tensor, std::allocator<paddle::Tensor> >, 15u>&, bool, bool)
2026-04-27T12:46:24.0705187Z     76	3   paddle::experimental::matmul_grad(paddle::Tensor const&, paddle::Tensor const&, paddle::Tensor const&, bool, bool, paddle::Tensor*, paddle::Tensor*)
2026-04-27T12:46:24.0706307Z     77	4   void phi::MatmulGradStrideKernel<float, phi::GPUContext>(phi::GPUContext const&, phi::DenseTensor const&, phi::DenseTensor const&, phi::DenseTensor const&, bool, bool, phi::DenseTensor*, phi::DenseTensor*)
2026-04-27T12:46:24.0707137Z     78	5   phi::PrepareStridedOut(phi::DenseTensor*)
2026-04-27T12:46:24.0707545Z     79	6   phi::DenseTensorMeta::DenseTensorMeta(phi::DenseTensorMeta const&)
2026-04-27T12:46:24.0707920Z     80	
2026-04-27T12:46:24.0708110Z     81	----------------------
2026-04-27T12:46:24.0708368Z     82	Error Message Summary:
2026-04-27T12:46:24.0708612Z     83	----------------------
2026-04-27T12:46:24.0708985Z     84	FatalError: `Segmentation fault` is detected by the operating system.
2026-04-27T12:46:24.0709534Z     85	  [TimeInfo: *** Aborted at 1777293968 (unix time) try "date -d @1777293968" if you are using GNU date ***]
2026-04-27T12:46:24.0710126Z     86	  [SignalInfo: *** SIGSEGV (@0x10) received by PID 7988 (TID 0x7f9905499740) from PID 16 ***]
```
重命名后问题消失，可能是编译链接错函数了？无法解释。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

---

Cherry-pick of #78793 (authored by @wanghuancoder) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78793 <!-- For pass CI -->