### PR TITLE
[SOT] Support Python 3.11+ exception handling

### DIFF
--- a/paddle/fluid/pybind/sot/eval_frame.c
+++ b/paddle/fluid/pybind/sot/eval_frame.c
@@ -252,10 +252,6 @@ static PyObject *_custom_eval_frame(PyThreadState *tstate,
     eval_frame_callback_set(callback);
     return out;
   }
-  if (PyBytes_GET_SIZE(PyFrame_GET_CODE(frame)->co_exceptiontable)) {
-    eval_frame_callback_set(callback);
-    return eval_frame_default(tstate, frame, throw_flag);
-  }
   // PyFrame_FastToLocalsWithError receives a PyFrameObject, but if we created a
   // PyFrameObject from a PyInterpreterFrame, it will changes the original
   // PyInterpreterFrame and causes a Segmentation Fault when Fallback to run

--- a/python/paddle/jit/sot/opcode_translator/executor/exception_stack.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/exception_stack.py
@@ -39,6 +39,17 @@ class ExceptionStack:
     def clear_current_exception(self):
         self._current_exception = None
 
+    def restore_current_exception(
+        self, val: ExceptionVariable | ConstantVariable
+    ):
+        if isinstance(val, ExceptionVariable):
+            self._current_exception = val
+            return
+        if isinstance(val, ConstantVariable) and val.get_py_value() is None:
+            self.clear_current_exception()
+            return
+        raise InnerError(f"Can not restore exception state from {val}")
+
     def set_current_exception(
         self, val: ExceptionVariable, graph: FunctionGraph
     ):
@@ -53,6 +64,9 @@ class ExceptionStack:
         if self._current_exception is None:
             raise InnerError("Current exception should not be None")
         return self._current_exception
+
+    def has_current_exception(self) -> bool:
+        return self._current_exception is not None
 
     def _set_context_and_break_context_reference_cycle(
         self, val: ExceptionVariable, graph: FunctionGraph

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -381,7 +381,7 @@ def fallback_if_python_version_unsupported(fn: Callable):
     def inner(*args, **kwargs):
         if not ALREADY_SUPPORTED_EXCEPTION:
             raise FallbackError(
-                "SOT currently only partially supports exception handling (Python 3.10 and below). "
+                "SOT currently supports exception handling on Python 3.14 and below. "
                 "Unsupported exception bytecode will fall back to dynamic graph mode."
             )
         return fn(*args, **kwargs)
@@ -725,6 +725,11 @@ class OpcodeExecutorBase:
                 self.stack.pop()
 
             if exn_tab_entry.lasti:
+                if instr.offset is None:
+                    raise InnerError(
+                        "Exception handler requires a valid instruction offset "
+                        f"for {instr.opname}, but got None."
+                    )
                 self.stack.push(
                     ConstantVariable.wrap_literal(instr.offset, self._graph)
                 )

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -143,7 +143,6 @@ COMPARE_OP_NAME_TO_FN = {
 
 # In Python 3.13, the method layout is changed, and a NULL will be pushed after the value.
 CALL_METHOD_LAYOUT_NULL_AFTER_VALUE = sys.version_info >= (3, 13)
-ALREADY_SUPPORTED_EXCEPTION = sys.version_info < (3, 15)
 
 
 @dataclass
@@ -373,18 +372,6 @@ def fallback_when_occur_error(fn: Callable):
             raise FallbackError(
                 f'[Fallback] An exception occurred when processing break graph, fallback to dygraph, error message is: \n{type(e)} : {e}\n'
             )
-
-    return inner
-
-
-def fallback_if_python_version_unsupported(fn: Callable):
-    def inner(*args, **kwargs):
-        if not ALREADY_SUPPORTED_EXCEPTION:
-            raise FallbackError(
-                "SOT currently supports exception handling on Python 3.14 and below. "
-                "Unsupported exception bytecode will fall back to dynamic graph mode."
-            )
-        return fn(*args, **kwargs)
 
     return inner
 
@@ -2127,22 +2114,18 @@ class OpcodeExecutorBase:
         else:
             raise FallbackError(f"No support Intrinsics, {intrinsic_func.name}")
 
-    @fallback_if_python_version_unsupported
     def SETUP_FINALLY(self, instr: Instruction):
         self.vframe.block_stack.append(
             BlockStackItem(instr.opname, instr, instr.jump_to, len(self.stack))
         )
 
-    @fallback_if_python_version_unsupported
     def POP_BLOCK(self, instr: Instruction):
         self.vframe.block_stack.pop()
 
-    @fallback_if_python_version_unsupported
     def LOAD_ASSERTION_ERROR(self, instr: Instruction):
         value = self.vframe.builtins["AssertionError"]
         self.stack.push(value)
 
-    @fallback_if_python_version_unsupported
     def POP_EXCEPT(self, instr: Instruction):
         if sys.version_info >= (3, 11):
             prev_exc = self.stack.pop()
@@ -2190,7 +2173,6 @@ class OpcodeExecutorBase:
 
         raise FallbackError("Attempted to raise a non-Exception type/value.")
 
-    @fallback_if_python_version_unsupported
     def RAISE_VARARGS(self, instr: Instruction):
         if instr.arg == 0:
             if self.exception_stack.empty():
@@ -2223,7 +2205,6 @@ class OpcodeExecutorBase:
                 origin_exc=val.get_py_value()
             )
 
-    @fallback_if_python_version_unsupported
     def JUMP_IF_NOT_EXC_MATCH(self, instr: Instruction):
         assert len(self.stack) >= 2
         expected_exc_types = self.stack.pop()
@@ -2233,7 +2214,6 @@ class OpcodeExecutorBase:
         ):
             self.jump_to(instr.jump_to)
 
-    @fallback_if_python_version_unsupported
     def CHECK_EXC_MATCH(self, instr: Instruction):
         assert len(self.stack) >= 2
         expected_exc_types = self.stack.pop()
@@ -2243,7 +2223,6 @@ class OpcodeExecutorBase:
         )
         self.stack.push(ConstantVariable.wrap_literal(result, self._graph))
 
-    @fallback_if_python_version_unsupported
     def PUSH_EXC_INFO(self, instr: Instruction):
         val = self.stack.pop()
         if len(self.exception_stack) == 0:
