### PR TITLE
[Security] Fix RCE vulnerability in RestrictedUnpickler MRO check

### DIFF
--- a/python/paddle/framework/restricted_unpickler.py
+++ b/python/paddle/framework/restricted_unpickler.py
@@ -143,8 +143,14 @@ def _is_safe_class(cls) -> bool:
         '__setstate__',
     }
     for method in dangerous_methods:
-        if method in cls_dict:
-            return False
+        # Check each class in the MRO for dangerous method definitions
+        for base in cls.__mro__:
+            # Skip object - its default __reduce__ is safe for user-defined classes
+            if base is object:
+                continue
+            # Check if this base class defines the dangerous method
+            if method in getattr(base, '__dict__', {}):
+                return False
 
     return True
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Security

### Description
<!-- Describe what you’ve done -->
Fix RCE vulnerability in RestrictedUnpickler by checking full MRO for dangerous methods.
The _is_safe_class() function only checked the class's own __dict__ for dangerous magic methods (__reduce__, __reduce_ex__, __getstate__, __setstate__). It did NOT check the method resolution order (MRO), allowing classes that inherit these methods from parent classes to bypass the safety check.

This fix checks all classes in the MRO (except object, whose default __reduce__ is safe for user-defined classes) for dangerous method definitions.


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否