### PR TITLE
[Bug Fix] Fix error format mismatches in `paddle/phi`

### DIFF
--- a/paddle/phi/backends/custom/custom_context.cc
+++ b/paddle/phi/backends/custom/custom_context.cc
@@ -436,8 +436,8 @@ struct CustomContext::Impl {
     PADDLE_ENFORCE_NE(
         iter,
         dnn_attrs_.end(),
-        common::errors::NotFound("Attribute `%s` is not found in CustomContext.",
-                                 attr_name));
+        common::errors::NotFound(
+            "Attribute `%s` is not found in CustomContext.", attr_name));
     return iter->second;
   }
 

--- a/paddle/phi/backends/custom/custom_context.cc
+++ b/paddle/phi/backends/custom/custom_context.cc
@@ -433,10 +433,11 @@ struct CustomContext::Impl {
 
   const Attribute& GetDnnAttr(const std::string& attr_name) const {
     auto iter = dnn_attrs_.find(attr_name);
-    PADDLE_ENFORCE_NE(iter,
-                      dnn_attrs_.end(),
-                      common::errors::NotFound(
-                          "Attribute `%s` is not found in CustomContext."));
+    PADDLE_ENFORCE_NE(
+        iter,
+        dnn_attrs_.end(),
+        common::errors::NotFound("Attribute `%s` is not found in CustomContext.",
+                                 attr_name));
     return iter->second;
   }
 

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -851,10 +851,11 @@ struct GPUContext::Impl {
 
   const Attribute& GetDnnAttr(const std::string& attr_name) const {
     auto iter = dnn_attrs_.find(attr_name);
-    PADDLE_ENFORCE_NE(iter,
-                      dnn_attrs_.end(),
-                      common::errors::NotFound(
-                          "Attribute `%s` is not found in OneDNNContext."));
+    PADDLE_ENFORCE_NE(
+        iter,
+        dnn_attrs_.end(),
+      common::errors::NotFound("Attribute `%s` is not found in GPUContext.",
+                               attr_name));
     return iter->second;
   }
 

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -854,8 +854,8 @@ struct GPUContext::Impl {
     PADDLE_ENFORCE_NE(
         iter,
         dnn_attrs_.end(),
-      common::errors::NotFound("Attribute `%s` is not found in GPUContext.",
-                               attr_name));
+        common::errors::NotFound("Attribute `%s` is not found in GPUContext.",
+                                 attr_name));
     return iter->second;
   }
 

--- a/paddle/phi/backends/onednn/onednn_context.cc
+++ b/paddle/phi/backends/onednn/onednn_context.cc
@@ -297,10 +297,11 @@ struct OneDNNContext::Impl {
   }
   const Attribute& GetDnnAttr(const std::string& attr_name) const {
     auto iter = dnn_attrs_.find(attr_name);
-    PADDLE_ENFORCE_NE(iter,
-                      dnn_attrs_.end(),
-                      common::errors::NotFound(
-                          "Attribute `%s` is not found in OneDNNContext."));
+    PADDLE_ENFORCE_NE(
+        iter,
+        dnn_attrs_.end(),
+        common::errors::NotFound(
+            "Attribute `%s` is not found in OneDNNContext.", attr_name));
     return iter->second;
   }
 
@@ -320,7 +321,7 @@ struct OneDNNContext::Impl {
         iter,
         dnn_inputs_.end(),
         common::errors::NotFound(
-            "Input DenseTensor `%s` is not found in OneDNNContext."));
+            "Input DenseTensor `%s` is not found in OneDNNContext.", input_name));
     return iter->second;
   }
 

--- a/paddle/phi/backends/onednn/onednn_context.cc
+++ b/paddle/phi/backends/onednn/onednn_context.cc
@@ -321,7 +321,8 @@ struct OneDNNContext::Impl {
         iter,
         dnn_inputs_.end(),
         common::errors::NotFound(
-            "Input DenseTensor `%s` is not found in OneDNNContext.", input_name));
+            "Input DenseTensor `%s` is not found in OneDNNContext.",
+            input_name));
     return iter->second;
   }
 

--- a/paddle/phi/backends/onednn/onednn_reuse.h
+++ b/paddle/phi/backends/onednn/onednn_reuse.h
@@ -639,7 +639,7 @@ class OneDNNHandlerNoCachingT {
     // AcquireForwardPrimitiveDescriptor
     PADDLE_ENFORCE_NOT_NULL(
         fwd_pd_,
-        errors::Unavailable("Get oneDNN Forward primitive %s failed."));
+        errors::Unavailable("FWD PD should be set when getting backward primitive descriptor."));
     bwd_pd_ = std::make_shared<typename TBackward::primitive_desc>(
         engine_, std::forward<Args>(args)..., *fwd_pd_);
   }
@@ -650,7 +650,7 @@ class OneDNNHandlerNoCachingT {
     // AcquireForwardPrimitiveDescriptor
     PADDLE_ENFORCE_NOT_NULL(
         fwd_pd_,
-        errors::Unavailable("Get oneDNN Forward primitive %s failed."));
+        errors::Unavailable("FWD PD should be set when getting backward primitive descriptor."));
     auto bwd_desc =
         typename TBackward_params::desc(std::forward<Args>(args)...);
     bwd_w_pd_ = std::make_shared<typename TBackward_params::primitive_desc>(

--- a/paddle/phi/backends/onednn/onednn_reuse.h
+++ b/paddle/phi/backends/onednn/onednn_reuse.h
@@ -639,7 +639,8 @@ class OneDNNHandlerNoCachingT {
     // AcquireForwardPrimitiveDescriptor
     PADDLE_ENFORCE_NOT_NULL(
         fwd_pd_,
-        errors::Unavailable("FWD PD should be set when getting backward primitive descriptor."));
+        errors::Unavailable("FWD PD should be set when getting backward "
+                            "primitive descriptor."));
     bwd_pd_ = std::make_shared<typename TBackward::primitive_desc>(
         engine_, std::forward<Args>(args)..., *fwd_pd_);
   }
@@ -650,7 +651,8 @@ class OneDNNHandlerNoCachingT {
     // AcquireForwardPrimitiveDescriptor
     PADDLE_ENFORCE_NOT_NULL(
         fwd_pd_,
-        errors::Unavailable("FWD PD should be set when getting backward primitive descriptor."));
+        errors::Unavailable("FWD PD should be set when getting backward "
+                            "primitive descriptor."));
     auto bwd_desc =
         typename TBackward_params::desc(std::forward<Args>(args)...);
     bwd_w_pd_ = std::make_shared<typename TBackward_params::primitive_desc>(

--- a/paddle/phi/backends/xpu/enforce_xpu.h
+++ b/paddle/phi/backends/xpu/enforce_xpu.h
@@ -137,15 +137,15 @@ DEFINE_EXTERNAL_API_TYPE(cudaError_t, cudaSuccess);
     }                                                                   \
   } while (0)
 
-#define PADDLE_ENFORCE_XRE_SUCCESS(COND)                            \
-  do {                                                              \
-    auto __cond__ = (COND);                                         \
-    auto xre_msg = xpu_strerror(__cond__);                          \
-    if (UNLIKELY(__cond__ != XPU_SUCCESS)) {                        \
-      auto __summary__ =                                            \
-          common::errors::External("XPU Runtime Error: ", xre_msg); \
-      __THROW_ERROR_INTERNAL__(__summary__);                        \
-    }                                                               \
+#define PADDLE_ENFORCE_XRE_SUCCESS(COND)                              \
+  do {                                                                \
+    auto __cond__ = (COND);                                           \
+    auto xre_msg = xpu_strerror(__cond__);                            \
+    if (UNLIKELY(__cond__ != XPU_SUCCESS)) {                          \
+      auto __summary__ =                                              \
+          common::errors::External("XPU Runtime Error: %s", xre_msg); \
+      __THROW_ERROR_INTERNAL__(__summary__);                          \
+    }                                                                 \
   } while (0)
 
 // TODO(lijin23): support fine-grained error msg.

--- a/paddle/phi/core/dense_tensor_impl.cc
+++ b/paddle/phi/core/dense_tensor_impl.cc
@@ -108,9 +108,8 @@ void* DenseTensor::mutable_data(const Place& place,
       0,
       common::errors::PreconditionNotMet(
           "The Tensor's element number must be equal or greater than zero. "
-          "The Tensor's shape is [",
-          dims(),
-          "] now"));
+          "The Tensor's shape is %s now.",
+          dims()));
   size_t size = numel() * SizeOf(dtype());
   if (requested_size && (requested_size > size)) {
     size = requested_size;
@@ -140,9 +139,8 @@ void* DenseTensor::mutable_data(const Place& place,
       0,
       common::errors::PreconditionNotMet(
           "The Tensor's element number must be equal or greater than zero. "
-          "The Tensor's shape is [",
-          dims(),
-          "] now"));
+          "The Tensor's shape is %s now.",
+          dims()));
   size_t size = numel() * SizeOf(dtype());
 
   /* some versions of paddle::variant don't have operator!= */
