### PR TITLE
CI测试不review update allocator.h [phi_ops]

### DIFF
--- a/paddle/phi/api/include/compat/c10/core/Storage.h
+++ b/paddle/phi/api/include/compat/c10/core/Storage.h
@@ -73,13 +73,13 @@ class StorageHolderView final : public phi::Allocation {
 
   size_t size() const noexcept override { return impl_ ? impl_->nbytes_ : 0; }
 
-  const Place& place() const noexcept override {
+  const phi::Place& place() const noexcept override {
     return impl_ ? impl_->place_ : place_;
   }
 
  private:
   std::shared_ptr<StorageImpl> impl_;
-  Place place_;
+  phi::Place place_;
 };
 
 struct Storage {

--- a/paddle/phi/api/include/compat/c10/core/Storage.h
+++ b/paddle/phi/api/include/compat/c10/core/Storage.h
@@ -32,6 +32,7 @@ namespace c10 {
 
 struct Storage;
 class StorageHolderView;
+using Place = Place;
 
 // Check if two storages share the same underlying allocation
 inline bool isSharedStorageAlias(const Storage& storage0,
@@ -46,7 +47,7 @@ struct StorageImpl {
   phi::Allocator* allocator_ = nullptr;
   size_t nbytes_ = 0;
   bool resizable_ = false;
-  phi::Place place_;
+  Place place_;
   // DataPtr is stored directly (not in a shared_ptr) because all Storage
   // copies already share this StorageImpl, so one level of indirection
   // suffices to propagate mutations.
@@ -73,13 +74,13 @@ class StorageHolderView final : public phi::Allocation {
 
   size_t size() const noexcept override { return impl_ ? impl_->nbytes_ : 0; }
 
-  const phi::Place& place() const noexcept override {
+  const Place& place() const noexcept override {
     return impl_ ? impl_->place_ : place_;
   }
 
  private:
   std::shared_ptr<StorageImpl> impl_;
-  phi::Place place_;
+  Place place_;
 };
 
 struct Storage {
@@ -311,8 +312,8 @@ struct Storage {
   }
 
   // Get the device/place
-  phi::Place device() const {
-    if (!impl_) return phi::Place();
+  Place device() const {
+    if (!impl_) return Place();
     if (impl_->data_allocation_) return impl_->data_allocation_->place();
     return impl_->place_;
   }
@@ -394,7 +395,7 @@ struct Storage {
       impl_->place_ = impl_->data_allocation_->place();
     } else {
       impl_->nbytes_ = 0;
-      impl_->place_ = phi::Place();
+      impl_->place_ = Place();
     }
     impl_->data_ptr_ = viewDataPtrFrom(impl_->data_allocation_);
   }
@@ -403,7 +404,7 @@ struct Storage {
     impl_->data_allocation_ = nullptr;
     impl_->nbytes_ = size_bytes;
     impl_->place_ =
-        new_data_ptr ? new_data_ptr.device()._PD_GetInner() : phi::Place();
+        new_data_ptr ? new_data_ptr.device()._PD_GetInner() : Place();
     impl_->data_ptr_ = std::move(new_data_ptr);
   }
 

--- a/paddle/phi/api/include/compat/c10/core/Storage.h
+++ b/paddle/phi/api/include/compat/c10/core/Storage.h
@@ -32,7 +32,7 @@ namespace c10 {
 
 struct Storage;
 class StorageHolderView;
-using Place = Place;
+using Place = phi::Place;
 
 // Check if two storages share the same underlying allocation
 inline bool isSharedStorageAlias(const Storage& storage0,

--- a/paddle/phi/core/allocator.h
+++ b/paddle/phi/core/allocator.h
@@ -28,7 +28,6 @@ namespace phi {
 /// support being inherited.
 class Allocation {
  public:
-  using Place = phi::Place;
   using DeleterFnPtr = void (*)(Allocation*);
 
   Allocation() = default;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience

### PR Types
Others

### Description
<!-- Describe what you’ve done -->
paddle/phi/core/allocator.h已经是phi空间，不设置 using Place = phi::Place;
修改为 paddle/phi/api/include/compat/c10/core/Storage.h 中设置

### 是否引起精度变化
否