### PR TITLE
[Bug fixes] fix view infershape bug

### DIFF
--- a/paddle/phi/kernels/stride/view_kernel.cc
+++ b/paddle/phi/kernels/stride/view_kernel.cc
@@ -33,8 +33,8 @@ void ViewShapeStridedKernel(const Context& dev_ctx,
   }
   // infer dims
   auto infer_dim = -1;
-  auto new_size = 1;
-  auto numel = input.numel();
+  int64_t new_size = 1;
+  int64_t numel = input.numel();
   std::vector<int64_t> dims_copy = dims;
   for (int dim = 0, ndim = dims_copy.size(); dim < ndim; ++dim) {
     if (dims_copy[dim] == -1) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
解决大Tensor问题，当Tensor的size很大时，当前auto为int类型会出现数值溢出bug；size/numel应该用int64表示。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否