### PR TITLE
[XPU] Fix logical_and mixed complex inputs

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -202,6 +202,24 @@ PyObject * eager_api_{}(PyObject *self, PyObject *args, PyObject *kwargs) {{
 
 NOAMP_DYGRAPH_FUNCTION_TEMPLATE = "decltype({}({})) ad_func_out = {}({});"
 
+XPU_LOGICAL_AND_DYGRAPH_FUNCTION_TEMPLATE = """// Avoid unsupported XPU complex128 promotion for bool-only logical_and.
+    if (phi::is_xpu_place(place) &&
+        ({x}.dtype() != phi::DataType::BOOL || {y}.dtype() != phi::DataType::BOOL)) {{
+      auto bool_{x} = {x}.dtype() == phi::DataType::BOOL
+                        ? {x}
+                        : paddle::experimental::cast({x}, phi::DataType::BOOL);
+      auto bool_{y} = {y}.dtype() == phi::DataType::BOOL
+                        ? {y}
+                        : paddle::experimental::cast({y}, phi::DataType::BOOL);
+      decltype({function_name}({bool_args})) ad_func_out =
+          {function_name}({bool_args});
+      PyEval_RestoreThread(tstate);
+      tstate = nullptr;
+      {return_str}
+    }}
+
+    {default_call}"""
+
 
 FUNCTION_SET_DEVICE_TEMPLATE = """{}
     SetPythonStack();
@@ -243,6 +261,7 @@ PYTHON_C_FUNCTION_REG_TEMPLATE = '  {{"{}{}", (PyCFunction)(void(*)(void)) {}eag
 PYTHON_C_WRAPPER_TEMPLATE = """
 #include <Python.h>
 #include "paddle/fluid/platform/enforce.h"
+#include "paddle/phi/api/include/api.h"
 #include "paddle/phi/api/include/strings_api.h"
 #include "paddle/phi/backends/device_manager.h"
 #include "paddle/fluid/pybind/eager_utils.h"
@@ -854,6 +873,23 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             return_str += "    return ToPyObject(ad_func_out, args, kwargs, inplace_var_idx_map, inplace_var_name_map);"
         else:
             return_str = "    return ToPyObject(ad_func_out);"
+
+        if forward_api_name == "logical_and" and not inplace:
+            x = "x"
+            y = "y"
+            call_args = dygraph_function_call_str.split(",")
+            call_args[forward_inputs_position_map[x][1]] = f"bool_{x}"
+            call_args[forward_inputs_position_map[y][1]] = f"bool_{y}"
+            noamp_dygraph_function_str = (
+                XPU_LOGICAL_AND_DYGRAPH_FUNCTION_TEMPLATE.format(
+                    x=x,
+                    y=y,
+                    function_name=fwd_function_name,
+                    bool_args=",".join(call_args),
+                    return_str=return_str.strip(),
+                    default_call=noamp_dygraph_function_str,
+                )
+            )
 
         # Generate Record Event for performance profiling
         pythonc_record_event_str = RECORD_EVENT_TEMPLATE.format(

--- a/paddle/phi/kernels/xpu/cast_kernel.cc
+++ b/paddle/phi/kernels/xpu/cast_kernel.cc
@@ -171,6 +171,28 @@ void CastKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
     }
     return;
   }
+  if (out_dtype == DataType::BOOL) {
+    // Preserve imaginary-only truthiness for complex-to-bool casts.
+    DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+    DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
+    DenseTensor real_bool;
+    real_bool.Resize(x.dims());
+    CastXPUKernelImpl<float, bool, XPUContext>(dev_ctx, x_real, &real_bool);
+    DenseTensor imag_bool;
+    imag_bool.Resize(x.dims());
+    CastXPUKernelImpl<float, bool, XPUContext>(dev_ctx, x_imag, &imag_bool);
+    dev_ctx.template Alloc<bool>(out);
+    if (out->numel() == 0) {
+      return;
+    }
+    int r = xpu::logical_or<bool, bool>(dev_ctx.x_context(),
+                                        real_bool.data<bool>(),
+                                        imag_bool.data<bool>(),
+                                        out->data<bool>(),
+                                        out->numel());
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "logical_or");
+    return;
+  }
   DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
   CastKernel<float, XPUContext>(dev_ctx, x_real, out_dtype, out);
 }

--- a/paddle/phi/kernels/xpu/logical_kernel.cc
+++ b/paddle/phi/kernels/xpu/logical_kernel.cc
@@ -173,6 +173,11 @@ void LogicalXorKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(logical_not, XPU, ALL_LAYOUT, phi::LogicalNotKernel, bool) {}
-PD_REGISTER_KERNEL(logical_and, XPU, ALL_LAYOUT, phi::LogicalAndKernel, bool) {}
+PD_REGISTER_KERNEL(logical_and, XPU, ALL_LAYOUT, phi::LogicalAndKernel, bool) {
+  // XPU logical kernels are bool-only.
+  kernel->InputAt(0).SetDataType(phi::DataType::BOOL);
+  kernel->InputAt(1).SetDataType(phi::DataType::BOOL);
+  kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
+}
 PD_REGISTER_KERNEL(logical_or, XPU, ALL_LAYOUT, phi::LogicalOrKernel, bool) {}
 PD_REGISTER_KERNEL(logical_xor, XPU, ALL_LAYOUT, phi::LogicalXorKernel, bool) {}


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes an XPU runtime error in `paddle.logical_and` for mixed `complex64` and `float64` inputs.

XPU logical kernels are bool-only, but the eager path could promote mixed complex/numeric inputs to `complex128` before dispatch. XPU does not support that cast path, so the API failed before reaching the existing bool logical kernel.

The change prepares non-inplace XPU `logical_and` inputs as bool before unsupported complex128 promotion, keeps the XPU logical kernel registration bool-only, and preserves complex64-to-bool truthiness for imaginary-only nonzero values.

Verified the two reported failing cases and all `paddle.logical_and` configs from `/workspace/PaddleAPITest/all_config.txt`: 27,962 passed, 0 failed, and 18 explicit complex128 cases were skipped by PaddleAPITest because XPU does not support complex128.

### 是否引起精度变化
否