### PR TITLE
[Custom Device] Fix timer synchronization by replacing cuda.synchronize() with device.synchronize()

### DIFF
--- a/python/paddle/distributed/fleet/utils/timer_helper.py
+++ b/python/paddle/distributed/fleet/utils/timer_helper.py
@@ -59,14 +59,14 @@ class _Timer:
     def start(self):
         """Start the timer."""
         assert not self.started_, "timer has already started"
-        paddle.device.cuda.synchronize()
+        paddle.device.synchronize()
         self.start_time = time.time()
         self.started_ = True
 
     def stop(self):
         """Stop the timers."""
         assert self.started_, "timer is not started."
-        paddle.device.cuda.synchronize()
+        paddle.device.synchronize()
         self.elapsed_ += time.time() - self.start_time
         self.started_ = False
 


### PR DESCRIPTION


<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
 Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
统一使用paddle.device.synchronize()作为同步方法

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否