### PR TITLE
[XPU] Fix precision for paddle.gather

### DIFF
--- a/paddle/phi/kernels/xpu/gather_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/gather_grad_kernel.cc
@@ -64,33 +64,79 @@ void GatherGradKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(x_grad);
   using XPUType = typename XPUTypeTrait<T>::Type;
 
+  int64_t index_len = index.dims().size() == 0 ? 1 : index.dims()[0];
+  // XPU SDK gather_grad may exceed grid limits for large index tensors.
+  // Empirically, the SDK fails when index_len >= ~65500.
+  constexpr int64_t kMaxChunkSize = 32768;
+
   int r = 0;
-  if (index_type == DataType::INT32) {
-    r = xpu::gather_grad<XPUType, int>(
-        dev_ctx.x_context(),
-        reinterpret_cast<const XPUType*>(out_grad.data<T>()),
-        index.data<int>(),
-        reinterpret_cast<XPUType*>(x_grad->data<T>()),
-        xshape,
-        index.dims().size() == 0 ? 1 : index.dims()[0],
-        axis_v,
-        false);
-  } else if (index_type == DataType::INT64) {
-    r = xpu::gather_grad<XPUType, int64_t>(
-        dev_ctx.x_context(),
-        reinterpret_cast<const XPUType*>(out_grad.data<T>()),
-        index.data<int64_t>(),
-        reinterpret_cast<XPUType*>(x_grad->data<T>()),
-        xshape,
-        index.dims().size() == 0 ? 1 : index.dims()[0],
-        axis_v,
-        false);
+  if (index_len <= kMaxChunkSize) {
+    // Small enough to process with gather_grad in a single call
+    if (index_type == DataType::INT32) {
+      r = xpu::gather_grad<XPUType, int>(
+          dev_ctx.x_context(),
+          reinterpret_cast<const XPUType*>(out_grad.data<T>()),
+          index.data<int>(),
+          reinterpret_cast<XPUType*>(x_grad->data<T>()),
+          xshape,
+          index_len,
+          axis_v,
+          false);
+    } else if (index_type == DataType::INT64) {
+      r = xpu::gather_grad<XPUType, int64_t>(
+          dev_ctx.x_context(),
+          reinterpret_cast<const XPUType*>(out_grad.data<T>()),
+          index.data<int64_t>(),
+          reinterpret_cast<XPUType*>(x_grad->data<T>()),
+          xshape,
+          index_len,
+          axis_v,
+          false);
+    } else {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Unsupported index type, expected int32 or int64, but got type %s",
+          DataTypeToString(index_type)));
+    }
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "gather_grad");
   } else {
-    PADDLE_THROW(common::errors::InvalidArgument(
-        "Unsupported index type, expected int32 or int64, but got type %s",
-        DataTypeToString(index_type)));
+    // Large index: use scatter_add instead of gather_grad, because
+    // gather_grad zeroes output internally on every call and cannot be
+    // used for chunked accumulation. scatter_add does true atomic
+    // scatter-add.
+    r = xpu::constant<XPUType>(dev_ctx.x_context(),
+                               reinterpret_cast<XPUType*>(x_grad->data<T>()),
+                               x_grad->numel(),
+                               static_cast<XPUType>(0));
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
+
+    auto out_grad_shape = vectorize<int64_t>(out_grad.dims());
+    auto index_shape = vectorize<int64_t>(index.dims());
+
+    if (index_type == DataType::INT32) {
+      r = xpu::scatter_add<XPUType, int>(
+          dev_ctx.x_context(),
+          reinterpret_cast<const XPUType*>(x_grad->data<T>()),
+          reinterpret_cast<const XPUType*>(out_grad.data<T>()),
+          index.data<int>(),
+          reinterpret_cast<XPUType*>(x_grad->data<T>()),
+          xshape,
+          out_grad_shape,
+          index_shape,
+          axis_v);
+    } else {
+      r = xpu::scatter_add<XPUType, int64_t>(
+          dev_ctx.x_context(),
+          reinterpret_cast<const XPUType*>(x_grad->data<T>()),
+          reinterpret_cast<const XPUType*>(out_grad.data<T>()),
+          index.data<int64_t>(),
+          reinterpret_cast<XPUType*>(x_grad->data<T>()),
+          xshape,
+          out_grad_shape,
+          index_shape,
+          axis_v);
+    }
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "scatter_add");
   }
-  PADDLE_ENFORCE_XDNN_SUCCESS(r, "gather_grad");
 }
 
 }  // namespace phi
@@ -105,5 +151,4 @@ PD_REGISTER_KERNEL(gather_grad,
                    int8_t,
                    int16_t,
                    int32_t,
-                   int64_t,
-                   bool) {}
+                   int64_t) {}

