### PR TITLE
[XPU] Fix crash for paddle.fft.ifft2 — CPU fallback for small axis sizes

### DIFF
--- a/paddle/phi/kernels/funcs/xpufft_util.h
+++ b/paddle/phi/kernels/funcs/xpufft_util.h
@@ -81,14 +81,16 @@ class FFTConfig {
     // Check if the number of elements participating in FFT transformation is
     // greater than 8 (XPU hardware requirement)
     for (int i = 0; i < signal_ndim; ++i) {
-      if (signal_sizes[i] <= 8) {
-        PADDLE_THROW(common::errors::InvalidArgument(
-            "XPU FFT requires all axes to have greater than 8 elements, "
-            "but axis %d has size %d.Set XFFT_DEBUG=1 environment variable "
-            "to inspect dimensions.",
-            i,
-            signal_sizes[i]));
-      }
+      PADDLE_ENFORCE_GT(signal_sizes[i],
+                        8,
+                        common::errors::InvalidArgument(
+                            "XPU FFT requires all axes to have greater than 8 "
+                            "elements, but axis %d has size %d. "
+                            "This check should be handled by the kernel-level "
+                            "CPU fallback. If you see this error, the fallback "
+                            "may not be working correctly.",
+                            i,
+                            signal_sizes[i]));
     }
 
     cufftType exec_type;

--- a/paddle/phi/kernels/xpu/fft_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/fft_grad_kernel.cc
@@ -37,7 +37,7 @@ namespace phi {
 // XPU FFT hardware requires all FFT axes to have > 8 elements.
 // Returns true if all axes meet the XPU hardware constraint.
 static bool XPUFFTAxesMeetConstraint(const DDim& dims,
-                                      const std::vector<int64_t>& axes) {
+                                     const std::vector<int64_t>& axes) {
   for (auto axis : axes) {
     if (dims[axis] <= 8) {
       return false;
@@ -129,16 +129,19 @@ void FFTR2CGradKernel(const Context& dev_ctx,
       DenseTensorMeta full_dy_meta(out_grad_cpu.type(), x_grad->dims());
       full_dy_cpu.set_meta(full_dy_meta);
       cpu_ctx->template Alloc<T>(&full_dy_cpu);
-      auto zero_length =
-          static_cast<int>(full_dy_cpu.dims().at(axes.back()) -
-                           out_grad_cpu.dims().at(axes.back()));
+      auto zero_length = static_cast<int>(full_dy_cpu.dims().at(axes.back()) -
+                                          out_grad_cpu.dims().at(axes.back()));
       auto rank = out_grad_cpu.dims().size();
       std::vector<int> pads(rank * 2, 0);
       pads[axes.back() * 2 + 1] = zero_length;
       PadKernel<T>(
           *cpu_ctx, out_grad_cpu, pads, static_cast<float>(0.0), &full_dy_cpu);
-      fft_c2c_cpu_func(
-          *cpu_ctx, full_dy_cpu, &complex_x_grad_cpu, axes, norm_type, !forward);
+      fft_c2c_cpu_func(*cpu_ctx,
+                       full_dy_cpu,
+                       &complex_x_grad_cpu,
+                       axes,
+                       norm_type,
+                       !forward);
     }
 
     // Run RealKernel on CPU and copy result back to XPU
@@ -217,14 +220,12 @@ void FFTC2RGradKernel(const Context& dev_ctx,
     }
     int64_t stride_second_to_last_axis =
         stride_to_last_axis * ddim[axes.back()];
-    funcs::ForRange<phi::CPUContext> for_range(*cpu_ctx,
-                                                x_grad_cpu.numel());
-    funcs::FFTFillConjGradFunctor<C> grad_functor(
-        x_grad_cpu.data<C>(),
-        axes.back(),
-        stride_second_to_last_axis,
-        stride_to_last_axis,
-        double_length);
+    funcs::ForRange<phi::CPUContext> for_range(*cpu_ctx, x_grad_cpu.numel());
+    funcs::FFTFillConjGradFunctor<C> grad_functor(x_grad_cpu.data<C>(),
+                                                  axes.back(),
+                                                  stride_second_to_last_axis,
+                                                  stride_to_last_axis,
+                                                  double_length);
     for_range(grad_functor);
 
     dev_ctx.template Alloc<C>(x_grad);

--- a/paddle/phi/kernels/xpu/fft_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/fft_grad_kernel.cc
@@ -21,15 +21,31 @@
 #include "paddle/phi/kernels/fft_grad_kernel.h"
 
 #include "paddle/common/ddim.h"
+#include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/common/data_type.h"
+#include "paddle/phi/common/place.h"
 #include "paddle/phi/core/tensor_meta.h"
 #include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/empty_kernel.h"
 #include "paddle/phi/kernels/funcs/fft.h"
+#include "paddle/phi/kernels/funcs/fft_fill_conj.h"
 #include "paddle/phi/kernels/funcs/fft_fill_conj_xpu.h"
 #include "paddle/phi/kernels/pad_kernel.h"
 
 namespace phi {
+
+// XPU FFT hardware requires all FFT axes to have > 8 elements.
+// Returns true if all axes meet the XPU hardware constraint.
+static bool XPUFFTAxesMeetConstraint(const DDim& dims,
+                                      const std::vector<int64_t>& axes) {
+  for (auto axis : axes) {
+    if (dims[axis] <= 8) {
+      return false;
+    }
+  }
+  return true;
+}
+
 template <typename T, typename Context>
 void FFTC2CGradKernel(const Context& dev_ctx,
                       const DenseTensor& out_grad,
@@ -37,11 +53,35 @@ void FFTC2CGradKernel(const Context& dev_ctx,
                       const std::string& normalization,
                       bool forward,
                       DenseTensor* x_grad) {
-  dev_ctx.template Alloc<T>(x_grad);
   if (x_grad && x_grad->numel() == 0) {
     return;
   }
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // Fall back to CPU when any FFT axis has <= 8 elements,
+  // which does not meet the XPU FFT hardware requirement.
+  if (!XPUFFTAxesMeetConstraint(out_grad.dims(), axes)) {
+    auto cpu_place = phi::CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(pool.Get(cpu_place));
+
+    phi::DenseTensor out_grad_cpu;
+    phi::Copy(dev_ctx, out_grad, cpu_place, false, &out_grad_cpu);
+
+    phi::DenseTensor x_grad_cpu;
+    x_grad_cpu.Resize(x_grad->dims());
+    cpu_ctx->template Alloc<T>(&x_grad_cpu);
+
+    funcs::FFTC2CFunctor<phi::CPUContext, T, T> fft_c2c_cpu_func;
+    fft_c2c_cpu_func(
+        *cpu_ctx, out_grad_cpu, &x_grad_cpu, axes, norm_type, !forward);
+
+    dev_ctx.template Alloc<T>(x_grad);
+    phi::Copy(dev_ctx, x_grad_cpu, dev_ctx.GetPlace(), false, x_grad);
+    return;
+  }
+
+  dev_ctx.template Alloc<T>(x_grad);
   funcs::FFTC2CFunctor<Context, T, T> fft_c2c_func;
   fft_c2c_func(dev_ctx, out_grad, x_grad, axes, norm_type, !forward);
 }
@@ -56,12 +96,65 @@ void FFTR2CGradKernel(const Context& dev_ctx,
                       bool onesided,
                       DenseTensor* x_grad) {
   using R = typename T::value_type;
-  DenseTensor complex_x_grad = EmptyLike<T>(dev_ctx, x);
-  dev_ctx.template Alloc<R>(x_grad);
   if (x_grad && x_grad->numel() == 0) {
     return;
   }
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // Fall back to CPU when any FFT axis has <= 8 elements,
+  // which does not meet the XPU FFT hardware requirement.
+  // Use x.dims() because it has the full real signal sizes.
+  if (!XPUFFTAxesMeetConstraint(x.dims(), axes)) {
+    auto cpu_place = phi::CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(pool.Get(cpu_place));
+
+    phi::DenseTensor out_grad_cpu;
+    phi::Copy(dev_ctx, out_grad, cpu_place, false, &out_grad_cpu);
+
+    DenseTensor complex_x_grad_cpu =
+        Empty<T, phi::CPUContext>(*cpu_ctx, vectorize(x.dims()));
+
+    funcs::FFTC2CFunctor<phi::CPUContext, T, T> fft_c2c_cpu_func;
+
+    if (!onesided) {
+      fft_c2c_cpu_func(*cpu_ctx,
+                       out_grad_cpu,
+                       &complex_x_grad_cpu,
+                       axes,
+                       norm_type,
+                       !forward);
+    } else {
+      DenseTensor full_dy_cpu;
+      DenseTensorMeta full_dy_meta(out_grad_cpu.type(), x_grad->dims());
+      full_dy_cpu.set_meta(full_dy_meta);
+      cpu_ctx->template Alloc<T>(&full_dy_cpu);
+      auto zero_length =
+          static_cast<int>(full_dy_cpu.dims().at(axes.back()) -
+                           out_grad_cpu.dims().at(axes.back()));
+      auto rank = out_grad_cpu.dims().size();
+      std::vector<int> pads(rank * 2, 0);
+      pads[axes.back() * 2 + 1] = zero_length;
+      PadKernel<T>(
+          *cpu_ctx, out_grad_cpu, pads, static_cast<float>(0.0), &full_dy_cpu);
+      fft_c2c_cpu_func(
+          *cpu_ctx, full_dy_cpu, &complex_x_grad_cpu, axes, norm_type, !forward);
+    }
+
+    // Run RealKernel on CPU and copy result back to XPU
+    phi::DenseTensor x_grad_cpu;
+    x_grad_cpu.Resize(x_grad->dims());
+    cpu_ctx->template Alloc<R>(&x_grad_cpu);
+    RealKernel<T>(*cpu_ctx, complex_x_grad_cpu, &x_grad_cpu);
+
+    dev_ctx.template Alloc<R>(x_grad);
+    phi::Copy(dev_ctx, x_grad_cpu, dev_ctx.GetPlace(), false, x_grad);
+    return;
+  }
+
+  DenseTensor complex_x_grad = EmptyLike<T>(dev_ctx, x);
+  dev_ctx.template Alloc<R>(x_grad);
+
   funcs::FFTC2CFunctor<Context, T, T> fft_c2c_func;
 
   if (!onesided) {
@@ -90,11 +183,56 @@ void FFTC2RGradKernel(const Context& dev_ctx,
                       int64_t last_dim_size UNUSED,
                       DenseTensor* x_grad) {
   using C = phi::dtype::complex<T>;
-  dev_ctx.template Alloc<C>(x_grad);
   if (x_grad && x_grad->numel() == 0) {
     return;
   }
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // Fall back to CPU when any FFT axis has <= 8 elements,
+  // which does not meet the XPU FFT hardware requirement.
+  if (!XPUFFTAxesMeetConstraint(out_grad.dims(), axes)) {
+    auto cpu_place = phi::CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(pool.Get(cpu_place));
+
+    phi::DenseTensor out_grad_cpu;
+    phi::Copy(dev_ctx, out_grad, cpu_place, false, &out_grad_cpu);
+
+    phi::DenseTensor x_grad_cpu;
+    x_grad_cpu.Resize(x_grad->dims());
+    cpu_ctx->template Alloc<C>(&x_grad_cpu);
+
+    // Run R2C functor on CPU
+    funcs::FFTR2CFunctor<phi::CPUContext, T, C> fft_r2c_cpu_func;
+    fft_r2c_cpu_func(
+        *cpu_ctx, out_grad_cpu, &x_grad_cpu, axes, norm_type, !forward);
+
+    // Run FFTFillConjGrad on CPU using the generic functor
+    size_t double_length =
+        out_grad_cpu.dims()[axes.back()] - x_grad_cpu.dims()[axes.back()];
+    int64_t stride_to_last_axis = 1;
+    auto ddim = x_grad_cpu.dims();
+    for (int i = ddim.size() - 2; i >= axes.back(); --i) {
+      stride_to_last_axis *= ddim[i + 1];
+    }
+    int64_t stride_second_to_last_axis =
+        stride_to_last_axis * ddim[axes.back()];
+    funcs::ForRange<phi::CPUContext> for_range(*cpu_ctx,
+                                                x_grad_cpu.numel());
+    funcs::FFTFillConjGradFunctor<C> grad_functor(
+        x_grad_cpu.data<C>(),
+        axes.back(),
+        stride_second_to_last_axis,
+        stride_to_last_axis,
+        double_length);
+    for_range(grad_functor);
+
+    dev_ctx.template Alloc<C>(x_grad);
+    phi::Copy(dev_ctx, x_grad_cpu, dev_ctx.GetPlace(), false, x_grad);
+    return;
+  }
+
+  dev_ctx.template Alloc<C>(x_grad);
   funcs::FFTR2CFunctor<Context, T, C> fft_r2c_func;
   fft_r2c_func(dev_ctx, out_grad, x_grad, axes, norm_type, !forward);
   funcs::FFTFillConjGrad<Context, C>(dev_ctx, out_grad, axes, x_grad);

--- a/paddle/phi/kernels/xpu/fft_kernel.cc
+++ b/paddle/phi/kernels/xpu/fft_kernel.cc
@@ -21,12 +21,28 @@
 #include "paddle/phi/kernels/fft_kernel.h"
 
 #include "paddle/common/ddim.h"
+#include "paddle/phi/backends/context_pool.h"
+#include "paddle/phi/common/place.h"
 #include "paddle/phi/kernels/empty_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/fft.h"
+#include "paddle/phi/kernels/funcs/fft_fill_conj.h"
 #include "paddle/phi/kernels/funcs/fft_fill_conj_xpu.h"
 
 namespace phi {
+
+// XPU FFT hardware requires all FFT axes to have > 8 elements.
+// Returns true if all axes meet the XPU hardware constraint.
+static bool XPUFFTAxesMeetConstraint(const DDim& dims,
+                                      const std::vector<int64_t>& axes) {
+  for (auto axis : axes) {
+    if (dims[axis] <= 8) {
+      return false;
+    }
+  }
+  return true;
+}
+
 template <typename T, typename Context>
 void FFTC2CKernel(const Context& dev_ctx,
                   const DenseTensor& x,
@@ -40,6 +56,28 @@ void FFTC2CKernel(const Context& dev_ctx,
     return;
   }
   const auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // Fall back to CPU when any FFT axis has <= 8 elements,
+  // which does not meet the XPU FFT hardware requirement.
+  if (!XPUFFTAxesMeetConstraint(x.dims(), axes)) {
+    auto cpu_place = phi::CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(pool.Get(cpu_place));
+
+    phi::DenseTensor x_cpu;
+    phi::Copy(dev_ctx, x, cpu_place, false, &x_cpu);
+
+    phi::DenseTensor out_cpu;
+    out_cpu.Resize(out->dims());
+    cpu_ctx->template Alloc<T>(&out_cpu);
+
+    funcs::FFTC2CFunctor<phi::CPUContext, T, T> fft_c2c_cpu_func;
+    fft_c2c_cpu_func(*cpu_ctx, x_cpu, &out_cpu, axes, norm_type, forward);
+
+    phi::Copy(dev_ctx, out_cpu, dev_ctx.GetPlace(), false, out);
+    return;
+  }
+
   funcs::FFTC2CFunctor<Context, T, T> fft_c2c_func;
   fft_c2c_func(dev_ctx, x, out, axes, norm_type, forward);
 }
@@ -59,6 +97,28 @@ void FFTC2RKernel(const Context& dev_ctx,
     return;
   }
   const auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // Fall back to CPU when any FFT axis has <= 8 elements,
+  // which does not meet the XPU FFT hardware requirement.
+  if (!XPUFFTAxesMeetConstraint(x.dims(), axes)) {
+    auto cpu_place = phi::CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(pool.Get(cpu_place));
+
+    phi::DenseTensor x_cpu;
+    phi::Copy(dev_ctx, x, cpu_place, false, &x_cpu);
+
+    phi::DenseTensor out_cpu;
+    out_cpu.Resize(out->dims());
+    cpu_ctx->template Alloc<R>(&out_cpu);
+
+    funcs::FFTC2RFunctor<phi::CPUContext, T, R> fft_c2r_cpu_func;
+    fft_c2r_cpu_func(*cpu_ctx, x_cpu, &out_cpu, axes, norm_type, forward);
+
+    phi::Copy(dev_ctx, out_cpu, dev_ctx.GetPlace(), false, out);
+    return;
+  }
+
   funcs::FFTC2RFunctor<Context, T, R> fft_c2r_func;
   fft_c2r_func(dev_ctx, x, out, axes, norm_type, forward);
 }
@@ -78,6 +138,86 @@ void FFTR2CKernel(const Context& dev_ctx,
     return;
   }
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // Fall back to CPU when any FFT axis has <= 8 elements,
+  // which does not meet the XPU FFT hardware requirement.
+  if (!XPUFFTAxesMeetConstraint(x.dims(), axes)) {
+    auto cpu_place = phi::CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(pool.Get(cpu_place));
+
+    phi::DenseTensor x_cpu;
+    phi::Copy(dev_ctx, x, cpu_place, false, &x_cpu);
+
+    if (onesided) {
+      // Simple case: run R2C directly on CPU
+      phi::DenseTensor out_cpu;
+      out_cpu.Resize(out->dims());
+      cpu_ctx->template Alloc<C>(&out_cpu);
+
+      funcs::FFTR2CFunctor<phi::CPUContext, T, C> fft_r2c_cpu_func;
+      fft_r2c_cpu_func(
+          *cpu_ctx, x_cpu, &out_cpu, axes, norm_type, forward);
+
+      phi::Copy(dev_ctx, out_cpu, dev_ctx.GetPlace(), false, out);
+    } else {
+      // Non-onesided: run R2C on CPU with half-size output on last FFT axis,
+      // then fill conjugate symmetry on CPU to produce full output.
+      DDim onesided_out_shape = x_cpu.dims();
+      const int64_t last_fft_axis = axes.back();
+      const int64_t onesided_last_axis_size =
+          out->dims().at(last_fft_axis) / 2 + 1;
+      onesided_out_shape[last_fft_axis] = onesided_last_axis_size;
+
+      phi::DenseTensor onesided_out_cpu =
+          Empty<C, phi::CPUContext>(
+              *cpu_ctx, vectorize(onesided_out_shape));
+      funcs::FFTR2CFunctor<phi::CPUContext, T, C> fft_r2c_cpu_func;
+      fft_r2c_cpu_func(*cpu_ctx,
+                       x_cpu,
+                       &onesided_out_cpu,
+                       axes,
+                       norm_type,
+                       forward);
+
+      // Fill conjugate on CPU (manual implementation without XPU deps)
+      phi::DenseTensor out_cpu;
+      out_cpu.Resize(out->dims());
+      cpu_ctx->template Alloc<C>(&out_cpu);
+
+      std::vector<int64_t> src_strides_v =
+          vectorize<int64_t>(common::stride(onesided_out_cpu.dims()));
+      std::vector<int64_t> dst_strides_v =
+          vectorize<int64_t>(common::stride(out_cpu.dims()));
+      std::vector<int64_t> dst_shape_v =
+          vectorize<int64_t>(out_cpu.dims());
+      const auto last_axis = axes.back();
+      const auto last_axis_size = out_cpu.dims().at(last_axis) / 2 + 1;
+      const int64_t rank = out_cpu.dims().size();
+      auto _is_fft_axis = std::make_unique<bool[]>(rank);
+      for (const auto i : axes) {
+        _is_fft_axis[i] = true;
+      }
+
+      funcs::ForRange<phi::CPUContext> for_range(*cpu_ctx,
+                                                  out_cpu.numel());
+      funcs::FFTFillConjFunctor<C> fill_conj_functor(
+          onesided_out_cpu.data<C>(),
+          out_cpu.data<C>(),
+          src_strides_v.data(),
+          dst_strides_v.data(),
+          dst_shape_v.data(),
+          _is_fft_axis.get(),
+          last_axis,
+          last_axis_size,
+          rank);
+      for_range(fill_conj_functor);
+
+      phi::Copy(dev_ctx, out_cpu, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+
   funcs::FFTR2CFunctor<Context, T, C> fft_r2c_func;
 
   if (onesided) {

--- a/paddle/phi/kernels/xpu/fft_kernel.cc
+++ b/paddle/phi/kernels/xpu/fft_kernel.cc
@@ -34,7 +34,7 @@ namespace phi {
 // XPU FFT hardware requires all FFT axes to have > 8 elements.
 // Returns true if all axes meet the XPU hardware constraint.
 static bool XPUFFTAxesMeetConstraint(const DDim& dims,
-                                      const std::vector<int64_t>& axes) {
+                                     const std::vector<int64_t>& axes) {
   for (auto axis : axes) {
     if (dims[axis] <= 8) {
       return false;
@@ -156,8 +156,7 @@ void FFTR2CKernel(const Context& dev_ctx,
       cpu_ctx->template Alloc<C>(&out_cpu);
 
       funcs::FFTR2CFunctor<phi::CPUContext, T, C> fft_r2c_cpu_func;
-      fft_r2c_cpu_func(
-          *cpu_ctx, x_cpu, &out_cpu, axes, norm_type, forward);
+      fft_r2c_cpu_func(*cpu_ctx, x_cpu, &out_cpu, axes, norm_type, forward);
 
       phi::Copy(dev_ctx, out_cpu, dev_ctx.GetPlace(), false, out);
     } else {
@@ -170,15 +169,10 @@ void FFTR2CKernel(const Context& dev_ctx,
       onesided_out_shape[last_fft_axis] = onesided_last_axis_size;
 
       phi::DenseTensor onesided_out_cpu =
-          Empty<C, phi::CPUContext>(
-              *cpu_ctx, vectorize(onesided_out_shape));
+          Empty<C, phi::CPUContext>(*cpu_ctx, vectorize(onesided_out_shape));
       funcs::FFTR2CFunctor<phi::CPUContext, T, C> fft_r2c_cpu_func;
-      fft_r2c_cpu_func(*cpu_ctx,
-                       x_cpu,
-                       &onesided_out_cpu,
-                       axes,
-                       norm_type,
-                       forward);
+      fft_r2c_cpu_func(
+          *cpu_ctx, x_cpu, &onesided_out_cpu, axes, norm_type, forward);
 
       // Fill conjugate on CPU (manual implementation without XPU deps)
       phi::DenseTensor out_cpu;
@@ -189,8 +183,7 @@ void FFTR2CKernel(const Context& dev_ctx,
           vectorize<int64_t>(common::stride(onesided_out_cpu.dims()));
       std::vector<int64_t> dst_strides_v =
           vectorize<int64_t>(common::stride(out_cpu.dims()));
-      std::vector<int64_t> dst_shape_v =
-          vectorize<int64_t>(out_cpu.dims());
+      std::vector<int64_t> dst_shape_v = vectorize<int64_t>(out_cpu.dims());
       const auto last_axis = axes.back();
       const auto last_axis_size = out_cpu.dims().at(last_axis) / 2 + 1;
       const int64_t rank = out_cpu.dims().size();
@@ -199,18 +192,16 @@ void FFTR2CKernel(const Context& dev_ctx,
         _is_fft_axis[i] = true;
       }
 
-      funcs::ForRange<phi::CPUContext> for_range(*cpu_ctx,
-                                                  out_cpu.numel());
-      funcs::FFTFillConjFunctor<C> fill_conj_functor(
-          onesided_out_cpu.data<C>(),
-          out_cpu.data<C>(),
-          src_strides_v.data(),
-          dst_strides_v.data(),
-          dst_shape_v.data(),
-          _is_fft_axis.get(),
-          last_axis,
-          last_axis_size,
-          rank);
+      funcs::ForRange<phi::CPUContext> for_range(*cpu_ctx, out_cpu.numel());
+      funcs::FFTFillConjFunctor<C> fill_conj_functor(onesided_out_cpu.data<C>(),
+                                                     out_cpu.data<C>(),
+                                                     src_strides_v.data(),
+                                                     dst_strides_v.data(),
+                                                     dst_shape_v.data(),
+                                                     _is_fft_axis.get(),
+                                                     last_axis,
+                                                     last_axis_size,
+                                                     rank);
       for_range(fill_conj_functor);
 
       phi::Copy(dev_ctx, out_cpu, dev_ctx.GetPlace(), false, out);


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix XPU FFT crash for `paddle.fft.ifft2` with small input sizes. The XPU FFT hardware requires all FFT axes to have more than 8 elements. For inputs like `[4,4]` float32, the FFT config constructor throws a hard error.

This fix adds a CPU fallback in both forward and backward XPU FFT kernels:
- When any FFT axis has ≤ 8 elements, the computation is performed on CPU and the result is copied back to XPU
- The constraint check in `xpufft_util.h` is changed from `PADDLE_THROW` to `PADDLE_ENFORCE_GT` as a safety assertion (should never be reached since the kernel layer handles the fallback)
- The backward kernels check the constraint before any XPU allocations to avoid issues with null-allocated tensors from `TensorWrapper`

#### Test Results
All runnable test cases pass with exact numerical match (max_abs_diff=0, max_rel_diff=0):
- `paddle.fft.ifft2(x=Tensor([4,4],float32))` — forward + backward pass
- `paddle.fft.ifft2(x=Tensor([2,4],float64))` — forward + backward pass
- `paddle.fft.ifft2(x=Tensor([4,4],float64))` — forward + backward pass
- 7 complex128 test cases are skipped (XPU does not support complex128)

### 是否引起精度变化
否