### PR TITLE
[API compatibility] Align special.erf/sinc

### DIFF
--- a/python/paddle/special.py
+++ b/python/paddle/special.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from .tensor.compat_softmax import log_softmax, softmax
-from .tensor.creation import assign
 from .tensor.math import (
     erf,
     expm1,
@@ -24,9 +23,8 @@ from .tensor.math import (
     log1p,
     logit,
     logsumexp,
-    sinc as _sinc,
+    sinc,
 )
-from .utils.decorator_utils import param_one_alias
 
 __all__ = [
     "erf",
@@ -42,42 +40,3 @@ __all__ = [
     "softmax",
     "expm1",
 ]
-
-
-@param_one_alias(["x", "input"])
-def sinc(x, name=None, *, out=None):
-    r"""
-    Calculate the normalized sinc of ``x`` elementwise.
-
-    .. math::
-
-        out_i =
-        \left\{
-        \begin{aligned}
-        &1 & \text{ if $x_i = 0$} \\
-        &\frac{\sin(\pi x_i)}{\pi x_i} & \text{ otherwise}
-        \end{aligned}
-        \right.
-
-    Args:
-        x (Tensor): The input Tensor. Must be one of the following types: bfloat16, float16, float32, float64. Alias: ``input``.
-        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
-
-    Keyword Args:
-        out (Tensor|None, optional): The output Tensor. If set, the result will be stored in this Tensor. Default is None.
-
-    Returns:
-        out (Tensor), The Tensor of elementwise-computed normalized sinc result.
-
-    Examples:
-        .. code-block:: pycon
-
-            >>> import paddle
-
-            >>> x = paddle.to_tensor([0.0, 0.5, 1.0], dtype='float32')
-            >>> paddle.special.sinc(x)
-            Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [1.        , 0.63661975, 0.        ])
-    """
-    result = _sinc(x, name=name)
-    return assign(result, out) if out is not None else result

--- a/python/paddle/special.py
+++ b/python/paddle/special.py
@@ -15,7 +15,7 @@
 from .tensor.compat_softmax import log_softmax, softmax
 from .tensor.creation import assign
 from .tensor.math import (
-    erf as _erf,
+    erf,
     expm1,
     i0,
     i0e,
@@ -45,12 +45,39 @@ __all__ = [
 
 
 @param_one_alias(["x", "input"])
-def erf(x, name=None, *, out=None):
-    result = _erf(x, name=name)
-    return assign(result, out) if out is not None else result
-
-
-@param_one_alias(["x", "input"])
 def sinc(x, name=None, *, out=None):
+    r"""
+    Calculate the normalized sinc of ``x`` elementwise.
+
+    .. math::
+
+        out_i =
+        \left\{
+        \begin{aligned}
+        &1 & \text{ if $x_i = 0$} \\
+        &\frac{\sin(\pi x_i)}{\pi x_i} & \text{ otherwise}
+        \end{aligned}
+        \right.
+
+    Args:
+        x (Tensor): The input Tensor. Must be one of the following types: bfloat16, float16, float32, float64. Alias: ``input``.
+        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+
+    Keyword Args:
+        out (Tensor|None, optional): The output Tensor. If set, the result will be stored in this Tensor. Default is None.
+
+    Returns:
+        out (Tensor), The Tensor of elementwise-computed normalized sinc result.
+
+    Examples:
+        .. code-block:: pycon
+
+            >>> import paddle
+
+            >>> x = paddle.to_tensor([0.0, 0.5, 1.0], dtype='float32')
+            >>> paddle.special.sinc(x)
+            Tensor(shape=[3], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [1.        , 0.63661975, 0.        ])
+    """
     result = _sinc(x, name=name)
     return assign(result, out) if out is not None else result

--- a/python/paddle/special.py
+++ b/python/paddle/special.py
@@ -13,9 +13,23 @@
 # limitations under the License.
 
 from .tensor.compat_softmax import log_softmax, softmax
-from .tensor.math import expm1, i0, i0e, i1, i1e, log1p, logit, logsumexp
+from .tensor.creation import assign
+from .tensor.math import (
+    erf as _erf,
+    expm1,
+    i0,
+    i0e,
+    i1,
+    i1e,
+    log1p,
+    logit,
+    logsumexp,
+    sinc as _sinc,
+)
+from .utils.decorator_utils import param_one_alias
 
 __all__ = [
+    "erf",
     "i0",
     "i0e",
     "i1",
@@ -24,6 +38,19 @@ __all__ = [
     "log_softmax",
     "logit",
     "logsumexp",
+    "sinc",
     "softmax",
     "expm1",
 ]
+
+
+@param_one_alias(["x", "input"])
+def erf(x, name=None, *, out=None):
+    result = _erf(x, name=name)
+    return assign(result, out) if out is not None else result
+
+
+@param_one_alias(["x", "input"])
+def sinc(x, name=None, *, out=None):
+    result = _sinc(x, name=name)
+    return assign(result, out) if out is not None else result

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -6605,7 +6605,10 @@ def isreal(x: Tensor, name: str | None = None) -> Tensor:
     return paddle.equal(paddle.imag(x), 0)
 
 
-def sinc(x: Tensor, name: str | None = None) -> Tensor:
+@param_one_alias(["x", "input"])
+def sinc(
+    x: Tensor, name: str | None = None, *, out: Tensor | None = None
+) -> Tensor:
     r"""
     Calculate the normalized sinc of ``x`` elementwise.
 
@@ -6620,8 +6623,11 @@ def sinc(x: Tensor, name: str | None = None) -> Tensor:
         \right.
 
     Args:
-        x (Tensor): The input Tensor. Must be one of the following types: bfloat16, float16, float32, float64.
+        x (Tensor): The input Tensor. Must be one of the following types: bfloat16, float16, float32, float64. Alias: ``input``.
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+
+    Keyword Args:
+        out (Tensor|None, optional): The output Tensor. If set, the result will be stored in this Tensor. Default is None.
 
     Returns:
         out (Tensor), The Tensor of elementwise-computed normalized sinc result.
@@ -6657,7 +6663,8 @@ def sinc(x: Tensor, name: str | None = None) -> Tensor:
     tmp = paddle.where(x != 0, x, paddle.full_like(x, 1.0e-20))
     tmp = paddle.multiply(tmp, paddle.to_tensor(math.pi, dtype=x.dtype))
     tmp = paddle.divide(tmp.sin(), tmp)
-    return paddle.where(~paddle.isnan(tmp), tmp, paddle.full_like(x, 1.0))
+    result = paddle.where(~paddle.isnan(tmp), tmp, paddle.full_like(x, 1.0))
+    return assign(result, out) if out is not None else result
 
 
 @inplace_apis_in_dygraph_only

--- a/test/legacy_test/test_api_compatibility_part3.py
+++ b/test/legacy_test/test_api_compatibility_part3.py
@@ -2156,10 +2156,12 @@ class TestSpecialSincAPI(unittest.TestCase):
             # 4. out parameter test
             out4 = paddle.empty_like(x)
             out5 = paddle.special.sinc(x, out=out4)
+            out6 = paddle.empty_like(x)
+            out7 = paddle.sinc(input=x, out=out6)
 
             # Verify all outputs
             expected = np.sinc(np_x)
-            for out in [out1, out2, out3, out4, out5]:
+            for out in [out1, out2, out3, out4, out5, out6, out7]:
                 np.testing.assert_allclose(
                     out.numpy(), expected, rtol=1e-5, atol=1e-6
                 )
@@ -2184,12 +2186,13 @@ class TestSpecialSincAPI(unittest.TestCase):
                 out2 = paddle.special.sinc(x=x)
                 # 3. PyTorch keyword arguments (alias)
                 out3 = paddle.special.sinc(input=x)
+                out4 = paddle.sinc(input=x)
 
                 exe = paddle.static.Executor()
                 fetches = exe.run(
                     main,
                     feed={f"sinc_x_{i}": np_x},
-                    fetch_list=[out1, out2, out3],
+                    fetch_list=[out1, out2, out3, out4],
                 )
 
                 # Verify all outputs

--- a/test/legacy_test/test_api_compatibility_part3.py
+++ b/test/legacy_test/test_api_compatibility_part3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import sys
 import unittest
 
@@ -2057,6 +2058,146 @@ class TestLogitAPI(unittest.TestCase):
         np.testing.assert_allclose(
             fetches[3], ref_out_eps, rtol=1e-5, atol=1e-6
         )
+
+
+class TestSpecialErfAPI(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2025)
+        self.shape = [3, 4]
+        self.inputs = [
+            np.random.uniform(-3.0, 3.0, self.shape).astype(dtype)
+            for dtype in ["float32", "float64"]
+        ]
+
+    def _ref_erf(self, x):
+        return np.array(
+            [math.erf(float(v)) for v in x.flatten()], dtype=x.dtype
+        ).reshape(x.shape)
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        for np_x in self.inputs:
+            x = paddle.to_tensor(np_x)
+
+            # 1. Paddle Positional arguments
+            out1 = paddle.special.erf(x)
+            # 2. Paddle keyword arguments
+            out2 = paddle.special.erf(x=x)
+            # 3. PyTorch keyword arguments (alias)
+            out3 = paddle.special.erf(input=x)
+            # 4. out parameter test
+            out4 = paddle.empty_like(x)
+            out5 = paddle.special.erf(x, out=out4)
+
+            # Verify all outputs
+            expected = self._ref_erf(np_x)
+            for out in [out1, out2, out3, out4, out5]:
+                np.testing.assert_allclose(
+                    out.numpy(), expected, rtol=1e-5, atol=1e-6
+                )
+
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        for i, np_x in enumerate(self.inputs):
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                x = paddle.static.data(
+                    name=f"x_{i}", shape=self.shape, dtype=str(np_x.dtype)
+                )
+
+                # 1. Paddle Positional arguments
+                out1 = paddle.special.erf(x)
+                # 2. Paddle keyword arguments
+                out2 = paddle.special.erf(x=x)
+                # 3. PyTorch keyword arguments (alias)
+                out3 = paddle.special.erf(input=x)
+
+                exe = paddle.static.Executor()
+                fetches = exe.run(
+                    main,
+                    feed={f"x_{i}": np_x},
+                    fetch_list=[out1, out2, out3],
+                )
+
+                # Verify all outputs
+                expected = self._ref_erf(np_x)
+                for out in fetches:
+                    np.testing.assert_allclose(
+                        out, expected, rtol=1e-5, atol=1e-6
+                    )
+
+
+class TestSpecialSincAPI(unittest.TestCase):
+    def setUp(self):
+        self.shape = [3, 4]
+        base = np.array(
+            [
+                [0.0, -3.0, -1.5, -0.25],
+                [0.25, 0.5, 1.0, 1.5],
+                [2.0, 2.5, 3.0, 4.25],
+            ]
+        )
+        self.inputs = [base.astype(dtype) for dtype in ["float32", "float64"]]
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        for np_x in self.inputs:
+            x = paddle.to_tensor(np_x)
+
+            # 1. Paddle Positional arguments
+            out1 = paddle.special.sinc(x)
+            # 2. Paddle keyword arguments
+            out2 = paddle.special.sinc(x=x)
+            # 3. PyTorch keyword arguments (alias)
+            out3 = paddle.special.sinc(input=x)
+            # 4. out parameter test
+            out4 = paddle.empty_like(x)
+            out5 = paddle.special.sinc(x, out=out4)
+
+            # Verify all outputs
+            expected = np.sinc(np_x)
+            for out in [out1, out2, out3, out4, out5]:
+                np.testing.assert_allclose(
+                    out.numpy(), expected, rtol=1e-5, atol=1e-6
+                )
+
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        for i, np_x in enumerate(self.inputs):
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                x = paddle.static.data(
+                    name=f"sinc_x_{i}",
+                    shape=self.shape,
+                    dtype=str(np_x.dtype),
+                )
+
+                # 1. Paddle Positional arguments
+                out1 = paddle.special.sinc(x)
+                # 2. Paddle keyword arguments
+                out2 = paddle.special.sinc(x=x)
+                # 3. PyTorch keyword arguments (alias)
+                out3 = paddle.special.sinc(input=x)
+
+                exe = paddle.static.Executor()
+                fetches = exe.run(
+                    main,
+                    feed={f"sinc_x_{i}": np_x},
+                    fetch_list=[out1, out2, out3],
+                )
+
+                # Verify all outputs
+                expected = np.sinc(np_x)
+                for out in fetches:
+                    np.testing.assert_allclose(
+                        out, expected, rtol=1e-5, atol=1e-6
+                    )
 
 
 # Test conv1d_transpose / conv_transpose1d compatibility


### PR DESCRIPTION
### PR Category
  User Experience

### PR Types
  New features

### Description

  - python/paddle/special.py
      - 新增 paddle.special.erf
      - 新增 paddle.special.sinc
      - 两者都复用已有 paddle.erf / paddle.sinc
      - 支持 PyTorch 参数名 input -> x
      - 支持 out，通过 paddle.assign(result, out) 写回
  - test/legacy_test/test_api_compatibility_part3.py
      - 新增 TestSpecialErfAPI
      - 新增 TestSpecialSincAPI
      - 覆盖动态图、静态图、位置参数、x=、input=、动态图 out
      - 覆盖 float32 和 float64

### 是否引起精度变化
否

😺