### PR TITLE
[XPU] Fix precision for paddle.nn.functional.gelu

### DIFF
--- a/paddle/phi/kernels/xpu/gelu_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/gelu_grad_kernel.cc
@@ -31,14 +31,9 @@ void GeluGradKernel(const Context& dev_ctx,
   if (x_grad && x_grad->numel() == 0) {
     return;
   }
-  // Use high-precision variant for float16/bfloat16 to promote intermediate
-  // computations to float32, matching GPU behavior via MPTypeTrait.
-  // This avoids catastrophic rounding errors when computing gelu_grad entirely
-  // in reduced-precision types (e.g. bfloat16 max_abs_diff ~46051).
   int r = 0;
-  if constexpr (std::is_same_v<T, phi::dtype::float16> ||
-                std::is_same_v<T, phi::dtype::bfloat16>) {
-    r = xpu::gelu_grad_highprecision<XPUType>(
+  if constexpr (std::is_same_v<T, phi::dtype::bfloat16>) {
+    r = xpu::gelu_grad_nvidia_highprecision<XPUType>(
         dev_ctx.x_context(),
         reinterpret_cast<const XPUType*>(x.data<T>()),
         reinterpret_cast<const XPUType*>(out_grad.data<T>()),

--- a/paddle/phi/kernels/xpu/gelu_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/gelu_grad_kernel.cc
@@ -31,13 +31,29 @@ void GeluGradKernel(const Context& dev_ctx,
   if (x_grad && x_grad->numel() == 0) {
     return;
   }
-  int r = xpu::gelu_grad<XPUType>(
-      dev_ctx.x_context(),
-      reinterpret_cast<const XPUType*>(x.data<T>()),
-      reinterpret_cast<const XPUType*>(out_grad.data<T>()),
-      reinterpret_cast<XPUType*>(x_grad->data<T>()),
-      x_grad->numel(),
-      approximate);
+  // Use high-precision variant for float16/bfloat16 to promote intermediate
+  // computations to float32, matching GPU behavior via MPTypeTrait.
+  // This avoids catastrophic rounding errors when computing gelu_grad entirely
+  // in reduced-precision types (e.g. bfloat16 max_abs_diff ~46051).
+  int r = 0;
+  if constexpr (std::is_same_v<T, phi::dtype::float16> ||
+                std::is_same_v<T, phi::dtype::bfloat16>) {
+    r = xpu::gelu_grad_highprecision<XPUType>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(x.data<T>()),
+        reinterpret_cast<const XPUType*>(out_grad.data<T>()),
+        reinterpret_cast<XPUType*>(x_grad->data<T>()),
+        x_grad->numel(),
+        approximate);
+  } else {
+    r = xpu::gelu_grad<XPUType>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(x.data<T>()),
+        reinterpret_cast<const XPUType*>(out_grad.data<T>()),
+        reinterpret_cast<XPUType*>(x_grad->data<T>()),
+        x_grad->numel(),
+        approximate);
+  }
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "gelu_grad");
 }
 }  // namespace phi

--- a/paddle/phi/kernels/xpu/gelu_kernel.cc
+++ b/paddle/phi/kernels/xpu/gelu_kernel.cc
@@ -31,14 +31,9 @@ void GeluKernel(const Context& dev_ctx,
   if (out && out->numel() == 0) {
     return;
   }
-  // Use high-precision variant for float16/bfloat16 to promote intermediate
-  // computations to float32, matching GPU behavior via MPTypeTrait.
-  // This avoids catastrophic rounding errors when computing gelu entirely
-  // in reduced-precision types (e.g. bfloat16 max_abs_diff ~46051).
   int r = 0;
-  if constexpr (std::is_same_v<T, phi::dtype::float16> ||
-                std::is_same_v<T, phi::dtype::bfloat16>) {
-    r = xpu::gelu_highprecision<XPUType>(
+  if constexpr (std::is_same_v<T, phi::dtype::bfloat16>) {
+    r = xpu::gelu_nvidia_highprecision<XPUType>(
         dev_ctx.x_context(),
         reinterpret_cast<const XPUType*>(x.data<T>()),
         reinterpret_cast<XPUType*>(out->data<T>()),

--- a/paddle/phi/kernels/xpu/gelu_kernel.cc
+++ b/paddle/phi/kernels/xpu/gelu_kernel.cc
@@ -31,11 +31,26 @@ void GeluKernel(const Context& dev_ctx,
   if (out && out->numel() == 0) {
     return;
   }
-  int r = xpu::gelu<XPUType>(dev_ctx.x_context(),
-                             reinterpret_cast<const XPUType*>(x.data<T>()),
-                             reinterpret_cast<XPUType*>(out->data<T>()),
-                             out->numel(),
-                             approximate);
+  // Use high-precision variant for float16/bfloat16 to promote intermediate
+  // computations to float32, matching GPU behavior via MPTypeTrait.
+  // This avoids catastrophic rounding errors when computing gelu entirely
+  // in reduced-precision types (e.g. bfloat16 max_abs_diff ~46051).
+  int r = 0;
+  if constexpr (std::is_same_v<T, phi::dtype::float16> ||
+                std::is_same_v<T, phi::dtype::bfloat16>) {
+    r = xpu::gelu_highprecision<XPUType>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType*>(x.data<T>()),
+        reinterpret_cast<XPUType*>(out->data<T>()),
+        out->numel(),
+        approximate);
+  } else {
+    r = xpu::gelu<XPUType>(dev_ctx.x_context(),
+                           reinterpret_cast<const XPUType*>(x.data<T>()),
+                           reinterpret_cast<XPUType*>(out->data<T>()),
+                           out->numel(),
+                           approximate);
+  }
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "gelu");
 }
 }  // namespace phi


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
修复 XPU 上 `paddle.nn.functional.gelu` 在 bfloat16 输入下的精度问题。

XPU 原始 bfloat16 `gelu` / `gelu_grad` 路径会用低精度类型执行 GELU 中间计算，在部分 bfloat16 配置下与 GPU 结果存在明显差异。GPU/NVIDIA 参考路径会使用更高精度的中间计算。

本次修复将 bfloat16 输入切换到 XPU SDK 提供的 `xpu::gelu_nvidia_highprecision` / `xpu::gelu_grad_nvidia_highprecision`，覆盖 `approximate=True` 和 `approximate=False` 两种模式。float16 和 float32 输入继续使用原有 `xpu::gelu` / `xpu::gelu_grad` 路径，避免扩大影响面。

#### 修改文件

- `paddle/phi/kernels/xpu/gelu_kernel.cc` — bfloat16 输入使用 `xpu::gelu_nvidia_highprecision`
- `paddle/phi/kernels/xpu/gelu_grad_kernel.cc` — bfloat16 输入使用 `xpu::gelu_grad_nvidia_highprecision`

#### 验证结果

- 本地 XPU 构建成功。
- PaddleAPITest 中 `paddle.nn.functional.gelu` 全量配置已运行：3058 个配置中，所有 bfloat16 配置通过，包括 PAD-179 原始失败配置 `Tensor([1, 8192, 6912], "bfloat16"), approximate=True`，以及此前失败的 21 个 bfloat16 `approximate=False` 配置。
- 全量验证中仅剩 1 个非目标 float32 配置触发 XPU runtime abort；该路径未被本 PR 修改，单独复现仍为 XPU runtime error 299。

### 是否引起精度变化
否 — XPU bfloat16 GELU 精度修正为与 GPU/NVIDIA 参考行为对齐。