### PR TITLE
[XPU] Fix precision for paddle.nn.functional.gelu backward with bfloat16

### DIFF
--- a/paddle/phi/kernels/xpu/gelu_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/gelu_grad_kernel.cc
@@ -31,14 +31,31 @@ void GeluGradKernel(const Context& dev_ctx,
   if (x_grad && x_grad->numel() == 0) {
     return;
   }
-  int r = xpu::gelu_grad<XPUType>(
-      dev_ctx.x_context(),
-      reinterpret_cast<const XPUType*>(x.data<T>()),
-      reinterpret_cast<const XPUType*>(out_grad.data<T>()),
-      reinterpret_cast<XPUType*>(x_grad->data<T>()),
-      x_grad->numel(),
-      approximate);
-  PADDLE_ENFORCE_XDNN_SUCCESS(r, "gelu_grad");
+  // For bfloat16 and float16, use the highprecision variant which performs
+  // intermediate computations in float32 to avoid overflow, matching the GPU
+  // kernel behavior (which uses MPTypeTrait to upcast to float32).
+  // For float32, the standard variant is sufficient.
+  int r = 0;
+  if (std::is_same<T, phi::bfloat16>::value ||
+      std::is_same<T, phi::float16>::value) {
+    r = xpu::gelu_grad_highprecision<XPUType>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(x.data<T>()),
+        reinterpret_cast<const XPUType*>(out_grad.data<T>()),
+        reinterpret_cast<XPUType*>(x_grad->data<T>()),
+        x_grad->numel(),
+        approximate);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "gelu_grad_highprecision");
+  } else {
+    r = xpu::gelu_grad<XPUType>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(x.data<T>()),
+        reinterpret_cast<const XPUType*>(out_grad.data<T>()),
+        reinterpret_cast<XPUType*>(x_grad->data<T>()),
+        x_grad->numel(),
+        approximate);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "gelu_grad");
+  }
 }
 }  // namespace phi
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

#### paddle.nn.functional.gelu

**问题：** `paddle.nn.functional.gelu(Tensor([1, 8192, 6912], "bfloat16"), approximate=True)` 的反向传播在 XPU 上存在精度问题。XPU kernel 调用 `xpu::gelu_grad<bfloat16>`，所有中间计算在原生 bfloat16 精度下执行，导致数值溢出（max_abs_diff=32768 = 2^15）。

**根本原因：** GPU kernel 使用 `MPTypeTrait<T>::Type`，将 bfloat16 提升为 float32 进行所有中间计算（x_sq、x_cube、tanh、tanh_derivative 等），结果再转回 bfloat16。XPU kernel 缺少这种精度提升机制。

**修复方案：** 在 `paddle/phi/kernels/xpu/gelu_grad_kernel.cc` 中，对 bfloat16 和 float16 输入，使用 `xpu::gelu_grad_highprecision<XPUType>` 替代 `xpu::gelu_grad<XPUType>`。该高精度变体在内部使用 float32 执行中间计算，与 GPU kernel 行为保持一致。float32 输入继续使用原有路径。

**验证结果：** 修复后，反向传播 max_abs_diff=0.004571（atol=0.01 → PASS），max_rel_diff=0.004049（rtol=0.01 → PASS），梯度中无 NaN 或 Inf。

### 是否引起精度变化
是 — XPU bfloat16/float16 的 gelu 反向精度与 GPU 对齐，修复了溢出问题。