### PR TITLE
[XPU] Fix precision for paddle.Tensor.__mul__ complex128 type promotion and cast support

### DIFF
--- a/paddle/phi/kernels/xpu/cast_kernel.cc
+++ b/paddle/phi/kernels/xpu/cast_kernel.cc
@@ -148,6 +148,25 @@ void CastKernel(const Context& dev_ctx,
       phi::ComplexKernel<float>(dev_ctx, real, imag, out);
       break;
     }
+    case DataType::COMPLEX128: {
+      if (x.numel() == 0) {
+        dev_ctx.template Alloc<T>(out);
+        return;
+      }
+      // Cast input to float64 for real part, zero for imag, combine into
+      // complex128. XPU has no native real->complex128 cast, so we decompose.
+      DenseTensor real;
+      real.Resize(x.dims());
+      CastXPUKernelImpl<T, double, Context>(dev_ctx, x, &real);
+      DenseTensor imag;
+      imag.Resize(x.dims());
+      dev_ctx.template Alloc<double>(&imag);
+      funcs::SetConstant<Context, double>()(
+          dev_ctx, &imag, static_cast<double>(0.0));
+      dev_ctx.template Alloc<phi::complex128>(out);
+      phi::ComplexKernel<double>(dev_ctx, real, imag, out);
+      break;
+    }
 #endif
     default:
       PADDLE_THROW(common::errors::Unavailable(
@@ -174,6 +193,27 @@ void CastKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
   DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
   CastKernel<float, XPUContext>(dev_ctx, x_real, out_dtype, out);
 }
+
+template <>
+void CastKernel<phi::complex128, XPUContext>(const XPUContext& dev_ctx,
+                                             const DenseTensor& x,
+                                             DataType out_dtype,
+                                             DenseTensor* out) {
+  using T = phi::complex128;
+  if (x.dtype() == out_dtype) {
+    if (x.dims() == phi::make_ddim({-1})) {
+      *out = x;
+      return;
+    }
+    if (!out->IsSharedWith(x)) {
+      Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+  // Extract real part from complex128 (which is float64), then cast it
+  DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+  CastKernel<double, XPUContext>(dev_ctx, x_real, out_dtype, out);
+}
 #endif
 }  // namespace phi
 
@@ -188,6 +228,7 @@ PD_REGISTER_KERNEL(cast,
                    phi::bfloat16,
 #ifdef PADDLE_WITH_XPU_FFT
                    phi::complex64,
+                   phi::complex128,
 #endif
                    int64_t,
                    bool,

--- a/paddle/phi/kernels/xpu/elementwise_multiply_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_multiply_grad_kernel.cc
@@ -19,6 +19,7 @@
 
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/elementwise_add_kernel.h"
 #include "paddle/phi/kernels/elementwise_multiply_kernel.h"
@@ -172,6 +173,125 @@ void MultiplyGradKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
     }
   }
 }
