### PR TITLE
[XPU] Fix paddle.fft.rfftn kernel errors

### DIFF
--- a/paddle/phi/kernels/xpu/fft_kernel.cc
+++ b/paddle/phi/kernels/xpu/fft_kernel.cc
@@ -21,6 +21,10 @@
 #include "paddle/phi/kernels/fft_kernel.h"
 
 #include "paddle/common/ddim.h"
+#include "paddle/phi/backends/context_pool.h"
+#include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/common/place.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/empty_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/fft.h"
@@ -40,6 +44,33 @@ void FFTC2CKernel(const Context& dev_ctx,
     return;
   }
   const auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // XPU FFT library requires all axes to have > 8 elements.
+  // For small axes, fall back to CPU FFT.
+  bool need_cpu_fallback = false;
+  for (auto axis : axes) {
+    if (x.dims()[axis] <= 8) {
+      need_cpu_fallback = true;
+      break;
+    }
+  }
+  if (need_cpu_fallback) {
+    auto cpu_place = CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<CPUContext*>(pool.Get(cpu_place));
+    DenseTensor cpu_x;
+    cpu_x.Resize(x.dims());
+    (*cpu_ctx).template Alloc<T>(&cpu_x);
+    phi::Copy(dev_ctx, x, cpu_place, true, &cpu_x);
+    DenseTensor cpu_out;
+    cpu_out.Resize(out->dims());
+    (*cpu_ctx).template Alloc<T>(&cpu_out);
+    funcs::FFTC2CFunctor<CPUContext, T, T> fft_c2c_cpu_func;
+    fft_c2c_cpu_func(*cpu_ctx, cpu_x, &cpu_out, axes, norm_type, forward);
+    phi::Copy(dev_ctx, cpu_out, dev_ctx.GetPlace(), false, out);
+    return;
+  }
+
   funcs::FFTC2CFunctor<Context, T, T> fft_c2c_func;
   fft_c2c_func(dev_ctx, x, out, axes, norm_type, forward);
 }
@@ -59,6 +90,33 @@ void FFTC2RKernel(const Context& dev_ctx,
     return;
   }
   const auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // XPU FFT library requires all axes to have > 8 elements.
+  // For small axes, fall back to CPU FFT.
+  bool need_cpu_fallback = false;
+  for (auto axis : axes) {
+    if (x.dims()[axis] <= 8) {
+      need_cpu_fallback = true;
+      break;
+    }
+  }
+  if (need_cpu_fallback) {
+    auto cpu_place = CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<CPUContext*>(pool.Get(cpu_place));
+    DenseTensor cpu_x;
+    cpu_x.Resize(x.dims());
+    (*cpu_ctx).template Alloc<T>(&cpu_x);
+    phi::Copy(dev_ctx, x, cpu_place, true, &cpu_x);
+    DenseTensor cpu_out;
+    cpu_out.Resize(out->dims());
+    (*cpu_ctx).template Alloc<R>(&cpu_out);
+    funcs::FFTC2RFunctor<CPUContext, T, R> fft_c2r_cpu_func;
+    fft_c2r_cpu_func(*cpu_ctx, cpu_x, &cpu_out, axes, norm_type, forward);
+    phi::Copy(dev_ctx, cpu_out, dev_ctx.GetPlace(), false, out);
+    return;
+  }
+
   funcs::FFTC2RFunctor<Context, T, R> fft_c2r_func;
   fft_c2r_func(dev_ctx, x, out, axes, norm_type, forward);
 }
