### PR TITLE
[FlexCheckPoint] fix memory leaking of a recursive function (#78922)

### DIFF
--- a/python/paddle/distributed/flex_checkpoint/dcp/utils.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/utils.py
@@ -113,6 +113,7 @@ def flatten_state_dict(state_dict):
     mapping = {}
 
     def _flatten(key, value):
+        nonlocal _flatten
         if isinstance(value, dict):
             for k, v in value.items():
                 assert isinstance(k, str), f"The key should be str, but is {k}"
@@ -127,6 +128,7 @@ def flatten_state_dict(state_dict):
             )
 
     _flatten((), state_dict)
+    del _flatten  # force python gc of recursive closure
 
     return flatten_state_dict, mapping
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Auto Parallel


### PR Types
Bug fixes


### Description
修复一处因为函数循环引用导致的显存泄漏问题

`_flatten`因为递归调用了自己，所以产生了循环引用，如果不主动删除或者调用 gc.collect，就不会释放，导致 flatten_state_dict 里面的 tensor 显存泄漏；实际表现为训练时每次 save model 后显存都会增加，直到 OOM

<b>原来为什么没问题：</b>其实这段代码两年前就有了，之前没暴露可能是因为之前的 trainer 里每个 step 都会调用一下 gc.collect，现在新的 trainer 不调用了，所以它就不释放了；这个问题大概是 4.26-4.30 期间才暴露的，但是无从定位是哪个 commit 的问题了，只能正向修复

### 经验总结
1. 说白了还是 python gc 其实有很多坑，尤其是和 paddle 这种 GPU 框架一起用，需要特别小心
2. 最坑的是，paddle.Tensor 是没有 gc 的，只有引用计数，所以如果一个 Tensor 进行了循环引用，那就永远删不掉了
3. 然后，python gc 的阈值是 700 个对象，必须累积 700 个已跟踪的对象才会进行一次，而 gc 能够跟踪的对象其实很少，比如常见的 int、str、Tensor 这些都不跟踪，实际上很难被动触发
4. 所以这次这个问题，其实如果累积了足够多个 flatten_state_dict，其实是可以触发 gc 的，但是可能要高达 700 次 save_model 才触发，早就把显存撑爆了


### 是否引起精度变化
否

devPR:https://github.com/PaddlePaddle/Paddle/pull/78922

Pcard-85711