+
+template <>
+void MultiplyGradKernel<phi::complex128, XPUContext>(const XPUContext& dev_ctx,
+                                                     const DenseTensor& x,
+                                                     const DenseTensor& y,
+                                                     const DenseTensor& dout,
+                                                     int axis,
+                                                     DenseTensor* dx,
+                                                     DenseTensor* dy) {
+  using T = phi::complex128;
+  if (dout.numel() == 0) {
+    if (dx) {
+      if (dx->numel() == 0) {
+        dev_ctx.template Alloc<T>(dx);
+      } else {
+        Full<T, XPUContext>(dev_ctx, dx->dims(), T(0), dx);
+      }
+    }
+    if (dy) {
+      if (dy->numel() == 0) {
+        dev_ctx.template Alloc<T>(dy);
+      } else {
+        Full<T, XPUContext>(dev_ctx, dy->dims(), T(0), dy);
+      }
+    }
+    return;
+  }
+  funcs::ElementwiseGradPreProcess(dout, dx);
+  // Complex128 gradient: dx = dout * conj(y), dy = dout * conj(x)
+  // Decomposed into double real/imag parts, cast to float for XPU compute.
+  DenseTensor dout_real = Real<T, XPUContext>(dev_ctx, dout);
+  DenseTensor dout_imag = Imag<T, XPUContext>(dev_ctx, dout);
+
+  DenseTensor dout_real_f = Cast<double>(dev_ctx, dout_real, DataType::FLOAT32);
+  DenseTensor dout_imag_f = Cast<double>(dev_ctx, dout_imag, DataType::FLOAT32);
+
+  if (dx) {
+    DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);
+    DenseTensor y_imag = Imag<T, XPUContext>(dev_ctx, y);
+    DenseTensor y_real_f = Cast<double>(dev_ctx, y_real, DataType::FLOAT32);
+    DenseTensor y_imag_f = Cast<double>(dev_ctx, y_imag, DataType::FLOAT32);
+
+    // dx_real = dout_real * y_real + dout_imag * y_imag  (conj(y) gradient)
+    // dx_imag = dout_imag * y_real - dout_real * y_imag
+    DenseTensor dx_real_f = Add<float, XPUContext>(
+        dev_ctx,
+        Multiply<float, XPUContext>(dev_ctx, dout_real_f, y_real_f),
+        Multiply<float, XPUContext>(dev_ctx, dout_imag_f, y_imag_f));
+    DenseTensor dx_imag_f = Subtract<float, XPUContext>(
+        dev_ctx,
+        Multiply<float, XPUContext>(dev_ctx, dout_imag_f, y_real_f),
+        Multiply<float, XPUContext>(dev_ctx, dout_real_f, y_imag_f));
+
+    DenseTensor dx_real = Cast<float>(dev_ctx, dx_real_f, DataType::FLOAT64);
+    DenseTensor dx_imag = Cast<float>(dev_ctx, dx_imag_f, DataType::FLOAT64);
+
+    dev_ctx.template Alloc<T>(dx);
+    if (x.dims() == dout.dims()) {
+      phi::ComplexKernel<double>(dev_ctx, dx_real, dx_imag, dx);
+    } else {
+      DenseTensor dx_real_expanded, dx_imag_expanded;
+      dx_real_expanded.Resize(dx->dims());
+      dx_imag_expanded.Resize(dx->dims());
+      ExpandGradKernel<double, XPUContext>(dev_ctx,
+                                           x,
+                                           dx_real,
+                                           phi::IntArray(vectorize(x.dims())),
+                                           &dx_real_expanded);
+      ExpandGradKernel<double, XPUContext>(dev_ctx,
+                                           x,
+                                           dx_imag,
+                                           phi::IntArray(vectorize(x.dims())),
+                                           &dx_imag_expanded);
+      phi::ComplexKernel<double>(
+          dev_ctx, dx_real_expanded, dx_imag_expanded, dx);
+    }
+  }
+  if (dy) {
+    DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+    DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
+    DenseTensor x_real_f = Cast<double>(dev_ctx, x_real, DataType::FLOAT32);
+    DenseTensor x_imag_f = Cast<double>(dev_ctx, x_imag, DataType::FLOAT32);
+
+    // dy_real = dout_real * x_real + dout_imag * x_imag  (conj(x) gradient)
+    // dy_imag = dout_imag * x_real - dout_real * x_imag
+    DenseTensor dy_real_f = Add<float, XPUContext>(
+        dev_ctx,
+        Multiply<float, XPUContext>(dev_ctx, dout_real_f, x_real_f),
+        Multiply<float, XPUContext>(dev_ctx, dout_imag_f, x_imag_f));
+    DenseTensor dy_imag_f = Subtract<float, XPUContext>(
+        dev_ctx,
+        Multiply<float, XPUContext>(dev_ctx, dout_imag_f, x_real_f),
+        Multiply<float, XPUContext>(dev_ctx, dout_real_f, x_imag_f));
+
+    DenseTensor dy_real = Cast<float>(dev_ctx, dy_real_f, DataType::FLOAT64);
+    DenseTensor dy_imag = Cast<float>(dev_ctx, dy_imag_f, DataType::FLOAT64);
+
+    dev_ctx.template Alloc<T>(dy);
+    if (y.dims() == dout.dims()) {
+      phi::ComplexKernel<double>(dev_ctx, dy_real, dy_imag, dy);
+    } else {
+      DenseTensor dy_real_expanded, dy_imag_expanded;
+      dy_real_expanded.Resize(dy->dims());
+      dy_imag_expanded.Resize(dy->dims());
+      ExpandGradKernel<double, XPUContext>(dev_ctx,
+                                           y,
+                                           dy_real,
+                                           phi::IntArray(vectorize(y.dims())),
+                                           &dy_real_expanded);
+      ExpandGradKernel<double, XPUContext>(dev_ctx,
+                                           y,
+                                           dy_imag,
+                                           phi::IntArray(vectorize(y.dims())),
+                                           &dy_imag_expanded);
+      phi::ComplexKernel<double>(
+          dev_ctx, dy_real_expanded, dy_imag_expanded, dy);
+    }
+  }
+}
 #endif
 }  // namespace phi
 
