### PR TITLE
[release/3.4][CI] Restore self-hosted runners for GitHub workflows

### DIFF
--- a/.github/workflows/Approval.yml
+++ b/.github/workflows/Approval.yml
@@ -24,9 +24,13 @@ jobs:
     name: Check approval
     needs: [check-bypass]
     if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     timeout-minutes: 10
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/CI-Build.yml
+++ b/.github/workflows/CI-Build.yml
@@ -19,7 +19,8 @@ jobs:
   check-skill:
     name: Check file paths
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     continue-on-error: true
     permissions:
       contents: read
@@ -27,6 +28,9 @@ jobs:
     outputs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip || 'false' }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run skip check

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -19,12 +19,16 @@ jobs:
   check-skill:
     name: Check file paths
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     permissions:
       contents: read
     outputs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run skip check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,12 +19,16 @@ jobs:
   check-skill:
     name: Check file paths
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     permissions:
       contents: read
     outputs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run skip check

--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -18,13 +18,17 @@ jobs:
     name: Pre Commit
     if: ${{ github.repository_owner == 'PaddlePaddle' && needs.check-bypass.outputs.can-skip != 'true' }}
     needs: [check-bypass]
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     timeout-minutes: 10
     env:
       PR_ID: ${{ github.event.pull_request.number }}
       BRANCH: develop
 
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout base repo
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -31,7 +31,8 @@ defaults:
 jobs:
   check-skill:
     name: Check file paths
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     continue-on-error: true
     permissions:
       contents: read
@@ -39,6 +40,9 @@ jobs:
     outputs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip || 'false' }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run skip check

--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -33,7 +33,8 @@ jobs:
   check-skill:
     name: Check file paths
     if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     continue-on-error: true
     permissions:
       contents: read
@@ -41,6 +42,9 @@ jobs:
     outputs:
       can-skip: ${{ steps.skip-skill.outputs.should-skip }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run skip check

--- a/.github/workflows/Preview-Url-Comment.yml
+++ b/.github/workflows/Preview-Url-Comment.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   comment:
     name: Post Preview URLs Comment
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
@@ -17,6 +18,9 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Download artifacts
         id: download
         uses: actions/download-artifact@v8

--- a/.github/workflows/cancel-CI-build.yml
+++ b/.github/workflows/cancel-CI-build.yml
@@ -18,8 +18,12 @@ env:
 jobs:
   cancel:
     name: Cancel CI-Build for ${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Cancel CI-build
         run: |
           exit 0

--- a/.github/workflows/cancel-CI.yml
+++ b/.github/workflows/cancel-CI.yml
@@ -18,8 +18,12 @@ env:
 jobs:
   cancel:
     name: Cancel CI for ${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Cancel CI
         run: |
           exit 0

--- a/.github/workflows/cancel-coverage.yml
+++ b/.github/workflows/cancel-coverage.yml
@@ -18,8 +18,12 @@ env:
 jobs:
   cancel:
     name: Cancel Coverage for ${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Cancel Coverage
         run: |
           exit 0

--- a/.github/workflows/cancel-windows.yml
+++ b/.github/workflows/cancel-windows.yml
@@ -18,8 +18,12 @@ env:
 jobs:
   cancel:
     name: Cancel CI-Windows for ${{ github.event.pull_request.number }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Cancel CI-Windows
         run: |
           exit 0

--- a/.github/workflows/check-bypass-slice.yml
+++ b/.github/workflows/check-bypass-slice.yml
@@ -15,7 +15,8 @@ on:
 jobs:
   check-bypass:
     name: Check bypass
-    runs-on: ubuntu-slim
+    runs-on:
+      group: APPROVAL
     permissions:
       contents: read
     env:
@@ -23,6 +24,9 @@ jobs:
     outputs:
       can-skip: ${{ steps.check-bypass.outputs.can-skip }}
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - id: check-bypass
         name: Check Bypass
         uses: PFCCLab/ci-bypass@v2

--- a/.github/workflows/check-bypass.yml
+++ b/.github/workflows/check-bypass.yml
@@ -15,7 +15,8 @@ on:
 jobs:
   check-bypass:
     name: Check bypass
-    runs-on: ubuntu-slim
+    runs-on:
+      group: APPROVAL
     permissions:
       contents: read
     env:
@@ -24,6 +25,9 @@ jobs:
       can-skip: ${{ steps.check-bypass.outputs.can-skip }}
     timeout-minutes: 3
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - id: check-bypass
         name: Check Bypass
         uses: PFCCLab/ci-bypass@v2

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -22,8 +22,12 @@ jobs:
         github.event.action == 'labeled' ||
         contains(join(github.event.pull_request.labels.*.name, ' '), 'cherry-pick')
       )
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/remove-skip-ci-labels.yml
+++ b/.github/workflows/remove-skip-ci-labels.yml
@@ -10,8 +10,12 @@ permissions:
 jobs:
   remove-skip-ci-labels:
     name: Remove skip-ci labels on new commits
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Get PR labels
         id: get-labels
         uses: actions/github-script@v8

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -7,8 +7,12 @@ on:
 jobs:
   re-run:
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/re-run')  && github.event.comment.user.login == github.event.issue.user.login }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/validate-pir-versions.yml
+++ b/.github/workflows/validate-pir-versions.yml
@@ -6,9 +6,13 @@ on:
 
 jobs:
   check-version-and-create-issue:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: APPROVAL
     if: github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release/') && github.repository_owner == 'PaddlePaddle'
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
       - name: Checkout code
         uses: actions/checkout@v6
 


### PR DESCRIPTION
### PR Category

Environment Adaptation


### PR Types

Improvements


### Description

Manual cherry-pick of #79123 to `release/3.4` after the automated cherry-pick reported conflicts.

This PR keeps the release/3.4 workflow structure and applies the same runner migration:

- replace the remaining GitHub-hosted runners (`ubuntu-latest` / `ubuntu-slim`) in `.github/workflows` with:

  ```yaml
  runs-on:
    group: APPROVAL
  ```

- add the self-hosted runner cleanup as the first step in each converted job:

  ```bash
  rm -rf * .[^.]*
  ```

Conflict resolution:

- `.github/workflows/Coverage.yml`
- `.github/workflows/remove-skip-ci-labels.yml`

For both files, I preserved the `release/3.4` workflow structure and only applied the runner/cleanup changes from #79123.

Validation:

- `rg -n "\\b(ubuntu-(latest|[0-9]{2}\\.[0-9]{2}|slim)|windows-(latest|[0-9]{4})|macos-(latest|[0-9]+|[0-9]{2}))\\b" .github/workflows .github/actions`: no matches
- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "parsed #{f}" }' $(git diff --name-only HEAD~1 HEAD)`: passed for all 18 changed workflow files
- `git diff --check HEAD~1..HEAD`: passed
- `pre-commit run --files $(git diff --name-only HEAD~1 HEAD)`: passed

Full CI must run on GitHub Actions.

---

Cherry-pick of #79123 (authored by @ShigureNyako) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79123 <!-- For pass CI -->


### 是否引起精度变化

否