@@ -317,7 +315,7 @@ DenseTensor DenseTensor::Slice(int64_t begin_idx, int64_t end_idx) const {
       begin_idx,
       0,
       common::errors::OutOfRange("The start row index must be greater than 0."
-                                 "But received the start index is d%.",
+                                 "But received the start index is %d.",
                                  begin_idx));
   PADDLE_ENFORCE_LE(
       end_idx,

--- a/paddle/phi/core/distributed/auto_parallel/process_mesh.cc
+++ b/paddle/phi/core/distributed/auto_parallel/process_mesh.cc
@@ -36,10 +36,11 @@ ProcessMesh::ProcessMesh(const std::vector<int64_t> &shape,
   PADDLE_ENFORCE_EQ(
       size,
       process_ids.size(),
-      errors::InvalidArgument("The size of this process mesh must be "
-                              "equal to the size of its process ids.",
-                              size,
-                              process_ids.size()));
+      errors::InvalidArgument(
+          "The size of this process mesh must be equal to the size of its "
+          "process ids, but got mesh size %d and process id size %d.",
+          size,
+          process_ids.size()));
   PADDLE_ENFORCE_EQ(
       has_duplicates(process_ids),
       false,
@@ -47,13 +48,14 @@ ProcessMesh::ProcessMesh(const std::vector<int64_t> &shape,
                               str_join(process_ids_)));
   process_ids_ = process_ids;
 
-  PADDLE_ENFORCE_EQ(shape_.size(),
-                    dim_names.size(),
-                    errors::InvalidArgument(
-                        "The size of mesh shape must be equal to the size "
-                        "of the dimension names.",
-                        shape_.size(),
-                        dim_names_.size()));
+  PADDLE_ENFORCE_EQ(
+      shape_.size(),
+      dim_names.size(),
+      errors::InvalidArgument(
+          "The size of mesh shape must be equal to the size of the dimension "
+          "names, but got shape size %d and dimension name size %d.",
+          shape_.size(),
+          dim_names.size()));
   PADDLE_ENFORCE_EQ(has_duplicates(dim_names),
                     false,
                     errors::InvalidArgument(

--- a/paddle/phi/core/framework/var_type_helper.cc
+++ b/paddle/phi/core/framework/var_type_helper.cc
@@ -112,7 +112,7 @@ int DataTypeNumAlign(const VarType::Type t) {
   } else {
     PADDLE_THROW(common::errors::Unavailable(
         "Only supports to align data type include float32, float64, complex64 "
-        "and complex128, but received data type is `s`.",
+        "and complex128, but received data type is %s.",
         VarDataTypeToString(t)));
   }
   return cast_type_num;

--- a/paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.cc
+++ b/paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.cc
@@ -158,8 +158,7 @@ phi::Allocation* CUDAVirtualMemAllocator::AllocateImpl(size_t size) {
         place_.device,
         string::HumanReadableSize(virtual_mem_alloced_offset_),
         string::HumanReadableSize(virtual_mem_size_ -
-                                  virtual_mem_alloced_offset_),
-        place_.device));
+                                  virtual_mem_alloced_offset_)));
     return nullptr;
   }
 

--- a/paddle/phi/core/memory/allocation/mmap_allocator.cc
+++ b/paddle/phi/core/memory/allocation/mmap_allocator.cc
@@ -113,7 +113,7 @@ void AllocateMemoryMap(std::string filename,
     PADDLE_ENFORCE_NE(::close(fd),
                       -1,
                       common::errors::Unavailable(
-                          "Error closing memory mapped file <", filename, ">"));
+                          "Error closing memory mapped file %s", filename));
 
     *shared_fd = -1;
   }
@@ -163,7 +163,7 @@ void MemoryMapAllocation::close() {
       PADDLE_ENFORCE_NE(::close(fd_),
                         -1,
                         common::errors::Unavailable(
-                            "Error closing file descriptor <", fd_, ">"));
+                            "Error closing file descriptor <%d>", fd_));
     }
   }
   if (closed_) {
@@ -211,10 +211,10 @@ void RefcountedMemoryMapAllocation::close() {
   --info->refcount;
   if (flags_ & MAPPED_KEEPFD) {
     closed_fd_ = true;
-    PADDLE_ENFORCE_NE(::close(fd_),
-                      -1,
-                      common::errors::Unavailable(
-                          "Error closing file descriptor <", fd_, ">"));
+    PADDLE_ENFORCE_NE(
+        ::close(fd_),
+        -1,
+        common::errors::Unavailable("Error closing file descriptor <%d>", fd_));
     VLOG(6) << "close fd: " << fd_;
   }
 
@@ -236,11 +236,9 @@ void RefcountedMemoryMapAllocation::close() {
       PADDLE_ENFORCE_NE(munmap(map_ptr_, map_size_),
                         -1,
                         common::errors::Unavailable(
-                            "could not unmap the shared memory file: ",
+                            "could not unmap the shared memory file: %s (%d)",
                             strerror(errno),
-                            " (",
-                            errno,
-                            ")"));
+                            errno));
     }
   }
 }
@@ -405,14 +403,12 @@ void MemoryMapAllocationPool::Clear() {
     if (rlt == 0) {
       VLOG(4) << "MemoryMapAllocationPool: clear " << mmap.file_name_;
     }
-    PADDLE_ENFORCE_NE(
-        munmap(mmap.mmap_ptr_, mmap.data_size_ + mmap_alignment),
-        -1,
-        common::errors::Unavailable("could not unmap the shared memory file: ",
-                                    strerror(errno),
-                                    " (",
-                                    errno,
-                                    ")"));
+    PADDLE_ENFORCE_NE(munmap(mmap.mmap_ptr_, mmap.data_size_ + mmap_alignment),
+                      -1,
+                      common::errors::Unavailable(
+                          "could not unmap the shared memory file: %s (%d)",
+                          strerror(errno),
+                          errno));
   }
   memory_map_allocations_.clear();
 }

