### PR TITLE
[TVM FFI] Bump tvm ffi to `0.1.10` in unittests and run checks in separate function to avoid lifecycle issue

### DIFF
--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -19,6 +19,6 @@ xdoctest==1.3.0
 ubelt==1.4.0 # just for xdoctest
 mypy==1.19.1
 soundfile
-apache-tvm-ffi==0.1.5
+apache-tvm-ffi==0.1.10
 graphviz
 nvidia-ml-py3 ; platform_system != "Darwin"

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -63,13 +63,19 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
         """
 
         mod: Module = tvm_ffi.cpp.load_inline(
-            name='mod', cpp_sources=cpp_source, functions='add_one_cpu'
+            name='mod',
+            cpp_sources=cpp_source,
+            functions='add_one_cpu',
+            keep_module_alive=False,
         )
 
-        x = paddle.full((3,), 1.0, dtype='float32').cpu()
-        y = paddle.zeros((3,), dtype='float32').cpu()
-        mod.add_one_cpu(x, y)
-        np.testing.assert_allclose(y.numpy(), [2.0, 2.0, 2.0])
+        def run_check():
+            x = paddle.full((3,), 1.0, dtype='float32').cpu()
+            y = paddle.zeros((3,), dtype='float32').cpu()
+            mod.add_one_cpu(x, y)
+            np.testing.assert_allclose(y.numpy(), [2.0, 2.0, 2.0])
+
+        run_check()
 
     def test_c_dlpack_exchange_api_gpu(self):
         if not paddle.is_compiled_with_cuda():
@@ -116,12 +122,16 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
             cpp_sources=cpp_sources,
             cuda_sources=cuda_sources,
             functions=['add_one_cuda'],
+            keep_module_alive=False,
         )
 
-        x = paddle.full((3,), 1.0, dtype='float32').cuda()
-        y = paddle.zeros((3,), dtype='float32').cuda()
-        mod.add_one_cuda(x, y)
-        np.testing.assert_allclose(y.numpy(), [2.0, 2.0, 2.0])
+        def run_check():
+            x = paddle.full((3,), 1.0, dtype='float32').cuda()
+            y = paddle.zeros((3,), dtype='float32').cuda()
+            mod.add_one_cuda(x, y)
+            np.testing.assert_allclose(y.numpy(), [2.0, 2.0, 2.0])
+
+        run_check()
 
     def test_c_dlpack_exchange_api_alloc_tensor(self):
         cpp_source = r"""
@@ -141,7 +151,10 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
             }
         """
         mod: Module = tvm_ffi.cpp.load_inline(
-            name='mod', cpp_sources=cpp_source, functions=['add_one_cpu']
+            name='mod',
+            cpp_sources=cpp_source,
+            functions=['add_one_cpu'],
+            keep_module_alive=False,
         )
 
         def run_check():
@@ -200,21 +213,28 @@ class TestDLPackDataType(unittest.TestCase):
             }
         """
         mod: Module = tvm_ffi.cpp.load_inline(
-            name='mod', cpp_sources=cpp_source, functions='check_dtype'
+            name='mod',
+            cpp_sources=cpp_source,
+            functions='check_dtype',
+            keep_module_alive=False,
         )
-        for dtype in [
-            paddle.bool,
-            paddle.uint8,
-            paddle.int16,
-            paddle.int32,
-            paddle.int64,
-            paddle.float32,
-            paddle.float64,
-            paddle.float16,
-            paddle.bfloat16,
-        ]:
-            x = paddle.zeros((10,), dtype=dtype).cpu()
-            mod.check_dtype(x, dtype)
+
+        def run_check():
+            for dtype in [
+                paddle.bool,
+                paddle.uint8,
+                paddle.int16,
+                paddle.int32,
+                paddle.int64,
+                paddle.float32,
+                paddle.float64,
+                paddle.float16,
+                paddle.bfloat16,
+            ]:
+                x = paddle.zeros((10,), dtype=dtype).cpu()
+                mod.check_dtype(x, dtype)
+
+        run_check()
 
 
 class TestDLPackDeviceType(unittest.TestCase):
