### PR TITLE
[CodeStyle][Typos] Bump `typos` to `v1.46.2`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
             paddle/cinn/utils/registry.h
           )$
   - repo: https://github.com/PFCCLab/typos-pre-commit-mirror.git
-    rev: v1.45.0
+    rev: v1.46.2
     hooks:
       - id: typos
         args: [--force-exclude]


### PR DESCRIPTION
### PR Category

Environment Adaptation

### PR Types

Improvements

### Description

Bump `typos` from `v1.45.0` to `v1.46.2` in `.pre-commit-config.yaml`.

Validation:
- `pre-commit run typos --all-files --color never`
- `pre-commit run --files .pre-commit-config.yaml --color never`

No new typos or whitelist changes were required under `v1.46.2`.

### 是否引起精度变化

否
