### PR TITLE
[API compatibility] Align torch.nn.Module

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1453,7 +1453,7 @@ static PyObject* tensor_method_detach(TensorObject* self,
     auto v = reinterpret_cast<TensorObject*>(obj);
     new (&(v->tensor)) Tensor();
     v->tensor.set_impl(self->tensor.impl());
-    v->tensor.set_name(egr::Controller::Instance().GenerateUniqueName());
+    v->tensor.set_name(self->tensor.name());
     auto autograd_meta_src = egr::EagerUtils::autograd_meta(&(self->tensor));
     auto autograd_meta = egr::EagerUtils::autograd_meta(&(v->tensor));
     autograd_meta->SetPersistable(autograd_meta_src->Persistable());

--- a/paddle/phi/api/include/compat/ATen/ops/detach.h
+++ b/paddle/phi/api/include/compat/ATen/ops/detach.h
@@ -20,7 +20,9 @@ namespace at {
 
 inline at::Tensor detach(const at::Tensor& self) {
   // Create a new Tensor that shares data but has no autograd history
-  PaddleTensor detached_tensor(self._PD_GetInner().impl());
+  auto inner = self._PD_GetInner();
+  PaddleTensor detached_tensor(inner.impl());
+  detached_tensor.set_name(inner.name());
   detached_tensor.set_autograd_meta(nullptr);
   return Tensor(detached_tensor);
 }

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -794,6 +794,8 @@ class StateDictHook:
         with paddle.base.framework._dygraph_guard(paddle.base.dygraph.Tracer()):
             for key in state_dict:
                 param = state_dict[key]
+                if not isinstance(param, paddle.Tensor):
+                    continue
                 if paddle.is_floating_point(param):
                     param_applied = paddle.cast(param, self._save_dtype)
                     param_applied.name = param.name
@@ -1339,6 +1341,18 @@ def decorate(
             )
             use_multi_precision = master_weight is not False
             _set_multi_precision(optimizers, use_multi_precision)
+            if save_dtype is not None:
+                if save_dtype not in [
+                    'float16',
+                    'bfloat16',
+                    'float32',
+                    'float64',
+                ]:
+                    raise ValueError(
+                        f"save_dtype can only be float16 float32 or float64, but your input save_dtype is {save_dtype}."
+                    )
+                for layer in models.sublayers(include_self=True):
+                    layer.register_state_dict_hook(StateDictHook(save_dtype))
             if optimizers is None:
                 return models
             else:

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -1341,18 +1341,6 @@ def decorate(
             )
             use_multi_precision = master_weight is not False
             _set_multi_precision(optimizers, use_multi_precision)
-            if save_dtype is not None:
-                if save_dtype not in [
-                    'float16',
-                    'bfloat16',
-                    'float32',
-                    'float64',
-                ]:
-                    raise ValueError(
-                        f"save_dtype can only be float16 float32 or float64, but your input save_dtype is {save_dtype}."
-                    )
-                for layer in models.sublayers(include_self=True):
-                    layer.register_state_dict_hook(StateDictHook(save_dtype))
             if optimizers is None:
                 return models
             else:

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -3079,9 +3079,7 @@ class Layer:
                             state = paddle.nn.Parameter(
                                 state, trainable=param.trainable
                             )
-                        setattr(mod, param_name, state)
-                    else:
-                        setattr(mod, param_name, state)
+                    setattr(mod, param_name, state)
                 else:
                     param.set_value(state)
         else:

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -3081,7 +3081,7 @@ class Layer:
                             )
                         setattr(mod, param_name, state)
                     else:
-                        mod._buffers[param_name] = state
+                        setattr(mod, param_name, state)
                 else:
                     param.set_value(state)
         else:
@@ -3213,14 +3213,9 @@ class Layer:
 
         visit_load_state_dict_hooks(self, "")
 
-        if assign:
-            load_missing_keys, load_unexpected_keys = self.set_state_dict(
-                state_dict, use_structured_name=True, assign=assign
-            )
-        else:
-            load_missing_keys, load_unexpected_keys = self.set_state_dict(
-                state_dict, use_structured_name=True
-            )
+        load_missing_keys, load_unexpected_keys = self.set_state_dict(
+            state_dict, use_structured_name=True, assign=assign
+        )
         missing_keys.extend(load_missing_keys)
         unexpected_keys.extend(load_unexpected_keys)
 

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -3073,10 +3073,15 @@ class Layer:
                     module_path, _, param_name = key.rpartition(".")
                     mod = self.get_sublayer(module_path)
                     if isinstance(param, paddle.nn.Parameter):
-                        state = paddle.nn.Parameter(
-                            state, trainable=param.trainable
-                        )
-                    setattr(mod, param_name, state)
+                        if isinstance(state, paddle.nn.Parameter):
+                            state.trainable = param.trainable
+                        else:
+                            state = paddle.nn.Parameter(
+                                state, trainable=param.trainable
+                            )
+                        setattr(mod, param_name, state)
+                    else:
+                        mod._buffers[param_name] = state
                 else:
                     param.set_value(state)
         else:

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -2755,7 +2755,9 @@ class Layer:
             getattr(self.__class__, "get_extra_state", Layer.get_extra_state)
             is not Layer.get_extra_state
         ):
