### PR TITLE
[Metax] Fix pid_t format specifier in DataLoader error message

### DIFF
--- a/paddle/fluid/imperative/data_loader.cc
+++ b/paddle/fluid/imperative/data_loader.cc
@@ -171,7 +171,7 @@ void ThrowErrorIfLoadProcessFailed() {
               "space of `/dev/shm`. Shared storage space needs to be greater "
               "than (DataLoader Num * DataLoader queue capacity * 1 batch data "
               "size).\n  You can solve this problem by increasing the shared "
-              "storage space or reducing the queue capacity appropriately.\n",
+              "storage space or reducing the queue capacity appropriately.\n"
               "  1. If run DataLoader by DataLoader.from_generator(...), queue "
               "capacity is set by from_generator(..., capacity=xx, ...).\n"
               "  2. If run DataLoader by DataLoader(dataset, ...), queue "


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix incorrect format specifier for pid_t in DataLoader error handler

The function ThrowErrorIfLoadProcessFailed used `%ld` to format `process_pid`,
which is of type `pid_t` (typically `int` on LP64 Linux). This type mismatch
is undefined behavior. In certain environments it corrupted the formatted
error string, causing the PID and signal name (e.g., "Bus error") to be garbled,
and making related tests fail on some machines.

Fixed three occurrences by using the correct specifier `%d`, matching the
actual type of `pid_t`. This makes the error messages stable and reliable.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否