### PR TITLE
[Operator Mechanism] Fix adaptive max pool2d error on XPU

### DIFF
--- a/paddle/phi/kernels/xpu/pool_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/pool_grad_kernel.cc
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/pool_grad_kernel.h"
 
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/pooling.h"
 
@@ -430,8 +431,6 @@ void MaxPool2dWithIndexGradKernel(const Context& dev_ctx,
                                       "dimension pooling!, but received "
                                       "%d-dimension pool kernel size",
                                       kernel_size.size()));
-  global_pooling =
-      global_pooling || (adaptive && (kernel_size[0] * kernel_size[1] == 1));
   if (global_pooling) {
     for (size_t i = 0; i < kernel_size.size(); ++i) {
       paddings[i] = 0;
@@ -442,9 +441,49 @@ void MaxPool2dWithIndexGradKernel(const Context& dev_ctx,
   const int64_t c = dx->dims()[1];
   const int64_t in_h = dx->dims()[2];
   const int64_t in_w = dx->dims()[3];
+  const int64_t out_h = dout.dims()[2];
+  const int64_t out_w = dout.dims()[3];
   auto output_grad = reinterpret_cast<const XPUType*>(dout.data<T>());
 
   int r = 0;
+  if (adaptive) {
+    // Scatter dout by the int32 mask produced by the adaptive fallback.
+    std::vector<int> mask_cpu(mask.numel());
+    std::vector<T> output_grad_cpu(dout.numel());
+    memory_utils::Copy(CPUPlace(),
+                       mask_cpu.data(),
+                       mask.place(),
+                       mask.data<int>(),
+                       mask.numel() * sizeof(int));
+    memory_utils::Copy(CPUPlace(),
+                       output_grad_cpu.data(),
+                       dout.place(),
+                       dout.data<T>(),
+                       dout.numel() * sizeof(T));
+    dev_ctx.Wait();
+
+    std::vector<T> input_grad_cpu(dx->numel(), static_cast<T>(0));
+    const int64_t input_stride = in_h * in_w;
+    const int64_t output_stride = out_h * out_w;
+    for (int64_t ni = 0; ni < n; ++ni) {
+      for (int64_t ci = 0; ci < c; ++ci) {
+        const int64_t base = (ni * c + ci) * input_stride;
+        const int64_t out_base = (ni * c + ci) * output_stride;
+        for (int64_t idx = 0; idx < output_stride; ++idx) {
+          input_grad_cpu[base + mask_cpu[out_base + idx]] +=
+              output_grad_cpu[out_base + idx];
+        }
+      }
+    }
+
+    memory_utils::Copy(dev_ctx.GetPlace(),
+                       dx->data<T>(),
+                       CPUPlace(),
+                       input_grad_cpu.data(),
+                       dx->numel() * sizeof(T));
+    return;
+  }
+
   // pass a nullptr as input to XDNN is fine as long as index_data exists
   r = xpu::max_pool2d_grad<XPUType>(dev_ctx.x_context(),
                                     /*input*/ nullptr,

--- a/paddle/phi/kernels/xpu/pool_kernel.cc
+++ b/paddle/phi/kernels/xpu/pool_kernel.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/common/macros.h"
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/funcs/pooling.h"
@@ -356,13 +357,6 @@ void MaxPool2dWithIndexKernel(const Context& dev_ctx,
                         "The Pool2d XPU OP only support 2 dimension pooling, "
                         "but received kernel_size with size %d",
                         kernel_size.size()));
-  PADDLE_ENFORCE_EQ(!adaptive || (kernel_size[0] * kernel_size[1] == 1),
-                    true,
-                    common::errors::InvalidArgument(
-                        "The Pool2d XPU OP does not support (adaptive == "
-                        "true && output_size != 1)"));
-  global_pooling =
-      global_pooling || (adaptive && (kernel_size[0] * kernel_size[1] == 1));
   if (global_pooling) {
     for (size_t i = 0; i < kernel_size.size(); ++i) {
       paddings[i] = 0;
@@ -373,10 +367,65 @@ void MaxPool2dWithIndexKernel(const Context& dev_ctx,
   const int64_t c = x.dims()[1];
   const int64_t in_h = x.dims()[2];
   const int64_t in_w = x.dims()[3];
+  const int64_t out_h = out->dims()[2];
+  const int64_t out_w = out->dims()[3];
   auto input = reinterpret_cast<const XPUType*>(x.data<T>());
   dev_ctx.template Alloc<T>(out);
   auto output = reinterpret_cast<XPUType*>(out->data<T>());
   int r = 0;
+  if (adaptive) {
+    // XDNN rejects int32 index output for some float32 adaptive cases.
+    std::vector<T> input_cpu(x.numel());
+    memory_utils::Copy(CPUPlace(),
+                       input_cpu.data(),
+                       x.place(),
+                       x.data<T>(),
+                       x.numel() * sizeof(T));
+    dev_ctx.Wait();
+
+    std::vector<T> output_cpu(out->numel());
+    std::vector<int> mask_cpu(mask->numel());
+    for (int64_t ni = 0; ni < n; ++ni) {
+      for (int64_t ci = 0; ci < c; ++ci) {
+        const int64_t base = (ni * c + ci) * in_h * in_w;
+        const int64_t out_base = (ni * c + ci) * out_h * out_w;
+        for (int64_t ph = 0; ph < out_h; ++ph) {
+          const int64_t hstart = funcs::AdaptStartIndex(ph, in_h, out_h);
+          const int64_t hend = funcs::AdaptEndIndex(ph, in_h, out_h);
+          for (int64_t pw = 0; pw < out_w; ++pw) {
+            const int64_t wstart = funcs::AdaptStartIndex(pw, in_w, out_w);
+            const int64_t wend = funcs::AdaptEndIndex(pw, in_w, out_w);
+            T max_value = input_cpu[base + hstart * in_w + wstart];
+            int max_index = static_cast<int>(hstart * in_w + wstart);
+            for (int64_t h = hstart; h < hend; ++h) {
+              for (int64_t w = wstart; w < wend; ++w) {
+                const T value = input_cpu[base + h * in_w + w];
+                if (max_value < value) {
+                  max_value = value;
+                  max_index = static_cast<int>(h * in_w + w);
+                }
+              }
+            }
+            output_cpu[out_base + ph * out_w + pw] = max_value;
+            mask_cpu[out_base + ph * out_w + pw] = max_index;
+          }
+        }
+      }
+    }
+
+    memory_utils::Copy(dev_ctx.GetPlace(),
+                       out->data<T>(),
+                       CPUPlace(),
+                       output_cpu.data(),
+                       out->numel() * sizeof(T));
+    memory_utils::Copy(dev_ctx.GetPlace(),
+                       index_data,
+                       CPUPlace(),
+                       mask_cpu.data(),
+                       mask->numel() * sizeof(int));
+    return;
+  }
+
   r = xpu::max_pool2d<XPUType>(dev_ctx.x_context(),
                                input,
                                output,


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix `paddle.nn.functional.adaptive_max_pool2d` errors on XPU when `output_size != 1`.

#### paddle.nn.functional.adaptive_max_pool2d
The XPU `MaxPool2dWithIndexKernel` path previously rejected `adaptive && output_size != 1`, while the Python API routes adaptive max pool 2D through this indexed kernel even when `return_mask=False`.

This PR removes that unsupported guard and adds an adaptive XPU fallback path that computes output and int32 mask consistently for adaptive windows. The matching gradient path scatters `dout` through the saved int32 mask. Non-adaptive XPU max pooling continues to use the existing XDNN implementation.

This fallback avoids the current XDNN float32 adaptive index-output runtime error and is intended as a correctness fix for the missing adaptive indexed path. Native XDNN acceleration can replace it later when that path supports the required mask behavior.

Validated all 18 `paddle.nn.functional.adaptive_max_pool2d` cases found in `/workspace/PaddleAPITest/all_config.txt`; all passed XPU vs GPU accuracy comparison.

### 是否引起精度变化
否