### PR TITLE
[XPU] Fix precision for paddle.ones

### DIFF
--- a/paddle/phi/kernels/xpu/full_kernel.cc
+++ b/paddle/phi/kernels/xpu/full_kernel.cc
@@ -14,6 +14,9 @@
 
 #include "paddle/phi/kernels/full_kernel.h"
 
+#include <type_traits>
+#include <vector>
+
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -36,11 +39,21 @@ void FullKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out);
   if (out->numel() > 0) {
     auto out_data = reinterpret_cast<XPUInTDType*>(out->data<T>());
-    int r = xpu::constant(dev_ctx.x_context(),
-                          out_data,
-                          out->numel(),
-                          static_cast<XPUInTDType>(val.to<T>()));
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
+    if constexpr (std::is_same_v<T, int64_t>) {
+      // Avoid XDNN int64 constant failures on non-vector-aligned sizes.
+      std::vector<int64_t> cpu_data(out->numel(), val.to<int64_t>());
+      memory_utils::Copy(dev_ctx.GetPlace(),
+                         out_data,
+                         CPUPlace(),
+                         cpu_data.data(),
+                         out->numel() * sizeof(int64_t));
+    } else {
+      int r = xpu::constant(dev_ctx.x_context(),
+                            out_data,
+                            out->numel(),
+                            static_cast<XPUInTDType>(val.to<T>()));
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
+    }
   }
 }
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
#### paddle.ones
This PR fixes an XPU int64 `full`/`ones` kernel error by avoiding XDNN int64 constant failures on non-vector-aligned sizes. The XPU `FullKernel<int64_t>` now materializes the scalar-filled buffer on host and copies it to XPU memory, while other dtypes continue using the existing XDNN `constant` path.

Verified all 5084 `paddle.ones` cases from `/workspace/PaddleAPITest/all_config.txt` passed, including the PAD-319 case.

### 是否引起精度变化
否