### PR TITLE
[release/3.3] Fix permute big tensor error

### DIFF
--- a/paddle/phi/kernels/gpu/moe_permute_utils.h
+++ b/paddle/phi/kernels/gpu/moe_permute_utils.h
@@ -362,7 +362,7 @@ __global__ __launch_bounds__(512) void filling_padding_rows_kernel(
     const int cols,
     const int quanted_cols,
     const int* __restrict__ padding_rows) {
-  uint32_t rows = padding_rows[blockIdx.x];
+  int64_t rows = static_cast<int64_t>(padding_rows[blockIdx.x]);
   if constexpr (FILLING_X_UNZIPPED) {
     vectorized_memset(
         &X_unzipped_ptr[rows * cols], static_cast<TokenT>(0), cols);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
 Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复premute fill padding的kernel时可能存在的大Tensor问题

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

---

Cherry-pick of #78973 (authored by @DanielSun11) to `release/3.3`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78973 <!-- For pass CI -->