### PR TITLE
[Operator Mechanism] Fix XPU relu6 float16 grad kernel error

### DIFF
--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -352,7 +352,7 @@ XPUOpMap& get_kl2_ops() {
       {"reduce_sum",
        XPUKernelSet({FLOAT16, INT64, INT32, INT8, FLOAT32, BFLOAT16})},
       {"relu6", XPUKernelSet({FLOAT32, FLOAT16})},
-      {"relu6_grad", XPUKernelSet({FLOAT32})},
+      {"relu6_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"relu_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"relu", XPUKernelSet({FLOAT32, FLOAT16})},
       {"repeat_interleave", XPUKernelSet({INT32, INT64})},

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -665,7 +665,7 @@ XPUOpMap& get_kl3_ops() {
       {"reduce_sum",
        XPUKernelSet({FLOAT16, INT64, INT32, INT8, FLOAT32, BFLOAT16, BOOL})},
       {"relu6", XPUKernelSet({FLOAT32, FLOAT16})},
-      {"relu6_grad", XPUKernelSet({FLOAT32})},
+      {"relu6_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"relu_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"relu", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"reshape2_grad",

--- a/paddle/phi/kernels/xpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_grad_kernel.cc
@@ -369,9 +369,43 @@ struct XPURelu6GradFunctor : public funcs::BaseActivationFunctor<T> {
                   const DenseTensor* out,
                   const DenseTensor* dout,
                   DenseTensor* dx) const {
-    int r = xpu_activation_backward<Context, T, XPUType>(
-        dev_ctx, x, out, dout, dx, xpu::relu6_grad<XPUType>);
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "relu6_grad");
+    if constexpr (std::is_same_v<T, phi::float16>) {
+      // XPU relu6_grad does not support float16 directly. Match GPU behavior
+      // by computing the backward mask in float32, then cast the result back.
+      xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+      float* out_fp32 = RAII_GUARD.alloc_l3_or_gm<float>(out->numel());
+      float* dout_fp32 = RAII_GUARD.alloc_l3_or_gm<float>(dout->numel());
+      float* dx_fp32 = RAII_GUARD.alloc_l3_or_gm<float>(dx->numel());
+
+      int r = xpu::cast<XPUType, float>(dev_ctx.x_context(),
+                                        reinterpret_cast<const XPUType*>(
+                                            out->data<T>()),
+                                        out_fp32,
+                                        out->numel());
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+      r = xpu::cast<XPUType, float>(dev_ctx.x_context(),
+                                    reinterpret_cast<const XPUType*>(
+                                        dout->data<T>()),
+                                    dout_fp32,
+                                    dout->numel());
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+      r = xpu::relu6_grad<float>(dev_ctx.x_context(),
+                                  nullptr,
+                                  out_fp32,
+                                  dout_fp32,
+                                  dx_fp32,
+                                  dx->numel());
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "relu6_grad");
+      r = xpu::cast<float, XPUType>(dev_ctx.x_context(),
+                                    dx_fp32,
+                                    reinterpret_cast<XPUType*>(dx->data<T>()),
+                                    dx->numel());
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+    } else {
+      int r = xpu_activation_backward<Context, T, XPUType>(
+          dev_ctx, x, out, dout, dx, xpu::relu6_grad<XPUType>);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "relu6_grad");
+    }
   }
 };
 
@@ -849,7 +883,8 @@ PD_REGISTER_ACTIVATION_GRAD_KERNEL(log_grad, LogGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(leaky_relu_grad, LeakyReluGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(hardsigmoid_grad, HardSigmoidGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(reciprocal_grad, ReciprocalGradKernel)
-PD_REGISTER_ACTIVATION_GRAD_KERNEL(relu6_grad, Relu6GradKernel)
+PD_REGISTER_KERNEL(
+    relu6_grad, XPU, ALL_LAYOUT, phi::Relu6GradKernel, float, phi::float16) {}
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(mish_grad, MishGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(softplus_grad, SoftplusGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(sin_grad, SinGradKernel)

--- a/paddle/phi/kernels/xpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_grad_kernel.cc
@@ -377,24 +377,24 @@ struct XPURelu6GradFunctor : public funcs::BaseActivationFunctor<T> {
       float* dout_fp32 = RAII_GUARD.alloc_l3_or_gm<float>(dout->numel());
       float* dx_fp32 = RAII_GUARD.alloc_l3_or_gm<float>(dx->numel());
 
-      int r = xpu::cast<XPUType, float>(dev_ctx.x_context(),
-                                        reinterpret_cast<const XPUType*>(
-                                            out->data<T>()),
-                                        out_fp32,
-                                        out->numel());
+      int r = xpu::cast<XPUType, float>(
+          dev_ctx.x_context(),
+          reinterpret_cast<const XPUType*>(out->data<T>()),
+          out_fp32,
+          out->numel());
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
-      r = xpu::cast<XPUType, float>(dev_ctx.x_context(),
-                                    reinterpret_cast<const XPUType*>(
-                                        dout->data<T>()),
-                                    dout_fp32,
-                                    dout->numel());
+      r = xpu::cast<XPUType, float>(
+          dev_ctx.x_context(),
+          reinterpret_cast<const XPUType*>(dout->data<T>()),
+          dout_fp32,
+          dout->numel());
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
       r = xpu::relu6_grad<float>(dev_ctx.x_context(),
-                                  nullptr,
-                                  out_fp32,
-                                  dout_fp32,
-                                  dx_fp32,
-                                  dx->numel());
+                                 nullptr,
+                                 out_fp32,
+                                 dout_fp32,
+                                 dx_fp32,
+                                 dx->numel());
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "relu6_grad");
       r = xpu::cast<float, XPUType>(dev_ctx.x_context(),
                                     dx_fp32,


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes the XPU backward kernel error for `paddle.nn.functional.relu6` with float16 inputs.

#### paddle.nn.functional.relu6
The forward XPU `relu6` kernel already supports float16, but `relu6_grad` was only registered and advertised for float32. Float16 autograd cases therefore failed because the XPU float16 `relu6_grad` kernel could not be found.

This change adds a float16 path for XPU `relu6_grad` that casts `out` and `dout` to float32, reuses the existing XPU float32 `relu6_grad` primitive, and casts the gradient output back to float16. It also updates the XPU2/XPU3 op capability lists to include FLOAT16 for `relu6_grad`.

Validation:
- Built and installed Paddle XPU successfully.
- Ran all 232 `paddle.nn.functional.relu6` PaddleAPITest cases from `/workspace/PaddleAPITest/all_config.txt`.
- One initial remote GPU HTTP OOM case was rerun and passed; final result: all cases passed.
- Ran `prek` on the changed files successfully.

### 是否引起精度变化
否. This fixes an XPU float16 kernel registration/runtime error by aligning XPU behavior with the existing GPU-supported float16 backward path.