### PR TITLE
 [CINN] Fix format specifier mismatches in PADDLE_ENFORCE/PADDLE_THROW error messages

### DIFF
--- a/paddle/cinn/common/ir_util.cc
+++ b/paddle/cinn/common/ir_util.cc
@@ -196,7 +196,7 @@ Expr IndiceToAbsOffset(const std::vector<Expr> &shape,
         true,
         ::common::errors::InvalidArgument(
             "The shape data type currently supports only int32 or int64, but "
-            "the current data type of shape[{}] is {}",
+            "the current data type of shape[%d] is %s",
             i,
             shape[i].type()));
 

--- a/paddle/cinn/ir/layout.cc
+++ b/paddle/cinn/ir/layout.cc
@@ -42,7 +42,7 @@ void Layout::Verify() {
       PADDLE_ENFORCE_EQ(axis_names_.find(axis_name) == axis_names_.npos,
                         true,
                         ::common::errors::InvalidArgument(
-                            "{} has already existed.", axis_name));
+                            "%c has already existed.", axis_name));
       axis_names_ += axis_name;
     }
     int offset = 'A' - 'a';
@@ -57,7 +57,7 @@ void Layout::Verify() {
             axis_names_.find(axis_name + offset) == axis_names_.npos,
             true,
             ::common::errors::InvalidArgument(
-                "sub-axis {} finds no primal axis", axis_name));
+                "sub-axis %c finds no primal axis", axis_name));
       }
     }
   }

--- a/paddle/cinn/runtime/sycl/sycl_backend_api.cc
+++ b/paddle/cinn/runtime/sycl/sycl_backend_api.cc
@@ -74,7 +74,7 @@ void SYCLBackendAPI::set_device(int device_id) {
       device_id,
       this->devices.size() - 1,
       ::common::errors::InvalidArgument(
-          "set valid device id! device id: %d > max device id: %zu",
+          "set valid device id! device id: %d > max device id: %d",
           device_id,
           this->devices.size() - 1));
   if (this->contexts[device_id] == nullptr) {

--- a/paddle/cinn/runtime/sycl/sycl_backend_api.cc
+++ b/paddle/cinn/runtime/sycl/sycl_backend_api.cc
@@ -65,17 +65,18 @@ void SYCLBackendAPI::Init(Arch arch) {
 
 void SYCLBackendAPI::set_device(int device_id) {
   if (!initialized_) Init(common::UnknownArch{});
-  PADDLE_ENFORCE_GE(device_id,
-                    0UL,
-                    ::common::errors::InvalidArgument(
-                        "please set valid device id! device id", device_id));
+  PADDLE_ENFORCE_GE(
+      device_id,
+      0UL,
+      ::common::errors::InvalidArgument(
+          "please set valid device id! device id: %d", device_id));
   PADDLE_ENFORCE_LE(
       device_id,
       this->devices.size() - 1,
-      ::common::errors::InvalidArgument("set valid device id! device id: ",
-                                        device_id,
-                                        " > max device id:",
-                                        this->devices.size() - 1));
+      ::common::errors::InvalidArgument(
+          "set valid device id! device id: %d > max device id: %zu",
+          device_id,
+          this->devices.size() - 1));
   if (this->contexts[device_id] == nullptr) {
     auto exception_handler = [](::sycl::exception_list exceptions) {
       for (const std::exception_ptr& e : exceptions) {

--- a/paddle/cinn/runtime/sycl/sycl_backend_api.cc
+++ b/paddle/cinn/runtime/sycl/sycl_backend_api.cc
@@ -67,7 +67,7 @@ void SYCLBackendAPI::set_device(int device_id) {
   if (!initialized_) Init(common::UnknownArch{});
   PADDLE_ENFORCE_GE(
       device_id,
-      0UL,
+      0,
       ::common::errors::InvalidArgument(
           "please set valid device id! device id: %d", device_id));
   PADDLE_ENFORCE_LE(

--- a/paddle/cinn/runtime/sycl/sycl_module.cc
+++ b/paddle/cinn/runtime/sycl/sycl_module.cc
@@ -61,7 +61,7 @@ void* SYCLModule::GetFunction(const std::string& func_name) {
       kernel_func,
       nullptr,
       ::common::errors::InvalidArgument(
-          "Errors: Sycl failed to get function %s", dlerror(), ":dlsym\n"));
+          "Errors: Sycl failed to get function %s:dlsym", dlerror()));
   return reinterpret_cast<void*>(kernel_func);
 }
 

--- a/paddle/cinn/runtime/sycl/sycl_util.cc
+++ b/paddle/cinn/runtime/sycl/sycl_util.cc
@@ -215,11 +215,10 @@ cnnlDataType_t convert_to_cnnl_dtype(void *v_args, int num_args) {
   } else if (is_float8e4m3) {
     data_type = CUDA_R_8F_E4M3;
   } else {
-    PADDLE_THROW(
-        ::common::errors::InvalidArgument("unsupported cudnn data type: ",
-                                          static_cast<int>(type_code),
-                                          ", bits = ",
-                                          bits));
+    PADDLE_THROW(::common::errors::InvalidArgument(
+        "unsupported cudnn data type: %d, bits = %d",
+        static_cast<int>(type_code),
+        bits));
   }
   return data_type;
 }
@@ -475,11 +474,10 @@ void cinn_call_cnnl_matmul(void *v_args,
     std::stringstream ss;
     ss << "unsupported cublas data type: " << static_cast<int>(type_code)
        << ", bytes = " << bytes;
-    PADDLE_THROW(
-        ::common::errors::InvalidArgument("unsupported cublas data type: ",
-                                          static_cast<int>(type_code),
-                                          ", bytes = ",
-                                          bytes));
+    PADDLE_THROW(::common::errors::InvalidArgument(
+        "unsupported cublas data type: %d, bytes = %d",
+        static_cast<int>(type_code),
+        bytes));
   }
 
   if (a1 * a2 * b1 * b2 == 1) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Execute Infrastructure 
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
Bug fixes
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->


### Description
<!-- Describe what you’ve done -->
 Fix 8 places in paddle/cinn where error message format strings did not match the number of arguments passed to common::errors::*, causing tinyformat (Sprintf) to silently drop runtime diagnostic information:
 - common/ir_util.cc: replace `{}` placeholders with `%d`/`%s`
 - ir/layout.cc: replace two `{}` placeholders with `%c`
 - runtime/sycl/sycl_backend_api.cc: add missing `%d`/`%zu` specifiers and collapse string-concatenation-style multi-arg calls into a single format string
 - runtime/sycl/sycl_module.cc: remove extra arg by merging literal suffix into the format string
 - runtime/sycl/sycl_util.cc: fix two string-concatenation-style PADDLE_THROW calls to use proper `%d` specifiers


### 是否引起精度变化
 否 
