### PR TITLE
[CI][H-Coverage] Use YAML timeouts for Fleet single/multi-card tests

### DIFF
--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -497,7 +497,7 @@ jobs:
     if: needs.build.outputs.can-skip != 'true'
     runs-on:
       group: Fleet-H-single-card
-    timeout-minutes: 70
+    timeout-minutes: 60
     env:
       PIP_CACHE_DIR: /root/.cache/pip
       CACHE_DIR: /root/.cache
@@ -616,7 +616,7 @@ jobs:
     if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' && needs.check-skill.outputs.can-skip != 'true' }}
     runs-on:
       group: Fleet-H-multi-card
-    timeout-minutes: 70
+    timeout-minutes: 60
     env:
       PIP_CACHE_DIR: /root/.cache/pip
       TASK: paddle-fleet-CI-${{ github.event.pull_request.number }}-multi-card_test

--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -497,7 +497,7 @@ jobs:
     if: needs.build.outputs.can-skip != 'true'
     runs-on:
       group: Fleet-H-single-card
-    timeout-minutes: 60
+    timeout-minutes: 70
     env:
       PIP_CACHE_DIR: /root/.cache/pip
       CACHE_DIR: /root/.cache
@@ -577,6 +577,7 @@ jobs:
           '
 
       - name: Single card test
+        timeout-minutes: 50
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -xce '
           pwd
@@ -592,7 +593,7 @@ jobs:
           export UV_NO_SYNC=1 # This environment variable prevents uv sync from being executed when running un run.
           export UV_HTTP_TIMEOUT=300
           python -c "import paddle; print(paddle.version.commit)"
-          timeout 40m bash ci/single_card_test.sh
+          bash ci/single_card_test.sh
           single_card_exit_code=$?
           if [[ "$single_card_exit_code" != "0" ]]; then
             echo -e "::error:: \033[31mSingle card test failed.\033[0m"
@@ -615,7 +616,7 @@ jobs:
     if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' && needs.check-skill.outputs.can-skip != 'true' }}
     runs-on:
       group: Fleet-H-multi-card
-    timeout-minutes: 60
+    timeout-minutes: 70
     env:
       PIP_CACHE_DIR: /root/.cache/pip
       TASK: paddle-fleet-CI-${{ github.event.pull_request.number }}-multi-card_test
@@ -689,6 +690,7 @@ jobs:
           '
 
       - name: Multi-card test
+        timeout-minutes: 30
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -ce '
           export PYTHONPATH=$(pwd)
@@ -704,7 +706,7 @@ jobs:
           export UV_SKIP_WHEEL_FILENAME_CHECK=1 #This environment variable allows installing the latest commit-level whl package of Paddle.
           export UV_NO_SYNC=1 # This environment variable prevents uv sync from being executed when running un run.
           export UV_HTTP_TIMEOUT=300
-          timeout 20m bash ci/multi-card_test.sh
+          bash ci/multi-card_test.sh
           multi_card_exit_code=$?
           if [[ "$multi_card_exit_code" != "0" ]]; then
             echo -e "::error:: \033[31mMulti card test failed.\033[0m"


### PR DESCRIPTION
### PR Category
Environment Adaptation



### PR Types
Devs

### Description
Follow-up for SigureMo's review note on #79114.

- update `.github/workflows/H-Coverage.yml`
- replace the shell `timeout` wrapper in the Fleet single-card and multi-card test steps with GitHub Actions step-level `timeout-minutes`, so timeout failures are surfaced by Actions directly
- increase the Fleet single-card test step timeout from `40m` to `50m`
- increase the Fleet multi-card test step timeout from `20m` to `30m`
- keep the enclosing Fleet test job-level timeout unchanged at `60`

Local checks:
- `git diff --check upstream/develop...HEAD`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/H-Coverage.yml")'`

### 是否引起精度变化
否
