### PR TITLE
Optimize squared_l2_norm GPU kernel: use new ReduceGpuKernel and prom…

### DIFF
--- a/paddle/phi/kernels/gpu/squared_l2_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/squared_l2_norm_kernel.cu
@@ -18,7 +18,10 @@
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/reduce_function.h"
+#include "paddle/phi/kernels/gpu/reduce.h"
+
 namespace phi {
+
 template <typename T, typename Context>
 void SquaredL2NormKernel(const Context& dev_ctx,
                          const DenseTensor& x,
@@ -28,8 +31,8 @@ void SquaredL2NormKernel(const Context& dev_ctx,
   for (size_t i = 0; i < x.dims().size(); i++) {
     origin_reduce_dims.push_back(i);
   }
-  funcs::ReduceKernel<T, T, kps::AddFunctor, kps::SquareFunctor<T, T>>(
-      dev_ctx, x, out, kps::SquareFunctor<T, T>(), origin_reduce_dims);
+  funcs::ReduceGpuKernel<T, T, kps::SquaredL2NormOps>(
+      dev_ctx, x, out, origin_reduce_dims);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/primitive/reduce_primitives.h
+++ b/paddle/phi/kernels/primitive/reduce_primitives.h
@@ -382,6 +382,26 @@ struct L2NormOps {
 };
 
 template <typename InT, typename MPType = InT, typename OutT = MPType>
+struct SquaredL2NormOps {
+  inline DEVICE MPType compute(MPType a, InT b) const {
+    MPType b_ = static_cast<MPType>(b) * static_cast<MPType>(b);
+    return reduce(a, b_);
+  }
+
+  inline DEVICE MPType reduce(MPType a, MPType b) const { return (a + b); }
+
+  inline DEVICE OutT post_process(MPType a) const {
+    return static_cast<OutT>(a);
+  }
+
+  inline DEVICE MPType shfl_sync(unsigned mask, MPType data, int offset) const {
+    return phi::backends::gpu::CudaShuffleDownSync(mask, data, offset);
+  }
+
+  SquaredL2NormOps() {}
+};
+
+template <typename InT, typename MPType = InT, typename OutT = MPType>
 struct GenericPNormOps {
   MPType norm_;
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->

1. 替换为新版 Reduce 框架：将旧版 funcs::ReduceKernel 替换为新版 funcs::ReduceGpuKernel，提升 reduce 性能。
2. 低精度类型精度提升：当输入为 float16/bfloat16 时，平方运算从原来的半精度下计算（T * T）改为先提升到 float32 再计算（static_cast<float>(b) * static_cast<float>(b)），减少半精度平方的精度损失。（T * T）的临时结果也是用32存的，累加同样在 float32 下进行，整个运算就是在32下进行的，防止精度损失。
3. 新增 SquaredL2NormOps：在 reduce_primitives.h 中新增 ReduceOp，参考 L2NormOps（compute 做平方累加），区别是 post_process 不做 sqrt，直接输出 sum(x²)。

paddleAPITEST 测试覆盖了以下维度，精度逐位对齐手写 torch 版本：
  数据类型：float32、float16、bfloat16
  张量形状：
  1D：[32], [128], [1024], [4096], [100000]
  2D：[3,4], [16,32], [64,128], [1024,1024], [4096,4096], [8192,4096], [16384,16384]
  3D：[8,16,32], [1,1,1], [5,0,3]
  4D：[2,4,8,16]
  超大张量：[1, 536870912], [1, 2147483648]
  边界条件：含 0 维度的张量（如 [0], [0,4], [3,0], [0,0], [0,0,0]）


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是