@@ -2255,7 +2234,6 @@ class OpcodeExecutorBase:
         self.stack.push(val)
         self.exception_stack.move_current_exception_to_stack()
 
-    @fallback_if_python_version_unsupported
     def RERAISE(self, instr: Instruction):
         if sys.version_info >= (3, 11):
             exc_instance = self.stack.pop()

--- a/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/opcode_executor.py
@@ -143,7 +143,7 @@ COMPARE_OP_NAME_TO_FN = {
 
 # In Python 3.13, the method layout is changed, and a NULL will be pushed after the value.
 CALL_METHOD_LAYOUT_NULL_AFTER_VALUE = sys.version_info >= (3, 13)
-ALREADY_SUPPORTED_EXCEPTION = sys.version_info < (3, 11)
+ALREADY_SUPPORTED_EXCEPTION = sys.version_info < (3, 15)
 
 
 @dataclass
@@ -698,9 +698,9 @@ class OpcodeExecutorBase:
             try:
                 return getattr(self, opname)(instr)  # run single step.
             except SotCapturedException as e:
-                self.handle_exception(e)
+                self.handle_exception(e, instr)
 
-    def handle_exception(self, e: SotCapturedException):
+    def handle_exception(self, e: SotCapturedException, instr: Instruction):
         # TODO(DrRyanHuang): The newly created ExceptionVariable might differ from the previous one
         e_var = VariableFactory.from_value(
             e,
@@ -710,10 +710,28 @@ class OpcodeExecutorBase:
 
         # The exception is not raised by `raise Exception`
         if (
-            self.exception_stack.empty()
+            not self.exception_stack.has_current_exception()
             or self.exception_stack.get_current_exception() != e_var
         ):
             self.exception_stack.set_current_exception(e_var, self._graph)
+
+        if sys.version_info >= (3, 11):
+            exn_tab_entry = instr.exn_tab_entry
+            if exn_tab_entry is None:
+                self.stack.pop_n(len(self.stack))
+                raise e
+
+            while len(self.stack) > exn_tab_entry.depth:
+                self.stack.pop()
+
+            if exn_tab_entry.lasti:
+                self.stack.push(
+                    ConstantVariable.wrap_literal(instr.offset, self._graph)
+                )
+
+            self.stack.push(self.exception_stack.get_current_exception())
+            self.jump_to(exn_tab_entry.target)
+            return
 
         if self.vframe.block_stack:
             # The implementation is referenced from the exception_unwind section
@@ -1031,6 +1049,11 @@ class OpcodeExecutorBase:
     def LOAD_FAST_CHECK(self, instr: Instruction):
         self.LOAD_FAST(instr)
 
+    def LOAD_FAST_AND_CLEAR(self, instr: Instruction):
+        name = self.vframe.code.co_varnames[instr.arg]
+        var = self.vframe.locals.pop(name, NullVariable())
+        self.stack.push(var)
+
     def LOAD_SMALL_INT(self, instr: Instruction):
         int_value = instr.argval
         int_var = ConstantVariable.wrap_literal(int_value, self._graph)
@@ -1164,6 +1187,9 @@ class OpcodeExecutorBase:
         """
         var = self.stack.pop()
         name = self.vframe.code.co_varnames[instr.arg]
+        if isinstance(var, NullVariable):
+            self.vframe.locals.pop(name, None)
+            return
         self.vframe.locals[name] = var
 
     def STORE_GLOBAL(self, instr: Instruction):
@@ -2113,6 +2139,13 @@ class OpcodeExecutorBase:
 
     @fallback_if_python_version_unsupported
     def POP_EXCEPT(self, instr: Instruction):
+        if sys.version_info >= (3, 11):
+            prev_exc = self.stack.pop()
+            if self.exception_stack:
+                self.exception_stack.pop()
+            self.exception_stack.restore_current_exception(prev_exc)
+            return
+
         assert len(self.vframe.block_stack) > 0
 
         if self.vframe.block_stack[-1].inst.opname != ExceptionHandler.opname:
@@ -2196,7 +2229,38 @@ class OpcodeExecutorBase:
             self.jump_to(instr.jump_to)
 
     @fallback_if_python_version_unsupported
+    def CHECK_EXC_MATCH(self, instr: Instruction):
+        assert len(self.stack) >= 2
+        expected_exc_types = self.stack.pop()
+        exc_instance = self.stack.top
+        result = ExceptionVariable.check_if_exception_matches(
+            exc_instance, expected_exc_types
+        )
+        self.stack.push(ConstantVariable.wrap_literal(result, self._graph))
+
+    @fallback_if_python_version_unsupported
+    def PUSH_EXC_INFO(self, instr: Instruction):
+        val = self.stack.pop()
+        if len(self.exception_stack) == 0:
+            prev_exc = ConstantVariable.wrap_literal(None, self._graph)
+        else:
+            prev_exc = self.exception_stack[-1]
+
+        self.stack.push(prev_exc)
+        self.stack.push(val)
+        self.exception_stack.move_current_exception_to_stack()
+
+    @fallback_if_python_version_unsupported
     def RERAISE(self, instr: Instruction):
+        if sys.version_info >= (3, 11):
+            exc_instance = self.stack.pop()
+            if instr.arg:
+                self.stack.pop()
+            else:
+                self.stack.push(exc_instance)
+            self._raise_exception_instance(exc_instance)
+            return
+
         _exc_type = self.stack.pop()
         _exc_instance = self.stack.pop()
         _traceback = self.stack.pop()
@@ -2666,6 +2730,12 @@ class OpcodeExecutor(OpcodeExecutorBase):
             iterator.id,
         ]
         output_var_names = [*list(write_names), iterator.id]
+        stack_args = list(self.stack)
+        stack_null_indices = [
+            idx
+            for idx, stack_arg in enumerate(stack_args)
+            if isinstance(stack_arg, NullVariable)
+        ]
 
         # 2. create inline call loop fn
         def create_inline_call_fn():
@@ -2674,6 +2744,8 @@ class OpcodeExecutor(OpcodeExecutorBase):
                 self.vframe.code,
                 start_idx,
                 end_idx,
+                len(stack_args),
+                tuple(stack_null_indices),
             )
             resume_fn_creator = ResumeFunctionCreator(
                 self._graph.pycode_gen._origin_code,
@@ -2686,7 +2758,11 @@ class OpcodeExecutor(OpcodeExecutorBase):
             pycode_gen = resume_fn_creator.codegen
             origin_instrs = get_instructions(pycode_gen._origin_code)
 
-            resume_fn_creator.set_inputs(input_var_names, stack_size=0)
+            resume_fn_creator.set_inputs(
+                input_var_names,
+                stack_size=len(stack_args),
+                null_indices=stack_null_indices,
+            )
 
             # 2.1. load iter, it is a input of loop fn
             pycode_gen.gen_load_fast(iterator.id)
@@ -2727,6 +2803,8 @@ class OpcodeExecutor(OpcodeExecutorBase):
             if sys.version_info >= (3, 12):
                 for_iter_instr.jump_to = end_for
 
+            for _ in stack_args:
+                pycode_gen.gen_pop_top()
             resume_fn_creator.set_outputs(output_var_names)
             inline_call_fn = resume_fn_creator.generate(cache_key=cache_key)
 
@@ -2749,9 +2827,17 @@ class OpcodeExecutor(OpcodeExecutorBase):
 
         # 4. prepare input datas and call
         input_vars = [
-            self.get_var(name, allow_undefined=True)
-            for name in input_var_names[:-1]
-        ] + [iterator]
+            *[
+                stack_arg
+                for idx, stack_arg in enumerate(stack_args)
+                if idx not in stack_null_indices
+            ],
+            *[
+                self.get_var(name, allow_undefined=True)
+                for name in input_var_names[:-1]
+            ],
+            iterator,
+        ]
 
         ret = fn(*input_vars)
 

--- a/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/pycode_generator.py
@@ -40,7 +40,9 @@ from ...utils import (
 )
 from ..instruction_utils import (
     apply_instr_pass,
+    assemble_exception_table,
     calc_stack_effect,
+    compute_exception_table,
     gen_instr,
     get_instruction_size,
     instrs_info,
@@ -155,8 +157,9 @@ def gen_new_opcode(
     code_options["co_nlocals"] = len(code_options["co_varnames"])
     code_options["co_stacksize"] = stacksize(instrs)
     if sys.version_info >= (3, 11):
-        # TODO: generate 3.11 exception table
-        code_options["co_exceptiontable"] = bytes([])
+        code_options["co_exceptiontable"] = assemble_exception_table(
+            compute_exception_table(instrs)
+        )
     for key, val in code_options.items():
         if isinstance(val, list):
             code_options[key] = tuple(val)

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/__init__.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/__init__.py
@@ -16,8 +16,10 @@ from .instruction_pass import apply_instr_pass  # noqa: F401
 from .instruction_utils import (  # noqa: F401
     Instruction,
     Space,
+    assemble_exception_table,
     calc_offset_from_bytecode_offset,
     calc_stack_effect,
+    compute_exception_table,
     convert_instruction,
     gen_instr,
     get_instruction_size,

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_pass.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_pass.py
@@ -21,7 +21,11 @@ from typing import TYPE_CHECKING
 from paddle.jit.sot.utils import log, log_do
 
 from ...utils import InnerError
-from .instruction_utils import instrs_info
+from .instruction_utils import (
+    instrs_info,
+    replace_exception_table_entries,
+    replace_jump_target,
+)
 from .opcode_info import TO_FUSED_INSTS
 from .stack_analyse import StackAnalyser
 
@@ -304,12 +308,14 @@ def fuse_double_super_instrs(instrs: list[Instruction], code_options):
     Fuse two consecutive LOAD_FAST or STORE_FAST instructions into one.
     """
     co_varnames = code_options['co_varnames']
+    replacements = {}
 
     def able_to_merge(idx: int):
         return (
             idx > 0
             and (instrs[idx - 1].opname, instrs[idx].opname)
             in TO_FUSED_INSTS.keys()
+            and instrs[idx - 1].exn_tab_entry is instrs[idx].exn_tab_entry
             and not instrs[idx].is_jump_target
             and not instrs[idx - 1].is_jump_target
             and co_varnames.index(instrs[idx - 1].argval) < 16
@@ -322,6 +328,7 @@ def fuse_double_super_instrs(instrs: list[Instruction], code_options):
         prev_instr.opcode = dis.opmap[prev_instr.opname]
         prev_instr.is_generated = True
         prev_instr.argval = (prev_instr.argval, instr.argval)
+        replacements[instr] = [prev_instr]
         instrs.remove(instr)
 
     idx = 0
@@ -332,3 +339,10 @@ def fuse_double_super_instrs(instrs: list[Instruction], code_options):
             continue
 
         idx += 1
+
+    if replacements:
+        jump_replacements = {
+            instr: replacement[0] for instr, replacement in replacements.items()
+        }
+        replace_jump_target(instrs, jump_replacements)
+        replace_exception_table_entries(instrs, replacements)

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -49,6 +49,7 @@ class Instruction:
     # for analysis EXTENDED_ARG
     first_ex_arg: Instruction | None = None
     ex_arg_for: Instruction | None = None
+    exn_tab_entry: ExceptionTableEntry | None = None
 
     # used in modify_extended_args
     def __hash__(self):
@@ -56,6 +57,213 @@ class Instruction:
 
     def __eq__(self, instr):
         return id(self) == id(instr)
+
+
+@dataclasses.dataclass
+class ExceptionTableEntry:
+    start: Instruction
+    end: Instruction
+    target: Instruction
+    depth: int
+    lasti: bool
+
+
+@dataclasses.dataclass
+class RawExceptionTableEntry:
+    start: int
+    end: int
+    target: int
+    depth: int
+    lasti: bool
+
+
+def decode_exception_table_varint(bytes_iter) -> int:
+    b = next(bytes_iter)
+    val = b & 63
+    while b & 64:
+        val <<= 6
+        b = next(bytes_iter)
+        val |= b & 63
+    return val
+
+
+def encode_exception_table_varint(value: int) -> list[int]:
+    assert value >= 0
+    bytes_ = [value & 63]
+    value >>= 6
+    while value:
+        bytes_.append(value & 63)
+        value >>= 6
+    bytes_.reverse()
+    for idx in range(len(bytes_) - 1):
+        bytes_[idx] |= 64
+    return bytes_
+
+
+def parse_exception_table(exntab: bytes) -> list[RawExceptionTableEntry]:
+    exntab_iter = iter(exntab)
+    entries = []
+    try:
+        while True:
+            start = decode_exception_table_varint(exntab_iter) * 2
+            length = decode_exception_table_varint(exntab_iter) * 2
+            end = start + length - 2
+            target = decode_exception_table_varint(exntab_iter) * 2
+            depth_and_lasti = decode_exception_table_varint(exntab_iter)
+            entries.append(
+                RawExceptionTableEntry(
+                    start=start,
+                    end=end,
+                    target=target,
+                    depth=depth_and_lasti >> 1,
+                    lasti=bool(depth_and_lasti & 1),
+                )
+            )
+    except StopIteration:
+        return entries
+
+
+def check_exception_table(entries: list[RawExceptionTableEntry]) -> None:
+    for entry in entries:
+        assert entry.start <= entry.end
+    for lhs, rhs in zip(entries, entries[1:]):
+        assert lhs.end < rhs.start
+
+
+def assemble_exception_table(entries: list[RawExceptionTableEntry]) -> bytes:
+    encoded = []
+    check_exception_table(entries)
+    for entry in entries:
+        start = encode_exception_table_varint(entry.start // 2)
+        start[0] |= 128
+        encoded.extend(start)
+
+        length = entry.end - entry.start + 2
+        encoded.extend(encode_exception_table_varint(length // 2))
+        encoded.extend(encode_exception_table_varint(entry.target // 2))
+        encoded.extend(
+            encode_exception_table_varint((entry.depth << 1) | entry.lasti)
+        )
+    return bytes(encoded)
+
+
+def get_instruction_front(instr: Instruction) -> Instruction:
+    return instr.first_ex_arg or instr
+
+
+def get_instruction_end_offset(instr: Instruction) -> int:
+    assert instr.offset is not None
+    return instr.offset + get_instruction_size(instr) - 2
+
+
+def compute_exception_table(
+    instructions: list[Instruction],
+) -> list[RawExceptionTableEntry]:
+    if sys.version_info < (3, 11):
+        return []
+
+    instruction_set = set(instructions)
+    entries: list[RawExceptionTableEntry] = []
+    active_entry: ExceptionTableEntry | None = None
+    start_instr: Instruction | None = None
+    end_instr: Instruction | None = None
+
+    def flush_entry():
+        nonlocal active_entry, start_instr, end_instr
+        if active_entry is None or start_instr is None or end_instr is None:
+            return
+        if active_entry.target not in instruction_set:
+            active_entry = None
+            start_instr = None
+            end_instr = None
+            return
+
+        start = get_instruction_front(start_instr).offset
+        end = get_instruction_end_offset(end_instr)
+        target = get_instruction_front(active_entry.target).offset
+        assert start is not None
+        assert target is not None
+        entries.append(
+            RawExceptionTableEntry(
+                start=start,
+                end=end,
+                target=target,
+                depth=active_entry.depth,
+                lasti=active_entry.lasti,
+            )
+        )
+        active_entry = None
+        start_instr = None
+        end_instr = None
+
+    for instr in instructions:
+        entry = instr.exn_tab_entry
+        if entry is None or entry.target not in instruction_set:
+            flush_entry()
+            continue
+        if entry != active_entry:
+            flush_entry()
+            active_entry = entry
+            start_instr = instr
+        end_instr = instr
+
+    flush_entry()
+    check_exception_table(entries)
+    return entries
+
+
+def find_instruction_at_or_before_offset(
+    offset: int,
+    instructions: list[Instruction],
+) -> Instruction:
+    candidates = [
+        instr
+        for instr in instructions
+        if instr.offset is not None and instr.offset <= offset
+    ]
+    if not candidates:
+        raise InnerError(f"Can not find instruction before offset {offset}")
+    return candidates[-1]
+
+
+def virtualize_exception_table(
+    code: types.CodeType,
+    instructions: list[Instruction],
+) -> None:
+    if sys.version_info < (3, 11) or not code.co_exceptiontable:
+        return
+
+    offset_to_instr = {
+        instr.offset: instr
+        for instr in instructions
+        if instr.offset is not None
+    }
+    raw_entries = parse_exception_table(code.co_exceptiontable)
+
+    for raw_entry in raw_entries:
+        if raw_entry.start not in offset_to_instr:
+            raise InnerError(
+                f"Can not find exception table start offset {raw_entry.start}"
+            )
+        if raw_entry.target not in offset_to_instr:
+            raise InnerError(
+                f"Can not find exception table target offset {raw_entry.target}"
+            )
+
+        entry = ExceptionTableEntry(
+            start=offset_to_instr[raw_entry.start],
+            end=find_instruction_at_or_before_offset(
+                raw_entry.end, instructions
+            ),
+            target=offset_to_instr[raw_entry.target],
+            depth=raw_entry.depth,
+            lasti=raw_entry.lasti,
+        )
+
+        for instr in instructions:
+            assert instr.offset is not None
+            if raw_entry.start <= instr.offset <= raw_entry.end:
+                instr.exn_tab_entry = entry
 
 
 def get_instruction_size(instr: Instruction) -> int:
@@ -129,6 +337,7 @@ def expand_super_instrs(instructions: list[Instruction]) -> list[Instruction]:
             is_jump_target=is_jump_target,
             is_generated=is_generated,
             jump_to=instr.jump_to,
+            exn_tab_entry=instr.exn_tab_entry,
         )
 
     for instr in instructions:
@@ -174,6 +383,7 @@ def expand_super_instrs(instructions: list[Instruction]) -> list[Instruction]:
                 None,
                 None,
                 is_generated=True,
+                exn_tab_entry=instr.exn_tab_entry,
             )
             replacements[instr] = instr1
             expanded_instrs.append(instr1)
@@ -210,6 +420,7 @@ def replace_load_fast_borrow_with_strong_ref(
                 is_generated=instr.is_generated,
                 is_jump_target=instr.is_jump_target,
                 jump_to=instr.jump_to,
+                exn_tab_entry=instr.exn_tab_entry,
             )
             replacements[instr] = instr1
             expanded_instrs.append(instr1)
@@ -263,6 +474,7 @@ def get_instructions(code: types.CodeType) -> list[Instruction]:
     #         XX 388    <-  256 + 132
     # filter all EXTENDED_ARG here
     instrs = [x for x in instrs if x.opname != "EXTENDED_ARG"]
+    virtualize_exception_table(code, instrs)
     prepare_passes = [expand_super_instrs]
     if sys.version_info >= (3, 14):
         prepare_passes.append(replace_load_fast_borrow_with_strong_ref)
@@ -450,6 +662,7 @@ def modify_extended_args(instructions: list[Instruction]) -> bool:
             instr.starts_line = None
             ex_arg.is_jump_target = instr.is_jump_target
             instr.is_jump_target = False
+            ex_arg.exn_tab_entry = instr.exn_tab_entry
 
             if instr.ex_arg_for is not None:
                 # instr is also an ex_arg for another instr
@@ -473,6 +686,7 @@ def modify_vars(instructions: list[Instruction], code_options):
     for instrs in instructions:
         if instrs.opname in [
             'LOAD_FAST',
+            'LOAD_FAST_AND_CLEAR',
             'LOAD_FAST_BORROW',
             'LOAD_FAST_CHECK',
             'STORE_FAST',

--- a/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
+++ b/python/paddle/jit/sot/opcode_translator/instruction_utils/instruction_utils.py
@@ -322,18 +322,57 @@ def replace_jump_target(
             instr.jump_to = replacements[instr.jump_to]
 
 
+def replace_exception_table_entries(
+    instrs: list[Instruction],
+    replacements: dict[Instruction, list[Instruction]],
+) -> None:
+    """
+    Remap virtualized exception-table entries after instruction replacement.
+
+    ExceptionTableEntry keeps Instruction references because the table is
+    rebuilt after bytecode rewriting. When one source instruction expands into
+    multiple instructions, exception ranges should start/target at the first
+    replacement instruction and end at the last replacement instruction.
+    """
+
+    def first_replacement(instr: Instruction) -> Instruction:
+        return replacements[instr][0] if instr in replacements else instr
+
+    def last_replacement(instr: Instruction) -> Instruction:
+        return replacements[instr][-1] if instr in replacements else instr
+
+    remapped_entries: dict[int, ExceptionTableEntry] = {}
+    for instr in instrs:
+        entry = instr.exn_tab_entry
+        if entry is None:
+            continue
+
+        entry_id = id(entry)
+        if entry_id not in remapped_entries:
+            remapped_entries[entry_id] = ExceptionTableEntry(
+                start=first_replacement(entry.start),
+                end=last_replacement(entry.end),
+                target=first_replacement(entry.target),
+                depth=entry.depth,
+                lasti=entry.lasti,
+            )
+        instr.exn_tab_entry = remapped_entries[entry_id]
+
+
 def expand_super_instrs(instructions: list[Instruction]) -> list[Instruction]:
     expanded_instrs = []
-    replacements = {}
+    replacements: dict[Instruction, list[Instruction]] = {}
 
     def copy_instruction(
-        instr, opname, argval, arg, is_jump_target, is_generated
+        instr, opname, argval, arg, is_jump_target, is_generated, starts_line
     ):
         return Instruction(
             opcode=dis.opmap[opname],
             opname=opname,
             arg=arg,
             argval=argval,
+            offset=instr.offset,
+            starts_line=starts_line,
             is_jump_target=is_jump_target,
             is_generated=is_generated,
             jump_to=instr.jump_to,
@@ -349,6 +388,7 @@ def expand_super_instrs(instructions: list[Instruction]) -> list[Instruction]:
                 instr.arg >> 4,
                 instr.is_jump_target,
                 True,
+                instr.starts_line,
             )
             instr2 = copy_instruction(
                 instr,
@@ -357,8 +397,9 @@ def expand_super_instrs(instructions: list[Instruction]) -> list[Instruction]:
                 instr.arg & 15,
                 False,
                 False,
+                None,
             )
-            replacements[instr] = instr1
+            replacements[instr] = [instr1, instr2]
             expanded_instrs.append(instr1)
             expanded_instrs.append(instr2)
         # If the LOAD_ATTR opcode will lead to load_method in 3.13+, we manually split it into two instructions,
@@ -376,22 +417,29 @@ def expand_super_instrs(instructions: list[Instruction]) -> list[Instruction]:
                 instr.arg & ~1,
                 instr.is_jump_target,
                 True,
+                instr.starts_line,
             )
             instr2 = Instruction(
                 dis.opmap["PUSH_NULL"],
                 "PUSH_NULL",
                 None,
                 None,
+                offset=instr.offset,
+                starts_line=None,
                 is_generated=True,
                 exn_tab_entry=instr.exn_tab_entry,
             )
-            replacements[instr] = instr1
+            replacements[instr] = [instr1, instr2]
             expanded_instrs.append(instr1)
             expanded_instrs.append(instr2)
         else:
             expanded_instrs.append(instr)
 
-    replace_jump_target(expanded_instrs, replacements)
+    jump_replacements = {
+        instr: replacement[0] for instr, replacement in replacements.items()
+    }
+    replace_jump_target(expanded_instrs, jump_replacements)
+    replace_exception_table_entries(expanded_instrs, replacements)
     return expanded_instrs
 
 
@@ -408,7 +456,7 @@ def replace_load_fast_borrow_with_strong_ref(
     crashes when the variable is accessed later.
     To avoid these issues, we replace LOAD_FAST_BORROW with LOAD_FAST here.
     """
-    replacements = {}
+    replacements: dict[Instruction, list[Instruction]] = {}
     expanded_instrs = []
     for instr in instructions:
         if instr.opname == "LOAD_FAST_BORROW":
@@ -417,17 +465,23 @@ def replace_load_fast_borrow_with_strong_ref(
                 "LOAD_FAST",
                 instr.arg,
                 instr.argval,
+                offset=instr.offset,
+                starts_line=instr.starts_line,
                 is_generated=instr.is_generated,
                 is_jump_target=instr.is_jump_target,
                 jump_to=instr.jump_to,
                 exn_tab_entry=instr.exn_tab_entry,
             )
-            replacements[instr] = instr1
+            replacements[instr] = [instr1]
             expanded_instrs.append(instr1)
         else:
             expanded_instrs.append(instr)
 
-    replace_jump_target(expanded_instrs, replacements)
+    jump_replacements = {
+        instr: replacement[0] for instr, replacement in replacements.items()
+    }
+    replace_jump_target(expanded_instrs, jump_replacements)
+    replace_exception_table_entries(expanded_instrs, replacements)
     return expanded_instrs
 
 

--- a/test/sot/test_24_exceptions.py
+++ b/test/sot/test_24_exceptions.py
@@ -270,7 +270,6 @@ class TestRaiseVarargs(TestCaseBase):
             x += 5
         return x
 
-    @strict_mode_guard(True)
     def test_RAISE_VARARGS_argc(self):
         self.assert_results(
             self.argc_equal_to_0_wo_exception, paddle.to_tensor(0.01)
@@ -317,7 +316,6 @@ class TestException(TestCaseBase):
         return x
 
     @check_no_breakgraph
-    @strict_mode_guard(True)
     def test_dispatch(self):
         self.assert_results(
             self.create_builtin_exception, paddle.to_tensor(111.0)
@@ -478,7 +476,6 @@ class TestTryExcept(TestCaseBase):
             raise LookupError("TESTING!")
         return y + 3
 
-    @strict_mode_guard(True)
     def test_try_except(self):
         self.assert_results(self.try_except_wo_error, paddle.to_tensor(2))
         self.assert_results(
@@ -566,7 +563,6 @@ class TestTryFinally(TestCaseBase):
             x = 300 + x
         return x
 
-    @strict_mode_guard(True)
     def test_try_finally(self):
         self.assert_results(self.try_finally_wo_error, paddle.to_tensor(14))
         self.assert_results(
@@ -653,7 +649,6 @@ class TestTryExceptElse(TestCaseBase):
             raise ValueError("Testing!")
         return x
 
-    @strict_mode_guard(True)
     def test_try_except_else(self):
         # self.assert_results(self.try_except_else, paddle.to_tensor(14))
         self.assert_results(
@@ -663,7 +658,6 @@ class TestTryExceptElse(TestCaseBase):
         #     self.try_except_else_error_in_except, paddle.to_tensor(16)
         # )
 
-    @strict_mode_guard(True)
     def test_error(self):
         # RERAISE
         self.assert_exceptions(
@@ -740,7 +734,6 @@ class TestTryExceptFinally(TestCaseBase):
             raise ValueError
         return x
 
-    @strict_mode_guard(True)
     def test_try_except_finally(self):
         self.assert_results(self.try_except_finally, paddle.to_tensor([0.11]))
         self.assert_results(
@@ -752,7 +745,6 @@ class TestTryExceptFinally(TestCaseBase):
             paddle.to_tensor([0.33]),
         )
 
-    @strict_mode_guard(True)
     def test_error(self):
         # RERAISE
         self.assert_exceptions(
@@ -841,7 +833,6 @@ class TestTryExceptElseFinally(TestCaseBase):
             raise SyntaxError("TESTING")
         return x
 
-    @strict_mode_guard(True)
     def test_try_except_finally(self):
         self.assert_results(
             self.try_except_else_finally, paddle.to_tensor([0.11])
@@ -851,7 +842,6 @@ class TestTryExceptElseFinally(TestCaseBase):
             paddle.to_tensor([0.22]),
         )
 
-    @strict_mode_guard(True)
     def test_error(self):
         # RERAISE
         self.assert_exceptions(
@@ -875,7 +865,6 @@ class TestTryExceptElseFinally(TestCaseBase):
 
 
 class TestNestingCase(TestCaseBase):
-    @strict_mode_guard(True)
     @check_no_breakgraph
     def test_try_nesting(self):
         def try_nesting_wo_error(x):
@@ -920,7 +909,6 @@ class TestNestingCase(TestCaseBase):
 
         self.assert_results(try_nesting_wo_error, paddle.to_tensor(0.5))
 
-    @strict_mode_guard(True)
     @check_no_breakgraph
     def test_function_nesting(self):
         def raise_value_error_obj(x):
@@ -1001,7 +989,6 @@ class TestAssertException(TestCaseBase):
             x *= 4
         return x / 5
 
-    @strict_mode_guard(True)
     def test_assert_with_py_var_as_condition(self):
         # Test the case where `condition` is Python variable
         self.assert_results(self.try_assert, paddle.to_tensor(1), False)
@@ -1029,7 +1016,6 @@ class TestAssertException(TestCaseBase):
             self.try_assert, paddle.to_tensor(10), paddle.to_tensor(-1)
         )
 
-    @strict_mode_guard(True)
     def test_assert_true(self):
         @check_no_breakgraph
         def try_assert_except(x, y):
@@ -1043,7 +1029,6 @@ class TestAssertException(TestCaseBase):
 
         self.assert_results(try_assert_except, paddle.to_tensor(10), 10)
 
-    @strict_mode_guard(True)
     def test_assert_false(self):
         @check_no_breakgraph
         def try_assert_except(x, y):

--- a/test/sot/test_24_exceptions.py
+++ b/test/sot/test_24_exceptions.py
@@ -21,9 +21,6 @@ from test_case_base import (
 
 import paddle
 from paddle.jit.sot import symbolic_translate
-from paddle.jit.sot.opcode_translator.executor.opcode_executor import (
-    ALREADY_SUPPORTED_EXCEPTION,
-)
 from paddle.jit.sot.opcode_translator.instruction_utils.instruction_pass import (
     fuse_double_super_instrs,
 )
@@ -35,8 +32,6 @@ from paddle.jit.sot.opcode_translator.instruction_utils.instruction_utils import
 )
 from paddle.jit.sot.psdb import check_no_breakgraph
 from paddle.jit.sot.utils import strict_mode_guard
-
-NOT_ALLOW_FALLBACK = ALREADY_SUPPORTED_EXCEPTION
 
 
 class TestInstructionRewriteMetadata(unittest.TestCase):
@@ -275,7 +270,7 @@ class TestRaiseVarargs(TestCaseBase):
             x += 5
         return x
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_RAISE_VARARGS_argc(self):
         self.assert_results(
             self.argc_equal_to_0_wo_exception, paddle.to_tensor(0.01)
@@ -322,7 +317,7 @@ class TestException(TestCaseBase):
         return x
 
     @check_no_breakgraph
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_dispatch(self):
         self.assert_results(
             self.create_builtin_exception, paddle.to_tensor(111.0)
@@ -483,7 +478,7 @@ class TestTryExcept(TestCaseBase):
             raise LookupError("TESTING!")
         return y + 3
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_try_except(self):
         self.assert_results(self.try_except_wo_error, paddle.to_tensor(2))
         self.assert_results(
@@ -571,7 +566,7 @@ class TestTryFinally(TestCaseBase):
             x = 300 + x
         return x
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_try_finally(self):
         self.assert_results(self.try_finally_wo_error, paddle.to_tensor(14))
         self.assert_results(
@@ -658,7 +653,7 @@ class TestTryExceptElse(TestCaseBase):
             raise ValueError("Testing!")
         return x
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_try_except_else(self):
         # self.assert_results(self.try_except_else, paddle.to_tensor(14))
         self.assert_results(
@@ -668,7 +663,7 @@ class TestTryExceptElse(TestCaseBase):
         #     self.try_except_else_error_in_except, paddle.to_tensor(16)
         # )
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_error(self):
         # RERAISE
         self.assert_exceptions(
@@ -745,7 +740,7 @@ class TestTryExceptFinally(TestCaseBase):
             raise ValueError
         return x
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_try_except_finally(self):
         self.assert_results(self.try_except_finally, paddle.to_tensor([0.11]))
         self.assert_results(
@@ -757,7 +752,7 @@ class TestTryExceptFinally(TestCaseBase):
             paddle.to_tensor([0.33]),
         )
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_error(self):
         # RERAISE
         self.assert_exceptions(
@@ -846,7 +841,7 @@ class TestTryExceptElseFinally(TestCaseBase):
             raise SyntaxError("TESTING")
         return x
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_try_except_finally(self):
         self.assert_results(
             self.try_except_else_finally, paddle.to_tensor([0.11])
@@ -856,7 +851,7 @@ class TestTryExceptElseFinally(TestCaseBase):
             paddle.to_tensor([0.22]),
         )
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_error(self):
         # RERAISE
         self.assert_exceptions(
@@ -880,7 +875,7 @@ class TestTryExceptElseFinally(TestCaseBase):
 
 
 class TestNestingCase(TestCaseBase):
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     @check_no_breakgraph
     def test_try_nesting(self):
         def try_nesting_wo_error(x):
@@ -925,7 +920,7 @@ class TestNestingCase(TestCaseBase):
 
         self.assert_results(try_nesting_wo_error, paddle.to_tensor(0.5))
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     @check_no_breakgraph
     def test_function_nesting(self):
         def raise_value_error_obj(x):
@@ -1006,7 +1001,7 @@ class TestAssertException(TestCaseBase):
             x *= 4
         return x / 5
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_assert_with_py_var_as_condition(self):
         # Test the case where `condition` is Python variable
         self.assert_results(self.try_assert, paddle.to_tensor(1), False)
@@ -1034,7 +1029,7 @@ class TestAssertException(TestCaseBase):
             self.try_assert, paddle.to_tensor(10), paddle.to_tensor(-1)
         )
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_assert_true(self):
         @check_no_breakgraph
         def try_assert_except(x, y):
@@ -1048,7 +1043,7 @@ class TestAssertException(TestCaseBase):
 
         self.assert_results(try_assert_except, paddle.to_tensor(10), 10)
 
-    @strict_mode_guard(NOT_ALLOW_FALLBACK)
+    @strict_mode_guard(True)
     def test_assert_false(self):
         @check_no_breakgraph
         def try_assert_except(x, y):

--- a/test/sot/test_24_exceptions.py
+++ b/test/sot/test_24_exceptions.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import dis
 import sys
 import unittest
 
@@ -23,10 +24,142 @@ from paddle.jit.sot import symbolic_translate
 from paddle.jit.sot.opcode_translator.executor.opcode_executor import (
     ALREADY_SUPPORTED_EXCEPTION,
 )
+from paddle.jit.sot.opcode_translator.instruction_utils.instruction_pass import (
+    fuse_double_super_instrs,
+)
+from paddle.jit.sot.opcode_translator.instruction_utils.instruction_utils import (
+    ExceptionTableEntry,
+    Instruction,
+    expand_super_instrs,
+    replace_load_fast_borrow_with_strong_ref,
+)
 from paddle.jit.sot.psdb import check_no_breakgraph
 from paddle.jit.sot.utils import strict_mode_guard
 
 NOT_ALLOW_FALLBACK = ALREADY_SUPPORTED_EXCEPTION
+
+
+class TestInstructionRewriteMetadata(unittest.TestCase):
+    def test_expand_super_instrs_remaps_exception_table(self):
+        fused = Instruction(
+            0,
+            "LOAD_FAST_LOAD_FAST",
+            0x01,
+            ("x", "y"),
+            offset=8,
+            starts_line=123,
+            is_jump_target=True,
+        )
+        fused.jump_to = fused
+        fused.exn_tab_entry = ExceptionTableEntry(
+            start=fused,
+            end=fused,
+            target=fused,
+            depth=0,
+            lasti=True,
+        )
+
+        instrs = expand_super_instrs([fused])
+
+        self.assertEqual([instr.opname for instr in instrs], ["LOAD_FAST"] * 2)
+        self.assertEqual([instr.offset for instr in instrs], [8, 8])
+        self.assertEqual(instrs[0].starts_line, 123)
+        self.assertIsNone(instrs[1].starts_line)
+        self.assertIs(instrs[0].jump_to, instrs[0])
+
+        entry = instrs[0].exn_tab_entry
+        self.assertIs(entry, instrs[1].exn_tab_entry)
+        self.assertIs(entry.start, instrs[0])
+        self.assertIs(entry.end, instrs[1])
+        self.assertIs(entry.target, instrs[0])
+
+    def test_replace_load_fast_borrow_remaps_exception_table(self):
+        borrow = Instruction(
+            0,
+            "LOAD_FAST_BORROW",
+            0,
+            "x",
+            offset=10,
+            starts_line=124,
+            is_jump_target=True,
+        )
+        borrow.jump_to = borrow
+        borrow.exn_tab_entry = ExceptionTableEntry(
+            start=borrow,
+            end=borrow,
+            target=borrow,
+            depth=1,
+            lasti=True,
+        )
+
+        instrs = replace_load_fast_borrow_with_strong_ref([borrow])
+
+        self.assertEqual(len(instrs), 1)
+        instr = instrs[0]
+        self.assertEqual(instr.opname, "LOAD_FAST")
+        self.assertEqual(instr.offset, 10)
+        self.assertEqual(instr.starts_line, 124)
+        self.assertIs(instr.jump_to, instr)
+        self.assertIs(instr.exn_tab_entry.start, instr)
+        self.assertIs(instr.exn_tab_entry.end, instr)
+        self.assertIs(instr.exn_tab_entry.target, instr)
+
+    @unittest.skipIf(
+        "LOAD_FAST_LOAD_FAST" not in dis.opmap,
+        "LOAD_FAST_LOAD_FAST is only available on Python 3.13+.",
+    )
+    def test_fuse_double_super_instrs_remaps_external_target(self):
+        protected = Instruction(0, "NOP", None, None, offset=0)
+        handler_prev = Instruction(0, "LOAD_FAST", 0, "x", offset=2)
+        handler_target = Instruction(0, "LOAD_FAST", 1, "y", offset=4)
+        handler_entry = ExceptionTableEntry(
+            start=handler_prev,
+            end=handler_target,
+            target=handler_prev,
+            depth=1,
+            lasti=True,
+        )
+        handler_prev.exn_tab_entry = handler_entry
+        handler_target.exn_tab_entry = handler_entry
+        protected.exn_tab_entry = ExceptionTableEntry(
+            start=protected,
+            end=protected,
+            target=handler_target,
+            depth=0,
+            lasti=False,
+        )
+
+        instrs = [protected, handler_prev, handler_target]
+        fuse_double_super_instrs(instrs, {"co_varnames": ["x", "y"]})
+
+        self.assertEqual(
+            [instr.opname for instr in instrs], ["NOP", "LOAD_FAST_LOAD_FAST"]
+        )
+        self.assertIs(protected.exn_tab_entry.target, handler_prev)
+        self.assertIs(handler_prev.exn_tab_entry.start, handler_prev)
+        self.assertIs(handler_prev.exn_tab_entry.end, handler_prev)
+
+    @unittest.skipIf(
+        "LOAD_FAST_LOAD_FAST" not in dis.opmap,
+        "LOAD_FAST_LOAD_FAST is only available on Python 3.13+.",
+    )
+    def test_fuse_double_super_instrs_keeps_exception_boundaries(self):
+        protected = Instruction(0, "LOAD_FAST", 0, "x", offset=0)
+        outside = Instruction(0, "LOAD_FAST", 1, "y", offset=2)
+        protected.exn_tab_entry = ExceptionTableEntry(
+            start=protected,
+            end=protected,
+            target=outside,
+            depth=0,
+            lasti=False,
+        )
+
+        instrs = [protected, outside]
+        fuse_double_super_instrs(instrs, {"co_varnames": ["x", "y"]})
+
+        self.assertEqual(
+            [instr.opname for instr in instrs], ["LOAD_FAST", "LOAD_FAST"]
+        )
 
 
 class TestRaiseVarargs(TestCaseBase):

--- a/test/sot/test_tensor_dtype_in_guard.py
+++ b/test/sot/test_tensor_dtype_in_guard.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
 
 from test_case_base import (
@@ -65,11 +64,7 @@ class TestDtypeInGuard(TestCaseBase):
             x = paddle.to_tensor([2], dtype="float32")
             y = paddle.to_tensor([3], dtype="float32")
             self.assert_results(dtype_in_guard, x, y)
-            if sys.version_info >= (3, 11):
-                # skipped with co_exceptiontable flag
-                self.assertEqual(ctx.translate_count, 1)
-            else:
-                self.assertEqual(ctx.translate_count, 2)
+            self.assertEqual(ctx.translate_count, 2)
 
     @strict_mode_guard(False)
     def test_input_dtype_in_guard(self):
@@ -77,11 +72,7 @@ class TestDtypeInGuard(TestCaseBase):
             x = paddle.float32
             y = paddle.to_tensor([3], dtype="float32")
             self.assert_results(dtype_as_input, x, y)
-            if sys.version_info >= (3, 11):
-                # skipped with co_exceptiontable flag
-                self.assertEqual(ctx.translate_count, 1)
-            else:
-                self.assertEqual(ctx.translate_count, 2)
+            self.assertEqual(ctx.translate_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

这个 PR 为 SOT 补全 Python 3.11+ 异常处理支持，主要面向 Python 3.11-3.14。

之前 Python 3.11+ 只要函数包含 `co_exceptiontable` 就会在 C eval frame 入口直接跳过 SOT，导致异常路径和部分新字节码无法被 SOT 正常捕获。本次改动移除该跳过逻辑，并在 opcode translator 中解析、维护和重新生成 Python 3.11+ exception table，使 `try` / `except` / `finally` 等异常控制流在 SOT codegen 后仍保持正确的异常处理范围。

同时补齐 Python 3.11+ 异常相关 opcode 和 Python 3.12+ inlined comprehension 中使用到的 `LOAD_FAST_AND_CLEAR` 处理，并修正一个旧测试中基于“跳过 SOT”产生的不合理翻译次数期望。

本地验证：
- `rtk ninja -C build_312`
- `build_312`: `rtk ctest -I 458,557 --output-on-failure -j8`
- `build_310`: `rtk ctest -I 458,557 --output-on-failure -j8`
- `rtk prek`
- Python 3.14.4 `py_compile` 修改文件通过；当前 `build_314/python` 不是完整 Paddle 包，未跑 runtime SOT suite

<div align="right">
   <sup>This PR is authored by @codex (gpt-5.5 xhigh)</sup>
</div>

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否