### PR TITLE
[Operator Mechanism] Fix XPU reduce_min_grad kernel to support float16/bfloat16

### DIFF
--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -345,7 +345,7 @@ XPUOpMap& get_kl2_ops() {
        XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16, INT32, INT64, FLOAT16})},
       {"reduce_mean_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"reduce_mean", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
-      {"reduce_min_grad", XPUKernelSet({FLOAT32})},
+      {"reduce_min_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"reduce_min", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"reduce_prod", XPUKernelSet({FLOAT32, INT32, INT64})},
       {"reduce_sum_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -648,7 +648,12 @@ XPUOpMap& get_kl3_ops() {
       {"reduce_mean_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"reduce_mean",
        XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16, INT32, INT64, BOOL})},
-      {"reduce_min_grad", XPUKernelSet({FLOAT32})},
+      {"reduce_min_grad",
+       XPUKernelSet({
+           FLOAT32,
+           FLOAT16,
+           BFLOAT16,
+       })},
       {"reduce_min",
        XPUKernelSet({
            FLOAT32,

--- a/paddle/phi/kernels/xpu/reduce_min_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_min_grad_kernel.cc
@@ -35,14 +35,17 @@ void ReduceMinGradKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(x_grad);
     return;
   }
+  using XPUDataType = typename XPUTypeTrait<T>::Type;
   reduce_all = recompute_reduce_all(x, dims_arr, reduce_all);
   auto dims = dims_arr.GetData();
 
   dev_ctx.template Alloc<T>(x_grad);
-  const T* x_data = x.data<T>();
-  const T* out_data = out.data<T>();
-  const T* out_grad_data = out_grad.data<T>();
-  auto* x_grad_data = x_grad->data<T>();
+  const XPUDataType* x_data = reinterpret_cast<const XPUDataType*>(x.data<T>());
+  const XPUDataType* out_data =
+      reinterpret_cast<const XPUDataType*>(out.data<T>());
+  const XPUDataType* out_grad_data =
+      reinterpret_cast<const XPUDataType*>(out_grad.data<T>());
+  XPUDataType* x_grad_data = reinterpret_cast<XPUDataType*>(x_grad->data<T>());
   const auto& input_dim_size = x.dims().size();
   std::vector<int64_t> true_dims;
   for (size_t i = 0; i < dims.size(); ++i) {
@@ -64,13 +67,13 @@ void ReduceMinGradKernel(const Context& dev_ctx,
     }
   }
 
-  T* broadcast1 = nullptr;
-  T* broadcast2 = nullptr;
+  XPUDataType* broadcast1 = nullptr;
+  XPUDataType* broadcast2 = nullptr;
   bool* equal = nullptr;
 
   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
 
-  broadcast1 = RAII_GUARD.alloc_l3_or_gm<T>(x.numel());
+  broadcast1 = RAII_GUARD.alloc_l3_or_gm<XPUDataType>(x.numel());
   PADDLE_ENFORCE_NOT_NULL(
       broadcast1, errors::ResourceExhausted("XPU has no enough memory"));
 
@@ -78,7 +81,7 @@ void ReduceMinGradKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_NOT_NULL(
       equal, errors::ResourceExhausted("XPU has no enough memory"));
 
-  broadcast2 = RAII_GUARD.alloc_l3_or_gm<T>(x.numel());
+  broadcast2 = RAII_GUARD.alloc_l3_or_gm<XPUDataType>(x.numel());
   PADDLE_ENFORCE_NOT_NULL(
       broadcast2, errors::ResourceExhausted("XPU has no enough memory"));
 
@@ -91,31 +94,37 @@ void ReduceMinGradKernel(const Context& dev_ctx,
   }
 
   // step 1. broadcast out and out_grad
-  int r = xpu::broadcast<T>(
-      dev_ctx.x_context(), out_data, broadcast1, ydims, xdims);
+  int r =
+      xpu::broadcast(dev_ctx.x_context(), out_data, broadcast1, ydims, xdims);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast");
 
-  r = xpu::broadcast<T>(
+  r = xpu::broadcast(
       dev_ctx.x_context(), out_grad_data, broadcast2, ydims, xdims);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast");
 
   // step 2. compare out_broadcast and x
-  r = xpu::equal<T>(dev_ctx.x_context(), x_data, broadcast1, equal, x.numel());
+  r = xpu::equal(dev_ctx.x_context(), x_data, broadcast1, equal, x.numel());
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "equal");
   // step 3. get x_grad
-  r = xpu::constant<T>(dev_ctx.x_context(), broadcast1, x.numel(), 0);
+  r = xpu::constant(
+      dev_ctx.x_context(), broadcast1, x.numel(), static_cast<XPUDataType>(0));
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
-  r = xpu::where<T>(dev_ctx.x_context(),
-                    equal,
-                    broadcast2,
-                    broadcast1,
-                    x_grad_data,
-                    xdims,
-                    xdims);
+  r = xpu::where(dev_ctx.x_context(),
+                 equal,
+                 broadcast2,
+                 broadcast1,
+                 x_grad_data,
+                 xdims,
+                 xdims);
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "where");
 }
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(min_grad, XPU, ALL_LAYOUT, phi::ReduceMinGradKernel, float) {
-}
+PD_REGISTER_KERNEL(min_grad,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::ReduceMinGradKernel,
+                   float,
+                   phi::float16,
+                   phi::bfloat16) {}


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
#### paddle.min
Fixes XPU `min_grad` registration and runtime support for float16 inputs. The XPU backward kernel existed but was registered only for float, causing `paddle.min(Tensor([128, 4], "float16"), axis=1, keepdim=True)` to fail when running backward.

This change aligns `reduce_min_grad` with the XPU type-trait handling used by `reduce_max_grad`, registers float16/bfloat16 support, and updates XPU capability lists.

Verification: built Paddle XPU successfully and ran all 34 `paddle.min` cases from `/workspace/PaddleAPITest/all_config.txt`; all passed.

### 是否引起精度变化
否