### PR TITLE
Fix ChooseAlgoByWorkspace to use actual algorithm count instead of ve…

### DIFF
--- a/paddle/phi/kernels/gpudnn/conv_cudnn_v7.h
+++ b/paddle/phi/kernels/gpudnn/conv_cudnn_v7.h
@@ -48,9 +48,10 @@ std::string GetPerfResultString(std::string prefix,
 template <typename PerfT, typename AlgoT>
 void ChooseAlgoByWorkspace(const std::vector<PerfT>& perf_results,
                            size_t workspace_limit,
-                           SearchResult<AlgoT>* search_result) {
+                           SearchResult<AlgoT>* search_result,
+                           int available_algo_num) {
   int best_algo_idx = -1;
-  for (size_t i = 0; i < perf_results.size(); ++i) {
+  for (size_t i = 0; i < available_algo_num; ++i) {
     const auto& result = perf_results[i];
     if (result.status == CUDNN_STATUS_SUCCESS &&
         result.memory <= workspace_limit) {
@@ -158,7 +159,7 @@ struct SearchAlgorithmBase<ConvKind::kForward> {
                                             workspace_size_limit);
       // cudnnGetConvolutionForwardAlgorithm is removed in CUDNN-8
       ChooseAlgoByWorkspace<PerfT, AlgoT>(
-          perf_results, workspace_size_limit, &result);
+          perf_results, workspace_size_limit, &result, actual_perf_count);
     }
 
     result.workspace_size = GetWorkspaceSize(args, result.algo);
@@ -205,7 +206,7 @@ struct SearchAlgorithmBase<ConvKind::kForward> {
         returned_algo_count,
         workspace_size_limit);
     ChooseAlgoByWorkspace<PerfT, AlgoT>(
-        perf_results, workspace_size_limit, &result);
+        perf_results, workspace_size_limit, &result, returned_algo_count);
 
     result.workspace_size = GetWorkspaceSize(args, result.algo);
     return result;
@@ -301,7 +302,7 @@ struct SearchAlgorithmBase<ConvKind::kBackwardData> {
     if (result.workspace_size > workspace_size_limit) {
       // cudnnGetConvolutionBackwardDataAlgorithm is removed in CUDNN-8
       ChooseAlgoByWorkspace<PerfT, AlgoT>(
-          perf_results, workspace_size_limit, &result);
+          perf_results, workspace_size_limit, &result, actual_perf_count);
     }
     result.workspace_size = GetWorkspaceSize(args, result.algo);
     return result;
@@ -347,7 +348,7 @@ struct SearchAlgorithmBase<ConvKind::kBackwardData> {
         returned_algo_count,
         workspace_size_limit);
     ChooseAlgoByWorkspace<PerfT, AlgoT>(
-        perf_results, workspace_size_limit, &result);
+        perf_results, workspace_size_limit, &result, returned_algo_count);
 
     result.workspace_size = GetWorkspaceSize(args, result.algo);
     return result;
@@ -443,7 +444,7 @@ struct SearchAlgorithmBase<ConvKind::kBackwardFilter> {
     if (result.workspace_size > workspace_size_limit) {
       // cudnnGetConvolutionBackwardFilterAlgorithm is removed in CUDNN-8
       ChooseAlgoByWorkspace<PerfT, AlgoT>(
-          perf_results, workspace_size_limit, &result);
+          perf_results, workspace_size_limit, &result, actual_perf_count);
     }
 
     result.workspace_size = GetWorkspaceSize(args, result.algo);
@@ -491,7 +492,7 @@ struct SearchAlgorithmBase<ConvKind::kBackwardFilter> {
           returned_algo_count,
           workspace_size_limit);
       ChooseAlgoByWorkspace<PerfT, AlgoT>(
-          perf_results, workspace_size_limit, &result);
+          perf_results, workspace_size_limit, &result, returned_algo_count);
     } else {
       int max_algos = GetAlgorithmMaxCount(args.handle);
       std::vector<PerfT> perf_results(max_algos);
@@ -513,7 +514,7 @@ struct SearchAlgorithmBase<ConvKind::kBackwardFilter> {
           perf_results.size(),
           workspace_size_limit);
       ChooseAlgoByWorkspace<PerfT, AlgoT>(
-          perf_results, workspace_size_limit, &result);
+          perf_results, workspace_size_limit, &result, returned_algo_count);
     }
 
     result.workspace_size = GetWorkspaceSize(args, result.algo);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
ChooseAlgoByWorkspace函数使用perf_results.size()遍历循环，但perf_results向量预分配的大小可能大于实际返回的算法数量，导致访问未初始化内存。修改为传递并使用实际返回的算法数量(available_algo_num)作为循环边界。
- cuDNN卷积算法搜索（前向、反向数据、反向滤波器）
- 无功能变化，仅修复潜在的内存访问问题

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否