### PR TITLE
Add deepseekv4 Newton-Schulz coefficient set and update test coverage

### DIFF
--- a/python/paddle/optimizer/muon.py
+++ b/python/paddle/optimizer/muon.py
@@ -106,6 +106,9 @@ _NS_COEFFICIENT_SETS = {
         (2.7573, -3.2939, 1.4254),
         (2.7215, -3.0494, 1.3169),
     ],
+    "deepseekv4":
+    # From DeepSeekV4: https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/resolve/main/DeepSeek_V4.pdf
+    [(3.4445, -4.7750, 2.0315)] * 8 + [(2.0, -1.5, 0.5)] * 2,
 }
 
 # ------------------------------------------------------------------
@@ -168,6 +171,13 @@ class Muon(Optimizer):
         adam_beta2 (float): β₂ for the AdamW fallback. Default: ``0.95``.
         weight_decay (float): Decoupled weight decay. Default: ``0.01``.
         ns_steps (int): Newton-Schulz iteration steps. Default: ``5``.
+        ns_coeff_type (str): Preset name for Newton-Schulz coefficients.
+            Options: ``"simple"``, ``"quintic"``, ``"polar_express"``,
+            ``"aol"``, ``"deepseekv4"``, ``"custom"``. Default: ``"simple"``.
+        ns_coeffs (list[tuple[float, float, float]] | None): Custom
+            Newton-Schulz coefficient set. Each tuple is ``(a, b, c)``
+            for one iteration step. Default: ``None``.
+            Only used when ns_coeff_type=``custom``.
         nesterov (bool): Use Nesterov momentum in Muon. Default: ``True``.
         adam_epsilon (float): ε for numerical stability in AdamW. Default: ``1e-9``.
         grad_clip (GradientClipBase | None): Gradient clipping. Default: ``None``.
@@ -185,11 +195,6 @@ class Muon(Optimizer):
             dict mapping param name to :class:`MuonParamInfo` (use_muon,
             split_concat_func). Built by Trainer and passed in.
             Default: ``None``.
-        muon_slice_config (dict | None): Declarative slice configuration mapping
-            param name to (slice_fn, slice_kwargs) tuple. Built by model's
-            _build_muon_slice_config method and passed in. This allows slice
-            strategies to be defined in the model configuration rather than
-            hard-coded in the optimizer. Default: ``None``.
         ns_matmul_dtype (paddle.dtype | None): Dtype for Newton-Schulz matmul
             iterations. ``None`` = auto-detect: bfloat16 on Ampere+ (capability
             >= 8.0), float32 on V100 and older. Pass ``paddle.float32``
@@ -214,6 +219,7 @@ class Muon(Optimizer):
         weight_decay=0.01,
         ns_steps=5,
         ns_coeff_type="simple",
+        ns_coeffs=None,
         nesterov=True,
         adam_epsilon=1e-9,
         grad_clip=None,
@@ -274,6 +280,16 @@ class Muon(Optimizer):
         self._muon_exclude_patterns = muon_exclude_patterns
         self._muon_extra_scale_factor = muon_extra_scale_factor
         self._ns_coeff_type = ns_coeff_type
+        if ns_coeff_type == "custom":
+            assert ns_coeffs is not None, (
+                "ns_coeffs must be provided when ns_coeff_type is 'custom'."
+            )
+            self._ns_coeffs = ns_coeffs
+        else:
+            assert ns_coeff_type in _NS_COEFFICIENT_SETS, (
+                f"Invalid ns_coeff_type: {ns_coeff_type}"
+            )
+            self._ns_coeffs = _NS_COEFFICIENT_SETS[ns_coeff_type]
         self._muon_param_info_map = muon_param_info_map or {}
         # Dtype for Newton-Schulz matmul.
         # None = auto: bfloat16 on Ampere+ (capability >= 8.0), float32 on older.
@@ -364,7 +380,7 @@ class Muon(Optimizer):
         X,
         steps=5,
         eps=1e-9,
-        ns_coeff_type="simple",
+        ns_coeffs=None,
         ns_matmul_dtype=paddle.bfloat16,
     ):
         """Approximate the matrix sign function via Newton-Schulz iteration.
@@ -373,14 +389,15 @@ class Muon(Optimizer):
             X: Input tensor to orthogonalize.
             steps: Number of Newton-Schulz iterations.
             eps: Small constant for numerical stability.
-            ns_coeff_type: Type of coefficient set to use.
-                Options: "simple", "quintic", "polar_express", "aol".
+            ns_coeffs: List of (a, b, c) coefficient tuples for iteration.
+                If None, uses the "simple" preset.
             ns_matmul_dtype: Dtype for matmul iterations. Defaults to
                 bfloat16. Pass paddle.float32 for V100 compatibility.
         """
