### PR TITLE
[Operator Mechanism] Fix float16/bfloat16 backward support for paddle.Tensor.sin on XPU

### DIFF
--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -558,7 +558,7 @@ XPUOpMap& get_kl2_ops() {
       {"where_grad", XPUKernelSet({INT32, INT64, FLOAT16, FLOAT32})},
       {"where", XPUKernelSet({INT32, INT64, FLOAT32, FLOAT16, BFLOAT16})},
       {"sin", XPUKernelSet({FLOAT32, FLOAT16})},
-      {"sin_grad", XPUKernelSet({FLOAT32})},
+      {"sin_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"cos", XPUKernelSet({FLOAT32, FLOAT16})},
       {"cos_grad", XPUKernelSet({FLOAT32})},
       {"linspace", XPUKernelSet({FLOAT32, INT32, INT64})},

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -993,7 +993,7 @@ XPUOpMap& get_kl3_ops() {
       {"where",
        XPUKernelSet({INT32, INT64, FLOAT64, FLOAT32, FLOAT16, BFLOAT16})},
       {"sin", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
-      {"sin_grad", XPUKernelSet({FLOAT32})},
+      {"sin_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"cos", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"cos_grad", XPUKernelSet({FLOAT32})},
       {"linspace",

--- a/paddle/phi/kernels/xpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_grad_kernel.cc
@@ -18,6 +18,8 @@ limitations under the License. */
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/activation_functor.h"
 
+#include <type_traits>
+
 namespace phi {
 
 template <typename T, typename Context, typename Functor>
@@ -601,12 +603,40 @@ struct XPUSinGradFunctor : public funcs::BaseActivationFunctor<T> {
     auto dout_data = dout->data<T>();
     auto x_data = x->data<T>();
 
-    int r = xpu::sin_grad<T>(dev_ctx.x_context(),
-                             reinterpret_cast<const XPUType*>(x_data),
-                             reinterpret_cast<const XPUType*>(dout_data),
-                             reinterpret_cast<XPUType*>(dx_data),
-                             len);
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "sin_grad");
+    if constexpr (std::is_same<T, phi::bfloat16>::value) {
+      // Backend sin_grad does not provide bfloat16; use float temporaries.
+      xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+      float* x_float = RAII_GUARD.alloc_l3_or_gm<float>(len);
+      float* dout_float = RAII_GUARD.alloc_l3_or_gm<float>(len);
+      float* dx_float = RAII_GUARD.alloc_l3_or_gm<float>(len);
+      PADDLE_ENFORCE_XDNN_NOT_NULL(x_float);
+      PADDLE_ENFORCE_XDNN_NOT_NULL(dout_float);
+      PADDLE_ENFORCE_XDNN_NOT_NULL(dx_float);
+
+      int r = xpu::cast<XPUType, float>(
+          dev_ctx.x_context(), reinterpret_cast<const XPUType*>(x_data), x_float, len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+      r = xpu::cast<XPUType, float>(dev_ctx.x_context(),
+                                    reinterpret_cast<const XPUType*>(dout_data),
+                                    dout_float,
+                                    len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+      r = xpu::sin_grad<float>(
+          dev_ctx.x_context(), x_float, dout_float, dx_float, len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "sin_grad");
+      r = xpu::cast<float, XPUType>(dev_ctx.x_context(),
+                                    dx_float,
+                                    reinterpret_cast<XPUType*>(dx_data),
+                                    len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+    } else {
+      int r = xpu::sin_grad<XPUType>(dev_ctx.x_context(),
+                                     reinterpret_cast<const XPUType*>(x_data),
+                                     reinterpret_cast<const XPUType*>(dout_data),
+                                     reinterpret_cast<XPUType*>(dx_data),
+                                     len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "sin_grad");
+    }
   }
 };
 
@@ -852,5 +882,11 @@ PD_REGISTER_ACTIVATION_GRAD_KERNEL(reciprocal_grad, ReciprocalGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(relu6_grad, Relu6GradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(mish_grad, MishGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(softplus_grad, SoftplusGradKernel)
-PD_REGISTER_ACTIVATION_GRAD_KERNEL(sin_grad, SinGradKernel)
+PD_REGISTER_KERNEL(sin_grad,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::SinGradKernel,
+                   float,
+                   phi::float16,
+                   phi::bfloat16) {}
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(cos_grad, CosGradKernel)

--- a/paddle/phi/kernels/xpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_grad_kernel.cc
@@ -14,11 +14,11 @@ limitations under the License. */
 
 #include "paddle/phi/kernels/activation_grad_kernel.h"
 
+#include <type_traits>
+
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/activation_functor.h"
-
-#include <type_traits>
 
 namespace phi {
 
@@ -613,8 +613,11 @@ struct XPUSinGradFunctor : public funcs::BaseActivationFunctor<T> {
       PADDLE_ENFORCE_XDNN_NOT_NULL(dout_float);
       PADDLE_ENFORCE_XDNN_NOT_NULL(dx_float);
 
-      int r = xpu::cast<XPUType, float>(
-          dev_ctx.x_context(), reinterpret_cast<const XPUType*>(x_data), x_float, len);
+      int r =
+          xpu::cast<XPUType, float>(dev_ctx.x_context(),
+                                    reinterpret_cast<const XPUType*>(x_data),
+                                    x_float,
+                                    len);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
       r = xpu::cast<XPUType, float>(dev_ctx.x_context(),
                                     reinterpret_cast<const XPUType*>(dout_data),
@@ -630,11 +633,12 @@ struct XPUSinGradFunctor : public funcs::BaseActivationFunctor<T> {
                                     len);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
     } else {
-      int r = xpu::sin_grad<XPUType>(dev_ctx.x_context(),
-                                     reinterpret_cast<const XPUType*>(x_data),
-                                     reinterpret_cast<const XPUType*>(dout_data),
-                                     reinterpret_cast<XPUType*>(dx_data),
-                                     len);
+      int r =
+          xpu::sin_grad<XPUType>(dev_ctx.x_context(),
+                                 reinterpret_cast<const XPUType*>(x_data),
+                                 reinterpret_cast<const XPUType*>(dout_data),
+                                 reinterpret_cast<XPUType*>(dx_data),
+                                 len);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "sin_grad");
     }
   }


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
#### paddle.Tensor.sin
Fix XPU `sin_grad` dtype support so `paddle.Tensor.sin` backward tests run on float16 and bfloat16 inputs. The change registers XPU `sin_grad` for float16/bfloat16, updates XPU op support lists, and uses float temporaries for bfloat16 because the XPU backend does not provide a native `sin_grad<bfloat16>` symbol.

Verification:
- Built and installed Paddle XPU wheel: `/workspace/paddle-4/build/python/dist/paddlepaddle_xpu-3.5.0.dev20260516-cp310-cp310-linux_x86_64.whl`
- Ran all `paddle.Tensor.sin` cases from `/workspace/PaddleAPITest/all_config.txt`: 279 passed, 0 failed
- Ran `prek run --from-ref origin/develop --to-ref HEAD`: passed

### 是否引起精度变化
否