### PR TITLE
[Bug Fix][XPU] Fix logical_or complex promotion

### DIFF
--- a/paddle/phi/kernels/xpu/cast_kernel.cc
+++ b/paddle/phi/kernels/xpu/cast_kernel.cc
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/cast_kernel.h"
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
@@ -31,6 +32,29 @@ static DenseTensor Fill(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(&ret);
   funcs::SetConstant<Context, T>()(dev_ctx, &ret, fill_value);
   return ret;
+}
+
+template <typename ComplexT>
+void CastComplexToBool(const XPUContext& dev_ctx,
+                       const DenseTensor& x,
+                       DenseTensor* out) {
+  using RealT = phi::dtype::Real<ComplexT>;
+  DenseTensor real = Real<ComplexT, XPUContext>(dev_ctx, x);
+  DenseTensor imag = Imag<ComplexT, XPUContext>(dev_ctx, x);
+  DenseTensor real_bool =
+      Cast<RealT, XPUContext>(dev_ctx, real, DataType::BOOL);
+  DenseTensor imag_bool =
+      Cast<RealT, XPUContext>(dev_ctx, imag, DataType::BOOL);
+  dev_ctx.template Alloc<bool>(out);
+  if (out->numel() == 0) {
+    return;
+  }
+  int r = xpu::logical_or<bool, bool>(dev_ctx.x_context(),
+                                      real_bool.data<bool>(),
+                                      imag_bool.data<bool>(),
+                                      out->data<bool>(),
+                                      out->numel());
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "logical_or");
 }
 #endif
 
@@ -136,16 +160,30 @@ void CastKernel(const Context& dev_ctx,
 #ifdef PADDLE_WITH_XPU_FFT
     case DataType::COMPLEX64: {
       if (x.numel() == 0) {
-        dev_ctx.template Alloc<T>(out);
+        dev_ctx.template Alloc<phi::complex64>(out);
         return;
       }
       DenseTensor real;
       real.Resize(x.dims());
       CastXPUKernelImpl<T, float, Context>(dev_ctx, x, &real);
-      dev_ctx.template Alloc<T>(out);
+      dev_ctx.template Alloc<phi::complex64>(out);
       DenseTensor imag = Fill<float, Context>(
           dev_ctx, vectorize<int>(x.dims()), static_cast<float>(0.0));
       phi::ComplexKernel<float>(dev_ctx, real, imag, out);
+      break;
+    }
+    case DataType::COMPLEX128: {
+      if (x.numel() == 0) {
+        dev_ctx.template Alloc<phi::complex128>(out);
+        return;
+      }
+      DenseTensor real;
+      real.Resize(x.dims());
+      CastXPUKernelImpl<T, double, Context>(dev_ctx, x, &real);
+      dev_ctx.template Alloc<phi::complex128>(out);
+      DenseTensor imag = Fill<double, Context>(
+          dev_ctx, vectorize<int>(x.dims()), static_cast<double>(0.0));
+      phi::ComplexKernel<double>(dev_ctx, real, imag, out);
       break;
     }
 #endif
@@ -171,8 +209,47 @@ void CastKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
     }
     return;
   }
+  if (out_dtype == DataType::BOOL) {
+    CastComplexToBool<T>(dev_ctx, x, out);
+    return;
+  }
   DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+  DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
+  if (out_dtype == DataType::COMPLEX128) {
+    DenseTensor real, imag;
+    real.Resize(x.dims());
+    imag.Resize(x.dims());
+    CastXPUKernelImpl<float, double, XPUContext>(dev_ctx, x_real, &real);
+    CastXPUKernelImpl<float, double, XPUContext>(dev_ctx, x_imag, &imag);
+    dev_ctx.template Alloc<phi::complex128>(out);
+    phi::ComplexKernel<double>(dev_ctx, real, imag, out);
+    return;
+  }
   CastKernel<float, XPUContext>(dev_ctx, x_real, out_dtype, out);
