### PR TITLE
[XPU] Fix hardswish float16 dispatch

### DIFF
--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -414,7 +414,7 @@ XPUOpMap& get_kl3_ops() {
       {"hard_sigmoid_grad", XPUKernelSet({FLOAT32})},
       {"hard_sigmoid", XPUKernelSet({FLOAT32, FLOAT16})},
       {"hard_swish_grad", XPUKernelSet({FLOAT32, FLOAT16})},
-      {"hard_swish", XPUKernelSet({FLOAT32})},
+      {"hard_swish", XPUKernelSet({FLOAT32, FLOAT16})},
       {"huber_loss_grad", XPUKernelSet({FLOAT32})},
       {"huber_loss", XPUKernelSet({FLOAT32})},
       {"kldiv_loss", XPUKernelSet({FLOAT32})},

--- a/paddle/phi/backends/xpu/xpu_op_kpfirst_list.h
+++ b/paddle/phi/backends/xpu/xpu_op_kpfirst_list.h
@@ -34,7 +34,8 @@ XPUOpMap& get_kp_ops() {
       {"elementwise_floordiv", XPUKernelSet({phi::DataType::INT32})},
       // activation op
       {"exp", XPUKernelSet({phi::DataType::FLOAT32})},
-      {"hard_swish", XPUKernelSet({phi::DataType::FLOAT32})},
+      {"hard_swish",
+       XPUKernelSet({phi::DataType::FLOAT32, phi::DataType::FLOAT16})},
       {"leaky_relu", XPUKernelSet({phi::DataType::FLOAT32})},
       {"softplus", XPUKernelSet({phi::DataType::FLOAT32})},
       {"reciprocal", XPUKernelSet({phi::DataType::FLOAT32})},


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
#### paddle.nn.functional.hardswish
This PR fixes XPU float16 `hardswish` dispatch by aligning XPU support metadata with the existing XPU kernel registration and XPU2/gradient support lists.

The XPU `hardswish` kernel already supports `phi::float16`, but `hard_swish` was still advertised as FLOAT32-only in XPU3 and KP-first metadata. As a result, float16 inputs could fail dispatch with a NotFound kernel error. This change advertises FLOAT16 support in the XPU metadata so the existing kernel can be selected.

Verification:
- Built and installed Paddle XPU successfully.
- Ran all 2358 `paddle.nn.functional.hardswish` cases from `/workspace/PaddleAPITest/all_config.txt`; all passed.
- Both reported float16 PaddleError cases passed.

### 是否引起精度变化
否