### PR TITLE
[XPU] Fix masked_fill value gradient

### DIFF
--- a/paddle/phi/kernels/xpu/masked_fill_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/masked_fill_grad_kernel.cc
@@ -21,6 +21,7 @@
 #include "paddle/phi/kernels/expand_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/common_infer_shape_functions.h"
+#include "paddle/phi/kernels/where_kernel.h"
 
 namespace phi {
 
@@ -129,6 +130,14 @@ void MaskedFillGradKernel(const Context& dev_ctx,
       reinterpret_cast<XPUType*>(dy_ptr),
       len);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "masked_fill_grad");
+
+  if (value_grad_tmp) {
+    DenseTensor zero_tensor;
+    Full<T, Context>(dev_ctx, expanded_dims, 0, &zero_tensor);
+    // Ensure only true-mask elements contribute to reduced value gradients.
+    WhereKernel<T, Context>(
+        dev_ctx, mask_expand, out_grad, zero_tensor, value_grad_tmp);
+  }
 
   if (x_grad && expand_x) {
     ExpandGradKernel<T, Context>(


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes the XPU backward path of `paddle.masked_fill` when `value` is a Tensor. The previous XPU value-gradient path could let false-mask positions contribute to the reduced `value_grad`, which caused XPU vs GPU accuracy mismatches in scalar and broadcasted value-gradient cases.

The XPU kernel now explicitly computes the temporary value gradient as `where(mask, out_grad, 0)` before reduction, aligning the behavior with the GPU implementation while keeping interfaces unchanged.

Verified all 33 `paddle.masked_fill` cases from `/workspace/PaddleAPITest/all_config.txt` pass XPU vs GPU accuracy checks.

### 是否引起精度变化
否. This corrects XPU `masked_fill` backward results to match GPU behavior and does not change GPU precision.