### PR TITLE
[CI] Restore IXUCA workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -97,12 +97,12 @@ jobs:
       can-skip: ${{ needs.cpu.outputs.can-skip == 'true' || needs.clone.outputs.can-skip == 'true' }}
       docker_npu_image: ${{ needs.build-docker.outputs.docker_npu_image }}
 
-  # ixuca:
-  #   name: Linux-IXUCA
-  #   uses: ./.github/workflows/_Linux-IXUCA.yml
-  #   needs: [clone]
-  #   with:
-  #     can-skip: ${{ needs.clone.outputs.can-skip }}
+  ixuca:
+    name: Linux-IXUCA
+    uses: ./.github/workflows/_Linux-IXUCA.yml
+    needs: [clone]
+    with:
+      can-skip: ${{ needs.clone.outputs.can-skip }}
 
   distribute:
     name: Distribute-stable-build


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Not User Facing

### Description
本 PR 恢复主 CI 编排中的 Linux-IXUCA workflow，用于重新触发并观察 IXUCA 相关流水线是否可以正常通过。

改动范围仅包含 `.github/workflows/CI.yml` 中的 `ixuca` job 配置，未修改源码、算子逻辑或运行时行为。

已执行 `pre-commit run --all-files`，所有检查通过。当前环境未安装 `prek` 命令，因此使用仓库已有的 `pre-commit` 配置完成等价检查。

### 是否引起精度变化
否。该改动仅调整 CI workflow 配置，不影响模型训练、推理或数值计算逻辑。