### PR TITLE
SGD: use float64 learning_rate to avoid precision truncation

### DIFF
--- a/paddle/phi/kernels/cpu/sgd_kernel.cc
+++ b/paddle/phi/kernels/cpu/sgd_kernel.cc
@@ -28,14 +28,14 @@ void sgd_dense_param_dense_grad_impl(const DenseTensor& param,
                                      DenseTensor* param_out) {
   const auto sz = param_out->numel();
   jit::sgd_attr_t attr(1, sz, 1, sz, 1);
-  const T* lr = learning_rate.data<T>();
+  T lr_val = static_cast<T>(learning_rate.data<double>()[0]);
   const T* param_data = param.data<T>();
   const T* grad_data = grad.data<T>();
   int64_t rows_idx = 0;
   T* out_data = param_out->data<T>();
 
   auto sgd = jit::KernelFuncs<jit::SgdTuple<T>, CPUPlace>::Cache().At(attr);
-  sgd(lr, param_data, grad_data, &rows_idx, out_data, &attr);
+  sgd(&lr_val, param_data, grad_data, &rows_idx, out_data, &attr);
 }
 
 template <>
@@ -46,9 +46,9 @@ void sgd_dense_param_dense_grad_impl<bfloat16>(const DenseTensor& param,
   auto p = EigenVector<bfloat16>::Flatten(param);
   auto g = EigenVector<bfloat16>::Flatten(grad);
   auto o = EigenVector<bfloat16>::Flatten(*param_out);
-  const auto* lr = learning_rate.data<bfloat16>();
+  const auto* lr = learning_rate.data<double>();
 
-  o = p - lr[0] * g;
+  o = p - static_cast<bfloat16>(lr[0]) * g;
 }
 
 template <typename T>
@@ -58,7 +58,7 @@ void sgd_dense_param_dense_grad_mixed_impl(const DenseTensor& param,
                                            DenseTensor* param_out) {
   const T* param_data = param.data<T>();
   const float* grad_data = grad.data<float>();
-  const T* lr_ptr = learning_rate.data<T>();
+  const double* lr_ptr = learning_rate.data<double>();
 
   float lr = static_cast<float>(lr_ptr[0]);
   T* out_data = param_out->data<T>();
@@ -83,7 +83,7 @@ void sgd_dense_param_sparse_grad_impl(const DenseTensor& param,
   const auto& grad_rows = grad.rows();
   const T* param_data = param.data<T>();
   const T* grad_data = grad_value.data<T>();
-  const T* lr = learning_rate.data<T>();
+  T lr_val = static_cast<T>(learning_rate.data<double>()[0]);
   const int64_t* rows_data = grad_rows.data();
   T* out_data = param_out->data<T>();
 
@@ -96,7 +96,7 @@ void sgd_dense_param_sparse_grad_impl(const DenseTensor& param,
   attr.selected_rows_size = static_cast<int>(grad_rows.size());
 
   auto sgd = jit::KernelFuncs<jit::SgdTuple<T>, CPUPlace>::Cache().At(attr);
-  sgd(lr, param_data, grad_data, rows_data, out_data, &attr);
+  sgd(&lr_val, param_data, grad_data, rows_data, out_data, &attr);
 }
 
 template <>
@@ -113,7 +113,7 @@ void sgd_dense_param_sparse_grad_impl<bfloat16>(
 
   const auto* grad_data = grad_value.data<bfloat16>();
   auto* out_data = param_out->data<bfloat16>();
-  const auto* lr = learning_rate.data<bfloat16>();
+  const auto* lr = learning_rate.data<double>();
 
   for (size_t i = 0; i < grad_rows.size(); ++i) {
     PADDLE_ENFORCE_LT(
@@ -126,7 +126,8 @@ void sgd_dense_param_sparse_grad_impl<bfloat16>(
             grad_height));
     const int64_t row = grad_rows[i];
     for (int64_t j = 0; j < grad_width; ++j) {
-      out_data[row * grad_width + j] -= lr[0] * grad_data[i * grad_width + j];
+      out_data[row * grad_width + j] -=
+          static_cast<bfloat16>(lr[0]) * grad_data[i * grad_width + j];
     }
   }
 }
@@ -191,7 +192,7 @@ void SGDSparseParamSparseGradKernel(const Context& dev_ctx UNUSED,
           param_row_width,
           grad_row_width));
 
-  const auto* lr = learning_rate.data<T>();
+  const T lr_val = static_cast<T>(learning_rate.data<double>()[0]);
   const auto* grad_data = grad.value().data<T>();
   auto* out_data = param_out->mutable_value()->data<T>();
   for (size_t i = 0; i < grad.rows().size(); i++) {
@@ -204,7 +205,7 @@ void SGDSparseParamSparseGradKernel(const Context& dev_ctx UNUSED,
             id_index));
     for (int64_t j = 0; j < grad_row_width; j++) {
       out_data[id_index * grad_row_width + j] -=
-          lr[0] * grad_data[i * grad_row_width + j];
+          lr_val * grad_data[i * grad_row_width + j];
     }
   }
 }
