### PR TITLE
[XPU] Fix precision for paddle.Tensor.bmm

### DIFF
--- a/paddle/phi/kernels/xpu/bmm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/bmm_grad_kernel.cc
@@ -30,6 +30,11 @@ void MatMul(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out);
   xpu::Context* xpu_ctx = dev_ctx.x_context();
   int fc_calc_type = FCCalcType<XPUType>();
+  // For float32 bmm_grad, use FC_FLOAT to match forward pass and GPU precision.
+  if (fc_calc_type == XPUFCCalcType::FC_TF32 &&
+      std::is_same<XPUType, float>::value) {
+    fc_calc_type = XPUFCCalcType::FC_FLOAT;
+  }
   if (fc_calc_type == XPUFCCalcType::FC_INT32) {
     MatMulXPUFunction<T, int32_t>(a, b, out, trans_a, trans_b, xpu_ctx);
   } else if (fc_calc_type == XPUFCCalcType::FC_FLOAT) {

--- a/paddle/phi/kernels/xpu/bmm_kernel.cc
+++ b/paddle/phi/kernels/xpu/bmm_kernel.cc
@@ -64,6 +64,14 @@ void BmmKernel(const Context& dev_ctx,
 
   xpu::Context* xpu_ctx = dev_ctx.x_context();
   int fc_calc_type = FCCalcType<XPUType>();
+  // For float32 bmm, use FC_FLOAT (full fp32 accumulation) to match GPU
+  // precision. GPU uses CUBLAS_COMPUTE_32F for float32 bmm; XPU defaults to
+  // FC_TF32 (tfloat32) which has only 10 mantissa bits vs 23 for fp32, causing
+  // precision discrepancies.
+  if (fc_calc_type == XPUFCCalcType::FC_TF32 &&
+      std::is_same<XPUType, float>::value) {
+    fc_calc_type = XPUFCCalcType::FC_FLOAT;
+  }
   if (fc_calc_type == XPUFCCalcType::FC_INT32) {
     MatMulXPUFunction<T, int32_t>(x, y, out, trans_x, trans_y, xpu_ctx);
   } else if (fc_calc_type == XPUFCCalcType::FC_FLOAT) {

--- a/paddle/phi/kernels/xpu/bmm_xpu_utils.h
+++ b/paddle/phi/kernels/xpu/bmm_xpu_utils.h
@@ -41,6 +41,11 @@ static void MatMulXPUFunction(const DenseTensor& x,
   int64_t batch_size = mat_dim_a.batch_size_;
   // batch matmul
   int fc_calc_type = FCCalcType<XPUType>();
+  // Override TF32 to FC_FLOAT for float32 bmm to match GPU precision.
+  if (fc_calc_type == XPUFCCalcType::FC_TF32 &&
+      std::is_same<XPUType, float>::value) {
+    fc_calc_type = XPUFCCalcType::FC_FLOAT;
+  }
   decltype(&xblas_fc_batch_wrapper<XPUType, int16_t, float>)
       xblas_fc_batch_api_list[6] = {
           &xblas_fc_batch_wrapper<XPUType, int16_t, float>,


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

On XRE5 hardware, the XPU bmm kernel defaults to FC_TF32 (tfloat32 with only 10 mantissa bits) for float32 inputs, while GPU uses CUBLAS_COMPUTE_32F (full fp32 with 23 mantissa bits). This causes precision discrepancies that scale with matrix dimensions — the original failing case had max_abs_diff=0.000183254 and max_rel_diff=0.394162.

#### Fix

Override FCCalcType from FC_TF32 to FC_FLOAT when the input type is float32, in the bmm forward kernel, backward kernel, and batched FC utility path. This ensures full fp32 accumulation matching GPU behavior.

#### Modified files

- `paddle/phi/kernels/xpu/bmm_kernel.cc` — Forward kernel override
- `paddle/phi/kernels/xpu/bmm_grad_kernel.cc` — Backward kernel override
- `paddle/phi/kernels/xpu/bmm_xpu_utils.h` — Batched FC utility override

#### Verification

All 19 test cases from all_config.txt now pass with max_abs_diff in range 1.04e-07 to 2.98e-07 (well within atol=1e-4 tolerance).

### 是否引起精度变化
否 — XPU precision corrected to align with GPU (TF32 accumulation → full fp32 accumulation for bmm float32).