### PR TITLE
Add full coverage mode switch to Coverage pipeline

### DIFF
--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches: [develop, release/**]
+  workflow_dispatch:
+    inputs:
+      full_coverage:
+        description: 'Enable full coverage mode (upload coverage-full.info to BOS)'
+        type: boolean
+        default: false
 
 permissions: read-all
 
@@ -298,6 +304,7 @@ jobs:
           PY_VERSION: 3.9
           WITH_SHARED_PHI: "ON"
           WITH_CINN: "ON"
+          WITH_ALL_COVERAGE: ${{ inputs.full_coverage && 'ON' || 'OFF' }}
           INFERENCE_DEMO_INSTALL_DIR: /root/.cache/coverage
           CCACHE_MAXSIZE: 200G
           CCACHE_LIMIT_MULTIPLE: 0.8
@@ -340,6 +347,7 @@ jobs:
             -e PY_VERSION \
             -e WITH_SHARED_PHI \
             -e WITH_CINN \
+            -e WITH_ALL_COVERAGE \
             -e INFERENCE_DEMO_INSTALL_DIR \
             -e CCACHE_MAXSIZE \
             -e CCACHE_LIMIT_MULTIPLE \
@@ -386,6 +394,41 @@ jobs:
           source ${ci_scripts}/utils.sh; check_coverage
           mkdir -p /home/data/cfs/coverage/${PR_ID}/${COMMIT_ID}
           cp build/coverage_files/* /home/data/cfs/coverage/${PR_ID}/${COMMIT_ID}
+          '
+
+      - name: Upload full coverage to BOS
+        if: inputs.full_coverage
+        env:
+          home_path: ${{ github.workspace }}/..
+          bos_file: ${{ github.workspace }}/../bos_retry/BosClient.py
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -c '
+          echo "::group::Install bce-python-sdk"
+          source ${{ github.workspace }}/../../../proxy
+          python -m pip install bce-python-sdk==0.8.74
+          echo "::endgroup::"
+          export AK=paddle
+          export SK=paddle
+          if [ ! -f "${{ env.bos_file }}" ]; then
+            wget -q --no-proxy -O ${{ env.home_path }}/bos_retry.tar.gz https://xly-devops.bj.bcebos.com/home/bos_retry.tar.gz --no-check-certificate
+            mkdir ${{ env.home_path }}/bos_retry
+            tar xf ${{ env.home_path }}/bos_retry.tar.gz -C ${{ env.home_path }}/bos_retry
+          fi
+          cd ${work_dir}/build
+          echo "Uploading coverage-full.info"
+          if [ -f coverage-full.info ]; then
+            python ${{ env.bos_file }} coverage-full.info paddle-github-action/PR/coverage/${PR_ID}/${COMMIT_ID}
+            echo "Uploaded coverage-full.info"
+          else
+            echo "WARNING: coverage-full.info not found, skipping C++ full coverage upload"
+          fi
+          echo "Uploading python-coverage-full.info"
+          if [ -f python-coverage-full.info ]; then
+            python ${{ env.bos_file }} python-coverage-full.info paddle-github-action/PR/coverage/${PR_ID}/${COMMIT_ID}
+            echo "Uploaded python-coverage-full.info"
+          else
+            echo "WARNING: python-coverage-full.info not found, skipping Python full coverage upload"
+          fi
           '
 
       - name: Upload coverage report

--- a/ci/coverage_info.sh
+++ b/ci/coverage_info.sh
@@ -32,12 +32,14 @@ echo "::endgroup::"
 
 cd ${PADDLE_ROOT}/build
 
-# NOTE: This gcda pre-cleaning step keeps/removes files by mapping PR
-# changed files to "*.gcda" paths. That is not always correct: for header-only
-# changes, or changes whose coverage is recorded in other translation units,
-# valid gcda may be removed before lcov capture. Keep the current behavior for
-# now because removing this step may increase "lcov/gcov --capture -d" cost.
-python ${PADDLE_ROOT}/ci/coverage_gcda_clean.py ${PR_ID} || exit 101
+if [ ${WITH_ALL_COVERAGE:-OFF} == "OFF" ]; then
+    # NOTE: This gcda pre-cleaning step keeps/removes files by mapping PR
+    # changed files to "*.gcda" paths. That is not always correct: for header-only
+    # changes, or changes whose coverage is recorded in other translation units,
+    # valid gcda may be removed before lcov capture. Keep the current behavior for
+    # now because removing this step may increase "lcov/gcov --capture -d" cost.
+    python ${PADDLE_ROOT}/ci/coverage_gcda_clean.py ${PR_ID} || exit 101
+fi
 echo "::group::Run lcov"
 lcov --ignore-errors gcov --capture -d ./ -o coverage.info --rc lcov_branch_coverage=0
 echo "::endgroup::"
@@ -148,6 +150,9 @@ python ${PADDLE_ROOT}/ci/coverage_diff.py coverage-diff.info git-diff.out > cove
 mv -f coverage-diff.tmp coverage-diff.info
 
 cp coverage-diff.info coverage_files
+if [ ${WITH_ALL_COVERAGE:-OFF} == "ON" ]; then
+    cp coverage-full.info coverage_files/
+fi
 
 # python coverage
 
@@ -195,3 +200,6 @@ python ${PADDLE_ROOT}/ci/coverage_diff.py python-coverage-diff.info python-git-d
 mv -f python-coverage-diff.tmp python-coverage-diff.info
 
 cp python-coverage-diff.info coverage_files
+if [ ${WITH_ALL_COVERAGE:-OFF} == "ON" ]; then
+    cp python-coverage-full.info coverage_files/
+fi


### PR DESCRIPTION
## Summary

Add a `full_coverage` switch to the PR Coverage pipeline, controlled via `workflow_dispatch` input. When enabled, the pipeline uploads full coverage data to BOS in addition to the normal incremental diff coverage.

## Changes

### `ci/coverage_info.sh`
- `WITH_ALL_COVERAGE=OFF` (default): keep existing behavior (gcda_clean + only diff files)
- `WITH_ALL_COVERAGE=ON`: skip gcda_clean, also copy `coverage-full.info` and `python-coverage-full.info` to `coverage_files/`

### `.github/workflows/Coverage.yml`
- Add `workflow_dispatch` trigger with `full_coverage` boolean input (default: false)
- Pass `WITH_ALL_COVERAGE` env var into test container
- Add "Upload full coverage to BOS" step, conditional on `full_coverage`

## Behavior

| Mode | Trigger | gcda_clean | Output files | BOS upload |
|---|---|---|---|---|
| Incremental (default) | `pull_request` | Yes | diff only | No |
| Full coverage | `workflow_dispatch` | No | diff + full | Yes |

## Test plan

- [ ] Verify default `pull_request` trigger behavior is unchanged
- [ ] Manually trigger with `full_coverage=true` and verify full coverage is uploaded to BOS
- [ ] Verify diff coverage and 90% check still work in full coverage mode