### PR TITLE
fix fastdeploy compile bug

### DIFF
--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -739,6 +739,7 @@ class BuildExtension(build_ext):
                 )
             )
             cc_args = self._get_cc_args(pp_opts, debug, extra_preargs)
+            build_work_directory = os.getcwd()
             build_directory = os.path.dirname(objects[0]) if objects else "."
             config = ['ninja_required_version = 1.5', '']
             ccache_home = _get_ccache_home()
@@ -854,6 +855,7 @@ class BuildExtension(build_ext):
                 build_directory,
                 verbose=bool(current_extension_builder.verbose),
                 error_prefix='Failed to compile C++ extension with ninja',
+                work_directory=build_work_directory,
             )
             return objects
 
@@ -981,6 +983,7 @@ class BuildExtension(build_ext):
                     extra_postargs,
                 )
             )
+            build_work_directory = os.getcwd()
             compile_opts = list(extra_preargs or [])
             compile_opts.append('/c')
             if debug:
@@ -1093,6 +1096,7 @@ class BuildExtension(build_ext):
                 build_directory,
                 verbose=bool(current_extension_builder.verbose),
                 error_prefix='Failed to compile C++ extension with ninja',
+                work_directory=build_work_directory,
             )
             return objects
 
@@ -1817,8 +1821,12 @@ def _run_ninja_build(
     build_directory: str,
     verbose: bool,
     error_prefix: str,
+    work_directory: str | None = None,
 ) -> None:
     command = ['ninja', '-v']
+    cwd = build_directory if work_directory is None else work_directory
+    if os.path.abspath(cwd) != os.path.abspath(build_directory):
+        command.extend(['-f', os.path.join(build_directory, 'build.ninja')])
     num_workers = _get_num_workers(verbose)
     if num_workers is not None:
         command.extend(['-j', str(num_workers)])