--- a/paddle/phi/core/string_tensor.cc
+++ b/paddle/phi/core/string_tensor.cc
@@ -198,9 +198,8 @@ dtype::pstring* StringTensor::mutable_data(const Place& place,
       0,
       common::errors::PreconditionNotMet(
           "The Tensor's element number must be equal or greater than zero. "
-          "The Tensor's shape is [",
-          dims(),
-          "] now"));
+          "The Tensor's shape is %s now.",
+          dims()));
   size_t size = numel() * SizeOf(dtype());
   if (requested_size && (requested_size > size)) {
     size = requested_size;

--- a/paddle/phi/core/tensor_utils.h
+++ b/paddle/phi/core/tensor_utils.h
@@ -58,7 +58,7 @@ class DenseTensorUtils {
         begin_idx,
         0,
         common::errors::OutOfRange("The start row index must be greater than 0."
-                                   "But received the start index is d%.",
+                                   "But received the start index is %d.",
                                    begin_idx));
     PADDLE_ENFORCE_LE(
         end_idx,

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -1972,12 +1972,13 @@ void FusedDropoutAddInferMeta(const MetaTensor& x,
 static std::vector<int64_t> GetInputShape(DDim dim,
                                           std::vector<int> shape,
                                           std::vector<int> axis) {
-  PADDLE_ENFORCE_GT(dim.size(),
-                    0,
-                    common::errors::InvalidArgument(
-                        "The Input(%s) has not been initialized properly. The "
-                        "shape of Input(%s) = [%s].",
-                        dim));
+  PADDLE_ENFORCE_GT(
+      dim.size(),
+      0,
+      common::errors::InvalidArgument(
+          "The input has not been initialized properly. The shape of input = "
+          "[%s].",
+          dim));
 
   auto is_input_fused = (!shape.empty() && !axis.empty());
   if (is_input_fused) {
@@ -3537,9 +3538,8 @@ void PReluInferMeta(const MetaTensor& x,
         alpha_rank,
         x_rank,
         common::errors::InvalidArgument(
-            "For mode 'element', rank of weight Alpha must be ",
-            "equal to the rank of input(x). But received alpha's rank: %d, "
-            "x's rank: %d.",
+            "For mode 'element', rank of weight Alpha must be equal to the "
+            "rank of input(x). But received alpha's rank: %d, x's rank: %d.",
             alpha_rank,
             x_rank));
     size_t x_product = 1;
@@ -4044,7 +4044,7 @@ void SearchsortedInferMeta(const MetaTensor& sorted_sequence,
         sequences_dims[sequences_dims.size() - 1],
         std::numeric_limits<int>::max(),
         common::errors::Unavailable(
-            "The size of sorted_sequence %d exceed the maximum limit d%. "
+            "The size of sorted_sequence %d exceed the maximum limit %d. "
             "Because the size of sorted_sequence should be less than the "
             "output maximum value for int32 bit. Please set appropriate "
             "sorted_sequence to meet this requirement! ",
@@ -4335,19 +4335,21 @@ void TakeAlongAxisInferMeta(const MetaTensor& x,
   auto input_dim = x.dims();
   auto index_dim = index.dims();
 
-  PADDLE_ENFORCE_GT(input_dim.size(),
-                    0,
-                    common::errors::InvalidArgument(
-                        "Dimension of the input(Input) of TakeAlongAxisOp "
-                        "should be greater than 0.",
-                        input_dim));
+  PADDLE_ENFORCE_GT(
+      input_dim.size(),
+      0,
+      common::errors::InvalidArgument(
+          "Dimension of the input(Input) of TakeAlongAxisOp should be greater "
+          "than 0, but received %d.",
+          input_dim.size()));
 
-  PADDLE_ENFORCE_GT(index_dim.size(),
-                    0,
-                    common::errors::InvalidArgument(
-                        "Dimension of the input(Index) of TakeAlongAxisOp "
-                        "should be greater than 0.",
-                        index_dim));
+  PADDLE_ENFORCE_GT(
+      index_dim.size(),
+      0,
+      common::errors::InvalidArgument(
+          "Dimension of the input(Index) of TakeAlongAxisOp should be greater "
+          "than 0, but received %d.",
+          index_dim.size()));
 
   out->set_dims(index_dim);
   out->set_dtype(x.dtype());

--- a/paddle/phi/infermeta/fusion.cc
+++ b/paddle/phi/infermeta/fusion.cc
@@ -3582,7 +3582,7 @@ void FusedFCElementwiseLayerNormInferMeta(const MetaTensor& x,
       2,
       common::errors::InvalidArgument(
           "The input Weight of fc is expected to be a 2-D tensor. "
-          "But received the number of Weight's dimensions is %d, ",
+          "But received the number of Weight's dimensions is %d, "
           "Weight's shape is %s.",
           w_dims.size(),
           w_dims));
@@ -4790,60 +4790,61 @@ void CrossAttentionXPUInferMeta(
   PADDLE_ENFORCE_EQ(input_q_dims.size(),
                     3,
                     common::errors::InvalidArgument(
-                        "The dim of input_q should be 3! But received ",
+                        "The dim of input_q should be 3! But received %d.",
                         input_q_dims.size()));
   PADDLE_ENFORCE_EQ(input_kv_dims.size(),
                     3,
                     common::errors::InvalidArgument(
-                        "The dim of input_kv should be 3! But received ",
+                        "The dim of input_kv should be 3! But received %d.",
                         input_kv_dims.size()));
   // sequence length of q and k/v  not required to be equal
   // but batch size and dim should be the same
   PADDLE_ENFORCE_EQ(
       input_q_dims[0],
       input_kv_dims[0],
-      common::errors::InvalidArgument("The batch size of input_q and input_kv "
-                                      "should be the same! Received ",
-                                      input_q_dims[0],
-                                      " vs ",
-                                      input_kv_dims[0]));
+      common::errors::InvalidArgument(
+          "The batch size of input_q and input_kv should be the same! "
+          "Received %d vs %d.",
+          input_q_dims[0],
+          input_kv_dims[0]));
   PADDLE_ENFORCE_EQ(
       input_q_dims[2],
       input_kv_dims[2],
-      common::errors::InvalidArgument("The hidden_dim of input_q and input_kv "
-                                      "should be the same! Received ",
-                                      input_q_dims[2],
-                                      " vs ",
-                                      input_kv_dims[2]));
-  int hidden_dim = head_num * head_dim;
-  PADDLE_ENFORCE_EQ(
-      input_q_dims[2],
-      hidden_dim,
       common::errors::InvalidArgument(
-          "The last dimension of input_q should be [H*D]! Received ",
+          "The hidden_dim of input_q and input_kv should be the same! "
+          "Received %d vs %d.",
           input_q_dims[2],
-          " != expected ",
-          hidden_dim));
+          input_kv_dims[2]));
+  int hidden_dim = head_num * head_dim;
+  PADDLE_ENFORCE_EQ(input_q_dims[2],
+                    hidden_dim,
+                    common::errors::InvalidArgument(
+                        "The last dimension of input_q should be [H*D]! "
+                        "Received %d != expected %d.",
+                        input_q_dims[2],
+                        hidden_dim));
   PADDLE_ENFORCE_EQ(fc_weight.size(),
                     3,
                     common::errors::InvalidArgument(
-                        "The size of fc_weight should be 3! But received ",
+                        "The size of fc_weight should be 3! But received %d.",
                         fc_weight.size()));
-  PADDLE_ENFORCE_EQ(fc_weight_max.size(),
-                    3,
-                    common::errors::InvalidArgument(
-                        "The size of fc_weight_max should be 3! But received ",
-                        fc_weight_max.size()));
+  PADDLE_ENFORCE_EQ(
+      fc_weight_max.size(),
+      3,
+      common::errors::InvalidArgument(
+          "The size of fc_weight_max should be 3! But received %d.",
+          fc_weight_max.size()));
   PADDLE_ENFORCE_EQ(
       fc_bias.size(),
       3,
       common::errors::InvalidArgument(
-          "The size of fc_bias should be 3! But received ", fc_bias.size()));
+          "The size of fc_bias should be 3! But received %d.", fc_bias.size()));
   PADDLE_ENFORCE_LE(
       mask_dims.size(),
       4,
       common::errors::InvalidArgument(
-          "The dim of mask should be not greater than 4!", mask_dims.size()));
+          "The dim of mask should be not greater than 4! But received %d.",
+          mask_dims.size()));
 
   // output shape: {B, qL, H*D}
   qkv->set_dims(

--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -4160,12 +4160,12 @@ void LogspaceInferMeta(const MetaTensor& start,
                                       "but received input size is %s.",
                                       common::product(num_dims)));
   auto b_dims = base.dims();
-  PADDLE_ENFORCE_EQ(common::product(b_dims),
-                    true,
-                    common::errors::InvalidArgument(
-                        "The size of Input(Base) must be 1,"
-                        "but received input size is common::product(b_dims).",
-                        common::product(b_dims)));
+  PADDLE_ENFORCE_EQ(
+      common::product(b_dims),
+      1,
+      common::errors::InvalidArgument("The size of Input(Base) must be 1,"
+                                      "but received input size is %s.",
+                                      common::product(b_dims)));
   out->set_dims(make_ddim({-1}));
   out->set_dtype(dtype);
 }
@@ -5783,6 +5783,7 @@ void WarpctcInferMeta(const MetaTensor& logits,
       errors::InvalidArgument(
           "The value of Attr(blank) should be in interval [0, %d), "
           "but received %d",
+          sequence_width,
           blank));
   PADDLE_ENFORCE_LT(
       blank,
@@ -5790,6 +5791,7 @@ void WarpctcInferMeta(const MetaTensor& logits,
       errors::InvalidArgument(
           "The value of Attr(blank) should be in interval [0, %d), "
           "but received %d",
+          sequence_width,
           blank));
 
   loss->set_dims({num_sequences, 1});
@@ -5815,6 +5817,7 @@ void WarprnntInferMeta(const MetaTensor& input,
       errors::InvalidArgument(
           "The value of Attr(blank) should be in interval [0, %d), "
           "but received %d",
+          D,
           blank));
   PADDLE_ENFORCE_LT(
       blank,
@@ -5822,6 +5825,7 @@ void WarprnntInferMeta(const MetaTensor& input,
       errors::InvalidArgument(
           "The value of Attr(blank) should be in interval [0, %d), "
           "but received %d",
+          D,
           blank));
 
   loss->set_dims({input_dims[0]});
@@ -5886,7 +5890,8 @@ void WeightOnlyLinearInferMeta(const MetaTensor& x,
         bias_dims.size(),
         1UL,
         errors::InvalidArgument(
-            "The size of Input(Bias)'s dimension should equal to 1UL.",
+            "The size of Input(Bias)'s dimension should equal to 1UL, but "
+            "received %d.",
             bias_dims.size()));
   }
 
@@ -6056,9 +6061,9 @@ void YoloLossInferMeta(const MetaTensor& x,
   PADDLE_ENFORCE_EQ(
       dim_gtbox[2],
       4,
-      common::errors::InvalidArgument("Input(GTBox) dim[2] should be 4",
-                                      "But receive dim[2](%s) != 5. ",
-                                      dim_gtbox[2]));
+      common::errors::InvalidArgument(
+          "Input(GTBox) dim[2] should be 4, but receive dim[2](%s) != 4.",
+          dim_gtbox[2]));
   PADDLE_ENFORCE_EQ(dim_gtlabel.size(),
                     2,
                     common::errors::InvalidArgument(

--- a/paddle/phi/infermeta/spmd_rules/argsort.cc
+++ b/paddle/phi/infermeta/spmd_rules/argsort.cc
@@ -130,8 +130,8 @@ SpmdInfo ArgSortGradInferSpmd(const DistMetaTensor& indices,
     PADDLE_ENFORCE_EQ(
         x_dims_mapping[i] == ind_dims_mapping[i],
         1,
-        errors::InvalidArgument("ArgSortGrad x dims_mapping[%d]=[%d] should be "
-                                "equal to indices dims_mapping[%d]=[%d].",
+        errors::InvalidArgument("ArgSortGrad x dims_mapping[%d]=[%s] should be "
+                                "equal to indices dims_mapping[%d]=[%s].",
                                 i,
                                 str_join(x_dims_mapping[i]),
                                 i,

--- a/paddle/phi/infermeta/spmd_rules/conv2d.cc
+++ b/paddle/phi/infermeta/spmd_rules/conv2d.cc
@@ -78,9 +78,9 @@ SpmdInfo Conv2dInferSpmdBase(const DistMetaTensor& input,
                         "The Input channel's dims mapping must be equal to "
                         "filter channel's dims mapping in conv2d. "
                         "When shard channel dim to a mesh (multiple cards), "
-                        "each card will compute partial output, ",
+                        "each card will compute partial output, "
                         "otherwise, mark channel dim as replicate, each card "
-                        "will compute complete output.",
+                        "will compute complete output. "
                         "But now the Input channel's dims mapping is [%d], and "
                         "the filter channel's dims mapping is [%d].",
                         input_dims_mapping[channel_dim],

--- a/paddle/phi/infermeta/spmd_rules/conv2d_transpose.cc
+++ b/paddle/phi/infermeta/spmd_rules/conv2d_transpose.cc
@@ -87,9 +87,9 @@ SpmdInfo Conv2dTransposeInferSpmd(const DistMetaTensor& input,
                         "The Input channel's dims mapping must be equal to "
                         "filter channel's dims mapping in conv2d_transpose. "
                         "When shard channel dim to a mesh (multiple cards), "
-                        "each card will compute partial output, ",
+                        "each card will compute partial output,"
                         "otherwise, mark channel dim as replicate, each card "
-                        "will compute complete output.",
+                        "will compute complete output."
                         "But now the Input channel's dims mapping is [%d], and "
                         "the filter channel's dims mapping is [%d].",
                         input_dims_mapping[input_channel_dim],

--- a/paddle/phi/infermeta/spmd_rules/conv2d_transpose.cc
+++ b/paddle/phi/infermeta/spmd_rules/conv2d_transpose.cc
@@ -87,9 +87,9 @@ SpmdInfo Conv2dTransposeInferSpmd(const DistMetaTensor& input,
                         "The Input channel's dims mapping must be equal to "
                         "filter channel's dims mapping in conv2d_transpose. "
                         "When shard channel dim to a mesh (multiple cards), "
-                        "each card will compute partial output,"
+                        "each card will compute partial output, "
                         "otherwise, mark channel dim as replicate, each card "
-                        "will compute complete output."
+                        "will compute complete output. "
                         "But now the Input channel's dims mapping is [%d], and "
                         "the filter channel's dims mapping is [%d].",
                         input_dims_mapping[input_channel_dim],

--- a/paddle/phi/infermeta/spmd_rules/conv3d.cc
+++ b/paddle/phi/infermeta/spmd_rules/conv3d.cc
@@ -82,7 +82,7 @@ SpmdInfo Conv3dInferSpmdBase(const DistMetaTensor& input,
                         "When shard channel dim to a mesh (multiple cards), "
                         "each card will compute partial output, "
                         "otherwise, mark channel dim as replicate, each card "
-                        "will compute complete output."
+                        "will compute complete output. "
                         "But now the Input channel's dims mapping is [%d], and "
                         "the filter channel's dims mapping is [%d].",
                         input_dims_mapping[input_channel_dim],

--- a/paddle/phi/infermeta/spmd_rules/conv3d.cc
+++ b/paddle/phi/infermeta/spmd_rules/conv3d.cc
@@ -80,9 +80,9 @@ SpmdInfo Conv3dInferSpmdBase(const DistMetaTensor& input,
                         "The Input channel's dims mapping must be equal to "
                         "filter channel's dims mapping in conv3d. "
                         "When shard channel dim to a mesh (multiple cards), "
-                        "each card will compute partial output, ",
+                        "each card will compute partial output, "
                         "otherwise, mark channel dim as replicate, each card "
-                        "will compute complete output.",
+                        "will compute complete output."
                         "But now the Input channel's dims mapping is [%d], and "
                         "the filter channel's dims mapping is [%d].",
                         input_dims_mapping[input_channel_dim],

--- a/paddle/phi/infermeta/spmd_rules/depthwise_conv2d.cc
+++ b/paddle/phi/infermeta/spmd_rules/depthwise_conv2d.cc
@@ -77,13 +77,13 @@ SpmdInfo DepthwiseConv2dInferSpmd(const DistMetaTensor& input,
                         "dims_mapping size [%d] are not matched.",
                         filter_ndim,
                         filter_dims_mapping.size()));
-  PADDLE_ENFORCE_EQ(filter_dims_mapping[1],
-                    -1,
-                    common::errors::InvalidArgument(
-                        "The Tensor Filter's dims_mapping on channel dim "
-                        "should always be -1.",
-                        "But now it's [%d]",
-                        filter_dims_mapping[1]));
+  PADDLE_ENFORCE_EQ(
+      filter_dims_mapping[1],
+      -1,
+      common::errors::InvalidArgument(
+          "The Tensor Filter's dims_mapping on channel dim should "
+          "always be -1. But now it's [%d]",
+          filter_dims_mapping[1]));
 
   VLOG(6) << "DepthwiseConv2D InferForward Inputs: "
           << "Input shape: [" << str_join(original_input_shape)

--- a/paddle/phi/infermeta/spmd_rules/flash_attention.cc
+++ b/paddle/phi/infermeta/spmd_rules/flash_attention.cc
@@ -464,7 +464,7 @@ SpmdInfo FlashAttInferSpmdReverse(const DistMetaTensor& q,
       batch_size,
       batch_size_2,
       common::errors::InvalidArgument(
-          "batch size of Tensor out and softmax_lse is not matched: [] vs []",
+          "batch size of Tensor out and softmax_lse is not matched: %d vs %d",
           batch_size,
           batch_size_2));
 
@@ -472,7 +472,7 @@ SpmdInfo FlashAttInferSpmdReverse(const DistMetaTensor& q,
       num_heads,
       num_heads_2,
       common::errors::InvalidArgument(
-          "num heads of Tensor out and softmax_lse is not matched: [] vs []",
+          "num heads of Tensor out and softmax_lse is not matched: %d vs %d",
           num_heads,
           num_heads_2));
 
@@ -480,7 +480,7 @@ SpmdInfo FlashAttInferSpmdReverse(const DistMetaTensor& q,
       seq_len_q,
       seq_len_q_2,
       common::errors::InvalidArgument(
-          "seq_len_q of Tensor out and softmax_lse is not matched: [] vs []",
+          "seq_len_q of Tensor out and softmax_lse is not matched: %d vs %d",
           seq_len_q,
           seq_len_q_2));
 

--- a/paddle/phi/infermeta/spmd_rules/spmd_rule_macro_define.h
+++ b/paddle/phi/infermeta/spmd_rules/spmd_rule_macro_define.h
@@ -27,7 +27,7 @@ using phi::distributed::auto_parallel::str_join;
   PADDLE_ENFORCE_EQ(x##_ndim,                                          \
                     x##_dims_mapping_src.size(),                       \
                     common::errors::InvalidArgument(                   \
-                        "[%d] [%d] The Tensor [%d]'s rank [%d] and "   \
+                        "[%s] [%d] The Tensor [%s]'s rank [%d] and "   \
                         "dims_mapping size [%d] are not matched.",     \
                         __FILE__,                                      \
                         __LINE__,                                      \
@@ -41,7 +41,7 @@ using phi::distributed::auto_parallel::str_join;
   PADDLE_ENFORCE_EQ(x##_ndim,                                                \
                     x##_dims_mapping_src.size(),                             \
                     common::errors::InvalidArgument(                         \
-                        "[%d] [%d] The Tensor [%d]'s rank [%d] and "         \
+                        "[%s] [%d] The Tensor [%s]'s rank [%d] and "         \
                         "dims_mapping size [%d] are not matched.",           \
                         __FILE__,                                            \
                         __LINE__,                                            \
@@ -54,7 +54,7 @@ using phi::distributed::auto_parallel::str_join;
   PADDLE_ENFORCE_EQ(x##_ndim,                                        \
                     x##_dims_mapping_src.size(),                     \
                     common::errors::InvalidArgument(                 \
-                        "[%d] [%d] The Tensor [%d]'s rank [%d] and " \
+                        "[%s] [%d] The Tensor [%s]'s rank [%d] and " \
                         "dims_mapping size [%d] are not matched.",   \
                         __FILE__,                                    \
                         __LINE__,                                    \

--- a/paddle/phi/infermeta/spmd_rules/triu.cc
+++ b/paddle/phi/infermeta/spmd_rules/triu.cc
@@ -37,7 +37,7 @@ SpmdInfo TriuInferSpmdBase(const DistMetaTensor& x) {
   PADDLE_ENFORCE_GE(x_ndim,
                     2,
                     common::errors::InvalidArgument(
-                        "The Tensor x's rank [%d] must be ge than 2"));
+                        "The Tensor x's rank [%d] must be ge than 2", x_ndim));
 
   std::vector<int64_t> dims_to_unshard;
   for (int i = x_ndim - 2; i < x_ndim; ++i) {
@@ -82,10 +82,11 @@ SpmdInfo TriuInferSpmdReverseBase(const DistMetaTensor& x,
                                       out_ndim,
                                       out_dims_mapping.size()));
 
-  PADDLE_ENFORCE_GE(out_ndim,
-                    2,
-                    common::errors::InvalidArgument(
-                        "The Tensor x's rank [%d] must be ge than 2"));
+  PADDLE_ENFORCE_GE(
+      out_ndim,
+      2,
+      common::errors::InvalidArgument(
+          "The Tensor x's rank [%d] must be ge than 2", out_ndim));
 
   std::vector<int64_t> dims_to_unshard;
   for (int i = out_ndim - 2; i < out_ndim; ++i) {
@@ -129,10 +130,11 @@ SpmdInfo TriuGradInferSpmdBase(const DistMetaTensor& out_grad) {
                         out_ndim,
                         out_dims_mapping.size()));
 
-  PADDLE_ENFORCE_GE(out_ndim,
-                    2,
-                    common::errors::InvalidArgument(
-                        "The Tensor x's rank [%d] must be ge than 2"));
+  PADDLE_ENFORCE_GE(
+      out_ndim,
+      2,
+      common::errors::InvalidArgument(
+          "The Tensor x's rank [%d] must be ge than 2", out_ndim));
 
   std::vector<int64_t> dims_to_unshard;
   for (int i = out_ndim - 2; i < out_ndim; ++i) {

--- a/paddle/phi/infermeta/spmd_rules/unbind.cc
+++ b/paddle/phi/infermeta/spmd_rules/unbind.cc
@@ -32,7 +32,7 @@ SpmdInfo UnbindInferSpmd(const DistMetaTensor& x, int axis) {
   PADDLE_ENFORCE_LT(
       axis,
       x_ndim,
-      common::errors::InvalidArgument("[%d] [%d] The axis [%d] should be less "
+      common::errors::InvalidArgument("[%s] [%d] The axis [%d] should be less "
                                       "than the rank of input tensor [%d].",
                                       __FILE__,
                                       __LINE__,

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -841,8 +841,8 @@ void DecodeJpegInferMeta(const MetaTensor& x,
   } else if (mode == "rgb") {
     out_dims = {3, -1, -1};
   } else {
-    errors::Fatal("The provided mode is not supported for JPEG files on GPU: ",
-                  mode);
+    errors::Fatal(
+        "The provided mode is not supported for JPEG files on GPU: %s", mode);
   }
   if (out != nullptr) {
     out->set_dims(make_ddim(out_dims));
@@ -4859,7 +4859,7 @@ void ViewSliceInferMeta(const MetaTensor& input,
       begin_idx,
       0,
       common::errors::OutOfRange("The start row index must be greater than 0."
-                                 "But received the start index is d%.",
+                                 "But received the start index is %d.",
                                  begin_idx));
   PADDLE_ENFORCE_LE(
       end_idx,

--- a/paddle/phi/kernels/cpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/cpu/add_n_kernel.cc
@@ -70,6 +70,7 @@ void AddNKernel(const Context& dev_ctx,
             "Expected type of Input(X) of %d-th must be Tensor, "
             "SelectedRows. But got "
             "unsupported type: %s.",
+            i,
             x[i]->type_info().name()));
       }
     }
@@ -113,6 +114,7 @@ void AddNKernel(const Context& dev_ctx,
             "Expected type of Input(X) of %d-th must be Tensor, "
             "SelectedRows. But got "
             "unsupported type: %s.",
+            i,
             x[i]->type_info().name()));
       }
     }

--- a/paddle/phi/kernels/cpu/broadcast_tensors_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/broadcast_tensors_grad_kernel.cc
@@ -78,7 +78,7 @@ void BroadcastTensorsGradKernel(const Context& dev_ctx,
       num_ins,
       1,
       errors::InvalidArgument(
-          "Expected at least 2 input tensors, but only received d%.",
+          "Expected at least 2 input tensors, but only received %d.",
           in_tensors.size()));
 
   PADDLE_ENFORCE_EQ(num_ins,

--- a/paddle/phi/kernels/cpu/dpsgd_kernel.cc
+++ b/paddle/phi/kernels/cpu/dpsgd_kernel.cc
@@ -42,14 +42,14 @@ void DpsgdOpKernel(const Context &dev_ctx,
                     sz,
                     common::errors::InvalidArgument(
                         "Input parameter's number of elements is error, "
-                        "expected %d, but received %d.",
+                        "expected %lld, but received %lld.",
                         sz,
                         param->numel()));
   PADDLE_ENFORCE_EQ(grad->numel(),
                     sz,
                     common::errors::InvalidArgument(
                         "Input gradient's number of elements is error, "
-                        "expected %d, but received %d.",
+                        "expected %lld, but received %lld.",
                         sz,
                         grad->numel()));
 

--- a/paddle/phi/kernels/cpu/dpsgd_kernel.cc
+++ b/paddle/phi/kernels/cpu/dpsgd_kernel.cc
@@ -42,12 +42,16 @@ void DpsgdOpKernel(const Context &dev_ctx,
                     sz,
                     common::errors::InvalidArgument(
                         "Input parameter's number of elements is error, "
-                        "expected %zu, but received %zu."));
+                        "expected %d, but received %d.",
+                        sz,
+                        param->numel()));
   PADDLE_ENFORCE_EQ(grad->numel(),
                     sz,
                     common::errors::InvalidArgument(
                         "Input gradient's number of elements is error, "
-                        "expected %zu, but received %zu."));
+                        "expected %d, but received %d.",
+                        sz,
+                        grad->numel()));
 
   const T *lr = learning_rate->data<T>();
   const T *param_data = param->data<T>();

--- a/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
@@ -143,8 +143,8 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                     common::errors::InvalidArgument(
                         "Index holds the wrong type, it holds [%s], but "
                         "desires to be [%s].",
-                        index_type,
-                        DataType::INT64));
+                        DataTypeToString(index_type),
+                        DataTypeToString(DataType::INT64)));
   CPUIndexElementwiseGetGrad<T, int64_t>(dev_ctx,
                                          x,
                                          out_grad,

--- a/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_elementwise_get_grad_kernel.cc
@@ -144,7 +144,6 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                         "Index holds the wrong type, it holds [%s], but "
                         "desires to be [%s].",
                         index_type,
-                        DataType::INT32,
                         DataType::INT64));
   CPUIndexElementwiseGetGrad<T, int64_t>(dev_ctx,
                                          x,

--- a/paddle/phi/kernels/funcs/fused_gemm_epilogue.h
+++ b/paddle/phi/kernels/funcs/fused_gemm_epilogue.h
@@ -386,7 +386,8 @@ static GPU(blasLtEpilogue_t)
   } else {
     PADDLE_THROW(common::errors::InvalidArgument(
         "The activation attribute of fused_gemm_epilogue op should be"
-        " one of {\"none\", \"relu\", \"gelu\"}. But received %s." activation));
+        " one of {\"none\", \"relu\", \"gelu\"}. But received %s.",
+        activation));
   }
 }
 

--- a/paddle/phi/kernels/funcs/fused_gemm_epilogue.h
+++ b/paddle/phi/kernels/funcs/fused_gemm_epilogue.h
@@ -386,9 +386,7 @@ static GPU(blasLtEpilogue_t)
   } else {
     PADDLE_THROW(common::errors::InvalidArgument(
         "The activation attribute of fused_gemm_epilogue op should be"
-        " one of {\"none\", \"relu\", \"gelu\"}. But received %s."
-        "But received activation=%s.",
-        activation));
+        " one of {\"none\", \"relu\", \"gelu\"}. But received %s." activation));
   }
 }
 
@@ -688,8 +686,8 @@ static GPU(blasLtEpilogue_t)
   } else {
     PADDLE_THROW(common::errors::InvalidArgument(
         "The activation_grad attribute of fused_gemm_epilogue op should "
-        "be one of {\"none\", \"relu\", \"gelu\"}. But received %s."
-        "But received activation_grad=%s.",
+        "be one of {\"none\", \"relu\", \"gelu\"}. But received "
+        "activation_grad=%s.",
         activation_grad));
   }
 }

--- a/paddle/phi/kernels/funcs/index_elementwise.cu.h
+++ b/paddle/phi/kernels/funcs/index_elementwise.cu.h
@@ -154,7 +154,7 @@ struct OffsetCalculator {
         dims,
         MAX_DIMS,
         common::errors::InvalidArgument(
-            "Tensor has too many dims. Maximum dim is d%.", MAX_DIMS));
+            "Tensor has too many dims. Maximum dim is %d.", MAX_DIMS));
     for (int i = 0; i < dims; i++) {
       shape_[i] = IntDivider<INDEX_T>(shape[i]);
       for (int arg = 0; arg < NARGS; arg++) {

--- a/paddle/phi/kernels/funcs/index_elementwise.h
+++ b/paddle/phi/kernels/funcs/index_elementwise.h
@@ -59,7 +59,7 @@ struct CPUOffsetCalculator {
         dims,
         MAX_DIMS,
         common::errors::InvalidArgument(
-            "Tensor has too many dims. Maximum dim is d%.", MAX_DIMS));
+            "Tensor has too many dims. Maximum dim is %d.", MAX_DIMS));
     for (int i = 0; i < dims; i++) {
       sizes_[i] = CPUIntDivider<index_t>(sizes[i]);
       for (int arg = 0; arg < NARGS; arg++) {

--- a/paddle/phi/kernels/funcs/indexing.h
+++ b/paddle/phi/kernels/funcs/indexing.h
@@ -58,12 +58,12 @@ static inline common::DDim InferSizeSymdimvector(const common::DDim& a,
     PADDLE_ENFORCE_EQ(
         sizeA == sizeB || sizeA == 1 || sizeB == 1,
         true,
-        common::errors::Fatal("The size of tensor a (",
-                              sizeA,
-                              ") must match the size of tensor b (",
-                              sizeB,
-                              ") at non-singleton dimension ",
-                              i));
+        common::errors::Fatal(
+            "The size of tensor a (%d) must match the size of tensor b "
+            "(%d) at non-singleton dimension %d",
+            sizeA,
+            sizeB,
+            i));
 
     expandedSizes[i] = sizeA == 1 ? sizeB : sizeA;
   }

--- a/paddle/phi/kernels/funcs/interpolate_function.h
+++ b/paddle/phi/kernels/funcs/interpolate_function.h
@@ -125,7 +125,7 @@ inline std::vector<int> get_new_shape(
         true,
         errors::InvalidArgument(
             "The shape of dimension tensor should be [1] or [],"
-            "but received d%.",
+            "but received %s.",
             tensor->dims()));
     if (tensor->dtype() == DataType::INT64) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE

--- a/paddle/phi/kernels/funcs/unsqueeze.h
+++ b/paddle/phi/kernels/funcs/unsqueeze.h
@@ -43,14 +43,18 @@ inline DDim GetOutputSqueezeShape(const std::vector<int> squeeze_dims,
             common::errors::InvalidArgument(
                 "For 0D Tensor, Each axis in Attr(axes) should be in the range "
                 "of [-1, 0]"
-                "But current axis is:%d, input tensor's shape = [%s]."));
+                "But current axis is:%d, input tensor's shape = [%s].",
+                squeeze_dims[i],
+                in_dims));
         PADDLE_ENFORCE_LE(
             squeeze_dims[i],
             0,
             common::errors::InvalidArgument(
                 "For 0D Tensor, Each axis in Attr(axes) should be in the range "
                 "of [-1, 0]"
-                "But current axis is:%d, input tensor's shape = [%s]."));
+                "But current axis is:%d, input tensor's shape = [%s].",
+                squeeze_dims[i],
+                in_dims));
         continue;
       }
 