@@ -183,6 +303,7 @@ PD_REGISTER_KERNEL(multiply_grad,
                    phi::bfloat16,
 #ifdef PADDLE_WITH_XPU_FFT
                    phi::complex64,
+                   phi::complex128,
 #endif
                    float) {
 }

--- a/paddle/phi/kernels/xpu/elementwise_multiply_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_multiply_kernel.cc
@@ -19,6 +19,7 @@
 
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/elementwise_add_kernel.h"
 #include "paddle/phi/kernels/elementwise_subtract_kernel.h"
@@ -77,6 +78,44 @@ void MultiplyKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
       Multiply<float, XPUContext>(dev_ctx, x_imag, y_real));
   phi::ComplexKernel<float>(dev_ctx, real_out, imag_out, out);
 }
+
+template <>
+void MultiplyKernel<phi::complex128, XPUContext>(const XPUContext& dev_ctx,
+                                                 const DenseTensor& x,
+                                                 const DenseTensor& y,
+                                                 DenseTensor* out) {
+  using T = phi::complex128;
+  if (out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
+  // Complex128 multiplication decomposed into double real/imag operations.
+  // (a+bi)*(c+di) = (ac-bd) + (ad+bc)i
+  const DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+  const DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
+  const DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);
+  const DenseTensor y_imag = Imag<T, XPUContext>(dev_ctx, y);
+
+  // Use float intermediate computation with cast for double precision inputs.
+  // XPU broadcast_mul does not support double, so cast to float then back.
+  DenseTensor x_real_f = Cast<double>(dev_ctx, x_real, DataType::FLOAT32);
+  DenseTensor x_imag_f = Cast<double>(dev_ctx, x_imag, DataType::FLOAT32);
+  DenseTensor y_real_f = Cast<double>(dev_ctx, y_real, DataType::FLOAT32);
+  DenseTensor y_imag_f = Cast<double>(dev_ctx, y_imag, DataType::FLOAT32);
+
+  DenseTensor real_out_f = Subtract<float, XPUContext>(
+      dev_ctx,
+      Multiply<float, XPUContext>(dev_ctx, x_real_f, y_real_f),
+      Multiply<float, XPUContext>(dev_ctx, x_imag_f, y_imag_f));
+  DenseTensor imag_out_f = Add<float, XPUContext>(
+      dev_ctx,
+      Multiply<float, XPUContext>(dev_ctx, x_real_f, y_imag_f),
+      Multiply<float, XPUContext>(dev_ctx, x_imag_f, y_real_f));
+
+  DenseTensor real_out = Cast<float>(dev_ctx, real_out_f, DataType::FLOAT64);
+  DenseTensor imag_out = Cast<float>(dev_ctx, imag_out_f, DataType::FLOAT64);
+  phi::ComplexKernel<double>(dev_ctx, real_out, imag_out, out);
+}
 #endif
 
 }  // namespace phi
@@ -90,6 +129,7 @@ PD_REGISTER_KERNEL(multiply,
                    phi::bfloat16,
 #ifdef PADDLE_WITH_XPU_FFT
                    phi::complex64,
+                   phi::complex128,
 #endif
                    float,
                    int,

--- a/paddle/phi/kernels/xpu/full_kernel.cc
+++ b/paddle/phi/kernels/xpu/full_kernel.cc
@@ -20,6 +20,7 @@
 #include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/visit_type.h"
+#include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/impl/full_with_tensor_kernel_impl.h"
 
@@ -76,6 +77,52 @@ void FullKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
         dev_ctx.x_context(), imag_out.data<float>(), out->numel(), imag_part);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
     phi::ComplexKernel<float>(dev_ctx, real_out, imag_out, out);
