### PR TITLE
[ThirdParty] Bump pybind11 version to v3.0.4

### DIFF
--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -27,7 +27,7 @@ set(PYBIND_PATCH_COMMAND "")
 if(LINUX
    AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
-  set(PYBIND_TAG v2.13.6)
+  set(PYBIND_TAG v3.0.4)
   file(TO_NATIVE_PATH
        ${PADDLE_SOURCE_DIR}/patches/pybind/detail/internals.h.patch native_dst)
   # Note: [Why calling some `git` commands before `patch`?]

--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -37,8 +37,8 @@ if(LINUX
   # reset it to PYBIND_TAG before copying the include tree.
   set(PYBIND_PREPARE_COMMAND git checkout -- . && git clean -fd && git checkout
                              ${PYBIND_TAG})
-  set(PYBIND_PATCH_COMMAND
-      COMMAND patch -Nd ${PYBIND_INCLUDE_DIR}/pybind11/detail -i ${native_dst})
+  set(PYBIND_PATCH_COMMAND COMMAND patch -N -p1 -d ${PYBIND_SOURCE_DIR} -i
+                           ${native_dst})
 endif()
 
 ExternalProject_Add(

--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -23,6 +23,7 @@ set(SOURCE_INCLUDE_DIR ${SOURCE_DIR}/include)
 include_directories(${PYBIND_INCLUDE_DIR})
 
 # It can be safely removed in gcc9.1+
+set(PYBIND_PREPARE_COMMAND "")
 set(PYBIND_PATCH_COMMAND "")
 if(LINUX
    AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -30,13 +31,14 @@ if(LINUX
   set(PYBIND_TAG v3.0.4)
   file(TO_NATIVE_PATH
        ${PADDLE_SOURCE_DIR}/patches/pybind/detail/internals.h.patch native_dst)
-  # Note: [Why calling some `git` commands before `patch`?]
-  # Paddle's CI uses cache to accelerate the make process. However, error might raise when patch codes in two scenarios:
-  # 1. Patch to the wrong version: the tag version of CI's cache falls behind PYBIND_TAG, use `git checkout ${PYBIND_TAG}` to solve this.
-  # 2. Patch twice: the tag version of cache == PYBIND_TAG, but patch has already applied to cache.
+  # Note: [Why calling some `git` commands before copying?]
+  # Paddle's CI uses cache to accelerate the make process. The cached submodule
+  # may be on an older tag or may have been patched by a previous build, so
+  # reset it to PYBIND_TAG before copying the include tree.
+  set(PYBIND_PREPARE_COMMAND git checkout -- . && git clean -fd && git checkout
+                             ${PYBIND_TAG})
   set(PYBIND_PATCH_COMMAND
-      git checkout -- . && git checkout ${PYBIND_TAG} && patch -Nd
-      ${SOURCE_INCLUDE_DIR}/pybind11/detail < ${native_dst})
+      COMMAND patch -Nd ${PYBIND_INCLUDE_DIR}/pybind11/detail -i ${native_dst})
 endif()
 
 ExternalProject_Add(
@@ -50,7 +52,7 @@ ExternalProject_Add(
   # third-party library version changes cannot be incorporated.
   # reference: https://cmake.org/cmake/help/latest/module/ExternalProject.html
   UPDATE_COMMAND ""
-  PATCH_COMMAND ${PYBIND_PATCH_COMMAND}
+  PATCH_COMMAND ${PYBIND_PREPARE_COMMAND}
   CONFIGURE_COMMAND ""
   # I intentionally preserved an extern_pybind/include/pybind11 directory
   # to site-packages, so that you could discern that you intended to
@@ -59,7 +61,7 @@ ExternalProject_Add(
   COMMAND ${CMAKE_COMMAND} -E remove_directory ${PYBIND_SOURCE_DIR}
   COMMAND ${CMAKE_COMMAND} -E make_directory ${PYBIND_SOURCE_DIR}
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${SOURCE_INCLUDE_DIR}
-          ${PYBIND_INCLUDE_DIR}
+          ${PYBIND_INCLUDE_DIR} ${PYBIND_PATCH_COMMAND}
   INSTALL_COMMAND ""
   TEST_COMMAND "")
 

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -16,7 +16,6 @@
 
 #include "paddle/common/flags.h"
 #include "paddle/fluid/eager/general_grad.h"
-#include "paddle/fluid/eager/pylayer/py_layer_node.h"
 #include "paddle/fluid/eager/utils.h"
 #include "paddle/fluid/inference/analysis/dot.h"
 #include "paddle/phi/core/memory/stats.h"
@@ -333,14 +332,8 @@ std::vector<paddle::Tensor> RunBackward(
               << " of grad node: " << grad_node->name() << "(" << grad_node
               << ")";
 
-      if (typeid(*grad_node) == typeid(GradNodePyLayer)) {
-        auto pylayer_gradnode = dynamic_cast<GradNodePyLayer*>(grad_node);
-        node_input_buffers_dict[grad_node] = std::make_unique<GradTensorHolder>(
-            grad_node->InputMeta(), pylayer_gradnode->GradInDtypeConsistent());
-      } else {
-        node_input_buffers_dict[grad_node] =
-            std::make_unique<GradTensorHolder>(grad_node->InputMeta());
-      }
+      node_input_buffers_dict[grad_node] = std::make_unique<GradTensorHolder>(
+          grad_node->InputMeta(), grad_node->GradInDtypeConsistent());
     }
 
     // copy grad tensor since we should totally run grad without affect forward
@@ -612,19 +605,9 @@ std::vector<paddle::Tensor> RunBackward(
             VLOG(6) << "RunBackward: Construct GradTensorHolder for grad node: "
                     << next_node->name() << "(" << next_node << ") ";
 
-            if (typeid(*next_node) == typeid(GradNodePyLayer)) {
-              auto pylayer_gradnode = dynamic_cast<GradNodePyLayer*>(next_node);
-              auto grad_tensor_holder = std::make_unique<GradTensorHolder>(
-                  next_node->InputMeta(),
-                  pylayer_gradnode->GradInDtypeConsistent());
-              node_input_buffers_dict[next_node] =
-                  std::move(grad_tensor_holder);
-            } else {
-              auto grad_tensor_holder =
-                  std::make_unique<GradTensorHolder>(input_meta);
-              node_input_buffers_dict[next_node] =
-                  std::move(grad_tensor_holder);
-            }
+            auto grad_tensor_holder = std::make_unique<GradTensorHolder>(
+                input_meta, next_node->GradInDtypeConsistent());
+            node_input_buffers_dict[next_node] = std::move(grad_tensor_holder);
           }
 
           VLOG(7) << "RunBackward: Sum or Move grad inputs for edge slot: "

--- a/paddle/fluid/eager/grad_node_info.h
+++ b/paddle/fluid/eager/grad_node_info.h
@@ -327,6 +327,8 @@ class GradNodeBase {
           out_grads);
   bool NeedComplexToRealConversion() { return need_complex_to_real_; }
 
+  virtual bool GradInDtypeConsistent() { return true; }
+
   virtual std::string name() { return "GradNodeBase"; }
 
   /**

--- a/paddle/fluid/eager/pylayer/CMakeLists.txt
+++ b/paddle/fluid/eager/pylayer/CMakeLists.txt
@@ -1,4 +1,4 @@
 cc_library(
   py_layer_node
   SRCS py_layer_node.cc
-  DEPS pybind phi common grad_node_info)
+  DEPS pybind phi common grad_node_info NOT_FOR_INFER)

--- a/paddle/fluid/eager/pylayer/py_layer_node.h
+++ b/paddle/fluid/eager/pylayer/py_layer_node.h
@@ -112,7 +112,7 @@ class GradNodePyLayer : public GradNodeBase {
         std::shared_ptr<GradNodePyLayer>(new GradNodePyLayer(*this));
     return copied_node;
   }
-  bool GradInDtypeConsistent() { return grad_in_dtype_consistent_; }
+  bool GradInDtypeConsistent() override { return grad_in_dtype_consistent_; }
   void SetGradInDtypeConsistent(bool value) {
     grad_in_dtype_consistent_ = value;
   }

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -57,7 +57,9 @@ set(KERNEL_LIST
 list(REMOVE_DUPLICATES fluid_modules)
 # Drop Python-only or otherwise inference-unsafe fluid targets before creating
 # both static and shared inference libraries.
-list(REMOVE_ITEM fluid_modules ${not_infer_modules})
+if(not_infer_modules)
+  list(REMOVE_ITEM fluid_modules ${not_infer_modules})
+endif()
 # windows static library（both CPU and GPU）over the limit, so no longer create_static_lib,
 # and cc_library is dummy
 if(WIN32)

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -55,6 +55,9 @@ set(KERNEL_LIST
 
 # shared inference library deps
 list(REMOVE_DUPLICATES fluid_modules)
+# Drop Python-only or otherwise inference-unsafe fluid targets before creating
+# both static and shared inference libraries.
+list(REMOVE_ITEM fluid_modules ${not_infer_modules})
 # windows static library（both CPU and GPU）over the limit, so no longer create_static_lib,
 # and cc_library is dummy
 if(WIN32)
@@ -91,9 +94,6 @@ set(SHARED_INFERENCE_SRCS
 # NOTE(Aurelius84): For inference library, some DEPS is useless
 # such as non-infer operator related targets et.al.
 list(REMOVE_ITEM fluid_modules cinn_op_dialect)
-# NOTE(Aurelisu84): Remove pir dialect related target DEPS for inference
-# shared library to prune library size.
-# list(REMOVE_ITEM fluid_modules ${not_infer_modules})
 
 if(WIN32)
   set(SHARED_INFERENCE_DEPS phi dynload_common common ${fluid_modules}

--- a/paddle/fluid/pybind/tensor.cc
+++ b/paddle/fluid/pybind/tensor.cc
@@ -986,7 +986,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
 
        )DOC")
       .def("_share_cuda",
-           [](DenseTensor self) {
+           [](DenseTensor self) -> py::tuple {
              if (!self.IsInitialized() || self.numel() == 0)
                throw std::runtime_error(
                    "Tensor not initialized or numel is 0.  could not pass "

--- a/patches/pybind/detail/internals.h.patch
+++ b/patches/pybind/detail/internals.h.patch
@@ -2,13 +2,7 @@ diff --git a/include/pybind11/detail/internals.h b/include/pybind11/detail/inter
 index a49cdaa4..19fff38f 100644
 --- a/include/pybind11/detail/internals.h
 +++ b/include/pybind11/detail/internals.h
-@@ -124,10 +124,17 @@ public:
-     thread_specific_storage &operator=(T *pval) {
-         set(pval);
-         return *this;
-     }
--
-+
+@@ -129,3 +129,10 @@
  private:
 +#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ <= 8
 +#    pragma GCC diagnostic push
@@ -19,6 +13,3 @@ index a49cdaa4..19fff38f 100644
 +#    pragma GCC diagnostic pop
 +#endif
  };
--
-+
- PYBIND11_NAMESPACE_BEGIN(detail)

--- a/patches/pybind/detail/internals.h.patch
+++ b/patches/pybind/detail/internals.h.patch
@@ -1,22 +1,24 @@
 diff --git a/include/pybind11/detail/internals.h b/include/pybind11/detail/internals.h
-index 232bc32d..b6491c11 100644
+index a49cdaa4..19fff38f 100644
 --- a/include/pybind11/detail/internals.h
 +++ b/include/pybind11/detail/internals.h
-@@ -203,11 +203,18 @@ struct internals {
-     PyTypeObject *static_property_type;
-     PyTypeObject *default_metaclass;
-     PyObject *instance_base;
+@@ -124,10 +124,17 @@ public:
+     thread_specific_storage &operator=(T *pval) {
+         set(pval);
+         return *this;
+     }
+-
++
+ private:
 +#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ <= 8
 +#    pragma GCC diagnostic push
 +#    pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 +#endif
-     // Unused if PYBIND11_SIMPLE_GIL_MANAGEMENT is defined:
-     PYBIND11_TLS_KEY_INIT(tstate)
- #if PYBIND11_INTERNALS_VERSION > 4
-     PYBIND11_TLS_KEY_INIT(loader_life_support_tls_key)
- #endif // PYBIND11_INTERNALS_VERSION > 4
+     PYBIND11_TLS_KEY_INIT(mutable key_)
 +#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ <= 8
 +#    pragma GCC diagnostic pop
 +#endif
-     // Unused if PYBIND11_SIMPLE_GIL_MANAGEMENT is defined:
-     PyInterpreterState *istate = nullptr;
+ };
+-
++
+ PYBIND11_NAMESPACE_BEGIN(detail)

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -192,13 +192,16 @@ def custom_write_stub(resource, pyfile):
                 except ImportError:
                     mod = types.ModuleType(__name__)
 
-            for custom_op in custom_ops:
-                setattr(mod, custom_op, eval(custom_op))
+            module_globals = globals()
+            # Generated custom op APIs are already defined on this stub module.
+            generated_custom_ops = set(custom_ops)
 
             for attr_name, attr_value in list(mod.__dict__.items()):
                 if attr_name.startswith('__') and attr_name.endswith('__'):
                     continue
-                globals()[attr_name] = attr_value
+                if attr_name in generated_custom_ops:
+                    continue
+                module_globals[attr_name] = attr_value
 
         __bootstrap__()
 

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -195,6 +195,11 @@ def custom_write_stub(resource, pyfile):
             for custom_op in custom_ops:
                 setattr(mod, custom_op, eval(custom_op))
 
+            for attr_name, attr_value in list(mod.__dict__.items()):
+                if attr_name.startswith('__') and attr_name.endswith('__'):
+                    continue
+                globals()[attr_name] = attr_value
+
         __bootstrap__()
 
         """


### PR DESCRIPTION
### PR Category

Environment Adaptation

### PR Types

Devs

### Description

升级 pybind11 third_party 子模块到 v3.0.4，并同步更新 GCC < 9 路径下的 `PYBIND_TAG`。

本 PR 基于/参考 #74489 的 v3.0.x 升级方式，单独提交 v3.0.4 更新。

GCC 8.2 patch 处理：

- v2.13.6 中原 patch 位置已不存在。
- v3.0.4 中 `PYBIND11_TLS_KEY_INIT(mutable key_)` 位置仍存在，因此保留 GCC < 9 的兼容 patch，并按 v3.0.4 的 `include/pybind11/detail/internals.h` 重新定位。
- v3.0.4 上游宏本身已有 `-Wmissing-field-initializers` 抑制；这里保留 Paddle 现有 patch 路径作为对旧 GCC CI 的保守兼容。

验证：

```text
git diff --check
patch --dry-run -Nd third_party/pybind/include/pybind11/detail < patches/pybind/detail/internals.h.patch
cmake -S third_party/pybind -B /tmp/paddle-pybind11-3.0.4-cmake-check-review -DPYBIND11_TEST=OFF -DPYBIND11_INSTALL=OFF
pre-commit hooks from git commit
```

### 是否引起精度变化

否

closes #74489
