### PR TITLE
Add full coverage mode switch to Coverage pipeline

### DIFF
--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches: [develop, release/**]
+  workflow_dispatch:
+    inputs:
+      full_coverage:
+        description: 'Enable full coverage mode (OFF: incremental diff coverage, ON: full coverage)'
+        type: boolean
+        default: false
 
 permissions: read-all
 
@@ -298,6 +304,7 @@ jobs:
           PY_VERSION: 3.9
           WITH_SHARED_PHI: "ON"
           WITH_CINN: "ON"
+          WITH_ALL_COVERAGE: ${{ inputs.full_coverage && 'ON' || 'OFF' }}
           INFERENCE_DEMO_INSTALL_DIR: /root/.cache/coverage
           CCACHE_MAXSIZE: 200G
           CCACHE_LIMIT_MULTIPLE: 0.8
@@ -340,6 +347,7 @@ jobs:
             -e PY_VERSION \
             -e WITH_SHARED_PHI \
             -e WITH_CINN \
+            -e WITH_ALL_COVERAGE \
             -e INFERENCE_DEMO_INSTALL_DIR \
             -e CCACHE_MAXSIZE \
             -e CCACHE_LIMIT_MULTIPLE \
@@ -395,6 +403,7 @@ jobs:
           verbose: true
 
       - name: Determine whether the coverage rate reaches 90%
+        if: "!inputs.full_coverage"
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           source ~/.bashrc


### PR DESCRIPTION
## Summary

- Create `ci/coverage_full_info.sh` for full (non-incremental) coverage generation, which skips gcda pre-cleaning and PR diff filtering, only producing `coverage-full.info` and `python-coverage-full.info`
- Update `ci/utils.sh` dispatch logic: `WITH_ALL_COVERAGE=ON` now correctly calls `coverage_full_info.sh` (previously referenced non-existent `coverage_all_info.sh`)
- Add `workflow_dispatch` trigger with `full_coverage` boolean input to `Coverage.yml` (default: `false`)
- Skip 90% diff coverage assertion (`coverage_judge.sh`) when full coverage mode is enabled

## Behavior

| Mode | Trigger | Script | Output |
|---|---|---|---|
| Incremental (default) | `pull_request` | `coverage_info.sh` | `coverage-diff.info` + `coverage-full.info` |
| Full coverage | `workflow_dispatch` with `full_coverage=true` | `coverage_full_info.sh` | `coverage-full.info` only |

## Test plan

- [ ] Verify default `pull_request` trigger still runs incremental coverage (no behavior change)
- [ ] Manually trigger workflow_dispatch with `full_coverage=true` and verify full coverage report is generated
- [ ] Verify 90% diff coverage check is skipped in full coverage mode