### PR TITLE
[Operator Mechanism] Fix complex multiplication accuracy issue on GPU with FMA intrinsics

### DIFF
--- a/paddle/phi/common/complex.h
+++ b/paddle/phi/common/complex.h
@@ -343,18 +343,8 @@ HOSTDEVICE inline complex<T>& operator-=(complex<T>& a,  // NOLINT
 template <typename T>
 HOSTDEVICE inline complex<T>& operator*=(complex<T>& a,  // NOLINT
                                          const complex<T>& b) {
-#if defined(PADDLE_WITH_CUDA_OR_HIP_COMPLEX) && \
-    (defined(__CUDA_ARCH__) || defined(__HIPCC__))
-  a = complex<T>(thrust::complex<T>(a.real, a.imag) *=
-                 thrust::complex<T>(b.real, b.imag));
+  a = a * b;
   return a;
-#else
-  T r = a.real * b.real - a.imag * b.imag;
-  T i = a.imag * b.real + b.imag * a.real;
-  a.real = r;
-  a.imag = i;
-  return a;
-#endif
 }
 
 template <typename T>

--- a/paddle/phi/common/complex.h
+++ b/paddle/phi/common/complex.h
@@ -221,7 +221,7 @@ template <typename T>
 HOSTDEVICE inline complex<T> operator*(const complex<T>& a,
                                        const complex<T>& b) {
 #if defined(PADDLE_WITH_CUDA_OR_HIP_COMPLEX) && \
-    (defined(__CUDA_ARCH__) || defined(__HIPCC__))
+    (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__))
   if constexpr (std::is_same<T, double>::value) {
     // real = a.real*b.real - a.imag*b.imag = fma(a.real, b.real,
     // -(a.imag*b.imag)) imag = a.imag*b.real + b.imag*a.real = fma(b.imag,

--- a/paddle/phi/common/complex.h
+++ b/paddle/phi/common/complex.h
@@ -222,7 +222,16 @@ HOSTDEVICE inline complex<T> operator*(const complex<T>& a,
                                        const complex<T>& b) {
 #if defined(PADDLE_WITH_CUDA_OR_HIP_COMPLEX) && \
     (defined(__CUDA_ARCH__) || defined(__HIPCC__))
-  return complex<T>(thrust::complex<T>(a) * thrust::complex<T>(b));
+  if constexpr (std::is_same<T, double>::value) {
+    // real = a.real*b.real - a.imag*b.imag = fma(a.real, b.real,
+    // -(a.imag*b.imag)) imag = a.imag*b.real + b.imag*a.real = fma(b.imag,
+    // a.real, a.imag*b.real)
+    return complex<T>(__fma_rn(a.real, b.real, -__dmul_rn(a.imag, b.imag)),
+                      __fma_rn(b.imag, a.real, __dmul_rn(a.imag, b.real)));
+  } else {
+    return complex<T>(__fmaf_rn(a.real, b.real, -__fmul_rn(a.imag, b.imag)),
+                      __fmaf_rn(b.imag, a.real, __fmul_rn(a.imag, b.real)));
+  }
 #else
   return complex<T>(a.real * b.real - a.imag * b.imag,
                     a.imag * b.real + b.imag * a.real);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
#### 修复 complex multiplication 的精度对齐问题

Paddle 与 PyTorch 在复数乘法中存在精度差异。虽然数学公式一致：

```text
real = a.real * b.real - a.imag * b.imag
imag = a.imag * b.real + b.imag * a.real
```

但 Paddle 原实现未在 CUDA/HIP 设备侧使用 FMA，导致 complex multiplication 的舍入路径与 PyTorch 存在差异。

本 PR 针对 GPU complex multiplication 使用 FMA 计算：

- `complex64` 使用 `__fmaf_rn`
- `complex128` 使用 `__fma_rn`

从而减少复数乘法中的舍入误差，并对齐 PyTorch 的计算结果。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是