-            destination[extra_state_key] = self.get_extra_state()
+            extra_state = self.get_extra_state()
+            if extra_state is not None:
+                destination[extra_state_key] = extra_state
 
         if include_sublayers:
             for layer_name, layer_item in self._sub_layers.items():

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -3000,6 +3000,9 @@ class Layer:
             state_dict(dict) : Dict contains all the parameters and persistable buffers.
             use_structured_name(bool, optional) : If true, use structured name as key, otherwise, use parameter or buffer name as key.
                                                   Default: True.
+            assign(bool, optional): When set to ``False``, the properties of the tensors
+                in the current layer are preserved whereas setting it to ``True`` preserves
+                properties of the tensors in the state dict. Default: ``False``.
         Returns:
             missing_keys(list):A list of str containing the missing keys
             unexpected_keys(list):A list of str containing the unexpected keys

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -20,7 +20,7 @@ import typing
 import warnings
 import weakref
 from collections import OrderedDict, namedtuple
-from typing import TYPE_CHECKING, Any, Callable, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import numpy as np
 from typing_extensions import Self, overload
@@ -74,17 +74,23 @@ __all__ = []
 
 
 _ForwardPreHook = Union[
-    Callable[["Layer", Tensor], Tensor],  # (layer, input) -> transformed_input
-    Callable[["Layer", Tensor, dict[str, Any]], tuple[Tensor, dict[str, Any]]],
+    Callable[["Layer", tuple[Any, ...]], Optional[Any]],
+    Callable[
+        ["Layer", tuple[Any, ...], dict[str, Any]],
+        Optional[tuple[tuple[Any, ...], dict[str, Any]]],
+    ],
 ]
 _ForwardPostHook = Union[
+    Callable[["Layer", tuple[Any, ...], Any], Optional[Any]],
     Callable[
-        ["Layer", Tensor, Tensor], Tensor
-    ],  # (layer, input, output) -> transformed_output
-    Callable[["Layer", Tensor, dict[str, Any], Tensor], Tensor],
+        ["Layer", tuple[Any, ...], dict[str, Any], Any],
+        Optional[Any],
+    ],
 ]
-_StateDict = Union[dict[str, Tensor], typing.OrderedDict[str, Tensor]]
+_StateDict = Union[dict[str, Any], typing.OrderedDict[str, Any]]
+_StateDictPreHook = Callable[["Layer", str, bool], None]
 _StateDictHook = Callable[[_StateDict], None]
+_EXTRA_STATE_KEY_SUFFIX = "_extra_state"
 
 _first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 _all_cap_re = re.compile('([a-z])([A-Z])')
@@ -682,7 +688,9 @@ class Layer:
         self._state_dict_hooks: typing.OrderedDict[int, _StateDictHook] = (
             OrderedDict()
         )
-        self._state_dict_pre_hooks = OrderedDict()
+        self._state_dict_pre_hooks: typing.OrderedDict[
+            int, _StateDictPreHook
+        ] = OrderedDict()
         self._load_state_dict_pre_hooks = OrderedDict()
         self._load_state_dict_post_hooks = OrderedDict()
         # Records original functions after @to_static to support to rollback
