### PR TITLE
[Operator Mechanism] Fix XPU paddle.sin low-precision gradient

### DIFF
--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -558,7 +558,7 @@ XPUOpMap& get_kl2_ops() {
       {"where_grad", XPUKernelSet({INT32, INT64, FLOAT16, FLOAT32})},
       {"where", XPUKernelSet({INT32, INT64, FLOAT32, FLOAT16, BFLOAT16})},
       {"sin", XPUKernelSet({FLOAT32, FLOAT16})},
-      {"sin_grad", XPUKernelSet({FLOAT32})},
+      {"sin_grad", XPUKernelSet({FLOAT32, FLOAT16})},
       {"cos", XPUKernelSet({FLOAT32, FLOAT16})},
       {"cos_grad", XPUKernelSet({FLOAT32})},
       {"linspace", XPUKernelSet({FLOAT32, INT32, INT64})},

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -993,7 +993,7 @@ XPUOpMap& get_kl3_ops() {
       {"where",
        XPUKernelSet({INT32, INT64, FLOAT64, FLOAT32, FLOAT16, BFLOAT16})},
       {"sin", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
-      {"sin_grad", XPUKernelSet({FLOAT32})},
+      {"sin_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"cos", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"cos_grad", XPUKernelSet({FLOAT32})},
       {"linspace",

--- a/paddle/phi/kernels/xpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_grad_kernel.cc
@@ -608,10 +608,11 @@ struct XPUSinGradFunctor : public funcs::BaseActivationFunctor<T> {
       float* dout_fp32 = RAII_GUARD.alloc_l3_or_gm<float>(len);
       float* cos_fp32 = RAII_GUARD.alloc_l3_or_gm<float>(len);
       float* dx_fp32 = RAII_GUARD.alloc_l3_or_gm<float>(len);
-      int r = xpu::cast<XPUType, float>(dev_ctx.x_context(),
-                                        reinterpret_cast<const XPUType*>(x_data),
-                                        x_fp32,
-                                        len);
+      int r =
+          xpu::cast<XPUType, float>(dev_ctx.x_context(),
+                                    reinterpret_cast<const XPUType*>(x_data),
+                                    x_fp32,
+                                    len);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
       r = xpu::cast<XPUType, float>(dev_ctx.x_context(),
                                     reinterpret_cast<const XPUType*>(dout_data),
@@ -620,7 +621,8 @@ struct XPUSinGradFunctor : public funcs::BaseActivationFunctor<T> {
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
       r = xpu::cos<float>(dev_ctx.x_context(), x_fp32, cos_fp32, len);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "cos");
-      r = xpu::mul<float>(dev_ctx.x_context(), dout_fp32, cos_fp32, dx_fp32, len);
+      r = xpu::mul<float>(
+          dev_ctx.x_context(), dout_fp32, cos_fp32, dx_fp32, len);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "mul");
       r = xpu::cast<float, XPUType>(dev_ctx.x_context(),
                                     dx_fp32,
@@ -628,11 +630,12 @@ struct XPUSinGradFunctor : public funcs::BaseActivationFunctor<T> {
                                     len);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
     } else {
-      int r = xpu::sin_grad<XPUType>(dev_ctx.x_context(),
-                                     reinterpret_cast<const XPUType*>(x_data),
-                                     reinterpret_cast<const XPUType*>(dout_data),
-                                     reinterpret_cast<XPUType*>(dx_data),
-                                     len);
+      int r =
+          xpu::sin_grad<XPUType>(dev_ctx.x_context(),
+                                 reinterpret_cast<const XPUType*>(x_data),
+                                 reinterpret_cast<const XPUType*>(dout_data),
+                                 reinterpret_cast<XPUType*>(dx_data),
+                                 len);
       PADDLE_ENFORCE_XDNN_SUCCESS(r, "sin_grad");
     }
   }

--- a/paddle/phi/kernels/xpu/activation_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/activation_grad_kernel.cc
@@ -601,12 +601,40 @@ struct XPUSinGradFunctor : public funcs::BaseActivationFunctor<T> {
     auto dout_data = dout->data<T>();
     auto x_data = x->data<T>();
 
-    int r = xpu::sin_grad<T>(dev_ctx.x_context(),
-                             reinterpret_cast<const XPUType*>(x_data),
-                             reinterpret_cast<const XPUType*>(dout_data),
-                             reinterpret_cast<XPUType*>(dx_data),
-                             len);
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "sin_grad");
+    if constexpr (std::is_same<T, phi::bfloat16>::value) {
+      // XDNN does not provide sin_grad<bfloat16>.
+      xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+      float* x_fp32 = RAII_GUARD.alloc_l3_or_gm<float>(len);
+      float* dout_fp32 = RAII_GUARD.alloc_l3_or_gm<float>(len);
+      float* cos_fp32 = RAII_GUARD.alloc_l3_or_gm<float>(len);
+      float* dx_fp32 = RAII_GUARD.alloc_l3_or_gm<float>(len);
+      int r = xpu::cast<XPUType, float>(dev_ctx.x_context(),
+                                        reinterpret_cast<const XPUType*>(x_data),
+                                        x_fp32,
+                                        len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+      r = xpu::cast<XPUType, float>(dev_ctx.x_context(),
+                                    reinterpret_cast<const XPUType*>(dout_data),
+                                    dout_fp32,
+                                    len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+      r = xpu::cos<float>(dev_ctx.x_context(), x_fp32, cos_fp32, len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cos");
+      r = xpu::mul<float>(dev_ctx.x_context(), dout_fp32, cos_fp32, dx_fp32, len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "mul");
+      r = xpu::cast<float, XPUType>(dev_ctx.x_context(),
+                                    dx_fp32,
+                                    reinterpret_cast<XPUType*>(dx_data),
+                                    len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "cast");
+    } else {
+      int r = xpu::sin_grad<XPUType>(dev_ctx.x_context(),
+                                     reinterpret_cast<const XPUType*>(x_data),
+                                     reinterpret_cast<const XPUType*>(dout_data),
+                                     reinterpret_cast<XPUType*>(dx_data),
+                                     len);
+      PADDLE_ENFORCE_XDNN_SUCCESS(r, "sin_grad");
+    }
   }
 };
 
@@ -852,5 +880,11 @@ PD_REGISTER_ACTIVATION_GRAD_KERNEL(reciprocal_grad, ReciprocalGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(relu6_grad, Relu6GradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(mish_grad, MishGradKernel)
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(softplus_grad, SoftplusGradKernel)
-PD_REGISTER_ACTIVATION_GRAD_KERNEL(sin_grad, SinGradKernel)
+PD_REGISTER_KERNEL(sin_grad,
+                   XPU,
+                   ALL_LAYOUT,
+                   phi::SinGradKernel,
+                   float,
+                   phi::float16,
+                   phi::bfloat16) {}
 PD_REGISTER_ACTIVATION_GRAD_KERNEL(cos_grad, CosGradKernel)


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
This PR fixes XPU `paddle.sin` failures for low-precision gradient cases.

The XPU `sin_grad` kernel was only registered for float32, so float16 and bfloat16 test cases could fail during gradient kernel lookup. This change registers low-precision XPU `sin_grad` support and updates the XPU op capability lists consistently.

For bfloat16, XDNN does not provide a direct `sin_grad<bfloat16>` symbol, so the XPU implementation computes `dx = dout * cos(x)` with existing fp32 XPU primitives and casts the result back to bfloat16.

Verified with all applicable `paddle.sin` PaddleAPITest configs; the reported float16 and bfloat16 XPU error cases now pass.

### 是否引起精度变化
否

XPU low-precision gradient behavior is corrected to run successfully and align with the existing mathematical definition; GPU precision is unchanged.