### PR TITLE
[XPU] Fix precision for paddle.Tensor.__matmul__ — use FC_FLOAT accumulation to match GPU fp32

### DIFF
--- a/paddle/phi/kernels/xpu/matmul_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/matmul_grad_kernel.cc
@@ -103,7 +103,8 @@ void MatmulGradKernel(const Context& dev_ctx,
                                  dout_ptr);
   std::tie(info_dx, info_dy, a_1, b_1, a_2, b_2) = fc_info;
   if (dx) {
-    MatMulXPUFunction<XPUType>(xpu_ctx, a_1, b_1, c_1, info_dx, 1.0f);
+    MatMulXPUFunction<XPUType>(
+        xpu_ctx, a_1, b_1, c_1, info_dx, 1.0f, 0.f, true);
     if (info_forward.is_x_need_broadcast) {
       int r =
           xpu::reduce_sum<XPUType>(xpu_ctx,
@@ -117,7 +118,8 @@ void MatmulGradKernel(const Context& dev_ctx,
     }
   }
   if (dy) {
-    MatMulXPUFunction<XPUType>(xpu_ctx, a_2, b_2, c_2, info_dy, 1.0f);
+    MatMulXPUFunction<XPUType>(
+        xpu_ctx, a_2, b_2, c_2, info_dy, 1.0f, 0.f, true);
     if (info_forward.is_y_need_broadcast) {
       int r =
           xpu::reduce_sum<XPUType>(xpu_ctx,
@@ -199,10 +201,12 @@ void MatmulWithFlattenGradKernel(const Context& dev_ctx,
                                       dout_ptr);
   std::tie(info_dx, info_dy, a_1, b_1, a_2, b_2) = fc_info;
   if (x_grad) {
-    phi::MatMulXPUFunction<XPUType>(xpu_ctx, a_1, b_1, c_1, info_dx, 1.0f);
+    phi::MatMulXPUFunction<XPUType>(
+        xpu_ctx, a_1, b_1, c_1, info_dx, 1.0f, 0.f, true);
   }
   if (y_grad) {
-    phi::MatMulXPUFunction<XPUType>(xpu_ctx, a_2, b_2, c_2, info_dy, 1.0f);
+    phi::MatMulXPUFunction<XPUType>(
+        xpu_ctx, a_2, b_2, c_2, info_dy, 1.0f, 0.f, true);
   }
 }
 

--- a/paddle/phi/kernels/xpu/xpu_api_wrapper.h
+++ b/paddle/phi/kernels/xpu/xpu_api_wrapper.h
@@ -64,7 +64,8 @@ inline XPUFCCalcType FCCalcType() {
       {"XPU_PADDLE_FC_INT32_WITH_LL", XPUFCCalcType::FC_INT32_WITH_LL},
   };
 #ifdef PADDLE_WITH_XPU_XRE5
-  auto default_calc_type = XPUFCCalcType::FC_TF32;
+  // Use FC_FLOAT to match GPU's CUBLAS_COMPUTE_32F accumulation precision
+  auto default_calc_type = XPUFCCalcType::FC_FLOAT;
 #else
   auto default_calc_type = XPUFCCalcType::FC_INT16;
 #endif
@@ -89,10 +90,11 @@ inline XPUFCCalcType FCCalcType<XPUTypeFP16>() {
 template <>
 inline XPUFCCalcType FCCalcType<XPUTypeBF16>() {
   XPUFCCalcTypeMap calc_type_map = {
-      // TF32 is the default, do not need to be listed here.
+      {"XPU_PADDLE_FC_TF32", XPUFCCalcType::FC_TF32},
       {"XPU_PADDLE_FC_FLOAT", XPUFCCalcType::FC_FLOAT},
       {"XPU_PADDLE_FC_LOCAL_INT16", XPUFCCalcType::FC_FLOAT}};
-  auto default_calc_type = XPUFCCalcType::FC_TF32;
+  // Use FC_FLOAT to match GPU's fp32 accumulation for bf16 matmul
+  auto default_calc_type = XPUFCCalcType::FC_FLOAT;
   return GetFCCalcTypeFromEnv(calc_type_map, default_calc_type);
 }
 
@@ -637,10 +639,11 @@ static void MatMulXPUFunction(
 
   auto xblas_fc_api = xblas_fc_api_list[fc_calc_type];
 
-  if (std::getenv("XPU_PADDLE_FC_GRAD_LOCAL") != nullptr) {
-    if (is_grad) {
-      xblas_fc_api = xblas_fc_api_list[2];
-    }
+  // Always use FC_FLOAT (full fp32 accumulation) for gradient computation
+  // to match GPU's fp32 grad accumulation and prevent catastrophic precision
+  // loss, especially for bf16 backward pass
+  if (is_grad) {
+    xblas_fc_api = xblas_fc_api_list[2];
   }
   auto xblas_fc_batch_api = xblas_fc_batch_api_list[fc_calc_type];
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix XPU matmul precision gap between XPU and GPU. On XRE5, XPU matmul defaulted to TF32 (reduced-precision) accumulation for float32 and bfloat16, while GPU uses full fp32 accumulation (CUBLAS_COMPUTE_32F). This caused systematic ~0.0001-0.0003 absolute diff for float32 matmul and catastrophic backward gradient errors for bfloat16.

#### Changes in `xpu_api_wrapper.h`

- Changed `FCCalcType<float>()` default from `FC_TF32` to `FC_FLOAT` on XRE5, matching GPU's full fp32 accumulation.
- Changed `FCCalcType<XPUTypeBF16>()` default from `FC_TF32` to `FC_FLOAT`, ensuring bf16 matmul uses fp32 accumulation like GPU.
- Added `XPU_PADDLE_FC_TF32` env var override to the bf16 calc_type_map for users who want to revert to TF32 for performance.
- Always use `FC_FLOAT` for gradient computation when `is_grad=true` (removed dependency on `XPU_PADDLE_FC_GRAD_LOCAL` env var).

#### Changes in `matmul_grad_kernel.cc`

- All 4 `MatMulXPUFunction` calls now pass `is_grad=true` to ensure gradient computation always uses FC_FLOAT accumulation, preventing catastrophic bf16 backward precision loss.

### Does this PR introduce a precision change?
Yes — XPU matmul accumulation precision corrected from TF32 to fp32 for float32 and bfloat16, aligning with GPU behavior. This improves numerical accuracy but may slightly reduce XPU matmul performance on XRE5. Users can revert via `XPU_PADDLE_FC_TF32` env var if needed.