### PR TITLE
[Operator Mechanism] Fix paddle.fft.hfftn on XPU for small FFT axes

### DIFF
--- a/paddle/phi/kernels/funcs/fft_xpu.cc
+++ b/paddle/phi/kernels/funcs/fft_xpu.cc
@@ -143,6 +143,7 @@ void exec_fft(const XPUContext& dev_ctx,
       }
     }
 
+    dev_ctx.Alloc<To>(out);
     phi::memory_utils::Copy(out->place(),
                             out->data(),
                             phi::CPUPlace(),

--- a/paddle/phi/kernels/funcs/fft_xpu.cc
+++ b/paddle/phi/kernels/funcs/fft_xpu.cc
@@ -14,11 +14,14 @@
 
 #ifdef PADDLE_WITH_XPU_FFT
 #include <cmath>
+#include <type_traits>
 
 #include "paddle/phi/kernels/funcs/fft.h"
 #include "paddle/phi/kernels/funcs/fft_cache.h"
 
 #include "paddle/common/ddim.h"
+#include "paddle/phi/backends/context_pool.h"
+#include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -94,6 +97,57 @@ void exec_fft(const XPUContext& dev_ctx,
   const int signal_ndim = axes.size();
   const int batch_ndim = ndim - signal_ndim;
   const DDim& out_sizes = out->dims();
+
+  // XPU FFT requires all signal axes to have > 8 elements.
+  // For small axes, fall back to CPU FFT which has no such restriction.
+  bool need_cpu_fallback = false;
+  for (auto axis : axes) {
+    if (x.dims()[axis] <= 8) {
+      need_cpu_fallback = true;
+      break;
+    }
+  }
+
+  if (need_cpu_fallback) {
+    auto& cpu_ctx = static_cast<phi::CPUContext&>(
+        *(phi::DeviceContextPool::Instance().Get(phi::CPUPlace())));
+
+    DenseTensor cpu_x;
+    cpu_x.Resize(x.dims());
+    cpu_ctx.Alloc<Ti>(&cpu_x);
+    phi::memory_utils::Copy(phi::CPUPlace(),
+                            cpu_x.data(),
+                            x.place(),
+                            x.data(),
+                            x.numel() * sizeof(Ti));
+
+    DenseTensor cpu_out;
+    cpu_out.Resize(out->dims());
+    cpu_ctx.Alloc<To>(&cpu_out);
+
+    if constexpr (std::is_same_v<Ti, phi::dtype::complex<float>> &&
+                  std::is_same_v<To, float>) {
+      // C2R — CPU functor internally handles conj+inverse for forward case
+      FFTC2RFunctor<phi::CPUContext, Ti, To> func;
+      func(cpu_ctx, cpu_x, &cpu_out, axes, FFTNormMode::none, forward);
+    } else if constexpr (std::is_same_v<Ti, float> &&
+                         std::is_same_v<To, phi::dtype::complex<float>>) {
+      // R2C — CPU functor internally handles exec_plan+conj for inverse case
+      FFTR2CFunctor<phi::CPUContext, Ti, To> func;
+      func(cpu_ctx, cpu_x, &cpu_out, axes, FFTNormMode::none, forward);
+    } else {
+      // C2C
+      FFTC2CFunctor<phi::CPUContext, Ti, To> func;
+      func(cpu_ctx, cpu_x, &cpu_out, axes, FFTNormMode::none, forward);
+    }
+
+    phi::memory_utils::Copy(out->place(),
+                          out->data(),
+                          phi::CPUPlace(),
+                          cpu_out.data(),
+                          out->numel() * sizeof(To));
+    return;
+  }
 
   // make a dim permutation
   std::vector<int> dim_permute(ndim);

--- a/paddle/phi/kernels/funcs/fft_xpu.cc
+++ b/paddle/phi/kernels/funcs/fft_xpu.cc
@@ -130,22 +130,24 @@ void exec_fft(const XPUContext& dev_ctx,
       // C2R — CPU functor internally handles conj+inverse for forward case
       FFTC2RFunctor<phi::CPUContext, Ti, To> func;
       func(cpu_ctx, cpu_x, &cpu_out, axes, FFTNormMode::none, forward);
-    } else if constexpr (std::is_same_v<Ti, float> &&
-                         std::is_same_v<To, phi::dtype::complex<float>>) {
-      // R2C — CPU functor internally handles exec_plan+conj for inverse case
-      FFTR2CFunctor<phi::CPUContext, Ti, To> func;
-      func(cpu_ctx, cpu_x, &cpu_out, axes, FFTNormMode::none, forward);
     } else {
-      // C2C
-      FFTC2CFunctor<phi::CPUContext, Ti, To> func;
-      func(cpu_ctx, cpu_x, &cpu_out, axes, FFTNormMode::none, forward);
+      if constexpr (std::is_same_v<Ti, float> &&
+                    std::is_same_v<To, phi::dtype::complex<float>>) {
+        // R2C — CPU functor internally handles exec_plan+conj for inverse case
+        FFTR2CFunctor<phi::CPUContext, Ti, To> func;
+        func(cpu_ctx, cpu_x, &cpu_out, axes, FFTNormMode::none, forward);
+      } else {
+        // C2C
+        FFTC2CFunctor<phi::CPUContext, Ti, To> func;
+        func(cpu_ctx, cpu_x, &cpu_out, axes, FFTNormMode::none, forward);
+      }
     }
 
     phi::memory_utils::Copy(out->place(),
-                          out->data(),
-                          phi::CPUPlace(),
-                          cpu_out.data(),
-                          out->numel() * sizeof(To));
+                            out->data(),
+                            phi::CPUPlace(),
+                            cpu_out.data(),
+                            out->numel() * sizeof(To));
     return;
   }
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix `paddle.fft.hfftn` kernel errors on XPU when input tensors have small FFT axis sizes.

#### Root Cause
The XPU FFT library enforces a hard constraint that all signal axes must have > 8 elements (`xpufft_util.h:84`). This causes `paddle.fft.hfftn` to throw `InvalidArgument` when processing small input tensors (e.g., `shape=[3]` or `shape=[3,4]` with complex64).

#### Fix
In `fft_xpu.cc`, added a CPU fallback path in `exec_fft` for axes with size <= 8. When small axes are detected:
1. Copy input tensor from XPU to CPU
2. Run the FFT using the existing CPU FFT implementation (MKL/PocketFFT)
3. Allocate the XPU output tensor and copy the CPU result back to XPU

The CPU FFT has no axis size restriction and handles all sizes correctly. The XPU FFTConfig check remains as a safety net.

#### Modified File
- `paddle/phi/kernels/funcs/fft_xpu.cc`

#### Affected API
- `paddle.fft.hfftn` — 2 previously-failing complex64 test cases now pass

### 是否引起精度变化
否