### PR TITLE
[XPU] Fix crash for paddle.cartesian_prod with zero-size tensor inputs

### DIFF
--- a/paddle/phi/api/lib/tensor.cc
+++ b/paddle/phi/api/lib/tensor.cc
@@ -126,11 +126,26 @@ void Tensor::reshape(const std::vector<int64_t> &shape) {
   }
 }
 
-DataType Tensor::dtype() const { return impl_->dtype(); }
+DataType Tensor::dtype() const {
+  if (impl_ == nullptr) {
+    return DataType::UNDEFINED;
+  }
+  return impl_->dtype();
+}
 
-DataType Tensor::type() const { return impl_->dtype(); }
+DataType Tensor::type() const {
+  if (impl_ == nullptr) {
+    return DataType::UNDEFINED;
+  }
+  return impl_->dtype();
+}
 
-phi::DataLayout Tensor::layout() const { return impl_->layout(); }
+phi::DataLayout Tensor::layout() const {
+  if (impl_ == nullptr) {
+    return phi::DataLayout::UNDEFINED;
+  }
+  return impl_->layout();
+}
 
 bool Tensor::is_dense_tensor() const {
   if (impl_ == nullptr) {

--- a/paddle/phi/kernels/xpu/stack_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/stack_grad_kernel.cc
@@ -54,6 +54,18 @@ void StackGradKernel(const Context& dev_ctx,
   }
 
   if (valid_slices.empty()) {
+    // Allocate zero-size grad tensors so downstream nodes receive properly
+    // defined tensors with valid metadata (matching GPU UnStackRawKernel).
+    // Pass requested_size=sizeof(T) to force real allocation; otherwise
+    // Alloc for zero-numel tensors uses zero_allocator_ which may not
+    // create a proper holder, causing downstream null-pointer crashes.
+    for (size_t i = 0; i < x_grad.size(); ++i) {
+      DenseTensor* dx_i = x_grad[i];
+      if (dx_i != nullptr) {
+        dev_ctx.template Alloc<T>(dx_i, sizeof(T));
+        dx_i->Resize(dx_i->dims());
+      }
+    }
     return;
   }
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix SIGSEGV crash in `paddle.cartesian_prod` backward pass on XPU when input tensors include zero-size tensors.

#### Root Cause
The XPU `stack_grad_kernel` skipped allocation for zero-size output gradient tensors, unlike GPU's `UnStackRawKernel` which always allocates even zero-size tensors. This caused downstream `meshgrid_grad` (auto-generated API) to receive Tensors with null `impl_`, crashing in `ParseDataType` → `Tensor::type()`.

#### Changes
1. **`paddle/phi/kernels/xpu/stack_grad_kernel.cc`**: When all output gradient slices are zero-size, allocate each with `requested_size=sizeof(T)` to force real allocation (avoiding zero-allocator that skips zero-byte allocations), matching GPU behavior.

2. **`paddle/phi/api/lib/tensor.cc`**: Added null `impl_` guards to `Tensor::type()`, `Tensor::dtype()`, and `Tensor::layout()` — following the existing pattern used by `is_dense_tensor()` and `is_dist_tensor()`.

#### Test Results
- All 4 crash cases from the issue now pass without crash
- 31/41 total test cases pass (remaining 10 are pre-existing limitations: float16 multi-tensor has no XPU meshgrid kernel, complex128 skipped by test harness)

### Does this PR introduce a precision change?
Yes — XPU precision aligned with GPU for zero-size tensor backward pass (previously crashed).