-        # Get coefficient set
-        coeff_sets = _NS_COEFFICIENT_SETS.get(
-            ns_coeff_type, _NS_COEFFICIENT_SETS["simple"]
+        coeff_sets = (
+            ns_coeffs
+            if ns_coeffs is not None
+            else _NS_COEFFICIENT_SETS["simple"]
         )
 
         if X.shape[-2] > X.shape[-1]:
@@ -518,13 +535,13 @@ class Muon(Optimizer):
             # are already 2D/3D (no sharding gather needed).
             matrix_2d_global = update_buffer.reshape(param_shape)
 
-            # Shared NS + scaling closure (captures ns_steps, epsilon, version, ns_coeff_type)
+            # Shared NS + scaling closure (captures ns_steps, epsilon, version, ns_coeffs)
             def ortho_fn(m):
                 ns_out = Muon._zeropower_via_newtonschulz5(
                     m,
                     steps=ns_steps,
                     eps=epsilon,
-                    ns_coeff_type=self._ns_coeff_type,
+                    ns_coeffs=self._ns_coeffs,
                     ns_matmul_dtype=self._ns_matmul_dtype,
                 )
                 scaled = Muon._scaling_fn(

--- a/test/collective/fleet/hybrid_parallel_sharding_muon_model.py
+++ b/test/collective/fleet/hybrid_parallel_sharding_muon_model.py
@@ -47,7 +47,7 @@ g_release_gradients = int(os.environ.get("RELEASE_GRADIENTS", "0"))
 g_multi_precision = int(os.environ.get("MULTI_PRECISION", "0"))
 
 # Parameter combinations
-NS_COEFF_TYPES = ["simple", "quintic", "polar_express", "aol"]
+NS_COEFF_TYPES = ["simple", "quintic", "polar_express", "aol", "deepseekv4"]
 
 # Model config
 vocab_size = 20
@@ -287,6 +287,7 @@ class TestDistShardingMuonTraining(unittest.TestCase):
         ns_matmul_dtype=None,
         multi_precision=False,
         apply_decay_param_fun=None,
+        ns_coeffs=None,
     ):
         """Build Muon optimizer.
 
@@ -301,6 +302,7 @@ class TestDistShardingMuonTraining(unittest.TestCase):
                 Covers muon.py L560-564, L574-575, L582-583.
             apply_decay_param_fun: Optional callable(param_name) -> bool.
                 Covers muon.py L443-446, L568-572.
+            ns_coeffs: Optional custom NS coefficient list.
         """
         muon_param_info_map = {}
         exclude_patterns = ["embed", "bias", "lm_head"]
@@ -318,6 +320,8 @@ class TestDistShardingMuonTraining(unittest.TestCase):
         kwargs = {}
         if ns_matmul_dtype is not None:
             kwargs['ns_matmul_dtype'] = ns_matmul_dtype
+        if ns_coeffs is not None:
+            kwargs['ns_coeffs'] = ns_coeffs
 
         return paddle.optimizer.Muon(
             parameters=model.parameters(),
@@ -325,6 +329,7 @@ class TestDistShardingMuonTraining(unittest.TestCase):
             weight_decay=0.00001,
             grad_clip=paddle.nn.ClipGradByGlobalNorm(0.5),
             muon_param_info_map=muon_param_info_map,
+            ns_steps=10 if ns_coeff == "deepseekv4" else 5,
             ns_coeff_type=ns_coeff,
             multi_precision=multi_precision,
             apply_decay_param_fun=apply_decay_param_fun,
@@ -357,6 +362,7 @@ class TestDistShardingMuonTraining(unittest.TestCase):
         explicit_dtype=False,
         multi_precision=False,
         apply_decay_param_fun=None,
+        ns_coeffs=None,
     ):
         """Run single test combination.
 
@@ -372,6 +378,7 @@ class TestDistShardingMuonTraining(unittest.TestCase):
                 (covers muon.py L560-564, L574-575, L582-583).
             apply_decay_param_fun: Optional callable(param_name) -> bool
                 (covers muon.py L443-446, L568-572).
+            ns_coeffs: Optional custom NS coefficient list.
         """
         # Allow env var to force multi_precision on
         if g_multi_precision:
@@ -406,6 +413,7 @@ class TestDistShardingMuonTraining(unittest.TestCase):
             ns_matmul_dtype=ns_dtype,
             multi_precision=multi_precision,
             apply_decay_param_fun=apply_decay_param_fun,
+            ns_coeffs=ns_coeffs,
         )
 
         # --- Reference model (model_b, single-GPU) ---
