### PR TITLE
[XPU] Fix XPU kernel errors for paddle.diagonal_scatter

### DIFF
--- a/paddle/phi/kernels/xpu/fill_diagonal_tensor_kernel.cc
+++ b/paddle/phi/kernels/xpu/fill_diagonal_tensor_kernel.cc
@@ -14,8 +14,12 @@
 
 #include "paddle/phi/kernels/fill_diagonal_tensor_kernel.h"
 
+#include <array>
+
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
 
 namespace phi {
 
@@ -35,20 +39,56 @@ void FillDiagonalTensorKernel(const Context &dev_ctx,
                     x.numel());
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "copy");
 
-  std::vector<int64_t> xshape = vectorize<int64_t>(x.dims());
-  std::vector<int64_t> yshape = vectorize<int64_t>(y.dims());
+  // Compute diagonal positions on CPU (XDNN fill_diagonal_tensor does not
+  // support all dtypes that Paddle registers, so we implement the fill logic
+  // ourselves using a CPU round-trip for the diagonal data, matching the
+  // CPU kernel algorithm).
+  auto out_dims = out->dims();
+  const auto &matdims = y.dims();
+  auto fill_dims = common::flatten_to_2d(matdims, matdims.size() - 1);
 
-  r = xpu::fill_diagonal_tensor(dev_ctx.x_context(),
-                                reinterpret_cast<const XPUType *>(x.data<T>()),
-                                reinterpret_cast<const XPUType *>(y.data<T>()),
-                                reinterpret_cast<XPUType *>(out_data),
-                                xshape,
-                                yshape,
-                                dim1,
-                                dim2,
-                                offset);
+  std::array<int64_t, 2> new_dims = {};
+  std::array<int64_t, 2> strides = {};
+  std::vector<int64_t> matdim;
+  matdim.resize(fill_dims[0]);
+  CalMatDims(out_dims,
+             dim1,
+             dim2,
+             &offset,
+             new_dims.data(),
+             strides.data(),
+             matdim.data());
 
-  PADDLE_ENFORCE_XDNN_SUCCESS(r, "fill_diagonal_tensor");
+  auto place = dev_ctx.GetPlace();
+  auto cpu_place = CPUPlace();
+  auto size = out->numel();
+
+  // Copy out to CPU, fill diagonal values, then copy back to XPU
+  DenseTensor out_cpu;
+  out_cpu.Resize(out->dims());
+  T *out_cpu_data = dev_ctx.template HostAlloc<T>(&out_cpu);
+  memory_utils::Copy(
+      cpu_place, out_cpu_data, place, out_data, sizeof(T) * size);
+
+  DenseTensor y_cpu;
+  y_cpu.Resize(y.dims());
+  T *y_cpu_data = dev_ctx.template HostAlloc<T>(&y_cpu);
+  memory_utils::Copy(
+      cpu_place, y_cpu_data, place, y.data<T>(), sizeof(T) * y.numel());
+
+  const T *fill_data = y_cpu_data;
+  for (int64_t i = 0; i < fill_dims[0]; ++i) {
+    auto sumoff = matdim[i] + offset;
+    for (int64_t j = 0; j < fill_dims[1]; ++j) {
+      auto fill_index = j * (strides[1] + strides[0]) + sumoff;
+      if (fill_index < size) {
+        out_cpu_data[fill_index] = fill_data[i * fill_dims[1] + j];
+      }
+    }
+  }
+
+  memory_utils::Copy(
+      place, out_data, cpu_place, out_cpu_data, sizeof(T) * size);
 }
 }  // namespace phi
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix XPU kernel errors for `paddle.diagonal_scatter` where the underlying XDNN `fill_diagonal_tensor` function rejected several data types (`float32`, `int64`, `int32`, `float16`, `bool`) with `XDNN_INVALID_PARAM`.

#### Root Cause
The XPU kernel at `paddle/phi/kernels/xpu/fill_diagonal_tensor_kernel.cc` delegated the diagonal fill logic entirely to the XDNN library's `xpu::fill_diagonal_tensor` function. This function does not support all the data types that Paddle registers the kernel for, causing runtime errors for those dtypes.

#### Fix
Replaced the XDNN `fill_diagonal_tensor` call with a CPU round-trip approach:
1. Copy the output tensor from XPU to CPU
2. Copy the fill tensor from XPU to CPU  
3. Compute diagonal positions using `CalMatDims` (same as CPU/GPU kernel)
4. Overwrite diagonal values on CPU
5. Copy the result back to XPU

This approach:
- Uses the same diagonal index computation algorithm as the CPU and GPU kernels
- Works for all data types registered by the kernel
- Follows established XPU kernel patterns (similar to `unique_kernel.cc`, `generate_proposals_kernel.cc`)
- No changes to interface definitions or behavior

#### Test Results
All 13 testable cases from `PaddleAPITest/all_config.txt` pass with `max_abs_diff=0, max_rel_diff=0` (bitwise identical XPU vs GPU outputs):
- `bool`, `complex64`, `float16`, `float32` (offset=0/1/-2, axis1=0/1 axis2=0/1), `float64`, `int8`, `int16`, `int32`, `int64`, `uint8`

`complex128` is skipped by the test framework (known XPU platform limitation).

### Does this PR introduce a precision change?
Yes — XPU precision corrected to align with GPU for previously failing data types.