### PR TITLE
Add Batched NS-Iter

### DIFF
--- a/python/paddle/optimizer/muon.py
+++ b/python/paddle/optimizer/muon.py
@@ -386,7 +386,8 @@ class Muon(Optimizer):
         """Approximate the matrix sign function via Newton-Schulz iteration.
 
         Args:
-            X: Input tensor to orthogonalize.
+            X: Input tensor to orthogonalize. Must be 2D (M, N) or
+                3D (B, M, N) for batched operation.
             steps: Number of Newton-Schulz iterations.
             eps: Small constant for numerical stability.
             ns_coeffs: List of (a, b, c) coefficient tuples for iteration.
@@ -394,6 +395,11 @@ class Muon(Optimizer):
             ns_matmul_dtype: Dtype for matmul iterations. Defaults to
                 bfloat16. Pass paddle.float32 for V100 compatibility.
         """
+        if X.ndim < 2 or X.ndim > 3:
+            raise ValueError(
+                f"Input tensor X must be 2D or 3D (batched), got {X.ndim}D"
+            )
+
         coeff_sets = (
             ns_coeffs
             if ns_coeffs is not None
@@ -401,7 +407,10 @@ class Muon(Optimizer):
         )
 
         if X.shape[-2] > X.shape[-1]:
-            X = X.T
+            X = paddle.transpose(
+                X,
+                perm=[1, 0] if X.ndim == 2 else [0, 2, 1],
+            )
             transpose = True
         else:
             transpose = False
@@ -413,19 +422,39 @@ class Muon(Optimizer):
         )
         X = X_flat.reshape(orig_shape).astype(ns_matmul_dtype)
 
-        # Iterate with cycling coefficients
+        if X.ndim == 3:
+            ns_step_fn = Muon._batched_newton_schulz_step
+        else:
+            ns_step_fn = Muon._newton_schulz_step
+
         for i in range(steps):
             a, b, c = coeff_sets[i % len(coeff_sets)]
-            A = paddle.matmul(X, X, transpose_y=True)
-            B = paddle.addmm(input=A, x=A, y=A, beta=b, alpha=c)
-            X = paddle.addmm(input=X, x=B, y=X, beta=a, alpha=1.0)
+            X = ns_step_fn(X, a, b, c)
 
-        return X.T if transpose else X
+        if transpose:
+            X = paddle.transpose(X, perm=[1, 0] if X.ndim == 2 else [0, 2, 1])
+        return X
+
+    @staticmethod
+    def _newton_schulz_step(X, a, b, c):
+        """Single Newton-Schulz iteration step for 2D input."""
+        A = paddle.matmul(X, X, transpose_y=True)
+        B = paddle.addmm(input=A, x=A, y=A, beta=b, alpha=c)
+        X = paddle.addmm(input=X, x=B, y=X, beta=a, alpha=1.0)
+        return X
+
+    @staticmethod
+    def _batched_newton_schulz_step(X, a, b, c):
+        """Single Newton-Schulz iteration step for 3D batched input."""
+        A = paddle.matmul(X, X, transpose_y=True)
+        B = paddle.baddbmm(A, A, A, beta=b, alpha=c)
+        X = paddle.baddbmm(X, B, X, beta=a, alpha=1.0)
+        return X
 
     @staticmethod
     def _scaling_fn(orthogonal_update, version, extra_scale_factor=1.0):
         """Apply dimension-dependent scaling to the orthogonal update."""
-        din, dout = orthogonal_update.shape[0], orthogonal_update.shape[1]
+        din, dout = orthogonal_update.shape[-2], orthogonal_update.shape[-1]
         if version == 1:
             scale = max(1, dout / din) ** 0.5
         elif version == 2:

--- a/test/collective/fleet/hybrid_parallel_sharding_muon_model.py
+++ b/test/collective/fleet/hybrid_parallel_sharding_muon_model.py
@@ -57,6 +57,11 @@ kv_head_num = 2  # num_key_value_heads (GQA)
 head_dim = hidden_size // head_num
 intermediate_size = 128
 qkv_dim = (head_num + 2 * kv_head_num) * head_dim
+batched_proj_shape = (
+    2,
+    256,
+    128,
+)  # 3D: triggers batched NS + transpose (256 > 128)
 seq_length = 2
 batch_size = 4
 STEPS = 3
@@ -120,6 +125,7 @@ class QKVFFNNet(paddle.nn.Layer):
         np_up_gate,
         np_down_proj,
         np_lm_head,
+        np_batched_proj,
     ):
         super().__init__()
         self.config = config
@@ -177,6 +183,12 @@ class QKVFFNNet(paddle.nn.Layer):
             ),
         )
 
+        self.batched_proj = paddle.create_parameter(
+            shape=list(batched_proj_shape),
+            dtype='float32',
+            default_initializer=paddle.nn.initializer.Assign(np_batched_proj),
+        )
+
     def forward(self, x):
         # Embedding
         h = self.embed_tokens(x)  # [batch, seq, hidden]
@@ -198,6 +210,10 @@ class QKVFFNNet(paddle.nn.Layer):
 
         # Down projection
         out = self.down_proj(out)  # [batch, seq, hidden]
+
+        # Batched projection (3D param: triggers batched NS + transpose path)
+        bp_scale = paddle.einsum('bsh,kmn->', out, self.batched_proj)
+        out = out + bp_scale * 1e-4
 
         # LM head
         logits = self.lm_head(out)  # [batch, seq, vocab]
@@ -259,6 +275,7 @@ class TestDistShardingMuonTraining(unittest.TestCase):
             np.random.random_sample((hidden_size, 2 * intermediate_size)),
             np.random.random_sample((hidden_size, hidden_size)),
             np.random.random_sample((hidden_size, vocab_size)),
+            np.random.random_sample(batched_proj_shape),
         )
 
     def _build_split_concat_func_map(self, model):
@@ -338,9 +355,15 @@ class TestDistShardingMuonTraining(unittest.TestCase):
 
     def _build_model(self, weights):
         """Build a single model instance from weights."""
-        np_embed, np_qkv, np_o_proj, np_up_gate, np_down_proj, np_lm_head = (
-            weights
-        )
+        (
+            np_embed,
+            np_qkv,
+            np_o_proj,
+            np_up_gate,
+            np_down_proj,
+            np_lm_head,
+            np_batched_proj,
+        ) = weights
         model = QKVFFNNet(
             self.config,
             np_embed,
@@ -349,6 +372,7 @@ class TestDistShardingMuonTraining(unittest.TestCase):
             np_up_gate,
             np_down_proj,
             np_lm_head,
+            np_batched_proj,
         )
         model = mix_precision_utils.MixPrecisionLayer(model, dtype="bfloat16")
         model = paddle.amp.decorate(models=model, level='O2', dtype='bfloat16')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Muon optimizer performance optimization: 

Added Batched NS iteration during NS iteration, replacing `paddle.addmm` with the `paddle.baddbmm` operator to improve computational density. 

Corresponding unit tests have also been added.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否