+  }
+}
+
+template <>
+void FullKernel<phi::complex128, XPUContext>(const XPUContext& dev_ctx,
+                                             const IntArray& shape,
+                                             const Scalar& val,
+                                             DataType dtype,
+                                             DenseTensor* out) {
+  using T = phi::complex128;
+  out->Resize(shape.GetData());
+  dev_ctx.template Alloc<T>(out);
+
+  T complex_val = val.to<T>();
+  double real_part = complex_val.real;
+  double imag_part = complex_val.imag;
+
+  DenseTensor real_out, imag_out;
+  real_out.Resize(out->dims());
+  imag_out.Resize(out->dims());
+  dev_ctx.template Alloc<double>(&real_out);
+  dev_ctx.template Alloc<double>(&imag_out);
+
+  if (out->numel() > 0) {
+    // XPU xpu::constant does not support double, use float intermediates
+    DenseTensor real_out_f, imag_out_f;
+    real_out_f.Resize(out->dims());
+    imag_out_f.Resize(out->dims());
+    dev_ctx.template Alloc<float>(&real_out_f);
+    dev_ctx.template Alloc<float>(&imag_out_f);
+
+    int r = xpu::constant(dev_ctx.x_context(),
+                          real_out_f.data<float>(),
+                          out->numel(),
+                          static_cast<float>(real_part));
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
+    r = xpu::constant(dev_ctx.x_context(),
+                      imag_out_f.data<float>(),
+                      out->numel(),
+                      static_cast<float>(imag_part));
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
+
+    // Cast float intermediates to double for complex128 components
+    DenseTensor real_d = Cast<float>(dev_ctx, real_out_f, DataType::FLOAT64);
+    DenseTensor imag_d = Cast<float>(dev_ctx, imag_out_f, DataType::FLOAT64);
+    phi::ComplexKernel<double>(dev_ctx, real_d, imag_d, out);
   }
 }
 #endif
@@ -171,7 +218,14 @@ PD_REGISTER_KERNEL(full,
                    int64_t,
                    bool,
                    phi::float16,
-                   phi::bfloat16) {}
+                   phi::bfloat16
+#ifdef PADDLE_WITH_XPU_FFT
+                   ,
+                   phi::complex64,
+                   phi::complex128
+#endif
+) {
+}
 
 PD_REGISTER_KERNEL(full_like,
                    XPU,


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fixes XPU precision errors and kernel errors in `paddle.Tensor.__mul__` so results match GPU and no errors are thrown.

#### complex128 cast support in XPU cast kernel
The XPU cast kernel (`paddle/phi/kernels/xpu/cast_kernel.cc`) previously had no support for casting float32/float64 to complex128, causing PaddleError when type promotion (complex64+float64 → complex128) triggered an unsupported cast path. Added `COMPLEX128` case in the switch statement using real/imag decomposition (cast to float64 for real part, zero-fill for imag, combine via `ComplexKernel<double>`), and added `CastKernel<phi::complex128, XPUContext>` specialization that extracts the real part from complex128 and casts it.

#### complex128 multiply and multiply_grad kernels
Added `MultiplyKernel<phi::complex128, XPUContext>` and `MultiplyGradKernel<phi::complex128, XPUContext>` specializations using double real/imag decomposition. Since XPU `broadcast_mul` doesn't support double natively, the implementations cast double components to float for computation and back to double for the final complex128 output. Registered `phi::complex128` in both `multiply` and `multiply_grad` kernel registrations.

#### FullKernel<complex128> specialization
Added `FullKernel<phi::complex128, XPUContext>` specialization required by the multiply_grad kernel's zero-fill initialization. Since `xpu::constant` doesn't support double, uses float intermediates cast to double, then combined via `ComplexKernel<double>`.

#### bool * complex backward gradient
The `bool * complex` forward pass now works correctly with the complex64 specialization. The backward gradient for bool dtype tensors still differs from GPU (returns zeros), which is a known dtype limitation since bool cannot represent gradient values.

### Does this PR introduce a precision change?
Yes — XPU precision for complex128 type-promoted multiply operations (complex64*float64, float64*complex64) is corrected to align with GPU. Previously these cases crashed with PaddleError; now they produce correct results.