### PR TITLE
[Compat] Force create arange attributes on CPU

### DIFF
--- a/paddle/phi/api/include/compat/ATen/ops/arange.h
+++ b/paddle/phi/api/include/compat/ATen/ops/arange.h
@@ -63,9 +63,8 @@ inline at::ScalarType _PD_ResolveArangeDtype(const at::Scalar& start,
 }
 
 inline paddle::Tensor _PD_MakeArangeScalarTensor(const at::Scalar& scalar,
-                                                 phi::DataType dtype,
-                                                 const phi::Place& place) {
-  return paddle::experimental::full({}, scalar, dtype, place);
+                                                 phi::DataType dtype) {
+  return paddle::experimental::full({}, scalar, dtype, phi::CPUPlace());
 }
 
 }  // namespace detail
@@ -87,19 +86,17 @@ inline at::Tensor arange(const at::Scalar& start,
     phi::Place base_place = options._PD_GetPlace();
     phi::Place pinned_place = compat::_PD_GetCreatePinnedPlace(base_place);
     auto dense = paddle::experimental::arange(
-        detail::_PD_MakeArangeScalarTensor(start, pd_dtype, phi::CPUPlace()),
-        detail::_PD_MakeArangeScalarTensor(end, pd_dtype, phi::CPUPlace()),
-        detail::_PD_MakeArangeScalarTensor(step, pd_dtype, phi::CPUPlace()),
+        detail::_PD_MakeArangeScalarTensor(start, pd_dtype),
+        detail::_PD_MakeArangeScalarTensor(end, pd_dtype),
+        detail::_PD_MakeArangeScalarTensor(step, pd_dtype),
         pd_dtype,
         phi::CPUPlace());
     return dense.copy_to(pinned_place, /*blocking=*/true);
   }
   return paddle::experimental::arange(
-      detail::_PD_MakeArangeScalarTensor(
-          start, pd_dtype, options._PD_GetPlace()),
-      detail::_PD_MakeArangeScalarTensor(end, pd_dtype, options._PD_GetPlace()),
-      detail::_PD_MakeArangeScalarTensor(
-          step, pd_dtype, options._PD_GetPlace()),
+      detail::_PD_MakeArangeScalarTensor(start, pd_dtype),
+      detail::_PD_MakeArangeScalarTensor(end, pd_dtype),
+      detail::_PD_MakeArangeScalarTensor(step, pd_dtype),
       pd_dtype,
       options._PD_GetPlace());
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

兼容层 arange 的 start step end 强制放在 cpu 而非 gpu 上，避免后续取 gpu tensor 结果导致 D2H，进而引发 DeepGEMM 明显降速

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否