### PR TITLE
[CMake] Fix build xxhash out of source

### DIFF
--- a/cmake/external/xxhash.cmake
+++ b/cmake/external/xxhash.cmake
@@ -33,27 +33,6 @@ endif()
 
 include_directories(${XXHASH_INCLUDE_DIR})
 
-if(APPLE)
-  set(BUILD_CMD
-      sed
-      -i
-      \"\"
-      "s/-Wstrict-prototypes -Wundef/-Wstrict-prototypes -Wundef -fPIC/g"
-      ${SOURCE_DIR}/Makefile
-      &&
-      make
-      lib)
-elseif(UNIX)
-  set(BUILD_CMD
-      sed
-      -i
-      "s/-Wstrict-prototypes -Wundef/-Wstrict-prototypes -Wundef -fPIC/g"
-      ${SOURCE_DIR}/Makefile
-      &&
-      make
-      lib)
-endif()
-
 if(WIN32)
   set(XXHASH_LIBRARIES "${XXHASH_INSTALL_DIR}/lib/xxhash.lib")
   set(XXHASH_CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4710 /wd4711")
@@ -90,6 +69,17 @@ if(WIN32)
     TEST_COMMAND ""
     BUILD_BYPRODUCTS ${XXHASH_LIBRARIES})
 else()
+  set(XXHASH_INSTALLED_HEADER ${XXHASH_INCLUDE_DIR}/xxhash.h)
+  set(XXHASH_BUILD_DIR ${XXHASH_PREFIX_DIR}/build)
+  set(XXHASH_MAKEFILE ${XXHASH_PREFIX_DIR}/Makefile)
+  find_program(XXHASH_MAKE_EXECUTABLE make REQUIRED)
+  set(XXHASH_MAKE_C_FLAGS "${XXHASH_CMAKE_C_FLAGS} -fPIC")
+  string(STRIP "${XXHASH_MAKE_C_FLAGS}" XXHASH_MAKE_C_FLAGS)
+
+  file(MAKE_DIRECTORY ${XXHASH_PREFIX_DIR})
+  file(WRITE ${XXHASH_MAKEFILE}
+       "vpath %.c ${SOURCE_DIR}\ninclude ${SOURCE_DIR}/Makefile\n")
+
   ExternalProject_Add(
     extern_xxhash
     ${EXTERNAL_PROJECT_LOG_ARGS}
@@ -97,11 +87,18 @@ else()
     PREFIX ${XXHASH_PREFIX_DIR}
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_IN_SOURCE 1
-    BUILD_COMMAND ${BUILD_CMD}
-    INSTALL_COMMAND make PREFIX=${XXHASH_INSTALL_DIR} install
+    BUILD_COMMAND ${CMAKE_COMMAND} -E make_directory ${XXHASH_BUILD_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${XXHASH_MAKEFILE}
+            ${XXHASH_BUILD_DIR}/Makefile
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${SOURCE_DIR}/xxhash.h
+            ${XXHASH_BUILD_DIR}/xxhash.h
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${SOURCE_DIR}/xxhsum.1
+            ${XXHASH_BUILD_DIR}/xxhsum.1
+    COMMAND ${XXHASH_MAKE_EXECUTABLE} -C ${XXHASH_BUILD_DIR}
+            "CFLAGS=${XXHASH_MAKE_C_FLAGS}" PREFIX=${XXHASH_INSTALL_DIR} install
+    INSTALL_COMMAND ""
     TEST_COMMAND ""
-    BUILD_BYPRODUCTS ${XXHASH_LIBRARIES})
+    BUILD_BYPRODUCTS ${XXHASH_LIBRARIES} ${XXHASH_INSTALLED_HEADER})
 endif()
 
 add_library(xxhash STATIC IMPORTED GLOBAL)

--- a/cmake/external/xxhash.cmake
+++ b/cmake/external/xxhash.cmake
@@ -33,27 +33,6 @@ endif()
 
 include_directories(${XXHASH_INCLUDE_DIR})
 
