### PR TITLE
[cherry-pick] Fix learning_rate precision in SGD GPU kernel to use MT instead of T

### DIFF
--- a/paddle/phi/kernels/cpu/sgd_kernel.cc
+++ b/paddle/phi/kernels/cpu/sgd_kernel.cc
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/sgd_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/jit/kernels.h"
@@ -49,9 +50,9 @@ void sgd_dense_param_dense_grad_impl<phi::bfloat16>(
   auto p = EigenVector<phi::bfloat16>::Flatten(param);
   auto g = EigenVector<phi::bfloat16>::Flatten(grad);
   auto o = EigenVector<phi::bfloat16>::Flatten(*param_out);
-  const auto* lr = learning_rate.data<phi::bfloat16>();
+  const auto* lr = learning_rate.data<float>();
 
-  o = p - lr[0] * g;
+  o = p - static_cast<phi::bfloat16>(lr[0]) * g;
 }
 
 template <typename T>
@@ -95,7 +96,7 @@ void sgd_dense_param_sparse_grad_impl<phi::bfloat16>(
 
   const auto* grad_data = grad_value.data<phi::bfloat16>();
   auto* out_data = param_out->data<phi::bfloat16>();
-  const auto* lr = learning_rate.data<phi::bfloat16>();
+  const auto* lr = learning_rate.data<float>();
 
   for (size_t i = 0; i < grad_rows.size(); ++i) {
     PADDLE_ENFORCE_LT(
@@ -108,7 +109,8 @@ void sgd_dense_param_sparse_grad_impl<phi::bfloat16>(
             grad_height));
     const int64_t row = grad_rows[i];
     for (int64_t j = 0; j < grad_width; ++j) {
-      out_data[row * grad_width + j] -= lr[0] * grad_data[i * grad_width + j];
+      out_data[row * grad_width + j] -=
+          static_cast<phi::bfloat16>(lr[0]) * grad_data[i * grad_width + j];
     }
   }
 }
@@ -168,7 +170,8 @@ void SGDSparseParamSparseGradKernel(
           param_row_width,
           grad_row_width));
 
-  const auto* lr = learning_rate.data<T>();
+  using MT = typename dtype::MPTypeTrait<T>::Type;
+  const auto* lr = learning_rate.data<MT>();
   const auto* grad_data = grad.value().data<T>();
   auto* out_data = param_out->mutable_value()->data<T>();
   for (size_t i = 0; i < grad.rows().size(); i++) {
@@ -180,8 +183,8 @@ void SGDSparseParamSparseGradKernel(
             "The id in SgdOp should be >= 0. But received id_index is [%s]",
             id_index));
     for (int64_t j = 0; j < grad_row_width; j++) {
-      out_data[id_index * grad_row_width + j] -=
-          lr[0] * grad_data[i * grad_row_width + j];
+      out_data[id_index * grad_row_width + j] -= static_cast<T>(
+          lr[0] * static_cast<MT>(grad_data[i * grad_row_width + j]));
     }
   }
 }

--- a/paddle/phi/kernels/gpu/sgd_kernel.cu
+++ b/paddle/phi/kernels/gpu/sgd_kernel.cu
@@ -26,7 +26,7 @@ namespace phi {
 template <typename T, typename MT>
 __global__ void SGDKernelMT(const T* param,
                             const T* grad,
-                            const T* learning_rate,
+                            const MT* learning_rate,
                             const int64_t num,
                             T* param_out,
                             const MT* master_param,
@@ -43,13 +43,14 @@ __global__ void SGDKernelMT(const T* param,
   }
 }
 
-template <typename T>
+template <typename T, typename MT>
 __global__ void SparseSGDFunctorKernel(const T* selected_rows,
                                        const int64_t* rows,
-                                       const T* learning_rate,
+                                       const MT* learning_rate,
                                        T* tensor_out,
                                        int64_t row_numel,
                                        int64_t limit) {
+  MT lr = learning_rate[0];
   for (int64_t i = blockIdx.x; i < limit; i += gridDim.x) {
     const T* selected_rows_ptr = selected_rows + i * row_numel;
     T* tensor_out_ptr = tensor_out + rows[i] * row_numel;
@@ -58,7 +59,7 @@ __global__ void SparseSGDFunctorKernel(const T* selected_rows,
       // Atomic Operation to avoid concurrent write error.
       phi::CudaAtomicAdd(
           tensor_out_ptr + index,
-          -static_cast<T>(1.0) * learning_rate[0] * selected_rows_ptr[index]);
+          static_cast<T>(-lr * static_cast<MT>(selected_rows_ptr[index])));
     }
   }
 }
