### PR TITLE
[XPU] Fix precision for paddle.fft.irfftn

### DIFF
--- a/paddle/phi/kernels/funcs/fft_xpu.cc
+++ b/paddle/phi/kernels/funcs/fft_xpu.cc
@@ -244,7 +244,13 @@ struct FFTC2RFunctor<XPUContext, Ti, To> {
                   bool forward) {
     std::vector<int64_t> out_dims = vectorize(out->dims());
 
-    if (detail::use_optimized_fft_path(axes)) {
+    // Decompose multi-dim C2R into C2C + 1D C2R when the last-dim complex
+    // input size is 9 or 10, to work around precision issues in the XPU
+    // FFT library's fused multi-dimension C2R plan for these sizes.
+    bool decompose_for_precision =
+        (axes.size() > 1) &&
+        (x.dims()[axes.back()] == 9 || x.dims()[axes.back()] == 10);
+    if (detail::use_optimized_fft_path(axes) && !decompose_for_precision) {
       DenseTensor x_copy = Assign(dev_ctx, x);
       detail::exec_fft<Ti, To>(dev_ctx, x_copy, out, axes, forward);
     } else {


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

Fix XPU precision for `paddle.fft.irfftn` by decomposing multi-dimension C2R transforms into sequential C2C + 1D C2R steps when the last-dimension complex input size is 9 or 10. This avoids precision issues in the XPU FFT library's fused multi-dimension C2R plan for these specific dimension sizes.

#### Background

The XPU FFT library (accessed through the cuFFT API compatibility layer) can produce inaccurate results for certain dimension sizes in its multi-dimension C2R implementation. Specifically, when the C2R complex input last dimension is 9 or 10 (mapping to real output sizes 16 or 19), the fused 2D C2R plan produces results that differ from GPU by abs_diff ~0.01-0.14.

#### Fix

In `FFTC2RFunctor<XPUContext>`, when `use_optimized_fft_path` would normally create a fused multi-dim C2R plan AND the C2R last-dimension complex input size is 9 or 10, decompose the transform into:
1. C2C FFT on all dims except the last
2. 1D C2R FFT on the last dim only

The 1D transforms are more numerically stable on XPU hardware for these sizes. All other cases continue to use the original fused plan path.

#### Test Results

- `[16,32,16,9]` with `s=(16,16), axes=(-2,-1)`: Forward precision fixed (abs_diff from 0.136 → passing)
- `[16,32,19,10]` with `s=(19,19), axes=(-2,-1)`: Still has minor precision gap (deeper XPU FFT library issue with dim 10)
- All other tested configurations: No regression

### Does this PR introduce a precision change?
No