--- a/paddle/phi/kernels/fusion/gpu/distributed_fused_lamb_init_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/distributed_fused_lamb_init_kernel.cu
@@ -422,12 +422,13 @@ void DistributedFusedLambInitOpKernel(
                         g_out,
                         errors::InvalidArgument(
                             "The %d-th Input(Grad) and Output(Grad) should "
-                            "be the same tensor."));
+                            "be the same tensor.",
+                            i));
       auto numel = p->numel();
-      PADDLE_ENFORCE_GT(
-          numel,
-          0,
-          errors::InvalidArgument("The %d-th Input(Param) have no elements."));
+      PADDLE_ENFORCE_GT(numel,
+                        0,
+                        errors::InvalidArgument(
+                            "The %d-th Input(Param) have no elements.", i));
 
       void *g_data = nullptr;
       if (g->IsInitialized()) {

--- a/paddle/phi/kernels/fusion/xpu/cross_attention_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/cross_attention_xpu_kernel.cc
@@ -231,8 +231,7 @@ void CrossAttentionXPUKernel(
     return;
   }
   PADDLE_THROW(common::errors::Unimplemented(
-      "Not support q_dtype is %s, k_dtype is %s, k_dtype is %s "
-      "and qkv_dtype is %s.",
+      "Not support q_dtype is %s, kv_dtype is %s and qkv_dtype is %s.",
       DataTypeToString(input_q.dtype()),
       DataTypeToString(input_kv.dtype()),
       DataTypeToString(qkv_dtype)));

--- a/paddle/phi/kernels/fusion/xpu/fast_where_xpu_kernel.cc
+++ b/paddle/phi/kernels/fusion/xpu/fast_where_xpu_kernel.cc
@@ -37,11 +37,10 @@ void FastWhereXPUKernel(const Context& dev_ctx,
       x_dims,
       y_dims,
       errors::PreconditionNotMet(
-          "The dimensions of inputs should be equal, but x_dims=[",
+          "The dimensions of inputs should be equal, but x_dims=[%s] and "
+          "y_dims=[%s]",
           x.dims(),
-          "] and y_dims=[",
-          y.dims(),
-          "]"));
+          y.dims()));
 #ifndef PADDLE_WITH_XPU_PLUGIN
   LOG(INFO)
       << "Add -DWITH_XPU_PLUGIN=ON to build xpu::plugin::fast_where(), or use "