-if(APPLE)
-  set(BUILD_CMD
-      sed
-      -i
-      \"\"
-      "s/-Wstrict-prototypes -Wundef/-Wstrict-prototypes -Wundef -fPIC/g"
-      ${SOURCE_DIR}/Makefile
-      &&
-      make
-      lib)
-elseif(UNIX)
-  set(BUILD_CMD
-      sed
-      -i
-      "s/-Wstrict-prototypes -Wundef/-Wstrict-prototypes -Wundef -fPIC/g"
-      ${SOURCE_DIR}/Makefile
-      &&
-      make
-      lib)
-endif()
-
 if(WIN32)
   set(XXHASH_LIBRARIES "${XXHASH_INSTALL_DIR}/lib/xxhash.lib")
   set(XXHASH_CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4710 /wd4711")
@@ -90,6 +69,16 @@ if(WIN32)
     TEST_COMMAND ""
     BUILD_BYPRODUCTS ${XXHASH_LIBRARIES})
 else()
+  set(XXHASH_INSTALLED_HEADER ${XXHASH_INCLUDE_DIR}/xxhash.h)
+  set(XXHASH_BUILD_DIR ${XXHASH_PREFIX_DIR}/build)
+  set(XXHASH_MAKEFILE ${XXHASH_PREFIX_DIR}/Makefile)
+  set(XXHASH_MAKE_C_FLAGS "${XXHASH_CMAKE_C_FLAGS} -fPIC")
+  string(STRIP "${XXHASH_MAKE_C_FLAGS}" XXHASH_MAKE_C_FLAGS)
+
+  file(MAKE_DIRECTORY ${XXHASH_PREFIX_DIR})
+  file(WRITE ${XXHASH_MAKEFILE}
+       "vpath %.c ${SOURCE_DIR}\ninclude ${SOURCE_DIR}/Makefile\n")
+
   ExternalProject_Add(
     extern_xxhash
     ${EXTERNAL_PROJECT_LOG_ARGS}
@@ -97,11 +86,18 @@ else()
     PREFIX ${XXHASH_PREFIX_DIR}
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_IN_SOURCE 1
-    BUILD_COMMAND ${BUILD_CMD}
-    INSTALL_COMMAND make PREFIX=${XXHASH_INSTALL_DIR} install
+    BUILD_COMMAND ${CMAKE_COMMAND} -E make_directory ${XXHASH_BUILD_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${XXHASH_MAKEFILE}
+            ${XXHASH_BUILD_DIR}/Makefile
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${SOURCE_DIR}/xxhash.h
+            ${XXHASH_BUILD_DIR}/xxhash.h
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${SOURCE_DIR}/xxhsum.1
+            ${XXHASH_BUILD_DIR}/xxhsum.1
+    COMMAND $(MAKE) -C ${XXHASH_BUILD_DIR} "CFLAGS=${XXHASH_MAKE_C_FLAGS}"
+            PREFIX=${XXHASH_INSTALL_DIR} install
+    INSTALL_COMMAND ""
     TEST_COMMAND ""
-    BUILD_BYPRODUCTS ${XXHASH_LIBRARIES})
+    BUILD_BYPRODUCTS ${XXHASH_LIBRARIES} ${XXHASH_INSTALLED_HEADER})
 endif()
 
 add_library(xxhash STATIC IMPORTED GLOBAL)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复非 Windows 平台下 xxhash 通过上游 Makefile 构建时污染源码目录的问题。

此前 xxhash 使用 `BUILD_IN_SOURCE` 在 `third_party/xxhash` 中直接构建，可能在源码目录残留 `xxhash.o`、`libxxhash.*` 等产物。当源码目录被宿主和容器共享时，容易出现构建产物架构不一致的问题，例如容器内链接到宿主侧生成的对象文件，导致 `XXH32`、`XXH64` 等符号链接失败。

本 PR 将非 Windows 下的 xxhash 构建调整为 out-of-source：

- 在 `${XXHASH_PREFIX_DIR}/build` 中执行上游 Makefile 构建
- 使用 wrapper Makefile + `vpath` 从 `third_party/xxhash` 读取 `.c` 源文件
- 仅在 build 目录中创建 `xxhash.h` 和 `xxhsum.1` 的链接，以兼容上游 Makefile 的当前目录假设
- 保持安装产物仍输出到 `${XXHASH_INSTALL_DIR}`
- 移除对上游 Makefile 的 `sed` 修改，避免污染源码目录
- 声明安装后的静态库和头文件为 `BUILD_BYPRODUCTS`


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否