### PR TITLE
[cherry-pick]Optimize squared_l2_norm GPU kernel: use new ReduceGpuKernel and prom

### DIFF
--- a/paddle/phi/kernels/gpu/squared_l2_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/squared_l2_norm_kernel.cu
@@ -18,7 +18,10 @@
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/reduce_function.h"
+#include "paddle/phi/kernels/gpu/reduce.h"
+
 namespace phi {
+
 template <typename T, typename Context>
 void SquaredL2NormKernel(const Context& dev_ctx,
                          const DenseTensor& x,
@@ -28,8 +31,8 @@ void SquaredL2NormKernel(const Context& dev_ctx,
   for (size_t i = 0; i < x.dims().size(); i++) {
     origin_reduce_dims.push_back(i);
   }
-  funcs::ReduceKernel<T, T, kps::AddFunctor, kps::SquareFunctor<T, T>>(
-      dev_ctx, x, out, kps::SquareFunctor<T, T>(), origin_reduce_dims);
+  funcs::ReduceGpuKernel<T, T, kps::SquaredL2NormOps>(
+      dev_ctx, x, out, origin_reduce_dims);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/primitive/reduce_primitives.h
+++ b/paddle/phi/kernels/primitive/reduce_primitives.h
@@ -382,6 +382,26 @@ struct L2NormOps {
 };
 
 template <typename InT, typename MPType = InT, typename OutT = MPType>
+struct SquaredL2NormOps {
+  inline DEVICE MPType compute(MPType a, InT b) const {
+    MPType b_ = static_cast<MPType>(b) * static_cast<MPType>(b);
+    return reduce(a, b_);
+  }
+
+  inline DEVICE MPType reduce(MPType a, MPType b) const { return (a + b); }
+
+  inline DEVICE OutT post_process(MPType a) const {
+    return static_cast<OutT>(a);
+  }
+
+  inline DEVICE MPType shfl_sync(unsigned mask, MPType data, int offset) const {
+    return phi::backends::gpu::CudaShuffleDownSync(mask, data, offset);
+  }
+
+  SquaredL2NormOps() {}
+};
+
+template <typename InT, typename MPType = InT, typename OutT = MPType>
 struct GenericPNormOps {
   MPType norm_;
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
Cherry-pick from develop：
devPR:https://github.com/PaddlePaddle/Paddle/pull/79011

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是