--- a/paddle/phi/kernels/gpu/add_n_kernel.cu
+++ b/paddle/phi/kernels/gpu/add_n_kernel.cu
@@ -169,6 +169,7 @@ void AddNKernel(const Context &dev_ctx,
           errors::InvalidArgument("The dtype of inputs should be the same, "
                                   "but received the dtype of input 1 is %s, "
                                   "input %d is %s",
+                                  in_other_dtype,
                                   i,
                                   x[i]->dtype()));
       if (DenseTensor::classof(x[i])) {

--- a/paddle/phi/kernels/gpu/broadcast_tensors_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/broadcast_tensors_grad_kernel.cu
@@ -42,7 +42,7 @@ void BroadcastTensorsGradKernel(const Context& dev_ctx,
       num_ins,
       1,
       errors::InvalidArgument(
-          "Expected at least 2 input tensors, but only received d%.",
+          "Expected at least 2 input tensors, but only received %d.",
           in_tensors.size()));
 
   PADDLE_ENFORCE_EQ(

--- a/paddle/phi/kernels/gpu/decode_jpeg_kernel.cu
+++ b/paddle/phi/kernels/gpu/decode_jpeg_kernel.cu
@@ -44,7 +44,8 @@ void DecodeJpegKernel(const Context& dev_ctx,
 
     PADDLE_ENFORCE_EQ(create_status,
                       NVJPEG_STATUS_SUCCESS,
-                      errors::Fatal("nvjpegCreateSimple failed."));
+                      errors::Fatal("nvjpegCreateSimple failed: %d.",
+                                    static_cast<int>(create_status)));
   }
 
   nvjpegJpegState_t nvjpeg_state;
@@ -53,7 +54,8 @@ void DecodeJpegKernel(const Context& dev_ctx,
 
   PADDLE_ENFORCE_EQ(state_status,
                     NVJPEG_STATUS_SUCCESS,
-                    errors::Fatal("nvjpegJpegStateCreate failed."));
+                    errors::Fatal("nvjpegJpegStateCreate failed: %d",
+                                  static_cast<int>(state_status)));
 
   int components;
   nvjpegChromaSubsampling_t subsampling;
@@ -72,7 +74,8 @@ void DecodeJpegKernel(const Context& dev_ctx,
                                   heights);
   PADDLE_ENFORCE_EQ(info_status,
                     NVJPEG_STATUS_SUCCESS,
-                    errors::Fatal("nvjpegGetImageInfo failed."));
+                    errors::Fatal("nvjpegGetImageInfo failed: %d",
+                                  static_cast<int>(info_status)));
 
   int width = widths[0];
   int height = heights[0];

