### PR TITLE
[CINN][Custom Device] Optimize GroupSchedule for CustomDevice

### DIFF
--- a/paddle/cinn/common/target.cc
+++ b/paddle/cinn/common/target.cc
@@ -125,8 +125,10 @@ int GetMaxNumThreadsImpl(HygonDCUArchSYCL arch) { return 1024; }
 
 int GetMaxNumThreadsImpl(CustomDeviceArch arch) {
 #ifdef CINN_WITH_CUSTOM_DEVICE
-  return static_cast<int>(phi::DeviceManager::GetMaxThreadsPerBlock(
+  if (arch.device_type.empty()) return 1024;
+  int v = static_cast<int>(phi::DeviceManager::GetMaxThreadsPerBlock(
       phi::CustomPlace(arch.device_type, arch.device_id)));
+  return v > 0 ? v : 1024;
 #else
   PADDLE_THROW(::common::errors::Unimplemented(
       "GetMaxNumThreadsImpl(CustomDeviceArch) requires "
@@ -174,8 +176,10 @@ int GetMultiProcessCountImpl(HygonDCUArchSYCL arch) {
 
 int GetMultiProcessCountImpl(CustomDeviceArch arch) {
 #ifdef CINN_WITH_CUSTOM_DEVICE
-  return static_cast<int>(phi::DeviceManager::GetMultiProcessors(
+  if (arch.device_type.empty()) return 1;
+  int v = static_cast<int>(phi::DeviceManager::GetMultiProcessors(
       phi::CustomPlace(arch.device_type, arch.device_id)));
+  return v > 0 ? v : 1;
 #else
   PADDLE_THROW(::common::errors::Unimplemented(
       "GetMultiProcessCountImpl(CustomDeviceArch) requires "
@@ -229,8 +233,10 @@ int GetMaxThreadsPerSmImpl(HygonDCUArchSYCL arch) {
 
 int GetMaxThreadsPerSmImpl(CustomDeviceArch arch) {
 #ifdef CINN_WITH_CUSTOM_DEVICE
-  return static_cast<int>(phi::DeviceManager::GetMaxThreadsPerMultiProcessor(
+  if (arch.device_type.empty()) return 2048;
+  int v = static_cast<int>(phi::DeviceManager::GetMaxThreadsPerMultiProcessor(
       phi::CustomPlace(arch.device_type, arch.device_id)));
+  return v > 0 ? v : 2048;
 #else
   PADDLE_THROW(::common::errors::Unimplemented(
       "GetMaxThreadsPerSmImpl(CustomDeviceArch) requires "
@@ -282,8 +288,10 @@ int GetMaxBlocksPerSmImpl(HygonDCUArchSYCL arch) {
 
 int GetMaxBlocksPerSmImpl(CustomDeviceArch arch) {
 #ifdef CINN_WITH_CUSTOM_DEVICE
-  return static_cast<int>(phi::DeviceManager::GetMaxBlocksPerMultiProcessor(
+  if (arch.device_type.empty()) return 0;
+  int v = static_cast<int>(phi::DeviceManager::GetMaxBlocksPerMultiProcessor(
       phi::CustomPlace(arch.device_type, arch.device_id)));
+  return v > 0 ? v : 0;  // 0 = "unknown", callers check `if (hw_max_bps > 0)`
 #else
   PADDLE_THROW(::common::errors::Unimplemented(
       "GetMaxBlocksPerSmImpl(CustomDeviceArch) requires "
@@ -478,7 +486,7 @@ int GetMaxThreads() {
     auto place = phi::CustomPlace(dev_type, device_id);
     max_threads = static_cast<int>(
         phi::DeviceManager::GetMultiProcessors(place) *
-        phi::DeviceManager::GetMaxThreadsPerMultiProcessor(place));
+        phi::DeviceManager::GetMaxThreadsPerMultiProcessor(place) * 4);
   }
 #endif
   return max_threads;

--- a/paddle/cinn/common/target.cc
+++ b/paddle/cinn/common/target.cc
@@ -484,6 +484,9 @@ int GetMaxThreads() {
     int device_id = phi::DeviceManager::GetDevice(dev_types[0]);
     std::string dev_type = dev_types[0];
     auto place = phi::CustomPlace(dev_type, device_id);
+    // Align with CUDA path: * 4 approximates concurrent warp batches per SM.
+    // Without this factor, CustomDevice reports a 4x lower upper bound than
+    // CUDA on equivalent hardware, which over-throttles GroupSchedule.
     max_threads = static_cast<int>(
         phi::DeviceManager::GetMultiProcessors(place) *
         phi::DeviceManager::GetMaxThreadsPerMultiProcessor(place) * 4);

--- a/paddle/cinn/hlir/pe/schedule.cc
+++ b/paddle/cinn/hlir/pe/schedule.cc
@@ -24,12 +24,12 @@
 #include <numeric>
 #include <utility>
 
+#include "paddle/cinn/common/target.h"
 #include "paddle/cinn/hlir/pe/load_x86_params.h"
 #include "paddle/cinn/optim/ir_simplify.h"
 #include "paddle/cinn/utils/string.h"
 #include "paddle/common/enforce.h"
 #include "paddle/utils/flat_hash_map.h"
-#include "paddle/cinn/common/target.h"
 PD_DECLARE_bool(cinn_use_cuda_vectorize);
 namespace cinn {
 namespace hlir {
@@ -84,12 +84,13 @@ int GetInnerSplitter(int origin, int other_axis) {
   int a = SplitEven(two_exp);
   int b = two_exp / a;
 #ifdef CINN_WITH_CUSTOM_DEVICE
-  int max_thread_block = cinn::common::DefaultDeviceTarget().max_num_threads();
-  if (max_thread_block <= 0) max_thread_block = 1024;
+  static int v = cinn::common::DefaultDeviceTarget().max_num_threads();
+  const int max_thread_block = v > 0 ? v : 1024;
 #else
   constexpr int max_thread_block = 1024;
 #endif
-  while (a * other_axis >= max_thread_block || b * other_axis >= max_thread_block) {
+  while (a * other_axis >= max_thread_block ||
+         b * other_axis >= max_thread_block) {
     two_exp = two_exp / 2;
     a = SplitEven(two_exp);
     b = two_exp / a;

--- a/paddle/cinn/hlir/pe/schedule.cc
+++ b/paddle/cinn/hlir/pe/schedule.cc
@@ -29,6 +29,7 @@
 #include "paddle/cinn/utils/string.h"
 #include "paddle/common/enforce.h"
 #include "paddle/utils/flat_hash_map.h"
+#include "paddle/cinn/common/target.h"
 PD_DECLARE_bool(cinn_use_cuda_vectorize);
 namespace cinn {
 namespace hlir {
@@ -82,7 +83,13 @@ int GetInnerSplitter(int origin, int other_axis) {
   two_exp = two_exp / 2;
   int a = SplitEven(two_exp);
   int b = two_exp / a;
-  while (a * other_axis >= 1024 || b * other_axis >= 1024) {
+#ifdef CINN_WITH_CUSTOM_DEVICE
+  int max_thread_block = cinn::common::DefaultDeviceTarget().max_num_threads();
+  if (max_thread_block <= 0) max_thread_block = 1024;
+#else
+  constexpr int max_thread_block = 1024;
+#endif
+  while (a * other_axis >= max_thread_block || b * other_axis >= max_thread_block) {
     two_exp = two_exp / 2;
     a = SplitEven(two_exp);
     b = two_exp / a;

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -330,7 +330,7 @@ int CalculateWarpNums(const SMConfig& sm_config,
     thread_configs.push_back(t);
   }
   if (thread_configs.empty()) {
-    thread_configs.push_back(max_threads); 
+    thread_configs.push_back(max_threads);
   }
 #else
   int best_warp_nums = 8;
@@ -594,7 +594,11 @@ bool RegisterNumsLimitedCheckInCTACanApplyVectorize(
   int max_blocks_per_sm_limit = target.get_max_blocks_per_sm();
   int max_regs_per_sm = GetMaxRegistersPerSM(target);
   int max_blocks_per_sm =
-      Trim(CeilDiv(max_warps_per_sm, warp_nums), 1, max_blocks_per_sm_limit);
+      max_blocks_per_sm_limit > 0
+          ? Trim(CeilDiv(max_warps_per_sm, warp_nums),
+                 1,
+                 max_blocks_per_sm_limit)
+          : std::max(int64_t(1), CeilDiv(max_warps_per_sm, warp_nums));
   int best_register_nums_per_thread =
       max_regs_per_sm / max_blocks_per_sm / warp_nums / warp_size;
 #else
@@ -685,9 +689,9 @@ TileConfigMap BuildVectorizeConfig(
   bool can_vectorize = false;
   bool is_sm_fully_utilized = true;
   ReduceMethod reduce_method = NoneReduceMethod();
-  SMConfig sm_config(target.get_max_threads_per_sm(),
-                     target.get_max_blocks_per_sm(),
-                     target.get_multi_processor_count());
+  SMConfig sm_config(std::max(1, target.get_max_threads_per_sm()),
+                     std::max(1, target.get_max_blocks_per_sm()),
+                     std::max(1, target.get_multi_processor_count()));
 #ifdef CINN_WITH_CUSTOM_DEVICE
   int max_threads_per_block = target.max_num_threads();
   int max_warp_cnt = max_threads_per_block / warp_size;

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -1063,8 +1063,8 @@ TileConfigMap BuildStaticSpatialConfig(
     if (hw_max_bps > 0) blocks_per_sm = std::min(blocks_per_sm, hw_max_bps);
     blocks_per_sm = std::max(1, blocks_per_sm);
     int64_t rd_block_num = std::max(int64_t(1),
-        FloorPow2(static_cast<int64_t>(sm_count) * blocks_per_sm /
-                  sp_block_num));
+                                    FloorPow2(static_cast<int64_t>(sm_count) *
+                                              blocks_per_sm / sp_block_num));
 
     if (rd_block_num > 1 && base_info->can_apply_grid_reduce) {
       int64_t rd_threshold =

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -986,8 +986,8 @@ TileConfigMap BuildStaticSpatialConfig(
     if (hw_max_bps > 0) blocks_per_sm = std::min(blocks_per_sm, hw_max_bps);
     blocks_per_sm = std::max(1, blocks_per_sm);
     rd_block_num = std::max(int64_t(1),
-        FloorPow2(static_cast<int64_t>(sm_count) * blocks_per_sm /
-                  sp_block_num));
+                            FloorPow2(static_cast<int64_t>(sm_count) *
+                                      blocks_per_sm / sp_block_num));
 
     collector({1, kMaxNumel, 1, medium_bucket_threshold},
               {small_warp_num,

--- a/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
+++ b/paddle/cinn/ir/group_schedule/config/group_tile_config.cc
@@ -319,13 +319,18 @@ int CalculateWarpNums(const SMConfig& sm_config,
   int min_diff_to_full_sm = sm_config.sm_count;
 #ifdef CINN_WITH_CUSTOM_DEVICE
   int best_warp_nums = std::min(8, max_warp_cnt);
+  // Top = max_threads, bottom = warp_size * 4 (latency-hiding lower bound),
+  // halve per step. Ladder length adapts to hardware automatically:
+  //   A100  : {1024,512,256,128}  (NV-equivalent)
+  //   MetaX : {1024,512,256}      (drops 2-warp 128)
+  //   Iluvatar: {4096,2048,1024,512,256}
   std::vector<int> thread_configs;
-  if (max_threads >= 1024) thread_configs.push_back(1024);
-  if (max_threads >= 512) thread_configs.push_back(512);
-  if (max_threads >= 256) thread_configs.push_back(256);
-  if (max_threads >= 128) thread_configs.push_back(128);
-  if (thread_configs.empty() || thread_configs[0] != max_threads) {
-    if (thread_configs.empty()) thread_configs.push_back(max_threads);
+  const int min_block = warp_size * 4;
+  for (int t = max_threads; t >= min_block; t /= 2) {
+    thread_configs.push_back(t);
+  }
+  if (thread_configs.empty()) {
+    thread_configs.push_back(max_threads); 
   }
 #else
   int best_warp_nums = 8;
@@ -367,14 +372,14 @@ int UpdateWarpNumsInDifferentCase(
   const auto& last_dim = base_info->iter_space_type.back().first;
   if (group_vectorize_info.has_if_else_op && last_dim == "R") {
 #ifdef CINN_WITH_CUSTOM_DEVICE
-    warp_nums = Trim(warp_nums, 1, std::min(16, max_warp_cnt));
+    warp_nums = Trim(warp_nums, 1, std::max(1, max_warp_cnt / 2));
 #else
     warp_nums = Trim(warp_nums, 1, 16);
 #endif
   } else if (!group_vectorize_info.args_broadcast_axis_info.empty() &&
              last_dim == "S") {
 #ifdef CINN_WITH_CUSTOM_DEVICE
-    warp_nums = Trim(warp_nums, 1, std::min(8, max_warp_cnt));
+    warp_nums = Trim(warp_nums, 1, std::max(1, max_warp_cnt / 4));
 #else
     warp_nums = Trim(warp_nums, 1, 8);
 #endif
@@ -968,10 +973,22 @@ TileConfigMap BuildStaticSpatialConfig(
 
   if (last_dim == "R") {
     int64_t sp_block_num = std::max(spatial_numel, int64_t(1));
-    int64_t rd_block_num = FloorPow2(sm_count / sp_block_num);
+    int64_t rd_block_num = FloorPow2(sm_count / sp_block_num);  // NV baseline
 
 #ifdef CINN_WITH_CUSTOM_DEVICE
-    int small_warp_num = std::min(8, max_warp_cnt);
+    int small_warp_num = std::max(1, max_warp_cnt / 4);
+    int max_thr_per_sm = target.get_max_threads_per_sm();
+    int est_thr_per_block = small_warp_num * warp_size;
+    int blocks_per_sm = (max_thr_per_sm > 0 && est_thr_per_block > 0)
+                            ? max_thr_per_sm / est_thr_per_block
+                            : 1;
+    int hw_max_bps = target.get_max_blocks_per_sm();
+    if (hw_max_bps > 0) blocks_per_sm = std::min(blocks_per_sm, hw_max_bps);
+    blocks_per_sm = std::max(1, blocks_per_sm);
+    rd_block_num = std::max(int64_t(1),
+        FloorPow2(static_cast<int64_t>(sm_count) * blocks_per_sm /
+                  sp_block_num));
+
     collector({1, kMaxNumel, 1, medium_bucket_threshold},
               {small_warp_num,
                warp_size,
@@ -1036,8 +1053,18 @@ TileConfigMap BuildStaticSpatialConfig(
 #ifdef CINN_WITH_CUSTOM_DEVICE
     int64_t sp_block_num =
         std::max(CeilDiv(spatial_numel, warp_size), int64_t(1));
-    int64_t rd_block_num = FloorPow2(sm_count / sp_block_num);
-    int spatial_warp_num = std::min(16, max_warp_cnt);
+    int spatial_warp_num = std::max(1, max_warp_cnt / 2);
+    int max_thr_per_sm = target.get_max_threads_per_sm();
+    int est_thr_per_block = spatial_warp_num * warp_size;
+    int blocks_per_sm = (max_thr_per_sm > 0 && est_thr_per_block > 0)
+                            ? max_thr_per_sm / est_thr_per_block
+                            : 1;
+    int hw_max_bps = target.get_max_blocks_per_sm();
+    if (hw_max_bps > 0) blocks_per_sm = std::min(blocks_per_sm, hw_max_bps);
+    blocks_per_sm = std::max(1, blocks_per_sm);
+    int64_t rd_block_num = std::max(int64_t(1),
+        FloorPow2(static_cast<int64_t>(sm_count) * blocks_per_sm /
+                  sp_block_num));
 
     if (rd_block_num > 1 && base_info->can_apply_grid_reduce) {
       int64_t rd_threshold =

--- a/paddle/cinn/ir/group_schedule/tactic/tile_broadcast_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_broadcast_tactic.cc
@@ -614,6 +614,17 @@ void TileBroadcastTactic::Apply(ir::IRSchedule* sch,
     ApplyVectorize(sch, block_id, block_size);
     return;
   }
+#ifdef CINN_WITH_CUSTOM_DEVICE
+  // Thick-SM upgrade: only takes effect on devices like Iluvatar (mtps >= 4096).
+  // Doubles per-block work density; matches NV's medium-bucket serial-8 intent.
+  // Vectorize path uses the original block_size unchanged.
+  const int mtps = context_->target.get_max_threads_per_sm();
+  if (mtps >= 4096) {
+    const int ws = context_->config.tile_config.warp_size;
+    block_size = std::min(static_cast<int>(ws * 16),
+                          static_cast<int>(context_->target.max_num_threads()));
+  }
+#endif
   // check the number of warps here, if not a applicable
   // preserved_size, func will return later
   if (applied_layout_ == BroadcastLayout::NHWCLayout) {

--- a/paddle/cinn/ir/group_schedule/tactic/tile_broadcast_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_broadcast_tactic.cc
@@ -615,11 +615,17 @@ void TileBroadcastTactic::Apply(ir::IRSchedule* sch,
     return;
   }
 #ifdef CINN_WITH_CUSTOM_DEVICE
-  // Thick-SM upgrade: only takes effect on devices like Iluvatar (mtps >= 4096).
-  // Doubles per-block work density; matches NV's medium-bucket serial-8 intent.
+  // Thick-SM upgrade: wide-SM CustomDevices (e.g. Iluvatar) benefit from
+  // doubled per-block work density; smaller-SM devices keep the default
+  // block_size. Matches NV's medium-bucket serial-8 intent.
   // Vectorize path uses the original block_size unchanged.
+  // NOTE: currently only Iluvatar-class devices are known to satisfy this
+  // threshold. If a future CustomDevice with mtps >= kWideSmMtpsThreshold
+  // turns out to be unsuitable for this amplification, switch to an explicit
+  // device-capability whitelist instead of a single mtps threshold.
+  constexpr int kWideSmMtpsThreshold = 4096;
   const int mtps = context_->target.get_max_threads_per_sm();
-  if (mtps >= 4096) {
+  if (mtps >= kWideSmMtpsThreshold) {
     const int ws = context_->config.tile_config.warp_size;
     block_size = std::min(static_cast<int>(ws * 16),
                           static_cast<int>(context_->target.max_num_threads()));

--- a/paddle/cinn/ir/group_schedule/tactic/tile_broadcast_tactic.cc
+++ b/paddle/cinn/ir/group_schedule/tactic/tile_broadcast_tactic.cc
@@ -618,7 +618,8 @@ void TileBroadcastTactic::Apply(ir::IRSchedule* sch,
   // Thick-SM upgrade: wide-SM CustomDevices (e.g. Iluvatar) benefit from
   // doubled per-block work density; smaller-SM devices keep the default
   // block_size. Matches NV's medium-bucket serial-8 intent.
-  // Vectorize path uses the original block_size unchanged.
+  // Vectorize path is already handled and has returned above; the
+  // amplification below only affects the non-vectorize NHWCLayout path.
   // NOTE: currently only Iluvatar-class devices are known to satisfy this
   // threshold. If a future CustomDevice with mtps >= kWideSmMtpsThreshold
   // turns out to be unsuitable for this amplification, switch to an explicit

--- a/paddle/cinn/ir/schedule/ir_schedule_util.cc
+++ b/paddle/cinn/ir/schedule/ir_schedule_util.cc
@@ -184,30 +184,38 @@ void SetCudaAxisInfo(ir::LoweredFunc lowered_func) {
     info.set_max_threads_per_block(max_threads_per_block);
     if (!lowered_func->temp_spaces.empty()) {
 #ifdef CINN_WITH_CUSTOM_DEVICE
-      // Maintain ">= 64 reg/thread" budget (A100: 65536/1024 = 64).
-      // Scale by RegistersPerSM, not MaxThreadsPerSM, to avoid spill on
-      // wide-register architectures (e.g. MetaX 2x, Iluvatar 4x NV regs).
+      // Cap regs/thread via min_blocks_per_sm to keep occupancy:
+      //   target_threads_per_sm = reg_per_sm / 64
+      //   min_blocks_per_sm     = target_threads_per_sm / max_threads_per_block
+      // Scaling by RegistersPerSM (not MaxThreadsPerSM) avoids spill on
+      // wide-register devices (MetaX 2x, Iluvatar 4x NV regs).
+      // If RegistersPerSM is unavailable, leave min_blocks_per_sm = -1 and
+      // let the compiler pick its default occupancy, instead of using
+      // NV's 65536 which would under-tune wide-register devices.
       constexpr int kTargetRegPerThread = 64;
       const auto& tgt = cinn::common::DefaultDeviceTarget();
-      int reg_per_sm = 65536;  // NV fallback
-      if (auto* arch =
-              std::get_if<cinn::common::CustomDeviceArch>(&tgt.arch.variant())) {
+      int reg_per_sm = 0;
+      if (auto* arch = std::get_if<cinn::common::CustomDeviceArch>(
+              &tgt.arch.variant())) {
         if (!arch->device_type.empty()) {
           int v = phi::DeviceManager::GetMaxRegistersPerMultiProcessor(
               phi::CustomPlace(arch->device_type, arch->device_id));
           if (v > 0) reg_per_sm = v;
         }
       }
-      int mtps = tgt.get_max_threads_per_sm();
-      int target_total = reg_per_sm / kTargetRegPerThread;
-      if (mtps > 0) target_total = std::min(target_total, mtps);
-      if (target_total <= 0) target_total = 1024;  // extreme fallback
-      min_blocks_per_sm = target_total / max_threads_per_block;
-
-      int hw_max_bps = tgt.get_max_blocks_per_sm();
-      if (hw_max_bps > 0) {
-        min_blocks_per_sm = std::min(min_blocks_per_sm, hw_max_bps);
+      if (reg_per_sm > 0) {
+        int mtps = tgt.get_max_threads_per_sm();
+        int target_total = reg_per_sm / kTargetRegPerThread;
+        if (mtps > 0) target_total = std::min(target_total, mtps);
+        if (target_total > 0) {
+          min_blocks_per_sm = target_total / max_threads_per_block;
+          int hw_max_bps = tgt.get_max_blocks_per_sm();
+          if (hw_max_bps > 0) {
+            min_blocks_per_sm = std::min(min_blocks_per_sm, hw_max_bps);
+          }
+        }
       }
+      // Query failed: keep min_blocks_per_sm == -1 so it is not emitted.
 #else
       min_blocks_per_sm = 1024 / max_threads_per_block;
 #endif

--- a/paddle/cinn/ir/schedule/ir_schedule_util.cc
+++ b/paddle/cinn/ir/schedule/ir_schedule_util.cc
@@ -192,6 +192,9 @@ void SetCudaAxisInfo(ir::LoweredFunc lowered_func) {
       // If RegistersPerSM is unavailable, leave min_blocks_per_sm = -1 and
       // let the compiler pick its default occupancy, instead of using
       // NV's 65536 which would under-tune wide-register devices.
+      // 64 is NV's typical regs/thread budget. On wide-register devices it
+      // is conservative -- yields a smaller min_blocks_per_sm, only relaxes
+      // the occupancy hint, never causes spill.
       constexpr int kTargetRegPerThread = 64;
       const auto& tgt = cinn::common::DefaultDeviceTarget();
       int reg_per_sm = 0;

--- a/paddle/cinn/ir/schedule/ir_schedule_util.cc
+++ b/paddle/cinn/ir/schedule/ir_schedule_util.cc
@@ -25,6 +25,11 @@
 
 #include "paddle/cinn/common/integer_set.h"
 #include "paddle/cinn/common/ir_util.h"
+#include "paddle/cinn/common/target.h"
+#ifdef CINN_WITH_CUSTOM_DEVICE
+#include "paddle/phi/backends/device_manager.h"
+#include "paddle/phi/common/place.h"
+#endif
 #include "paddle/cinn/ir/ir.h"
 #include "paddle/cinn/ir/ir_printer.h"
 #include "paddle/cinn/ir/ir_visitor.h"
@@ -178,7 +183,34 @@ void SetCudaAxisInfo(ir::LoweredFunc lowered_func) {
     int min_blocks_per_sm = -1;
     info.set_max_threads_per_block(max_threads_per_block);
     if (!lowered_func->temp_spaces.empty()) {
+#ifdef CINN_WITH_CUSTOM_DEVICE
+      // Maintain ">= 64 reg/thread" budget (A100: 65536/1024 = 64).
+      // Scale by RegistersPerSM, not MaxThreadsPerSM, to avoid spill on
+      // wide-register architectures (e.g. MetaX 2x, Iluvatar 4x NV regs).
+      constexpr int kTargetRegPerThread = 64;
+      const auto& tgt = cinn::common::DefaultDeviceTarget();
+      int reg_per_sm = 65536;  // NV fallback
+      if (auto* arch =
+              std::get_if<cinn::common::CustomDeviceArch>(&tgt.arch.variant())) {
+        if (!arch->device_type.empty()) {
+          int v = phi::DeviceManager::GetMaxRegistersPerMultiProcessor(
+              phi::CustomPlace(arch->device_type, arch->device_id));
+          if (v > 0) reg_per_sm = v;
+        }
+      }
+      int mtps = tgt.get_max_threads_per_sm();
+      int target_total = reg_per_sm / kTargetRegPerThread;
+      if (mtps > 0) target_total = std::min(target_total, mtps);
+      if (target_total <= 0) target_total = 1024;  // extreme fallback
+      min_blocks_per_sm = target_total / max_threads_per_block;
+
+      int hw_max_bps = tgt.get_max_blocks_per_sm();
+      if (hw_max_bps > 0) {
+        min_blocks_per_sm = std::min(min_blocks_per_sm, hw_max_bps);
+      }
+#else
       min_blocks_per_sm = 1024 / max_threads_per_block;
+#endif
       if (min_blocks_per_sm > 1) {
         info.set_min_blocks_per_sm(min_blocks_per_sm);
       }

--- a/paddle/cinn/ir/schedule/ir_schedule_util.cc
+++ b/paddle/cinn/ir/schedule/ir_schedule_util.cc
@@ -210,7 +210,7 @@ void SetCudaAxisInfo(ir::LoweredFunc lowered_func) {
         int mtps = tgt.get_max_threads_per_sm();
         int target_total = reg_per_sm / kTargetRegPerThread;
         if (mtps > 0) target_total = std::min(target_total, mtps);
-        if (target_total > 0) {
+        if (target_total > 0 && max_threads_per_block > 0) {
           min_blocks_per_sm = target_total / max_threads_per_block;
           int hw_max_bps = tgt.get_max_blocks_per_sm();
           if (hw_max_bps > 0) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
CINN

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you've done -->
针对 CustomDevice（如 MetaX、Iluvatar 等硬件）优化 CINN GroupSchedule 调度策略：
- 在 `target.cc` 中为 CustomDeviceArch 的各硬件参数查询函数（GetMaxNumThreads、GetMultiProcessCount、GetMaxThreadsPerSm、GetMaxBlocksPerSm）添加 `device_type.empty()` 防御检查和合理默认值（1024/1/2048/0），避免空设备类型时 crash。
- 在 `group_tile_config.cc` 的 CalculateWarpNums/BuildStaticSpatialConfig 中，用硬件动态查询（GetMaxThreadsPerSM、GetMaxBlocksPerSM、GetMaxRegistersPerSM）替换 NVIDIA 专用魔法数（1024/8 warp/16 warp 等），使调度参数自适应硬件规格。
- 在 `tile_broadcast_tactic.cc` 中为大 mtps 设备（如 Iluvatar mtps >= 4096）增加 block_size 放大逻辑，提升计算密度。
- 在 `ir_schedule_util.cc` 的 SetCudaAxisInfo 中，用动态寄存器查询替换硬编码的 65536 NV fallback，计算 min_blocks_per_sm 时考虑硬件实际寄存器容量。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否