### PR TITLE
[XPU] Fix precision for paddle.fft.ifft

### DIFF
--- a/paddle/phi/kernels/funcs/xpufft_util.h
+++ b/paddle/phi/kernels/funcs/xpufft_util.h
@@ -78,21 +78,23 @@ class FFTConfig {
     std::vector<plan_size_type> signal_sizes(sizes.cbegin() + 1, sizes.cend());
     const int signal_ndim = sizes.size() - 1;
 
-    // Check if the number of elements participating in FFT transformation is
-    // greater than 8 (XPU hardware requirement)
-    for (int i = 0; i < signal_ndim; ++i) {
-      if (signal_sizes[i] <= 8) {
-        PADDLE_THROW(common::errors::InvalidArgument(
-            "XPU FFT requires all axes to have greater than 8 elements, "
-            "but axis %d has size %d.Set XFFT_DEBUG=1 environment variable "
-            "to inspect dimensions.",
-            i,
-            signal_sizes[i]));
-      }
-    }
-
     cufftType exec_type;
     exec_type = type_input(fft_type);
+
+    // R2C and C2R transforms on XPU require signal sizes > 8
+    if (fft_type == FFTTransformType::R2C ||
+        fft_type == FFTTransformType::C2R) {
+      for (int i = 0; i < signal_ndim; ++i) {
+        if (signal_sizes[i] <= 8) {
+          PADDLE_THROW(common::errors::InvalidArgument(
+              "XPU R2C/C2R FFT requires all axes to have greater than 8 "
+              "elements, but axis %d has size %d.Set XFFT_DEBUG=1 environment "
+              "variable to inspect dimensions.",
+              i,
+              signal_sizes[i]));
+        }
+      }
+    }
 
     // disable auto allocation of workspace to use allocator from the framework
     PADDLE_ENFORCE_FFT_SUCCESS(

--- a/paddle/phi/kernels/xpu/fft_kernel.cc
+++ b/paddle/phi/kernels/xpu/fft_kernel.cc
@@ -21,6 +21,7 @@
 #include "paddle/phi/kernels/fft_kernel.h"
 
 #include "paddle/common/ddim.h"
+#include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/empty_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/fft.h"
@@ -78,6 +79,30 @@ void FFTR2CKernel(const Context& dev_ctx,
     return;
   }
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // XPU R2C kernel does not support signal sizes <= 8.
+  // For small signal sizes, fall back to C2C-based computation.
+  bool use_c2c_fallback = false;
+  for (const auto& axis : axes) {
+    if (x.dims()[axis] <= 8) {
+      use_c2c_fallback = true;
+      break;
+    }
+  }
+
+  if (use_c2c_fallback && !onesided) {
+    // Convert real input to complex (imag = 0) and use C2C kernel.
+    // For pure real input, C2C produces the same result as R2C + FillConj.
+    DenseTensor imag =
+        Full<T>(dev_ctx, vectorize(x.dims()), Scalar(static_cast<T>(0)));
+    DenseTensor x_complex = Empty<C>(dev_ctx, vectorize(x.dims()));
+    phi::ComplexKernel<T, Context>(dev_ctx, x, imag, &x_complex);
+
+    funcs::FFTC2CFunctor<Context, C, C> fft_c2c_func;
+    fft_c2c_func(dev_ctx, x_complex, out, axes, norm_type, forward);
+    return;
+  }
+
   funcs::FFTR2CFunctor<Context, T, C> fft_r2c_func;
 
   if (onesided) {


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix XPU error for `paddle.fft.ifft` with small signal sizes (≤ 8 elements).

#### paddle.fft.ifft

**Problem:** `paddle.fft.ifft(x=Tensor([7],"float32"))` failed on XPU with `(InvalidArgument) XPU FFT requires all axes to have greater than 8 elements`.

**Root Cause:** The XPU FFT utility (`xpufft_util.h`) had a blanket check rejecting ALL FFT types with signal sizes ≤ 8. However, C2C transforms work fine for small sizes — only R2C/C2R transforms have this XPU hardware limitation. The Python `ifft(real_input)` dispatches to `fft_r2c(x, forward=False, onesided=False)`, which hit this check.

**Fix:**
1. Scoped the size check in `xpufft_util.h` to R2C/C2R transforms only, allowing C2C for all sizes.
2. Added a C2C fallback in `FFTR2CKernel` for small signal sizes (≤ 8): converts real input to complex (imaginary = 0) and uses the C2C kernel instead. For pure real input, C2C produces the same result as R2C + FillConj, but without the hardware limitation.

**Modified files:**
- `paddle/phi/kernels/funcs/xpufft_util.h`
- `paddle/phi/kernels/xpu/fft_kernel.cc`

**Verification:** All 8 test configs from `all_config.txt` for `paddle.fft.ifft` pass (2 applicable: float32/float64 OK, 6 skipped: complex128 not supported on XPU).

### 是否引起精度变化
否