@@ -260,15 +280,21 @@ class TestDLPackDeviceType(unittest.TestCase):
             }
         """
         mod: Module = tvm_ffi.cpp.load_inline(
-            name='mod', cpp_sources=cpp_source, functions='check_device'
+            name='mod',
+            cpp_sources=cpp_source,
+            functions='check_device',
+            keep_module_alive=False,
         )
 
-        x_cpu = paddle.zeros((10,), dtype='float32').cpu()
-        mod.check_device(x_cpu, x_cpu.place)
+        def run_check():
+            x_cpu = paddle.zeros((10,), dtype='float32').cpu()
+            mod.check_device(x_cpu, x_cpu.place)
 
-        if paddle.is_compiled_with_cuda():
-            x_gpu = paddle.zeros((10,), dtype='float32').cuda()
-            mod.check_device(x_gpu, x_gpu.place)
+            if paddle.is_compiled_with_cuda():
+                x_gpu = paddle.zeros((10,), dtype='float32').cuda()
+                mod.check_device(x_gpu, x_gpu.place)
+
+        run_check()
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -143,9 +143,18 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
         mod: Module = tvm_ffi.cpp.load_inline(
             name='mod', cpp_sources=cpp_source, functions=['add_one_cpu']
         )
-        x = paddle.full((3,), 1.0, dtype='float32').cpu()
-        y = mod.add_one_cpu(x)
-        np.testing.assert_allclose(y.numpy(), [2.0, 2.0, 2.0])
+
+        def run_check():
+            """Must run in a separate function to ensure deletion happens before mod unloads.
+
+            When a module returns an object, the object deleter address is part of the
+            loaded library. We need to keep the module loaded until the object is deleted.
+            """
+            x = paddle.full((3,), 1.0, dtype='float32').cpu()
+            y = mod.add_one_cpu(x)
+            np.testing.assert_allclose(y.numpy(), [2.0, 2.0, 2.0])
+
+        run_check()
 
 
 class TestDLPackDataType(unittest.TestCase):

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -28,12 +28,6 @@ if TYPE_CHECKING:
     from tvm_ffi import Module
 
 
-def _windows_tvm_ffi_extra_cflags():
-    if platform.system() == "Windows":
-        return ["/FIalgorithm"]
-    return None
-
-
 class TestTVMFFIEnvStream(unittest.TestCase):
     def test_tvm_ffi_env_stream_for_gpu_tensor(self):
         if not paddle.is_compiled_with_cuda():
@@ -72,7 +66,6 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
             name='mod',
             cpp_sources=cpp_source,
             functions='add_one_cpu',
-            extra_cflags=_windows_tvm_ffi_extra_cflags(),
             keep_module_alive=False,
         )
 
@@ -154,7 +147,7 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
             name='mod',
             cpp_sources=cpp_source,
             functions=['add_one_cpu'],
-            extra_cflags=_windows_tvm_ffi_extra_cflags(),
+            keep_module_alive=False,
         )
 
         def run_check():
@@ -216,7 +209,6 @@ class TestDLPackDataType(unittest.TestCase):
             name='mod',
             cpp_sources=cpp_source,
             functions='check_dtype',
-            extra_cflags=_windows_tvm_ffi_extra_cflags(),
             keep_module_alive=False,
         )
         for dtype in [
@@ -280,7 +272,6 @@ class TestDLPackDeviceType(unittest.TestCase):
             name='mod',
             cpp_sources=cpp_source,
             functions='check_device',
-            extra_cflags=_windows_tvm_ffi_extra_cflags(),
             keep_module_alive=False,
         )
 

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -63,19 +63,13 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
         """
 
         mod: Module = tvm_ffi.cpp.load_inline(
-            name='mod',
-            cpp_sources=cpp_source,
-            functions='add_one_cpu',
-            keep_module_alive=False,
+            name='mod', cpp_sources=cpp_source, functions='add_one_cpu'
         )
 
