### PR TITLE
[XPU] Fix index_select crash in backward

### DIFF
--- a/paddle/phi/kernels/xpu/index_select_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_select_grad_kernel.cc
@@ -15,10 +15,125 @@
 #include "paddle/phi/kernels/index_select_grad_kernel.h"
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/utils/data_type.h"
 #include "paddle/phi/kernels/full_kernel.h"
+
+#include <algorithm>
+#include <type_traits>
+#include <vector>
 namespace phi {
+
+template <typename Context, typename IndexT>
+void ValidateIndexSelectGradIndex(const Context& dev_ctx,
+                                  const DenseTensor& index,
+                                  int64_t axis_dim) {
+  const IndexT* index_data = nullptr;
+  std::vector<IndexT> index_cpu_data;
+  if (index.place().GetType() == AllocationType::CPU) {
+    index_data = index.data<IndexT>();
+  } else {
+    index_cpu_data.resize(index.numel());
+    memory_utils::Copy(CPUPlace(),
+                       index_cpu_data.data(),
+                       dev_ctx.GetPlace(),
+                       index.data<IndexT>(),
+                       sizeof(IndexT) * index.numel());
+    index_data = index_cpu_data.data();
+  }
+
+  for (int64_t i = 0; i < index.numel(); ++i) {
+    PADDLE_ENFORCE_GE(
+        index_data[i],
+        -axis_dim,
+        common::errors::InvalidArgument(
+            "Variable value (index) of OP(index_select) "
+            "expected >= %ld and < %ld, but got %ld. Please check input "
+            "value.",
+            -axis_dim,
+            axis_dim,
+            static_cast<int64_t>(index_data[i])));
+    PADDLE_ENFORCE_LT(
+        index_data[i],
+        axis_dim,
+        common::errors::InvalidArgument(
+            "Variable value (index) of OP(index_select) "
+            "expected >= %ld and < %ld, but got %ld. Please check input "
+            "value.",
+            -axis_dim,
+            axis_dim,
+            static_cast<int64_t>(index_data[i])));
+  }
+}
+
+template <typename T, typename Context, typename IndexT>
+void IndexSelectGradFallback(const Context& dev_ctx,
+                             const DenseTensor& index,
+                             const DenseTensor& out_grad,
+                             int dim,
+                             DenseTensor* x_grad) {
+  ValidateIndexSelectGradIndex<Context, IndexT>(
+      dev_ctx, index, x_grad->dims()[dim]);
+
+  std::vector<T> out_grad_cpu(out_grad.numel());
+  memory_utils::Copy(CPUPlace(),
+                     out_grad_cpu.data(),
+                     out_grad.place(),
+                     out_grad.data<T>(),
+                     sizeof(T) * out_grad.numel());
+
+  std::vector<IndexT> index_cpu(index.numel());
+  if (index.place().GetType() == AllocationType::CPU) {
+    std::copy(index.data<IndexT>(),
+              index.data<IndexT>() + index.numel(),
+              index_cpu.data());
+  } else {
+    memory_utils::Copy(CPUPlace(),
+                       index_cpu.data(),
+                       index.place(),
+                       index.data<IndexT>(),
+                       sizeof(IndexT) * index.numel());
+  }
+
+  std::vector<T> x_grad_cpu(x_grad->numel(), static_cast<T>(0));
+  const auto input_dim = out_grad.dims();
+  const auto output_dim = x_grad->dims();
+
+  int64_t slice_size = 1;
+  for (auto i = dim + 1; i < input_dim.size(); ++i) {
+    slice_size *= input_dim[i];
+  }
+  const int64_t input_width = slice_size * input_dim[dim];
+  const int64_t output_width = slice_size * output_dim[dim];
+  int64_t outer_nums = 1;
+  for (auto i = 0; i < dim; ++i) {
+    outer_nums *= input_dim[i];
+  }
+
+  for (int64_t i = 0; i < outer_nums; ++i) {
+    const int64_t input_start_offset = i * input_width;
+    const int64_t output_start_offset = i * output_width;
+    for (int64_t j = 0; j < index.numel(); ++j) {
+      IndexT index_value = index_cpu[j];
+      if (index_value < 0) {
+        index_value += output_dim[dim];
+      }
+      const T* src = out_grad_cpu.data() + input_start_offset + j * slice_size;
+      T* dst = x_grad_cpu.data() + output_start_offset + index_value * slice_size;
+      for (int64_t k = 0; k < slice_size; ++k) {
+        dst[k] = static_cast<T>(dst[k] + src[k]);
+      }
+    }
+  }
+
+  T* x_grad_data = dev_ctx.template Alloc<T>(x_grad);
+  memory_utils::Copy(dev_ctx.GetPlace(),
+                     x_grad_data,
+                     CPUPlace(),
+                     x_grad_cpu.data(),
+                     sizeof(T) * x_grad->numel());
+}
 
 template <typename T, typename Context>
 void IndexSelectGradKernel(const Context& dev_ctx,
@@ -27,7 +142,6 @@ void IndexSelectGradKernel(const Context& dev_ctx,
                            const DenseTensor& out_grad,
                            int dim,
                            DenseTensor* x_grad) {
-  using XPUType = typename XPUTypeTrait<T>::Type;
   if (out_grad.numel() == 0) {
     Full<T, Context>(dev_ctx, x.dims(), 0, x_grad);
     return;
@@ -47,37 +161,77 @@ void IndexSelectGradKernel(const Context& dev_ctx,
                         DataType::INT32,
                         DataType::INT64));
 
-  XPUType* x_grad_data =
-      reinterpret_cast<XPUType*>((dev_ctx.template Alloc<T>(x_grad)));
-  const XPUType* out_grad_data =
-      reinterpret_cast<const XPUType*>(out_grad.data<T>());
+  if constexpr (std::is_same<T, float>::value ||
+                std::is_same<T, phi::float16>::value ||
+                std::is_same<T, phi::bfloat16>::value) {
+    using XPUType = typename XPUTypeTrait<T>::Type;
+    XPUType* x_grad_data =
+        reinterpret_cast<XPUType*>((dev_ctx.template Alloc<T>(x_grad)));
+    const XPUType* out_grad_data =
+        reinterpret_cast<const XPUType*>(out_grad.data<T>());
 
-  auto out_grad_shape = vectorize<int64_t>(out_grad.dims());
-  auto x_grad_shape = vectorize<int64_t>(x_grad->dims());
+    auto out_grad_shape = vectorize<int64_t>(out_grad.dims());
+    auto x_grad_shape = vectorize<int64_t>(x_grad->dims());
 
-  int r = 0;
-  if (index_type == DataType::INT32) {
-    const int* index_data = index.data<int>();
-    r = xpu::index_select_grad<XPUType, int>(dev_ctx.x_context(),
-                                             nullptr,
-                                             index_data,
-                                             out_grad_data,
-                                             dim,
-                                             x_grad_data,
-                                             out_grad_shape,
-                                             x_grad_shape);
-  } else if (index_type == DataType::INT64) {
-    const int64_t* index_data = index.data<int64_t>();
-    r = xpu::index_select_grad<XPUType, int64_t>(dev_ctx.x_context(),
-                                                 nullptr,
-                                                 index_data,
-                                                 out_grad_data,
-                                                 dim,
-                                                 x_grad_data,
-                                                 out_grad_shape,
-                                                 x_grad_shape);
+    int r = 0;
+    xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+    int8_t* index_ptr = nullptr;
+    int byte_times = SizeOf(index_type);
+    if (index.place() == CPUPlace()) {
+      index_ptr = RAII_GUARD.alloc_l3_or_gm<int8_t>(byte_times * index.numel());
+      PADDLE_ENFORCE_XDNN_NOT_NULL(index_ptr);
+      const void* cpu_idx_data = nullptr;
+      if (index_type == DataType::INT64) {
+        cpu_idx_data = reinterpret_cast<const void*>(index.data<int64_t>());
+      } else if (index_type == DataType::INT32) {
+        cpu_idx_data = reinterpret_cast<const void*>(index.data<int>());
+      }
+      memory_utils::Copy(dev_ctx.GetPlace(),
+                         reinterpret_cast<void*>(index_ptr),
+                         CPUPlace(),
+                         cpu_idx_data,
+                         byte_times * index.numel());
+    }
+    if (index_type == DataType::INT32) {
+      // XDNN may crash on invalid indices, so match CPU validation first.
+      ValidateIndexSelectGradIndex<Context, int>(
+          dev_ctx, index, x_grad->dims()[dim]);
+      const int* index_data = index_ptr ? reinterpret_cast<const int*>(index_ptr)
+                                        : index.data<int>();
+      r = xpu::index_select_grad<XPUType, int>(dev_ctx.x_context(),
+                                               nullptr,
+                                               index_data,
+                                               out_grad_data,
+                                               dim,
+                                               x_grad_data,
+                                               out_grad_shape,
+                                               x_grad_shape);
+    } else if (index_type == DataType::INT64) {
+      // XDNN may crash on invalid indices, so match CPU validation first.
+      ValidateIndexSelectGradIndex<Context, int64_t>(
+          dev_ctx, index, x_grad->dims()[dim]);
+      const int64_t* index_data =
+          index_ptr ? reinterpret_cast<const int64_t*>(index_ptr)
+                    : index.data<int64_t>();
+      r = xpu::index_select_grad<XPUType, int64_t>(dev_ctx.x_context(),
+                                                   nullptr,
+                                                   index_data,
+                                                   out_grad_data,
+                                                   dim,
+                                                   x_grad_data,
+                                                   out_grad_shape,
+                                                   x_grad_shape);
+    }
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "index_select_grad");
+  } else {
+    if (index_type == DataType::INT32) {
+      IndexSelectGradFallback<T, Context, int>(
+          dev_ctx, index, out_grad, dim, x_grad);
+    } else if (index_type == DataType::INT64) {
+      IndexSelectGradFallback<T, Context, int64_t>(
+          dev_ctx, index, out_grad, dim, x_grad);
+    }
   }
-  PADDLE_ENFORCE_XDNN_SUCCESS(r, "index_select_grad");
 }
 
 }  // namespace phi
@@ -88,4 +242,7 @@ PD_REGISTER_KERNEL(index_select_grad,
                    phi::IndexSelectGradKernel,
                    float,
                    phi::float16,
-                   phi::bfloat16) {}
+                   phi::bfloat16,
+                   double,
+                   int,
+                   int64_t) {}

