### PR TITLE
[Operator Mechanism] Fix XPU multiply crash for mixed complex promotion

### DIFF
--- a/paddle/phi/kernels/xpu/cast_kernel.cc
+++ b/paddle/phi/kernels/xpu/cast_kernel.cc
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/cast_kernel.h"
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
@@ -87,6 +88,41 @@ void CastXPUKernelImpl(const Context& dev_ctx,
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
 }
 
+#ifdef PADDLE_WITH_XPU_FFT
+template <typename InT, typename RealT, typename Context>
+void CastRealToComplexXPUKernelImpl(const Context& dev_ctx,
+                                    const DenseTensor& x,
+                                    DenseTensor* out) {
+  if (x.numel() == 0) {
+    dev_ctx.template Alloc<phi::dtype::complex<RealT>>(out);
+    return;
+  }
+
+  DenseTensor real;
+  real.Resize(x.dims());
+  CastXPUKernelImpl<InT, RealT, Context>(dev_ctx, x, &real);
+  DenseTensor imag = Fill<RealT, Context>(
+      dev_ctx, vectorize<int>(x.dims()), static_cast<RealT>(0.0));
+  phi::ComplexKernel<RealT>(dev_ctx, real, imag, out);
+}
+
+template <typename InT, typename OutRealT, typename Context>
+void CastComplexToComplexXPUKernelImpl(const Context& dev_ctx,
+                                       const DenseTensor& x,
+                                       DenseTensor* out) {
+  using InRealT = dtype::Real<InT>;
+  DenseTensor real = Real<InT, Context>(dev_ctx, x);
+  DenseTensor imag = Imag<InT, Context>(dev_ctx, x);
+  DenseTensor out_real;
+  DenseTensor out_imag;
+  out_real.Resize(x.dims());
+  out_imag.Resize(x.dims());
+  CastXPUKernelImpl<InRealT, OutRealT, Context>(dev_ctx, real, &out_real);
+  CastXPUKernelImpl<InRealT, OutRealT, Context>(dev_ctx, imag, &out_imag);
+  phi::ComplexKernel<OutRealT>(dev_ctx, out_real, out_imag, out);
+}
+#endif
+
 template <typename T, typename Context>
 void CastKernel(const Context& dev_ctx,
                 const DenseTensor& x,
@@ -134,20 +170,12 @@ void CastKernel(const Context& dev_ctx,
       CastXPUKernelImpl<T, int16_t, Context>(dev_ctx, x, out);
       break;
 #ifdef PADDLE_WITH_XPU_FFT
-    case DataType::COMPLEX64: {
-      if (x.numel() == 0) {
-        dev_ctx.template Alloc<T>(out);
-        return;
-      }
-      DenseTensor real;
-      real.Resize(x.dims());
-      CastXPUKernelImpl<T, float, Context>(dev_ctx, x, &real);
-      dev_ctx.template Alloc<T>(out);
-      DenseTensor imag = Fill<float, Context>(
-          dev_ctx, vectorize<int>(x.dims()), static_cast<float>(0.0));
-      phi::ComplexKernel<float>(dev_ctx, real, imag, out);
+    case DataType::COMPLEX64:
+      CastRealToComplexXPUKernelImpl<T, float, Context>(dev_ctx, x, out);
       break;
-    }
+    case DataType::COMPLEX128:
+      CastRealToComplexXPUKernelImpl<T, double, Context>(dev_ctx, x, out);
+      break;
 #endif
     default:
       PADDLE_THROW(common::errors::Unavailable(
@@ -171,8 +199,36 @@ void CastKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
     }
     return;
   }
+  if (out_dtype == DataType::COMPLEX128) {
+    CastComplexToComplexXPUKernelImpl<T, double, XPUContext>(dev_ctx, x, out);
+    return;
+  }
   DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
   CastKernel<float, XPUContext>(dev_ctx, x_real, out_dtype, out);
+}
+
+template <>
+void CastKernel<phi::complex128, XPUContext>(const XPUContext& dev_ctx,
+                                             const DenseTensor& x,
+                                             DataType out_dtype,
+                                             DenseTensor* out) {
+  using T = phi::complex128;
+  if (x.dtype() == out_dtype) {
+    if (x.dims() == make_ddim({-1})) {
+      *out = x;
+      return;
+    }
+    if (!out->IsSharedWith(x)) {
+      Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    }
+    return;
+  }
+  if (out_dtype == DataType::COMPLEX64) {
+    CastComplexToComplexXPUKernelImpl<T, float, XPUContext>(dev_ctx, x, out);
+    return;
+  }
+  DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
+  CastKernel<double, XPUContext>(dev_ctx, x_real, out_dtype, out);
 }
 #endif
 }  // namespace phi
