### PR TITLE
[XPU] Fix fused_bias_act precision

### DIFF
--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -1019,7 +1019,7 @@ XPUOpMap& get_kl3_ops() {
       {"squeeze_excitation_block", XPUKernelSet({FLOAT32, FLOAT16})},
       {"resnet_basic_block_grad", XPUKernelSet({FLOAT32})},
       {"resnet_basic_block", XPUKernelSet({FLOAT32})},
-      {"fused_bias_act", XPUKernelSet({FLOAT16, BFLOAT16})},
+      {"fused_bias_act", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16, INT32})},
       {"fused_bias_residual_layernorm",
        XPUKernelSet({FLOAT32, BFLOAT16, FLOAT16})},
       {"fused_gemm_epilogue", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},

--- a/paddle/phi/kernels/fusion/xpu/fused_bias_act_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_bias_act_kernel.cc
@@ -13,76 +13,286 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/fused_bias_act_kernel.h"
+
+#include <type_traits>
+
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/math_function.h"
 
 namespace phi {
 namespace fusion {
 
-template <typename T>
-static void DispatchComputeImpl(const XPUContext *xpu_ctx,
-                                const DenseTensor &x,
-                                const DenseTensor *bias,
-                                const DenseTensor &dequant_scales,
-                                const DenseTensor &shift,
-                                const DenseTensor &smooth,
-                                const std::string &act_method,
-                                const float quant_scale,
-                                const int quant_round_type,
-                                const float quant_max_bound,
-                                const float quant_min_bound,
-                                DenseTensor *out) {
-  PADDLE_THROW(
-      common::errors::Unimplemented("fused_bias_act with smooth "
-                                    "quant on xpu is not implemented yet."));
+template <typename T, typename Context>
+static void ComputeImpl(const Context &dev_ctx,
+                        const DenseTensor &x,
+                        const optional<DenseTensor> &bias,
+                        const std::string &act_method,
+                        DenseTensor *out);
+
+template <typename T, typename Context>
+static void DispatchInt32ComputeImpl(const Context &dev_ctx,
+                                     const DenseTensor &x,
+                                     const optional<DenseTensor> &bias,
+                                     const DenseTensor &dequant_scales,
+                                     const optional<DenseTensor> &shift,
+                                     const optional<DenseTensor> &smooth,
+                                     const std::string &act_method,
+                                     const float quant_scale,
+                                     const float quant_max_bound,
+                                     DenseTensor *out) {
+  DenseTensor compute_x;
+  compute_x.Resize(x.dims());
+  dev_ctx.template Alloc<T>(&compute_x);
+
+  auto xpu_ctx = static_cast<const XPUContext *>(&dev_ctx);
+  using XPUType = typename XPUTypeTrait<T>::Type;
+  int64_t cols = x.dims()[x.dims().size() - 1];
+  int64_t rows = x.numel() / cols;
+  PADDLE_ENFORCE_LE_INT_MAX(rows, "rows");
+  PADDLE_ENFORCE_LE_INT_MAX(cols, "cols");
+
+  int r = 0;
+  if constexpr (std::is_same_v<T, float>) {
+    DenseTensor cast_x;
+    cast_x.Resize(x.dims());
+    dev_ctx.template Alloc<float>(&cast_x);
+    r = baidu::xpu::api::cast<int32_t, float>(dev_ctx.x_context(),
+                                              x.data<int32_t>(),
+                                              cast_x.data<float>(),
+                                              x.numel());
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::cast failed."));
+    r = baidu::xpu::api::broadcast_mul<float>(
+        dev_ctx.x_context(),
+        cast_x.data<float>(),
+        dequant_scales.data<float>(),
+        compute_x.data<float>(),
+        {static_cast<int>(rows), static_cast<int>(cols)},
+        {static_cast<int>(cols)});
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::broadcast_mul failed."));
+  } else {
+    DenseTensor cast_x_fp32;
+    cast_x_fp32.Resize(x.dims());
+    dev_ctx.template Alloc<float>(&cast_x_fp32);
+    DenseTensor compute_x_fp32;
+    compute_x_fp32.Resize(x.dims());
+    dev_ctx.template Alloc<float>(&compute_x_fp32);
+    r = baidu::xpu::api::cast<int32_t, float>(dev_ctx.x_context(),
+                                              x.data<int32_t>(),
+                                              cast_x_fp32.data<float>(),
+                                              x.numel());
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::cast failed."));
+    r = baidu::xpu::api::broadcast_mul<float>(
+        dev_ctx.x_context(),
+        cast_x_fp32.data<float>(),
+        dequant_scales.data<float>(),
+        compute_x_fp32.data<float>(),
+        {static_cast<int>(rows), static_cast<int>(cols)},
+        {static_cast<int>(cols)});
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::broadcast_mul failed."));
+    r = baidu::xpu::api::cast<float, XPUType>(
+        dev_ctx.x_context(),
+        compute_x_fp32.data<float>(),
+        reinterpret_cast<XPUType *>(compute_x.data<T>()),
+        x.numel());
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::cast failed."));
+  }
+
+  if (shift || smooth) {
+    PADDLE_ENFORCE_EQ(shift && smooth,
+                      true,
+                      common::errors::InvalidArgument(
+                          "shift and smooth must be both set or both unset."));
+  }
+
+  DenseTensor compute_out;
+  compute_out.Resize(out->dims());
+  dev_ctx.template Alloc<T>(&compute_out);
+  ComputeImpl<T, Context>(dev_ctx, compute_x, bias, act_method, &compute_out);
+
+  int64_t out_cols = out->dims()[out->dims().size() - 1];
+  int64_t out_rows = out->numel() / out_cols;
+  PADDLE_ENFORCE_LE_INT_MAX(out_rows, "out_rows");
+  PADDLE_ENFORCE_LE_INT_MAX(out_cols, "out_cols");
+  if (shift && smooth) {
+    r = baidu::xpu::api::broadcast_add<XPUType>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType *>(compute_out.data<T>()),
+        reinterpret_cast<const XPUType *>(shift.get().data<T>()),
+        reinterpret_cast<XPUType *>(compute_out.data<T>()),
+        {static_cast<int>(out_rows), static_cast<int>(out_cols)},
+        {static_cast<int>(out_cols)});
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::broadcast_add failed."));
+    r = baidu::xpu::api::broadcast_mul<XPUType>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType *>(compute_out.data<T>()),
+        reinterpret_cast<const XPUType *>(smooth.get().data<T>()),
+        reinterpret_cast<XPUType *>(compute_out.data<T>()),
+        {static_cast<int>(out_rows), static_cast<int>(out_cols)},
+        {static_cast<int>(out_cols)});
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::broadcast_mul failed."));
+  }
+
+  if (quant_scale > 0) {
+    xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+    float *maxptr = RAII_GUARD.template alloc_l3_or_gm<float>(
+        dev_ctx.x_context()->max_ptr_size());
+    r = baidu::xpu::api::constant<float>(
+        dev_ctx.x_context(),
+        maxptr,
+        dev_ctx.x_context()->max_ptr_size(),
+        127.0f / (quant_max_bound * quant_scale));
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::constant failed."));
+    r = baidu::xpu::api::quantization<XPUType, int8_t>(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType *>(compute_out.data<T>()),
+        out->data<int8_t>(),
+        out->numel(),
+        maxptr);
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::quantization failed."));
+  } else {
+    r = baidu::xpu::api::copy(
+        dev_ctx.x_context(),
+        reinterpret_cast<const XPUType *>(compute_out.data<T>()),
+        reinterpret_cast<XPUType *>(out->data<T>()),
+        out->numel());
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::copy failed."));
+  }
 }
 
-template <typename T>
-static void ComputeImpl(const XPUContext *xpu_ctx,
+template <typename T, typename Context>
+static void ComputeImpl(const Context &dev_ctx,
                         const DenseTensor &x,
                         const optional<DenseTensor> &bias,
                         const std::string &act_method,
                         DenseTensor *out) {
+  auto xpu_ctx = static_cast<const XPUContext *>(&dev_ctx);
   using XPUType = typename XPUTypeTrait<T>::Type;
-  int64_t rows = x.dims()[0];
-  int64_t cols = x.dims()[1];
+  int64_t cols = x.dims()[x.dims().size() - 1];
+  int64_t rows = x.numel() / cols;
 
   // TODO(large-tensor): XPU broadcast_add API not support int64
   PADDLE_ENFORCE_LE_INT_MAX(rows, "rows");
   PADDLE_ENFORCE_LE_INT_MAX(cols, "cols");
 
   int r = 0;
+  const XPUType *x_data = reinterpret_cast<const XPUType *>(x.data<T>());
+  DenseTensor bias_out;
+  bool use_glu = act_method == "geglu" || act_method == "swiglu";
   if (bias) {
+    XPUType *bias_out_data = reinterpret_cast<XPUType *>(out->data<T>());
+    if (use_glu) {
+      bias_out.Resize(x.dims());
+      dev_ctx.template Alloc<T>(&bias_out);
+      bias_out_data = reinterpret_cast<XPUType *>(bias_out.data<T>());
+    }
     r = baidu::xpu::api::broadcast_add<XPUType>(
         xpu_ctx->x_context(),
-        reinterpret_cast<const XPUType *>(x.data<T>()),
+        x_data,
         reinterpret_cast<const XPUType *>(bias.get().data<T>()),
-        reinterpret_cast<XPUType *>(const_cast<T *>(x.data<T>())),
+        bias_out_data,
         {static_cast<int>(rows), static_cast<int>(cols)},
-        {1, cols});
+        {static_cast<int>(cols)});
     PADDLE_ENFORCE_EQ(
         r, 0, common::errors::Fatal("baidu::xpu::api::broadcast_add failed."));
+    x_data = bias_out_data;
   }
   if (act_method == "geglu") {
-    PD_THROW(
-        "NOT supported GeGLU. "
-        "Currently Only Support SwiGLU, GeLU, ReLU");
-  } else if (act_method == "swiglu") {
-    r = baidu::xpu::api::swiglu<XPUType>(
+    DenseTensor gate;
+    gate.Resize(out->dims());
+    DenseTensor up;
+    up.Resize(out->dims());
+    dev_ctx.template Alloc<T>(&gate);
+    dev_ctx.template Alloc<T>(&up);
+    r = baidu::xpu::api::slice<XPUType>(
         xpu_ctx->x_context(),
-        reinterpret_cast<const XPUType *>(x.data<T>()),
-        reinterpret_cast<XPUType *>(out->data<T>()),
+        x_data,
+        reinterpret_cast<XPUType *>(gate.data<T>()),
         {rows, cols},
-        1,
-        true);
+        {0, 0},
+        {rows, cols / 2});
     PADDLE_ENFORCE_EQ(
-        r, 0, common::errors::Fatal("baidu::xpu::api::swiglu failed."));
+        r, 0, common::errors::Fatal("baidu::xpu::api::slice failed."));
+    r = baidu::xpu::api::slice<XPUType>(
+        xpu_ctx->x_context(),
+        x_data,
+        reinterpret_cast<XPUType *>(up.data<T>()),
+        {rows, cols},
+        {0, cols / 2},
+        {rows, cols});
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::slice failed."));
+    r = baidu::xpu::api::gelu<XPUType>(
+        xpu_ctx->x_context(),
+        reinterpret_cast<const XPUType *>(gate.data<T>()),
+        reinterpret_cast<XPUType *>(gate.data<T>()),
+        rows * cols / 2);
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::gelu failed."));
+    r = baidu::xpu::api::mul<XPUType>(
+        xpu_ctx->x_context(),
+        reinterpret_cast<const XPUType *>(gate.data<T>()),
+        reinterpret_cast<const XPUType *>(up.data<T>()),
+        reinterpret_cast<XPUType *>(out->data<T>()),
+        rows * cols / 2);
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::mul failed."));
+  } else if (act_method == "swiglu") {
+    DenseTensor gate;
+    gate.Resize(out->dims());
+    DenseTensor up;
+    up.Resize(out->dims());
+    dev_ctx.template Alloc<T>(&gate);
+    dev_ctx.template Alloc<T>(&up);
+    r = baidu::xpu::api::slice<XPUType>(
+        xpu_ctx->x_context(),
+        x_data,
+        reinterpret_cast<XPUType *>(gate.data<T>()),
+        {rows, cols},
+        {0, 0},
+        {rows, cols / 2});
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::slice failed."));
+    r = baidu::xpu::api::slice<XPUType>(
+        xpu_ctx->x_context(),
+        x_data,
+        reinterpret_cast<XPUType *>(up.data<T>()),
+        {rows, cols},
+        {0, cols / 2},
+        {rows, cols});
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::slice failed."));
+    r = baidu::xpu::api::silu<XPUType>(
+        xpu_ctx->x_context(),
+        reinterpret_cast<const XPUType *>(gate.data<T>()),
+        reinterpret_cast<XPUType *>(gate.data<T>()),
+        rows * cols / 2);
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::silu failed."));
+    r = baidu::xpu::api::mul<XPUType>(
+        xpu_ctx->x_context(),
+        reinterpret_cast<const XPUType *>(gate.data<T>()),
+        reinterpret_cast<const XPUType *>(up.data<T>()),
+        reinterpret_cast<XPUType *>(out->data<T>()),
+        rows * cols / 2);
+    PADDLE_ENFORCE_EQ(
+        r, 0, common::errors::Fatal("baidu::xpu::api::mul failed."));
   } else if (act_method == "gelu") {
     r = baidu::xpu::api::gelu<XPUType>(
         xpu_ctx->x_context(),
-        reinterpret_cast<const XPUType *>(x.data<T>()),
+        x_data,
         reinterpret_cast<XPUType *>(out->data<T>()),
         rows * cols);
     PADDLE_ENFORCE_EQ(
@@ -90,7 +300,7 @@ static void ComputeImpl(const XPUContext *xpu_ctx,
   } else if (act_method == "relu") {
     r = baidu::xpu::api::relu<XPUType>(
         xpu_ctx->x_context(),
-        reinterpret_cast<const XPUType *>(x.data<T>()),
+        x_data,
         reinterpret_cast<XPUType *>(out->data<T>()),
         rows * cols);
     PADDLE_ENFORCE_EQ(
@@ -98,7 +308,7 @@ static void ComputeImpl(const XPUContext *xpu_ctx,
   } else {
     PD_THROW(
         "NOT supported. "
-        "Currently Only Support SwiGLU, GeLU, ReLU");
+        "Currently Only Support GeGLU, SwiGLU, GeLU, ReLU");
   }
 }
 
@@ -116,25 +326,74 @@ void FusedBiasActKernel(const Context &dev_ctx,
                         float quant_max_bound,
                         float quant_min_bound,
                         DenseTensor *out) {
-  auto xpu_ctx = static_cast<const XPUContext *>(&dev_ctx);
-  dev_ctx.template Alloc<T>(out);
-  if (out->numel() == 0) return;
+  if (x.dtype() == DataType::INT32) {
+    PADDLE_ENFORCE_NE(
+        dequant_scales.get_ptr(),
+        nullptr,
+        common::errors::InvalidArgument(
+            "dequant_scales must be set when Input(x) dtype is INT32."));
+    if (quant_scale > 0) {
+      dev_ctx.template Alloc<int8_t>(out);
+    } else if (compute_dtype == "fp32") {
+      dev_ctx.template Alloc<float>(out);
+    } else if (compute_dtype == "fp16") {
+      dev_ctx.template Alloc<phi::float16>(out);
+    } else if (compute_dtype == "bf16") {
+      dev_ctx.template Alloc<phi::bfloat16>(out);
+    }
+    if (out->numel() == 0) return;
+    if (compute_dtype == "fp32") {
+      return DispatchInt32ComputeImpl<float, Context>(dev_ctx,
+                                                      x,
+                                                      bias,
+                                                      dequant_scales.get(),
+                                                      shift,
+                                                      smooth,
+                                                      act_method,
+                                                      quant_scale,
+                                                      quant_max_bound,
+                                                      out);
+    } else if (compute_dtype == "fp16") {
+      return DispatchInt32ComputeImpl<phi::float16, Context>(
+          dev_ctx,
+          x,
+          bias,
+          dequant_scales.get(),
+          shift,
+          smooth,
+          act_method,
+          quant_scale,
+          quant_max_bound,
+          out);
+    } else if (compute_dtype == "bf16") {
+      return DispatchInt32ComputeImpl<phi::bfloat16, Context>(
+          dev_ctx,
+          x,
+          bias,
+          dequant_scales.get(),
+          shift,
+          smooth,
+          act_method,
+          quant_scale,
+          quant_max_bound,
+          out);
+    } else {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "When Input(x) dtype is INT32, compute_dtype must be fp32, fp16, or "
+          "bf16, but got %s.",
+          compute_dtype));
+    }
+  }
 
-  if (dequant_scales && dequant_scales.get().numel() > 0) {
-    return DispatchComputeImpl<T>(xpu_ctx,
-                                  x,
-                                  bias ? &(bias.get()) : nullptr,
-                                  dequant_scales.get(),
-                                  shift.get(),
-                                  smooth.get(),
-                                  act_method,
-                                  quant_scale,
-                                  quant_round_type,
-                                  quant_max_bound,
-                                  quant_min_bound,
-                                  out);
+  if constexpr (std::is_same_v<T, int32_t>) {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "Input(x) dtype INT32 requires dequant_scales and a valid "
+        "compute_dtype."));
   } else {
-    return ComputeImpl<T>(xpu_ctx, x, bias, act_method, out);
+    dev_ctx.template Alloc<T>(out);
+    if (out->numel() == 0) return;
+
+    return ComputeImpl<T, Context>(dev_ctx, x, bias, act_method, out);
   }
 }
 
