### PR TITLE
[XPU] Fix hardsigmoid float16 grad dispatch

### DIFF
--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -243,7 +243,7 @@ XPUOpMap& get_kl2_ops() {
       {"grid_sampler", XPUKernelSet({FLOAT32})},
       {"group_norm_silu_xpu", XPUKernelSet({FLOAT32, FLOAT16})},
       {"layer_norm_relu_xpu", XPUKernelSet({FLOAT32, FLOAT16})},
-      {"hard_sigmoid_grad", XPUKernelSet({FLOAT32})},
+      {"hard_sigmoid_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"hard_sigmoid", XPUKernelSet({FLOAT32, FLOAT16})},
       {"hard_swish_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"hard_swish", XPUKernelSet({FLOAT32, FLOAT16})},

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -411,7 +411,7 @@ XPUOpMap& get_kl3_ops() {
       {"grid_sampler", XPUKernelSet({FLOAT32})},
       {"grid_sampler_grad", XPUKernelSet({FLOAT32})},
       {"group_norm_silu_xpu", XPUKernelSet({FLOAT32, FLOAT16})},
-      {"hard_sigmoid_grad", XPUKernelSet({FLOAT32})},
+      {"hard_sigmoid_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"hard_sigmoid", XPUKernelSet({FLOAT32, FLOAT16})},
       {"hard_swish_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"hard_swish", XPUKernelSet({FLOAT32})},

--- a/paddle/phi/kernels/xpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_grad_kernel.cc
@@ -847,7 +847,12 @@ PD_REGISTER_KERNEL(
 
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(log_grad, LogGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(leaky_relu_grad, LeakyReluGradKernel)
-PD_REGISTER_ACTIVATION_GRAD_KERNEL(hardsigmoid_grad, HardSigmoidGradKernel)
+PD_REGISTER_KERNEL(hardsigmoid_grad,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::HardSigmoidGradKernel,
+                   float,
+                   phi::float16) {}
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(reciprocal_grad, ReciprocalGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(relu6_grad, Relu6GradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(mish_grad, MishGradKernel)


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Fix XPU float16 backward dispatch for `paddle.nn.functional.hardsigmoid`.

#### paddle.nn.functional.hardsigmoid
The XPU hardsigmoid forward kernel already supports float16, but the gradient path could fail during dispatch for float16 cases. This PR registers the XPU `hardsigmoid_grad` kernel for `phi::float16` and adds `FLOAT16` support for `hard_sigmoid_grad` in both XPU2 and XPU3 op support lists, aligning the support whitelist with the existing XPU gradient implementation.

Validation:
- Built and installed Paddle XPU successfully.
- Ran all 330 `paddle.nn.functional.hardsigmoid` PaddleAPITest cases from `/workspace/PaddleAPITest/all_config.txt`; all passed.

### 是否引起精度变化
否