### PR TITLE
[Precision Depth Alignment]  UniformKernel in GPU

### DIFF
--- a/paddle/phi/kernels/funcs/distribution_helper.h
+++ b/paddle/phi/kernels/funcs/distribution_helper.h
@@ -69,22 +69,30 @@ struct exponential_transform {
   T lambda_;
 };
 
-template <typename T>
+// uniform_real_transform<T, DstT>:
+//   T    - the arithmetic type used for intermediate computation (e.g. float)
+//   DstT - the final output type written to memory (e.g. float16/bfloat16)
+//
+template <typename T, typename DstT = T>
 struct uniform_real_transform {
   explicit uniform_real_transform(T min, T max)
-      : range_(max - min), min_(min) {}
+      : range_(max - min),
+        min_(min),
+        min_dst_(static_cast<DstT>(min)),
+        max_dst_(static_cast<DstT>(max)) {}
 
-  HOSTDEVICE inline T operator()(T val) const {
-    if (UNLIKELY(val == static_cast<T>(1.0))) {
-      return min_;
-    } else {
-      return val * range_ + min_;
-    }
+  HOSTDEVICE inline DstT operator()(T val) const {
+    DstT result = static_cast<DstT>(val * range_ + min_);
+    // Also catch the case where float-precision arithmetic rounds up to max
+    // after casting to a lower-precision DstT (e.g. float16/bfloat16).
+    return (result == max_dst_) ? min_dst_ : result;
   }
 
  private:
   T range_;
   T min_;
+  DstT min_dst_;
+  DstT max_dst_;
 };
 
 template <typename T, typename R>

--- a/paddle/phi/kernels/gpu/uniform_kernel.cu
+++ b/paddle/phi/kernels/gpu/uniform_kernel.cu
@@ -165,7 +165,10 @@ struct UniformKernelImpl<T, Context, false> {
     if (seed == 0) {
       using MT = typename MPTypeTrait<T>::Type;
       funcs::uniform_distribution<MT> dist;
-      funcs::uniform_real_transform<MT> trans(min.to<float>(), max.to<float>());
+      // `range = MT(T(max)) - MT(T(min))`
+      MT min_val = static_cast<MT>(static_cast<T>(min.to<float>()));
+      MT max_val = static_cast<MT>(static_cast<T>(max.to<float>()));
+      funcs::uniform_real_transform<MT, T> trans(min_val, max_val);
       funcs::distribution_and_transform<T>(dev_ctx, out, dist, trans);
     } else {
       auto func = UniformGenerator<T>(

--- a/test/legacy_test/test_sparse_unary_op.py
+++ b/test/legacy_test/test_sparse_unary_op.py
@@ -62,6 +62,12 @@ class TestSparseUnary(unittest.TestCase):
             mask = paddle.randint(0, 2, [8, 16, 32]).astype(dtype)
             while paddle.sum(mask) == 0:
                 mask = paddle.randint(0, 2, [8, 16, 32]).astype(dtype)
+            # to_sparse_coo drops zero-valued elements, so sparse grad at those
+            # positions is always 0, while dense grad may be non-zero there
+            # (e.g. cos(0)=1), causing expect_grad to diverge from sp_x.grad.
+            # Under fp16, paddle.rand can produce exact zeros, so fold the
+            # origin_x==0 positions into mask to align with sparse semantics.
+            mask = mask * (origin_x != 0).astype(dtype)
 
         # --- check sparse coo with dense --- #
         dense_x = origin_x * mask


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Improvements

### Description
修复 GPU `UniformKernel` 在 float16/bfloat16 低精度类型下的精度问题，与 PyTorch 对齐。

**问题根因**：旧实现在 float（MT）精度中完成 `val * range + min` 后将结果隐式 cast 到 float16/bfloat16 输出类型。当某个 `val < 1.0` 的 curand 随机数计算结果非常接近 max 时，cast 会因精度截断舍入到 max，违反 `[min, max)` 半开区间语义。

**修复方案**：
1. `uniform_real_transform` 增加第二模板参数 `DstT`，在 float 精度计算后先 cast 到 `DstT`，若结果等于 `max_dst_` 则回退为 `min_dst_`。
2. `UniformKernel` `seed == 0` 分支传入 `uniform_real_transform<MT, T>`，min/max 先经 `T` 类型往返转换以保证边界精确。

### 是否引起精度变化
是

- **来源**：float16/bfloat16 在 cast 时会将接近 max 的值舍入到 max，旧代码未检查此边界；新代码补充了 cast 后对上边界的检查。
- **范围**：仅影响 GPU、float16/bfloat16 类型、`seed == 0` 分支；float32/float64 行为等价。
- **验证**：与 PyTorch `torch.Tensor.uniform_` 在 float16/bfloat16 上对比，确认输出不含等于 max 的值。