### PR TITLE
[API Compatibility] Fix paddle.set_device to immediately switch hardware device

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3684,6 +3684,7 @@ All parameter, weight, gradient are variables in Paddle.
           py::return_value_policy::take_ownership);
 
   m.def("op_support_gpu", OpSupportGPU);
+  m.def("eager_set_device_id", &EagerSetDeviceId);
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   m.def("get_cuda_device_count", platform::GetGPUDeviceCount);
   m.def("get_cuda_current_device_id", &platform::GetCurrentDeviceId);

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -878,7 +878,6 @@ def _set_expected_place(place):
     global _global_expected_place_
     _global_expected_place_ = place
     _set_dygraph_tracer_expected_place(place)
-    core.eager_set_device_id()
 
 
 def _cpu_num():

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -878,6 +878,7 @@ def _set_expected_place(place):
     global _global_expected_place_
     _global_expected_place_ = place
     _set_dygraph_tracer_expected_place(place)
+    core.eager_set_device_id()
 
 
 def _cpu_num():

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -644,6 +644,8 @@ def set_device(device: PlaceLike | int) -> PlaceLike:
     """
     place = device_to_place(device)
     framework._set_expected_place(place)
+    if framework.in_dygraph_mode():
+        core.eager_set_device_id()
     return place
 
 

--- a/test/legacy_test/test_device.py
+++ b/test/legacy_test/test_device.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import ctypes
 import unittest
 
 from op_test import get_device, get_device_class, is_custom_device
@@ -18,6 +19,49 @@ from op_test import get_device, get_device_class, is_custom_device
 import paddle
 from paddle import base
 from paddle.base import core, framework
+
+
+class TestSetDeviceEagerSwitch(unittest.TestCase):
+    """Test that paddle.set_device immediately switches the underlying
+    hardware device (e.g. cudaSetDevice) without creating any tensor."""
+
+    def _get_cuda_runtime_device_id(self):
+        """Use ctypes to call cudaGetDevice directly from CUDA runtime."""
+        try:
+            lib_name = 'libcudart.so'
+            cudart = ctypes.CDLL(lib_name)
+        except:
+            return None
+        device = ctypes.c_int(-1)
+        cudart.cudaGetDevice(ctypes.byref(device))
+        return device.value
+
+    def test_set_device_switches_cuda_device_immediately(self):
+        """After set_device('gpu:1'), cudaGetDevice should return 1
+        immediately, even before creating any tensor."""
+        if not core.is_compiled_with_cuda() or core.get_cuda_device_count() < 2:
+            return
+        paddle.disable_static()
+
+        paddle.device.set_device('gpu:1')
+        runtime_device = self._get_cuda_runtime_device_id()
+        if runtime_device is None:
+            return
+        self.assertEqual(
+            runtime_device,
+            1,
+            msg=f"Expected cudaGetDevice()=1 after set_device('gpu:1'), "
+            f"but got {runtime_device}",
+        )
+
+        paddle.device.set_device('gpu:0')
+        runtime_device = self._get_cuda_runtime_device_id()
+        self.assertEqual(
+            runtime_device,
+            0,
+            msg=f"Expected cudaGetDevice()=0 after set_device('gpu:0'), "
+            f"but got {runtime_device}",
+        )
 
 
 class TestStaticDeviceManage(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
问题
paddle.set_device('gpu:1') 仅在 Python 层设置全局变量，实际的 cudaSetDevice 调用被延迟到第一次执行 op 时才触发。这导致 set_device 后、创建 tensor 前，CUDA runtime 的当前设备仍是旧值，与 PyTorch 行为不一致。

修改
paddle/fluid/pybind/pybind.cc：新增一行绑定，将已有的多设备切换函数 EagerSetDeviceId() 暴露给 Python。
python/paddle/base/framework.py：在 _set_expected_place() 中调用 core.eager_set_device_id()，使硬件设备立即切换。
test/legacy_test/test_device.py：新增单测，通过 ctypes 直接调用 cudaGetDevice 验证 set_device 后设备立即生效。
性能
无影响。EagerSetDeviceId() 内部会判断当前设备是否已是目标设备，相同则跳过，不会产生额外开销。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否