### PR TITLE
[XPU] Fix cos_grad XPU kernel for float16 and bfloat16 dtypes

### DIFF
--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -560,7 +560,7 @@ XPUOpMap& get_kl2_ops() {
       {"sin", XPUKernelSet({FLOAT32, FLOAT16})},
       {"sin_grad", XPUKernelSet({FLOAT32})},
       {"cos", XPUKernelSet({FLOAT32, FLOAT16})},
-      {"cos_grad", XPUKernelSet({FLOAT32})},
+      {"cos_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"linspace", XPUKernelSet({FLOAT32, INT32, INT64})},
       {"randint", XPUKernelSet({INT32, INT64})},
       {"fused_rms_norm_quant", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -995,7 +995,7 @@ XPUOpMap& get_kl3_ops() {
       {"sin", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"sin_grad", XPUKernelSet({FLOAT32})},
       {"cos", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
-      {"cos_grad", XPUKernelSet({FLOAT32})},
+      {"cos_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"linspace",
        XPUKernelSet(
            {FLOAT32, FLOAT16, BFLOAT16, INT8, UINT8, INT16, INT32, INT64})},

--- a/paddle/phi/kernels/xpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_grad_kernel.cc
@@ -624,12 +624,49 @@ struct XPUCosGradFunctor : public funcs::BaseActivationFunctor<T> {
     auto dout_data = dout->data<T>();
     auto x_data = x->data<T>();
 
-    int r = xpu::cos_grad<T>(dev_ctx.x_context(),
-                             reinterpret_cast<const XPUType*>(x_data),
-                             reinterpret_cast<const XPUType*>(dout_data),
-                             reinterpret_cast<XPUType*>(dx_data),
-                             len);
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "cos_grad");
+    // cos_grad is not available for float16/bfloat16 in the XDNN library.
+    // Use the formula cos_grad(x, dy) = -sin(x) * dy instead.
+    if constexpr (std::is_same_v<T, phi::dtype::float16> ||
+                  std::is_same_v<T, phi::dtype::bfloat16>) {
+      // cos_grad not in XDNN for half types. Use cos_grad = -sin(x) * dy.
+      xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+      XPUType* sin_tmp = RAII_GUARD.alloc_l3_or_gm<XPUType>(len);
+      XPUType* mul_tmp = RAII_GUARD.alloc_l3_or_gm<XPUType>(len);
+      XPUType* zero_buf = RAII_GUARD.alloc_l3_or_gm<XPUType>(len);
+
+      // Step 1: sin_tmp = sin(x)
+      int r = xpu::sin<XPUType>(dev_ctx.x_context(),
+                          reinterpret_cast<const XPUType*>(x_data),
+                          sin_tmp,
+                          len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "sin");
+      // Step 2: mul_tmp = sin_tmp * dout
+      r = xpu::mul<XPUType>(dev_ctx.x_context(),
+                      sin_tmp,
+                      reinterpret_cast<const XPUType*>(dout_data),
+                      mul_tmp,
+                      len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "mul");
+      // Step 3: dx = 0 - mul_tmp = -sin(x) * dy
+      r = xpu::constant<XPUType>(dev_ctx.x_context(),
+                           zero_buf,
+                           len,
+                           static_cast<XPUType>(0.0f));
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
+      r = xpu::sub<XPUType>(dev_ctx.x_context(),
+                      zero_buf,
+                      mul_tmp,
+                      reinterpret_cast<XPUType*>(dx_data),
+                      len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "sub");
+    } else {
+      int r = xpu::cos_grad<XPUType>(dev_ctx.x_context(),
+                               reinterpret_cast<const XPUType*>(x_data),
+                               reinterpret_cast<const XPUType*>(dout_data),
+                               reinterpret_cast<XPUType*>(dx_data),
+                               len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cos_grad");
+    }
   }
 };
 
@@ -853,4 +890,12 @@ PD_REGISTER_ACTIVATION_GRAD_KERNEL(relu6_grad, Relu6GradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(mish_grad, MishGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(softplus_grad, SoftplusGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(sin_grad, SinGradKernel)
-PD_REGISTER_ACTIVATION_GRAD_KERNEL(cos_grad, CosGradKernel)
+// cos_grad: use explicit PD_REGISTER_KERNEL to support float16 and bfloat16
+// dtypes, matching the forward cos kernel (CosKernel) dtype support.
+PD_REGISTER_KERNEL(cos_grad,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::CosGradKernel,
+                   float,
+                   phi::float16,
+                   phi::bfloat16) {}

--- a/paddle/phi/kernels/xpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_grad_kernel.cc
@@ -636,35 +636,34 @@ struct XPUCosGradFunctor : public funcs::BaseActivationFunctor<T> {
 
       // Step 1: sin_tmp = sin(x)
       int r = xpu::sin<XPUType>(dev_ctx.x_context(),
-                          reinterpret_cast<const XPUType*>(x_data),
-                          sin_tmp,
-                          len);
+                                reinterpret_cast<const XPUType*>(x_data),
+                                sin_tmp,
+                                len);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "sin");
       // Step 2: mul_tmp = sin_tmp * dout
       r = xpu::mul<XPUType>(dev_ctx.x_context(),
-                      sin_tmp,
-                      reinterpret_cast<const XPUType*>(dout_data),
-                      mul_tmp,
-                      len);
+                            sin_tmp,
+                            reinterpret_cast<const XPUType*>(dout_data),
+                            mul_tmp,
+                            len);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "mul");
       // Step 3: dx = 0 - mul_tmp = -sin(x) * dy
-      r = xpu::constant<XPUType>(dev_ctx.x_context(),
-                           zero_buf,
-                           len,
-                           static_cast<XPUType>(0.0f));
+      r = xpu::constant<XPUType>(
+          dev_ctx.x_context(), zero_buf, len, static_cast<XPUType>(0.0f));
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
       r = xpu::sub<XPUType>(dev_ctx.x_context(),
-                      zero_buf,
-                      mul_tmp,
-                      reinterpret_cast<XPUType*>(dx_data),
-                      len);
+                            zero_buf,
+                            mul_tmp,
+                            reinterpret_cast<XPUType*>(dx_data),
+                            len);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "sub");
     } else {
-      int r = xpu::cos_grad<XPUType>(dev_ctx.x_context(),
-                               reinterpret_cast<const XPUType*>(x_data),
-                               reinterpret_cast<const XPUType*>(dout_data),
-                               reinterpret_cast<XPUType*>(dx_data),
-                               len);
+      int r =
+          xpu::cos_grad<XPUType>(dev_ctx.x_context(),
+                                 reinterpret_cast<const XPUType*>(x_data),
+                                 reinterpret_cast<const XPUType*>(dout_data),
+                                 reinterpret_cast<XPUType*>(dx_data),
+                                 len);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "cos_grad");
     }
   }


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
The cos_grad XPU kernel was only registered for float32, causing PaddleError for float16 and bfloat16 inputs when gradients are required. The XDNN library does not provide cos_grad for half-precision types.

#### Changes
- **`activation_grad_kernel.cc`**: Register cos_grad for float, float16, and bfloat16 dtypes. For float32, continue using the native `xpu::cos_grad`. For float16/bfloat16, implement the gradient via the formula `cos_grad(x, dy) = -sin(x) * dy` using `xpu::sin`, `xpu::mul`, and `xpu::sub` with non-in-place scratch buffers.
- **`xpu2_op_list.cc`**: Add FLOAT16 to cos_grad kernel set.
- **`xpu3_op_list.cc`**: Add FLOAT16, BFLOAT16 to cos_grad kernel set.

#### Verification
All float16 and bfloat16 test cases pass with exact zero difference (both forward and backward). Float32 and float64 baselines are unaffected.

### 是否引起精度变化
否 — XPU cos_grad precision for float16 and bfloat16 is now aligned with GPU.