### PR TITLE
[Operator Mechanism] Fix XPU matmul mixed dtype dispatch mismatch

### DIFF
--- a/paddle/phi/kernels/xpu/matmul_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/matmul_grad_kernel.cc
@@ -104,6 +104,51 @@ void CastXpuMatmulGradOutputByDtype(const Context& dev_ctx,
   }
 }
 
+template <typename Context>
+void AllocXpuMatmulGradOutputByDtype(const Context& dev_ctx,
+                                     DenseTensor* output) {
+  switch (output->dtype()) {
+    case DataType::FLOAT32:
+      dev_ctx.template Alloc<float>(output);
+      break;
+    case DataType::FLOAT16:
+      dev_ctx.template Alloc<dtype::float16>(output);
+      break;
+    case DataType::BFLOAT16:
+      dev_ctx.template Alloc<dtype::bfloat16>(output);
+      break;
+    default:
+      PADDLE_THROW(
+          common::errors::Unavailable("XPU matmul_grad only supports float32, "
+                                      "float16 and bfloat16 gradient "
+                                      "outputs, but received %s.",
+                                      output->dtype()));
+  }
+}
+
+template <typename Context>
+void FullXpuMatmulGradOutputByDtype(const Context& dev_ctx,
+                                    const DDim& dims,
+                                    DenseTensor* output) {
+  switch (output->dtype()) {
+    case DataType::FLOAT32:
+      Full<float, Context>(dev_ctx, dims, 0, output);
+      break;
+    case DataType::FLOAT16:
+      Full<dtype::float16, Context>(dev_ctx, dims, 0, output);
+      break;
+    case DataType::BFLOAT16:
+      Full<dtype::bfloat16, Context>(dev_ctx, dims, 0, output);
+      break;
+    default:
+      PADDLE_THROW(
+          common::errors::Unavailable("XPU matmul_grad only supports float32, "
+                                      "float16 and bfloat16 gradient "
+                                      "outputs, but received %s.",
+                                      output->dtype()));
+  }
+}
+
 template <typename ComputeT, typename Context>
 void MatmulGradKernelImpl(const Context& dev_ctx,
                           const DenseTensor& x,
@@ -115,13 +160,21 @@ void MatmulGradKernelImpl(const Context& dev_ctx,
                           DenseTensor* dy) {
   using XPUType = typename XPUTypeTrait<ComputeT>::Type;
   if (x.numel() == 0) {
-    dev_ctx.template Alloc<ComputeT>(dx);
-    Full<ComputeT, Context>(dev_ctx, y.dims(), 0, dy);
+    if (dx) {
+      AllocXpuMatmulGradOutputByDtype(dev_ctx, dx);
+    }
+    if (dy) {
+      FullXpuMatmulGradOutputByDtype(dev_ctx, y.dims(), dy);
+    }
     return;
   }
   if (y.numel() == 0) {
-    dev_ctx.template Alloc<ComputeT>(dy);
-    Full<ComputeT, Context>(dev_ctx, x.dims(), 0, dx);
+    if (dy) {
+      AllocXpuMatmulGradOutputByDtype(dev_ctx, dy);
+    }
+    if (dx) {
+      FullXpuMatmulGradOutputByDtype(dev_ctx, x.dims(), dx);
+    }
     return;
   }
 

--- a/paddle/phi/kernels/xpu/matmul_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/matmul_grad_kernel.cc
@@ -20,40 +20,130 @@
 #include "paddle/phi/kernels/xpu/xpu_api_wrapper.h"
 namespace phi {
 
-template <typename T, typename Context>
-void MatmulGradKernel(const Context& dev_ctx,
-                      const DenseTensor& x,
-                      const DenseTensor& y,
-                      const DenseTensor& dout,
-                      bool transpose_x,
-                      bool transpose_y,
-                      DenseTensor* dx,
-                      DenseTensor* dy) {
-  using XPUType = typename XPUTypeTrait<T>::Type;
+template <typename InT, typename OutT, typename Context>
+DenseTensor CastXpuMatmulGradInputImpl(const Context& dev_ctx,
+                                       const DenseTensor& input) {
+  using XPUInT = typename XPUTypeTrait<InT>::Type;
+  using XPUOutT = typename XPUTypeTrait<OutT>::Type;
+  DenseTensor casted_input;
+  casted_input.Resize(input.dims());
+  dev_ctx.template Alloc<OutT>(&casted_input);
+  int r = baidu::xpu::api::cast<XPUInT, XPUOutT>(
+      dev_ctx.x_context(),
+      reinterpret_cast<const XPUInT*>(input.data<InT>()),
+      reinterpret_cast<XPUOutT*>(casted_input.data<OutT>()),
+      input.numel());
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+  return casted_input;
+}
+
+// Use direct XPU casts for mixed matmul grad inputs. This keeps all internal
+// matmul operands in dout's compute dtype without relying on generic CastKernel
+// for float16/bfloat16/float32 input alignment.
+template <typename OutT, typename Context>
+DenseTensor CastXpuMatmulGradInput(const Context& dev_ctx,
+                                   const DenseTensor& input) {
+  if (input.dtype() == phi::CppTypeToDataType<OutT>::Type()) {
+    return input;
+  }
+
+  switch (input.dtype()) {
+    case DataType::FLOAT32:
+      return CastXpuMatmulGradInputImpl<float, OutT, Context>(dev_ctx, input);
+    case DataType::FLOAT16:
+      return CastXpuMatmulGradInputImpl<dtype::float16, OutT, Context>(dev_ctx,
+                                                                       input);
+    case DataType::BFLOAT16:
+      return CastXpuMatmulGradInputImpl<dtype::bfloat16, OutT, Context>(dev_ctx,
+                                                                        input);
+    default:
+      PADDLE_THROW(common::errors::Unavailable(
+          "XPU matmul_grad only supports float32, float16 and bfloat16 "
+          "inputs, but received %s.",
+          input.dtype()));
+  }
+}
+
+template <typename InT, typename OutT, typename Context>
+void CastXpuMatmulGradOutput(const Context& dev_ctx,
+                             const DenseTensor& input,
+                             DenseTensor* output) {
+  using XPUInT = typename XPUTypeTrait<InT>::Type;
+  using XPUOutT = typename XPUTypeTrait<OutT>::Type;
+  dev_ctx.template Alloc<OutT>(output);
+  int r = baidu::xpu::api::cast<XPUInT, XPUOutT>(
+      dev_ctx.x_context(),
+      reinterpret_cast<const XPUInT*>(input.data<InT>()),
+      reinterpret_cast<XPUOutT*>(output->data<OutT>()),
+      input.numel());
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+}
+
+template <typename InT, typename Context>
+void CastXpuMatmulGradOutputByDtype(const Context& dev_ctx,
+                                    const DenseTensor& input,
+                                    DenseTensor* output) {
+  switch (output->dtype()) {
+    case DataType::FLOAT32:
+      CastXpuMatmulGradOutput<InT, float, Context>(dev_ctx, input, output);
+      break;
+    case DataType::FLOAT16:
+      CastXpuMatmulGradOutput<InT, dtype::float16, Context>(
+          dev_ctx, input, output);
+      break;
+    case DataType::BFLOAT16:
+      CastXpuMatmulGradOutput<InT, dtype::bfloat16, Context>(
+          dev_ctx, input, output);
+      break;
+    default:
+      PADDLE_THROW(
+          common::errors::Unavailable("XPU matmul_grad only supports float32, "
+                                      "float16 and bfloat16 gradient "
+                                      "outputs, but received %s.",
+                                      output->dtype()));
+  }
+}
+
+template <typename ComputeT, typename Context>
+void MatmulGradKernelImpl(const Context& dev_ctx,
+                          const DenseTensor& x,
+                          const DenseTensor& y,
+                          const DenseTensor& dout,
+                          bool transpose_x,
+                          bool transpose_y,
+                          DenseTensor* dx,
+                          DenseTensor* dy) {
+  using XPUType = typename XPUTypeTrait<ComputeT>::Type;
   if (x.numel() == 0) {
-    dev_ctx.template Alloc<T>(dx);
-    Full<T, Context>(dev_ctx, y.dims(), 0, dy);
+    dev_ctx.template Alloc<ComputeT>(dx);
+    Full<ComputeT, Context>(dev_ctx, y.dims(), 0, dy);
     return;
   }
   if (y.numel() == 0) {
-    dev_ctx.template Alloc<T>(dy);
-    Full<T, Context>(dev_ctx, x.dims(), 0, dx);
+    dev_ctx.template Alloc<ComputeT>(dy);
+    Full<ComputeT, Context>(dev_ctx, x.dims(), 0, dx);
     return;
-  }
-
-  if (dx) {
-    dev_ctx.template Alloc<T>(dx);
-  }
-  if (dy) {
-    dev_ctx.template Alloc<T>(dy);
   }
 
   if (!transpose_x && transpose_y && y.dims().size() < 2) {
     transpose_y = false;
   }
-  const XPUType* dout_ptr = reinterpret_cast<const XPUType*>(dout.data<T>());
-  const XPUType* x_ptr = reinterpret_cast<const XPUType*>(x.data<T>());
-  const XPUType* y_ptr = reinterpret_cast<const XPUType*>(y.data<T>());
+  // Compute follows dout's dtype; cast operands directly and avoid accessing
+  // tensors through the dispatch template dtype when mixed inputs are present.
+  const DenseTensor x_cast =
+      x.dtype() == dout.dtype()
+          ? x
+          : CastXpuMatmulGradInput<ComputeT, Context>(dev_ctx, x);
+  const DenseTensor y_cast =
+      y.dtype() == dout.dtype()
+          ? y
+          : CastXpuMatmulGradInput<ComputeT, Context>(dev_ctx, y);
+  const XPUType* dout_ptr =
+      reinterpret_cast<const XPUType*>(dout.data<ComputeT>());
+  const XPUType* x_ptr =
+      reinterpret_cast<const XPUType*>(x_cast.data<ComputeT>());
+  const XPUType* y_ptr =
+      reinterpret_cast<const XPUType*>(y_cast.data<ComputeT>());
 
   xpu::Context* xpu_ctx = dev_ctx.x_context();
 
@@ -65,10 +155,28 @@ void MatmulGradKernel(const Context& dev_ctx,
   const XPUType* b_1 = reinterpret_cast<const XPUType*>(NULL);
   const XPUType* a_2 = reinterpret_cast<const XPUType*>(NULL);
   const XPUType* b_2 = reinterpret_cast<const XPUType*>(NULL);
-  XPUType* c_1 = (dx == NULL) ? reinterpret_cast<XPUType*>(NULL)
-                              : reinterpret_cast<XPUType*>(dx->data<T>());
-  XPUType* c_2 = (dy == NULL) ? reinterpret_cast<XPUType*>(NULL)
-                              : reinterpret_cast<XPUType*>(dy->data<T>());
+  DenseTensor dx_tmp;
+  XPUType* c_1 = reinterpret_cast<XPUType*>(NULL);
+  if (dx) {
+    if (dx->dtype() == dout.dtype()) {
+      c_1 = reinterpret_cast<XPUType*>(dev_ctx.template Alloc<ComputeT>(dx));
+    } else {
+      dx_tmp.Resize(dx->dims());
+      c_1 =
+          reinterpret_cast<XPUType*>(dev_ctx.template Alloc<ComputeT>(&dx_tmp));
+    }
+  }
+  DenseTensor dy_tmp;
+  XPUType* c_2 = reinterpret_cast<XPUType*>(NULL);
+  if (dy) {
+    if (dy->dtype() == dout.dtype()) {
+      c_2 = reinterpret_cast<XPUType*>(dev_ctx.template Alloc<ComputeT>(dy));
+    } else {
+      dy_tmp.Resize(dy->dims());
+      c_2 =
+          reinterpret_cast<XPUType*>(dev_ctx.template Alloc<ComputeT>(&dy_tmp));
+    }
+  }
 
   if (info_forward.is_x_need_broadcast) {
     XPUType* new_c_1 = nullptr;
@@ -105,43 +213,82 @@ void MatmulGradKernel(const Context& dev_ctx,
   if (dx) {
     MatMulXPUFunction<XPUType>(xpu_ctx, a_1, b_1, c_1, info_dx, 1.0f);
     if (info_forward.is_x_need_broadcast) {
-      int r =
-          xpu::reduce_sum<XPUType>(xpu_ctx,
-                                   c_1,
-                                   reinterpret_cast<XPUType*>(dx->data<T>()),
-                                   {(int64_t)info_forward.bs,
-                                    (int64_t)info_forward.m,
-                                    (int64_t)info_forward.k},
-                                   {0LL});
+      XPUType* dx_data =
+          dx->dtype() == dout.dtype()
+              ? reinterpret_cast<XPUType*>(dx->data<ComputeT>())
+              : reinterpret_cast<XPUType*>(dx_tmp.data<ComputeT>());
+      int r = xpu::reduce_sum<XPUType>(xpu_ctx,
+                                       c_1,
+                                       dx_data,
+                                       {(int64_t)info_forward.bs,
+                                        (int64_t)info_forward.m,
+                                        (int64_t)info_forward.k},
+                                       {0LL});
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "reduce_sum");
+    }
+    if (dx->dtype() != dout.dtype()) {
+      CastXpuMatmulGradOutputByDtype<ComputeT, Context>(dev_ctx, dx_tmp, dx);
     }
   }
   if (dy) {
     MatMulXPUFunction<XPUType>(xpu_ctx, a_2, b_2, c_2, info_dy, 1.0f);
     if (info_forward.is_y_need_broadcast) {
-      int r =
-          xpu::reduce_sum<XPUType>(xpu_ctx,
-                                   c_2,
-                                   reinterpret_cast<XPUType*>(dy->data<T>()),
-                                   {(int64_t)info_forward.bs,
-                                    (int64_t)info_forward.k,
-                                    (int64_t)info_forward.n},
-                                   {0LL});
+      XPUType* dy_data =
+          dy->dtype() == dout.dtype()
+              ? reinterpret_cast<XPUType*>(dy->data<ComputeT>())
+              : reinterpret_cast<XPUType*>(dy_tmp.data<ComputeT>());
+      int r = xpu::reduce_sum<XPUType>(xpu_ctx,
+                                       c_2,
+                                       dy_data,
+                                       {(int64_t)info_forward.bs,
+                                        (int64_t)info_forward.k,
+                                        (int64_t)info_forward.n},
+                                       {0LL});
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "reduce_sum");
+    }
+    if (dy->dtype() != dout.dtype()) {
+      CastXpuMatmulGradOutputByDtype<ComputeT, Context>(dev_ctx, dy_tmp, dy);
     }
   }
 }
 
 template <typename T, typename Context>
-void MatmulWithFlattenGradKernel(const Context& dev_ctx,
-                                 const DenseTensor& x,
-                                 const DenseTensor& y,
-                                 const DenseTensor& out_grad,
-                                 int x_num_col_dims,
-                                 int y_num_col_dims,
-                                 DenseTensor* x_grad,
-                                 DenseTensor* y_grad) {
-  using XPUType = typename XPUTypeTrait<T>::Type;
+void MatmulGradKernel(const Context& dev_ctx,
+                      const DenseTensor& x,
+                      const DenseTensor& y,
+                      const DenseTensor& dout,
+                      bool transpose_x,
+                      bool transpose_y,
+                      DenseTensor* dx,
+                      DenseTensor* dy) {
+  switch (dout.dtype()) {
+    case DataType::FLOAT32:
+      return MatmulGradKernelImpl<float, Context>(
+          dev_ctx, x, y, dout, transpose_x, transpose_y, dx, dy);
+    case DataType::FLOAT16:
+      return MatmulGradKernelImpl<dtype::float16, Context>(
+          dev_ctx, x, y, dout, transpose_x, transpose_y, dx, dy);
+    case DataType::BFLOAT16:
+      return MatmulGradKernelImpl<dtype::bfloat16, Context>(
+          dev_ctx, x, y, dout, transpose_x, transpose_y, dx, dy);
+    default:
+      PADDLE_THROW(common::errors::Unavailable(
+          "XPU matmul_grad only supports float32, float16 and bfloat16 dout, "
+          "but received %s.",
+          dout.dtype()));
+  }
+}
+
+template <typename ComputeT, typename Context>
+void MatmulWithFlattenGradKernelImpl(const Context& dev_ctx,
+                                     const DenseTensor& x,
+                                     const DenseTensor& y,
+                                     const DenseTensor& out_grad,
+                                     int x_num_col_dims,
+                                     int y_num_col_dims,
+                                     DenseTensor* x_grad,
+                                     DenseTensor* y_grad) {
+  using XPUType = typename XPUTypeTrait<ComputeT>::Type;
 
   auto x_matrix = x.dims().size() > 2 ? ReshapeToMatrix(x, x_num_col_dims)
                                       : static_cast<const DenseTensor&>(x);
@@ -161,10 +308,20 @@ void MatmulWithFlattenGradKernel(const Context& dev_ctx,
   phi::XpuFcInfo info_forward;
   phi::GetFCInfo(x_matrix.dims(), y_matrix.dims(), false, false, &info_forward);
 
+  const DenseTensor x_cast =
+      out_grad.dtype() == x_matrix.dtype()
+          ? x_matrix
+          : CastXpuMatmulGradInput<ComputeT, Context>(dev_ctx, x_matrix);
+  const DenseTensor y_cast =
+      out_grad.dtype() == y_matrix.dtype()
+          ? y_matrix
+          : CastXpuMatmulGradInput<ComputeT, Context>(dev_ctx, y_matrix);
   const XPUType* dout_ptr =
-      reinterpret_cast<const XPUType*>(out_grad.data<T>());
-  const XPUType* x_ptr = reinterpret_cast<const XPUType*>(x.data<T>());
-  const XPUType* y_ptr = reinterpret_cast<const XPUType*>(y.data<T>());
+      reinterpret_cast<const XPUType*>(out_grad.data<ComputeT>());
+  const XPUType* x_ptr =
+      reinterpret_cast<const XPUType*>(x_cast.data<ComputeT>());
+  const XPUType* y_ptr =
+      reinterpret_cast<const XPUType*>(y_cast.data<ComputeT>());
 
   xpu::Context* xpu_ctx = dev_ctx.x_context();
   xpu::ctx_guard RAII_GUARD(xpu_ctx);
@@ -173,14 +330,30 @@ void MatmulWithFlattenGradKernel(const Context& dev_ctx,
   const XPUType* b_1 = reinterpret_cast<const XPUType*>(NULL);
   const XPUType* a_2 = reinterpret_cast<const XPUType*>(NULL);
   const XPUType* b_2 = reinterpret_cast<const XPUType*>(NULL);
-  XPUType* c_1 =
-      (x_grad == NULL)
-          ? reinterpret_cast<XPUType*>(NULL)
-          : reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(x_grad));
-  XPUType* c_2 =
-      (y_grad == NULL)
-          ? reinterpret_cast<XPUType*>(NULL)
-          : reinterpret_cast<XPUType*>(dev_ctx.template Alloc<T>(y_grad));
+  DenseTensor x_grad_tmp;
+  XPUType* c_1 = reinterpret_cast<XPUType*>(NULL);
+  if (x_grad) {
+    if (x_grad->dtype() == out_grad.dtype()) {
+      c_1 =
+          reinterpret_cast<XPUType*>(dev_ctx.template Alloc<ComputeT>(x_grad));
+    } else {
+      x_grad_tmp.Resize(x_grad->dims());
+      c_1 = reinterpret_cast<XPUType*>(
+          dev_ctx.template Alloc<ComputeT>(&x_grad_tmp));
+    }
+  }
+  DenseTensor y_grad_tmp;
+  XPUType* c_2 = reinterpret_cast<XPUType*>(NULL);
+  if (y_grad) {
+    if (y_grad->dtype() == out_grad.dtype()) {
+      c_2 =
+          reinterpret_cast<XPUType*>(dev_ctx.template Alloc<ComputeT>(y_grad));
+    } else {
+      y_grad_tmp.Resize(y_grad->dims());
+      c_2 = reinterpret_cast<XPUType*>(
+          dev_ctx.template Alloc<ComputeT>(&y_grad_tmp));
+    }
+  }
   phi::XpuFcInfo info_dx;
   phi::XpuFcInfo info_dy;
   std::tuple<phi::XpuFcInfo,
@@ -200,9 +373,64 @@ void MatmulWithFlattenGradKernel(const Context& dev_ctx,
   std::tie(info_dx, info_dy, a_1, b_1, a_2, b_2) = fc_info;
   if (x_grad) {
     phi::MatMulXPUFunction<XPUType>(xpu_ctx, a_1, b_1, c_1, info_dx, 1.0f);
+    if (x_grad->dtype() != out_grad.dtype()) {
+      CastXpuMatmulGradOutputByDtype<ComputeT, Context>(
+          dev_ctx, x_grad_tmp, x_grad);
+    }
   }
   if (y_grad) {
     phi::MatMulXPUFunction<XPUType>(xpu_ctx, a_2, b_2, c_2, info_dy, 1.0f);
+    if (y_grad->dtype() != out_grad.dtype()) {
+      CastXpuMatmulGradOutputByDtype<ComputeT, Context>(
+          dev_ctx, y_grad_tmp, y_grad);
+    }
+  }
+}
+
+template <typename T, typename Context>
+void MatmulWithFlattenGradKernel(const Context& dev_ctx,
+                                 const DenseTensor& x,
+                                 const DenseTensor& y,
+                                 const DenseTensor& out_grad,
+                                 int x_num_col_dims,
+                                 int y_num_col_dims,
+                                 DenseTensor* x_grad,
+                                 DenseTensor* y_grad) {
+  switch (out_grad.dtype()) {
+    case DataType::FLOAT32:
+      return MatmulWithFlattenGradKernelImpl<float, Context>(dev_ctx,
+                                                             x,
+                                                             y,
+                                                             out_grad,
+                                                             x_num_col_dims,
+                                                             y_num_col_dims,
+                                                             x_grad,
+                                                             y_grad);
+    case DataType::FLOAT16:
+      return MatmulWithFlattenGradKernelImpl<dtype::float16, Context>(
+          dev_ctx,
+          x,
+          y,
+          out_grad,
+          x_num_col_dims,
+          y_num_col_dims,
+          x_grad,
+          y_grad);
+    case DataType::BFLOAT16:
+      return MatmulWithFlattenGradKernelImpl<dtype::bfloat16, Context>(
+          dev_ctx,
+          x,
+          y,
+          out_grad,
+          x_num_col_dims,
+          y_num_col_dims,
+          x_grad,
+          y_grad);
+    default:
+      PADDLE_THROW(common::errors::Unavailable(
+          "XPU matmul_with_flatten_grad only supports float32, float16 and "
+          "bfloat16 out_grad, but received %s.",
+          out_grad.dtype()));
   }
 }
 

--- a/paddle/phi/kernels/xpu/matmul_kernel.cc
+++ b/paddle/phi/kernels/xpu/matmul_kernel.cc
@@ -21,24 +21,82 @@
 
 namespace phi {
 
-template <typename T, typename Context>
-void MatmulKernel(const Context& dev_ctx,
-                  const DenseTensor& x,
-                  const DenseTensor& y,
-                  bool transpose_x,
-                  bool transpose_y,
-                  DenseTensor* out) {
+template <typename InT, typename OutT, typename Context>
+DenseTensor CastXpuMatmulInputImpl(const Context& dev_ctx,
+                                   const DenseTensor& input) {
+  using XPUInT = typename XPUTypeTrait<InT>::Type;
+  using XPUOutT = typename XPUTypeTrait<OutT>::Type;
+  DenseTensor casted_input;
+  casted_input.Resize(input.dims());
+  dev_ctx.template Alloc<OutT>(&casted_input);
+  int r = baidu::xpu::api::cast<XPUInT, XPUOutT>(
+      dev_ctx.x_context(),
+      reinterpret_cast<const XPUInT*>(input.data<InT>()),
+      reinterpret_cast<XPUOutT*>(casted_input.data<OutT>()),
+      input.numel());
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+  return casted_input;
+}
+
+// Use the direct XPU cast API for mixed matmul inputs. The generic XPU
+// CastKernel path can reject valid float16/bfloat16/float32 conversions before
+// matmul with XDNN_INVALID_PARAM on some devices.
+template <typename OutT, typename Context>
+DenseTensor CastXpuMatmulInput(const Context& dev_ctx,
+                               const DenseTensor& input) {
+  if (input.dtype() == phi::CppTypeToDataType<OutT>::Type()) {
+    return input;
+  }
+
+  switch (input.dtype()) {
+    case DataType::FLOAT32:
+      return CastXpuMatmulInputImpl<float, OutT, Context>(dev_ctx, input);
+    case DataType::FLOAT16:
+      return CastXpuMatmulInputImpl<dtype::float16, OutT, Context>(dev_ctx,
+                                                                   input);
+    case DataType::BFLOAT16:
+      return CastXpuMatmulInputImpl<dtype::bfloat16, OutT, Context>(dev_ctx,
+                                                                    input);
+    default:
+      PADDLE_THROW(common::errors::Unavailable(
+          "XPU matmul only supports float32, float16 and bfloat16 inputs, but "
+          "received %s.",
+          input.dtype()));
+  }
+}
+
+template <typename ComputeT, typename Context>
+void MatmulKernelImpl(const Context& dev_ctx,
+                      const DenseTensor& x,
+                      const DenseTensor& y,
+                      bool transpose_x,
+                      bool transpose_y,
+                      DenseTensor* out) {
   if (x.numel() == 0 || y.numel() == 0) {
     // input shape [1, 1, 5, 0], [1, 1, 0, 5], result shape is [1, 1, 5, 5]
-    Full<T, Context>(dev_ctx, out->dims(), 0, out);
+    Full<ComputeT, Context>(dev_ctx, out->dims(), 0, out);
     return;
   }
-  using XPUType = typename XPUTypeTrait<T>::Type;
+  using XPUType = typename XPUTypeTrait<ComputeT>::Type;
 
-  dev_ctx.template Alloc<T>(out);
-  const XPUType* x_ptr = reinterpret_cast<const XPUType*>(x.data<T>());
-  const XPUType* y_ptr = reinterpret_cast<const XPUType*>(y.data<T>());
-  XPUType* out_ptr = reinterpret_cast<XPUType*>(out->data<T>());
+  dev_ctx.template Alloc<ComputeT>(out);
+  // XPU dispatch may instantiate this kernel from y's dtype while
+  // MatmulInferMeta keeps the output dtype aligned with x. Cast both operands
+  // to the actual output compute dtype and never read a tensor through the
+  // dispatch template dtype.
+  const DenseTensor x_cast =
+      x.dtype() == out->dtype()
+          ? x
+          : CastXpuMatmulInput<ComputeT, Context>(dev_ctx, x);
+  const DenseTensor y_cast =
+      y.dtype() == out->dtype()
+          ? y
+          : CastXpuMatmulInput<ComputeT, Context>(dev_ctx, y);
+  const XPUType* x_ptr =
+      reinterpret_cast<const XPUType*>(x_cast.data<ComputeT>());
+  const XPUType* y_ptr =
+      reinterpret_cast<const XPUType*>(y_cast.data<ComputeT>());
+  XPUType* out_ptr = reinterpret_cast<XPUType*>(out->data<ComputeT>());
   auto x_dims = x.dims();
   auto y_dims = y.dims();
 
@@ -49,22 +107,57 @@ void MatmulKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void MatmulWithFlattenKernel(const Context& dev_ctx,
-                             const DenseTensor& x,
-                             const DenseTensor& y,
-                             int x_num_col_dims,
-                             int y_num_col_dims,
-                             DenseTensor* out) {
-  using XPUType = typename XPUTypeTrait<T>::Type;
+void MatmulKernel(const Context& dev_ctx,
+                  const DenseTensor& x,
+                  const DenseTensor& y,
+                  bool transpose_x,
+                  bool transpose_y,
+                  DenseTensor* out) {
+  switch (out->dtype()) {
+    case DataType::FLOAT32:
+      return MatmulKernelImpl<float, Context>(
+          dev_ctx, x, y, transpose_x, transpose_y, out);
+    case DataType::FLOAT16:
+      return MatmulKernelImpl<dtype::float16, Context>(
+          dev_ctx, x, y, transpose_x, transpose_y, out);
+    case DataType::BFLOAT16:
+      return MatmulKernelImpl<dtype::bfloat16, Context>(
+          dev_ctx, x, y, transpose_x, transpose_y, out);
+    default:
+      PADDLE_THROW(common::errors::Unavailable(
+          "XPU matmul only supports float32, float16 and bfloat16 outputs, but "
+          "received %s.",
+          out->dtype()));
+  }
+}
+
+template <typename ComputeT, typename Context>
+void MatmulWithFlattenKernelImpl(const Context& dev_ctx,
+                                 const DenseTensor& x,
+                                 const DenseTensor& y,
+                                 int x_num_col_dims,
+                                 int y_num_col_dims,
+                                 DenseTensor* out) {
+  using XPUType = typename XPUTypeTrait<ComputeT>::Type;
   const DenseTensor x_matrix =
       x.dims().size() > 2 ? ReshapeToMatrix(x, x_num_col_dims) : x;
   const DenseTensor y_matrix =
       y.dims().size() > 2 ? ReshapeToMatrix(y, y_num_col_dims) : y;
-  dev_ctx.template Alloc<T>(out);
+  dev_ctx.template Alloc<ComputeT>(out);
 
-  const XPUType* x_ptr = reinterpret_cast<const XPUType*>(x_matrix.data<T>());
-  const XPUType* y_ptr = reinterpret_cast<const XPUType*>(y_matrix.data<T>());
-  XPUType* out_ptr = reinterpret_cast<XPUType*>(out->data<T>());
+  const DenseTensor x_matrix_cast =
+      x_matrix.dtype() == out->dtype()
+          ? x_matrix
+          : CastXpuMatmulInput<ComputeT, Context>(dev_ctx, x_matrix);
+  const DenseTensor y_matrix_cast =
+      y_matrix.dtype() == out->dtype()
+          ? y_matrix
+          : CastXpuMatmulInput<ComputeT, Context>(dev_ctx, y_matrix);
+  const XPUType* x_ptr =
+      reinterpret_cast<const XPUType*>(x_matrix_cast.data<ComputeT>());
+  const XPUType* y_ptr =
+      reinterpret_cast<const XPUType*>(y_matrix_cast.data<ComputeT>());
+  XPUType* out_ptr = reinterpret_cast<XPUType*>(out->data<ComputeT>());
 
   bool trans_a = false;
   bool trans_b = false;
@@ -78,6 +171,31 @@ void MatmulWithFlattenKernel(const Context& dev_ctx,
 
   phi::MatMulXPUFunction<XPUType>(
       xpu_ctx, x_ptr, y_ptr, out_ptr, fc_info, 1.0f);
+}
+
+template <typename T, typename Context>
+void MatmulWithFlattenKernel(const Context& dev_ctx,
+                             const DenseTensor& x,
+                             const DenseTensor& y,
+                             int x_num_col_dims,
+                             int y_num_col_dims,
+                             DenseTensor* out) {
+  switch (out->dtype()) {
+    case DataType::FLOAT32:
+      return MatmulWithFlattenKernelImpl<float, Context>(
+          dev_ctx, x, y, x_num_col_dims, y_num_col_dims, out);
+    case DataType::FLOAT16:
+      return MatmulWithFlattenKernelImpl<dtype::float16, Context>(
+          dev_ctx, x, y, x_num_col_dims, y_num_col_dims, out);
+    case DataType::BFLOAT16:
+      return MatmulWithFlattenKernelImpl<dtype::bfloat16, Context>(
+          dev_ctx, x, y, x_num_col_dims, y_num_col_dims, out);
+    default:
+      PADDLE_THROW(common::errors::Unavailable(
+          "XPU matmul_with_flatten only supports float32, float16 and bfloat16 "
+          "outputs, but received %s.",
+          out->dtype()));
+  }
 }
 
 template <typename T, typename Context>


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes XPU `paddle.mm` mixed dtype execution where kernel dispatch can instantiate from an input dtype that differs from the inferred output dtype. The previous XPU matmul path could read tensors through the dispatch template dtype, causing dtype mismatch errors for cases such as float32 x float16.

The XPU matmul and matmul gradient kernels now select their internal compute path from the actual output or gradient dtype, cast mixed float inputs with the direct XPU cast API, and avoid accessing tensors through a mismatched template dtype. Empty gradient early-return paths also allocate or fill using the actual requested gradient dtype so mixed dtype empty tensors do not regress.

Verification:
- Built and installed Paddle XPU wheel successfully for the original fix.
- The two listed float32 issue cases pass GPU-vs-XPU accuracy comparison.
- The listed mixed dtype case passes local XPU forward execution and autograd probing after the fix.
- A 210-case `paddle.mm` sweep was started; 57 comparable executed cases passed. The mixed dtype case still returns HTTP 500 from the remote GPU reference service before local XPU comparison, with the same dtype mismatch error on the remote `/paddle` path.
- `prek` passed after the empty-gradient follow-up fix.

### 是否引起精度变化
否