@@ -188,6 +244,7 @@ PD_REGISTER_KERNEL(cast,
                    phi::bfloat16,
 #ifdef PADDLE_WITH_XPU_FFT
                    phi::complex64,
+                   phi::complex128,
 #endif
                    int64_t,
                    bool,

--- a/paddle/phi/kernels/xpu/cast_kernel.cc
+++ b/paddle/phi/kernels/xpu/cast_kernel.cc
@@ -110,15 +110,16 @@ template <typename InT, typename OutRealT, typename Context>
 void CastComplexToComplexXPUKernelImpl(const Context& dev_ctx,
                                        const DenseTensor& x,
                                        DenseTensor* out) {
-  using InRealT = dtype::Real<InT>;
   DenseTensor real = Real<InT, Context>(dev_ctx, x);
   DenseTensor imag = Imag<InT, Context>(dev_ctx, x);
   DenseTensor out_real;
   DenseTensor out_imag;
   out_real.Resize(x.dims());
   out_imag.Resize(x.dims());
-  CastXPUKernelImpl<InRealT, OutRealT, Context>(dev_ctx, real, &out_real);
-  CastXPUKernelImpl<InRealT, OutRealT, Context>(dev_ctx, imag, &out_imag);
+  CastXPUKernelImpl<dtype::Real<InT>, OutRealT, Context>(
+      dev_ctx, real, &out_real);
+  CastXPUKernelImpl<dtype::Real<InT>, OutRealT, Context>(
+      dev_ctx, imag, &out_imag);
   phi::ComplexKernel<OutRealT>(dev_ctx, out_real, out_imag, out);
 }
 #endif

--- a/paddle/phi/kernels/xpu/elementwise_multiply_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_multiply_kernel.cc
@@ -18,7 +18,9 @@
 #include <string>
 
 #include "paddle/phi/backends/xpu/xpu_context.h"
+#include "paddle/phi/common/type_traits.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/elementwise_add_kernel.h"
 #include "paddle/phi/kernels/elementwise_subtract_kernel.h"
@@ -50,23 +52,27 @@ void MultiplyKernel(const Context& dev_ctx,
 }
 
 #ifdef PADDLE_WITH_XPU_FFT
-template <>
-void MultiplyKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
-                                                const DenseTensor& x,
-                                                const DenseTensor& y,
-                                                DenseTensor* out) {
-  using T = phi::complex64;
+template <typename T>
+void ComplexMultiplyWithFloatParts(const XPUContext& dev_ctx,
+                                   const DenseTensor& x,
+                                   const DenseTensor& y,
+                                   DenseTensor* out) {
   if (out->numel() == 0) {
     dev_ctx.template Alloc<T>(out);
     return;
   }
-  // The current complex number implementation uses separate real/imaginary
-  // parts,resulting in redundant operations and performance
-  // penalties.Optimization should address this in future iterations.
-  const DenseTensor x_real = Real<T, XPUContext>(dev_ctx, x);
-  const DenseTensor x_imag = Imag<T, XPUContext>(dev_ctx, x);
-  const DenseTensor y_real = Real<T, XPUContext>(dev_ctx, y);
-  const DenseTensor y_imag = Imag<T, XPUContext>(dev_ctx, y);
+  // XPU does not provide double elementwise arithmetic. For complex128, use
+  // the supported float elementwise path for real/imag parts, then cast the
+  // result parts back when composing the complex128 output.
+  using RealT = dtype::Real<T>;
+  const DenseTensor x_real = Cast<RealT, XPUContext>(
+      dev_ctx, Real<T, XPUContext>(dev_ctx, x), DataType::FLOAT32);
+  const DenseTensor x_imag = Cast<RealT, XPUContext>(
+      dev_ctx, Imag<T, XPUContext>(dev_ctx, x), DataType::FLOAT32);
+  const DenseTensor y_real = Cast<RealT, XPUContext>(
+      dev_ctx, Real<T, XPUContext>(dev_ctx, y), DataType::FLOAT32);
+  const DenseTensor y_imag = Cast<RealT, XPUContext>(
+      dev_ctx, Imag<T, XPUContext>(dev_ctx, y), DataType::FLOAT32);
   DenseTensor real_out = Subtract<float, XPUContext>(
       dev_ctx,
       Multiply<float, XPUContext>(dev_ctx, x_real, y_real),
@@ -75,7 +81,31 @@ void MultiplyKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
       dev_ctx,
       Multiply<float, XPUContext>(dev_ctx, x_real, y_imag),
       Multiply<float, XPUContext>(dev_ctx, x_imag, y_real));
-  phi::ComplexKernel<float>(dev_ctx, real_out, imag_out, out);
+  if constexpr (std::is_same_v<T, phi::complex64>) {
+    phi::ComplexKernel<float>(dev_ctx, real_out, imag_out, out);
+  } else {
+    phi::ComplexKernel<double>(
+        dev_ctx,
+        Cast<float, XPUContext>(dev_ctx, real_out, DataType::FLOAT64),
+        Cast<float, XPUContext>(dev_ctx, imag_out, DataType::FLOAT64),
+        out);
+  }
+}
+
+template <>
+void MultiplyKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
+                                                const DenseTensor& x,
+                                                const DenseTensor& y,
+                                                DenseTensor* out) {
+  ComplexMultiplyWithFloatParts<phi::complex64>(dev_ctx, x, y, out);
+}
+
+template <>
+void MultiplyKernel<phi::complex128, XPUContext>(const XPUContext& dev_ctx,
+                                                 const DenseTensor& x,
+                                                 const DenseTensor& y,
+                                                 DenseTensor* out) {
+  ComplexMultiplyWithFloatParts<phi::complex128>(dev_ctx, x, y, out);
 }
 #endif
 
