### PR TITLE
[XPU] Fix kernel error for paddle.divide with mixed float64/complex64 types

### DIFF
--- a/paddle/phi/kernels/xpu/cast_kernel.cc
+++ b/paddle/phi/kernels/xpu/cast_kernel.cc
@@ -148,6 +148,20 @@ void CastKernel(const Context& dev_ctx,
       phi::ComplexKernel<float>(dev_ctx, real, imag, out);
       break;
     }
+    case DataType::COMPLEX128: {
+      if (x.numel() == 0) {
+        dev_ctx.template Alloc<T>(out);
+        return;
+      }
+      DenseTensor real;
+      real.Resize(x.dims());
+      CastXPUKernelImpl<T, double, Context>(dev_ctx, x, &real);
+      dev_ctx.template Alloc<T>(out);
+      DenseTensor imag = Fill<double, Context>(
+          dev_ctx, vectorize<int>(x.dims()), static_cast<double>(0.0));
+      phi::ComplexKernel<double>(dev_ctx, real, imag, out);
+      break;
+    }
 #endif
     default:
       PADDLE_THROW(common::errors::Unavailable(
@@ -169,6 +183,24 @@ void CastKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
     if (!out->IsSharedWith(x)) {
       Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
     }
+    return;
+  }
+  if (out_dtype == DataType::COMPLEX128) {
+    if (x.numel() == 0) {
+      dev_ctx.template Alloc<T>(out);
+      return;
+    }
+    DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+    DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
+    DenseTensor x_real_double, x_imag_double;
+    x_real_double.Resize(x.dims());
+    x_imag_double.Resize(x.dims());
+    CastXPUKernelImpl<float, double, XPUContext>(
+        dev_ctx, x_real, &x_real_double);
+    CastXPUKernelImpl<float, double, XPUContext>(
+        dev_ctx, x_imag, &x_imag_double);
+    dev_ctx.template Alloc<T>(out);
+    phi::ComplexKernel<double>(dev_ctx, x_real_double, x_imag_double, out);
     return;
   }
   DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix XPU kernel error when `paddle.divide` mixes float64 and complex64 operands.

#### Problem
When `paddle.divide` is called with mixed float64 and complex64 types, type promotion promotes both operands to complex128. The XPU cast kernel (`paddle/phi/kernels/xpu/cast_kernel.cc`) was missing support for casting to complex128, causing "Not supported cast float64 -> complex128" errors.

#### Fix
Added `COMPLEX128` cast support to the XPU cast kernel:
1. Added `case DataType::COMPLEX128` in the main CastKernel switch, casting input to double and combining with zero imaginary part via `ComplexKernel<double>`.
2. Updated the `CastKernel<complex64>` specialization to properly handle `COMPLEX128` target by extracting and upcasting both real and imaginary parts.

#### Verification
All 138 test cases from `PaddleAPITest/all_config.txt` pass after the fix.

### 是否引起精度变化
否 — XPU precision corrected to align with GPU for mixed float64/complex64 division.