### PR TITLE
[API compatibility] Align torch.kaiser_window

### DIFF
--- a/python/paddle/audio/functional/window.py
+++ b/python/paddle/audio/functional/window.py
@@ -406,7 +406,7 @@ def get_window(
     window: _WindowLiteral | tuple[_WindowLiteral, float],
     win_length: int,
     fftbins: bool = True,
-    dtype: str = 'float64',
+    dtype: str | None = 'float64',
 ) -> Tensor:
     """Return a window of a given length and type.
 
@@ -430,6 +430,8 @@ def get_window(
             >>> std = 7
             >>> gaussian_window = paddle.audio.functional.get_window(('gaussian', std), n_fft)
     """
+    if dtype is None:
+        dtype = 'float32'
     sym = not fftbins
     args = ()
     if isinstance(window, tuple):
@@ -464,6 +466,10 @@ def _apply_window_postprocess(
     pin_memory: bool = False,
     requires_grad: bool = False,
 ) -> Tensor:
+    if layout not in (None, 'strided'):
+        raise RuntimeError(
+            "Window functions only support layout='strided' or None"
+        )
     if layout is not None:
         warnings.warn("layout only supports 'strided' in Paddle; ignored")
 
@@ -620,17 +626,12 @@ def kaiser_window(
             >>> win = paddle.kaiser_window(400, beta=8.6)
             >>> win = paddle.kaiser_window(400, requires_grad=True)
     """
-    if dtype is None:
-        dtype = 'float32'
-    if layout == 'sparse':
-        raise RuntimeError("kaiser_window is not implemented for sparse types")
-    layout_for_postprocess = None if layout == 'strided' else layout
     w = get_window(
         ('kaiser', beta), window_length, fftbins=periodic, dtype=dtype
     )
     w = _apply_window_postprocess(
         w,
-        layout=layout_for_postprocess,
+        layout=layout,
         device=device,
         pin_memory=pin_memory,
         requires_grad=requires_grad,

--- a/python/paddle/audio/functional/window.py
+++ b/python/paddle/audio/functional/window.py
@@ -586,11 +586,12 @@ def kaiser_window(
     periodic: bool = True,
     beta: float = 12.0,
     *,
-    dtype: str = 'float32',
+    dtype: str | None = 'float32',
     layout: str | None = None,
     device: PlaceLike | None = None,
     pin_memory: bool = False,
     requires_grad: bool = False,
+    out: Tensor | None = None,
 ):
     """
     Compute a Kaiser window.
@@ -606,6 +607,7 @@ def kaiser_window(
             device will be the CPU for CPU tensor types and the current CUDA device for CUDA tensor types. Default: None.
         pin_memory(bool, optional): If set, return tensor would be allocated in the pinned memory. Works only for CPU tensors. Default: False
         requires_grad(bool, optional):  If autograd should record operations on the returned tensor. Default: False.
+        out(Tensor|None, optional): The output tensor. Default: None.
 
     Returns:
         Tensor: A 1-D tensor of shape `(window_length,)` containing the Kaiser window.
@@ -618,16 +620,22 @@ def kaiser_window(
             >>> win = paddle.kaiser_window(400, beta=8.6)
             >>> win = paddle.kaiser_window(400, requires_grad=True)
     """
+    if dtype is None:
+        dtype = 'float32'
+    if layout == 'sparse':
+        raise RuntimeError("kaiser_window is not implemented for sparse types")
+    layout_for_postprocess = None if layout == 'strided' else layout
     w = get_window(
         ('kaiser', beta), window_length, fftbins=periodic, dtype=dtype
     )
-    return _apply_window_postprocess(
+    w = _apply_window_postprocess(
         w,
-        layout=layout,
+        layout=layout_for_postprocess,
         device=device,
         pin_memory=pin_memory,
         requires_grad=requires_grad,
     )
+    return paddle.assign(w, out) if out is not None else w
 
 
 def blackman_window(

--- a/test/legacy_test/test_api_compatibility_part3.py
+++ b/test/legacy_test/test_api_compatibility_part3.py
@@ -4086,5 +4086,133 @@ class TestTensorIndexCopyInplaceAPI(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestKaiserWindowAPI(unittest.TestCase):
+    def setUp(self):
+        self.window_length = 7
+        self.beta = 6.0
+
+    def _expected(
+        self, window_length, periodic=True, beta=12.0, dtype="float32"
+    ):
+        if window_length <= 1:
+            return np.ones((window_length,), dtype=dtype)
+
+        length = window_length + 1 if periodic else window_length
+        n = np.arange(length, dtype=dtype)
+        alpha = (length - 1) / 2.0
+        out = np.i0(beta * np.sqrt(1 - ((n - alpha) / alpha) ** 2.0)) / np.i0(
+            beta
+        )
+        if periodic:
+            out = out[:-1]
+        return out.astype(dtype)
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+
+        # 1. Paddle Positional arguments
+        out1 = paddle.kaiser_window(
+            self.window_length, False, self.beta, dtype='float64'
+        )
+        # 2. Paddle keyword arguments
+        out2 = paddle.kaiser_window(
+            window_length=self.window_length,
+            periodic=False,
+            beta=self.beta,
+            dtype='float64',
+        )
+        # 3. Mixed arguments
+        out3 = paddle.kaiser_window(
+            self.window_length, periodic=False, beta=self.beta, dtype='float64'
+        )
+        # 4-5. out parameter test
+        out4 = paddle.empty([self.window_length], dtype='float64')
+        out5 = paddle.kaiser_window(
+            self.window_length,
+            False,
+            self.beta,
+            dtype='float64',
+            out=out4,
+        )
+        assert out4 is out5
+        # 6. Explicit dtype=None compatibility
+        out6 = paddle.kaiser_window(3, dtype=None)
+        # 7. strided layout compatibility
+        out7 = paddle.kaiser_window(
+            self.window_length,
+            False,
+            self.beta,
+            dtype='float64',
+            layout='strided',
+        )
+        # 8. window_length=0 edge case
+        out8 = paddle.kaiser_window(0)
+        # 9. window_length=1 edge case
+        out9 = paddle.kaiser_window(1, dtype='float64')
+
+        expected = self._expected(
+            self.window_length, periodic=False, beta=self.beta, dtype='float64'
+        )
+        for out in [out1, out2, out3, out4, out5, out7]:
+            np.testing.assert_allclose(out.numpy(), expected, rtol=1e-12)
+        np.testing.assert_allclose(out6.numpy(), self._expected(3), rtol=1e-5)
+        self.assertEqual(out6.dtype, paddle.float32)
+        np.testing.assert_allclose(out8.numpy(), np.ones((0,), dtype='float32'))
+        np.testing.assert_allclose(out9.numpy(), np.ones((1,), dtype='float64'))
+        self.assertEqual(out9.dtype, paddle.float64)
+
+        with self.assertRaises(RuntimeError):
+            paddle.kaiser_window(3, layout='sparse')
+
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
+            # 1. Paddle Positional arguments
+            out1 = paddle.kaiser_window(
+                self.window_length, False, self.beta, dtype='float64'
+            )
+            # 2. Paddle keyword arguments
+            out2 = paddle.kaiser_window(
+                window_length=self.window_length,
+                periodic=False,
+                beta=self.beta,
+                dtype='float64',
+            )
+            # 3. Mixed arguments
+            out3 = paddle.kaiser_window(
+                self.window_length,
+                periodic=False,
+                beta=self.beta,
+                dtype='float64',
+            )
+            # 4. Explicit dtype=None compatibility
+            out4 = paddle.kaiser_window(3, dtype=None)
+            # 5. strided layout compatibility
+            out5 = paddle.kaiser_window(
+                self.window_length,
+                False,
+                self.beta,
+                dtype='float64',
+                layout='strided',
+            )
+
+            exe = paddle.static.Executor()
+            fetches = exe.run(
+                main,
+                fetch_list=[out1, out2, out3, out4, out5],
+            )
+
+        expected = self._expected(
+            self.window_length, periodic=False, beta=self.beta, dtype='float64'
+        )
+        for out in fetches[:3] + fetches[4:]:
+            np.testing.assert_allclose(out, expected, rtol=1e-12)
+        np.testing.assert_allclose(fetches[3], self._expected(3), rtol=1e-5)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_api_compatibility_part3.py
+++ b/test/legacy_test/test_api_compatibility_part3.py
@@ -1061,7 +1061,7 @@ class TestIsposinfAPICompatibility(unittest.TestCase):
         # 4-5. out parameter test
         out4 = paddle.zeros_like(out1)
         out5 = paddle.isposinf(x, out=out4)
-        assert out4 is out5
+        self.assertIs(out4, out5)
         # 6. Tensor method
         out6 = x.isposinf()
 
@@ -4134,7 +4134,7 @@ class TestKaiserWindowAPI(unittest.TestCase):
             dtype='float64',
             out=out4,
         )
-        assert out4 is out5
+        self.assertIs(out4, out5)
         # 6. Explicit dtype=None compatibility
         out6 = paddle.kaiser_window(3, dtype=None)
         # 7. strided layout compatibility


### PR DESCRIPTION
### PR Category
  User Experience

### PR Types
  New features

### Description
- paddle.kaiser_window 新增 out 参数。
- 显式传 dtype=None 保持 Paddle 现有兼容语义，转为 'float32'。
- layout='sparse' 按 PyTorch window_function_checks 行为报错。
- layout='strided' 不再走 Paddle 原先的 ignored warning 分支。
- out 使用 paddle.assign(w, out) 写回并返回。

### 是否引起精度变化
否

😺