### PR TITLE
[Operator Mechanism] Fix XPU fused_matmul_bias trans_y dimensions

### DIFF
--- a/paddle/phi/kernels/funcs/fused_gemm_epilogue_xpu.h
+++ b/paddle/phi/kernels/funcs/fused_gemm_epilogue_xpu.h
@@ -87,7 +87,8 @@ void ComputeFusedGemmEpilogueBackwardXPU(const XPUContext& dev_ctx,
       common::flatten_to_2d(x->dims(), trans_x ? 1 : x->dims().size() - 1);
   phi::XpuFcInfo info_forward;
   // Preserve Y's physical shape so trans_y is applied exactly once.
-  phi::GetFCInfo(x_mat_dims, y->dims(), trans_x, trans_y, &info_forward);
+  auto y_mat_dims = y == nullptr ? make_ddim({K, N}) : y->dims();
+  phi::GetFCInfo(x_mat_dims, y_mat_dims, trans_x, trans_y, &info_forward);
 
   // 2. fc_grad
   const XPUType* a_1 = reinterpret_cast<const XPUType*>(NULL);

--- a/paddle/phi/kernels/funcs/fused_gemm_epilogue_xpu.h
+++ b/paddle/phi/kernels/funcs/fused_gemm_epilogue_xpu.h
@@ -86,8 +86,8 @@ void ComputeFusedGemmEpilogueBackwardXPU(const XPUContext& dev_ctx,
   auto x_mat_dims =
       common::flatten_to_2d(x->dims(), trans_x ? 1 : x->dims().size() - 1);
   phi::XpuFcInfo info_forward;
-  phi::GetFCInfo(
-      x_mat_dims, make_ddim({K, N}), trans_x, trans_y, &info_forward);
+  // Preserve Y's physical shape so trans_y is applied exactly once.
+  phi::GetFCInfo(x_mat_dims, y->dims(), trans_x, trans_y, &info_forward);
 
   // 2. fc_grad
   const XPUType* a_1 = reinterpret_cast<const XPUType*>(NULL);

--- a/paddle/phi/kernels/fusion/xpu/fused_gemm_epilogue_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fused_gemm_epilogue_kernel.cc
@@ -70,8 +70,10 @@ void FusedGemmEpilogueKernel(const Context& dev_ctx,
   fc_info.bias = bias_ptr;
   auto mat_x_dims =
       common::flatten_to_2d(x.dims(), trans_x ? 1 : x.dims().size() - 1);
-  auto mat_y_dims = y.dims();
-  phi::GetFCInfo(mat_x_dims, mat_y_dims, trans_x, trans_y, &fc_info);
+  int64_t m = trans_x ? mat_x_dims[1] : mat_x_dims[0];
+  int64_t n = trans_y ? y.dims()[0] : y.dims()[1];
+  int64_t k = trans_y ? y.dims()[1] : y.dims()[0];
+  fc_info.InitFcInfo(1, m, n, k, trans_x, trans_y, nullptr, nullptr, nullptr);
   int batch_size = fc_info.bs;
   PADDLE_ENFORCE_LE(
       batch_size,


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
#### paddle.incubate.nn.functional.fused_matmul_bias

This fixes XPU fused GEMM epilogue dimension handling for cases with bias and transposed Y. The forward path now derives M/N/K consistently with GPU behavior, avoiding invalid shape validation before fused FC execution. The backward helper now preserves Y's physical tensor shape when reconstructing FC info so `trans_y` is applied once with the correct layout.

Verification:
- `/build-paddle-xpu /workspace/paddle-4` succeeded.
- `/check-paddle-api-accuracy paddle.incubate.nn.functional.fused_matmul_bias` passed all 16 configs from `/workspace/PaddleAPITest/all_config.txt`.

### 是否引起精度变化
否. This corrects XPU precision/error behavior to align with GPU and does not change GPU precision.