@@ -421,6 +429,7 @@ class TestDistShardingMuonTraining(unittest.TestCase):
             ns_matmul_dtype=ns_dtype,
             multi_precision=multi_precision,
             apply_decay_param_fun=apply_decay_param_fun,
+            ns_coeffs=ns_coeffs,
         )
         optimizer_b = mix_precision_utils.MixPrecisionOptimizer(optimizer_b)
 
@@ -459,9 +468,10 @@ class TestDistShardingMuonTraining(unittest.TestCase):
         """Test ns_coeff_type combinations + color/slice/dtype coverage.
 
         Phase 1: iterate all ns_coeff_types (basic, no slice, no color).
-        Phase 2: custom color group + split_concat_func + explicit fp32 dtype.
-        Phase 3: multi_precision=True (master weights for Muon 2D + AdamW 1D).
-        Phase 4: apply_decay_param_fun that excludes some params from decay.
+        Phase 2: custom ns_coeffs (user-provided coefficient list).
+        Phase 3: custom color group + split_concat_func + explicit fp32 dtype.
+        Phase 4: multi_precision=True (master weights for Muon 2D + AdamW 1D).
+        Phase 5: apply_decay_param_fun that excludes some params from decay.
           Covers:
           - muon_sharding_optimizer.py L388-394: custom color from param.color dict
           - muon_sharding_optimizer.py L627-635, L665-667: fused gradient comm buffers
@@ -472,8 +482,8 @@ class TestDistShardingMuonTraining(unittest.TestCase):
           - muon.py L560-564, L574-575, L582-583: find_master=True (Muon path)
         """
         total = (
-            len(NS_COEFF_TYPES) + 3
-        )  # +1 color/slice/dtype, +1 multi_precision, +1 decay_fun
+            len(NS_COEFF_TYPES) + 4
+        )  # +1 custom ns_coeffs, +1 color/slice/dtype, +1 multi_precision, +1 decay_fun
         passed = 0
         failed = []
 
@@ -488,7 +498,22 @@ class TestDistShardingMuonTraining(unittest.TestCase):
                 failed.append((ns_coeff, str(e)))
                 print(f"[FAIL] {ns_coeff}: {e}")
 
-        # Phase 2: color + split_concat_func + explicit fp32 dtype
+        # Phase 2: custom ns_coeffs (user-provided coefficient list)
+        print("\n[Muon Test] custom ns_coeffs")
+        try:
+            ns_coeff = "custom"
+            custom_coeffs = [(3.4445, -4.7750, 2.0315), (2.5, -2.0, 0.8)]
+            self._run_single_test(
+                ns_coeff,
+                ns_coeffs=custom_coeffs,
+            )
+            passed += 1
+            print("[PASS] custom ns_coeffs")
+        except Exception as e:
+            failed.append(("custom_ns_coeffs", str(e)))
+            print(f"[FAIL] custom ns_coeffs: {e}")
+
+        # Phase 3: color + split_concat_func + explicit fp32 dtype
         print("\n[Muon Test] color + split_concat_func + explicit fp32 dtype")
         try:
             self._run_single_test(
@@ -503,7 +528,7 @@ class TestDistShardingMuonTraining(unittest.TestCase):
             failed.append(("color+slice+dtype", str(e)))
             print(f"[FAIL] color + slice + dtype: {e}")
 
-        # Phase 3: multi_precision=True — covers find_master branch in Muon
+        # Phase 4: multi_precision=True — covers find_master branch in Muon
         # muon.py L560-564 (find_master=True), L574-575 (master_weight.scale_),
         # L582-583 (master_weight.subtract_ + assign)
         print("\n[Muon Test] multi_precision (master weights)")
@@ -518,7 +543,7 @@ class TestDistShardingMuonTraining(unittest.TestCase):
             failed.append(("multi_precision", str(e)))
             print(f"[FAIL] multi_precision: {e}")
 
-        # Phase 4: apply_decay_param_fun — covers with_decay=False branch
+        # Phase 5: apply_decay_param_fun — covers with_decay=False branch
         # muon.py L443-446 (AdamW path: with_decay=False)
         # muon.py L568-572 (Muon path: with_decay=False)
         print("\n[Muon Test] apply_decay_param_fun (selective decay)")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Muon supports DeepSeekV4 NS-Iters.

DeepSeekV4 hybrid Newton-Schulz performs 10 iterations over two distinct stages. 

During the first 8 steps, we use coefficients (𝑎, 𝑏, 𝑐)= (3.4445,−4.7750, 2.0315)to drive rapid convergence, bringing the singular values close to 1. 
In the final 2 steps, we switch to coefficients (𝑎, 𝑏, 𝑐)= (2,−1.5, 0.5), which stabilize the singular values precisely at 1.


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否