### PR TITLE
[Bug Fix] Avoid std::regex in phi::ListAllLibraries to fix custom-device init crash (#79056)

### DIFF
--- a/paddle/phi/backends/device_manager.cc
+++ b/paddle/phi/backends/device_manager.cc
@@ -24,7 +24,6 @@
 #endif
 
 #include <functional>
-#include <regex>
 
 #include "glog/logging.h"
 #include "paddle/utils/string/split.h"
@@ -1020,11 +1019,18 @@ void DeviceManager::Release() {
 std::vector<std::string> ListAllLibraries(const std::string& library_dir) {
   std::vector<std::string> libraries;
 #if defined(__APPLE__)
-  std::regex express(".*\\.dylib");
+  const std::string suffix = ".dylib";
 #else
-  std::regex express(".*\\.so");
+  const std::string suffix = ".so";
 #endif
-  std::match_results<std::string::iterator> results;
+
+  // Constructing std::regex initializes locale facets and can abort when an
+  // incompatible libstdc++ has already been loaded by another plugin.
+  auto has_suffix = [&suffix](const std::string& filename) {
+    return filename.size() >= suffix.size() &&
+           filename.compare(
+               filename.size() - suffix.size(), suffix.size(), suffix) == 0;
+  };
 
 #if !defined(_WIN32)
   DIR* dir = nullptr;
@@ -1036,8 +1042,7 @@ std::vector<std::string> ListAllLibraries(const std::string& library_dir) {
   } else {
     while ((ptr = readdir(dir)) != nullptr) {
       std::string filename(ptr->d_name);
-      if (std::regex_match(
-              filename.begin(), filename.end(), results, express)) {
+      if (has_suffix(filename)) {
         libraries.push_back(
             std::string(library_dir).append("/").append(filename));
         VLOG(4) << "Found lib: " << libraries.back();

--- a/test/cpp/phi/CMakeLists.txt
+++ b/test/cpp/phi/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_definitions(-DPADDLE_DLL_EXPORT)
 add_subdirectory(api)
+add_subdirectory(backends)
 add_subdirectory(common)
 add_subdirectory(core)
 add_subdirectory(kernels)

--- a/test/cpp/phi/backends/CMakeLists.txt
+++ b/test/cpp/phi/backends/CMakeLists.txt
@@ -1,3 +1,10 @@
+if(NOT WIN32)
+  cc_test(
+    phi_test_device_manager
+    SRCS test_device_manager.cc
+    DEPS phi common)
+endif()
+
 if(WITH_CUSTOM_DEVICE)
   paddle_test(capi_test SRCS custom/capi_test.cc DEPS phi common)
 endif()

--- a/test/cpp/phi/backends/test_device_manager.cc
+++ b/test/cpp/phi/backends/test_device_manager.cc
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paddle/phi/backends/device_manager.h"
+
+namespace phi {
+namespace {
+
+class ScopedTempDir {
+ public:
+  ScopedTempDir() {
+    std::string path_template = "/tmp/paddle_list_all_libraries_XXXXXX";
+    std::vector<char> writable_path(path_template.begin(), path_template.end());
+    writable_path.push_back('\0');
+    const char* created_path = mkdtemp(writable_path.data());
+    if (created_path == nullptr) {
+      throw std::runtime_error("Failed to create temporary directory");
+    }
+    path_ = created_path;
+  }
+
+  ~ScopedTempDir() {
+    for (const auto& file : files_) {
+      std::remove(file.c_str());
+    }
+    rmdir(path_.c_str());
+  }
+
+  const std::string& path() const { return path_; }
+
+  std::string CreateFile(const std::string& filename) {
+    const auto file_path = path_ + "/" + filename;
+    std::ofstream file(file_path);
+    if (!file.is_open()) {
+      throw std::runtime_error("Failed to create temporary file");
+    }
+    files_.push_back(file_path);
+    return file_path;
+  }
+
+ private:
+  std::string path_;
+  std::vector<std::string> files_;
+};
+
+TEST(ListAllLibraries, FiltersByPlatformLibrarySuffix) {
+  ScopedTempDir temp_dir;
+#if defined(__APPLE__)
+  const std::string suffix = ".dylib";
+  const std::string other_suffix = ".so";
+#else
+  const std::string suffix = ".so";
+  const std::string other_suffix = ".dylib";
+#endif
+
+  const auto first_library = temp_dir.CreateFile("libfirst" + suffix);
+  const auto second_library = temp_dir.CreateFile("libsecond" + suffix);
+  temp_dir.CreateFile("libversioned" + suffix + ".1");
+  temp_dir.CreateFile("libbackup" + suffix + ".bak");
+  temp_dir.CreateFile("libother" + other_suffix);
+  temp_dir.CreateFile("README.txt");
+
+  auto libraries = ListAllLibraries(temp_dir.path());
+  std::sort(libraries.begin(), libraries.end());
+  std::vector<std::string> expected = {first_library, second_library};
+  std::sort(expected.begin(), expected.end());
+
+  EXPECT_EQ(libraries, expected);
+}
+
+TEST(ListAllLibraries, ReturnsEmptyForMissingDirectory) {
+  ScopedTempDir temp_dir;
+  EXPECT_TRUE(ListAllLibraries(temp_dir.path() + "/missing").empty());
+}
+
+}  // namespace
+}  // namespace phi


### PR DESCRIPTION
### PR Category
Custom Device

### PR Types
Bug fixes

### Description

Fixes #79056.

#### Symptom
On Ascend NPU, a PaddleX high-performance inference pipeline can abort during the first custom-device initialization while `phi::ListAllLibraries` constructs `std::regex` only to recognize shared-library suffixes.

#### Fix
Replace the regular expression with an equivalent plain string suffix comparison. This removes `std::regex` and locale initialization from the custom-device library discovery path.

#### Scope
This PR is now based directly on the latest `develop` and contains only the `ListAllLibraries` fix. It no longer includes the unrelated norm InferMeta change from #79086.

#### Regression tests
Add a filesystem-backed C++ test that verifies platform library suffix filtering and the missing-directory behavior, together with the required test CMake wiring.

### 是否引起精度变化
否