--- a/paddle/phi/kernels/xpu/index_select_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_select_grad_kernel.cc
@@ -14,15 +14,16 @@
 
 #include "paddle/phi/kernels/index_select_grad_kernel.h"
 
+#include <algorithm>
+#include <type_traits>
+#include <vector>
+
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/utils/data_type.h"
 #include "paddle/phi/kernels/full_kernel.h"
 
-#include <algorithm>
-#include <type_traits>
-#include <vector>
 namespace phi {
 
 template <typename Context, typename IndexT>
@@ -120,7 +121,8 @@ void IndexSelectGradFallback(const Context& dev_ctx,
         index_value += output_dim[dim];
       }
       const T* src = out_grad_cpu.data() + input_start_offset + j * slice_size;
-      T* dst = x_grad_cpu.data() + output_start_offset + index_value * slice_size;
+      T* dst =
+          x_grad_cpu.data() + output_start_offset + index_value * slice_size;
       for (int64_t k = 0; k < slice_size; ++k) {
         dst[k] = static_cast<T>(dst[k] + src[k]);
       }
@@ -196,8 +198,9 @@ void IndexSelectGradKernel(const Context& dev_ctx,
       // XDNN may crash on invalid indices, so match CPU validation first.
       ValidateIndexSelectGradIndex<Context, int>(
           dev_ctx, index, x_grad->dims()[dim]);
-      const int* index_data = index_ptr ? reinterpret_cast<const int*>(index_ptr)
-                                        : index.data<int>();
+      const int* index_data = index_ptr
+                                  ? reinterpret_cast<const int*>(index_ptr)
+                                  : index.data<int>();
       r = xpu::index_select_grad<XPUType, int>(dev_ctx.x_context(),
                                                nullptr,
                                                index_data,

--- a/paddle/phi/kernels/xpu/index_select_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_select_grad_kernel.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/kernels/index_select_grad_kernel.h"
 
-#include <algorithm>
 #include <type_traits>
 #include <vector>
 
@@ -27,26 +26,24 @@
 namespace phi {
 
 template <typename Context, typename IndexT>
-void ValidateIndexSelectGradIndex(const Context& dev_ctx,
-                                  const DenseTensor& index,
-                                  int64_t axis_dim) {
-  const IndexT* index_data = nullptr;
-  std::vector<IndexT> index_cpu_data;
+std::vector<IndexT> GetValidatedIndexSelectGradIndex(const Context& dev_ctx,
+                                                     const DenseTensor& index,
+                                                     int64_t axis_dim) {
+  std::vector<IndexT> index_cpu_data(index.numel());
   if (index.place().GetType() == AllocationType::CPU) {
-    index_data = index.data<IndexT>();
+    const IndexT* index_data = index.data<IndexT>();
+    index_cpu_data.assign(index_data, index_data + index.numel());
   } else {
-    index_cpu_data.resize(index.numel());
     memory_utils::Copy(CPUPlace(),
                        index_cpu_data.data(),
                        dev_ctx.GetPlace(),
                        index.data<IndexT>(),
                        sizeof(IndexT) * index.numel());
-    index_data = index_cpu_data.data();
   }
 
   for (int64_t i = 0; i < index.numel(); ++i) {
     PADDLE_ENFORCE_GE(
-        index_data[i],
+        index_cpu_data[i],
         -axis_dim,
         common::errors::InvalidArgument(
             "Variable value (index) of OP(index_select) "
@@ -54,9 +51,9 @@ void ValidateIndexSelectGradIndex(const Context& dev_ctx,
             "value.",
             -axis_dim,
             axis_dim,
-            static_cast<int64_t>(index_data[i])));
+            static_cast<int64_t>(index_cpu_data[i])));
     PADDLE_ENFORCE_LT(
-        index_data[i],
+        index_cpu_data[i],
         axis_dim,
         common::errors::InvalidArgument(
             "Variable value (index) of OP(index_select) "
@@ -64,8 +61,12 @@ void ValidateIndexSelectGradIndex(const Context& dev_ctx,
             "value.",
             -axis_dim,
             axis_dim,
-            static_cast<int64_t>(index_data[i])));
+            static_cast<int64_t>(index_cpu_data[i])));
+    if (index_cpu_data[i] < 0) {
+      index_cpu_data[i] += axis_dim;
+    }
   }
+  return index_cpu_data;
 }
 
 template <typename T, typename Context, typename IndexT>
@@ -74,7 +75,7 @@ void IndexSelectGradFallback(const Context& dev_ctx,
                              const DenseTensor& out_grad,
                              int dim,
                              DenseTensor* x_grad) {
-  ValidateIndexSelectGradIndex<Context, IndexT>(
+  auto index_cpu = GetValidatedIndexSelectGradIndex<Context, IndexT>(
       dev_ctx, index, x_grad->dims()[dim]);
 
   std::vector<T> out_grad_cpu(out_grad.numel());
@@ -83,19 +84,6 @@ void IndexSelectGradFallback(const Context& dev_ctx,
                      out_grad.place(),
                      out_grad.data<T>(),
                      sizeof(T) * out_grad.numel());
-
-  std::vector<IndexT> index_cpu(index.numel());
-  if (index.place().GetType() == AllocationType::CPU) {
-    std::copy(index.data<IndexT>(),
-              index.data<IndexT>() + index.numel(),
-              index_cpu.data());
-  } else {
-    memory_utils::Copy(CPUPlace(),
-                       index_cpu.data(),
-                       index.place(),
-                       index.data<IndexT>(),
-                       sizeof(IndexT) * index.numel());
-  }
 
   std::vector<T> x_grad_cpu(x_grad->numel(), static_cast<T>(0));
   const auto input_dim = out_grad.dims();
@@ -116,10 +104,7 @@ void IndexSelectGradFallback(const Context& dev_ctx,
     const int64_t input_start_offset = i * input_width;
     const int64_t output_start_offset = i * output_width;
     for (int64_t j = 0; j < index.numel(); ++j) {
-      IndexT index_value = index_cpu[j];
-      if (index_value < 0) {
-        index_value += output_dim[dim];
-      }
+      const IndexT index_value = index_cpu[j];
       const T* src = out_grad_cpu.data() + input_start_offset + j * slice_size;
       T* dst =
           x_grad_cpu.data() + output_start_offset + index_value * slice_size;
@@ -177,48 +162,39 @@ void IndexSelectGradKernel(const Context& dev_ctx,
 
     int r = 0;
     xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
-    int8_t* index_ptr = nullptr;
     int byte_times = SizeOf(index_type);
-    if (index.place() == CPUPlace()) {
-      index_ptr = RAII_GUARD.alloc_l3_or_gm<int8_t>(byte_times * index.numel());
-      PADDLE_ENFORCE_XDNN_NOT_NULL(index_ptr);
-      const void* cpu_idx_data = nullptr;
-      if (index_type == DataType::INT64) {
-        cpu_idx_data = reinterpret_cast<const void*>(index.data<int64_t>());
-      } else if (index_type == DataType::INT32) {
-        cpu_idx_data = reinterpret_cast<const void*>(index.data<int>());
-      }
-      memory_utils::Copy(dev_ctx.GetPlace(),
-                         reinterpret_cast<void*>(index_ptr),
-                         CPUPlace(),
-                         cpu_idx_data,
-                         byte_times * index.numel());
-    }
     if (index_type == DataType::INT32) {
-      // XDNN may crash on invalid indices, so match CPU validation first.
-      ValidateIndexSelectGradIndex<Context, int>(
+      auto index_cpu_data = GetValidatedIndexSelectGradIndex<Context, int>(
           dev_ctx, index, x_grad->dims()[dim]);
-      const int* index_data = index_ptr
-                                  ? reinterpret_cast<const int*>(index_ptr)
-                                  : index.data<int>();
+      int* index_ptr = RAII_GUARD.alloc_l3_or_gm<int>(index_cpu_data.size());
+      PADDLE_ENFORCE_XDNN_NOT_NULL(index_ptr);
+      memory_utils::Copy(dev_ctx.GetPlace(),
+                         index_ptr,
+                         CPUPlace(),
+                         index_cpu_data.data(),
+                         byte_times * index.numel());
       r = xpu::index_select_grad<XPUType, int>(dev_ctx.x_context(),
                                                nullptr,
-                                               index_data,
+                                               index_ptr,
                                                out_grad_data,
                                                dim,
                                                x_grad_data,
                                                out_grad_shape,
                                                x_grad_shape);
     } else if (index_type == DataType::INT64) {
-      // XDNN may crash on invalid indices, so match CPU validation first.
-      ValidateIndexSelectGradIndex<Context, int64_t>(
+      auto index_cpu_data = GetValidatedIndexSelectGradIndex<Context, int64_t>(
           dev_ctx, index, x_grad->dims()[dim]);
-      const int64_t* index_data =
-          index_ptr ? reinterpret_cast<const int64_t*>(index_ptr)
-                    : index.data<int64_t>();
+      int64_t* index_ptr =
+          RAII_GUARD.alloc_l3_or_gm<int64_t>(index_cpu_data.size());
+      PADDLE_ENFORCE_XDNN_NOT_NULL(index_ptr);
+      memory_utils::Copy(dev_ctx.GetPlace(),
+                         index_ptr,
+                         CPUPlace(),
+                         index_cpu_data.data(),
+                         byte_times * index.numel());
       r = xpu::index_select_grad<XPUType, int64_t>(dev_ctx.x_context(),
                                                    nullptr,
-                                                   index_data,
+                                                   index_ptr,
                                                    out_grad_data,
                                                    dim,
                                                    x_grad_data,

--- a/paddle/phi/kernels/xpu/index_select_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_select_kernel.cc
@@ -25,26 +25,24 @@
 namespace phi {
 
 template <typename Context, typename IndexT>
-void ValidateIndexSelectIndex(const Context& dev_ctx,
-                              const DenseTensor& index,
-                              int64_t axis_dim) {
-  const IndexT* index_data = nullptr;
-  std::vector<IndexT> index_cpu_data;
+std::vector<IndexT> GetValidatedIndexSelectIndex(const Context& dev_ctx,
+                                                 const DenseTensor& index,
+                                                 int64_t axis_dim) {
+  std::vector<IndexT> index_cpu_data(index.numel());
   if (index.place().GetType() == AllocationType::CPU) {
-    index_data = index.data<IndexT>();
+    const IndexT* index_data = index.data<IndexT>();
+    index_cpu_data.assign(index_data, index_data + index.numel());
   } else {
-    index_cpu_data.resize(index.numel());
     memory_utils::Copy(CPUPlace(),
                        index_cpu_data.data(),
                        dev_ctx.GetPlace(),
                        index.data<IndexT>(),
                        sizeof(IndexT) * index.numel());
-    index_data = index_cpu_data.data();
   }
 
   for (int64_t i = 0; i < index.numel(); ++i) {
     PADDLE_ENFORCE_GE(
-        index_data[i],
+        index_cpu_data[i],
         -axis_dim,
         common::errors::InvalidArgument(
             "Variable value (index) of OP(index_select) "
@@ -52,9 +50,9 @@ void ValidateIndexSelectIndex(const Context& dev_ctx,
             "value.",
             -axis_dim,
             axis_dim,
-            static_cast<int64_t>(index_data[i])));
+            static_cast<int64_t>(index_cpu_data[i])));
     PADDLE_ENFORCE_LT(
-        index_data[i],
+        index_cpu_data[i],
         axis_dim,
         common::errors::InvalidArgument(
             "Variable value (index) of OP(index_select) "
@@ -62,8 +60,12 @@ void ValidateIndexSelectIndex(const Context& dev_ctx,
             "value.",
             -axis_dim,
             axis_dim,
-            static_cast<int64_t>(index_data[i])));
+            static_cast<int64_t>(index_cpu_data[i])));
+    if (index_cpu_data[i] < 0) {
+      index_cpu_data[i] += axis_dim;
+    }
   }
+  return index_cpu_data;
 }
 
 template <typename T, typename Context>
@@ -106,46 +108,40 @@ void IndexSelectKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(output);
   int r = 0;
   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
-  int8_t* index_ptr = nullptr;  // temp xpu buffer
   int byte_times = SizeOf(index_type);
-  if (index.place() == CPUPlace()) {
-    index_ptr = RAII_GUARD.alloc_l3_or_gm<int8_t>(byte_times * index.numel());
-    PADDLE_ENFORCE_XDNN_NOT_NULL(index_ptr);
-    const void* cpu_idx_data = nullptr;
-    if (index_type == DataType::INT64) {
-      cpu_idx_data = reinterpret_cast<const void*>(index.data<int64_t>());
-    } else if (index_type == DataType::INT32) {
-      cpu_idx_data = reinterpret_cast<const void*>(index.data<int>());
-    }
-    memory_utils::Copy(dev_ctx.GetPlace(),
-                       reinterpret_cast<void*>(index_ptr),
-                       CPUPlace(),
-                       cpu_idx_data,
-                       byte_times * index.numel());
-  }
   if (index_type == DataType::INT64) {
-    // XDNN may crash on invalid indices, so match CPU validation first.
-    ValidateIndexSelectIndex<Context, int64_t>(dev_ctx, index, input_dim[dim]);
-    const int64_t* index_data =
-        index_ptr ? reinterpret_cast<const int64_t*>(index_ptr)
-                  : index.template data<int64_t>();
+    auto index_cpu_data = GetValidatedIndexSelectIndex<Context, int64_t>(
+        dev_ctx, index, input_dim[dim]);
+    int64_t* index_ptr =
+        RAII_GUARD.alloc_l3_or_gm<int64_t>(index_cpu_data.size());
+    PADDLE_ENFORCE_XDNN_NOT_NULL(index_ptr);
+    memory_utils::Copy(dev_ctx.GetPlace(),
+                       index_ptr,
+                       CPUPlace(),
+                       index_cpu_data.data(),
+                       byte_times * index.numel());
     r = xpu::index_select<XPUType, int64_t>(
         dev_ctx.x_context(),
         reinterpret_cast<const XPUType*>(in_data),
-        reinterpret_cast<const int64_t*>(index_data),
+        index_ptr,
         reinterpret_cast<XPUType*>(output->data<T>()),
         in_shape,
         index_len,
         dim);
   } else {
-    // XDNN may crash on invalid indices, so match CPU validation first.
-    ValidateIndexSelectIndex<Context, int>(dev_ctx, index, input_dim[dim]);
-    const int* index_data = index_ptr ? reinterpret_cast<const int*>(index_ptr)
-                                      : index.template data<int>();
+    auto index_cpu_data = GetValidatedIndexSelectIndex<Context, int>(
+        dev_ctx, index, input_dim[dim]);
+    int* index_ptr = RAII_GUARD.alloc_l3_or_gm<int>(index_cpu_data.size());
+    PADDLE_ENFORCE_XDNN_NOT_NULL(index_ptr);
+    memory_utils::Copy(dev_ctx.GetPlace(),
+                       index_ptr,
+                       CPUPlace(),
+                       index_cpu_data.data(),
+                       byte_times * index.numel());
     r = xpu::index_select<XPUType, int>(
         dev_ctx.x_context(),
         reinterpret_cast<const XPUType*>(in_data),
-        reinterpret_cast<const int*>(index_data),
+        index_ptr,
         reinterpret_cast<XPUType*>(output->data<T>()),
         in_shape,
         index_len,

--- a/paddle/phi/kernels/xpu/index_select_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_select_kernel.cc
@@ -14,13 +14,13 @@
 
 #include "paddle/phi/kernels/index_select_kernel.h"
 
+#include <type_traits>
+#include <vector>
+
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/utils/data_type.h"
-
-#include <type_traits>
-#include <vector>
 
 namespace phi {
 

--- a/paddle/phi/kernels/xpu/index_select_kernel.cc
+++ b/paddle/phi/kernels/xpu/index_select_kernel.cc
@@ -19,7 +19,52 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/utils/data_type.h"
 
+#include <type_traits>
+#include <vector>
+
 namespace phi {
+
+template <typename Context, typename IndexT>
+void ValidateIndexSelectIndex(const Context& dev_ctx,
+                              const DenseTensor& index,
+                              int64_t axis_dim) {
+  const IndexT* index_data = nullptr;
+  std::vector<IndexT> index_cpu_data;
+  if (index.place().GetType() == AllocationType::CPU) {
+    index_data = index.data<IndexT>();
+  } else {
+    index_cpu_data.resize(index.numel());
+    memory_utils::Copy(CPUPlace(),
+                       index_cpu_data.data(),
+                       dev_ctx.GetPlace(),
+                       index.data<IndexT>(),
+                       sizeof(IndexT) * index.numel());
+    index_data = index_cpu_data.data();
+  }
+
+  for (int64_t i = 0; i < index.numel(); ++i) {
+    PADDLE_ENFORCE_GE(
+        index_data[i],
+        -axis_dim,
+        common::errors::InvalidArgument(
+            "Variable value (index) of OP(index_select) "
+            "expected >= %ld and < %ld, but got %ld. Please check input "
+            "value.",
+            -axis_dim,
+            axis_dim,
+            static_cast<int64_t>(index_data[i])));
+    PADDLE_ENFORCE_LT(
+        index_data[i],
+        axis_dim,
+        common::errors::InvalidArgument(
+            "Variable value (index) of OP(index_select) "
+            "expected >= %ld and < %ld, but got %ld. Please check input "
+            "value.",
+            -axis_dim,
+            axis_dim,
+            static_cast<int64_t>(index_data[i])));
+  }
+}
 
 template <typename T, typename Context>
 void IndexSelectKernel(const Context& dev_ctx,
@@ -45,6 +90,15 @@ void IndexSelectKernel(const Context& dev_ctx,
                         index_type,
                         DataType::INT32,
                         DataType::INT64));
+  PADDLE_ENFORCE_EQ(
+      (std::is_same<T, float>::value || std::is_same<T, phi::float16>::value ||
+       std::is_same<T, phi::bfloat16>::value || std::is_same<T, int>::value ||
+       std::is_same<T, int64_t>::value),
+      true,
+      common::errors::Unimplemented(
+          "XPU index_select only supports float32, float16, bfloat16, int32 "
+          "and int64 input tensors for the XDNN kernel, but got %s.",
+          x.dtype()));
   using XPUType = typename XPUTypeTrait<T>::Type;
   auto* in_data = x.data<T>();
   std::vector<int64_t> in_shape = vectorize<int64_t>(input_dim);
@@ -70,6 +124,8 @@ void IndexSelectKernel(const Context& dev_ctx,
                        byte_times * index.numel());
   }
   if (index_type == DataType::INT64) {
+    // XDNN may crash on invalid indices, so match CPU validation first.
+    ValidateIndexSelectIndex<Context, int64_t>(dev_ctx, index, input_dim[dim]);
     const int64_t* index_data =
         index_ptr ? reinterpret_cast<const int64_t*>(index_ptr)
                   : index.template data<int64_t>();
@@ -82,6 +138,8 @@ void IndexSelectKernel(const Context& dev_ctx,
         index_len,
         dim);
   } else {
+    // XDNN may crash on invalid indices, so match CPU validation first.
+    ValidateIndexSelectIndex<Context, int>(dev_ctx, index, input_dim[dim]);
     const int* index_data = index_ptr ? reinterpret_cast<const int*>(index_ptr)
                                       : index.template data<int>();
     r = xpu::index_select<XPUType, int>(

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -1906,9 +1906,8 @@
   kernel :
     func : index_select_grad
     data_type : out_grad
+    backend : x
   no_need_buffer : x
-  data_transform :
-    skip_transform : index
   backward: index_select_double_grad
 
 - backward_op : index_select_strided_grad

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -2988,8 +2988,6 @@
     func : index_select
     data_type : x
   backward : index_select_grad
-  data_transform :
-    skip_transform : index
   interfaces : paddle::dialect::InferSymbolicShapeInterface, paddle::dialect::LayoutTransformationInterface
 
 - op : index_select_strided


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes XPU crashes in `paddle.index_select` forward/backward paths.

The original crash happened when `index_select_grad` fell back to the CPU kernel while tensors such as `index` were still on XPU, causing CPU code to dereference XPU memory. The fix updates dispatch so backend selection follows the original `x` tensor and allows index transformation when fallback is required.

The XPU kernels now validate index ranges before XDNN dispatch, normalize valid negative indices before passing them to XDNN, mirror safe CPU-place index staging in grad, and provide a safe fallback path for double/int/int64 grad dtypes that are not supported by XDNN `index_select_grad` templates.

Verified all 601 `paddle.index_select` cases from `/workspace/PaddleAPITest/all_config.txt` pass on XPU with no remaining crashes.

### 是否引起精度变化
否