### PR TITLE
[XPU] Fix precision for paddle.take_along_axis

### DIFF
--- a/paddle/phi/kernels/xpu/take_along_axis_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/take_along_axis_grad_kernel.cc
@@ -69,7 +69,9 @@ void TakeAlongAxisGradKernel(const Context& dev_ctx,
         index_shape,
         axis,
         1,
-        false);
+        // x_grad is zero-filled above; include it as the scatter-add input so
+        // duplicate indices are accumulated consistently with GPU semantics.
+        true);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "paddle_put_along_axis");
   } else {
     r = xpu::paddle_put_along_axis<XPUType, int64_t>(
@@ -83,7 +85,9 @@ void TakeAlongAxisGradKernel(const Context& dev_ctx,
         index_shape,
         axis,
         1,
-        false);
+        // x_grad is zero-filled above; include it as the scatter-add input so
+        // duplicate indices are accumulated consistently with GPU semantics.
+        true);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "paddle_put_along_axis");
   }
 }


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
#### paddle.take_along_axis

This PR fixes XPU backward precision for `paddle.take_along_axis` when indices contain duplicates. The XPU gradient path now includes the zero-initialized `x_grad` in `paddle_put_along_axis` add mode, so duplicate indices accumulate consistently with GPU scatter-add semantics.

All valid `paddle.take_along_axis` cases from `/workspace/PaddleAPITest/all_config.txt` pass XPU vs GPU accuracy after the fix. Two invalid float-index cases still return remote GPU HTTP 500 and are not XPU precision failures.

### 是否引起精度变化
否