### PR TITLE
[XPU] Fix precision for paddle.Tensor.mean with integer input types

### DIFF
--- a/paddle/phi/backends/xpu/xpu1_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu1_op_list.cc
@@ -107,7 +107,7 @@ XPUOpMap& get_kl1_ops() {
       {"matmul_v2_grad", XPUKernelSet({FLOAT32})},
       {"matmul_v2", XPUKernelSet({FLOAT32})},
       {"matmul", XPUKernelSet({FLOAT32})},
-      {"mean_grad", XPUKernelSet({FLOAT32})},
+      {"mean_grad", XPUKernelSet({FLOAT32, INT32, INT64})},
       {"mean", XPUKernelSet({FLOAT32})},
       {"momentum", XPUKernelSet({FLOAT32})},
       {"mul_grad", XPUKernelSet({FLOAT32})},

--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -293,7 +293,7 @@ XPUOpMap& get_kl2_ops() {
       {"matmul_v2_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"matmul_v2", XPUKernelSet({FLOAT32, FLOAT16})},
       {"matmul", XPUKernelSet({FLOAT32, FLOAT16})},
-      {"mean_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
+      {"mean_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16, INT32, INT64})},
       {"mean", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"merged_adam", XPUKernelSet({FLOAT32})},
       {"merged_momentum", XPUKernelSet({FLOAT32, FLOAT16})},

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -527,7 +527,7 @@ XPUOpMap& get_kl3_ops() {
       {"matmul_v2", XPUKernelSet({FLOAT32, BFLOAT16, FLOAT16})},
       {"matmul", XPUKernelSet({FLOAT32, BFLOAT16, FLOAT16})},
       {"batched_gemm", XPUKernelSet({FLOAT32, BFLOAT16})},
-      {"mean_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
+      {"mean_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16, INT32, INT64})},
       {"mean", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"merged_momentum", XPUKernelSet({FLOAT32, FLOAT16})},
       {"momentum", XPUKernelSet({FLOAT32, FLOAT16})},

--- a/paddle/phi/kernels/xpu/reduce_mean_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_mean_grad_kernel.cc
@@ -37,10 +37,6 @@ void ReduceMeanGradKernel(const Context& dev_ctx,
 
   using XPUType = typename XPUTypeTrait<T>::Type;
   reduce_all = recompute_reduce_all(x, dims, reduce_all);
-  dev_ctx.template Alloc<T>(x_grad);
-  const XPUType* dy_data = reinterpret_cast<const XPUType*>(out_grad.data<T>());
-
-  XPUType* x_data = reinterpret_cast<XPUType*>(x_grad->data<T>());
 
   auto reduce_dims = dims.GetData();
 
@@ -68,12 +64,6 @@ void ReduceMeanGradKernel(const Context& dev_ctx,
     }
   }
 
-  float val = 1.0f / static_cast<float>(reduce_numel);
-
-  int r = xpu::constant(
-      dev_ctx.x_context(), x_data, x.numel(), static_cast<XPUType>(val));
-  PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
-
   // use [1] to replace [], because xpu not support []
   if (xdims.size() == 0) {
     xdims = std::vector<int64_t>({1});
@@ -81,6 +71,16 @@ void ReduceMeanGradKernel(const Context& dev_ctx,
   if (ydims.size() == 0) {
     ydims = std::vector<int64_t>({1});
   }
+
+  float val = 1.0f / static_cast<float>(reduce_numel);
+
+  dev_ctx.template Alloc<T>(x_grad);
+  const XPUType* dy_data = reinterpret_cast<const XPUType*>(out_grad.data<T>());
+  XPUType* x_data = reinterpret_cast<XPUType*>(x_grad->data<T>());
+
+  int r = xpu::constant(
+      dev_ctx.x_context(), x_data, x.numel(), static_cast<XPUType>(val));
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
 
   r = xpu::broadcast_mul(
       dev_ctx.x_context(), x_data, dy_data, x_data, xdims, ydims);
@@ -95,4 +95,8 @@ PD_REGISTER_KERNEL(mean_grad,
                    phi::ReduceMeanGradKernel,
                    float,
                    phi::float16,
-                   phi::bfloat16) {}
+                   phi::bfloat16,
+                   int,
+                   int64_t) {
+  kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
+}


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix XPU precision errors in `paddle.Tensor.mean` when called with int32/int64 input dtypes. The XPU `mean_grad` kernel was only registered for float types, causing the backward pass to fall back to an inconsistent code path for integer types.

#### Root Cause
When `paddle.Tensor.mean` is called on integer inputs, the forward pass casts int to float32, computes mean, and casts back to int. The backward pass needs a registered XPU `mean_grad` kernel for int types, but only float types were registered, leading to precision gaps between XPU and GPU.

#### Changes
- Added `int` and `int64_t` to the `mean_grad` kernel registration in `paddle/phi/kernels/xpu/reduce_mean_grad_kernel.cc`
- Set `Output(0).SetDataType(UNDEFINED)` to allow proper framework type inference
- Moved `Alloc<T>` after dims adjustment for edge-case correctness
- Auto-generated op_list files updated accordingly (xpu1/2/3_op_list.cc)

#### Verification
All 4 failing AccuracyError cases now pass XPU vs GPU comparison with exact match (max_abs_diff=0, max_rel_diff=0).

### 是否引起精度变化
否 — XPU backward gradient computation for int32/int64 mean now matches GPU behavior.