### PR TITLE
[API Compatibility] add attribute `itemsize` to paddle.dtype -part

### DIFF
--- a/python/paddle/framework/dtype.py
+++ b/python/paddle/framework/dtype.py
@@ -25,22 +25,8 @@ from ..base.core import (
     VarDesc,
     finfo as core_finfo,
     iinfo as core_iinfo,
-    size_of_dtype as _size_of_dtype,
+    size_of_dtype,
 )
-
-
-def _itemsize_property() -> property:
-    """Return a property that mirrors ``torch.dtype.itemsize``.
-
-    Returns the size in bytes of a single scalar value of this dtype, by
-    delegating to ``paddle.base.core.size_of_dtype``. For example,
-    ``paddle.float32.itemsize == 4`` and ``paddle.int64.itemsize == 8``.
-    """
-    return property(
-        lambda self: _size_of_dtype(self),
-        doc="The size in bytes of a single scalar value of this dtype.",
-    )
-
 
 if TYPE_CHECKING:
     from paddle._typing import DTypeLike
@@ -79,8 +65,10 @@ def bind_vartype():
     dtype = VarDesc.VarType
     dtype.__qualname__ = "dtype"
     dtype.__module__ = "paddle"
-    if not isinstance(getattr(dtype, "itemsize", None), property):
-        dtype.itemsize = _itemsize_property()
+    dtype.itemsize = property(
+        lambda self: size_of_dtype(self),
+        doc="The size in bytes of a single scalar value of this dtype.",
+    )
 
     uint8 = VarDesc.VarType.UINT8
     uint16 = VarDesc.VarType.UINT16
@@ -178,8 +166,10 @@ def bind_datatype():
     dtype = DataType
     dtype.__qualname__ = "dtype"
     dtype.__module__ = "paddle"
-    if not isinstance(getattr(dtype, "itemsize", None), property):
-        dtype.itemsize = _itemsize_property()
+    dtype.itemsize = property(
+        lambda self: size_of_dtype(self),
+        doc="The size in bytes of a single scalar value of this dtype.",
+    )
 
     uint8 = DataType.UINT8
     uint16 = DataType.UINT16

--- a/python/paddle/framework/dtype.py
+++ b/python/paddle/framework/dtype.py
@@ -25,7 +25,22 @@ from ..base.core import (
     VarDesc,
     finfo as core_finfo,
     iinfo as core_iinfo,
+    size_of_dtype as _size_of_dtype,
 )
+
+
+def _itemsize_property() -> property:
+    """Return a property that mirrors ``torch.dtype.itemsize``.
+
+    Returns the size in bytes of a single scalar value of this dtype, by
+    delegating to ``paddle.base.core.size_of_dtype``. For example,
+    ``paddle.float32.itemsize == 4`` and ``paddle.int64.itemsize == 8``.
+    """
+    return property(
+        lambda self: _size_of_dtype(self),
+        doc="The size in bytes of a single scalar value of this dtype.",
+    )
+
 
 if TYPE_CHECKING:
     from paddle._typing import DTypeLike
@@ -64,6 +79,8 @@ def bind_vartype():
     dtype = VarDesc.VarType
     dtype.__qualname__ = "dtype"
     dtype.__module__ = "paddle"
+    if not isinstance(getattr(dtype, "itemsize", None), property):
+        dtype.itemsize = _itemsize_property()
 
     uint8 = VarDesc.VarType.UINT8
     uint16 = VarDesc.VarType.UINT16
@@ -161,6 +178,8 @@ def bind_datatype():
     dtype = DataType
     dtype.__qualname__ = "dtype"
     dtype.__module__ = "paddle"
+    if not isinstance(getattr(dtype, "itemsize", None), property):
+        dtype.itemsize = _itemsize_property()
 
     uint8 = DataType.UINT8
     uint16 = DataType.UINT16

--- a/test/legacy_test/test_api_compatibility_part3.py
+++ b/test/legacy_test/test_api_compatibility_part3.py
@@ -1694,6 +1694,59 @@ class TestLayerAndTensorToAPI(unittest.TestCase):
             t.to('float64', copy='yes')
 
 
+# Test paddle.dtype.itemsize compatibility (mirrors torch.dtype.itemsize).
+class TestDtypeItemsizeAPI(unittest.TestCase):
+    EXPECTED = {
+        'float16': 2,
+        'bfloat16': 2,
+        'float32': 4,
+        'float64': 8,
+        'complex64': 8,
+        'complex128': 16,
+        'int8': 1,
+        'int16': 2,
+        'int32': 4,
+        'int64': 8,
+        'uint8': 1,
+        'uint16': 2,
+        'uint32': 4,
+        'uint64': 8,
+        'bool': 1,
+        'float8_e4m3fn': 1,
+        'float8_e5m2': 1,
+    }
+
+    def test_all_standard_dtypes(self):
+        for name, want in self.EXPECTED.items():
+            if not hasattr(paddle, name):
+                continue
+            with self.subTest(dtype=name):
+                self.assertEqual(getattr(paddle, name).itemsize, want)
+
+    def test_returns_int(self):
+        self.assertIsInstance(paddle.float32.itemsize, int)
+
+    def test_property_lives_on_class(self):
+        self.assertIsInstance(type(paddle.float32).itemsize, property)
+
+    def test_aliases_match(self):
+        self.assertEqual(paddle.float.itemsize, paddle.float32.itemsize)
+        self.assertEqual(paddle.double.itemsize, paddle.float64.itemsize)
+        self.assertEqual(paddle.half.itemsize, paddle.float16.itemsize)
+        self.assertEqual(paddle.short.itemsize, paddle.int16.itemsize)
+        self.assertEqual(paddle.long.itemsize, paddle.int64.itemsize)
+        self.assertEqual(paddle.cfloat.itemsize, paddle.complex64.itemsize)
+        self.assertEqual(paddle.cdouble.itemsize, paddle.complex128.itemsize)
+
+    def test_matches_tensor_element_size(self):
+        for name in ('float32', 'float64', 'int32', 'int64', 'bool'):
+            with self.subTest(dtype=name):
+                t = paddle.zeros([1], dtype=name)
+                self.assertEqual(
+                    getattr(paddle, name).itemsize, t.element_size()
+                )
+
+
 # Test select_scatter compatibility
 class TestSelectScatterAPICompatibility(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### PR Category
User Experience


### PR Types
New features


### Description
为 `paddle.dtype` 增加 `itemsize` 属性，对齐 `torch.dtype.itemsize`：返回该 dtype 单个标量的字节数（例 `paddle.float32.itemsize == 4`、`paddle.int64.itemsize == 8`、`paddle.bfloat16.itemsize == 2`）。

#### 实现
`python/paddle/framework/dtype.py`：新增 `_itemsize_property()` 辅助函数，内部委托至 `paddle.base.core.size_of_dtype`；分别在 `bind_vartype` 与 `bind_datatype` 中安装到 `VarDesc.VarType` / `DataType` 类上，保证启用 PIR 与否两条路径都生效。


### 是否引起精度变化
否
