### PR TITLE
[XPU] Fix expand_as kernel crash when y tensor is provided

### DIFF
--- a/paddle/phi/kernels/xpu/expand_as_kernel.cc
+++ b/paddle/phi/kernels/xpu/expand_as_kernel.cc
@@ -93,8 +93,12 @@ void ExpandAsKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(out);
     return;
   }
+  std::vector<int64_t> real_target_shape = target_shape;
+  if (y.get_ptr()) {
+    real_target_shape = vectorize<int64_t>(y.get_ptr()->dims());
+  }
   auto rank = x.dims().size();
-  auto target_rank = target_shape.size();
+  auto target_rank = real_target_shape.size();
   PADDLE_ENFORCE_GE(target_rank,
                     rank,
                     common::errors::InvalidArgument(
@@ -116,7 +120,7 @@ void ExpandAsKernel(const Context& dev_ctx,
                         "expand_as_v2 op must be less than or equal to %d.",
                         target_rank,
                         MAX_RANK_SUPPORTED));
-  ExpandAs<Context, T>(dev_ctx, x, target_shape, out);
+  ExpandAs<Context, T>(dev_ctx, x, real_target_shape, out);
 }
 }  // namespace phi
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
The XPU `ExpandAsKernel` crashes when `paddle.expand_as(x, y)` is called with a tensor `y` argument in eager mode. The kernel used the raw `target_shape` parameter (which defaults to empty `{}` when `y` is a tensor) for rank validation, causing a `PADDLE_ENFORCE_GE` failure.

#### Root Cause
When `paddle.expand_as(x, y_tensor)` is invoked, the framework passes `y` as a tensor and `target_shape` defaults to empty. The XPU kernel did not extract the shape from `y.get_ptr()->dims()`, while the GPU and CPU kernels both handle this correctly.

This was specifically triggered by float16 inputs because the GPU `expand_as` kernel does not register `phi::float16`, so float16 inputs fall back to a different code path on GPU — masking the issue there. The XPU kernel registers float16 and hits the bug.

#### Fix
Added shape extraction from the `y` tensor in the XPU `ExpandAsKernel`, matching the GPU kernel pattern:

```cpp
std::vector<int64_t> real_target_shape = target_shape;
if (y.get_ptr()) {
    real_target_shape = vectorize<int64_t>(y.get_ptr()->dims());
}
```

#### Verification
- All 1003 configs from `all_config.txt` pass on XPU
- The specific failing float16 case runs correctly with output shape [10, 2, 30, 30]

### 是否引起精度变化
否