### PR TITLE
[XPU] Fix leaky_relu fp16 grad on XPU

### DIFF
--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -267,7 +267,7 @@ XPUOpMap& get_kl2_ops() {
       {"lars_momentum", XPUKernelSet({FLOAT32, FLOAT16})},
       {"layer_norm_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"layer_norm", XPUKernelSet({FLOAT32, FLOAT16})},
-      {"leaky_relu_grad", XPUKernelSet({FLOAT32})},
+      {"leaky_relu_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"leaky_relu", XPUKernelSet({FLOAT32, FLOAT16})},
       {"less_equal", XPUKernelSet({INT64, INT32, FLOAT16, FLOAT32})},
       {"less_than", XPUKernelSet({INT64, INT32, FLOAT16, FLOAT32})},

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -495,7 +495,7 @@ XPUOpMap& get_kl3_ops() {
       {"label_smooth", XPUKernelSet({FLOAT32})},
       {"layer_norm_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"layer_norm", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
-      {"leaky_relu_grad", XPUKernelSet({FLOAT32})},
+      {"leaky_relu_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"leaky_relu", XPUKernelSet({FLOAT32, FLOAT16})},
       {"less_equal", XPUKernelSet({INT64, INT32, FLOAT16, BFLOAT16, FLOAT32})},
       {"less_than", XPUKernelSet({INT64, INT32, FLOAT16, BFLOAT16, FLOAT32})},

--- a/paddle/phi/kernels/xpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_grad_kernel.cc
@@ -224,6 +224,7 @@ struct XPULogGradFunctor : public funcs::BaseActivationFunctor<T> {
 
 template <typename T>
 struct XPULeakyReluGradFunctor : public funcs::BaseActivationFunctor<T> {
+  using XPUType = typename XPUTypeTrait<T>::Type;
   float alpha;
   typename funcs::BaseActivationFunctor<T>::AttrPair GetAttrs() {
     return {{"alpha", &alpha}};
@@ -246,10 +247,10 @@ struct XPULeakyReluGradFunctor : public funcs::BaseActivationFunctor<T> {
     // y == nullptr here,
     // so we give 2 x to the api
     int r = xpu::leaky_relu_grad(xpu_context,
-                                 reinterpret_cast<const float*>(x_data),
-                                 reinterpret_cast<const float*>(x_data),
-                                 reinterpret_cast<const float*>(y_grad),
-                                 reinterpret_cast<float*>(x_grad),
+                                 reinterpret_cast<const XPUType*>(x_data),
+                                 reinterpret_cast<const XPUType*>(x_data),
+                                 reinterpret_cast<const XPUType*>(y_grad),
+                                 reinterpret_cast<XPUType*>(x_grad),
                                  dx->numel(),
                                  alpha);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "leaky_relu_grad");
@@ -783,6 +784,8 @@ PD_REGISTER_KERNEL(silu_grad,
 
 #define PD_REGISTER_ACTIVATION_GRAD_KERNEL(name, func) \
   PD_REGISTER_KERNEL(name, XPU, ALL_LAYOUT, phi::func, float) {}
+#define PD_REGISTER_ACTIVATION_GRAD_KERNEL_FP16(name, func) \
+  PD_REGISTER_KERNEL(name, XPU, ALL_LAYOUT, phi::func, float, phi::float16) {}
 
 PD_REGISTER_KERNEL(tanh_grad,
                    XPU,
@@ -846,7 +849,7 @@ PD_REGISTER_KERNEL(
     sqrt_grad, XPU, ALL_LAYOUT, phi::SqrtGradKernel, float, phi::float16) {}
 
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(log_grad, LogGradKernel)
-PD_REGISTER_ACTIVATION_GRAD_KERNEL(leaky_relu_grad, LeakyReluGradKernel)
+PD_REGISTER_ACTIVATION_GRAD_KERNEL_FP16(leaky_relu_grad, LeakyReluGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(hardsigmoid_grad, HardSigmoidGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(reciprocal_grad, ReciprocalGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(relu6_grad, Relu6GradKernel)


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
#### paddle.nn.functional.leaky_relu
Fixes XPU float16 backward errors by registering `leaky_relu_grad` for `phi::float16`, using `XPUTypeTrait` pointer casts in the XPU grad functor, and enabling `FLOAT16` support metadata for `leaky_relu_grad` on XPU2/XPU3.

Verified all 664 `paddle.nn.functional.leaky_relu` PaddleAPITest cases pass after rebuild/install.

### 是否引起精度变化
否