@@ -90,6 +120,7 @@ PD_REGISTER_KERNEL(multiply,
                    phi::bfloat16,
 #ifdef PADDLE_WITH_XPU_FFT
                    phi::complex64,
+                   phi::complex128,
 #endif
                    float,
                    int,

--- a/paddle/phi/kernels/xpu/elementwise_multiply_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_multiply_kernel.cc
@@ -52,27 +52,19 @@ void MultiplyKernel(const Context& dev_ctx,
 }
 
 #ifdef PADDLE_WITH_XPU_FFT
-template <typename T>
-void ComplexMultiplyWithFloatParts(const XPUContext& dev_ctx,
-                                   const DenseTensor& x,
-                                   const DenseTensor& y,
-                                   DenseTensor* out) {
+template <>
+void MultiplyKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
+                                                const DenseTensor& x,
+                                                const DenseTensor& y,
+                                                DenseTensor* out) {
   if (out->numel() == 0) {
-    dev_ctx.template Alloc<T>(out);
+    dev_ctx.template Alloc<phi::complex64>(out);
     return;
   }
-  // XPU does not provide double elementwise arithmetic. For complex128, use
-  // the supported float elementwise path for real/imag parts, then cast the
-  // result parts back when composing the complex128 output.
-  using RealT = dtype::Real<T>;
-  const DenseTensor x_real = Cast<RealT, XPUContext>(
-      dev_ctx, Real<T, XPUContext>(dev_ctx, x), DataType::FLOAT32);
-  const DenseTensor x_imag = Cast<RealT, XPUContext>(
-      dev_ctx, Imag<T, XPUContext>(dev_ctx, x), DataType::FLOAT32);
-  const DenseTensor y_real = Cast<RealT, XPUContext>(
-      dev_ctx, Real<T, XPUContext>(dev_ctx, y), DataType::FLOAT32);
-  const DenseTensor y_imag = Cast<RealT, XPUContext>(
-      dev_ctx, Imag<T, XPUContext>(dev_ctx, y), DataType::FLOAT32);
+  auto x_real = Real<phi::complex64, XPUContext>(dev_ctx, x);
+  auto x_imag = Imag<phi::complex64, XPUContext>(dev_ctx, x);
+  auto y_real = Real<phi::complex64, XPUContext>(dev_ctx, y);
+  auto y_imag = Imag<phi::complex64, XPUContext>(dev_ctx, y);
   DenseTensor real_out = Subtract<float, XPUContext>(
       dev_ctx,
       Multiply<float, XPUContext>(dev_ctx, x_real, y_real),
@@ -81,31 +73,7 @@ void ComplexMultiplyWithFloatParts(const XPUContext& dev_ctx,
       dev_ctx,
       Multiply<float, XPUContext>(dev_ctx, x_real, y_imag),
       Multiply<float, XPUContext>(dev_ctx, x_imag, y_real));
-  if constexpr (std::is_same_v<T, phi::complex64>) {
-    phi::ComplexKernel<float>(dev_ctx, real_out, imag_out, out);
-  } else {
-    phi::ComplexKernel<double>(
-        dev_ctx,
-        Cast<float, XPUContext>(dev_ctx, real_out, DataType::FLOAT64),
-        Cast<float, XPUContext>(dev_ctx, imag_out, DataType::FLOAT64),
-        out);
-  }
-}
-
-template <>
-void MultiplyKernel<phi::complex64, XPUContext>(const XPUContext& dev_ctx,
-                                                const DenseTensor& x,
-                                                const DenseTensor& y,
-                                                DenseTensor* out) {
-  ComplexMultiplyWithFloatParts<phi::complex64>(dev_ctx, x, y, out);
-}
-
-template <>
-void MultiplyKernel<phi::complex128, XPUContext>(const XPUContext& dev_ctx,
-                                                 const DenseTensor& x,
-                                                 const DenseTensor& y,
-                                                 DenseTensor* out) {
-  ComplexMultiplyWithFloatParts<phi::complex128>(dev_ctx, x, y, out);
+  phi::ComplexKernel<float>(dev_ctx, real_out, imag_out, out);
 }
 #endif
 
@@ -120,7 +88,6 @@ PD_REGISTER_KERNEL(multiply,
                    phi::bfloat16,
 #ifdef PADDLE_WITH_XPU_FFT
                    phi::complex64,
-                   phi::complex128,
 #endif
                    float,
                    int,


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes XPU `paddle.multiply` failures for mixed `complex64` and `float64` inputs. These inputs are promoted to `complex128`, but the XPU cast path did not support complex128 outputs, causing the reported XPU errors.

The change adds XPU complex128 cast support while preserving real and imaginary components for complex-to-complex casts. The XPU multiply kernel keeps the existing complex64 implementation and intentionally does not register a complex128 XPU multiply path, because implementing complex128 multiply through float32 real/imag arithmetic would silently lose precision. With the complex128 XPU multiply kernel absent, Paddle uses the existing CPU fallback under the default API kernel fallback behavior instead of returning an XPU kernel error.

Validation:
- Built and installed Paddle XPU successfully: `/workspace/paddle-2/build/python/dist/paddlepaddle_xpu-3.5.0.dev20260509-cp310-cp310-linux_x86_64.whl`.
- Verified both PAD-280 issue cases pass.
- Grepped `/workspace/PaddleAPITest/all_config.txt` and ran all 3,117 `paddle.multiply` configs; all passed after the follow-up change.
- `prek` passed.

### 是否引起精度变化
否