-        def run_check():
-            x = paddle.full((3,), 1.0, dtype='float32').cpu()
-            y = paddle.zeros((3,), dtype='float32').cpu()
-            mod.add_one_cpu(x, y)
-            np.testing.assert_allclose(y.numpy(), [2.0, 2.0, 2.0])
-
-        run_check()
+        x = paddle.full((3,), 1.0, dtype='float32').cpu()
+        y = paddle.zeros((3,), dtype='float32').cpu()
+        mod.add_one_cpu(x, y)
+        np.testing.assert_allclose(y.numpy(), [2.0, 2.0, 2.0])
 
     def test_c_dlpack_exchange_api_gpu(self):
         if not paddle.is_compiled_with_cuda():
@@ -122,16 +116,12 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
             cpp_sources=cpp_sources,
             cuda_sources=cuda_sources,
             functions=['add_one_cuda'],
-            keep_module_alive=False,
         )
 
-        def run_check():
-            x = paddle.full((3,), 1.0, dtype='float32').cuda()
-            y = paddle.zeros((3,), dtype='float32').cuda()
-            mod.add_one_cuda(x, y)
-            np.testing.assert_allclose(y.numpy(), [2.0, 2.0, 2.0])
-
-        run_check()
+        x = paddle.full((3,), 1.0, dtype='float32').cuda()
+        y = paddle.zeros((3,), dtype='float32').cuda()
+        mod.add_one_cuda(x, y)
+        np.testing.assert_allclose(y.numpy(), [2.0, 2.0, 2.0])
 
     def test_c_dlpack_exchange_api_alloc_tensor(self):
         cpp_source = r"""
@@ -213,28 +203,21 @@ class TestDLPackDataType(unittest.TestCase):
             }
         """
         mod: Module = tvm_ffi.cpp.load_inline(
-            name='mod',
-            cpp_sources=cpp_source,
-            functions='check_dtype',
-            keep_module_alive=False,
+            name='mod', cpp_sources=cpp_source, functions='check_dtype'
         )
-
-        def run_check():
-            for dtype in [
-                paddle.bool,
-                paddle.uint8,
-                paddle.int16,
-                paddle.int32,
-                paddle.int64,
-                paddle.float32,
-                paddle.float64,
-                paddle.float16,
-                paddle.bfloat16,
-            ]:
-                x = paddle.zeros((10,), dtype=dtype).cpu()
-                mod.check_dtype(x, dtype)
-
-        run_check()
+        for dtype in [
+            paddle.bool,
+            paddle.uint8,
+            paddle.int16,
+            paddle.int32,
+            paddle.int64,
+            paddle.float32,
+            paddle.float64,
+            paddle.float16,
+            paddle.bfloat16,
+        ]:
+            x = paddle.zeros((10,), dtype=dtype).cpu()
+            mod.check_dtype(x, dtype)
 
 
 class TestDLPackDeviceType(unittest.TestCase):
@@ -280,21 +263,15 @@ class TestDLPackDeviceType(unittest.TestCase):
             }
         """
         mod: Module = tvm_ffi.cpp.load_inline(
-            name='mod',
-            cpp_sources=cpp_source,
-            functions='check_device',
-            keep_module_alive=False,
+            name='mod', cpp_sources=cpp_source, functions='check_device'
         )
 
-        def run_check():
-            x_cpu = paddle.zeros((10,), dtype='float32').cpu()
-            mod.check_device(x_cpu, x_cpu.place)
+        x_cpu = paddle.zeros((10,), dtype='float32').cpu()
+        mod.check_device(x_cpu, x_cpu.place)
 
-            if paddle.is_compiled_with_cuda():
-                x_gpu = paddle.zeros((10,), dtype='float32').cuda()
-                mod.check_device(x_gpu, x_gpu.place)
-
-        run_check()
+        if paddle.is_compiled_with_cuda():
+            x_gpu = paddle.zeros((10,), dtype='float32').cuda()
+            mod.check_device(x_gpu, x_gpu.place)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -63,7 +63,10 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
         """
 
         mod: Module = tvm_ffi.cpp.load_inline(
-            name='mod', cpp_sources=cpp_source, functions='add_one_cpu'
+            name='mod',
+            cpp_sources=cpp_source,
+            functions='add_one_cpu',
+            keep_module_alive=False,
         )
 
         x = paddle.full((3,), 1.0, dtype='float32').cpu()
