### PR TITLE
[Custom Device] Fix XPU precision for paddle.Tensor.__pow__ gradient with integral types

### DIFF
--- a/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
@@ -1456,15 +1456,16 @@ compute_pow_grad_dy(T x, T y, T out, T dout) {
 }
 #else
 // Integral types need double precision for pow/log intermediate computations
-// to match GPU behavior. MPTypeTrait<int64_t>::Type = int64_t, which causes
-// integer truncation in pow/log — the GPU path casts to double explicitly.
+// to match GPU behavior. The GPU path computes dout*y*pow(x,y-1) entirely in
+// double and only casts to T at return. Casting to T mid-computation truncates
+// fractional parts before multiplying by dout, causing gradient divergence.
 template <typename T, typename MPType>
 HOSTDEVICE typename std::enable_if<std::is_integral<T>::value, T>::type
 compute_pow_grad_dx(T x, T y, T out UNUSED, T dout) {
   if (y == static_cast<T>(0.0)) return static_cast<T>(0.0);
-  return dout * y *
-         static_cast<T>(
-             std::pow(static_cast<double>(x), static_cast<double>(y - 1)));
+  return static_cast<T>(
+      static_cast<double>(dout) * static_cast<double>(y) *
+      std::pow(static_cast<double>(x), static_cast<double>(y - 1)));
 }
 template <typename T, typename MPType>
 HOSTDEVICE typename std::enable_if<!std::is_integral<T>::value, T>::type
@@ -1474,14 +1475,16 @@ compute_pow_grad_dx(T x, T y, T out UNUSED, T dout) {
   MPType y_val = static_cast<MPType>(y);
   return dout * static_cast<T>(y_val * std::pow(x_val, y_val - 1));
 }
+// Integral types: compute dout*log(x)*pow(x,y) entirely in double, matching
+// the GPU path which keeps all intermediates in double before the final cast.
 template <typename T, typename MPType>
 HOSTDEVICE typename std::enable_if<std::is_integral<T>::value, T>::type
 compute_pow_grad_dy(T x, T y, T out UNUSED, T dout) {
   if (x == static_cast<T>(0) && y >= static_cast<T>(0))
     return static_cast<T>(0);
-  return dout * static_cast<T>(
-                    std::log(static_cast<double>(x)) *
-                    std::pow(static_cast<double>(x), static_cast<double>(y)));
+  return static_cast<T>(
+      static_cast<double>(dout) * std::log(static_cast<double>(x)) *
+      std::pow(static_cast<double>(x), static_cast<double>(y)));
 }
 template <typename T, typename MPType>
 HOSTDEVICE typename std::enable_if<!std::is_integral<T>::value, T>::type

--- a/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
@@ -1455,15 +1455,37 @@ compute_pow_grad_dy(T x, T y, T out, T dout) {
   return dout * static_cast<T>(log(x_val) * pow(x_val, y_val));
 }
 #else
+// Integral types need double precision for pow/log intermediate computations
+// to match GPU behavior. MPTypeTrait<int64_t>::Type = int64_t, which causes
+// integer truncation in pow/log — the GPU path casts to double explicitly.
 template <typename T, typename MPType>
-HOSTDEVICE T compute_pow_grad_dx(T x, T y, T out UNUSED, T dout) {
+HOSTDEVICE typename std::enable_if<std::is_integral<T>::value, T>::type
+compute_pow_grad_dx(T x, T y, T out UNUSED, T dout) {
+  if (y == static_cast<T>(0.0)) return static_cast<T>(0.0);
+  return dout * y *
+         static_cast<T>(
+             std::pow(static_cast<double>(x), static_cast<double>(y - 1)));
+}
+template <typename T, typename MPType>
+HOSTDEVICE typename std::enable_if<!std::is_integral<T>::value, T>::type
+compute_pow_grad_dx(T x, T y, T out UNUSED, T dout) {
   if (y == static_cast<T>(0.0)) return static_cast<T>(0.0);
   MPType x_val = static_cast<MPType>(x);
   MPType y_val = static_cast<MPType>(y);
   return dout * static_cast<T>(y_val * std::pow(x_val, y_val - 1));
 }
 template <typename T, typename MPType>
-HOSTDEVICE T compute_pow_grad_dy(T x, T y, T out UNUSED, T dout) {
+HOSTDEVICE typename std::enable_if<std::is_integral<T>::value, T>::type
+compute_pow_grad_dy(T x, T y, T out UNUSED, T dout) {
+  if (x == static_cast<T>(0) && y >= static_cast<T>(0))
+    return static_cast<T>(0);
+  return dout * static_cast<T>(
+                    std::log(static_cast<double>(x)) *
+                    std::pow(static_cast<double>(x), static_cast<double>(y)));
+}
+template <typename T, typename MPType>
+HOSTDEVICE typename std::enable_if<!std::is_integral<T>::value, T>::type
+compute_pow_grad_dy(T x, T y, T out UNUSED, T dout) {
   if (x == static_cast<T>(0) && y >= static_cast<T>(0))
     return static_cast<T>(0);
   MPType x_val = static_cast<MPType>(x);

--- a/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
@@ -1465,7 +1465,7 @@ compute_pow_grad_dx(T x, T y, T out UNUSED, T dout) {
   if (y == static_cast<T>(0.0)) return static_cast<T>(0.0);
   return static_cast<T>(
       static_cast<double>(dout) * static_cast<double>(y) *
-      std::pow(static_cast<double>(x), static_cast<double>(y - 1)));
+      std::pow(static_cast<double>(x), static_cast<double>(y) - 1.0));
 }
 template <typename T, typename MPType>
 HOSTDEVICE typename std::enable_if<!std::is_integral<T>::value, T>::type


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description
The `elementwise_pow_grad` kernel has no XPU registration, causing it to fall back to the CPU kernel. The CPU kernel's non-CUDA path uses `MPTypeTrait<int64_t>::Type = int64_t` for pow/log gradient computations, which causes integer truncation of fractional intermediate values. The GPU (CUDA) path has explicit `std::is_integral` overloads that cast all operands to `double` before computing gradients, keeping the entire expression in double precision until the final cast back to the result type.

#### paddle.Tensor.__pow__ — integral-type gradient precision

Modified `paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h` to add integral-type SFINAE overloads for `compute_pow_grad_dx` and `compute_pow_grad_dy` in the non-CUDA (`#else`) section, mirroring the GPU/CUDA section's approach. The integral overloads compute `dout*y*pow(x,y-1)` and `dout*log(x)*pow(x,y)` entirely in `double`, casting all operands (including `dout`) to `double` before multiplication, then only cast the final result back to `T`. This avoids truncation of fractional intermediate values before multiplying by `dout`, matching the GPU path exactly.

Follow-up update: addressed the automated review warning by casting `y` to `double` before subtracting `1.0` in `compute_pow_grad_dx`, avoiding possible integer underflow for integral `y` values.

Verification: All 216 test cases for `paddle.Tensor.__pow__` pass forward and backward accuracy checks. Both originally failing int64 cases now pass with max_abs_diff=0. The follow-up patch also passed `git diff --check`; `prek` could not be run locally because it is not installed in this environment.

### 是否引起精度变化
否 — XPU pow gradient for integral types now matches GPU precision (previously diverged due to integer truncation)