### PR TITLE
[XPU] Fix paddle.tile fp16 gradient error

### DIFF
--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -492,7 +492,7 @@ XPUOpMap& get_kl2_ops() {
       {"tril_grad", XPUKernelSet({FLOAT32, INT32, FLOAT16})},
       {"triu_grad", XPUKernelSet({FLOAT32, INT32, FLOAT16})},
       {"tile", XPUKernelSet({INT32, INT64, BOOL, FLOAT64, FLOAT32, FLOAT16})},
-      {"tile_grad", XPUKernelSet({FLOAT32})},
+      {"tile_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"transpose2_grad",
        XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16, INT64, INT32, BOOL})},
       {"transpose2",

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -884,7 +884,7 @@ XPUOpMap& get_kl3_ops() {
       {"triu_grad",
        XPUKernelSet({FLOAT32, INT32, INT64, FLOAT16, BFLOAT16, BOOL})},
       {"tile", XPUKernelSet({INT32, INT64, BOOL, FLOAT64, FLOAT32, BFLOAT16})},
-      {"tile_grad", XPUKernelSet({FLOAT32, BFLOAT16})},
+      {"tile_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"transpose2_grad",
        XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16, INT64, INT32, BOOL})},
       {"transpose2",

--- a/paddle/phi/kernels/xpu/tile_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/tile_grad_kernel.cc
@@ -14,8 +14,12 @@
 
 #include "paddle/phi/kernels/tile_grad_kernel.h"
 
+#include <type_traits>
+
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/cast_kernel.h"
+#include "paddle/phi/kernels/empty_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
 
 namespace phi {
@@ -89,20 +93,40 @@ void TileGradKernel(const Context& dev_ctx,
     using XPUType = typename XPUTypeTrait<T>::Type;
     // int reduce_sum(Context* xpu_ctx, const T* x, T* y, const
     // std::vector<int64_t>& xshape, const std::vector<int64_t>& rdims)
-    const auto* out_data = reinterpret_cast<const XPUType*>(out_grad.data<T>());
-    auto* x_grad_data = reinterpret_cast<XPUType*>(x_grad->data<T>());
     if (x_grad->numel() > 0) {
-      int r = xpu::reduce_sum<XPUType>(dev_ctx.x_context(),
-                                       out_data,
-                                       x_grad_data,
+      if constexpr (std::is_same_v<T, phi::float16>) {
+        const DenseTensor out_grad_fp32 =
+            Cast<T, Context>(dev_ctx, out_grad, DataType::FLOAT32);
+        DenseTensor x_grad_fp32 = EmptyLike<float, Context>(dev_ctx, *x_grad);
+        int r = xpu::reduce_sum<float>(dev_ctx.x_context(),
+                                       out_grad_fp32.data<float>(),
+                                       x_grad_fp32.data<float>(),
                                        reshape_dims_vec,
                                        reduce_dims_vec);
-      PADDLE_ENFORCE_XDNN_SUCCESS(r, "reduce_sum");
+        PADDLE_ENFORCE_XDNN_SUCCESS(r, "reduce_sum");
+        CastKernel<float, Context>(
+            dev_ctx, x_grad_fp32, DataType::FLOAT16, x_grad);
+      } else {
+        const auto* out_data =
+            reinterpret_cast<const XPUType*>(out_grad.data<T>());
+        auto* x_grad_data = reinterpret_cast<XPUType*>(x_grad->data<T>());
+        int r = xpu::reduce_sum<XPUType>(dev_ctx.x_context(),
+                                         out_data,
+                                         x_grad_data,
+                                         reshape_dims_vec,
+                                         reduce_dims_vec);
+        PADDLE_ENFORCE_XDNN_SUCCESS(r, "reduce_sum");
+      }
     }
   }
 }
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(
-    tile_grad, XPU, ALL_LAYOUT, phi::TileGradKernel, float, phi::bfloat16) {}
+PD_REGISTER_KERNEL(tile_grad,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::TileGradKernel,
+                   float,
+                   phi::float16,
+                   phi::bfloat16) {}


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes an XPU `paddle.tile` error for fp16 gradient execution. The XPU `tile_grad` kernel previously omitted fp16 registration, while the forward tile kernel supports fp16 and GPU tile gradient supports fp16 by accumulating in fp32.

#### paddle.tile
- Registers fp16 support for the XPU `tile_grad` kernel.
- Adds an fp16-specific XPU gradient path that casts `out_grad` to fp32, reduces in fp32, and casts the result back to fp16 to align with GPU behavior.
- Updates XPU2/XPU3 operator capability lists to include fp16 `tile_grad`.

Validation: all 805 `paddle.tile` cases from `/workspace/PaddleAPITest/all_config.txt` passed XPU vs GPU verification.

### 是否引起精度变化
否