### PR TITLE
[CI] add approval check for int variables in kernel code

### DIFF
--- a/ci/check_approval.sh
+++ b/ci/check_approval.sh
@@ -607,7 +607,11 @@ if [ -n "${BIGTENSOR_CHANGED}" ]; then
     echo_line="You must have one RD (zrr1999(Recommend) or wanghuancoder) approval for modifying kernel code with threadIdx, blockDim or blockIdx multiplications assigned to int, int32_t, uint32_t, or auto type variables.\nThe following lines were found:\n${BIGTENSOR_CHANGED}\n"
     check_approval 1 zrr1999 wanghuancoder
 fi
-
+BIGTENSOR_CHANGED=$(git diff -U0 upstream/$BRANCH -- "${BIGTENSOR_GLOBS[@]}" | grep "^+" | grep -E "int |int32|int32_t|uint32|uint32_t" || true)
+if [ -n "${BIGTENSOR_CHANGED}" ]; then
+    echo_line="You must have one RD (zrr1999(Recommend) or wanghuancoder) approval for modifying kernel code with int, int32_t, uint32_t, or auto type variables.\nThe following lines were found:\n${BIGTENSOR_CHANGED}\n"
+    check_approval 1 zrr1999 wanghuancoder
+fi
 
 HAS_MODIFIED_PHI_DIR=`git diff --name-only upstream/$BRANCH | grep "paddle/phi/" | grep -v "paddle/phi/api/" | grep -v "python_api_info.yaml" || true`
 if [ "${HAS_MODIFIED_PHI_DIR}" != "" ] && [ "${PR_ID}" != "" ]; then


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description
本 PR 增强 CI 审批检查逻辑，在修改 kernel 相关代码时，如果新增行中包含 `int`、`int32`、`int32_t`、`uint32` 或 `uint32_t` 等整型变量使用，将要求指定 RD 审批。

这样可以帮助提前发现 kernel 代码中潜在的大 Tensor 兼容风险，避免整型宽度不足导致的大 Tensor 场景问题。

### 是否引起精度变化
否