### PR TITLE
[release/3.4] fix(baddbmm_grad): use batched GEMM, gate split-scale behind flag

### DIFF
--- a/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
@@ -17,12 +17,15 @@ limitations under the License. */
 
 #include "glog/logging.h"
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/kernels/baddbmm_grad_kernel.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
 #include "paddle/phi/kernels/funcs/for_range.h"
+
+COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
 
 namespace phi {
 
@@ -206,51 +209,111 @@ void BaddbmmGradKernel(const Context& dev_ctx,
   if (x_grad) {
     dev_ctx.template Alloc<T>(x_grad);
     total_elems = x.dims()[0] * x.dims()[1] * x.dims()[2];
-    // x_grad = out_grad * y'. x_grad: B x M x K, out_grad : B x M x N, y : B x
-    // K x N
-    for (int64_t i = 0; i < x.dims()[0]; ++i) {
-      auto out_grad_slice = out_grad.Slice(i, i + 1);
-      auto y_slice = y.Slice(i, i + 1);
-      auto x_grad_slice = x_grad->Slice(i, i + 1);
-      auto x_grad_dims = x_grad_slice.dims();
-
-      x_grad_slice.Resize({x_grad_dims[1], x_grad_dims[2]});
-      y_slice.Resize({y_slice.dims()[1], y_slice.dims()[2]});
-      out_grad_slice.Resize(
-          {out_grad_slice.dims()[1], out_grad_slice.dims()[2]});
-      blas.MatMul(out_grad_slice, false, y_slice, true, &x_grad_slice);
-    }
-    if (!is_float16_or_bfloat16) {
-      mt_blas.SCAL(total_elems, alpha, x_grad->data<MPType>());
+    // x_grad = alpha * out_grad @ y^T
+    // out_grad: [B, M, N], y: [B, K, N], x_grad: [B, M, K]
+    int64_t B_dim = x.dims()[0];
+    int64_t M_dim = x.dims()[1];
+    int64_t K_dim = x.dims()[2];
+    int64_t N_dim = y.dims()[2];
+    if constexpr (std::is_same_v<MPType, float>) {
+      float gemm_alpha = FLAGS_use_accuracy_compatible_kernel ? 1.0f : alpha;
+      float zero = 0.0f;
+      blas.BatchedGEMM(CblasNoTrans,
+                       CblasTrans,
+                       M_dim,
+                       K_dim,
+                       N_dim,
+                       gemm_alpha,
+                       out_grad.data<T>(),
+                       y.data<T>(),
+                       zero,
+                       x_grad->data<T>(),
+                       B_dim,
+                       M_dim * N_dim,
+                       K_dim * N_dim);
     } else {
-      funcs::ForRange<Context> for_range(dev_ctx, total_elems);
-      BCopyOrScaleFunctor<T> functor(
-          alpha, x_grad->data<T>(), x_grad->data<T>(), total_elems);
-      for_range(functor);
+      T gemm_alpha = FLAGS_use_accuracy_compatible_kernel
+                         ? static_cast<T>(1)
+                         : static_cast<T>(alpha);
+      T zero = static_cast<T>(0);
+      blas.BatchedGEMM(CblasNoTrans,
+                       CblasTrans,
+                       M_dim,
+                       K_dim,
+                       N_dim,
+                       gemm_alpha,
+                       out_grad.data<T>(),
+                       y.data<T>(),
+                       zero,
+                       x_grad->data<T>(),
+                       B_dim,
+                       M_dim * N_dim,
+                       K_dim * N_dim);
+    }
+    if (FLAGS_use_accuracy_compatible_kernel) {
+      if (!is_float16_or_bfloat16) {
+        mt_blas.SCAL(total_elems, alpha, x_grad->data<MPType>());
+      } else {
+        funcs::ForRange<Context> for_range(dev_ctx, total_elems);
+        BCopyOrScaleFunctor<T> functor(
+            alpha, x_grad->data<T>(), x_grad->data<T>(), total_elems);
+        for_range(functor);
+      }
     }
   }
   if (y_grad) {
     dev_ctx.template Alloc<T>(y_grad);
     total_elems = y.dims()[0] * y.dims()[1] * y.dims()[2];
-    // y_grad = x' * out_grad. y_grad: B x K x N, out_grad : B x M x N, x : B x
-    // M x K
-    for (int64_t i = 0; i < x.dims()[0]; ++i) {
-      auto out_grad_slice = out_grad.Slice(i, i + 1);
-      auto x_slice = x.Slice(i, i + 1);
-      auto y_grad_slice = y_grad->Slice(i, i + 1);
-      out_grad_slice.Resize(
-          {out_grad_slice.dims()[1], out_grad_slice.dims()[2]});
-      x_slice.Resize({x_slice.dims()[1], x_slice.dims()[2]});
-      y_grad_slice.Resize({y_grad_slice.dims()[1], y_grad_slice.dims()[2]});
-      blas.MatMul(x_slice, true, out_grad_slice, false, &y_grad_slice);
-    }
-    if (!is_float16_or_bfloat16) {
-      mt_blas.SCAL(total_elems, alpha, y_grad->data<MPType>());
+    // y_grad = alpha * x^T @ out_grad
+    // x: [B, M, K], out_grad: [B, M, N], y_grad: [B, K, N]
+    int64_t B_dim = x.dims()[0];
+    int64_t M_dim = x.dims()[1];
+    int64_t K_dim = x.dims()[2];
+    int64_t N_dim = y.dims()[2];
+    if constexpr (std::is_same_v<MPType, float>) {
+      float gemm_alpha = FLAGS_use_accuracy_compatible_kernel ? 1.0f : alpha;
+      float zero = 0.0f;
+      blas.BatchedGEMM(CblasTrans,
+                       CblasNoTrans,
+                       K_dim,
+                       N_dim,
+                       M_dim,
+                       gemm_alpha,
+                       x.data<T>(),
+                       out_grad.data<T>(),
+                       zero,
+                       y_grad->data<T>(),
+                       B_dim,
+                       M_dim * K_dim,
+                       M_dim * N_dim);
     } else {
-      funcs::ForRange<Context> for_range(dev_ctx, total_elems);
-      BCopyOrScaleFunctor<T> functor(
-          alpha, y_grad->data<T>(), y_grad->data<T>(), total_elems);
-      for_range(functor);
+      T gemm_alpha = FLAGS_use_accuracy_compatible_kernel
+                         ? static_cast<T>(1)
+                         : static_cast<T>(alpha);
+      T zero = static_cast<T>(0);
+      blas.BatchedGEMM(CblasTrans,
+                       CblasNoTrans,
+                       K_dim,
+                       N_dim,
+                       M_dim,
+                       gemm_alpha,
+                       x.data<T>(),
+                       out_grad.data<T>(),
+                       zero,
+                       y_grad->data<T>(),
+                       B_dim,
+                       M_dim * K_dim,
+                       M_dim * N_dim);
+    }
+    if (FLAGS_use_accuracy_compatible_kernel) {
+      if (!is_float16_or_bfloat16) {
+        mt_blas.SCAL(total_elems, alpha, y_grad->data<MPType>());
+      } else {
+        funcs::ForRange<Context> for_range(dev_ctx, total_elems);
+        BCopyOrScaleFunctor<T> functor(
+            alpha, y_grad->data<T>(), y_grad->data<T>(), total_elems);
+        for_range(functor);
+      }
     }
   }
 }


### PR DESCRIPTION

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
The backward kernel previously looped over the batch dimension with 2D matmul per element. This caused cuBLAS to pick different tiling (TILE_32x32 vs 64x64) compared to PyTorch's batched dispatch.

Fix: replace per-element loop with BatchedGEMM.

When FLAGS_use_accuracy_compatible_kernel=true, additionally split the alpha scaling out of the GEMM (bmm + separate SCAL), matching PyTorch's backward rounding order for bitwise alignment. Default (flag=false) uses fused alpha for optimal performance.

baddbmm反向精度修复

pcard-91067


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是

---

Cherry-pick of #78970 (authored by @A-nnonymous) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78970 <!-- For pass CI -->