### PR TITLE
[XPU] Fix paddle.fft.ihfft crash for small signal sizes

### DIFF
--- a/paddle/phi/kernels/funcs/xpufft_util.h
+++ b/paddle/phi/kernels/funcs/xpufft_util.h
@@ -78,21 +78,24 @@ class FFTConfig {
     std::vector<plan_size_type> signal_sizes(sizes.cbegin() + 1, sizes.cend());
     const int signal_ndim = sizes.size() - 1;
 
-    // Check if the number of elements participating in FFT transformation is
-    // greater than 8 (XPU hardware requirement)
-    for (int i = 0; i < signal_ndim; ++i) {
-      if (signal_sizes[i] <= 8) {
-        PADDLE_THROW(common::errors::InvalidArgument(
-            "XPU FFT requires all axes to have greater than 8 elements, "
-            "but axis %d has size %d.Set XFFT_DEBUG=1 environment variable "
-            "to inspect dimensions.",
-            i,
-            signal_sizes[i]));
-      }
-    }
-
     cufftType exec_type;
     exec_type = type_input(fft_type);
+
+    // R2C and C2R transforms on XPU require signal sizes > 8
+    // C2C transforms work for all sizes
+    if (fft_type == FFTTransformType::R2C ||
+        fft_type == FFTTransformType::C2R) {
+      for (int i = 0; i < signal_ndim; ++i) {
+        if (signal_sizes[i] <= 8) {
+          PADDLE_THROW(common::errors::InvalidArgument(
+              "XPU R2C/C2R FFT requires all axes to have greater than 8 "
+              "elements, but axis %d has size %d.Set XFFT_DEBUG=1 environment "
+              "variable to inspect dimensions.",
+              i,
+              signal_sizes[i]));
+        }
+      }
+    }
 
     // disable auto allocation of workspace to use allocator from the framework
     PADDLE_ENFORCE_FFT_SUCCESS(

--- a/paddle/phi/kernels/xpu/fft_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/fft_grad_kernel.cc
@@ -38,7 +38,7 @@ namespace phi {
 // - C2C also has stability issues with small axes (e.g., <= 8)
 // For robustness, fall back to CPU when any FFT axis has <= 8 elements.
 static bool XPUFFTAxesMeetConstraint(const DDim& dims,
-                                      const std::vector<int64_t>& axes) {
+                                     const std::vector<int64_t>& axes) {
   for (auto axis : axes) {
     if (dims[axis] <= 8) {
       return false;
@@ -121,8 +121,12 @@ void FFTR2CGradKernel(const Context& dev_ctx,
     funcs::FFTC2CFunctor<phi::CPUContext, T, T> fft_c2c_cpu_func;
 
     if (!onesided) {
-      fft_c2c_cpu_func(
-          *cpu_ctx, out_grad_cpu, &complex_x_grad_cpu, axes, norm_type, !forward);
+      fft_c2c_cpu_func(*cpu_ctx,
+                       out_grad_cpu,
+                       &complex_x_grad_cpu,
+                       axes,
+                       norm_type,
+                       !forward);
     } else {
       phi::DenseTensor full_dy_cpu;
       full_dy_cpu.Resize(x_grad->dims());
@@ -132,9 +136,14 @@ void FFTR2CGradKernel(const Context& dev_ctx,
       auto rank = out_grad_cpu.dims().size();
       std::vector<int> pads(rank * 2, 0);
       pads[axes.back() * 2 + 1] = zero_length;
-      PadKernel<T>(*cpu_ctx, out_grad_cpu, pads, static_cast<float>(0.0), &full_dy_cpu);
-      fft_c2c_cpu_func(
-          *cpu_ctx, full_dy_cpu, &complex_x_grad_cpu, axes, norm_type, !forward);
+      PadKernel<T>(
+          *cpu_ctx, out_grad_cpu, pads, static_cast<float>(0.0), &full_dy_cpu);
+      fft_c2c_cpu_func(*cpu_ctx,
+                       full_dy_cpu,
+                       &complex_x_grad_cpu,
+                       axes,
+                       norm_type,
+                       !forward);
     }
 
     phi::DenseTensor x_grad_cpu;

--- a/paddle/phi/kernels/xpu/fft_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/fft_grad_kernel.cc
@@ -21,7 +21,9 @@
 #include "paddle/phi/kernels/fft_grad_kernel.h"
 
 #include "paddle/common/ddim.h"
+#include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/common/data_type.h"
+#include "paddle/phi/common/place.h"
 #include "paddle/phi/core/tensor_meta.h"
 #include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/empty_kernel.h"
@@ -30,6 +32,20 @@
 #include "paddle/phi/kernels/pad_kernel.h"
 
 namespace phi {
+
+// XPU FFT hardware has a requirement on axis sizes:
+// - R2C/C2R requires all axes to have > 8 elements
+// - C2C also has stability issues with small axes (e.g., <= 8)
+// For robustness, fall back to CPU when any FFT axis has <= 8 elements.
+static bool XPUFFTAxesMeetConstraint(const DDim& dims,
+                                      const std::vector<int64_t>& axes) {
+  for (auto axis : axes) {
+    if (dims[axis] <= 8) {
+      return false;
+    }
+  }
+  return true;
+}
 template <typename T, typename Context>
 void FFTC2CGradKernel(const Context& dev_ctx,
                       const DenseTensor& out_grad,
@@ -42,6 +58,30 @@ void FFTC2CGradKernel(const Context& dev_ctx,
     return;
   }
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // Fall back to CPU when any FFT axis has <= 8 elements.
+  if (!XPUFFTAxesMeetConstraint(out_grad.dims(), axes)) {
+    auto cpu_place = phi::CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(pool.Get(cpu_place));
+
+    phi::DenseTensor out_grad_cpu;
+    out_grad_cpu.Resize(out_grad.dims());
+    cpu_ctx->template Alloc<T>(&out_grad_cpu);
+    phi::Copy(dev_ctx, out_grad, cpu_place, true, &out_grad_cpu);
+
+    phi::DenseTensor x_grad_cpu;
+    x_grad_cpu.Resize(x_grad->dims());
+    cpu_ctx->template Alloc<T>(&x_grad_cpu);
+
+    funcs::FFTC2CFunctor<phi::CPUContext, T, T> fft_c2c_cpu_func;
+    fft_c2c_cpu_func(
+        *cpu_ctx, out_grad_cpu, &x_grad_cpu, axes, norm_type, !forward);
+
+    phi::Copy(dev_ctx, x_grad_cpu, dev_ctx.GetPlace(), true, x_grad);
+    return;
+  }
+
   funcs::FFTC2CFunctor<Context, T, T> fft_c2c_func;
   fft_c2c_func(dev_ctx, out_grad, x_grad, axes, norm_type, !forward);
 }
@@ -62,6 +102,51 @@ void FFTR2CGradKernel(const Context& dev_ctx,
     return;
   }
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // Fall back to CPU when any FFT axis has <= 8 elements.
+  if (!XPUFFTAxesMeetConstraint(x.dims(), axes)) {
+    auto cpu_place = phi::CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(pool.Get(cpu_place));
+
+    phi::DenseTensor out_grad_cpu;
+    out_grad_cpu.Resize(out_grad.dims());
+    cpu_ctx->template Alloc<T>(&out_grad_cpu);
+    phi::Copy(dev_ctx, out_grad, cpu_place, true, &out_grad_cpu);
+
+    phi::DenseTensor complex_x_grad_cpu;
+    complex_x_grad_cpu.Resize(x.dims());
+    cpu_ctx->template Alloc<T>(&complex_x_grad_cpu);
+
+    funcs::FFTC2CFunctor<phi::CPUContext, T, T> fft_c2c_cpu_func;
+
+    if (!onesided) {
+      fft_c2c_cpu_func(
+          *cpu_ctx, out_grad_cpu, &complex_x_grad_cpu, axes, norm_type, !forward);
+    } else {
+      phi::DenseTensor full_dy_cpu;
+      full_dy_cpu.Resize(x_grad->dims());
+      cpu_ctx->template Alloc<T>(&full_dy_cpu);
+      auto zero_length = static_cast<int>(full_dy_cpu.dims().at(axes.back()) -
+                                          out_grad_cpu.dims().at(axes.back()));
+      auto rank = out_grad_cpu.dims().size();
+      std::vector<int> pads(rank * 2, 0);
+      pads[axes.back() * 2 + 1] = zero_length;
+      PadKernel<T>(*cpu_ctx, out_grad_cpu, pads, static_cast<float>(0.0), &full_dy_cpu);
+      fft_c2c_cpu_func(
+          *cpu_ctx, full_dy_cpu, &complex_x_grad_cpu, axes, norm_type, !forward);
+    }
+
+    phi::DenseTensor x_grad_cpu;
+    x_grad_cpu.Resize(x_grad->dims());
+    cpu_ctx->template Alloc<R>(&x_grad_cpu);
+
+    RealKernel<T>(*cpu_ctx, complex_x_grad_cpu, &x_grad_cpu);
+
+    phi::Copy(dev_ctx, x_grad_cpu, dev_ctx.GetPlace(), false, x_grad);
+    return;
+  }
+
   funcs::FFTC2CFunctor<Context, T, T> fft_c2c_func;
 
   if (!onesided) {

--- a/paddle/phi/kernels/xpu/fft_kernel.cc
+++ b/paddle/phi/kernels/xpu/fft_kernel.cc
@@ -37,7 +37,7 @@ namespace phi {
 // - C2C also has stability issues with small axes (e.g., <= 8)
 // For robustness, fall back to CPU when any FFT axis has <= 8 elements.
 static bool XPUFFTAxesMeetConstraint(const DDim& dims,
-                                      const std::vector<int64_t>& axes) {
+                                     const std::vector<int64_t>& axes) {
   for (auto axis : axes) {
     if (dims[axis] <= 8) {
       return false;
@@ -159,8 +159,7 @@ void FFTR2CKernel(const Context& dev_ctx,
       cpu_ctx->template Alloc<C>(&out_cpu);
 
       funcs::FFTR2CFunctor<phi::CPUContext, T, C> fft_r2c_cpu_func;
-      fft_r2c_cpu_func(
-          *cpu_ctx, x_cpu, &out_cpu, axes, norm_type, forward);
+      fft_r2c_cpu_func(*cpu_ctx, x_cpu, &out_cpu, axes, norm_type, forward);
 
       phi::Copy(dev_ctx, out_cpu, dev_ctx.GetPlace(), false, out);
     } else {
@@ -173,15 +172,10 @@ void FFTR2CKernel(const Context& dev_ctx,
       onesided_out_shape[last_fft_axis] = onesided_last_axis_size;
 
       phi::DenseTensor onesided_out_cpu =
-          Empty<C, phi::CPUContext>(
-              *cpu_ctx, vectorize(onesided_out_shape));
+          Empty<C, phi::CPUContext>(*cpu_ctx, vectorize(onesided_out_shape));
       funcs::FFTR2CFunctor<phi::CPUContext, T, C> fft_r2c_cpu_func;
-      fft_r2c_cpu_func(*cpu_ctx,
-                       x_cpu,
-                       &onesided_out_cpu,
-                       axes,
-                       norm_type,
-                       forward);
+      fft_r2c_cpu_func(
+          *cpu_ctx, x_cpu, &onesided_out_cpu, axes, norm_type, forward);
 
       // Fill conjugate on CPU
       phi::DenseTensor out_cpu;
@@ -192,28 +186,26 @@ void FFTR2CKernel(const Context& dev_ctx,
           vectorize<int64_t>(common::stride(onesided_out_cpu.dims()));
       std::vector<int64_t> dst_strides_v =
           vectorize<int64_t>(common::stride(out_cpu.dims()));
-      std::vector<int64_t> dst_shape_v =
-          vectorize<int64_t>(out_cpu.dims());
+      std::vector<int64_t> dst_shape_v = vectorize<int64_t>(out_cpu.dims());
       const auto last_axis_fill = axes.back();
-      const auto last_axis_size_fill = out_cpu.dims().at(last_axis_fill) / 2 + 1;
+      const auto last_axis_size_fill =
+          out_cpu.dims().at(last_axis_fill) / 2 + 1;
       const int64_t rank = out_cpu.dims().size();
       auto _is_fft_axis = std::make_unique<bool[]>(rank);
       for (const auto i : axes) {
         _is_fft_axis[i] = true;
       }
 
-      funcs::ForRange<phi::CPUContext> for_range(*cpu_ctx,
-                                                  out_cpu.numel());
-      funcs::FFTFillConjFunctor<C> fill_conj_functor(
-          onesided_out_cpu.data<C>(),
-          out_cpu.data<C>(),
-          src_strides_v.data(),
-          dst_strides_v.data(),
-          dst_shape_v.data(),
-          _is_fft_axis.get(),
-          last_axis_fill,
-          last_axis_size_fill,
-          rank);
+      funcs::ForRange<phi::CPUContext> for_range(*cpu_ctx, out_cpu.numel());
+      funcs::FFTFillConjFunctor<C> fill_conj_functor(onesided_out_cpu.data<C>(),
+                                                     out_cpu.data<C>(),
+                                                     src_strides_v.data(),
+                                                     dst_strides_v.data(),
+                                                     dst_shape_v.data(),
+                                                     _is_fft_axis.get(),
+                                                     last_axis_fill,
+                                                     last_axis_size_fill,
+                                                     rank);
       for_range(fill_conj_functor);
 
       phi::Copy(dev_ctx, out_cpu, dev_ctx.GetPlace(), false, out);

--- a/paddle/phi/kernels/xpu/fft_kernel.cc
+++ b/paddle/phi/kernels/xpu/fft_kernel.cc
@@ -21,12 +21,30 @@
 #include "paddle/phi/kernels/fft_kernel.h"
 
 #include "paddle/common/ddim.h"
+#include "paddle/phi/backends/context_pool.h"
+#include "paddle/phi/common/place.h"
+#include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/empty_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/fft.h"
+#include "paddle/phi/kernels/funcs/fft_fill_conj.h"
 #include "paddle/phi/kernels/funcs/fft_fill_conj_xpu.h"
 
 namespace phi {
+
+// XPU FFT hardware has a requirement on axis sizes:
+// - R2C/C2R requires all axes to have > 8 elements
+// - C2C also has stability issues with small axes (e.g., <= 8)
+// For robustness, fall back to CPU when any FFT axis has <= 8 elements.
+static bool XPUFFTAxesMeetConstraint(const DDim& dims,
+                                      const std::vector<int64_t>& axes) {
+  for (auto axis : axes) {
+    if (dims[axis] <= 8) {
+      return false;
+    }
+  }
+  return true;
+}
 template <typename T, typename Context>
 void FFTC2CKernel(const Context& dev_ctx,
                   const DenseTensor& x,
@@ -40,6 +58,28 @@ void FFTC2CKernel(const Context& dev_ctx,
     return;
   }
   const auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // Fall back to CPU when any FFT axis has <= 8 elements,
+  // which does not meet the XPU FFT hardware requirement / stability.
+  if (!XPUFFTAxesMeetConstraint(x.dims(), axes)) {
+    auto cpu_place = phi::CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(pool.Get(cpu_place));
+
+    phi::DenseTensor x_cpu;
+    phi::Copy(dev_ctx, x, cpu_place, false, &x_cpu);
+
+    phi::DenseTensor out_cpu;
+    out_cpu.Resize(out->dims());
+    cpu_ctx->template Alloc<T>(&out_cpu);
+
+    funcs::FFTC2CFunctor<phi::CPUContext, T, T> fft_c2c_cpu_func;
+    fft_c2c_cpu_func(*cpu_ctx, x_cpu, &out_cpu, axes, norm_type, forward);
+
+    phi::Copy(dev_ctx, out_cpu, dev_ctx.GetPlace(), false, out);
+    return;
+  }
+
   funcs::FFTC2CFunctor<Context, T, T> fft_c2c_func;
   fft_c2c_func(dev_ctx, x, out, axes, norm_type, forward);
 }
@@ -59,6 +99,28 @@ void FFTC2RKernel(const Context& dev_ctx,
     return;
   }
   const auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // Fall back to CPU when any FFT axis has <= 8 elements,
+  // which does not meet the XPU FFT hardware requirement / stability.
+  if (!XPUFFTAxesMeetConstraint(x.dims(), axes)) {
+    auto cpu_place = phi::CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(pool.Get(cpu_place));
+
+    phi::DenseTensor x_cpu;
+    phi::Copy(dev_ctx, x, cpu_place, false, &x_cpu);
+
+    phi::DenseTensor out_cpu;
+    out_cpu.Resize(out->dims());
+    cpu_ctx->template Alloc<R>(&out_cpu);
+
+    funcs::FFTC2RFunctor<phi::CPUContext, T, R> fft_c2r_cpu_func;
+    fft_c2r_cpu_func(*cpu_ctx, x_cpu, &out_cpu, axes, norm_type, forward);
+
+    phi::Copy(dev_ctx, out_cpu, dev_ctx.GetPlace(), false, out);
+    return;
+  }
+
   funcs::FFTC2RFunctor<Context, T, R> fft_c2r_func;
   fft_c2r_func(dev_ctx, x, out, axes, norm_type, forward);
 }
@@ -78,6 +140,87 @@ void FFTR2CKernel(const Context& dev_ctx,
     return;
   }
   auto norm_type = funcs::get_norm_from_string(normalization, forward);
+
+  // XPU FFT hardware requires all axes to have > 8 elements for R2C/C2R
+  // transforms, and C2C also has stability issues with small axes.
+  // Fall back to CPU when any FFT axis has <= 8 elements.
+  if (!XPUFFTAxesMeetConstraint(x.dims(), axes)) {
+    auto cpu_place = phi::CPUPlace();
+    phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
+    auto* cpu_ctx = static_cast<phi::CPUContext*>(pool.Get(cpu_place));
+
+    phi::DenseTensor x_cpu;
+    phi::Copy(dev_ctx, x, cpu_place, false, &x_cpu);
+
+    if (onesided) {
+      // Run R2C directly on CPU for onesided=True case (hfft/ihfft).
+      phi::DenseTensor out_cpu;
+      out_cpu.Resize(out->dims());
+      cpu_ctx->template Alloc<C>(&out_cpu);
+
+      funcs::FFTR2CFunctor<phi::CPUContext, T, C> fft_r2c_cpu_func;
+      fft_r2c_cpu_func(
+          *cpu_ctx, x_cpu, &out_cpu, axes, norm_type, forward);
+
+      phi::Copy(dev_ctx, out_cpu, dev_ctx.GetPlace(), false, out);
+    } else {
+      // Non-onesided: run R2C on CPU with half-size output on last FFT axis,
+      // then fill conjugate symmetry on CPU to produce full output.
+      DDim onesided_out_shape = x_cpu.dims();
+      const int64_t last_fft_axis = axes.back();
+      const int64_t onesided_last_axis_size =
+          out->dims().at(last_fft_axis) / 2 + 1;
+      onesided_out_shape[last_fft_axis] = onesided_last_axis_size;
+
+      phi::DenseTensor onesided_out_cpu =
+          Empty<C, phi::CPUContext>(
+              *cpu_ctx, vectorize(onesided_out_shape));
+      funcs::FFTR2CFunctor<phi::CPUContext, T, C> fft_r2c_cpu_func;
+      fft_r2c_cpu_func(*cpu_ctx,
+                       x_cpu,
+                       &onesided_out_cpu,
+                       axes,
+                       norm_type,
+                       forward);
+
+      // Fill conjugate on CPU
+      phi::DenseTensor out_cpu;
+      out_cpu.Resize(out->dims());
+      cpu_ctx->template Alloc<C>(&out_cpu);
+
+      std::vector<int64_t> src_strides_v =
+          vectorize<int64_t>(common::stride(onesided_out_cpu.dims()));
+      std::vector<int64_t> dst_strides_v =
+          vectorize<int64_t>(common::stride(out_cpu.dims()));
+      std::vector<int64_t> dst_shape_v =
+          vectorize<int64_t>(out_cpu.dims());
+      const auto last_axis_fill = axes.back();
+      const auto last_axis_size_fill = out_cpu.dims().at(last_axis_fill) / 2 + 1;
+      const int64_t rank = out_cpu.dims().size();
+      auto _is_fft_axis = std::make_unique<bool[]>(rank);
+      for (const auto i : axes) {
+        _is_fft_axis[i] = true;
+      }
+
+      funcs::ForRange<phi::CPUContext> for_range(*cpu_ctx,
+                                                  out_cpu.numel());
+      funcs::FFTFillConjFunctor<C> fill_conj_functor(
+          onesided_out_cpu.data<C>(),
+          out_cpu.data<C>(),
+          src_strides_v.data(),
+          dst_strides_v.data(),
+          dst_shape_v.data(),
+          _is_fft_axis.get(),
+          last_axis_fill,
+          last_axis_size_fill,
+          rank);
+      for_range(fill_conj_functor);
+
+      phi::Copy(dev_ctx, out_cpu, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+
   funcs::FFTR2CFunctor<Context, T, C> fft_r2c_func;
 
   if (onesided) {


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix XPU kernel crash for `paddle.fft.ihfft` when input signal sizes are <= 8 elements.

The XPU FFT library (xpufft, based on KLL xpufft wrapping cuFFT API) has stability issues with all transform types (R2C, C2R, C2C) on small signal sizes (<= 8 elements). Previously a blanket size check rejected all FFT types for sizes <= 8, but this broke `paddle.fft.ihfft` with small float32 inputs (e.g., `Tensor([4],"float32")`).

Simply removing the check exposed heap corruption crashes in the underlying library.

#### Changes
- **`paddle/phi/kernels/funcs/xpufft_util.h`**: Scope the XPU FFT size check to R2C/C2R transforms only (C2C works for all sizes). This serves as a safety net in case the CPU fallback is bypassed.

- **`paddle/phi/kernels/xpu/fft_kernel.cc`**: Add CPU fallback for all FFT forward kernels (FFTC2C, FFTC2R, FFTR2C) when any FFT axis is <= 8 elements. The data is copied to CPU, the FFT is computed using the reliable CPU implementation, and the result is copied back to XPU.

- **`paddle/phi/kernels/xpu/fft_grad_kernel.cc`**: Add CPU fallback for all FFT gradient kernels (FFTC2CGrad, FFTR2CGrad) when any FFT axis is <= 8 elements. Handles both onesided (hfft/ihfft) and non-onesided (rfft/irfft) gradient paths.

#### Test
All 9 `paddle.fft.ihfft` test cases from PaddleAPITest pass on XPU, including forward + backward computation.

### 是否引起精度变化
否