--- a/paddle/phi/kernels/xpu/gather_kernel.cc
+++ b/paddle/phi/kernels/xpu/gather_kernel.cc
@@ -57,31 +57,73 @@ void GatherKernel(const Context& dev_ctx,
 
   using XPUType = typename XPUTypeTrait<T>::Type;
 
+  int64_t index_len = index.dims().size() == 0 ? 1 : index.dims()[0];
+  // XPU SDK paddle_gather may exceed grid limits for large index tensors.
+  constexpr int64_t kMaxChunkSize = 32768;
+
   int r = 0;
-  if (index_type == DataType::INT32) {
-    r = xpu::paddle_gather<XPUType, int>(
-        dev_ctx.x_context(),
-        reinterpret_cast<const XPUType*>(x.data<T>()),
-        index.data<int>(),
-        reinterpret_cast<XPUType*>(out->data<T>()),
-        xshape,
-        index.dims().size() == 0 ? 1 : index.dims()[0],
-        axis_v);
-  } else if (index_type == DataType::INT64) {
-    r = xpu::paddle_gather<XPUType, int64_t>(
-        dev_ctx.x_context(),
-        reinterpret_cast<const XPUType*>(x.data<T>()),
-        index.data<int64_t>(),
-        reinterpret_cast<XPUType*>(out->data<T>()),
-        xshape,
-        index.dims().size() == 0 ? 1 : index.dims()[0],
-        axis_v);
+  if (index_len <= kMaxChunkSize || axis_v != 0) {
+    // Small tensor or non-axis=0: single call is fine
+    if (index_type == DataType::INT32) {
+      r = xpu::paddle_gather<XPUType, int>(
+          dev_ctx.x_context(),
+          reinterpret_cast<const XPUType*>(x.data<T>()),
+          index.data<int>(),
+          reinterpret_cast<XPUType*>(out->data<T>()),
+          xshape,
+          index_len,
+          axis_v);
+    } else if (index_type == DataType::INT64) {
+      r = xpu::paddle_gather<XPUType, int64_t>(
+          dev_ctx.x_context(),
+          reinterpret_cast<const XPUType*>(x.data<T>()),
+          index.data<int64_t>(),
+          reinterpret_cast<XPUType*>(out->data<T>()),
+          xshape,
+          index_len,
+          axis_v);
+    } else {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "Unsupported index type, expected int32 or int64, but got type %s",
+          DataTypeToString(index_type)));
+    }
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "paddle_gather");
   } else {
-    PADDLE_THROW(common::errors::InvalidArgument(
-        "Unsupported index type, expected int32 or int64, but got type %s",
-        DataTypeToString(index_type)));
+    // Large index with axis=0: chunk to avoid XPU grid limit crash.
+    // Output for axis=0 has shape [index_len, D1, D2, ...], so each chunk
+    // produces a contiguous slice of the output.
+    int64_t inner_size = 1;
+    auto out_dims = out->dims();
+    for (int64_t i = 1; i < out_dims.size(); ++i) {
+      inner_size *= out_dims[i];
+    }
+
+    for (int64_t start = 0; start < index_len; start += kMaxChunkSize) {
+      int64_t chunk_len = std::min(kMaxChunkSize, index_len - start);
+      if (index_type == DataType::INT32) {
+        r = xpu::paddle_gather<XPUType, int>(
+            dev_ctx.x_context(),
+            reinterpret_cast<const XPUType*>(x.data<T>()),
+            index.data<int>() + start,
+            reinterpret_cast<XPUType*>(out->data<T>()) +
+                start * inner_size,
+            xshape,
+            chunk_len,
+            axis_v);
+      } else if (index_type == DataType::INT64) {
+        r = xpu::paddle_gather<XPUType, int64_t>(
+            dev_ctx.x_context(),
+            reinterpret_cast<const XPUType*>(x.data<T>()),
+            index.data<int64_t>() + start,
+            reinterpret_cast<XPUType*>(out->data<T>()) +
+                start * inner_size,
+            xshape,
+            chunk_len,
+            axis_v);
+      }
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "paddle_gather chunk");
+    }
   }
-  PADDLE_ENFORCE_XDNN_SUCCESS(r, "paddle_gather");
 }
 
 }  // namespace phi
@@ -96,5 +138,4 @@ PD_REGISTER_KERNEL(gather,
                    int8_t,
                    int16_t,
                    int32_t,
-                   int64_t,
-                   bool) {}
+                   int64_t) {}


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix XPU precision errors and crash issues in `paddle.gather`.

#### Bool dtype precision error
XPU SDK's `paddle_gather` does not handle 1-byte bool elements correctly, causing output to differ from GPU. Removed `bool` from XPU gather and gather_grad kernel registrations, allowing the framework to fall back to the CPU kernel which produces correct results. This matches GPU gather_grad behavior which also excludes `bool`.

#### Large tensor crash
XPU SDK's `paddle_gather` and `gather_grad` exceed grid dimension limits for tensors with 1M+ index elements, causing process termination. Added chunking to the forward gather kernel (axis=0, chunk size 32768) and switched the backward pass to use `xpu::scatter_add` for large tensors instead of `xpu::gather_grad`, since `gather_grad` internally zeroes output on every call and cannot be used for chunked accumulation.

#### Modified files
- `paddle/phi/kernels/xpu/gather_kernel.cc`
- `paddle/phi/kernels/xpu/gather_grad_kernel.cc`

### Does this PR introduce a precision change?
No