### PR TITLE
[Operator Mechanism] Refine group_norm/instance_norm InferMeta checks for unknown dims

### DIFF
--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -1262,6 +1262,9 @@ void InstanceNormInferMeta(const MetaTensor& x,
   auto N = x_dims[0];
   auto C = x_dims[1];
   auto NxC = N * C;
+  auto need_check_dim = [&config](const DDim& dims) {
+    return config.is_runtime || !contain_unknown_dim(dims);
+  };
   if (scale) {
     auto scale_dim = scale.dims();
     PADDLE_ENFORCE_EQ(
@@ -1273,18 +1276,14 @@ void InstanceNormInferMeta(const MetaTensor& x,
             "of scale is [%d]",
             scale_dim,
             scale_dim.size()));
-    bool check = config.is_runtime || contain_unknown_dim(scale_dim);
-    if (check) {
-      if (C != 0) {
-        PADDLE_ENFORCE_EQ(
-            scale_dim[0],
-            C,
-            common::errors::InvalidArgument(
-                "ShapeError: the shape of scale must equal to [%d]"
-                "But received: the shape of scale is [%d]",
-                C,
-                scale_dim[0]));
-      }
+    if (C != 0 && need_check_dim({scale_dim[0], C})) {
+      PADDLE_ENFORCE_EQ(scale_dim[0],
+                        C,
+                        common::errors::InvalidArgument(
+                            "ShapeError: the shape of scale must equal to [%d]"
+                            "But received: the shape of scale is [%d]",
+                            C,
+                            scale_dim[0]));
     }
   }
   if (bias) {
@@ -1298,17 +1297,14 @@ void InstanceNormInferMeta(const MetaTensor& x,
             "of bias is [%d]",
             bias_dim,
             bias_dim.size()));
-    bool check = config.is_runtime || !contain_unknown_dim(bias_dim);
-    if (check) {
-      if (C != 0) {
-        PADDLE_ENFORCE_EQ(bias_dim[0],
-                          C,
-                          common::errors::InvalidArgument(
-                              "ShapeError: the shape of bias must equal to [%d]"
-                              "But received: the shape of bias is [%d]",
-                              C,
-                              bias_dim[0]));
-      }
+    if (C != 0 && need_check_dim({bias_dim[0], C})) {
+      PADDLE_ENFORCE_EQ(bias_dim[0],
+                        C,
+                        common::errors::InvalidArgument(
+                            "ShapeError: the shape of bias must equal to [%d]"
+                            "But received: the shape of bias is [%d]",
+                            C,
+                            bias_dim[0]));
     }
   }
   y->set_dims(x_dims);
@@ -1556,8 +1552,10 @@ void GroupNormInferMeta(const MetaTensor& x,
   const int64_t channel_num =
       (data_layout == DataLayout::NCHW ? x_dim[1] : x_dim[x_dim.size() - 1]);
   auto batch_size = x_dim[0];
-  bool need_check = channel_num != -1 || config.is_runtime;
-  if (need_check) {
+  auto need_check_dim = [&config](const DDim& dims) {
+    return config.is_runtime || !contain_unknown_dim(dims);
+  };
+  if (need_check_dim({channel_num})) {
     PADDLE_ENFORCE_LE(
         groups,
         channel_num,
@@ -1569,13 +1567,15 @@ void GroupNormInferMeta(const MetaTensor& x,
             groups,
             channel_num,
             data_layout_str));
-    PADDLE_ENFORCE_GE(
-        groups,
-        1,
-        common::errors::InvalidArgument(
-            "The Attr(groups) of Op(group_norm) must be "
-            "greater than or equal to 1. But received: groups is [%s].",
-            groups));
+  }
+  PADDLE_ENFORCE_GE(
+      groups,
+      1,
+      common::errors::InvalidArgument(
+          "The Attr(groups) of Op(group_norm) must be "
+          "greater than or equal to 1. But received: groups is [%s].",
+          groups));
+  if (need_check_dim({channel_num})) {
     PADDLE_ENFORCE_EQ(
         channel_num % groups,
         0,
@@ -1586,49 +1586,55 @@ void GroupNormInferMeta(const MetaTensor& x,
             groups));
   }
 
-  if (scale && need_check) {
+  if (scale) {
+    const auto scale_dim = scale.dims();
     PADDLE_ENFORCE_EQ(
-        scale.dims().size(),
+        scale_dim.size(),
         1UL,
         common::errors::InvalidArgument(
             "The Input(Scale) of Op(group_norm) should be 1-D Tensor. "
             "But received: %u-D Tensor, the shape of Input(Scale) is [%s].",
-            scale.dims().size(),
-            scale.dims()));
-    PADDLE_ENFORCE_EQ(
-        scale.dims()[0],
-        channel_num,
-        common::errors::InvalidArgument(
-            "The Input(Scale)'s first dimension size of Op(group_norm) must "
-            "be equal to the number of channels. But received: the "
-            "Input(Scale)'s first dimension size is [%s], the channels is "
-            "[%s], the Attr(data_layout) is [%s]. The error may come "
-            "from wrong data_layout setting.",
-            scale.dims()[0],
-            channel_num,
-            data_layout_str));
+            scale_dim.size(),
+            scale_dim));
+    if (need_check_dim({scale_dim[0], channel_num})) {
+      PADDLE_ENFORCE_EQ(
+          scale_dim[0],
+          channel_num,
+          common::errors::InvalidArgument(
+              "The Input(Scale)'s first dimension size of Op(group_norm) must "
+              "be equal to the number of channels. But received: the "
+              "Input(Scale)'s first dimension size is [%s], the channels is "
+              "[%s], the Attr(data_layout) is [%s]. The error may come "
+              "from wrong data_layout setting.",
+              scale_dim[0],
+              channel_num,
+              data_layout_str));
+    }
   }
-  if (bias && need_check) {
+  if (bias) {
+    const auto bias_dim = bias.dims();
     PADDLE_ENFORCE_EQ(
-        bias.dims().size(),
+        bias_dim.size(),
         1UL,
         common::errors::InvalidArgument(
             "The Input(Bias) of Op(group_norm) should be 1-D Tensor. "
             "But received: %u-D Tensor, the shape of Input(Bias) is [%s].",
-            bias.dims().size(),
-            bias.dims()));
-    PADDLE_ENFORCE_EQ(
-        bias.dims()[0],
-        channel_num,
-        common::errors::InvalidArgument(
-            "The Input(Bias)'s first dimension size of "
-            "Op(group_norm) must be equal to the number of channels. "
-            "But received: the Input(Bias)'s first dimension size is [%s], "
-            "the channels is [%s], the Attr(data_layout) is [%s]. The "
-            "error may come from wrong data_layout setting.",
-            bias.dims()[0],
-            channel_num,
-            data_layout_str));
+            bias_dim.size(),
+            bias_dim));
+    if (need_check_dim({bias_dim[0], channel_num})) {
+      PADDLE_ENFORCE_EQ(
+          bias_dim[0],
+          channel_num,
+          common::errors::InvalidArgument(
+              "The Input(Bias)'s first dimension size of "
+              "Op(group_norm) must be equal to the number of channels. "
+              "But received: the Input(Bias)'s first dimension size is [%s], "
+              "the channels is [%s], the Attr(data_layout) is [%s]. The "
+              "error may come from wrong data_layout setting.",
+              bias_dim[0],
+              channel_num,
+              data_layout_str));
+    }
   }
   DDim output_dims = x_dim;
   int64_t weight_channel = data_layout == DataLayout::NCHW

--- a/test/dygraph_to_static/test_dynamic_shape_infermeta.py
+++ b/test/dygraph_to_static/test_dynamic_shape_infermeta.py
@@ -30,6 +30,40 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
 
+def group_norm_with_linspace(x):
+    weight = paddle.linspace(0.75, 1.25, 6, dtype='float32')
+    bias = paddle.linspace(-0.3, 0.3, 6, dtype='float32')
+    return paddle.nn.functional.group_norm(
+        x,
+        num_groups=3,
+        weight=weight,
+        bias=bias,
+        epsilon=1e-5,
+    )
+
+
+def instance_norm_with_linspace(x):
+    weight = paddle.linspace(0.8, 1.2, 6, dtype='float32')
+    bias = paddle.linspace(-0.2, 0.1, 6, dtype='float32')
+    return paddle.nn.functional.instance_norm(
+        x,
+        weight=weight,
+        bias=bias,
+        use_input_stats=True,
+        eps=1e-5,
+    )
+
+
+def instance_norm_with_affine_inputs(x, weight, bias):
+    return paddle.nn.functional.instance_norm(
+        x,
+        weight=weight,
+        bias=bias,
+        use_input_stats=True,
+        eps=1e-5,
+    )
+
+
 class TestDynamicShapeInfermeta(Dy2StTestBase):
     def check_dynamic_shape(
         self,
@@ -74,6 +108,39 @@ class TestDynamicShapeInfermeta(Dy2StTestBase):
             paddle.nn.GroupNorm(3, 3),
             [paddle.randn([1, 3, 32, 32])],
             [InputSpec(shape=[None, None, None, None], dtype='float32')],
+        )
+
+    @test_ast_only
+    def test_group_norm_with_linspace(self):
+        x = paddle.arange(-96, 96, dtype='float32').reshape([2, 6, 4, 4])
+        self.check_dynamic_shape(
+            group_norm_with_linspace,
+            [x / 17.0],
+            [InputSpec(shape=[2, 6, 4, 4], dtype='float32')],
+        )
+
+    @test_ast_only
+    def test_instance_norm_with_linspace(self):
+        x = paddle.arange(-150, 150, dtype='float32').reshape([2, 6, 5, 5])
+        self.check_dynamic_shape(
+            instance_norm_with_linspace,
+            [x / 23.0],
+            [InputSpec(shape=[2, 6, 5, 5], dtype='float32')],
+        )
+
+    @test_ast_only
+    def test_instance_norm_with_dynamic_channel(self):
+        x = paddle.arange(-150, 150, dtype='float32').reshape([2, 6, 5, 5])
+        weight = paddle.linspace(0.8, 1.2, 6, dtype='float32')
+        bias = paddle.linspace(-0.2, 0.1, 6, dtype='float32')
+        self.check_dynamic_shape(
+            instance_norm_with_affine_inputs,
+            [x / 23.0, weight, bias],
+            [
+                InputSpec(shape=[None, None, None, None], dtype='float32'),
+                InputSpec(shape=[6], dtype='float32'),
+                InputSpec(shape=[6], dtype='float32'),
+            ],
         )
 
     @test_ast_only


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

Fixes #79049.

#### Symptom
Under `paddle.jit.to_static(..., full_graph=True)` in PIR static graph mode, `group_norm` and `instance_norm` fail during InferMeta when `weight` or `bias` is created with `paddle.linspace`. The affine tensor can have static shape `[-1]` even though its runtime length matches the input channel count.

#### Root cause
The existing InferMeta logic applied broad guards around several independent validations. That either compared a known dimension with an unknown one, or skipped unrelated checks together. `InstanceNormInferMeta` also handled the knownness combinations of `C`, scale, and bias inconsistently.

#### Changes
- Replace the broad GroupNorm `need_check` block with per-check unknown-dimension guards.
- Keep validations that do not depend on an unknown dimension active, including affine rank and `groups >= 1`.
- Compare GroupNorm scale or bias with the channel count only when both dimensions are known.
- Apply the same combined-knownness rule to InstanceNorm `C`, scale, and bias.

#### Regression tests
Add `full_graph=True` regressions using `paddle.linspace` for GroupNorm and InstanceNorm, plus an InstanceNorm case with a dynamic input channel and known affine dimensions.

### 是否引起精度变化
否