+}
+
+template <>
+void CastKernel<phi::complex128, XPUContext>(const XPUContext& dev_ctx,
+                                             const DenseTensor& x,
+                                             DataType out_dtype,
+                                             DenseTensor* out) {
+  using T = phi::complex128;
+  if (x.dtype() == out_dtype) {
+    if (x.dims() == make_ddim({-1})) {
+      *out = x;
+      return;
+    }
+    if (!out->IsSharedWith(x)) {
+      Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+  if (out_dtype == DataType::BOOL) {
+    CastComplexToBool<T>(dev_ctx, x, out);
+    return;
+  }
+  DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+  CastKernel<double, XPUContext>(dev_ctx, x_real, out_dtype, out);
 }
 #endif
 }  // namespace phi
@@ -188,6 +265,7 @@ PD_REGISTER_KERNEL(cast,
                    phi::bfloat16,
 #ifdef PADDLE_WITH_XPU_FFT
                    phi::complex64,
+                   phi::complex128,
 #endif
                    int64_t,
                    bool,

--- a/paddle/phi/kernels/xpu/logical_kernel.cc
+++ b/paddle/phi/kernels/xpu/logical_kernel.cc
@@ -15,7 +15,10 @@
 #include "paddle/phi/kernels/logical_kernel.h"
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/cast_kernel.h"
+#include "paddle/phi/kernels/complex_kernel.h"
 
 namespace phi {
 
@@ -161,6 +164,56 @@ void LogicalOrKernel(const Context& dev_ctx,
       dev_ctx, x, y, out, xpu::logical_or<XPUType, XPUType>, "logical_or");
 }
 
+#ifdef PADDLE_WITH_XPU_FFT
+template <typename ComplexT>
+DenseTensor ComplexToBoolForLogicalOr(const XPUContext& dev_ctx,
+                                      const DenseTensor& x) {
+  using RealT = phi::dtype::Real<ComplexT>;
+  DenseTensor real = Real<ComplexT, XPUContext>(dev_ctx, x);
+  DenseTensor imag = Imag<ComplexT, XPUContext>(dev_ctx, x);
+  DenseTensor real_bool =
+      Cast<RealT, XPUContext>(dev_ctx, real, DataType::BOOL);
+  DenseTensor imag_bool =
+      Cast<RealT, XPUContext>(dev_ctx, imag, DataType::BOOL);
+  DenseTensor out;
+  out.Resize(x.dims());
+  LogicalBinaryKernel<bool, bool>(dev_ctx,
+                                  real_bool,
+                                  imag_bool,
+                                  &out,
+                                  xpu::logical_or<bool, bool>,
+                                  "logical_or");
+  return out;
+}
+
+template <typename ComplexT>
+void LogicalOrComplexKernel(const XPUContext& dev_ctx,
+                            const DenseTensor& x,
+                            const DenseTensor& y,
+                            DenseTensor* out) {
+  DenseTensor x_bool = ComplexToBoolForLogicalOr<ComplexT>(dev_ctx, x);
+  DenseTensor y_bool = ComplexToBoolForLogicalOr<ComplexT>(dev_ctx, y);
+  LogicalBinaryKernel<bool, bool>(
+      dev_ctx, x_bool, y_bool, out, xpu::logical_or<bool, bool>, "logical_or");
+}
+
+template <>
+void LogicalOrKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
+                                                 const DenseTensor& x,
+                                                 const DenseTensor& y,
+                                                 DenseTensor* out) {
+  LogicalOrComplexKernel<phi::complex64>(dev_ctx, x, y, out);
+}
+
+template <>
+void LogicalOrKernel<phi::complex128, XPUContext>(const XPUContext& dev_ctx,
+                                                  const DenseTensor& x,
+                                                  const DenseTensor& y,
+                                                  DenseTensor* out) {
+  LogicalOrComplexKernel<phi::complex128>(dev_ctx, x, y, out);
+}
+#endif
+
 template <typename T, typename Context>
 void LogicalXorKernel(const Context& dev_ctx,
                       const DenseTensor& x,
@@ -174,5 +227,24 @@ void LogicalXorKernel(const Context& dev_ctx,
 
 PD_REGISTER_KERNEL(logical_not, XPU, ALL_LAYOUT, phi::LogicalNotKernel, bool) {}
 PD_REGISTER_KERNEL(logical_and, XPU, ALL_LAYOUT, phi::LogicalAndKernel, bool) {}
-PD_REGISTER_KERNEL(logical_or, XPU, ALL_LAYOUT, phi::LogicalOrKernel, bool) {}
+PD_REGISTER_KERNEL(logical_or,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::LogicalOrKernel,
+                   bool
+#ifdef PADDLE_WITH_XPU_FFT
+                   ,
+                   phi::complex64,
+                   phi::complex128
+#endif
+) {
+#ifdef PADDLE_WITH_XPU_FFT
+  if (kernel_key.dtype() == phi::DataType::COMPLEX64 ||
+      kernel_key.dtype() == phi::DataType::COMPLEX128) {
+    kernel->InputAt(0).SetDataType(kernel_key.dtype());
+    kernel->InputAt(1).SetDataType(kernel_key.dtype());
+  }
+#endif
+  kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
+}
 PD_REGISTER_KERNEL(logical_xor, XPU, ALL_LAYOUT, phi::LogicalXorKernel, bool) {}


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes XPU runtime errors in `paddle.logical_or` when eager type promotion selects complex dtypes, especially mixed `complex64` and `float64` inputs that promote to `complex128`.

#### paddle.logical_or
- Adds XPU `logical_or` support for `complex64` and `complex128` by converting complex inputs to bool truthiness before invoking the bool logical path.
- Adds the XPU cast paths needed by promoted complex inputs, including real-to-`complex128`, `complex64`-to-`complex128`, and complex-to-bool truthiness casts.
- Keeps the changes scoped to XPU kernels and preserves CPU/GPU behavior.

Verified the two reported mixed `complex64`/`float64` XPU cases pass against GPU with zero diff. PaddleAPITest still skips explicit `complex128` comparison cases before execution, but direct Paddle XPU runtime checks for those complex128 combinations run successfully and return bool XPU tensors.

### 是否引起精度变化
否. The change fixes XPU logical truthiness handling to align with existing GPU behavior and does not change GPU precision.