@@ -212,7 +213,9 @@ void SGDSparseParamSparseGradKernel(const Context& dev_ctx UNUSED,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    sgd, CPU, ALL_LAYOUT, phi::SGDDenseKernel, phi::bfloat16, float, double) {}
+    sgd, CPU, ALL_LAYOUT, phi::SGDDenseKernel, phi::bfloat16, float, double) {
+  kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64);
+}
 
 PD_REGISTER_KERNEL(sgd_dense_param_sparse_grad,
                    CPU,
@@ -220,7 +223,9 @@ PD_REGISTER_KERNEL(sgd_dense_param_sparse_grad,
                    phi::SGDDenseParamSparseGradKernel,
                    phi::bfloat16,
                    float,
-                   double) {}
+                   double) {
+  kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64);
+}
 
 PD_REGISTER_KERNEL(sgd_sparse_param_sparse_grad,
                    CPU,
@@ -228,4 +233,6 @@ PD_REGISTER_KERNEL(sgd_sparse_param_sparse_grad,
                    phi::SGDSparseParamSparseGradKernel,
                    phi::bfloat16,
                    float,
-                   double) {}
+                   double) {
+  kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64);
+}

--- a/paddle/phi/kernels/gpu/sgd_kernel.cu
+++ b/paddle/phi/kernels/gpu/sgd_kernel.cu
@@ -26,7 +26,7 @@ namespace phi {
 template <typename T, typename MT, typename GradT>
 __global__ void SGDKernelMT(const T* param,
                             const GradT* grad,
-                            const T* learning_rate,
+                            const double* learning_rate,
                             const int64_t num,
                             T* param_out,
                             const MT* master_param,
@@ -46,7 +46,7 @@ __global__ void SGDKernelMT(const T* param,
 template <typename T>
 __global__ void SparseSGDFunctorKernel(const T* selected_rows,
                                        const int64_t* rows,
-                                       const T* learning_rate,
+                                       const double* learning_rate,
                                        T* tensor_out,
                                        int64_t row_numel,
                                        int64_t limit) {
@@ -56,9 +56,9 @@ __global__ void SparseSGDFunctorKernel(const T* selected_rows,
     for (int64_t index = threadIdx.x; index < row_numel; index += blockDim.x) {
       // Since index in rows of SelectedRows can be duplicate, we have to use
       // Atomic Operation to avoid concurrent write error.
-      CudaAtomicAdd(
-          tensor_out_ptr + index,
-          -static_cast<T>(1.0) * learning_rate[0] * selected_rows_ptr[index]);
+      CudaAtomicAdd(tensor_out_ptr + index,
+                    -static_cast<T>(1.0) * static_cast<T>(learning_rate[0]) *
+                        selected_rows_ptr[index]);
     }
   }
 }
@@ -93,7 +93,7 @@ void SGDDenseKernel(const Context& dev_ctx,
     SGDKernelMT<T, MT, float><<<grid, block, 0, dev_ctx.stream()>>>(
         param.data<T>(),
         grad.data<float>(),
-        learning_rate.data<T>(),
+        learning_rate.data<double>(),
         param.numel(),
         dev_ctx.template Alloc<T>(param_out),
         master_in_data,
@@ -102,7 +102,7 @@ void SGDDenseKernel(const Context& dev_ctx,
     SGDKernelMT<T, MT, T><<<grid, block, 0, dev_ctx.stream()>>>(
         param.data<T>(),
         grad.data<T>(),
-        learning_rate.data<T>(),
+        learning_rate.data<double>(),
         param.numel(),
         dev_ctx.template Alloc<T>(param_out),
         master_in_data,
@@ -168,10 +168,10 @@ void SGDDenseParamSparseGradKernel(const Context& dev_ctx,
   int max_threads = dev_ctx.GetMaxPhysicalThreadCount();
   int max_blocks = std::max(max_threads / kThreadsPerBlock, 1);
   MixVector<int64_t> mixv_in_rows(&in_rows);
-  SparseSGDFunctorKernel<<<max_blocks, thread_x, 0, dev_ctx.stream()>>>(
+  SparseSGDFunctorKernel<T><<<max_blocks, thread_x, 0, dev_ctx.stream()>>>(
       in_data,
       mixv_in_rows.CUDAData(dev_ctx.GetPlace()),
-      learning_rate.data<T>(),
+      learning_rate.data<double>(),
       out_data,
       in_row_numel,
       in_rows.size());
@@ -200,6 +200,7 @@ PD_REGISTER_KERNEL(sgd,
                    phi::bfloat16,
                    float,
                    double) {
+  kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64);
   if (kernel_key.dtype() == phi::DataType::FLOAT16 ||
       kernel_key.dtype() == phi::DataType::BFLOAT16) {
     kernel->OutputAt(1).SetDataType(phi::DataType::FLOAT32);
@@ -210,6 +211,7 @@ PD_REGISTER_KERNEL(sgd,
 #ifdef PADDLE_WITH_HIP
 PD_REGISTER_KERNEL(
     sgd, GPU, ALL_LAYOUT, phi::SGDDenseKernel, phi::float16, float, double) {
+  kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64);
   if (kernel_key.dtype() == phi::DataType::FLOAT16) {
     kernel->OutputAt(1).SetDataType(phi::DataType::FLOAT32);
   }
@@ -222,7 +224,9 @@ PD_REGISTER_KERNEL(sgd_dense_param_sparse_grad,
                    phi::SGDDenseParamSparseGradKernel,
                    phi::float16,
                    float,
-                   double) {}
+                   double) {
+  kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64);
+}
 
 PD_REGISTER_KERNEL(sgd_sparse_param_sparse_grad,
                    GPU,
@@ -230,4 +234,6 @@ PD_REGISTER_KERNEL(sgd_sparse_param_sparse_grad,
                    phi::SGDSparseParamSparseGradKernel,
                    phi::float16,
                    float,
-                   double) {}
+                   double) {
+  kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64);
+}

--- a/paddle/phi/kernels/onednn/sgd_kernel.cc
+++ b/paddle/phi/kernels/onednn/sgd_kernel.cc
@@ -48,12 +48,13 @@ void SGDDenseKernel(const Context& dev_ctx,
   auto* out_data = dev_ctx.template Alloc<T>(param_out);
   const T* param_data = param.data<T>();
   const auto* grad_data = grad.data<T>();
-  const auto* lr = learning_rate.data<T>();
+  const auto* lr = learning_rate.data<double>();
   // Since dense SGD is not in place operation, first copy params to output
   // tensor and then update it.
   std::memcpy(out_data, param_data, param.memory_size());
-  funcs::OneDNNAXPYHandler<T>(param_out->numel(), -lr[0], dev_ctx.GetEngine())(
-      grad_data, out_data);
+  funcs::OneDNNAXPYHandler<T>(param_out->numel(),
+                              static_cast<T>(-lr[0]),
+                              dev_ctx.GetEngine())(grad_data, out_data);
 }
 
 template <typename T, typename Context>
@@ -74,10 +75,10 @@ void SGDDenseParamSparseGradKernel(const Context& dev_ctx,
 
   const auto* grad_data = grad_value.data<T>();
   auto* out_data = param_out->data<T>();
-  const auto* lr = learning_rate.data<T>();
+  const auto* lr = learning_rate.data<double>();
 
   funcs::OneDNNAXPYHandler<T> axpy_handler(
-      grad_width, -lr[0], dev_ctx.GetEngine());
+      grad_width, static_cast<T>(-lr[0]), dev_ctx.GetEngine());
 
   for (size_t i = 0; i < grad_rows.size(); ++i) {
     PADDLE_ENFORCE_LT(
@@ -99,6 +100,7 @@ void SGDDenseParamSparseGradKernel(const Context& dev_ctx,
 
 PD_REGISTER_KERNEL(
     sgd, OneDNN, ONEDNN, phi::SGDDenseKernel, float, phi::bfloat16) {
+  kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64);
   kernel->check_if_onednn_kernel_support_ = phi::SgdCheckIfOneDNNSupport;
 }
 
@@ -108,5 +110,6 @@ PD_REGISTER_KERNEL(sgd_dense_param_sparse_grad,
                    phi::SGDDenseParamSparseGradKernel,
                    float,
                    phi::bfloat16) {
+  kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64);
   kernel->check_if_onednn_kernel_support_ = phi::SgdSparseCheckIfOneDNNSupport;
 }

--- a/paddle/phi/kernels/xpu/sgd_kernel.cc
+++ b/paddle/phi/kernels/xpu/sgd_kernel.cc
@@ -49,20 +49,13 @@ void SGDDenseKernel(const Context& dev_ctx,
                               grad.numel(),
                               sz));
 
-  const T* lr_t = learning_rate.data<T>();
   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
-  const float* lr = nullptr;
-  if (std::is_same<T, dtype::float16>::value) {
-    float* lr_float = RAII_GUARD.alloc_l3_or_gm<float>(learning_rate.numel());
-    int r = xpu::cast<XPUType, float>(dev_ctx.x_context(),
-                                      reinterpret_cast<const XPUType*>(lr_t),
-                                      lr_float,
-                                      learning_rate.numel());
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
-    lr = lr_float;
-  } else {
-    lr = reinterpret_cast<const float*>(lr_t);
-  }
+
+  // Cast learning_rate from float64 to float32 on device
+  float* lr_f32 = RAII_GUARD.alloc_l3_or_gm<float>(1);
+  int r_cast = xpu::cast<double, float>(
+      dev_ctx.x_context(), learning_rate.data<double>(), lr_f32, 1);
+  PADDLE_ENFORCE_XDNN_SUCCESS(r_cast, "cast_lr_fp64_to_fp32");
 
   const T* param_data = param.data<T>();
   const XPUType* grad_ptr = nullptr;
@@ -82,7 +75,7 @@ void SGDDenseKernel(const Context& dev_ctx,
   int r = xpu::sgd(dev_ctx.x_context(),
                    grad_ptr,
                    reinterpret_cast<const XPUType*>(param_data),
-                   lr,
+                   lr_f32,
                    reinterpret_cast<XPUType*>(out_data),
                    sz);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "sgd");
@@ -134,11 +127,18 @@ void SGDDenseParamSparseGradKernel(const Context& dev_ctx,
   auto* in_data = in_value.data<T>();
   auto* out_data = param_out->data<T>();
 
+  // Cast learning_rate from float64 to float32 on device
+  xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+  float* lr_f32 = RAII_GUARD.alloc_l3_or_gm<float>(1);
+  int r_cast = xpu::cast<double, float>(
+      dev_ctx.x_context(), learning_rate.data<double>(), lr_f32, 1);
+  PADDLE_ENFORCE_XDNN_SUCCESS(r_cast, "cast_lr_fp64_to_fp32");
+
   int r = xpu::sparse_sgd<XPUType, int64_t>(
       dev_ctx.x_context(),
       reinterpret_cast<const XPUType*>(in_data),
       reinterpret_cast<const XPUType*>(param.data<T>()),
-      learning_rate.data<float>(),
+      lr_f32,
       in_rows_vec,
       reinterpret_cast<XPUType*>(out_data),
       in_row_numel,
@@ -150,10 +150,14 @@ void SGDDenseParamSparseGradKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    sgd, XPU, ALL_LAYOUT, phi::SGDDenseKernel, phi::float16, float) {}
+    sgd, XPU, ALL_LAYOUT, phi::SGDDenseKernel, phi::float16, float) {
+  kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64);
+}
 PD_REGISTER_KERNEL(sgd_dense_param_sparse_grad,
                    XPU,
                    ALL_LAYOUT,
                    phi::SGDDenseParamSparseGradKernel,
                    phi::float16,
-                   float) {}
+                   float) {
+  kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64);
+}

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -5025,8 +5025,6 @@
            sgd_dense_param_sparse_grad {dense, dense, selected_rows, dense -> dense, dense},
            sgd_sparse_param_sparse_grad {selected_rows, dense, selected_rows, selected_rows -> selected_rows, selected_rows}
     data_type : param
-  data_transform :
-    support_trans_dtype : learning_rate
   optional : master_param, master_param_out
   inplace : (param -> param_out), (master_param -> master_param_out)
   traits : pir::SideEffectTrait, paddle::dialect::ForwardOnlyTrait

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -524,28 +524,30 @@ class Optimizer:
     def get_opti_var_name_list(self) -> list[str]:
         return self._opti_name_list
 
+    def get_lr_dtype(self) -> paddle.dtype:
+        # lr var can't be float16 or bfloat16, for pure fp16 or bf16 training, should extra handle the dtype for lr
+        _lr_dtype = (
+            paddle.get_default_dtype() if self._dtype is None else self._dtype
+        )
+        _lr_dtype = (
+            paddle.float32
+            if (
+                (
+                    paddle.get_default_dtype() != "float16"
+                    and _lr_dtype == paddle.float16
+                )
+                or (
+                    paddle.get_default_dtype() != "bfloat16"
+                    and _lr_dtype == paddle.bfloat16
+                )
+            )
+            else _lr_dtype
+        )
+        return _lr_dtype
+
     def _create_global_learning_rate(self):
         def do_create():
-            # lr var can't be float16 or bfloat16, for pure fp16 or bf16 training, should extra handle the dtype for lr
-            _lr_dtype = (
-                paddle.get_default_dtype()
-                if self._dtype is None
-                else self._dtype
-            )
-            _lr_dtype = (
-                paddle.float32
-                if (
-                    (
-                        paddle.get_default_dtype() != "float16"
-                        and _lr_dtype == paddle.float16
-                    )
-                    or (
-                        paddle.get_default_dtype() != "bfloat16"
-                        and _lr_dtype == paddle.bfloat16
-                    )
-                )
-                else _lr_dtype
-            )
+            _lr_dtype = self.get_lr_dtype()
             if isinstance(self._learning_rate, LRScheduler):
                 lr_var = self._global_learning_rate()
                 # only create global lr_var once

--- a/python/paddle/optimizer/sgd.py
+++ b/python/paddle/optimizer/sgd.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING
 
+import paddle
 from paddle import _C_ops, pir
 
 from ..base import framework
@@ -111,6 +112,9 @@ class SGD(Optimizer):
         self.type = "sgd"
         self._multi_precision = multi_precision
         self._master_weights = {}
+
+    def get_lr_dtype(self) -> paddle.dtype:
+        return paddle.float64
 
     def _create_accumulators(self, block, parameters):
         assert isinstance(block, (framework.Block, pir.Block))

--- a/python/paddle/static/amp/decorator.py
+++ b/python/paddle/static/amp/decorator.py
@@ -190,10 +190,11 @@ class OptimizerWithMixedPrecision:
                 )
 
             if isinstance(self._optimizer._learning_rate, float):
+                _lr_dtype = self._optimizer.get_lr_dtype()
                 self._optimizer._learning_rate_map[
                     paddle.static.default_main_program()
                 ] = paddle.pir.core.create_persistable_value(
-                    dtype='float32',
+                    dtype=_lr_dtype,
                     shape=[1],
                     name=unique_name.generate("learning_rate"),
                     initializer=paddle.nn.initializer.ConstantInitializer(
@@ -227,15 +228,16 @@ class OptimizerWithMixedPrecision:
                 persistable=True,
             )
 
-        # Ensure the data type of learning rate vars is float32 (same as the
+        # Ensure the data type of learning rate vars is float64 (same as the
         # master parameter dtype)
         if isinstance(self._optimizer._learning_rate, float):
+            _lr_dtype = self._optimizer.get_lr_dtype()
             self._optimizer._learning_rate_map[default_main_program()] = (
                 paddle.static.create_global_var(
                     name=unique_name.generate("learning_rate"),
                     shape=[1],
                     value=float(self._optimizer._learning_rate),
-                    dtype='float32',
+                    dtype=_lr_dtype,
                     persistable=True,
                 )
             )

--- a/test/legacy_test/test_sgd_op.py
+++ b/test/legacy_test/test_sgd_op.py
@@ -16,7 +16,14 @@ import unittest
 
 import numpy as np
 from op import Operator
-from op_test import OpTest, get_device_place, get_places, is_custom_device
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    convert_uint16_to_float,
+    get_device_place,
+    get_places,
+    is_custom_device,
+)
 from utils import dygraph_guard
 
 import paddle
@@ -41,7 +48,7 @@ class TestSGDOp(OpTest):
         self.conf()
         w = np.random.random((self.h, self.w)).astype("float32")
         g = np.random.random((self.h, self.w)).astype("float32")
-        lr = np.array([0.1]).astype("float32")
+        lr = np.array([0.1]).astype("float64")
 
         self.inputs = {'Param': w, 'Grad': g, 'LearningRate': lr}
         self.outputs = {'ParamOut': w - lr * g}
@@ -86,7 +93,7 @@ class TestSparseSGDOp(unittest.TestCase):
 
         # create and initialize LearningRate Variable
         lr = scope.var('LearningRate').get_tensor()
-        lr_array = np.full((1), 2.0).astype("float32")
+        lr_array = np.full((1), 2.0).astype("float64")
         lr.set(lr_array, place)
 
         # create and run sgd operator
@@ -169,7 +176,7 @@ class TestSGDOpOptimizeSelectedRows(unittest.TestCase):
         # create and initialize LearningRate Variable
         lr_value = 0.1
         lr = scope.var('LearningRate').get_tensor()
-        lr_array = np.full((1), lr_value).astype("float32")
+        lr_array = np.full((1), lr_value).astype("float64")
         lr.set(lr_array, place)
 
         # optimize with Python
@@ -322,6 +329,135 @@ class TestSGDSimple(unittest.TestCase):
         np.testing.assert_allclose(out1, out2)
 
 
+class TestSGDSparseBF16(unittest.TestCase):
+    """Test SGD with bfloat16 sparse grad on CPU (no oneDNN)."""
+
+    def test_sparse_grad_sgd_bf16(self):
+        paddle.enable_static()
+        scope = core.Scope()
+        place = core.CPUPlace()
+        height = 10
+        rows = [0, 4, 7]
+        row_numel = 12
+
+        # Grad: SelectedRows in bfloat16
+        grad_selected_rows = scope.var('Grad').get_selected_rows()
+        grad_selected_rows.set_height(height)
+        grad_selected_rows.set_rows(rows)
+        grad_np = np.random.random((len(rows), row_numel)).astype('float32')
+        grad_tensor = grad_selected_rows.get_tensor()
+        grad_tensor.set(convert_float_to_uint16(grad_np), place)
+
+        # Param: dense bfloat16
+        param_np = np.random.random((height, row_numel)).astype('float32')
+        param_var = scope.var('Param').get_tensor()
+        param_var.set(convert_float_to_uint16(param_np), place)
+
+        # LearningRate: float64
+        lr_value = 0.1
+        lr_var = scope.var('LearningRate').get_tensor()
+        lr_var.set(np.array([lr_value]).astype('float64'), place)
+
+        sgd_op = Operator(
+            "sgd",
+            Param='Param',
+            Grad='Grad',
+            ParamOut='Param',
+            LearningRate='LearningRate',
+        )
+        sgd_op.run(scope, place)
+
+        reference = np.copy(param_np)
+        for idx, row_id in enumerate(rows):
+            reference[row_id] -= lr_value * grad_np[idx]
+
+        result = convert_uint16_to_float(np.array(param_var))
+        np.testing.assert_allclose(result, reference, atol=5e-3, rtol=1e-1)
+        paddle.disable_static()
+
+
+class TestSGDDenseBF16OneDNN(unittest.TestCase):
+    """Test SGD with bfloat16 dense grad on CPU with oneDNN."""
+
+    def test_dense_sgd_bf16_onednn(self):
+        paddle.enable_static()
+        scope = core.Scope()
+        place = core.CPUPlace()
+        h, w = 10, 12
+
+        param_np = np.random.random((h, w)).astype('float32')
+        grad_np = np.random.random((h, w)).astype('float32')
+        lr_value = 0.1
+
+        param_var = scope.var('Param').get_tensor()
+        param_var.set(convert_float_to_uint16(param_np), place)
+
+        grad_var = scope.var('Grad').get_tensor()
+        grad_var.set(convert_float_to_uint16(grad_np), place)
+
+        lr_var = scope.var('LearningRate').get_tensor()
+        lr_var.set(np.array([lr_value]).astype('float64'), place)
+
+        sgd_op = Operator(
+            "sgd",
+            Param='Param',
+            Grad='Grad',
+            ParamOut='Param',
+            LearningRate='LearningRate',
+            use_onednn=True,
+        )
+        sgd_op.run(scope, place)
+
+        reference = param_np - lr_value * grad_np
+        result = convert_uint16_to_float(np.array(param_var))
+        np.testing.assert_allclose(result, reference, atol=5e-3, rtol=1e-1)
+        paddle.disable_static()
+
+    def test_sparse_grad_sgd_bf16_onednn(self):
+        paddle.enable_static()
+        scope = core.Scope()
+        place = core.CPUPlace()
+        height = 10
+        rows = [0, 4, 7]
+        row_numel = 12
+
+        # Grad: SelectedRows in bfloat16
+        grad_selected_rows = scope.var('Grad').get_selected_rows()
+        grad_selected_rows.set_height(height)
+        grad_selected_rows.set_rows(rows)
+        grad_np = np.random.random((len(rows), row_numel)).astype('float32')
+        grad_tensor = grad_selected_rows.get_tensor()
+        grad_tensor.set(convert_float_to_uint16(grad_np), place)
+
+        # Param: dense bfloat16
+        param_np = np.random.random((height, row_numel)).astype('float32')
+        param_var = scope.var('Param').get_tensor()
+        param_var.set(convert_float_to_uint16(param_np), place)
+
+        # LearningRate: float64
+        lr_value = 0.1
+        lr_var = scope.var('LearningRate').get_tensor()
+        lr_var.set(np.array([lr_value]).astype('float64'), place)
+
+        sgd_op = Operator(
+            "sgd",
+            Param='Param',
+            Grad='Grad',
+            ParamOut='Param',
+            LearningRate='LearningRate',
+            use_onednn=True,
+        )
+        sgd_op.run(scope, place)
+
+        reference = np.copy(param_np)
+        for idx, row_id in enumerate(rows):
+            reference[row_id] -= lr_value * grad_np[idx]
+
+        result = convert_uint16_to_float(np.array(param_var))
+        np.testing.assert_allclose(result, reference, atol=5e-3, rtol=1e-1)
+        paddle.disable_static()
+
+
 class TestSGDGradFP32(unittest.TestCase):
     def setUp(self):
         np.random.seed(2023)
@@ -348,7 +484,7 @@ class TestSGDGradFP32(unittest.TestCase):
                 param_dtype = 'float16'
             param = paddle.randn([self.h, self.w], dtype=param_dtype).to(place)
             grad = paddle.randn([self.h, self.w], dtype='float32').to(place)
-            lr = paddle.to_tensor([0.1], dtype='float32', place=place)
+            lr = paddle.to_tensor([0.1], dtype='float64', place=place)
             sgd_wrapper(param, lr, grad)
 
 

--- a/test/legacy_test/test_sgd_op_bf16.py
+++ b/test/legacy_test/test_sgd_op_bf16.py
@@ -46,10 +46,9 @@ class TestSGDOpBF16(OpTest):
         w_bf16 = convert_float_to_uint16(w)
         g = np.random.random((self.h, self.w)).astype('float32')
         g_bf16 = convert_float_to_uint16(g)
-        lr = np.array([0.1]).astype('float32')
-        lr_bf16 = convert_float_to_uint16(lr)
+        lr = np.array([0.1]).astype('float64')
 
-        self.inputs = {'Param': w_bf16, 'Grad': g_bf16, 'LearningRate': lr_bf16}
+        self.inputs = {'Param': w_bf16, 'Grad': g_bf16, 'LearningRate': lr}
         self.outputs = {'ParamOut': w - lr * g}
         self.attrs = {'use_onednn': self.use_onednn}
 
@@ -124,9 +123,8 @@ class TestSparseSGDOpBF16(unittest.TestCase):
     def create_dense_lr_var(self, scope, place):
         lr_tensor = scope.var('LearningRate').get_tensor()
         lr_value = np.random.uniform()
-        lr_array = np.full((1), lr_value, np.float32)
-        lr_array_bf16 = convert_float_to_uint16(lr_array)
-        lr_tensor.set(lr_array_bf16, place)
+        lr_array = np.full((1), lr_value, np.float64)
+        lr_tensor.set(lr_array, place)
 
         return lr_tensor, lr_value
 

--- a/test/xpu/test_sgd_op_xpu.py
+++ b/test/xpu/test_sgd_op_xpu.py
@@ -40,7 +40,7 @@ class XPUTestSgdOp(XPUOpTestWrapper):
             self.conf()
             w = np.random.random((self.h, self.w)).astype(self.dtype)
             g = np.random.random((self.h, self.w)).astype(self.dtype)
-            lr = np.array([0.1]).astype(self.dtype)
+            lr = np.array([0.1]).astype('float32')
 
             self.inputs = {'Param': w, 'Grad': g, 'LearningRate': lr}
             self.outputs = {'ParamOut': w - lr * g}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
#### 背景与动机

当前 SGD kernel 的 `learning_rate` 使用与 param 相同的 dtype（float32/float16/bfloat16）存储和传递。当参数为低精度类型时，学习率会被截断为低精度值，导致精度损失。

参考 PR #78830（AdamW 将 learning_rate 改为 float64），为 SGD kernel 做对齐改动：
- `learning_rate` 统一使用 float64 存储，避免 float32/float16 精度截断
- 与 AdamW 行为保持一致

#### 本次改动

1. **Python 侧**：
   - `optimizer.py` 基类中抽取 `get_lr_dtype()` 方法（与 PR #78830 一致的模式）
   - `sgd.py` 中 override `get_lr_dtype()` 返回 `paddle.float64`

2. **CPU Kernel**（`paddle/phi/kernels/cpu/sgd_kernel.cc`）：
   - 所有 `learning_rate.data<T>()` 改为 `learning_rate.data<double>()`，在使用处 `static_cast<T>()` 转换
   - JIT 路径：读取 double 后 cast 为局部 T 值，传指针给 JIT 函数
   - 三个 kernel 注册均添加 `kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64)`

3. **GPU Kernel**（`paddle/phi/kernels/gpu/sgd_kernel.cu`）：
   - CUDA kernel 的 lr 参数类型从 `const T*` 改为 `const double*`
   - kernel 内部保持原有计算逻辑不变，仅在读取时做类型转换
   - 所有 kernel 注册添加 `kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64)`

4. **OneDNN Kernel**（`paddle/phi/kernels/onednn/sgd_kernel.cc`）：
   - `learning_rate.data<T>()` 改为 `learning_rate.data<double>()`，使用处 `static_cast<T>()`
   - 两个 kernel 注册添加 `kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64)`

5. **XPU Kernel**（`paddle/phi/kernels/xpu/sgd_kernel.cc`）：
   - 读取 double 后在设备上 `xpu::cast<double, float>()` 转为 float32（XPU library 要求）
   - 两个 kernel 注册添加 `kernel->InputAt(1).SetDataType(phi::DataType::FLOAT64)`

6. **单元测试**（`test/legacy_test/test_sgd_op.py`）：
   - 所有 LearningRate 从 float32 更新为 float64
   - 新增 `TestSGDSparseBF16` 和 `TestSGDDenseBF16OneDNN` 测试类覆盖 bfloat16 路径


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是