### PR TITLE
[XPU] Fix precision for paddle.Tensor.__truediv__ complex number operations

### DIFF
--- a/paddle/phi/kernels/xpu/cast_kernel.cc
+++ b/paddle/phi/kernels/xpu/cast_kernel.cc
@@ -148,6 +148,23 @@ void CastKernel(const Context& dev_ctx,
       phi::ComplexKernel<float>(dev_ctx, real, imag, out);
       break;
     }
+    // COMPLEX128 output: cast input to double first, then combine with
+    // zero imaginary part to form complex128. This is needed because the
+    // XPU cast kernel does not support direct float64->complex128 conversion.
+    case DataType::COMPLEX128: {
+      if (x.numel() == 0) {
+        dev_ctx.template Alloc<T>(out);
+        return;
+      }
+      DenseTensor real;
+      real.Resize(x.dims());
+      CastXPUKernelImpl<T, double, Context>(dev_ctx, x, &real);
+      dev_ctx.template Alloc<T>(out);
+      DenseTensor imag = Fill<double, Context>(
+          dev_ctx, vectorize<int>(x.dims()), static_cast<double>(0.0));
+      phi::ComplexKernel<double>(dev_ctx, real, imag, out);
+      break;
+    }
 #endif
     default:
       PADDLE_THROW(common::errors::Unavailable(
@@ -174,6 +191,28 @@ void CastKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
   DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
   CastKernel<float, XPUContext>(dev_ctx, x_real, out_dtype, out);
 }
+// CastKernel specialization for complex128: extract real part and cast it
+// to the target dtype. This is needed because the XPU cast kernel does not
+// directly support complex128 inputs.
+template <>
+void CastKernel<phi::complex128, XPUContext>(const XPUContext& dev_ctx,
+                                             const DenseTensor& x,
+                                             DataType out_dtype,
+                                             DenseTensor* out) {
+  using T = phi::complex128;
+  if (x.dtype() == out_dtype) {
+    if (x.dims() == phi::make_ddim({-1})) {
+      *out = x;
+      return;
+    }
+    if (!out->IsSharedWith(x)) {
+      Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+  DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+  CastKernel<double, XPUContext>(dev_ctx, x_real, out_dtype, out);
+}
 #endif
 }  // namespace phi
 
@@ -188,6 +227,7 @@ PD_REGISTER_KERNEL(cast,
                    phi::bfloat16,
 #ifdef PADDLE_WITH_XPU_FFT
                    phi::complex64,
+                   phi::complex128,
 #endif
                    int64_t,
                    bool,

--- a/paddle/phi/kernels/xpu/elementwise_divide_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_divide_grad_kernel.cc
@@ -22,6 +22,16 @@
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
 #include "paddle/phi/kernels/xpu/elementwise.h"
 
+#ifdef PADDLE_WITH_XPU_FFT
+#include "paddle/phi/kernels/complex_kernel.h"
+#include "paddle/phi/kernels/elementwise_add_kernel.h"
+#include "paddle/phi/kernels/elementwise_divide_kernel.h"
+#include "paddle/phi/kernels/elementwise_multiply_kernel.h"
+#include "paddle/phi/kernels/elementwise_subtract_kernel.h"
+#include "paddle/phi/kernels/expand_grad_kernel.h"
+#include "paddle/phi/kernels/full_kernel.h"
+#endif
+
 namespace phi {
 
 template <typename T, typename Context>
@@ -52,6 +62,159 @@ void DivideGradKernel(const Context& dev_ctx,
   XPUElementwiseGrad<T, XPUType>(dev_ctx, x, y, dout, axis, dx, dy, f, true);
 }
 
+#ifdef PADDLE_WITH_XPU_FFT
+// Complex64 divide grad specialization: XPU does not have a native complex64
+// divide_grad kernel, so we implement complex division gradients using
+// real/imag decomposition.
+// For complex division out = x / y:
+//   dx = dout / conj(y) => dx_real = (dr*yr + di*yi) / (yr^2+yi^2), dx_imag =
+//   (di*yr - dr*yi) / (yr^2+yi^2) dy = -dout * conj(out/y) => dy_real = -(dr*or
+//   + di*oi) / (yr^2+yi^2), dy_imag = -(di*or - dr*oi) / (yr^2+yi^2)
+// where conj denotes complex conjugate and out/y uses the same denominator as
+// forward pass.
+template <>
+void DivideGradKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
+                                                  const DenseTensor& x,
+                                                  const DenseTensor& y,
+                                                  const DenseTensor& out,
+                                                  const DenseTensor& dout,
+                                                  int axis,
+                                                  DenseTensor* dx,
+                                                  DenseTensor* dy) {
+  using T = phi::complex64;
+  if (dout.numel() == 0) {
+    if (dx) {
+      if (dx->numel() == 0) {
+        dev_ctx.template Alloc<T>(dx);
+      } else {
+        Full<T, XPUContext>(dev_ctx, dx->dims(), T(0), dx);
+      }
+    }
+    if (dy) {
+      if (dy->numel() == 0) {
+        dev_ctx.template Alloc<T>(dy);
+      } else {
+        Full<T, XPUContext>(dev_ctx, dy->dims(), T(0), dy);
+      }
+    }
+    return;
+  }
+  funcs::ElementwiseGradPreProcess(dout, dx);
+
+  DenseTensor dout_real = Real<T, XPUContext>(dev_ctx, dout);
+  DenseTensor dout_imag = Imag<T, XPUContext>(dev_ctx, dout);
+  DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);
+  DenseTensor y_imag = Imag<T, XPUContext>(dev_ctx, y);
+
+  // Common denominator: y_real^2 + y_imag^2
+  DenseTensor denom = Add<float, XPUContext>(
+      dev_ctx,
+      Multiply<float, XPUContext>(dev_ctx, y_real, y_real),
+      Multiply<float, XPUContext>(dev_ctx, y_imag, y_imag));
+
+  if (dx) {
+    // dx = dout / conj(y)
+    // dx_real = (dout_real * y_real + dout_imag * y_imag) / denom
+    // dx_imag = (dout_imag * y_real - dout_real * y_imag) / denom
+    DenseTensor dx_real = Divide<float, XPUContext>(
+        dev_ctx,
+        Add<float, XPUContext>(
+            dev_ctx,
+            Multiply<float, XPUContext>(dev_ctx, dout_real, y_real),
+            Multiply<float, XPUContext>(dev_ctx, dout_imag, y_imag)),
+        denom);
+    DenseTensor dx_imag = Divide<float, XPUContext>(
+        dev_ctx,
+        Subtract<float, XPUContext>(
+            dev_ctx,
+            Multiply<float, XPUContext>(dev_ctx, dout_imag, y_real),
+            Multiply<float, XPUContext>(dev_ctx, dout_real, y_imag)),
+        denom);
+    dev_ctx.template Alloc<T>(dx);
+    if (x.dims() == dout.dims()) {
+      phi::ComplexKernel<float>(dev_ctx, dx_real, dx_imag, dx);
+    } else {
+      DenseTensor dx_real_expanded, dx_imag_expanded;
+      dx_real_expanded.Resize(dx->dims());
+      dx_imag_expanded.Resize(dx->dims());
+      ExpandGradKernel<float, XPUContext>(dev_ctx,
+                                          x,
+                                          dx_real,
+                                          phi::IntArray(vectorize(x.dims())),
+                                          &dx_real_expanded);
+      ExpandGradKernel<float, XPUContext>(dev_ctx,
+                                          x,
+                                          dx_imag,
+                                          phi::IntArray(vectorize(x.dims())),
+                                          &dx_imag_expanded);
+      phi::ComplexKernel<float>(
+          dev_ctx, dx_real_expanded, dx_imag_expanded, dx);
+    }
+  }
+
+  if (dy) {
+    DenseTensor out_real = Real<T, XPUContext>(dev_ctx, out);
+    DenseTensor out_imag = Imag<T, XPUContext>(dev_ctx, out);
+
+    // dy = -dout * conj(out/y)
+    // For complex: dy_real = -(dout_real * out_real + dout_imag * out_imag) /
+    // denom
+    //              dy_imag = -(dout_imag * out_real - dout_real * out_imag) /
+    //              denom
+    // Use Scalar(-1.0f) to negate dout before multiplying
+    DenseTensor neg_dout_real = Multiply<float, XPUContext>(
+        dev_ctx,
+        dout_real,
+        Full<float, XPUContext>(dev_ctx,
+                                phi::IntArray(vectorize(dout.dims())),
+                                phi::Scalar(-1.0f)));
+    DenseTensor neg_dout_imag = Multiply<float, XPUContext>(
+        dev_ctx,
+        dout_imag,
+        Full<float, XPUContext>(dev_ctx,
+                                phi::IntArray(vectorize(dout.dims())),
+                                phi::Scalar(-1.0f)));
+
+    DenseTensor dy_real = Divide<float, XPUContext>(
+        dev_ctx,
+        Add<float, XPUContext>(
+            dev_ctx,
+            Multiply<float, XPUContext>(dev_ctx, neg_dout_real, out_real),
+            Multiply<float, XPUContext>(dev_ctx, neg_dout_imag, out_imag)),
+        denom);
+
+    DenseTensor dy_imag = Divide<float, XPUContext>(
+        dev_ctx,
+        Subtract<float, XPUContext>(
+            dev_ctx,
+            Multiply<float, XPUContext>(dev_ctx, neg_dout_imag, out_real),
+            Multiply<float, XPUContext>(dev_ctx, neg_dout_real, out_imag)),
+        denom);
+
+    dev_ctx.template Alloc<T>(dy);
+    if (y.dims() == dout.dims()) {
+      phi::ComplexKernel<float>(dev_ctx, dy_real, dy_imag, dy);
+    } else {
+      DenseTensor dy_real_expanded, dy_imag_expanded;
+      dy_real_expanded.Resize(dy->dims());
+      dy_imag_expanded.Resize(dy->dims());
+      ExpandGradKernel<float, XPUContext>(dev_ctx,
+                                          y,
+                                          dy_real,
+                                          phi::IntArray(vectorize(y.dims())),
+                                          &dy_real_expanded);
+      ExpandGradKernel<float, XPUContext>(dev_ctx,
+                                          y,
+                                          dy_imag,
+                                          phi::IntArray(vectorize(y.dims())),
+                                          &dy_imag_expanded);
+      phi::ComplexKernel<float>(
+          dev_ctx, dy_real_expanded, dy_imag_expanded, dy);
+    }
+  }
+}
+#endif
+
 }  // namespace phi
 
 PD_REGISTER_KERNEL(divide_grad,
@@ -60,4 +223,8 @@ PD_REGISTER_KERNEL(divide_grad,
                    phi::DivideGradKernel,
                    phi::float16,
                    phi::bfloat16,
-                   float) {}
+#ifdef PADDLE_WITH_XPU_FFT
+                   phi::complex64,
+#endif
+                   float) {
+}

--- a/paddle/phi/kernels/xpu/elementwise_divide_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_divide_kernel.cc
@@ -22,6 +22,13 @@
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
 #include "paddle/phi/kernels/xpu/elementwise.h"
 
+#ifdef PADDLE_WITH_XPU_FFT
+#include "paddle/phi/kernels/complex_kernel.h"
+#include "paddle/phi/kernels/elementwise_add_kernel.h"
+#include "paddle/phi/kernels/elementwise_multiply_kernel.h"
+#include "paddle/phi/kernels/elementwise_subtract_kernel.h"
+#endif
+
 namespace phi {
 
 template <typename T, typename Context>
@@ -42,6 +49,54 @@ void DivideKernel(const Context& dev_ctx,
   XPUElementwise<T, XPUType>(dev_ctx, x, y, -1, out, f);
 }
 
+#ifdef PADDLE_WITH_XPU_FFT
+// Complex64 division specialization: XPU does not have a native complex64
+// divide kernel, so we implement complex division using real/imag
+// decomposition. Formula: (a + bi) / (c + di) = ((ac + bd) / (c^2 + d^2)) +
+// ((bc - ad) / (c^2 + d^2))i
+template <>
+void DivideKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
+                                              const DenseTensor& x,
+                                              const DenseTensor& y,
+                                              DenseTensor* out) {
+  using T = phi::complex64;
+  if (out->numel() == 0) {
+    dev_ctx.template Alloc<T>(out);
+    return;
+  }
+  const DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+  const DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
+  const DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);
+  const DenseTensor y_imag = Imag<T, XPUContext>(dev_ctx, y);
+
+  // Denominator: y_real^2 + y_imag^2
+  DenseTensor denom = Add<float, XPUContext>(
+      dev_ctx,
+      Multiply<float, XPUContext>(dev_ctx, y_real, y_real),
+      Multiply<float, XPUContext>(dev_ctx, y_imag, y_imag));
+
+  // Real part: (x_real * y_real + x_imag * y_imag) / denom
+  DenseTensor real_out = Divide<float, XPUContext>(
+      dev_ctx,
+      Add<float, XPUContext>(
+          dev_ctx,
+          Multiply<float, XPUContext>(dev_ctx, x_real, y_real),
+          Multiply<float, XPUContext>(dev_ctx, x_imag, y_imag)),
+      denom);
+
+  // Imaginary part: (x_imag * y_real - x_real * y_imag) / denom
+  DenseTensor imag_out = Divide<float, XPUContext>(
+      dev_ctx,
+      Subtract<float, XPUContext>(
+          dev_ctx,
+          Multiply<float, XPUContext>(dev_ctx, x_imag, y_real),
+          Multiply<float, XPUContext>(dev_ctx, x_real, y_imag)),
+      denom);
+
+  phi::ComplexKernel<float>(dev_ctx, real_out, imag_out, out);
+}
+#endif
+
 }  // namespace phi
 
 PD_REGISTER_KERNEL(divide,
@@ -51,5 +106,9 @@ PD_REGISTER_KERNEL(divide,
                    float,
                    phi::float16,
                    phi::bfloat16,
+#ifdef PADDLE_WITH_XPU_FFT
+                   phi::complex64,
+#endif
                    int,
-                   int64_t) {}
+                   int64_t) {
+}


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix XPU precision for `paddle.Tensor.__truediv__` complex number division operations. Three originally failing cases on XPU are now resolved:

