### PR TITLE
[API Compatibility] Support vararg and add alias for `paddle.io.TensorDataset`

### DIFF
--- a/python/paddle/io/dataloader/dataset.py
+++ b/python/paddle/io/dataloader/dataset.py
@@ -25,9 +25,10 @@ from typing import (
     TypeVar,
 )
 
-from typing_extensions import Never, TypeVarTuple, Unpack
+from typing_extensions import Never, TypeVarTuple, Unpack, overload
 
 import paddle
+from paddle.utils.decorator_utils import variadic_tensor_decorator
 
 from ... import framework
 
@@ -319,6 +320,13 @@ class TensorDataset(Dataset["Tensor"]):
 
     tensors: Sequence[Tensor]
 
+    @overload
+    def __init__(self, tensors: Sequence[Tensor]) -> None: ...
+
+    @overload
+    def __init__(self, *tensors: Tensor) -> None: ...
+
+    @variadic_tensor_decorator('tensors', 1)
     def __init__(self, tensors: Sequence[Tensor]) -> None:
         if not framework.in_dynamic_mode():
             raise RuntimeError(

--- a/python/paddle/utils/data/__init__.py
+++ b/python/paddle/utils/data/__init__.py
@@ -22,6 +22,7 @@ from .dataset import (
     Dataset,
     IterableDataset,
     Subset,
+    TensorDataset,
     random_split,
 )
 from .sampler import (
@@ -44,4 +45,5 @@ __all__ = [
     'RandomSampler',
     'Sampler',
     'SequentialSampler',
+    'TensorDataset',
 ]

--- a/python/paddle/utils/data/dataset.py
+++ b/python/paddle/utils/data/dataset.py
@@ -18,5 +18,6 @@ from paddle.io import (
     Dataset as Dataset,
     IterableDataset as IterableDataset,
     Subset as Subset,
+    TensorDataset as TensorDataset,
     random_split as random_split,
 )

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -961,6 +961,7 @@ def use_first_signature(
 
 def variadic_tensor_decorator(
     param_name: str,
+    param_pos: int = 0,
 ) -> Callable[[Callable[_InputT, _RetT]], Callable[_InputT, _RetT]]:
     """
     Decorator to handle variadic tensor arguments.
@@ -978,14 +979,14 @@ def variadic_tensor_decorator(
         def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
             # PyTorch usage: variadic tensor arguments
             if len(args) >= 1 and isinstance(
-                args[0], (paddle.Tensor, paddle.pir.Value)
+                args[param_pos], (paddle.Tensor, paddle.pir.Value)
             ):
-                kwargs[param_name] = list(args)
-                args = ()
+                kwargs[param_name] = list(args[param_pos:])
+                args = args[:param_pos]
             # Paddle usage: list/tuple argument
-            elif len(args) >= 1 and isinstance(args[0], (list, tuple)):
-                kwargs[param_name] = args[0]
-                args = ()
+            elif len(args) >= 1 and isinstance(args[param_pos], (list, tuple)):
+                kwargs[param_name] = args[param_pos]
+                args = args[:param_pos]
             return func(*args, **kwargs)
 
         wrapper.__signature__ = inspect.signature(func)

--- a/test/ai_edited_test/test_ai_dataloader.py
+++ b/test/ai_edited_test/test_ai_dataloader.py
@@ -96,6 +96,30 @@ class TestTensorDataset(unittest.TestCase):
         items = [dataset[i] for i in range(5)]
         self.assertEqual(len(items), 5)
 
+    def test_tensor_dataset_varargs(self):
+        """TensorDataset with variable arguments (*args)."""
+        data1 = paddle.randn([10, 5])
+        data2 = paddle.randn([10, 3])
+        data3 = paddle.randn([10, 2])
+        dataset = TensorDataset(data1, data2, data3)
+        self.assertEqual(len(dataset), 10)
+        item = dataset[0]
+        self.assertIsInstance(item, tuple)
+        self.assertEqual(len(item), 3)
+        self.assertEqual(item[0].shape, [5])
+        self.assertEqual(item[1].shape, [3])
+        self.assertEqual(item[2].shape, [2])
+
+    def test_tensor_dataset_varargs_single(self):
+        """TensorDataset with single tensor as vararg."""
+        data = paddle.randn([8, 4])
+        dataset = TensorDataset(data)
+        self.assertEqual(len(dataset), 8)
+        item = dataset[0]
+        self.assertIsInstance(item, tuple)
+        self.assertEqual(len(item), 1)
+        self.assertEqual(item[0].shape, [4])
+
 
 class TestComposeDataset(unittest.TestCase):
     """Test ComposeDataset."""

--- a/test/legacy_test/test_paddle_utils_data.py
+++ b/test/legacy_test/test_paddle_utils_data.py
@@ -24,104 +24,93 @@ class TestUtilsAttrError(unittest.TestCase):
 
 class TestAlias(unittest.TestCase):
     def setUp(self):
-        self.ioObject = paddle.io.Dataset
-        self.utilsObject = paddle.utils.data.Dataset
-        self.directObject = paddle.utils.data.dataset.Dataset
+        self.api_map = [
+            (
+                paddle.io.Dataset,
+                paddle.utils.data.Dataset,
+                paddle.utils.data.dataset.Dataset,
+                None,
+            ),
+            (
+                paddle.io.ChainDataset,
+                paddle.utils.data.ChainDataset,
+                paddle.utils.data.dataset.ChainDataset,
+                None,
+            ),
+            (
+                paddle.io.ConcatDataset,
+                paddle.utils.data.ConcatDataset,
+                paddle.utils.data.dataset.ConcatDataset,
+                None,
+            ),
+            (
+                paddle.io.IterableDataset,
+                paddle.utils.data.IterableDataset,
+                paddle.utils.data.dataset.IterableDataset,
+                None,
+            ),
+            (
+                paddle.io.Sampler,
+                paddle.utils.data.Sampler,
+                paddle.utils.data.sampler.Sampler,
+                None,
+            ),
+            (
+                paddle.io.SequenceSampler,
+                paddle.utils.data.SequentialSampler,
+                paddle.utils.data.sampler.SequentialSampler,
+                None,
+            ),
+            (
+                paddle.io.Subset,
+                paddle.utils.data.Subset,
+                paddle.utils.data.dataset.Subset,
+                None,
+            ),
+            (
+                paddle.io.get_worker_info,
+                paddle.utils.data.get_worker_info,
+                paddle.utils.data.dataloader.get_worker_info,
+                paddle.utils.data._utils.worker.get_worker_info,
+            ),
+            (
+                paddle.io.random_split,
+                paddle.utils.data.random_split,
+                paddle.utils.data.dataset.random_split,
+                None,
+            ),
+            (
+                paddle.io.dataloader.collate.default_collate_fn,
+                paddle.utils.data.default_collate,
+                paddle.utils.data.dataloader.default_collate,
+                paddle.utils.data._utils.collate.default_collate,
+            ),
+            (
+                paddle.io.BatchSampler,
+                paddle.utils.data.BatchSampler,
+                paddle.utils.data.sampler.BatchSampler,
+                None,
+            ),
+            (
+                paddle.io.RandomSampler,
+                paddle.utils.data.RandomSampler,
+                paddle.utils.data.sampler.RandomSampler,
+                None,
+            ),
+            (
+                paddle.io.TensorDataset,
+                paddle.utils.data.TensorDataset,
+                paddle.utils.data.dataset.TensorDataset,
+                None,
+            ),
+        ]
 
     def test_compatibility(self):
-        self.assertTrue(self.ioObject is self.utilsObject)
-        self.assertTrue(self.ioObject is self.directObject)
-
-
-class TestChainDatasetAlias(TestAlias):
-    def setUp(self):
-        self.ioObject = paddle.io.ChainDataset
-        self.utilsObject = paddle.utils.data.ChainDataset
-        self.directObject = paddle.utils.data.dataset.ChainDataset
-
-
-class TestConcatDatasetAlias(TestAlias):
-    def setUp(self):
-        self.ioObject = paddle.io.ConcatDataset
-        self.utilsObject = paddle.utils.data.ConcatDataset
-        self.directObject = paddle.utils.data.dataset.ConcatDataset
-
-
-class TestIterableDatasetAlias(TestAlias):
-    def setUp(self):
-        self.ioObject = paddle.io.IterableDataset
-        self.utilsObject = paddle.utils.data.IterableDataset
-        self.directObject = paddle.utils.data.dataset.IterableDataset
-
-
-class TestSamplerAlias(TestAlias):
-    def setUp(self):
-        self.ioObject = paddle.io.Sampler
-        self.utilsObject = paddle.utils.data.Sampler
-        self.directObject = paddle.utils.data.sampler.Sampler
-
-
-class TestSequentialSamplerAlias(TestAlias):
-    def setUp(self):
-        self.ioObject = paddle.io.SequenceSampler
-        self.utilsObject = paddle.utils.data.SequentialSampler
-        self.directObject = paddle.utils.data.sampler.SequentialSampler
-
-
-class TestSubsetAlias(TestAlias):
-    def setUp(self):
-        self.ioObject = paddle.io.Subset
-        self.utilsObject = paddle.utils.data.Subset
-        self.directObject = paddle.utils.data.dataset.Subset
-
-
-class TestGetWorkerInfoAlias(TestAlias):
-    def setUp(self):
-        self.ioObject = paddle.io.get_worker_info
-        self.utilsObject = paddle.utils.data.get_worker_info
-        self.directObject = paddle.utils.data.dataloader.get_worker_info
-        self.internalUtilsObject = (
-            paddle.utils.data._utils.worker.get_worker_info
-        )
-
-    def test_compatibility(self):
-        super().test_compatibility()
-        self.assertTrue(self.ioObject is self.internalUtilsObject)
-
-
-class TestRandomSplitAlias(TestAlias):
-    def setUp(self):
-        self.ioObject = paddle.io.random_split
-        self.utilsObject = paddle.utils.data.random_split
-        self.directObject = paddle.utils.data.dataset.random_split
-
-
-class TestDefaultCollateAlias(TestAlias):
-    def setUp(self):
-        self.ioObject = paddle.io.dataloader.collate.default_collate_fn
-        self.utilsObject = paddle.utils.data.default_collate
-        self.directObject = paddle.utils.data.dataloader.default_collate
-        self.internalUtilsObject = (
-            paddle.utils.data._utils.collate.default_collate
-        )
-
-    def test_compatibility(self):
-        super().test_compatibility()
-        self.assertTrue(self.ioObject is self.internalUtilsObject)
-
-
-class TestBatchSamplerAlias(TestAlias):
-    def setUp(self):
-        self.ioObject = paddle.io.BatchSampler
-        self.utilsObject = paddle.utils.data.BatchSampler
-        self.directObject = paddle.utils.data.sampler.BatchSampler
-
-
-class TestRandomSamplerAlias(TestAlias):
-    def setUp(self):
-        self.ioObject = paddle.io.RandomSampler
-        self.utilsObject = paddle.utils.data.RandomSampler
-        self.directObject = paddle.utils.data.sampler.RandomSampler
+        for pairs in self.api_map:
+            self.assertTrue(pairs[0], pairs[1])
+            self.assertTrue(pairs[0], pairs[2])
+            if pairs[3] is not None:
+                self.assertTrue(pairs[0], pairs[3])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Add alias for `paddle.io.TensorDataset`
- Refine existing alias test and add `paddle.utils.data.TensorDataset` alias test
- Add decorator to support vararg
- Update decorator to support selecting vararg position
- Add vararg test


### 是否引起精度变化
否