--- a/paddle/phi/kernels/gpu/decode_jpeg_kernel.cu
+++ b/paddle/phi/kernels/gpu/decode_jpeg_kernel.cu
@@ -42,20 +42,18 @@ void DecodeJpegKernel(const Context& dev_ctx,
   if (nvjpeg_handle == nullptr) {
     nvjpegStatus_t create_status = dynload::nvjpegCreateSimple(&nvjpeg_handle);
 
-    PADDLE_ENFORCE_EQ(
-        create_status,
-        NVJPEG_STATUS_SUCCESS,
-        errors::Fatal("nvjpegCreateSimple failed: ", create_status));
+    PADDLE_ENFORCE_EQ(create_status,
+                      NVJPEG_STATUS_SUCCESS,
+                      errors::Fatal("nvjpegCreateSimple failed."));
   }
 
   nvjpegJpegState_t nvjpeg_state;
   nvjpegStatus_t state_status =
       dynload::nvjpegJpegStateCreate(nvjpeg_handle, &nvjpeg_state);
 
-  PADDLE_ENFORCE_EQ(
-      state_status,
-      NVJPEG_STATUS_SUCCESS,
-      errors::Fatal("nvjpegJpegStateCreate failed: ", state_status));
+  PADDLE_ENFORCE_EQ(state_status,
+                    NVJPEG_STATUS_SUCCESS,
+                    errors::Fatal("nvjpegJpegStateCreate failed."));
 
   int components;
   nvjpegChromaSubsampling_t subsampling;
@@ -74,7 +72,7 @@ void DecodeJpegKernel(const Context& dev_ctx,
                                   heights);
   PADDLE_ENFORCE_EQ(info_status,
                     NVJPEG_STATUS_SUCCESS,
-                    errors::Fatal("nvjpegGetImageInfo failed: ", info_status));
+                    errors::Fatal("nvjpegGetImageInfo failed."));
 
   int width = widths[0];
   int height = heights[0];

