### PR TITLE
[PHI] Add missing dtype setting in unique infermeta

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -6442,6 +6442,7 @@ void UniqueRawInferMeta(const MetaTensor& x,
                         MetaTensor* indices,
                         MetaTensor* index,
                         MetaTensor* counts) {
+  out->set_dtype(x.dtype());
   if (!is_sorted) {
     PADDLE_ENFORCE_EQ(x.dims().size() == 1 || x.dims().size() == 0,
                       true,
@@ -6451,6 +6452,7 @@ void UniqueRawInferMeta(const MetaTensor& x,
                           x.dims().size()));
     out->set_dims(make_ddim({-1}));
     index->set_dims(x.dims());
+    index->set_dtype(dtype);
     return;
   }
 
@@ -6467,6 +6469,7 @@ void UniqueRawInferMeta(const MetaTensor& x,
     out->set_dims(make_ddim({-1}));
     if (return_inverse) {
       index->set_dims(make_ddim({common::product(x.dims())}));
+      index->set_dtype(dtype);
     }
   } else {
     int axis_value = axis[0];

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -6452,7 +6452,6 @@ void UniqueRawInferMeta(const MetaTensor& x,
                           x.dims().size()));
     out->set_dims(make_ddim({-1}));
     index->set_dims(x.dims());
-    index->set_dtype(dtype);
     return;
   }
 
@@ -6469,7 +6468,6 @@ void UniqueRawInferMeta(const MetaTensor& x,
     out->set_dims(make_ddim({-1}));
     if (return_inverse) {
       index->set_dims(make_ddim({common::product(x.dims())}));
-      index->set_dtype(dtype);
     }
   } else {
     int axis_value = axis[0];

--- a/test/legacy_test/test_unique.py
+++ b/test/legacy_test/test_unique.py
@@ -440,12 +440,38 @@ class TestUniqueAPI(unittest.TestCase):
             unique, inverse, counts = paddle.unique(
                 x, return_inverse=True, return_counts=True, axis=0
             )
+            self.assertEqual(unique.dtype, paddle.float64)
             place = paddle.CPUPlace()
             exe = paddle.static.Executor(place)
             x_np = np.array([[1, 2], [3, 4], [1, 2]]).astype('float64')
             result = exe.run(
                 feed={"x": x_np}, fetch_list=[unique, inverse, counts]
             )
+            np.testing.assert_array_equal(result[0], np.array([[1, 2], [3, 4]]))
+            np.testing.assert_array_equal(result[1], np.array([0, 1, 0]))
+            np.testing.assert_array_equal(result[2], np.array([2, 1]))
+
+    def test_static_graph_int64_input(self):
+        with (
+            paddle_static_guard(),
+            paddle.static.program_guard(
+                paddle.static.Program(), paddle.static.Program()
+            ),
+        ):
+            x = paddle.static.data(name='x', shape=[3, 2], dtype='int64')
+            unique, inverse, counts = paddle.unique(
+                x, return_inverse=True, return_counts=True, axis=0
+            )
+            self.assertEqual(unique.dtype, paddle.int64)
+            place = paddle.CPUPlace()
+            exe = paddle.static.Executor(place)
+            x_np = np.array([[1, 2], [3, 4], [1, 2]]).astype('int64')
+            result = exe.run(
+                feed={"x": x_np}, fetch_list=[unique, inverse, counts]
+            )
+            np.testing.assert_array_equal(result[0], np.array([[1, 2], [3, 4]]))
+            np.testing.assert_array_equal(result[1], np.array([0, 1, 0]))
+            np.testing.assert_array_equal(result[2], np.array([2, 1]))
 
 
 class TestUniqueError(unittest.TestCase):

--- a/test/legacy_test/test_unique.py
+++ b/test/legacy_test/test_unique.py
@@ -460,18 +460,18 @@ class TestUniqueAPI(unittest.TestCase):
         ):
             x = paddle.static.data(name='x', shape=[3, 2], dtype='int64')
             unique, inverse, counts = paddle.unique(
-                x, return_inverse=True, return_counts=True, axis=0, sorted=False
+                x, return_inverse=True, return_counts=True, axis=0
             )
             self.assertEqual(unique.dtype, paddle.int64)
             place = paddle.CPUPlace()
             exe = paddle.static.Executor(place)
-            x_np = np.array([[3, 4], [1, 2], [3, 4]]).astype('int64')
+            x_np = np.array([[1, 2], [3, 4], [1, 2]]).astype('int64')
             result = exe.run(
                 feed={"x": x_np}, fetch_list=[unique, inverse, counts]
             )
             np.testing.assert_array_equal(result[0], np.array([[1, 2], [3, 4]]))
-            np.testing.assert_array_equal(result[1], np.array([1, 0, 1]))
-            np.testing.assert_array_equal(result[2], np.array([1, 2]))
+            np.testing.assert_array_equal(result[1], np.array([0, 1, 0]))
+            np.testing.assert_array_equal(result[2], np.array([2, 1]))
 
 
 class TestUniqueError(unittest.TestCase):

--- a/test/legacy_test/test_unique.py
+++ b/test/legacy_test/test_unique.py
@@ -460,18 +460,18 @@ class TestUniqueAPI(unittest.TestCase):
         ):
             x = paddle.static.data(name='x', shape=[3, 2], dtype='int64')
             unique, inverse, counts = paddle.unique(
-                x, return_inverse=True, return_counts=True, axis=0
+                x, return_inverse=True, return_counts=True, axis=0, sorted=False
             )
             self.assertEqual(unique.dtype, paddle.int64)
             place = paddle.CPUPlace()
             exe = paddle.static.Executor(place)
-            x_np = np.array([[1, 2], [3, 4], [1, 2]]).astype('int64')
+            x_np = np.array([[3, 4], [1, 2], [3, 4]]).astype('int64')
             result = exe.run(
                 feed={"x": x_np}, fetch_list=[unique, inverse, counts]
             )
             np.testing.assert_array_equal(result[0], np.array([[1, 2], [3, 4]]))
-            np.testing.assert_array_equal(result[1], np.array([0, 1, 0]))
-            np.testing.assert_array_equal(result[2], np.array([2, 1]))
+            np.testing.assert_array_equal(result[1], np.array([1, 0, 1]))
+            np.testing.assert_array_equal(result[2], np.array([1, 2]))
 
 
 class TestUniqueError(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

fixes #78872

添加 infermeta 里漏掉的 out dtype 设置，导致静态图下 dtype 推错的问题，不影响动态图

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.5 xhigh)</sup>
</div>