@@ -147,4 +406,7 @@ PD_REGISTER_KERNEL(fused_bias_act,
                    phi::fusion::FusedBiasActKernel,
                    float,
                    phi::float16,
-                   phi::bfloat16) {}
+                   phi::bfloat16,
+                   int32_t) {
+  kernel->OutputAt(0).SetDataType(phi::DataType::UNDEFINED);
+}


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes XPU precision and dispatch issues in `paddle.incubate.nn.functional.fused_bias_act`.

The XPU implementation previously handled only the first two dimensions for bias/activation, mutated input memory while applying bias, lacked GeGLU and int32 dequantized paths, and did not advertise float32/int32 support in the XPU3 op list. These gaps caused accuracy failures and kernel dispatch errors for 3D inputs, GLU activations, and quantized int32 cases.

Main changes:
- Flatten leading dimensions and use the last dimension as the feature dimension, matching GPU behavior.
- Use safe temporaries for bias handling, including full input-shaped temporaries for GLU modes.
- Add GeGLU and explicit SwiGLU implementations using first-half activation ordering consistent with GPU.
- Add int32 dequantized execution with fp32 dequant multiplication, post-activation shift/smooth, and quantized output support.
- Register XPU3 float32 and int32 support for `fused_bias_act`.

Validation:
- Built Paddle XPU successfully.
- Verified 11/11 reported PAD-242 cases pass.
- Verified 73/73 `fused_bias_act` cases from `/workspace/PaddleAPITest/all_config.txt` pass.
- Ran pre-commit on the changed files; all hooks passed.

### 是否引起精度变化
否. This corrects XPU results to align with the existing GPU behavior and does not change GPU precision.