### PR TITLE
fix(addmm): preserve float32 precision for alpha/beta in bf16/fp16 GEMM

### DIFF
--- a/paddle/phi/kernels/impl/addmm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/addmm_kernel_impl.h
@@ -18,6 +18,7 @@ limitations under the License. */
 
 #include "glog/logging.h"
 
+#include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/kernels/addmm_kernel.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
@@ -118,21 +119,37 @@ void AddmmKernel(const Context& dev_ctx,
     return;
   }
 
-  T t_alpha = static_cast<T>(alpha);
-  T t_beta = static_cast<T>(beta);
-  blas.GEMM(false,
-            false,
-            x_dims[0],
-            y_dims[1],
-            x_dims[1],
-            t_alpha,
-            x.data<T>(),
-            x_dims[1],
-            y.data<T>(),
-            y_dims[1],
-            t_beta,
-            out->data<T>(),
-            y_dims[1]);
+  using MPType = typename dtype::MPTypeTrait<T>::Type;
+  if constexpr (std::is_same_v<MPType, float>) {
+    float t_alpha = alpha;
+    float t_beta = beta;
+    blas.GEMM(CblasNoTrans,
+              CblasNoTrans,
+              x_dims[0],
+              y_dims[1],
+              x_dims[1],
+              t_alpha,
+              x.data<T>(),
+              y.data<T>(),
+              t_beta,
+              out->data<T>());
+  } else {
+    T t_alpha = static_cast<T>(alpha);
+    T t_beta = static_cast<T>(beta);
+    blas.GEMM(false,
+              false,
+              x_dims[0],
+              y_dims[1],
+              x_dims[1],
+              t_alpha,
+              x.data<T>(),
+              x_dims[1],
+              y.data<T>(),
+              y_dims[1],
+              t_beta,
+              out->data<T>(),
+              y_dims[1]);
+  }
 }
 
 }  // namespace phi


### PR DESCRIPTION


<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description
addmm incorrectly cast alpha/beta to tensor dtype (bf16/fp16) before passing to cuBLAS, causing significant scalar precision loss (e.g. alpha=2.9270 → bf16(2.921875), losing 0.17%).

Use MPTypeTrait<T>::Type pattern (same as baddbmm) to keep scalars in float32 for half-precision types, matching PyTorch's opmath_type behavior.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78960

pcard-91067

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
 是