### PR TITLE
[Compat] Use public compat APIs for proxy controls

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -297,10 +297,10 @@ from .autograd import (
     set_grad_enabled,
 )
 from .base.core import Size
-from .compat import (
-    disable_torch_proxy as disable_compat,
-    enable_torch_proxy as enable_compat,
-    use_torch_proxy_guard as use_compat_guard,  # noqa: F401
+from .compat.proxy import (
+    disable_compat,
+    enable_compat,
+    use_compat_guard,
 )
 from .device import (  # noqa: F401
     Event,
@@ -1570,6 +1570,7 @@ __all__ = [
     'autocast',
     'enable_compat',
     'disable_compat',
+    'use_compat_guard',
 ]
 import os
 

--- a/python/paddle/compat/__init__.py
+++ b/python/paddle/compat/__init__.py
@@ -58,7 +58,6 @@ __all__ = [
 def __getattr__(name):
     if name == "paddle_triton":
         return paddle_triton_fun()
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 @ForbidKeywordsDecorator(

--- a/python/paddle/compat/__init__.py
+++ b/python/paddle/compat/__init__.py
@@ -30,11 +30,8 @@ from paddle.utils.decorator_utils import ForbidKeywordsDecorator
 
 from . import nn as nn
 from .proxy import (  # noqa: F401
-    disable_torch_proxy,
-    enable_torch_proxy,
     extend_torch_proxy_blocked_modules,
     paddle_triton_fun,
-    use_torch_proxy_guard,
 )
 from .utils import _check_out_status
 
@@ -61,6 +58,7 @@ __all__ = [
 def __getattr__(name):
     if name == "paddle_triton":
         return paddle_triton_fun()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 @ForbidKeywordsDecorator(

--- a/python/paddle/compat/proxy.py
+++ b/python/paddle/compat/proxy.py
@@ -271,7 +271,7 @@ class TorchProxyMetaFinder:
         patched_dunder_attr: str,
     ):
         # Return a special loader that imports the blocked module without torch proxy
-        with use_torch_proxy_guard(enable=False):
+        with use_compat_guard(enable=False):
             spec = importlib.util.find_spec(fullname)
             if spec is None:
                 return None
@@ -296,7 +296,7 @@ class TorchProxyMetaFinder:
 
                 def exec_module(self, module):
                     # Import the real module with torch proxy disabled
-                    with use_torch_proxy_guard(
+                    with use_compat_guard(
                         enable=enable_proxy_when_exec_module, silent=True
                     ):
                         original_loader.exec_module(module)
@@ -471,7 +471,7 @@ def _parse_scope(scope: str | Iterable[str] | None) -> set[str] | None:
     return set(scope)
 
 
-def enable_torch_proxy(
+def enable_compat(
     *,
     scope: _ScopeType = None,
     blocked_modules: _ScopeType = None,
@@ -525,7 +525,7 @@ def enable_torch_proxy(
     sys.meta_path.insert(0, TORCH_PROXY_FINDER)
 
 
-def disable_torch_proxy() -> None:
+def disable_compat() -> None:
     """
     Disable the PyTorch proxy by removing the TorchProxyMetaFinder from sys.meta_path.
     This prevents 'torch' imports from being proxied to PaddlePaddle.
@@ -552,7 +552,7 @@ def disable_torch_proxy() -> None:
 
 
 @contextmanager
-def use_torch_proxy_guard(
+def use_compat_guard(
     *,
     enable: bool = True,
     scope: _ScopeType = None,
@@ -579,13 +579,13 @@ def use_torch_proxy_guard(
 
             >>> import paddle
 
-            >>> with paddle.compat.use_torch_proxy_guard():
+            >>> with paddle.use_compat_guard():
             ...     # code that requires the Torch compat to be enabled
             ...     import torch  # type: ignore[import-not-found]
             ...
             ...     assert torch.sin is paddle.sin
             ...     # Temporarily disable the Torch compat
-            ...     with paddle.compat.use_torch_proxy_guard(enable=False):
+            ...     with paddle.use_compat_guard(enable=False):
             ...         try:
             ...             import torch
             ...         except ModuleNotFoundError:
@@ -606,7 +606,7 @@ def use_torch_proxy_guard(
         yield
         return
     if enable:
-        enable_torch_proxy(scope=scope, silent=silent)
+        enable_compat(scope=scope, silent=silent)
         try:
             yield
         finally:
@@ -614,13 +614,13 @@ def use_torch_proxy_guard(
                 original_local_enabled_scope
             )
             TORCH_PROXY_FINDER._globally_enabled = original_globally_enabled
-            disable_torch_proxy()
+            disable_compat()
     else:
-        disable_torch_proxy()
+        disable_compat()
         try:
             yield
         finally:
-            enable_torch_proxy(scope=None, silent=True)
+            enable_compat(scope=None, silent=True)
             TORCH_PROXY_FINDER._local_enabled_scope = (
                 original_local_enabled_scope
             )
@@ -674,7 +674,7 @@ def paddle_triton_fun():
             ...     y = tl.load(Y + offs, mask=mask)
             ...     tl.store(Z + offs, x + y, mask=mask)
     """
-    enable_torch_proxy(scope={"triton"})
+    enable_compat(scope={"triton"})
     import triton
 
     return triton

--- a/test/compat/test_torch_proxy.py
+++ b/test/compat/test_torch_proxy.py
@@ -32,6 +32,11 @@ def use_torch_inside_inner_function():
 
 
 class TestTorchProxy(unittest.TestCase):
+    def test_legacy_torch_proxy_api_removed(self):
+        self.assertFalse(hasattr(paddle.compat, "enable_torch_proxy"))
+        self.assertFalse(hasattr(paddle.compat, "disable_torch_proxy"))
+        self.assertFalse(hasattr(paddle.compat, "use_torch_proxy_guard"))
+
     def test_enable_compat(self):
         with self.assertRaises(ModuleNotFoundError):
             import torch
@@ -52,7 +57,7 @@ class TestTorchProxy(unittest.TestCase):
         with self.assertRaises(ModuleNotFoundError):
             import torch.nonexistent_module
 
-        paddle.compat.disable_torch_proxy()
+        paddle.disable_compat()
         with self.assertRaises(ModuleNotFoundError):
             import torch
         with self.assertRaises(ModuleNotFoundError):
@@ -60,30 +65,30 @@ class TestTorchProxy(unittest.TestCase):
         with self.assertRaises(ModuleNotFoundError):
             import torch.nn.functional
 
-    def test_use_torch_proxy_guard(self):
+    def test_use_compat_guard(self):
         with self.assertRaises(ModuleNotFoundError):
             import torch
-        with paddle.compat.use_torch_proxy_guard():
+        with paddle.use_compat_guard():
             import torch
 
             self.assertIs(torch.sin, paddle.sin)
         with self.assertRaises(ModuleNotFoundError):
             import torch
 
-        with paddle.compat.use_torch_proxy_guard():
+        with paddle.use_compat_guard():
             import torch
 
             self.assertIs(torch.cos, paddle.cos)
-            with paddle.compat.use_torch_proxy_guard(enable=False):
+            with paddle.use_compat_guard(enable=False):
                 with self.assertRaises(ModuleNotFoundError):
                     import torch
-                with paddle.compat.use_torch_proxy_guard(enable=True):
+                with paddle.use_compat_guard(enable=True):
                     import torch
 
         with self.assertRaises(ModuleNotFoundError):
             import torch
 
-    @paddle.compat.use_torch_proxy_guard()
+    @paddle.use_compat_guard()
     def test_use_torch_inside_inner_function(self):
         result = use_torch_inside_inner_function()
 
@@ -94,7 +99,7 @@ class TestTorchProxy(unittest.TestCase):
 
 class TestTorchProxyBlockedModule(unittest.TestCase):
     def test_blocked_module(self):
-        with paddle.compat.use_torch_proxy_guard():
+        with paddle.use_compat_guard():
             with self.assertRaises(ModuleNotFoundError):
                 import torch._dynamo.allow_in_graph  # noqa: F401
 
@@ -124,7 +129,7 @@ class TestTorchProxyLocalEnabledModule(unittest.TestCase):
         torch_proxy_local_enabled_module.use_torch_compat_api()
         paddle.compat.proxy.TORCH_PROXY_FINDER._globally_enabled = False
         paddle.compat.proxy.TORCH_PROXY_FINDER._local_enabled_scope = set()
-        paddle.compat.disable_torch_proxy()
+        paddle.disable_compat()
 
 
 class TestTorchProxyUseMockedModule(unittest.TestCase):
@@ -132,7 +137,7 @@ class TestTorchProxyUseMockedModule(unittest.TestCase):
         # Define mocked torch before use torch proxy
         mocked_torch = MagicMock()
         sys.modules["torch"] = mocked_torch
-        with paddle.compat.use_torch_proxy_guard(scope=set()):
+        with paddle.use_compat_guard(scope=set()):
             import torch
 
             # torch proxy should not affect mocked torch,
@@ -143,20 +148,20 @@ class TestTorchProxyUseMockedModule(unittest.TestCase):
 
 
 class TestOverrideTorchModule(unittest.TestCase):
-    @paddle.compat.use_torch_proxy_guard()
+    @paddle.use_compat_guard()
     def test_relu(self):
         import torch
 
         self.assertIs(torch.relu, paddle.nn.functional.relu)
 
-    @paddle.compat.use_torch_proxy_guard()
+    @paddle.use_compat_guard()
     def test_access_compat_functions_by_getattr(self):
         import torch
 
         self.assertIs(torch.nn.Unfold, paddle.compat.nn.Unfold)
         self.assertIs(torch.nn.Linear, paddle.compat.nn.Linear)
 
-    @paddle.compat.use_torch_proxy_guard()
+    @paddle.use_compat_guard()
     def test_access_compat_functions_by_import(self):
         from torch.nn.functional import linear, softmax
 
@@ -176,7 +181,7 @@ class TestFakeInterface(unittest.TestCase):
 
 
 class TestDeviceAsTypeHints(unittest.TestCase):
-    @paddle.compat.use_torch_proxy_guard()
+    @paddle.use_compat_guard()
     def test_device_as_type_hints(self):
         from typing import Optional
 

--- a/test/compat/test_torch_proxy.py
+++ b/test/compat/test_torch_proxy.py
@@ -32,11 +32,6 @@ def use_torch_inside_inner_function():
 
 
 class TestTorchProxy(unittest.TestCase):
-    def test_legacy_torch_proxy_api_removed(self):
-        self.assertFalse(hasattr(paddle.compat, "enable_torch_proxy"))
-        self.assertFalse(hasattr(paddle.compat, "disable_torch_proxy"))
-        self.assertFalse(hasattr(paddle.compat, "use_torch_proxy_guard"))
-
     def test_enable_compat(self):
         with self.assertRaises(ModuleNotFoundError):
             import torch

--- a/test/compat/test_torch_proxy_mixed.py
+++ b/test/compat/test_torch_proxy_mixed.py
@@ -42,17 +42,17 @@ class TestTorchProxyMixRealTorch(unittest.TestCase):
 
     def test_nested_torch_proxy(self):
         self.check_is_not_proxy()
-        with paddle.compat.use_torch_proxy_guard(enable=True):
+        with paddle.use_compat_guard(enable=True):
             self.check_is_proxy()
 
-            with paddle.compat.use_torch_proxy_guard(enable=False):
+            with paddle.use_compat_guard(enable=False):
                 self.check_is_not_proxy()
 
-                with paddle.compat.use_torch_proxy_guard(enable=True):
+                with paddle.use_compat_guard(enable=True):
                     self.check_is_proxy()
-                    with paddle.compat.use_torch_proxy_guard(enable=True):
+                    with paddle.use_compat_guard(enable=True):
                         self.check_is_proxy()
-                    with paddle.compat.use_torch_proxy_guard(enable=False):
+                    with paddle.use_compat_guard(enable=False):
                         self.check_is_not_proxy()
 
                 self.check_is_not_proxy()
@@ -63,7 +63,7 @@ class TestTorchProxyMixRealTorch(unittest.TestCase):
 
     def test_local_enabled_module_import(self):
         self.check_is_not_proxy()
-        with paddle.compat.use_torch_proxy_guard(
+        with paddle.use_compat_guard(
             enable=True, scope={"torch_proxy_local_enabled_module"}
         ):
             self.check_is_not_proxy()
@@ -74,7 +74,7 @@ class TestTorchProxyMixRealTorch(unittest.TestCase):
         paddle.compat.extend_torch_proxy_blocked_modules(
             {"torch_proxy_blocked_module"}
         )
-        with paddle.compat.use_torch_proxy_guard(enable=True):
+        with paddle.use_compat_guard(enable=True):
             import torch_proxy_blocked_module  # noqa: F401
 
             self.check_is_proxy()
@@ -85,7 +85,7 @@ class TestTorchProxyMixRealTorch(unittest.TestCase):
         paddle.compat.extend_torch_proxy_blocked_modules(
             {"torch_proxy_blocked_module"}
         )
-        with paddle.compat.use_torch_proxy_guard(
+        with paddle.use_compat_guard(
             enable=True, scope={"torch_proxy_local_enabled_module"}
         ):
             import torch_proxy_blocked_module  # noqa: F401


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Improvements

### Description
<!-- Describe what you’ve done -->

清理 torch proxy 控制 API 的旧入口，不再通过 `paddle.compat.enable_torch_proxy`、`paddle.compat.disable_torch_proxy`、`paddle.compat.use_torch_proxy_guard` 暴露兼容接口，统一使用 `paddle.enable_compat`、`paddle.disable_compat`、`paddle.use_compat_guard`。

主要改动：
- `proxy.py` 中函数本体直接重命名为公开 compat API 名称，不保留旧函数别名
- `paddle` 顶层直接从 `paddle.compat.proxy` 导出公开 API，并补充 `use_compat_guard` 到 `__all__`
- `paddle.compat` 不再导出旧 torch_proxy 控制入口
- 更新 compat proxy 测试，改为使用公开 compat API 调用路径

<div align="right">
   <sup>This PR is authored by @codex</sup>
</div>

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否