--- a/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
@@ -17,6 +17,7 @@
 #include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
+#include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/arange_kernel.h"
 #include "paddle/phi/kernels/contiguous_kernel.h"
@@ -419,9 +420,8 @@ void IndexElementwiseGetGradKernel(const Context& dev_ctx,
                     common::errors::InvalidArgument(
                         "Index holds the wrong type, it holds [%s], but "
                         "desires to be [%s].",
-                        index_type,
-                        DataType::INT32,
-                        DataType::INT64));
+                        DataTypeToString(index_type),
+                        DataTypeToString(DataType::INT64)));
 
   if (accumulate && index.size() == 1 && !is_combined) {
 #ifdef PADDLE_WITH_CUDA

--- a/paddle/phi/kernels/gpu/psroi_pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/psroi_pool_kernel.cu
@@ -191,9 +191,9 @@ void PsroiPoolKernel(const Context& dev_ctx,
                       rois_num_with_lod,
                       errors::InvalidArgument(
                           "The number of rois from input(ROIs) and its LOD "
-                          "must be the same. Received rois %d of input(ROIs) "
-                          "but the number of rois %d from its LOD is %d",
-                          rois_num,
+                          "must be the same. Received rois %d of input(ROIs), "
+                          "but the number of rois from its LOD is %d.",
+                          rois_num_t,
                           rois_num_with_lod));
 
     // set rois batch id

--- a/paddle/phi/kernels/gpu/roi_pool_kernel.cu
+++ b/paddle/phi/kernels/gpu/roi_pool_kernel.cu
@@ -184,8 +184,8 @@ void RoiPoolKernel(const Context& dev_ctx,
                       boxes_num_with_lod,
                       common::errors::InvalidArgument(
                           "The number of rois from input(ROIs) and its LOD "
-                          "must be the same. Received rois %d of input(ROIs) "
-                          "but the number of rois %d from its LOD is %d",
+                          "must be the same. Received rois %d of input(ROIs), "
+                          "but the number of rois from its LOD is %d.",
                           rois_num,
                           boxes_num_with_lod));
     for (int n = 0; n < boxes_batch_size; ++n) {

--- a/paddle/phi/kernels/impl/meshgrid_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/meshgrid_grad_kernel_impl.h
@@ -108,8 +108,7 @@ void MeshgridGradKernel(const Context& dev_ctx,
       break;
     default:
       PADDLE_THROW(common::errors::InvalidArgument(
-          "Excepted Tensor numbers between 1 and 6, but only received d% .",
-          n));
+          "Excepted Tensor numbers between 1 and 6, but only received %d.", n));
   }
 }
 

--- a/paddle/phi/kernels/impl/save_combine_kernel_impl.h
+++ b/paddle/phi/kernels/impl/save_combine_kernel_impl.h
@@ -108,8 +108,7 @@ void SaveCombineTensorKernel(const Context& dev_ctx,
     PADDLE_THROW(common::errors::PreconditionNotMet(
         "%s exists! Cannot save_combine to it when overwrite is set to "
         "false.",
-        file_path,
-        overwrite));
+        file_path));
   }
 
   if (save_to_memory) {
@@ -152,8 +151,7 @@ void SaveCombineVocabKernel(const Context& dev_ctx UNUSED,
     PADDLE_THROW(common::errors::PreconditionNotMet(
         "%s exists! Cannot save_combine to it when overwrite is set to "
         "false.",
-        file_path,
-        overwrite));
+        file_path));
   }
 
   std::ostringstream ss;