@@ -78,6 +136,62 @@ void FFTR2CKernel(const Context& dev_ctx,
     return;
   }
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // XPU FFT requires all axes to have > 8 elements (Problem 1).
+  // XPU legacy cufftPlanMany API has precision issues with
+  // multi-dimensional R2C transformations (Problem 2).
+  // For these cases, fall back to CPU FFT.
+  bool need_cpu_fallback = false;
+  for (auto axis : axes) {
+    if (x.dims()[axis] <= 8) {
+      need_cpu_fallback = true;
+      break;
+    }
+  }
+  if (!need_cpu_fallback && axes.size() > 1) {
+    need_cpu_fallback = true;
+  }
+  if (need_cpu_fallback) {
+    auto cpu_place = CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<CPUContext*>(pool.Get(cpu_place));
+    DenseTensor cpu_x;
+    cpu_x.Resize(x.dims());
+    (*cpu_ctx).template Alloc<T>(&cpu_x);
+    phi::Copy(dev_ctx, x, cpu_place, true, &cpu_x);
+    if (onesided) {
+      DenseTensor cpu_out;
+      cpu_out.Resize(out->dims());
+      (*cpu_ctx).template Alloc<C>(&cpu_out);
+      funcs::FFTR2CFunctor<CPUContext, T, C> fft_r2c_cpu_func;
+      fft_r2c_cpu_func(*cpu_ctx, cpu_x, &cpu_out, axes, norm_type, forward);
+      phi::Copy(dev_ctx, cpu_out, dev_ctx.GetPlace(), false, out);
+    } else {
+      // For non-onesided: compute onesided R2C on CPU,
+      // then fill conjugate on XPU.
+      DDim onesided_out_shape = x.dims();
+      const int64_t last_fft_axis = axes.back();
+      const int64_t onesided_last_axis_size =
+          out->dims().at(last_fft_axis) / 2 + 1;
+      onesided_out_shape[last_fft_axis] = onesided_last_axis_size;
+      DenseTensor cpu_onesided_out;
+      cpu_onesided_out.Resize(vectorize(onesided_out_shape));
+      (*cpu_ctx).template Alloc<C>(&cpu_onesided_out);
+      funcs::FFTR2CFunctor<CPUContext, T, C> fft_r2c_cpu_func;
+      fft_r2c_cpu_func(
+          *cpu_ctx, cpu_x, &cpu_onesided_out, axes, norm_type, forward);
+      DenseTensor xpu_onesided_out =
+          Empty<C, Context>(dev_ctx, vectorize(onesided_out_shape));
+      phi::Copy(dev_ctx,
+                cpu_onesided_out,
+                dev_ctx.GetPlace(),
+                false,
+                &xpu_onesided_out);
+      funcs::FFTFillConj<Context, C>(dev_ctx, &xpu_onesided_out, out, axes);
+    }
+    return;
+  }
+
   funcs::FFTR2CFunctor<Context, T, C> fft_r2c_func;
 
   if (onesided) {


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

Fix XPU errors and precision issues for `paddle.fft.rfftn`.

The XPU FFT library requires all transformed axes to have > 8 elements, but `paddle.fft.rfftn` can be called with small tensors (e.g. [2,2,2]) that violate this constraint, causing a hard `PADDLE_THROW` in `xpufft_util.h`. Additionally, the XPU legacy `cufftPlanMany` API produces large precision errors (max_abs_diff ~329089) for batched multi-dimensional R2C transformations (e.g. [16,32,16,16] with axes=[-2,-1]).

#### Fix
In `paddle/phi/kernels/xpu/fft_kernel.cc`, added CPU fallback logic in `FFTR2CKernel`, `FFTC2CKernel`, and `FFTC2RKernel`:
- If any transformed axis has <= 8 elements, fall back to CPU FFT
- If R2C with `axes.size() > 1`, fall back to CPU FFT (avoids XPU cuFFT precision bug for multi-dimensional R2C)

The fallback copies input from XPU to CPU, executes the CPU FFT functor, and copies results back to XPU.

#### Verification
All 26 test cases for `paddle.fft.rfftn` from the PaddleAPITest suite pass on XPU after the fix (previously 7 failed: 6 small-tensor errors + 1 multi-dim R2C precision failure).

### 是否引起精度变化
否