### PR TITLE
[Cherry-pick 3.4]Fix FP8 quantization operators to adapt Power2Scaling

### DIFF
--- a/paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_stack_transpose_quant_kernel.cu
@@ -82,7 +82,8 @@ __device__ float BlockReduceScale(__nv_bfloat16 x[8][4]) {
   if (threadIdx.y == 0 && threadIdx.x < 16) {
     warp_max = WarpReduceMax<16>(block_max[threadIdx.x]);
     if (threadIdx.x == 0) {
-      block_scale = ComputeScale<__nv_bfloat16, OutT>(warp_max, 0.0f);
+      block_scale = ComputeScale<__nv_bfloat16, OutT, MustUsePower2Scaling()>(
+          warp_max, 0.0f);
     }
   }
   __syncthreads();

--- a/paddle/phi/kernels/fusion/gpu/quant_utils.h
+++ b/paddle/phi/kernels/fusion/gpu/quant_utils.h
@@ -191,6 +191,14 @@ __device__ __forceinline__ float ComputeScale(const float amax,
       ComputeScaleImpl<IType, OType, Power2Scaling>(amax, eps));
 }
 
+__device__ __forceinline__ constexpr bool MustUsePower2Scaling() {
+#ifdef __CUDA_ARCH__
+  return __CUDA_ARCH__ != 900;
+#else
+  return false;
+#endif
+}
+
 // -------------------------------------- From Kitchen
 // ----------------------------------
 

--- a/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
@@ -131,8 +131,8 @@ __device__ __forceinline__ float device_max(float a, float b) {
 }
 
 template <bool Power2Scaling>
-__device__ __forceinline__ float ScaleWrapper(const float amax,
-                                              const float eps) {
+__device__ __forceinline__ float ScaleWrapperImpl(const float amax,
+                                                  const float eps) {
   constexpr float fp8_max = 448.0f;
   float amax_mod = fmaxf(amax, eps);
   if (amax_mod == 0.f) {
@@ -159,6 +159,13 @@ __device__ __forceinline__ float ScaleWrapper(const float amax,
     scale = ldexpf(1.0f, normal_biased_exp);
   }
   return scale;
+}
+
+template <bool Power2Scaling>
+__device__ __forceinline__ float ScaleWrapper(const float amax,
+                                              const float eps) {
+  return RoundPower2Scale<Power2Scaling>(
+      ScaleWrapperImpl<Power2Scaling>(amax, eps));
 }
 
 template <typename ScaleT, bool using_ue8m0_scale>
@@ -986,8 +993,6 @@ PD_REGISTER_KERNEL(fp8_quant_blockwise,
                    ALL_LAYOUT,
                    phi::FP8QuantBlockWiseKernel,
                    phi::float16,
-                   phi::bfloat16,
-                   float,
-                   double) {}
+                   phi::bfloat16) {}
 
 // NOLINTEND


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Fix FP8 quantization operators to adapt Power2Scaling.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
devPR:https://github.com/PaddlePaddle/Paddle/pull/79096