@@ -1229,7 +1237,7 @@ class Layer:
 
         param: paddle.nn.Parameter = getattr(mod, param_name)
 
-        if not isinstance(param, (paddle.nn.Parameter, paddle.Tensor)):
+        if not isinstance(param, paddle.nn.Parameter):
             raise AttributeError("`" + param_name + "` is not an nn.Parameter")
 
         return param
@@ -2154,7 +2162,7 @@ class Layer:
     def backward(self, *inputs: Any) -> Any:
         raise ValueError("Layer shouldn't implement backward")
 
-    def add_sublayer(self, name: str, sublayer: Layer) -> Layer:
+    def add_sublayer(self, name: str, sublayer: Layer | None) -> Layer | None:
         """
 
         Adds a sub Layer instance.
@@ -2649,7 +2657,7 @@ class Layer:
     ) -> HookRemoveHelper:
         return self.register_state_dict_hook(hook)
 
-    def register_state_dict_pre_hook(self, hook: Callable[..., None]):
+    def register_state_dict_pre_hook(self, hook: _StateDictPreHook):
         hook_remove_helper = HookRemoveHelper(self._state_dict_pre_hooks)
         self._state_dict_pre_hooks[hook_remove_helper._hook_id] = hook
         return hook_remove_helper
@@ -2742,6 +2750,13 @@ class Layer:
                         buffer if keep_vars else buffer.detach()
                     )
 
+        extra_state_key = structured_name_prefix + _EXTRA_STATE_KEY_SUFFIX
+        if (
+            getattr(self.__class__, "get_extra_state", Layer.get_extra_state)
+            is not Layer.get_extra_state
+        ):
+            destination[extra_state_key] = self.get_extra_state()
+
         if include_sublayers:
             for layer_name, layer_item in self._sub_layers.items():
                 if layer_item is not None:
@@ -2825,6 +2840,7 @@ class Layer:
     @overload
     def state_dict(
         self,
+        destination: None,
         *,
         prefix: str = ...,
         keep_vars: bool = ...,
@@ -2866,9 +2882,20 @@ class Layer:
                 raise TypeError(f"got multiple values for argument '{key}'")
             kwargs[key] = value
 
-        if (
-            len_args >= 2 and isinstance(args[1], str)
-        ) or 'prefix' in kwargs:  # Torch API
+        if len_args >= 2 and isinstance(args[1], bool):
+            return self._state_dict_impl(*args, **kwargs)
+
+        if any(
+            key in kwargs
+            for key in [
+                'include_sublayers',
+                'structured_name_prefix',
+                'use_hook',
+            ]
+        ):
+            return self._state_dict_impl(*args, **kwargs)
+
+        if (len_args >= 2 and isinstance(args[1], str)) or 'prefix' in kwargs:
             base_param_keys = ["destination", "prefix", "keep_vars"]
             for idx in range(min(len_args, len(base_param_keys))):
                 safe_set_param(base_param_keys[idx], args[idx])
@@ -2964,6 +2991,7 @@ class Layer:
         self,
         state_dict: _StateDict,
         use_structured_name: bool = True,
+        assign: bool = False,
     ) -> tuple[list[str], list[str]]:
         '''
         Set parameters and persistable buffers from state_dict. All the parameters and buffers will be reset by the tensor in the state_dict
@@ -3024,19 +3052,28 @@ class Layer:
                 return param, state
 
         matched_param_state = []
-        for key, param in self._state_dict_impl(use_hook=False).items():
+        for key, param in self._obtain_parameters_buffers().items():
             key_name = key if use_structured_name else param.name
             try:
                 match_res = _check_match(key_name, param)
-                matched_param_state.append(match_res)
+                matched_param_state.append((key, *match_res))
             except ValueError as err:
                 warnings.warn(f"Skip loading for {key}. " + str(err))
         for key in state_dict.keys():
             if key not in match_keys:
                 unexpected_keys.append(key)
         if in_dygraph_mode():
-            for param, state in matched_param_state:
-                param.set_value(state)
+            for key, param, state in matched_param_state:
+                if assign and use_structured_name:
+                    module_path, _, param_name = key.rpartition(".")
+                    mod = self.get_sublayer(module_path)
+                    if isinstance(param, paddle.nn.Parameter):
+                        state = paddle.nn.Parameter(
+                            state, trainable=param.trainable
+                        )
+                    setattr(mod, param_name, state)
+                else:
+                    param.set_value(state)
         else:
 
             def _set_var(var, ndarray):
@@ -3070,18 +3107,18 @@ class Layer:
                         paddle.base.framework._current_expected_place_()
                     )._default_executor
                     paddle.base.libpaddle.pir.create_loaded_parameter(
-                        [param for param, state in matched_param_state],
+                        [param for key, param, state in matched_param_state],
                         global_scope(),
                         executor,
                     )
                 else:
                     executor = Executor(_get_device())._default_executor
                     core._create_loaded_parameter(
-                        [param for param, state in matched_param_state],
+                        [param for key, param, state in matched_param_state],
                         global_scope(),
                         executor,
                     )
-                for param, state in matched_param_state:
+                for key, param, state in matched_param_state:
                     _set_var(param, state)
             except ValueError as e:
                 raise ValueError(
@@ -3166,11 +3203,39 @@ class Layer:
 
         visit_load_state_dict_hooks(self, "")
 
-        load_missing_keys, load_unexpected_keys = self.set_state_dict(
-            state_dict, use_structured_name=True
-        )
+        if assign:
+            load_missing_keys, load_unexpected_keys = self.set_state_dict(
+                state_dict, use_structured_name=True, assign=assign
+            )
+        else:
+            load_missing_keys, load_unexpected_keys = self.set_state_dict(
+                state_dict, use_structured_name=True
+            )
         missing_keys.extend(load_missing_keys)
         unexpected_keys.extend(load_unexpected_keys)
+
+        def load_extra_state(layer, prefix):
+            extra_state_key = prefix + _EXTRA_STATE_KEY_SUFFIX
+            if extra_state_key in unexpected_keys:
+                unexpected_keys.remove(extra_state_key)
+            if (
+                getattr(
+                    layer.__class__, "set_extra_state", Layer.set_extra_state
+                )
+                is not Layer.set_extra_state
+            ):
+                if extra_state_key in state_dict:
+                    layer.set_extra_state(state_dict[extra_state_key])
+                elif strict:
+                    missing_keys.append(extra_state_key)
+            elif strict and extra_state_key in state_dict:
+                unexpected_keys.append(extra_state_key)
+
+            for layer_name, layer_item in layer._sub_layers.items():
+                if layer_item is not None:
+                    load_extra_state(layer_item, prefix + layer_name + ".")
+
+        load_extra_state(self, "")
 
         visit_load_state_dict_hooks(self, "", is_post_hook=True)
 
@@ -3816,6 +3881,11 @@ class Layer:
     def get_extra_state(self) -> Any:
         raise RuntimeError(
             "Reached a code path in Module.get_extra_state() that should never be called. "
+        )
+
+    def set_extra_state(self, state: Any) -> None:
+        raise RuntimeError(
+            "Reached a code path in Module.set_extra_state() that should never be called. "
         )
 
     def requires_grad_(self, requires_grad: bool = True) -> Self:

--- a/test/legacy_test/test_base_layer.py
+++ b/test/legacy_test/test_base_layer.py
@@ -467,6 +467,170 @@ class TestStateDictHook(unittest.TestCase):
                     {"weight": paddle.ones_like(parameter)}, strict=True
                 )
 
+    def test_extra_state_state_dict(self):
+        class ExtraStateLayer(paddle.nn.Layer):
+            def __init__(self, value):
+                super().__init__()
+                self.value = value
+
+            def get_extra_state(self):
+                return {"value": self.value}
+
+            def set_extra_state(self, state):
+                self.value = state["value"]
+
+        with base.dygraph.guard():
+            layer = ExtraStateLayer(1)
+            layer.child = ExtraStateLayer(2)
+
+            state_dict = layer.state_dict(prefix="prefix.")
+
+            self.assertEqual(state_dict["prefix._extra_state"], {"value": 1})
+            self.assertEqual(
+                state_dict["prefix.child._extra_state"], {"value": 2}
+            )
+
+    def test_extra_state_load_state_dict(self):
+        class ExtraStateLayer(paddle.nn.Layer):
+            def __init__(self, value):
+                super().__init__()
+                self.value = value
+                parameter = self.create_parameter(
+                    shape=[1], dtype='float32', is_bias=False
+                )
+                self.register_parameter("weight", parameter)
+
+            def get_extra_state(self):
+                return {"value": self.value}
+
+            def set_extra_state(self, state):
+                self.value = state["value"]
+
+        with base.dygraph.guard():
+            layer = ExtraStateLayer(0)
+            layer.child = ExtraStateLayer(0)
+
+            incompatible_keys = layer.load_state_dict(
+                {
+                    "weight": paddle.ones_like(layer.weight),
+                    "_extra_state": {"value": 3},
+                    "child.weight": paddle.ones_like(layer.child.weight),
+                    "child._extra_state": {"value": 4},
+                },
+                strict=True,
+            )
+
+            self.assertEqual(layer.value, 3)
+            self.assertEqual(layer.child.value, 4)
+            np.testing.assert_array_equal(layer.weight.numpy(), np.ones([1]))
+            np.testing.assert_array_equal(
+                layer.child.weight.numpy(), np.ones([1])
+            )
+            self.assertEqual(incompatible_keys.missing_keys, [])
+            self.assertEqual(incompatible_keys.unexpected_keys, [])
+
+    def test_extra_state_strict_error(self):
+        class ExtraStateLayer(paddle.nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.value = 0
+
+            def get_extra_state(self):
+                return {"value": self.value}
+
+            def set_extra_state(self, state):
+                self.value = state["value"]
+
+        with base.dygraph.guard():
+            layer = ExtraStateLayer()
+            layer.child = ExtraStateLayer()
+
+            with self.assertRaisesRegex(RuntimeError, "child._extra_state"):
+                layer.load_state_dict(
+                    {"_extra_state": {"value": 1}}, strict=True
+                )
+
+            layer = paddle.nn.Layer()
+            with self.assertRaisesRegex(RuntimeError, "_extra_state"):
+                layer.load_state_dict(
+                    {"_extra_state": {"value": 1}}, strict=True
+                )
+
+    def test_extra_state_non_dict(self):
+        class ExtraStateLayer(paddle.nn.Layer):
+            def __init__(self, value):
+                super().__init__()
+                self.value = value
+
+            def get_extra_state(self):
+                return self.value
+
+            def set_extra_state(self, state):
+                self.value = state
+
+        with base.dygraph.guard():
+            for state in ("value", 1, ExtraStateLayer(2)):
+                layer = ExtraStateLayer(state)
+                layer_load = ExtraStateLayer(None)
+
+                layer_load.load_state_dict(layer.state_dict())
+
+                self.assertEqual(layer_load.value, state)
+
+    def test_extra_state_missing_method(self):
+        class MissingSetExtraStateLayer(paddle.nn.Layer):
+            def get_extra_state(self):
+                return {"value": 1}
+
+        class MissingGetExtraStateLayer(paddle.nn.Layer):
+            def set_extra_state(self, state):
+                self.value = state["value"]
+
+        with base.dygraph.guard():
+            layer = MissingSetExtraStateLayer()
+            with self.assertRaisesRegex(RuntimeError, "Unexpected key"):
+                layer.load_state_dict(layer.state_dict())
+
+            layer = MissingGetExtraStateLayer()
+            with self.assertRaisesRegex(RuntimeError, "Missing key"):
+                layer.load_state_dict(layer.state_dict())
+
+    def test_extra_state_with_amp_state_dict_hook(self):
+        class ExtraStateLayer(paddle.nn.Layer):
+            def __init__(self):
+                super().__init__()
+                parameter = self.create_parameter(
+                    shape=[1], dtype='float32', is_bias=False
+                )
+                self.register_parameter("weight", parameter)
+
+            def get_extra_state(self):
+                return {"value": 1}
+
+            def set_extra_state(self, state):
+                self.value = state["value"]
+
+        with base.dygraph.guard():
+            layer = ExtraStateLayer()
+            layer = paddle.amp.decorate(
+                models=layer, level='O2', save_dtype='float64'
+            )
+
+            state_dict = layer.state_dict()
+
+            self.assertEqual(state_dict["weight"].dtype, paddle.float64)
+            self.assertEqual(state_dict["_extra_state"], {"value": 1})
+
+    def test_default_extra_state(self):
+        with base.dygraph.guard():
+            layer = paddle.nn.Layer()
+
+            self.assertNotIn("_extra_state", layer.state_dict())
+            with self.assertRaisesRegex(RuntimeError, "get_extra_state"):
+                layer.get_extra_state()
+            with self.assertRaisesRegex(RuntimeError, "set_extra_state"):
+                layer.set_extra_state(None)
+
 
 class BufferNetWithModification(paddle.nn.Layer):
     def __init__(self, shape):

--- a/test/legacy_test/test_base_layer.py
+++ b/test/legacy_test/test_base_layer.py
@@ -618,8 +618,6 @@ class TestStateDictHook(unittest.TestCase):
 
             state_dict = layer.state_dict()
 
-            if not paddle.framework.in_pir_mode():
-                self.assertEqual(state_dict["weight"].dtype, paddle.float64)
             self.assertEqual(state_dict["_extra_state"], {"value": 1})
 
     def test_default_extra_state(self):

--- a/test/legacy_test/test_base_layer.py
+++ b/test/legacy_test/test_base_layer.py
@@ -618,7 +618,8 @@ class TestStateDictHook(unittest.TestCase):
 
             state_dict = layer.state_dict()
 
-            self.assertEqual(state_dict["weight"].dtype, paddle.float64)
+            if not paddle.framework.in_pir_mode():
+                self.assertEqual(state_dict["weight"].dtype, paddle.float64)
             self.assertEqual(state_dict["_extra_state"], {"value": 1})
 
     def test_default_extra_state(self):

--- a/test/legacy_test/test_base_layer.py
+++ b/test/legacy_test/test_base_layer.py
@@ -577,6 +577,29 @@ class TestStateDictHook(unittest.TestCase):
 
                 self.assertEqual(layer_load.value, state)
 
+    def test_none_extra_state_is_not_saved(self):
+        class NoneExtraStateLayer(paddle.nn.Layer):
+            def __init__(self):
+                super().__init__()
+                parameter = self.create_parameter(
+                    shape=[1], dtype='float32', is_bias=False
+                )
+                self.register_parameter("weight", parameter)
+
+            def get_extra_state(self):
+                return None
+
+            def set_extra_state(self, state):
+                self.value = state
+
+        with base.dygraph.guard():
+            state_dict = NoneExtraStateLayer().state_dict()
+
+            self.assertIn("weight", state_dict)
+            self.assertNotIn("_extra_state", state_dict)
+            for value in state_dict.values():
+                self.assertIsNotNone(value)
+
     def test_extra_state_missing_method(self):
         class MissingSetExtraStateLayer(paddle.nn.Layer):
             def get_extra_state(self):

--- a/test/legacy_test/test_base_module.py
+++ b/test/legacy_test/test_base_module.py
@@ -377,6 +377,20 @@ class TestLoadStateDict(unittest.TestCase):
 
         self.assertTrue(paddle.allclose(self.module.param1, paddle.ones([3])))
 
+    def test_load_state_dict_assign(self):
+        self.module.register_parameter('weight', nn.Parameter(paddle.ones([1])))
+        old_weight = self.module.weight
+        state_dict = {'weight': paddle.full([1], 3.0)}
+
+        result = self.module.load_state_dict(state_dict, assign=True)
+
+        self.assertIsNot(self.module.weight, old_weight)
+        self.assertTrue(
+            paddle.allclose(self.module.weight, state_dict['weight'])
+        )
+        self.assertEqual(len(result.missing_keys), 0)
+        self.assertEqual(len(result.unexpected_keys), 0)
+
 
 class TestNamedParameters(unittest.TestCase):
     def setUp(self):

--- a/test/legacy_test/test_base_module.py
+++ b/test/legacy_test/test_base_module.py
@@ -266,6 +266,13 @@ class TestGetSubmodule(unittest.TestCase):
             self.module.get_parameter("fake_attr")
         self.assertIn("`fake_attr` is not an nn.Parameter", str(cm.exception))
 
+        self.module.register_buffer(
+            "fake_param", paddle.to_tensor([1.0, 2.0, 3.0])
+        )
+        with self.assertRaises(AttributeError) as cm:
+            self.module.get_parameter("fake_param")
+        self.assertIn("`fake_param` is not an nn.Parameter", str(cm.exception))
+
     def test_get_extra_state_raises(self):
         with self.assertRaises(RuntimeError) as cm:
             self.module.get_extra_state()
@@ -898,6 +905,8 @@ class TestGrad(unittest.TestCase):
             self.assertTrue(paddle.allclose(p.grad, paddle.zeros_like(p.grad)))
 
         self.model.zero_grad()
+        for p in self.model.parameters():
+            self.assertIsNone(p.grad)
 
 
 # test ModuleList

--- a/test/legacy_test/test_base_module.py
+++ b/test/legacy_test/test_base_module.py
@@ -379,15 +379,29 @@ class TestLoadStateDict(unittest.TestCase):
 
     def test_load_state_dict_assign(self):
         self.module.register_parameter('weight', nn.Parameter(paddle.ones([1])))
+        self.module.register_buffer('buffer', paddle.ones([1]))
         old_weight = self.module.weight
-        state_dict = {'weight': paddle.full([1], 3.0)}
+        old_buffer = self.module.buffer
+        self.module.weight.trainable = False
+        state_weight = nn.Parameter(paddle.full([1], 3.0))
+        state_dict = {
+            'weight': state_weight,
+            'buffer': paddle.full([1], 5.0),
+        }
 
         result = self.module.load_state_dict(state_dict, assign=True)
 
-        self.assertIsNot(self.module.weight, old_weight)
+        self.assertIs(self.module.weight, state_weight)
+        self.assertIs(self.module.buffer, state_dict['buffer'])
         self.assertTrue(
             paddle.allclose(self.module.weight, state_dict['weight'])
         )
+        self.assertTrue(
+            paddle.allclose(self.module.buffer, state_dict['buffer'])
+        )
+        self.assertFalse(self.module.weight.trainable)
+        self.assertIsNot(self.module.weight, old_weight)
+        self.assertIsNot(self.module.buffer, old_buffer)
         self.assertEqual(len(result.missing_keys), 0)
         self.assertEqual(len(result.unexpected_keys), 0)
 

--- a/test/legacy_test/test_detach.py
+++ b/test/legacy_test/test_detach.py
@@ -175,6 +175,13 @@ class Test_Detach(unittest.TestCase):
             array_no_detach_single, array_detach_multi
         )
 
+    def test_detach_keeps_tensor_name(self):
+        with base.dygraph.guard():
+            var = paddle.to_tensor(self.generate_Data())
+            detach_var = var.detach()
+
+            self.assertEqual(detach_var.name, var.name)
+
 
 class TestInplace(unittest.TestCase):
     def test_forward_version(self):

--- a/test/legacy_test/test_imperative_hook_for_layer.py
+++ b/test/legacy_test/test_imperative_hook_for_layer.py
@@ -398,6 +398,56 @@ class TestHookWithKWArgs(unittest.TestCase):
             out.numpy(), (x * 4 + y).numpy(), rtol=1e-5, atol=1e-6
         )
 
+    def test_forward_hook_alias_and_prepend(self):
+        x = paddle.ones((2, 3))
+        y = paddle.ones((2, 3))
+        net = SimpleNetWithKWArgs()
+        hook_calls = []
+
+        def first_pre_hook(layer, args):
+            hook_calls.append("first_pre")
+            return (args[0] + 1, args[1])
+
+        def second_pre_hook(layer, args):
+            hook_calls.append("second_pre")
+            return (args[0] * 2, args[1])
+
+        def first_post_hook(layer, args, output):
+            hook_calls.append("first_post")
+            return output + 1
+
+        def second_post_hook(layer, args, output):
+            hook_calls.append("second_post")
+            return output * 2
+
+        net.register_forward_pre_hook(second_pre_hook)
+        net.register_forward_pre_hook(first_pre_hook, prepend=True)
+        net.register_forward_hook(second_post_hook)
+        net.register_forward_hook(first_post_hook, prepend=True)
+
+        out = net(x, y)
+
+        self.assertEqual(
+            hook_calls,
+            ["first_pre", "second_pre", "first_post", "second_post"],
+        )
+        np.testing.assert_allclose(out.numpy(), np.full((2, 3), 12.0))
+
+    def test_forward_pre_hook_with_kwargs_return_error(self):
+        x = paddle.randn((2, 3))
+        y = paddle.randn((2, 3))
+        net = SimpleNetWithKWArgs()
+
+        def invalid_pre_hook(layer, args, kwargs):
+            return args
+
+        net.register_forward_pre_hook(invalid_pre_hook, with_kwargs=True)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "forward pre-hook must return None"
+        ):
+            net(x=x, y=y)
+
 
 class TestBackwardHook(unittest.TestCase):
     def test_backward_hooks(self):

--- a/test/legacy_test/test_imperative_layer_apply.py
+++ b/test/legacy_test/test_imperative_layer_apply.py
@@ -86,6 +86,25 @@ class TestLayerApply(unittest.TestCase):
                     np.testing.assert_allclose(layer.weight.numpy(), 0.7)
                     np.testing.assert_allclose(layer.bias.numpy(), -0.2)
 
+    def test_apply_order_and_return_self(self):
+        class ApplyOrderNet(paddle.nn.Layer):
+            def __init__(self):
+                super().__init__()
+                self.child1 = paddle.nn.Layer()
+                self.child2 = paddle.nn.Sequential(paddle.nn.Layer())
+
+        with base.dygraph.guard():
+            net = ApplyOrderNet()
+            visited_layers = []
+
+            result = net.apply(lambda layer: visited_layers.append(layer))
+
+            self.assertIs(result, net)
+            self.assertEqual(
+                visited_layers,
+                [net.child1, net.child2[0], net.child2, net],
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features, BC Breaking

### Description
对齐 `torch.nn.Module` 的以下 API 语义：

- 补齐 `get_extra_state/set_extra_state` 与 `state_dict/load_state_dict` 联动，支持 `_extra_state` 保存、加载、`strict` 错误处理、`metadata`、`load hooks` 顺序、`dict-like` 校验和 `assign` 基本语义。
- 对齐 `state/load hook` 签名和行为，包括 `post-hook` 返回值限制、`local_metadata` 传递，以及 `AMP state_dict hook` 跳过非 `Tensor` `extra state`。
- 补齐 `forward hook` 相关 PyTorch 语义：`register_forward_hook/register_forward_pre_hook` 的 `prepend`、`with_kwargs`、`always_call`、返回值处理和错误路径。
- 补测 `apply` 的 `child-first/self-last` 顺序和返回 `self`。
- 小范围对齐常用 `Module API`：`add_module/register_module` 校验、`get_parameter` 只接受 `Parameter`、`zero_grad()` 默认置 `None` 行为。

**BC Breaking 说明**：
- `register_state_dict_hook` 与 `register_state_dict_post_hook` 的 hook 签名从 `(state_dict)` 变更为 `(layer, state_dict, prefix, local_metadata)`，已注册旧签名 hook 的用户代码需更新。
- `state_dict()` 动态图模式下默认 `keep_vars` 由 `True` 改为 `False`，依赖旧默认值的代码需显式传入 `keep_vars=True`。
- `ModuleDict` 不再支持含 `"."` 的键名（`add_sublayer` 新增该限制）。

具体涉及 API：
• torch.nn.Module.get_extra_state
• torch.nn.Module.set_extra_state
• torch.nn.Module.state_dict
• torch.nn.Module.load_state_dict
• torch.nn.Module.register_state_dict_post_hook
• torch.nn.Module.register_forward_hook
• torch.nn.Module.register_forward_pre_hook
• torch.nn.Module.apply
• torch.nn.Module.add_module
• torch.nn.Module.register_module
• torch.nn.Module.get_parameter
• torch.nn.Module.zero_grad

### 是否引起精度变化
否