### PR TITLE
[CI] Restore self-hosted runners for GitHub workflows

### DIFF
--- a/.github/workflows/Approval.yml
+++ b/.github/workflows/Approval.yml
@@ -25,9 +25,13 @@ jobs:
     name: Check approval
     needs: [check-bypass]
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     timeout-minutes: 10
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/CI-Build.yml
+++ b/.github/workflows/CI-Build.yml
@@ -19,7 +19,8 @@ jobs:
   check-skill:
     name: Check file paths
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     continue-on-error: true
     permissions:
       contents: read
@@ -27,6 +28,9 @@ jobs:
     outputs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip || 'false' }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run skip check

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -19,12 +19,16 @@ jobs:
   check-skill:
     name: Check file paths
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     permissions:
       contents: read
     outputs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run skip check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,12 +19,16 @@ jobs:
   check-skill:
     name: Check file paths
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     permissions:
       contents: read
     outputs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run skip check

--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -18,13 +18,17 @@ jobs:
     name: Pre Commit
     if: ${{ github.repository_owner == 'PaddlePaddle' && needs.check-bypass.outputs.can-skip != 'true' }}
     needs: [check-bypass]
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     timeout-minutes: 10
     env:
       PR_ID: ${{ github.event.pull_request.number }}
       BRANCH: develop
 
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout base repo
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -32,7 +32,8 @@ jobs:
   check-skill:
     name: Check file paths
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     continue-on-error: true
     permissions:
       contents: read
@@ -40,6 +41,9 @@ jobs:
     outputs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip || 'false' }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run skip check

--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -33,7 +33,8 @@ jobs:
   check-skill:
     name: Check file paths
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     continue-on-error: true
     permissions:
       contents: read
@@ -41,6 +42,9 @@ jobs:
     outputs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run skip check

--- a/.github/workflows/Preview-Url-Comment.yml
+++ b/.github/workflows/Preview-Url-Comment.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   comment:
     name: Post Preview URLs Comment
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
@@ -17,6 +18,9 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Download artifacts
         id: download
         uses: actions/download-artifact@v8

--- a/.github/workflows/cancel-CI-build.yml
+++ b/.github/workflows/cancel-CI-build.yml
@@ -18,8 +18,12 @@ env:
 jobs:
   cancel:
     name: Cancel CI-Build for ${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Cancel CI-build
         run: |
           exit 0

--- a/.github/workflows/cancel-CI.yml
+++ b/.github/workflows/cancel-CI.yml
@@ -18,8 +18,12 @@ env:
 jobs:
   cancel:
     name: Cancel CI for ${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Cancel CI
         run: |
           exit 0

--- a/.github/workflows/cancel-coverage.yml
+++ b/.github/workflows/cancel-coverage.yml
@@ -18,8 +18,12 @@ env:
 jobs:
   cancel:
     name: Cancel Coverage for ${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Cancel Coverage
         run: |
           exit 0

--- a/.github/workflows/cancel-windows.yml
+++ b/.github/workflows/cancel-windows.yml
@@ -18,8 +18,12 @@ env:
 jobs:
   cancel:
     name: Cancel CI-Windows for ${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Cancel CI-Windows
         run: |
           exit 0

--- a/.github/workflows/check-bypass-slice.yml
+++ b/.github/workflows/check-bypass-slice.yml
@@ -15,7 +15,8 @@ on:
 jobs:
   check-bypass:
     name: Check bypass
-    runs-on: ubuntu-slim
+    runs-on:
+      group: APPROVAL
     permissions:
       contents: read
     env:
@@ -23,6 +24,9 @@ jobs:
     outputs:
       can-skip: ${{ steps.check-bypass.outputs.can-skip }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - id: check-bypass
         name: Check Bypass
         uses: PFCCLab/ci-bypass@v2

--- a/.github/workflows/check-bypass.yml
+++ b/.github/workflows/check-bypass.yml
@@ -15,7 +15,8 @@ on:
 jobs:
   check-bypass:
     name: Check bypass
-    runs-on: ubuntu-slim
+    runs-on:
+      group: APPROVAL
     permissions:
       contents: read
     env:
@@ -24,6 +25,9 @@ jobs:
       can-skip: ${{ steps.check-bypass.outputs.can-skip }}
     timeout-minutes: 3
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - id: check-bypass
         name: Check Bypass
         uses: PFCCLab/ci-bypass@v2

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -23,8 +23,12 @@ jobs:
         github.event.action == 'labeled' ||
         contains(join(github.event.pull_request.labels.*.name, ' '), 'cherry-pick')
       )
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -11,8 +11,12 @@ jobs:
   remove-skip-ci-labels:
     name: Remove skip-ci labels on new commits
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Get PR labels
         id: get-labels
         uses: actions/github-script@v8

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -7,8 +7,12 @@ on:
 jobs:
   re-run:
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/re-run')  && github.event.comment.user.login == github.event.issue.user.login }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/validate-pir-versions.yml
+++ b/.github/workflows/validate-pir-versions.yml
@@ -6,9 +6,13 @@ on:
 
 jobs:
   check-version-and-create-issue:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     if: github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release/') && github.repository_owner == 'PaddlePaddle'
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout code
         uses: actions/checkout@v6
 


### PR DESCRIPTION
### PR Category

Environment Adaptation


### PR Types

Improvements


### Description

参考 #76887 做反向迁移，并覆盖当前 `develop` 上新增的 GitHub-hosted runner 使用点。

主要改动：

- 将 `.github/workflows` 中扫描到的 18 个静态 GitHub-hosted runner（`ubuntu-latest` / `ubuntu-slim`）改回 Paddle 当前通用自托管 runner：

  ```yaml
  runs-on:
    group: APPROVAL
  ```

- 恢复 #76887 中移除的 cleanup，并为本次新增覆盖的 self-hosted job 补充同样的首个步骤，避免 self-hosted runner 残留工作区污染：

  ```bash
  rm -rf * .[^.]*
  ```

覆盖范围包括 #76887 原始的 `Approval` / `Codestyle-Check` / `check-bypass` / `check-bypass-slice` / `rerun`，以及当前 `develop` 上额外存在的 check-skill、cancel、preview comment、skip-ci label cleanup、cherry-pick、release PIR version check 等轻量 workflow job。

验证：

- `rg -n "\\b(ubuntu-(latest|[0-9]{2}\\.[0-9]{2}|slim)|windows-(latest|[0-9]{4})|macos-(latest|[0-9]+|[0-9]{2}))\\b" .github/workflows .github/actions`：无匹配
- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "parsed #{f}" }' $(git diff --name-only HEAD~1)`：18 个改动 workflow 均可解析
- `git diff --check`：通过
- `pre-commit run --files $(git diff --name-only HEAD~1)`：通过

完整 CI 需由 GitHub Actions 触发，本地无法完整运行。


### 是否引起精度变化

否
