### PR TITLE
[Operator Mechanism] Fix max_pool1d ceil-mode precision on XPU

### DIFF
--- a/paddle/phi/kernels/xpu/pool_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/pool_grad_kernel.cc
@@ -396,7 +396,7 @@ void MaxPool2dWithIndexGradKernel(const Context& dev_ctx,
                                   const std::vector<int>& dilations_t,
                                   bool global_pooling,
                                   bool adaptive,
-                                  bool ceil_mode UNUSED,
+                                  bool ceil_mode,
                                   DenseTensor* dx) {
   // Check dilation support - XPU only supports dilation=1
   for (size_t i = 0; i < dilations_t.size(); ++i) {
@@ -419,6 +419,13 @@ void MaxPool2dWithIndexGradKernel(const Context& dev_ctx,
   std::vector<int64_t> kernel_size(kernel_size_t.begin(), kernel_size_t.end());
   std::vector<int64_t> strides(strides_t.begin(), strides_t.end());
   std::vector<int64_t> paddings(paddings_t.begin(), paddings_t.end());
+  funcs::UpdatePadding(&paddings,
+                       global_pooling,
+                       adaptive,
+                       "EXPLICIT",
+                       slice_ddim(dx->dims(), 2, dx->dims().size()),
+                       strides,
+                       kernel_size);
   const auto* index_data = mask.data<int>();
 
   PADDLE_ENFORCE_NOT_NULL(index_data,
@@ -442,6 +449,19 @@ void MaxPool2dWithIndexGradKernel(const Context& dev_ctx,
   const int64_t c = dx->dims()[1];
   const int64_t in_h = dx->dims()[2];
   const int64_t in_w = dx->dims()[3];
+  const int64_t out_h = dout.dims()[2];
+  const int64_t out_w = dout.dims()[3];
+
+  if (ceil_mode && !adaptive && !global_pooling) {
+    // Keep the gradient window geometry consistent with ceil-mode forward.
+    int64_t in_h_ceil =
+        (out_h - 1) * strides[0] + kernel_size[0] - 2 * paddings[0];
+    int64_t in_w_ceil =
+        (out_w - 1) * strides[1] + kernel_size[1] - 2 * paddings[2];
+    paddings[1] += (in_h_ceil - in_h);
+    paddings[3] += (in_w_ceil - in_w);
+  }
+
   auto output_grad = reinterpret_cast<const XPUType*>(dout.data<T>());
 
   int r = 0;

--- a/paddle/phi/kernels/xpu/pool_kernel.cc
+++ b/paddle/phi/kernels/xpu/pool_kernel.cc
@@ -318,7 +318,7 @@ void MaxPool2dWithIndexKernel(const Context& dev_ctx,
                               const std::vector<int>& dilations_t,
                               bool global_pooling,
                               bool adaptive,
-                              bool ceil_mode UNUSED,
+                              bool ceil_mode,
                               DenseTensor* out,
                               DenseTensor* mask) {
   // Check dilation support - XPU only supports dilation=1
@@ -349,6 +349,13 @@ void MaxPool2dWithIndexKernel(const Context& dev_ctx,
   std::vector<int64_t> kernel_size(kernel_size_t.begin(), kernel_size_t.end());
   std::vector<int64_t> strides(strides_t.begin(), strides_t.end());
   std::vector<int64_t> paddings(paddings_t.begin(), paddings_t.end());
+  funcs::UpdatePadding(&paddings,
+                       global_pooling,
+                       adaptive,
+                       "EXPLICIT",
+                       slice_ddim(x.dims(), 2, x.dims().size()),
+                       strides,
+                       kernel_size);
 
   PADDLE_ENFORCE_EQ(kernel_size.size(),
                     2,
@@ -373,6 +380,19 @@ void MaxPool2dWithIndexKernel(const Context& dev_ctx,
   const int64_t c = x.dims()[1];
   const int64_t in_h = x.dims()[2];
   const int64_t in_w = x.dims()[3];
+  const int64_t out_h = out->dims()[2];
+  const int64_t out_w = out->dims()[3];
+
+  if (ceil_mode && !adaptive && !global_pooling) {
+    // XDNN uses floor mode, so extend trailing padding for ceil-mode output.
+    int64_t in_h_ceil =
+        (out_h - 1) * strides[0] + kernel_size[0] - 2 * paddings[0];
+    int64_t in_w_ceil =
+        (out_w - 1) * strides[1] + kernel_size[1] - 2 * paddings[2];
+    paddings[1] += (in_h_ceil - in_h);
+    paddings[3] += (in_w_ceil - in_w);
+  }
+
   auto input = reinterpret_cast<const XPUType*>(x.data<T>());
   dev_ctx.template Alloc<T>(out);
   auto output = reinterpret_cast<XPUType*>(out->data<T>());


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes an XPU accuracy mismatch in `paddle.nn.functional.max_pool1d` when `ceil_mode=True` and `return_mask=True`.

The 1D API dispatches through the XPU `max_pool2d_with_index` path. Paddle infermeta allocates the ceil-mode output shape, but the XPU path passed compact padding directly to XDNN and did not extend trailing padding for the ceil-mode window. As a result, XDNN used floor-mode geometry and the trailing output position could differ from GPU.

This change normalizes padding in XPU `max_pool2d_with_index` forward and backward, then extends trailing bottom/right padding for non-adaptive, non-global ceil-mode pooling before invoking XDNN. The update is limited to XPU pooling kernels.

Verification: all 33 `paddle.nn.functional.max_pool1d` PaddleAPITest cases from `/workspace/PaddleAPITest/all_config.txt` pass on XPU after the fix.

### 是否引起精度变化
否. This corrects XPU behavior to match GPU for an existing API case.