1. `bool / complex(0,2)` — AccuracyError where XPU output differed from GPU
2. `float64 / complex64` — PaddleError where XPU kernel threw error
3. `complex64 / float64` — PaddleError where XPU kernel threw error

Root cause: XPU lacked kernel support for complex number division and casting operations. Three fixes were applied:

#### DivideKernel<complex64,XPUContext>
Implemented complex division via real/imag decomposition using float-level XPU APIs, since XPU lacks native `broadcast_div<complex64>`. Formula: (a+bi)/(c+di) = ((ac+bd)/(c²+d²)) + ((bc-ad)/(c²+d²))i. This fixes the `float64/complex64` and `complex64/float64` PaddleError cases.

#### DivideGradKernel<complex64,XPUContext>
Implemented complex division gradients (dx = dout/conj(y), dy = -dout*conj(out/y)) via real/imag decomposition with ExpandGradKernel for broadcasting. This fixes the `bool/complex(0,2)` AccuracyError case.

#### CastKernel<complex128,XPUContext> + COMPLEX128 case
Enabled float64→complex128 and float32→complex128 casting needed for type promotion when float64 and complex64 are combined. Added both the COMPLEX128 case in the CastKernel switch and a CastKernel<complex128> specialization that extracts real part and delegates to CastKernel<double>.

All changes are gated by `PADDLE_WITH_XPU_FFT` compile flag, following the pattern established by existing complex64 specializations in add/multiply kernels.

Modified files:
- `paddle/phi/kernels/xpu/elementwise_divide_kernel.cc` (+57 lines)
- `paddle/phi/kernels/xpu/elementwise_divide_grad_kernel.cc` (+158 lines)
- `paddle/phi/kernels/xpu/cast_kernel.cc` (+40 lines)

### Does this PR introduce a precision change?
Yes — XPU precision for complex number division operations now aligns with GPU/CPU behavior.