@@ -203,7 +206,10 @@ class TestDLPackDataType(unittest.TestCase):
             }
         """
         mod: Module = tvm_ffi.cpp.load_inline(
-            name='mod', cpp_sources=cpp_source, functions='check_dtype'
+            name='mod',
+            cpp_sources=cpp_source,
+            functions='check_dtype',
+            keep_module_alive=False,
         )
         for dtype in [
             paddle.bool,
@@ -263,7 +269,10 @@ class TestDLPackDeviceType(unittest.TestCase):
             }
         """
         mod: Module = tvm_ffi.cpp.load_inline(
-            name='mod', cpp_sources=cpp_source, functions='check_device'
+            name='mod',
+            cpp_sources=cpp_source,
+            functions='check_device',
+            keep_module_alive=False,
         )
 
         x_cpu = paddle.zeros((10,), dtype='float32').cpu()

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -28,6 +28,12 @@ if TYPE_CHECKING:
     from tvm_ffi import Module
 
 
+def _windows_tvm_ffi_extra_cflags():
+    if platform.system() == "Windows":
+        return ["/FIalgorithm"]
+    return None
+
+
 class TestTVMFFIEnvStream(unittest.TestCase):
     def test_tvm_ffi_env_stream_for_gpu_tensor(self):
         if not paddle.is_compiled_with_cuda():
@@ -66,6 +72,7 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
             name='mod',
             cpp_sources=cpp_source,
             functions='add_one_cpu',
+            extra_cflags=_windows_tvm_ffi_extra_cflags(),
             keep_module_alive=False,
         )
 
@@ -147,6 +154,7 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
             name='mod',
             cpp_sources=cpp_source,
             functions=['add_one_cpu'],
+            extra_cflags=_windows_tvm_ffi_extra_cflags(),
         )
 
         def run_check():
@@ -208,6 +216,7 @@ class TestDLPackDataType(unittest.TestCase):
             name='mod',
             cpp_sources=cpp_source,
             functions='check_dtype',
+            extra_cflags=_windows_tvm_ffi_extra_cflags(),
             keep_module_alive=False,
         )
         for dtype in [
@@ -271,6 +280,7 @@ class TestDLPackDeviceType(unittest.TestCase):
             name='mod',
             cpp_sources=cpp_source,
             functions='check_device',
+            extra_cflags=_windows_tvm_ffi_extra_cflags(),
             keep_module_alive=False,
         )
 

--- a/test/legacy_test/test_tvm_ffi.py
+++ b/test/legacy_test/test_tvm_ffi.py
@@ -147,7 +147,6 @@ class TestCDLPackExchangeAPI(unittest.TestCase):
             name='mod',
             cpp_sources=cpp_source,
             functions=['add_one_cpu'],
-            keep_module_alive=False,
         )
 
         def run_check():


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

参考 apache/tvm-ffi#128，另外额外加 `keep_module_alive`，尝试避免函数返回的 object 在 mod 之前析构导致段错误

这在之前表现为只要升级为 0.1.6+ Windows 上 CI 就会段错误

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否

<div align="right">
   <sup>This PR is co-authored with @copilot (gpt-5.4 xhigh)</sup>
</div>