### PR TITLE
[XPU] Fix eig complex cast error

### DIFF
--- a/paddle/fluid/framework/data_type_transform.cc
+++ b/paddle/fluid/framework/data_type_transform.cc
@@ -215,10 +215,13 @@ struct CastDataType {
 #endif
 #if defined(PADDLE_WITH_XPU)
     } else if (phi::is_xpu_place(in_.place())) {
+      auto* context = static_cast<const phi::XPUContext*>(ctx_);
       if (in_.dtype() == DataType::COMPLEX64 &&
           out_->dtype() == DataType::FLOAT32) {
-        auto* context = static_cast<const phi::XPUContext*>(ctx_);
         phi::RealKernel<phi::dtype::complex<float>>(*context, in_, out_);
+      } else if (in_.dtype() == DataType::COMPLEX128 &&
+                 out_->dtype() == DataType::FLOAT64) {
+        phi::RealKernel<phi::dtype::complex<double>>(*context, in_, out_);
       } else {
         PADDLE_THROW(common::errors::Unimplemented(
             "Place type is not supported when casting data type from %s to %s.",

--- a/paddle/phi/core/framework/data_type_transform.cc
+++ b/paddle/phi/core/framework/data_type_transform.cc
@@ -80,7 +80,7 @@ static void XPUComplexTransDataType(
     const phi::DeviceContext* ctx) {
   auto* context = static_cast<const phi::XPUContext*>(ctx);
   if (dst_type == proto::VarType::FP32 || dst_type == proto::VarType::FP64) {
-    // Match generic complex-to-real cast semantics via existing XPU real extraction.
+    // Mirror complex-to-real casts using existing XPU real extraction.
     DenseTensor real = phi::Real<InType>(*context, in);
     TransDataType(real, dst_type, out);
   } else {

--- a/paddle/phi/core/framework/data_type_transform.cc
+++ b/paddle/phi/core/framework/data_type_transform.cc
@@ -21,6 +21,9 @@
 
 #if defined(PADDLE_WITH_XPU)
 #include "paddle/phi/core/platform/device/device_wrapper.h"
+#ifdef PADDLE_WITH_XPU_FFT
+#include "paddle/phi/kernels/complex_kernel.h"
+#endif
 #endif
 
 namespace proto = paddle::framework::proto;
@@ -67,6 +70,26 @@ static void XPUCastData(const DenseTensor& in,
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
   dev_ctx->Wait();
 }
+
+#ifdef PADDLE_WITH_XPU_FFT
+template <typename InType>
+static void XPUComplexTransDataType(
+    const DenseTensor& in,
+    DenseTensor* out,
+    const paddle::framework::proto::VarType::Type& dst_type,
+    const phi::DeviceContext* ctx) {
+  auto* context = static_cast<const phi::XPUContext*>(ctx);
+  if (dst_type == proto::VarType::FP32 || dst_type == proto::VarType::FP64) {
+    // Match generic complex-to-real cast semantics via existing XPU real extraction.
+    DenseTensor real = phi::Real<InType>(*context, in);
+    TransDataType(real, dst_type, out);
+  } else {
+    PADDLE_THROW(common::errors::Unimplemented(
+        "Data type (%s) is not supported in XPU when casting data type.",
+        VarDataTypeToString(dst_type)));
+  }
+}
+#endif
 
 template <typename InType>
 static void XPUTransDataType(
@@ -199,6 +222,14 @@ void TransDataType(const DenseTensor& in,
       case proto::VarType::INT64:
         XPUTransDataType<int64_t>(in, out, dst_type, ctx);
         break;
+#ifdef PADDLE_WITH_XPU_FFT
+      case proto::VarType::COMPLEX64:
+        XPUComplexTransDataType<phi::complex64>(in, out, dst_type, ctx);
+        break;
+      case proto::VarType::COMPLEX128:
+        XPUComplexTransDataType<phi::complex128>(in, out, dst_type, ctx);
+        break;
+#endif
       default:
         PADDLE_THROW(common::errors::Unimplemented(
             "Data type (%s) is not supported in XPU when casting data type.",


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes an XPU data type transform error hit by `paddle.linalg.eig` float64 backward cases. The backward path needs to cast complex128 gradients to float64 on XPU, but the existing XPU transform path only handled complex64 to float32 and raised an unimplemented place error for complex128 to float64.

The change extends XPU complex-to-real data transforms to use existing XPU real extraction for complex128 to float64, and adds the corresponding handling in the phi transform path.

Verified with all `paddle.linalg.eig` cases from `/workspace/PaddleAPITest/all_config.txt`. The reported float64 case and other supported float32/float64/complex64 cases pass. The complex128 cases are skipped by PaddleAPITest because XPU has no registered complex128 eig kernel.

### Does this PR introduce a precision change?
No