--- a/paddle/phi/kernels/impl/save_kernel_impl.h
+++ b/paddle/phi/kernels/impl/save_kernel_impl.h
@@ -40,8 +40,7 @@ void SaveKernel(const Context& dev_ctx,
       false,
       common::errors::PreconditionNotMet(
           "%s exists!, cannot save to it when overwrite is set to false.",
-          file_path,
-          overwrite));
+          file_path));
 
   MkDirRecursively(DirName(file_path).c_str());
 

--- a/paddle/phi/kernels/onednn/quantize_kernel.cc
+++ b/paddle/phi/kernels/onednn/quantize_kernel.cc
@@ -38,11 +38,12 @@ void QuantOpKernel(const Context& dev_ctx,
                     0.0f,
                     common::errors::InvalidArgument(
                         "Quantization scale must be different than 0.0f"));
-  PADDLE_ENFORCE(quantization_shift <= 255 && quantization_shift >= 0,
-                 common::errors::InvalidArgument(
-                     "Quantization shift must be lower or equal to ",
-                     "255 and greater or equal to 0, but got %f",
-                     quantization_shift));
+  PADDLE_ENFORCE(
+      quantization_shift <= 255 && quantization_shift >= 0,
+      common::errors::InvalidArgument(
+          "Quantization shift must be lower or equal to 255 and greater or "
+          "equal to 0, but got %d",
+          quantization_shift));
 
   auto x_tz = vectorize<int64_t>(input.dims());
   dnnl::primitive_attr attrs;

--- a/paddle/phi/kernels/selected_rows/impl/save_kernel_impl.h
+++ b/paddle/phi/kernels/selected_rows/impl/save_kernel_impl.h
@@ -41,8 +41,7 @@ void SaveSelectedRowsKernel(const Context& dev_ctx,
       false,
       common::errors::PreconditionNotMet(
           "%s exists!, cannot save to it when overwrite is set to false.",
-          file_path,
-          overwrite));
+          file_path));
   PADDLE_ENFORCE_EQ(save_as_fp16,
                     false,
                     common::errors::Unimplemented(

--- a/paddle/phi/kernels/xpu/add_n_kernel.cc
+++ b/paddle/phi/kernels/xpu/add_n_kernel.cc
@@ -55,10 +55,11 @@ void AddNKernel(const Context& dev_ctx,
       }
       ptrs.push_back(reinterpret_cast<const XPUType*>(in_t.data<T>()));
     } else if (SelectedRows::classof(x[i])) {
-      PADDLE_ENFORCE_EQ(x[i]->dtype(),
-                        DataType::FLOAT32,
-                        errors::InvalidArgument("SelectedRowsAdd(scatter) only",
-                                                "supports float type"));
+      PADDLE_ENFORCE_EQ(
+          x[i]->dtype(),
+          DataType::FLOAT32,
+          errors::InvalidArgument(
+              "SelectedRowsAdd(scatter) only supports float type"));
 
       auto& in_t = *(static_cast<const SelectedRows*>(x[i]));
       functor(dev_ctx, in_t, out);
@@ -67,6 +68,7 @@ void AddNKernel(const Context& dev_ctx,
           "Expected type of Input(X) of %d-th must be Tensor, "
           "SelectedRows. But got "
           "unsupported type: %s.",
+          i,
           x[i]->type_info().name()));
     }
   }

--- a/paddle/phi/kernels/xpu/instance_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/instance_norm_grad_kernel.cc
@@ -40,9 +40,9 @@ void InstanceNormGradKernel(const Context& dev_ctx,
       x_dims.size() <= 5 && D == 1,
       true,
       common::errors::InvalidArgument(
-          "The size of input's dimensions should be less equal than 5",
-          "and the dimension of D should be equal to 1",
-          "But received: the size of input's dimensions is [%d]",
+          "The size of input's dimensions should be less equal than 5 and "
+          "the dimension of D should be equal to 1. But received: the size "
+          "of input's dimensions is [%d]",
           x_dims.size()));
 
   dev_ctx.template Alloc<T>(d_x);

--- a/paddle/phi/kernels/xpu/multiclass_nms3_kernel.cc
+++ b/paddle/phi/kernels/xpu/multiclass_nms3_kernel.cc
@@ -98,14 +98,14 @@ void MultiClassNMSKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(boxes_count == bboxes.dims()[0],
                       true,
                       common::errors::InvalidArgument(
-                          "boxes_count should equal boxes->dims()[0].",
+                          "boxes_count should equal boxes->dims()[0]."
                           "But received: (%d) and (%d)",
                           boxes_count,
                           bboxes.dims()[0]));
     PADDLE_ENFORCE_EQ(boxes_count == score_dims[0],
                       true,
                       common::errors::InvalidArgument(
-                          "boxes_count should equal score_dims[0].",
+                          "boxes_count should equal score_dims[0]."
                           "But received: (%d) and (%d)",
                           boxes_count,
                           score_dims[0]));

--- a/paddle/phi/kernels/xpu/pool_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/pool_grad_kernel.cc
@@ -130,7 +130,7 @@ void Pool2dGradKernel(const Context& dev_ctx,
           true);
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
-          "Unsupported pooling type for kunlun ", pooling_type));
+          "Unsupported pooling type for kunlun %s", pooling_type));
     }
 
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "adaptive_pool2d_grad");
@@ -176,7 +176,7 @@ void Pool2dGradKernel(const Context& dev_ctx,
           true);
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
-          "Unsupported pooling type for kunlun ", pooling_type));
+          "Unsupported pooling type for kunlun %s", pooling_type));
     }
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "pool2dgrad");
   }
@@ -321,7 +321,7 @@ void Pool3dGradKernel(const Context& dev_ctx,
           !channel_last);
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
-          "Unsupported pooling type for kunlun ", pooling_type));
+          "Unsupported pooling type for kunlun %s", pooling_type));
     }
 
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "adaptive_pool3d_grad");
@@ -379,7 +379,7 @@ void Pool3dGradKernel(const Context& dev_ctx,
           !channel_last);
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
-          "Unsupported pooling type for kunlun ", pooling_type));
+          "Unsupported pooling type for kunlun %s", pooling_type));
     }
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "pool3dgrad");
   }

--- a/paddle/phi/kernels/xpu/pool_kernel.cc
+++ b/paddle/phi/kernels/xpu/pool_kernel.cc
@@ -127,7 +127,7 @@ void Pool2dKernel(const Context& dev_ctx,
           true);
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
-          "Unsupported pooling type for kunlun ", pooling_type));
+          "Unsupported pooling type for kunlun %s", pooling_type));
     }
   } else {
     if (pooling_type == "max") {
@@ -157,7 +157,7 @@ void Pool2dKernel(const Context& dev_ctx,
           true);
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
-          "Unsupported pooling type for kunlun ", pooling_type));
+          "Unsupported pooling type for kunlun %s", pooling_type));
     }
   }
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "pool2d");
@@ -269,7 +269,7 @@ void Pool3dKernel(const Context& dev_ctx,
           data_format == "NCDHW");
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
-          "Unsupported pooling type for kunlun ", pooling_type));
+          "Unsupported pooling type for kunlun %s", pooling_type));
     }
   } else {
     if (pooling_type == "max") {
@@ -303,7 +303,7 @@ void Pool3dKernel(const Context& dev_ctx,
           data_format == "NCDHW");
     } else {
       PADDLE_THROW(common::errors::InvalidArgument(
-          "Unsupported pooling type for kunlun ", pooling_type));
+          "Unsupported pooling type for kunlun %s", pooling_type));
     }
   }
   PADDLE_ENFORCE_XDNN_SUCCESS(r, "pool3d");


### PR DESCRIPTION

### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
修复 `paddle/phi` 目录下 54 个文件中错误消息格式字符串的不匹配问题，包括：
- 格式符错误（`d%` → `%d`，`s%` → `%s` 等）
- 缺少对应的格式参数（格式符数少于实参数）
- 多余的重复错误描述文本（`fused_gemm_epilogue.h`）

### 是否引起精度变化
否