### PR TITLE
[XPU] Fix masked_select broadcast mask handling

### DIFF
--- a/paddle/phi/kernels/xpu/masked_select_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/masked_select_grad_kernel.cc
@@ -16,7 +16,9 @@
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/expand_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/funcs/common_shape.h"
 
 namespace phi {
 
@@ -37,13 +39,26 @@ void MaskedSelectGradKernel(const Context& dev_ctx,
     return;
   }
 
-  auto* mask_data = mask.data<bool>();
+  auto expanded_size = funcs::MatrixGetBroadcastBatchPortion(
+      vectorize(x_grad->dims()), vectorize(mask.dims()));
+  auto expanded_dims = make_ddim(expanded_size);
+
+  DenseTensor mask_expand;
+  // XDNN masked_select_grad requires x and mask to have matching shapes.
+  if (mask.dims() != expanded_dims) {
+    ExpandKernel<bool, Context>(
+        dev_ctx, mask, IntArray(expanded_size), &mask_expand);
+  } else {
+    mask_expand = mask;
+  }
+
+  auto* mask_data = mask_expand.data<bool>();
   auto* input_data = reinterpret_cast<const XPUType*>(out_grad.data<T>());
   auto* out_data = reinterpret_cast<XPUType*>(x_grad->data<T>());
 
-  auto mask_shape = vectorize<int64_t>(mask.dims());
+  auto mask_shape = vectorize<int64_t>(mask_expand.dims());
   auto xshape = vectorize<int64_t>(x_grad->dims());
-  if (mask.dims().size() == 0) {
+  if (mask_expand.dims().size() == 0) {
     mask_shape = std::vector<int64_t>({1});
   }
   if (x_grad->dims().size() == 0) {

--- a/paddle/phi/kernels/xpu/masked_select_kernel.cc
+++ b/paddle/phi/kernels/xpu/masked_select_kernel.cc
@@ -75,7 +75,7 @@ void MaskedSelectKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_XDNN_SUCCESS(
       xpu::nonzero_count(
-          dev_ctx.x_context(), mask_data, out_size, mask.numel()),
+          dev_ctx.x_context(), mask_data, out_size, mask_expand.numel()),
       "nonzero_count ");
   memory_utils::Copy(CPUPlace(),
                      static_cast<void*>(&out_size_cpu),


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes XPU `paddle.masked_select` failures when the mask needs broadcasting, such as masks with shape `[3, 1]` or scalar masks used with an input of shape `[3, 4]`.

The XPU forward kernel now counts selected elements over the expanded mask, and the XPU backward kernel expands the mask before calling XDNN so the input and mask shapes match.

All 289 `paddle.masked_select` cases from `/workspace/PaddleAPITest/all_config.txt` pass after the fix, including the previously failing broadcast and scalar-mask cases.

### 是否引起精度变化
否