@@ -1838,7 +1846,7 @@ def _run_ninja_build(
     try:
         subprocess.run(
             command,
-            cwd=build_directory,
+            cwd=cwd,
             env=env,
             check=True,
             stdout=None if verbose else subprocess.PIPE,

--- a/test/cpp_extension/test_cpp_extension_ninja.py
+++ b/test/cpp_extension/test_cpp_extension_ninja.py
@@ -133,6 +133,26 @@ class TestNinjaHelperFunctions(unittest.TestCase):
                 _run_ninja_build(tmpdir, verbose=True, error_prefix="Test")
                 mock_run.assert_called_once()
 
+    def test_run_ninja_build_with_work_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            build_dir = os.path.join(tmpdir, 'build')
+            work_dir = os.path.join(tmpdir, 'src')
+            os.makedirs(build_dir)
+            os.makedirs(work_dir)
+
+            with mock.patch('subprocess.run') as mock_run:
+                _run_ninja_build(
+                    build_dir,
+                    verbose=True,
+                    error_prefix='Test',
+                    work_directory=work_dir,
+                )
+
+        command = mock_run.call_args.args[0]
+        self.assertIn('-f', command)
+        self.assertIn(os.path.join(build_dir, 'build.ninja'), command)
+        self.assertEqual(mock_run.call_args.kwargs['cwd'], work_dir)
+
     def test_run_ninja_build_windows_with_vscmd_env(self):
         if sys.platform != 'win32':
             self.skipTest("Windows-only test")
@@ -316,6 +336,12 @@ class TestBuildExtension(unittest.TestCase):
                 captured['ninja_path'] = path
                 captured['ninja_content'] = content
 
+            def fake_run_ninja_build(
+                build_directory, verbose, error_prefix, work_directory=None
+            ):
+                captured['ninja_build_directory'] = build_directory
+                captured['ninja_work_directory'] = work_directory
+
             def fake_build_extensions(_):
                 _.compiler.compile(
                     sources,
@@ -349,7 +375,7 @@ class TestBuildExtension(unittest.TestCase):
                 ),
                 mock.patch(
                     'paddle.utils.cpp_extension.cpp_extension._run_ninja_build',
-                    return_value=None,
+                    side_effect=fake_run_ninja_build,
                 ),
                 mock.patch(
                     'paddle.utils.cpp_extension.cpp_extension.build_ext.build_extensions',
@@ -643,6 +669,67 @@ class TestBuildExtension(unittest.TestCase):
         self.assertIn(shlex.join(['-DNAME=value with space']), content)
         self.assertIn(shlex.join(['--compiler-options=-Wall -Wextra']), content)
         self.assertNotIn('"\'"\'"', content)
+
+    def test_unix_ninja_preserves_relative_include_flags(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_dir = Path(tmpdir)
+            sources = [
+                str(test_dir / "custom_extension.cc"),
+                str(test_dir / "custom_kernel.cu"),
+            ]
+            objects = [
+                str(test_dir / "build" / "custom_extension.o"),
+                str(test_dir / "build" / "custom_kernel.cu.o"),
+            ]
+            build_map = {
+                objects[0]: (sources[0], '.cc'),
+                objects[1]: (sources[1], '.cu'),
+            }
+            compiler = _FakeUnixCompiler(objects, build_map)
+
+            with (
+                mock.patch(
+                    'paddle.utils.cpp_extension.cpp_extension.os.getcwd',
+                    return_value=str(test_dir),
+                ),
+                mock.patch(
+                    'paddle.utils.cpp_extension.cpp_extension.CUDA_HOME',
+                    '/opt/cuda',
+                ),
+                mock.patch(
+                    'paddle.utils.cpp_extension.cpp_extension._get_ccache_home',
+                    return_value=None,
+                ),
+                mock.patch(
+                    'paddle.utils.cpp_extension.cpp_extension.prepare_unix_cudaflags',
+                    side_effect=lambda flags: ['--prepared', *flags],
+                ),
+                mock.patch(
+                    'paddle.utils.cpp_extension.cpp_extension.core.is_compiled_with_rocm',
+                    return_value=False,
+                ),
+                mock.patch(
+                    'paddle.utils.cpp_extension.cpp_extension.core.is_compiled_with_custom_device',
+                    return_value=False,
+                ),
+            ):
+                captured = self._run_build_with_fake_compiler(
+                    compiler,
+                    sources,
+                    extra_compile_args={
+                        'cxx': ['-Ithird_party/cxx', '-isystem', 'system/cxx'],
+                        'nvcc': ['-Ithird_party/cuda', '-I', 'cuda_split'],
+                    },
+                    include_dirs=['public/include'],
+                )
+
+        content = captured['ninja_content']
+        self.assertIn('-Ipublic/include', content)
+        self.assertIn('-Ithird_party/cxx', content)
+        self.assertIn('-isystem system/cxx', content)
+        self.assertIn('-Ithird_party/cuda', content)
+        self.assertIn('-I cuda_split', content)
+        self.assertEqual(captured['ninja_work_directory'], str(test_dir))
 
     def test_unix_ninja_uses_hipcc_for_rocm_sources(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -996,6 +1083,53 @@ class TestBuildExtension(unittest.TestCase):
         self.assertIn('--prepared', content)
         self.assertIn('/DPADDLE_WITH_CUDA', content)
         self.assertIn('deps = msvc', content)
+
+    def test_windows_ninja_preserves_relative_include_flags(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_dir = Path(tmpdir)
+            sources = [
+                str(test_dir / "custom_extension.cc"),
+                str(test_dir / "custom_kernel.cu"),
+            ]
+            objects = [
+                str(test_dir / "build" / "custom_extension.obj"),
+                str(test_dir / "build" / "custom_kernel.obj"),
+            ]
+            build_map = {
+                objects[0]: (sources[0], '.cc'),
+                objects[1]: (sources[1], '.cu'),
+            }
+            compiler = _FakeMsvcCompiler(objects, build_map)
+
+            with (
+                mock.patch(
+                    'paddle.utils.cpp_extension.cpp_extension.os.getcwd',
+                    return_value=str(test_dir),
+                ),
+                mock.patch(
+                    'paddle.utils.cpp_extension.cpp_extension.CUDA_HOME',
+                    '/opt/cuda',
+                ),
+                mock.patch(
+                    'paddle.utils.cpp_extension.cpp_extension.prepare_win_cudaflags',
+                    side_effect=lambda flags: ['--prepared', *flags],
+                ),
+            ):
+                captured = self._run_build_with_fake_compiler(
+                    compiler,
+                    sources,
+                    extra_compile_args={
+                        'cxx': ['/Ithird_party/cxx'],
+                        'nvcc': ['/Ithird_party/cuda'],
+                    },
+                    include_dirs=['public/include'],
+                )
+
+        content = captured['ninja_content']
+        self.assertIn('/Ipublic/include', content)
+        self.assertIn('/Ithird_party/cxx', content)
+        self.assertIn('/Ithird_party/cuda', content)
+        self.assertEqual(captured['ninja_work_directory'], str(test_dir))
 
     def test_windows_ninja_ignores_invalid_extra_compile_args(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/test/cpp_extension/test_cpp_extension_ninja.py
+++ b/test/cpp_extension/test_cpp_extension_ninja.py
@@ -140,7 +140,12 @@ class TestNinjaHelperFunctions(unittest.TestCase):
             os.makedirs(build_dir)
             os.makedirs(work_dir)
 
-            with mock.patch('subprocess.run') as mock_run:
+            with (
+                mock.patch.dict(
+                    os.environ, {'VSCMD_ARG_TGT_ARCH': 'x64'}, clear=False
+                ),
+                mock.patch('subprocess.run') as mock_run,
+            ):
                 _run_ninja_build(
                     build_dir,
                     verbose=True,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复[PR78520](https://github.com/PaddlePaddle/Paddle/pull/78520)引入的bug：setup_ops.py 中的 include 路径都是相对路径（如 -Ithird_party/nlohmann_json/include），但 Paddle 的 cpp_extension 使用 ninja 构建时，工作目录是 build 目录而非源码目录，导致相对路径解析失败。

<img width="1244" height="592" alt="2764240d8dcb011d816caa5a5582c24c" src="https://github.com/user-attachments/assets/5e489ae2-8e68-4ea3-b155-d7b87d12a025" />


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否