@@ -93,7 +94,7 @@ void SGDDenseKernel(const Context& dev_ctx,
   SGDKernelMT<T, MPDType><<<grid, block, 0, dev_ctx.stream()>>>(
       param.data<T>(),
       grad.data<T>(),
-      learning_rate.data<T>(),
+      learning_rate.data<MPDType>(),
       param.numel(),
       dev_ctx.template Alloc<T>(param_out),
       master_in_data,
@@ -160,13 +161,14 @@ void SGDDenseParamSparseGradKernel(
   int max_threads = dev_ctx.GetMaxPhysicalThreadCount();
   int max_blocks = std::max(max_threads / kThreadsPerBlock, 1);
   phi::MixVector<int64_t> mixv_in_rows(&in_rows);
-  SparseSGDFunctorKernel<<<max_blocks, thread_x, 0, dev_ctx.stream()>>>(
-      in_data,
-      mixv_in_rows.CUDAData(dev_ctx.GetPlace()),
-      learning_rate.data<T>(),
-      out_data,
-      in_row_numel,
-      in_rows.size());
+  SparseSGDFunctorKernel<T, MPDType>
+      <<<max_blocks, thread_x, 0, dev_ctx.stream()>>>(
+          in_data,
+          mixv_in_rows.CUDAData(dev_ctx.GetPlace()),
+          learning_rate.data<MPDType>(),
+          out_data,
+          in_row_numel,
+          in_rows.size());
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/onednn/sgd_kernel.cc
+++ b/paddle/phi/kernels/onednn/sgd_kernel.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/onednn/axpy_handler.h"
 #include "paddle/phi/backends/onednn/onednn_reuse.h"
+#include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 namespace phi {
@@ -48,12 +49,14 @@ void SGDDenseKernel(const Context& dev_ctx,
   auto* out_data = dev_ctx.template Alloc<T>(param_out);
   const T* param_data = param.data<T>();
   const auto* grad_data = grad.data<T>();
-  const auto* lr = learning_rate.data<T>();
+  using MT = typename dtype::MPTypeTrait<T>::Type;
+  const auto* lr = learning_rate.data<MT>();
   // Since dense SGD is not in place operation, first copy params to output
   // tensor and then update it.
   std::memcpy(out_data, param_data, param.memory_size());
-  funcs::OneDNNAXPYHandler<T>(param_out->numel(), -lr[0], dev_ctx.GetEngine())(
-      grad_data, out_data);
+  funcs::OneDNNAXPYHandler<T>(param_out->numel(),
+                              static_cast<T>(-lr[0]),
+                              dev_ctx.GetEngine())(grad_data, out_data);
 }
 
 template <typename T, typename Context>
@@ -74,10 +77,11 @@ void SGDDenseParamSparseGradKernel(
 
   const auto* grad_data = grad_value.data<T>();
   auto* out_data = param_out->data<T>();
-  const auto* lr = learning_rate.data<T>();
+  using MT = typename dtype::MPTypeTrait<T>::Type;
+  const auto* lr = learning_rate.data<MT>();
 
   funcs::OneDNNAXPYHandler<T> axpy_handler(
-      grad_width, -lr[0], dev_ctx.GetEngine());
+      grad_width, static_cast<T>(-lr[0]), dev_ctx.GetEngine());
 
   for (size_t i = 0; i < grad_rows.size(); ++i) {
     PADDLE_ENFORCE_LT(

--- a/paddle/phi/kernels/xpu/sgd_kernel.cc
+++ b/paddle/phi/kernels/xpu/sgd_kernel.cc
@@ -49,20 +49,8 @@ void SGDDenseKernel(const Context& dev_ctx,
                               grad.numel(),
                               sz));
 
-  const T* lr_t = learning_rate.data<T>();
+  const float* lr = learning_rate.data<float>();
   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
-  const float* lr = nullptr;
-  if (std::is_same<T, dtype::float16>::value) {
-    float* lr_float = RAII_GUARD.alloc_l3_or_gm<float>(learning_rate.numel());
-    int r = xpu::cast<XPUType, float>(dev_ctx.x_context(),
-                                      reinterpret_cast<const XPUType*>(lr_t),
-                                      lr_float,
-                                      learning_rate.numel());
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
-    lr = lr_float;
-  } else {
-    lr = reinterpret_cast<const float*>(lr_t);
-  }
 
   const T* param_data = param.data<T>();
   const T* grad_data = grad.data<T>();

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -4983,8 +4983,6 @@
            sgd_dense_param_sparse_grad {dense, dense, selected_rows, dense -> dense, dense},
            sgd_sparse_param_sparse_grad {selected_rows, dense, selected_rows, selected_rows -> selected_rows, selected_rows}
     data_type : param
-  data_transform :
-    support_trans_dtype : learning_rate
   optional : master_param, master_param_out
   inplace : (param -> param_out), (master_param -> master_param_out)
   traits : pir::SideEffectTrait, paddle::dialect::ForwardOnlyTrait

--- a/test/legacy_test/test_sgd_op.py
+++ b/test/legacy_test/test_sgd_op.py
@@ -16,7 +16,14 @@ import unittest
 
 import numpy as np
 from op import Operator
-from op_test import OpTest, get_device_place, get_places, is_custom_device
+from op_test import (
+    OpTest,
+    convert_float_to_uint16,
+    convert_uint16_to_float,
+    get_device_place,
+    get_places,
+    is_custom_device,
+)
 from utils import dygraph_guard
 
 import paddle
@@ -320,6 +327,135 @@ class TestSGDSimple(unittest.TestCase):
         out1 = self.run_dygraph()
         out2 = self.run_static()
         np.testing.assert_allclose(out1, out2)
+
+
+class TestSGDSparseBF16(unittest.TestCase):
+    """Test SGD with bfloat16 sparse grad on CPU (no oneDNN)."""
+
+    def test_sparse_grad_sgd_bf16(self):
+        paddle.enable_static()
+        scope = core.Scope()
+        place = core.CPUPlace()
+        height = 10
+        rows = [0, 4, 7]
+        row_numel = 12
+
+        # Grad: SelectedRows in bfloat16
+        grad_selected_rows = scope.var('Grad').get_selected_rows()
+        grad_selected_rows.set_height(height)
+        grad_selected_rows.set_rows(rows)
+        grad_np = np.random.random((len(rows), row_numel)).astype('float32')
+        grad_tensor = grad_selected_rows.get_tensor()
+        grad_tensor.set(convert_float_to_uint16(grad_np), place)
+
+        # Param: dense bfloat16
+        param_np = np.random.random((height, row_numel)).astype('float32')
+        param_var = scope.var('Param').get_tensor()
+        param_var.set(convert_float_to_uint16(param_np), place)
+
+        # LearningRate: float32
+        lr_value = 0.1
+        lr_var = scope.var('LearningRate').get_tensor()
+        lr_var.set(np.array([lr_value]).astype('float32'), place)
+
+        sgd_op = Operator(
+            "sgd",
+            Param='Param',
+            Grad='Grad',
+            ParamOut='Param',
+            LearningRate='LearningRate',
+        )
+        sgd_op.run(scope, place)
+
+        reference = np.copy(param_np)
+        for idx, row_id in enumerate(rows):
+            reference[row_id] -= lr_value * grad_np[idx]
+
+        result = convert_uint16_to_float(np.array(param_var))
+        np.testing.assert_allclose(result, reference, atol=5e-3, rtol=1e-1)
+        paddle.disable_static()
+
+
+class TestSGDDenseBF16OneDNN(unittest.TestCase):
+    """Test SGD with bfloat16 dense grad on CPU with oneDNN."""
+
+    def test_dense_sgd_bf16_onednn(self):
+        paddle.enable_static()
+        scope = core.Scope()
+        place = core.CPUPlace()
+        h, w = 10, 12
+
+        param_np = np.random.random((h, w)).astype('float32')
+        grad_np = np.random.random((h, w)).astype('float32')
+        lr_value = 0.1
+
+        param_var = scope.var('Param').get_tensor()
+        param_var.set(convert_float_to_uint16(param_np), place)
+
+        grad_var = scope.var('Grad').get_tensor()
+        grad_var.set(convert_float_to_uint16(grad_np), place)
+
+        lr_var = scope.var('LearningRate').get_tensor()
+        lr_var.set(np.array([lr_value]).astype('float32'), place)
+
+        sgd_op = Operator(
+            "sgd",
+            Param='Param',
+            Grad='Grad',
+            ParamOut='Param',
+            LearningRate='LearningRate',
+            use_onednn=True,
+        )
+        sgd_op.run(scope, place)
+
+        reference = param_np - lr_value * grad_np
+        result = convert_uint16_to_float(np.array(param_var))
+        np.testing.assert_allclose(result, reference, atol=5e-3, rtol=1e-1)
+        paddle.disable_static()
+
+    def test_sparse_grad_sgd_bf16_onednn(self):
+        paddle.enable_static()
+        scope = core.Scope()
+        place = core.CPUPlace()
+        height = 10
+        rows = [0, 4, 7]
+        row_numel = 12
+
+        # Grad: SelectedRows in bfloat16
+        grad_selected_rows = scope.var('Grad').get_selected_rows()
+        grad_selected_rows.set_height(height)
+        grad_selected_rows.set_rows(rows)
+        grad_np = np.random.random((len(rows), row_numel)).astype('float32')
+        grad_tensor = grad_selected_rows.get_tensor()
+        grad_tensor.set(convert_float_to_uint16(grad_np), place)
+
+        # Param: dense bfloat16
+        param_np = np.random.random((height, row_numel)).astype('float32')
+        param_var = scope.var('Param').get_tensor()
+        param_var.set(convert_float_to_uint16(param_np), place)
+
+        # LearningRate: float32
+        lr_value = 0.1
+        lr_var = scope.var('LearningRate').get_tensor()
+        lr_var.set(np.array([lr_value]).astype('float32'), place)
+
+        sgd_op = Operator(
+            "sgd",
+            Param='Param',
+            Grad='Grad',
+            ParamOut='Param',
+            LearningRate='LearningRate',
+            use_onednn=True,
+        )
+        sgd_op.run(scope, place)
+
+        reference = np.copy(param_np)
+        for idx, row_id in enumerate(rows):
+            reference[row_id] -= lr_value * grad_np[idx]
+
+        result = convert_uint16_to_float(np.array(param_var))
+        np.testing.assert_allclose(result, reference, atol=5e-3, rtol=1e-1)
+        paddle.disable_static()
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_sgd_op_bf16.py
+++ b/test/legacy_test/test_sgd_op_bf16.py
@@ -47,9 +47,8 @@ class TestSGDOpBF16(OpTest):
         g = np.random.random((self.h, self.w)).astype('float32')
         g_bf16 = convert_float_to_uint16(g)
         lr = np.array([0.1]).astype('float32')
-        lr_bf16 = convert_float_to_uint16(lr)
 
-        self.inputs = {'Param': w_bf16, 'Grad': g_bf16, 'LearningRate': lr_bf16}
+        self.inputs = {'Param': w_bf16, 'Grad': g_bf16, 'LearningRate': lr}
         self.outputs = {'ParamOut': w - lr * g}
         self.attrs = {'use_onednn': self.use_onednn}
 
@@ -125,8 +124,7 @@ class TestSparseSGDOpBF16(unittest.TestCase):
         lr_tensor = scope.var('LearningRate').get_tensor()
         lr_value = np.random.uniform()
         lr_array = np.full((1), lr_value, np.float32)
-        lr_array_bf16 = convert_float_to_uint16(lr_array)
-        lr_tensor.set(lr_array_bf16, place)
+        lr_tensor.set(lr_array, place)
 
         return lr_tensor, lr_value
 

--- a/test/xpu/test_sgd_op_xpu.py
+++ b/test/xpu/test_sgd_op_xpu.py
@@ -40,7 +40,7 @@ class XPUTestSgdOp(XPUOpTestWrapper):
             self.conf()
             w = np.random.random((self.h, self.w)).astype(self.dtype)
             g = np.random.random((self.h, self.w)).astype(self.dtype)
-            lr = np.array([0.1]).astype(self.dtype)
+            lr = np.array([0.1]).astype('float32')
 
             self.inputs = {'Param': w, 'Grad': g, 'LearningRate': lr}
             self.outputs = {'ParamOut': w - lr * g}


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Cherry-pick from develop：
devPR:https://github.com/PaddlePaddle/Paddle/pull/78761

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否