### PR TITLE
[release/3.4][Operator Mechanism] Harden permute and unpermute validation

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/phi/infermeta/multiary.h"
 
+#include <limits>
 #include <vector>
 
 #include "glog/logging.h"
@@ -6262,23 +6263,171 @@ void MoePermuteInferMeta(const MetaTensor& X,
                     true,
                     common::errors::InvalidArgument(
                         "Input expert_prob_topk's dtype should be FLOAT32"));
+  PADDLE_ENFORCE_EQ(
+      expert_routemap_topk.dims().size(),
+      2,
+      common::errors::InvalidArgument(
+          "Input expert_routemap_topk's dims should be 2, but got %u.",
+          expert_routemap_topk.dims().size()));
+  PADDLE_ENFORCE_EQ(
+      expert_prob_topk.dims().size(),
+      2,
+      common::errors::InvalidArgument(
+          "Input expert_prob_topk's dims should be 2, but got %u.",
+          expert_prob_topk.dims().size()));
   const int64_t rows = X.dims()[0];
   const int64_t cols = X.dims()[1];
-  int64_t output_rows = 0;
+  const int64_t topk = expert_routemap_topk.dims()[1];
+  const bool check_prob_shape =
+      !common::contain_unknown_dim(expert_routemap_topk.dims()) &&
+      !common::contain_unknown_dim(expert_prob_topk.dims());
+  if (check_prob_shape) {
+    PADDLE_ENFORCE_EQ(expert_prob_topk.dims(),
+                      expert_routemap_topk.dims(),
+                      common::errors::InvalidArgument(
+                          "Input expert_prob_topk's dims should be equal to "
+                          "expert_routemap_topk's dims, but got %s and %s.",
+                          expert_prob_topk.dims(),
+                          expert_routemap_topk.dims()));
+  }
+  const bool check_input_shape =
+      !common::contain_unknown_dim(X.dims()) &&
+      !common::contain_unknown_dim(expert_routemap_topk.dims());
+  if (check_input_shape) {
+    PADDLE_ENFORCE_EQ(
+        expert_routemap_topk.dims()[0],
+        rows,
+        common::errors::InvalidArgument(
+            "Input expert_routemap_topk's first dimension should be equal to "
+            "X.dims()[0], but got %ld and %ld.",
+            expert_routemap_topk.dims()[0],
+            rows));
+    PADDLE_ENFORCE_GE(
+        rows,
+        0,
+        common::errors::InvalidArgument(
+            "X.dims()[0] should be non-negative, but got %ld.", rows));
+    PADDLE_ENFORCE_LE(
+        rows,
+        static_cast<int64_t>(std::numeric_limits<int32_t>::max()) - 32,
+        common::errors::InvalidArgument(
+            "X.dims()[0] should be <= INT_MAX - 32, but got %ld.", rows));
+    PADDLE_ENFORCE_GE(
+        cols,
+        0,
+        common::errors::InvalidArgument(
+            "X.dims()[1] should be non-negative, but got %ld.", cols));
+    PADDLE_ENFORCE_LE(
+        cols,
+        static_cast<int64_t>(std::numeric_limits<int32_t>::max()),
+        common::errors::InvalidArgument(
+            "X.dims()[1] should be <= INT_MAX, but got %ld.", cols));
+    PADDLE_ENFORCE_GE(topk,
+                      1,
+                      common::errors::InvalidArgument(
+                          "topk should be greater than 0, but got %ld.", topk));
+    PADDLE_ENFORCE_LE(topk,
+                      16,
+                      common::errors::InvalidArgument(
+                          "topk should be <= 16, but got %ld.", topk));
+  }
+  PADDLE_ENFORCE_GE(
+      padding_alignment,
+      1,
+      common::errors::InvalidArgument(
+          "padding_alignment should be greater than 0, but got %d.",
+          padding_alignment));
+  PADDLE_ENFORCE_GE(
+      override_buffer_size,
+      -1,
+      common::errors::InvalidArgument(
+          "override_buffer_size should be -1 or non-negative, but got %d.",
+          override_buffer_size));
+  PADDLE_ENFORCE_GE(
+      num_experts,
+      1,
+      common::errors::InvalidArgument(
+          "num_experts should be greater than 0, but got %d.", num_experts));
+  PADDLE_ENFORCE_LE(
+      num_experts,
+      384,
+      common::errors::InvalidArgument(
+          "num_experts should be <= 384, but got %d.", num_experts));
+  if (check_input_shape) {
+    PADDLE_ENFORCE_LE(
+        rows,
+        static_cast<int64_t>(std::numeric_limits<int32_t>::max()) /
+            static_cast<int64_t>(num_experts),
+        common::errors::InvalidArgument(
+            "X.dims()[0] * num_experts should be <= INT_MAX, but got %ld * %d.",
+            rows,
+            num_experts));
+    PADDLE_ENFORCE_LE(
+        rows,
+        static_cast<int64_t>(std::numeric_limits<int32_t>::max()) / topk,
+        common::errors::InvalidArgument(
+            "X.dims()[0] * topk should be <= INT_MAX, but got %ld * %ld.",
+            rows,
+            topk));
+  }
 
-  // Using -1 as default value for not overriding buffer size,
-  // which also means that tokens_per_expert(CPU) is valid
-  // and will be used to calculate the output_rows.
-  if (override_buffer_size != -1) {
+  int64_t output_rows = 0;
+  const bool is_buffer_overridden = override_buffer_size >= 0;
+  if (is_buffer_overridden) {
     output_rows = override_buffer_size;
   } else {
+    PADDLE_ENFORCE_EQ(
+        tokens_per_expert.size(),
+        static_cast<size_t>(num_experts),
+        common::errors::InvalidArgument(
+            "tokens_per_expert's size should be equal to num_experts, but got "
+            "%zu and %d.",
+            tokens_per_expert.size(),
+            num_experts));
     for (int i = 0; i < num_experts; ++i) {
       const int64_t tokens = tokens_per_expert[i];
+      PADDLE_ENFORCE_GE(
+          tokens,
+          0,
+          common::errors::InvalidArgument(
+              "tokens_per_expert should be non-negative, but got %ld at "
+              "index %d.",
+              tokens,
+              i));
       output_rows += ((tokens + padding_alignment - 1) / padding_alignment) *
                      padding_alignment;
     }
   }
+  PADDLE_ENFORCE_LE(
+      output_rows,
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max()),
+      common::errors::InvalidArgument(
+          "The output rows of moe_permute should be <= INT_MAX, but got %ld.",
+          output_rows));
+  if (X.dtype() == DataType::FLOAT8_E4M3FN && do_gather) {
+    PADDLE_ENFORCE_EQ(XScale.initialized(),
+                      true,
+                      common::errors::InvalidArgument(
+                          "Input XScale should not be None when X's dtype is "
+                          "FLOAT8_E4M3FN and do_gather is True."));
+  }
   if (XScale && do_gather) {
+    PADDLE_ENFORCE_EQ(XScale.dims().size(),
+                      2,
+                      common::errors::InvalidArgument(
+                          "Input XScale's dims should be 2, but got %u.",
+                          XScale.dims().size()));
+    if (!common::contain_unknown_dim(XScale.dims()) &&
+        !common::contain_unknown_dim(X.dims())) {
+      PADDLE_ENFORCE_EQ(
+          XScale.dims()[0],
+          rows,
+          common::errors::InvalidArgument(
+              "Input XScale's first dimension should be equal to X.dims()[0], "
+              "but got %ld and %ld.",
+              XScale.dims()[0],
+              rows));
+    }
     if (using_ue8m0_scale) {
       PADDLE_ENFORCE_EQ(XScale.dtype(),
                         DataType::INT32,
@@ -6292,6 +6441,22 @@ void MoePermuteInferMeta(const MetaTensor& X,
                             "Input XScale's dtype should be FLOAT32"));
     }
     const int64_t quanted_cols = XScale.dims()[1];
+    if (!common::contain_unknown_dim(XScale.dims())) {
+      PADDLE_ENFORCE_GE(
+          quanted_cols,
+          0,
+          common::errors::InvalidArgument(
+              "Input XScale's second dimension should be non-negative, but got "
+              "%ld.",
+              quanted_cols));
+      PADDLE_ENFORCE_LE(
+          quanted_cols,
+          static_cast<int64_t>(std::numeric_limits<int32_t>::max()),
+          common::errors::InvalidArgument(
+              "Input XScale's second dimension should be <= INT_MAX, but got "
+              "%ld.",
+              quanted_cols));
+    }
     XScale_unzipped->set_dims({output_rows, quanted_cols});
     XScale_unzipped->set_dtype(XScale.dtype());
   } else {
@@ -6341,8 +6506,89 @@ void MoeUnpermuteInferMeta(const MetaTensor& unzipped_tokens,
       true,
       common::errors::InvalidArgument(
           "Input unzipped_token_probs's dtype should be FLOAT32"));
+  PADDLE_ENFORCE_EQ(unzipped_tokens.dims().size(),
+                    2,
+                    common::errors::InvalidArgument(
+                        "Input unzipped_tokens's dims should be 2, but got %u.",
+                        unzipped_tokens.dims().size()));
+  PADDLE_ENFORCE_EQ(
+      zipped_expertwise_rowmap.dims().size(),
+      2,
+      common::errors::InvalidArgument(
+          "Input zipped_expertwise_rowmap's dims should be 2, but got %u.",
+          zipped_expertwise_rowmap.dims().size()));
+  PADDLE_ENFORCE_EQ(
+      expert_routemap_topk.dims().size(),
+      2,
+      common::errors::InvalidArgument(
+          "Input expert_routemap_topk's dims should be 2, but got %u.",
+          expert_routemap_topk.dims().size()));
+  PADDLE_ENFORCE_GE(
+      total_zipped_tokens_num,
+      0,
+      common::errors::InvalidArgument(
+          "total_zipped_tokens_num should be non-negative, but got %d.",
+          total_zipped_tokens_num));
+  PADDLE_ENFORCE_GE(
+      num_experts,
+      1,
+      common::errors::InvalidArgument(
+          "num_experts should be greater than 0, but got %d.", num_experts));
+  PADDLE_ENFORCE_LE(
+      num_experts,
+      384,
+      common::errors::InvalidArgument(
+          "num_experts should be <= 384, but got %d.", num_experts));
+  if (!common::contain_unknown_dim(zipped_expertwise_rowmap.dims())) {
+    PADDLE_ENFORCE_EQ(zipped_expertwise_rowmap.dims()[0],
+                      total_zipped_tokens_num,
+                      common::errors::InvalidArgument(
+                          "Input zipped_expertwise_rowmap's first dimension "
+                          "should be equal to "
+                          "total_zipped_tokens_num, but got %ld and %d.",
+                          zipped_expertwise_rowmap.dims()[0],
+                          total_zipped_tokens_num));
+    PADDLE_ENFORCE_EQ(
+        zipped_expertwise_rowmap.dims()[1],
+        num_experts,
+        common::errors::InvalidArgument("Input zipped_expertwise_rowmap's "
+                                        "second dimension should be equal to "
+                                        "num_experts, but got %ld and %d.",
+                                        zipped_expertwise_rowmap.dims()[1],
+                                        num_experts));
+  }
+  if (!common::contain_unknown_dim(expert_routemap_topk.dims())) {
+    PADDLE_ENFORCE_EQ(
+        expert_routemap_topk.dims()[0],
+        total_zipped_tokens_num,
+        common::errors::InvalidArgument(
+            "Input expert_routemap_topk's first dimension should be equal to "
+            "total_zipped_tokens_num, but got %ld and %d.",
+            expert_routemap_topk.dims()[0],
+            total_zipped_tokens_num));
+  }
   const int64_t cols = unzipped_tokens.dims()[1];
   const int64_t topk = expert_routemap_topk.dims()[1];
+  if (!common::contain_unknown_dim(unzipped_tokens.dims())) {
+    PADDLE_ENFORCE_GE(cols,
+                      0,
+                      common::errors::InvalidArgument(
+                          "unzipped_tokens.dims()[1] should be non-negative, "
+                          "but got %ld.",
+                          cols));
+  }
+  if (!common::contain_unknown_dim(expert_routemap_topk.dims())) {
+    PADDLE_ENFORCE_GE(topk,
+                      1,
+                      common::errors::InvalidArgument(
+                          "topk should be greater than 0, but got %ld.", topk));
+  }
+  PADDLE_ENFORCE_LE(
+      static_cast<int64_t>(total_zipped_tokens_num),
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max()),
+      common::errors::InvalidArgument(
+          "total_zipped_tokens_num should be <= INT_MAX, but got %d.",
+          total_zipped_tokens_num));
   zipped_tokens->set_dims({total_zipped_tokens_num, cols});
   zipped_tokens->set_dtype(unzipped_tokens.dtype());
   zipped_probs_topk->set_dims({total_zipped_tokens_num, topk});

--- a/paddle/phi/kernels/gpu/moe_permute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_permute_kernel.cu
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
+
 #include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -409,7 +411,23 @@ void launch_permute_kernel(const phi::GPUContext &dev_ctx,
   constexpr int ROWS_PER_BLOCK = kPermuteBlockSize;
   constexpr int BLOCK_DIM_X = kPermuteBlockDimX;
 
-  dim3 grid((total_zipped_tokens_num + ROWS_PER_BLOCK - 1) / ROWS_PER_BLOCK);
+  PADDLE_ENFORCE_GE(
+      total_zipped_tokens_num,
+      0,
+      common::errors::InvalidArgument(
+          "total_zipped_tokens_num should be non-negative, but got %d.",
+          total_zipped_tokens_num));
+  if (total_zipped_tokens_num == 0) return;
+  const int64_t grid_x =
+      (static_cast<int64_t>(total_zipped_tokens_num) + ROWS_PER_BLOCK - 1) /
+      ROWS_PER_BLOCK;
+  PADDLE_ENFORCE_LE(
+      grid_x,
+      static_cast<int64_t>(std::numeric_limits<unsigned int>::max()),
+      common::errors::InvalidArgument(
+          "The grid size of moe_permute should be <= UINT_MAX, but got %ld.",
+          grid_x));
+  dim3 grid(static_cast<unsigned int>(grid_x));
   dim3 block(BLOCK_DIM_X);
 
   const TokenT *x_ptr = X.data<TokenT>();
@@ -631,6 +649,12 @@ void dispatch_preprocess_w_override(const Context &dev_ctx,
                                     DenseTensor *expert_offset_end,
                                     DenseTensor *expert_indices) {
   constexpr int BLOCK_SIZE = 1024;
+  PADDLE_ENFORCE_LE(
+      expert_routemap_topk.numel(),
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max()),
+      common::errors::InvalidArgument(
+          "expert_routemap_topk.numel() should be <= INT_MAX, but got %ld.",
+          expert_routemap_topk.numel()));
 
   dispatch::Bools(
       [&](auto fill_expert_indices_tag) {
@@ -672,38 +696,132 @@ void MoePermuteKernel(const Context &dev_ctx,
                       DenseTensor *token_prob_unzipped,
                       DenseTensor *XScale_unzipped,
                       DenseTensor *expert_indices) {
+  PADDLE_ENFORCE_EQ(
+      X.dims().size(),
+      2,
+      common::errors::InvalidArgument("Input X's dims should be 2, but got %u.",
+                                      X.dims().size()));
+  PADDLE_ENFORCE_EQ(
+      expert_routemap_topk.dims().size(),
+      2,
+      common::errors::InvalidArgument(
+          "Input expert_routemap_topk's dims should be 2, but got %u.",
+          expert_routemap_topk.dims().size()));
+  PADDLE_ENFORCE_EQ(
+      expert_prob_topk.dims().size(),
+      2,
+      common::errors::InvalidArgument(
+          "Input expert_prob_topk's dims should be 2, but got %u.",
+          expert_prob_topk.dims().size()));
+  PADDLE_ENFORCE_EQ(expert_prob_topk.dims(),
+                    expert_routemap_topk.dims(),
+                    common::errors::InvalidArgument(
+                        "Input expert_prob_topk's dims should be equal to "
+                        "expert_routemap_topk's dims, but got %s and %s.",
+                        expert_prob_topk.dims(),
+                        expert_routemap_topk.dims()));
+
   const int64_t rows = X.dims()[0];
   const int64_t cols = X.dims()[1];
   const int64_t topk = expert_routemap_topk.dims()[1];
-  const int64_t quanted_cols = (XScale) ? XScale.get_ptr()->dims()[1] : 0;
-  const bool is_buffer_overridden = (override_buffer_size > -1);
-
+  PADDLE_ENFORCE_EQ(
+      expert_routemap_topk.dims()[0],
+      rows,
+      common::errors::InvalidArgument(
+          "Input expert_routemap_topk's first dimension should be equal to "
+          "X.dims()[0], but got %ld and %ld.",
+          expert_routemap_topk.dims()[0],
+          rows));
+  PADDLE_ENFORCE_GE(
+      rows,
+      0,
+      common::errors::InvalidArgument(
+          "X.dims()[0] should be non-negative, received: (%ld)", rows));
   PADDLE_ENFORCE_LE(
       rows,
-      std::numeric_limits<int32_t>::max(),
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max()) -
+          static_cast<int64_t>(kPermuteBlockSize),
       common::errors::InvalidArgument(
-          "X.dims()[0] should be less than INT_MAX, received: (%ld)", rows));
+          "X.dims()[0] should be <= INT_MAX - %d, received: (%ld)",
+          kPermuteBlockSize,
+          rows));
+  PADDLE_ENFORCE_GE(
+      cols,
+      0,
+      common::errors::InvalidArgument(
+          "X.dims()[1] should be non-negative, received: (%ld)", cols));
   PADDLE_ENFORCE_LE(
       cols,
       std::numeric_limits<int32_t>::max(),
       common::errors::InvalidArgument(
           "X.dims()[1] should be less than INT_MAX, received: (%ld)", cols));
+  PADDLE_ENFORCE_GE(topk,
+                    1,
+                    common::errors::InvalidArgument(
+                        "topk should be > 0, received: (%ld)", topk));
   PADDLE_ENFORCE_LE(topk,
                     16,
                     common::errors::InvalidArgument(
                         "topk should be <= 16, received: (%ld)", topk));
+  PADDLE_ENFORCE_GE(
+      num_experts,
+      1,
+      common::errors::InvalidArgument(
+          "num_experts should be > 0, received: (%d)", num_experts));
   PADDLE_ENFORCE_LE(num_experts,
                     kMaxNumExperts,
                     common::errors::InvalidArgument(
                         "num_experts should be <= %d, received: (%d)",
                         kMaxNumExperts,
                         num_experts));
+  PADDLE_ENFORCE_GE(padding_alignment,
+                    1,
+                    common::errors::InvalidArgument(
+                        "padding_alignment should be > 0, received: (%d)",
+                        padding_alignment));
+  PADDLE_ENFORCE_GE(
+      override_buffer_size,
+      -1,
+      common::errors::InvalidArgument(
+          "override_buffer_size should be -1 or non-negative, received: (%d)",
+          override_buffer_size));
+  PADDLE_ENFORCE_LE(
+      rows,
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max()) /
+          static_cast<int64_t>(num_experts),
+      common::errors::InvalidArgument(
+          "X.dims()[0] * num_experts should be <= INT_MAX, received: %ld * %d.",
+          rows,
+          num_experts));
+  PADDLE_ENFORCE_LE(
+      expert_routemap_topk.numel(),
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max()),
+      common::errors::InvalidArgument(
+          "expert_routemap_topk.numel() should be <= INT_MAX, but got %ld.",
+          expert_routemap_topk.numel()));
+  if (X.dtype() == DataType::FLOAT8_E4M3FN && do_gather) {
+    PADDLE_ENFORCE_EQ(XScale.get_ptr() != nullptr,
+                      true,
+                      common::errors::InvalidArgument(
+                          "Input XScale should not be None when X's dtype is "
+                          "FLOAT8_E4M3FN and do_gather is True."));
+  }
+  if (XScale.get_ptr() != nullptr) {
+    PADDLE_ENFORCE_EQ(XScale.get_ptr()->dims().size(),
+                      2,
+                      common::errors::InvalidArgument(
+                          "Input XScale's dims should be 2, but got %u.",
+                          XScale.get_ptr()->dims().size()));
+  }
+  const int64_t quanted_cols =
+      (XScale.get_ptr() != nullptr) ? XScale.get_ptr()->dims()[1] : 0;
   PADDLE_ENFORCE_LE(
       quanted_cols,
       std::numeric_limits<int32_t>::max(),
       common::errors::InvalidArgument(
           "quanted_cols should be less than INT_MAX, received: (%ld)",
           quanted_cols));
+  const bool is_buffer_overridden = (override_buffer_size >= 0);
 
   // Output allocation
   void *XScale_unzipped_ptr = nullptr;
@@ -741,8 +859,18 @@ void MoePermuteKernel(const Context &dev_ctx,
 
   // Preprocess
   constexpr int kEffectiveBlockSize = kPermuteBlockSize;
-  const int cumsum_blocknum =
+  const int64_t cumsum_blocknum_i64 =
       (rows + kEffectiveBlockSize - 1) / kEffectiveBlockSize;
+  PADDLE_ENFORCE_LE(
+      cumsum_blocknum_i64 + 2,
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max()) /
+          static_cast<int64_t>(num_experts),
+      common::errors::InvalidArgument(
+          "The cumsum buffer size of moe_permute should be <= INT_MAX, but got "
+          "(%ld + 2) * %d.",
+          cumsum_blocknum_i64,
+          num_experts));
+  const int cumsum_blocknum = static_cast<int>(cumsum_blocknum_i64);
 
   DenseTensor expert_offset_tensor;
   DenseTensor expert_offset_end_tensor;

--- a/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/gpu/moe_unpermute_kernel.h"
+
+#include <limits>
+
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
@@ -188,8 +191,15 @@ void dispatch_tokens_zip(const Context &dev_ctx,
                          const int topk,
                          const bool MP,
                          const bool using_weighted_combine) {
+  PADDLE_ENFORCE_GE(
+      total_zipped_tokens_num,
+      0,
+      common::errors::InvalidArgument(
+          "total_zipped_tokens_num should be non-negative, but got %d.",
+          total_zipped_tokens_num));
+  if (total_zipped_tokens_num == 0) return;
   dim3 grid, block;
-  grid.x = total_zipped_tokens_num;
+  grid.x = static_cast<unsigned int>(total_zipped_tokens_num);
   block.x = 256;
 
   if (unzipped_token_probs.dtype() != paddle::DataType::FLOAT32) return;
@@ -233,38 +243,110 @@ void MoeUnpermuteKernel(const Context &dev_ctx,
                         const bool using_weighted_combine,
                         DenseTensor *zipped_tokens,
                         DenseTensor *zipped_probs_topk) {
+  PADDLE_ENFORCE_EQ(unzipped_tokens.dims().size(),
+                    2,
+                    common::errors::InvalidArgument(
+                        "Input unzipped_tokens's dims should be 2, but got %u.",
+                        unzipped_tokens.dims().size()));
+  PADDLE_ENFORCE_EQ(
+      zipped_expertwise_rowmap.dims().size(),
+      2,
+      common::errors::InvalidArgument(
+          "Input zipped_expertwise_rowmap's dims should be 2, but got %u.",
+          zipped_expertwise_rowmap.dims().size()));
+  PADDLE_ENFORCE_EQ(
+      expert_routemap_topk.dims().size(),
+      2,
+      common::errors::InvalidArgument(
+          "Input expert_routemap_topk's dims should be 2, but got %u.",
+          expert_routemap_topk.dims().size()));
+  PADDLE_ENFORCE_GE(
+      total_zipped_tokens_num,
+      0,
+      common::errors::InvalidArgument(
+          "total_zipped_tokens_num should be non-negative, but got %d.",
+          total_zipped_tokens_num));
+  PADDLE_ENFORCE_GE(
+      num_experts,
+      1,
+      common::errors::InvalidArgument(
+          "num_experts should be > 0, received: (%d)", num_experts));
+  PADDLE_ENFORCE_LE(
+      num_experts,
+      kMaxNumExperts,
+      common::errors::InvalidArgument(
+          "Currently we support no more than (%ld), received num_expert: "
+          "(%ld). Please check input value.",
+          kMaxNumExperts,
+          num_experts));
+  PADDLE_ENFORCE_EQ(
+      zipped_expertwise_rowmap.dims()[0],
+      total_zipped_tokens_num,
+      common::errors::InvalidArgument(
+          "Input zipped_expertwise_rowmap's first dimension should be equal to "
+          "total_zipped_tokens_num, but got %ld and %d.",
+          zipped_expertwise_rowmap.dims()[0],
+          total_zipped_tokens_num));
+  PADDLE_ENFORCE_EQ(
+      zipped_expertwise_rowmap.dims()[1],
+      num_experts,
+      common::errors::InvalidArgument("Input zipped_expertwise_rowmap's second "
+                                      "dimension should be equal to "
+                                      "num_experts, but got %ld and %d.",
+                                      zipped_expertwise_rowmap.dims()[1],
+                                      num_experts));
+  PADDLE_ENFORCE_EQ(
+      expert_routemap_topk.dims()[0],
+      total_zipped_tokens_num,
+      common::errors::InvalidArgument(
+          "Input expert_routemap_topk's first dimension should be equal to "
+          "total_zipped_tokens_num, but got %ld and %d.",
+          expert_routemap_topk.dims()[0],
+          total_zipped_tokens_num));
   const int64_t cols = unzipped_tokens.dims()[1];
+  PADDLE_ENFORCE_GE(
+      cols,
+      0,
+      common::errors::InvalidArgument(
+          "unzipped_tokens.dims()[1] should be non-negative, but got %ld.",
+          cols));
   PADDLE_ENFORCE_LE(cols,
                     std::numeric_limits<int32_t>::max(),
                     common::errors::InvalidArgument(
                         "unzipped_tokens.dims()[1] should be less than "
                         "INT_MAX, received unzipped_tokens.dims()[1]: (%ld)",
                         cols));
-  PADDLE_ENFORCE_LE(
-      num_experts,
-      kMaxNumExperts,
-      common::errors::InvalidArgument(
-          "Currently we support no more than (%ld), received num_expert: "
-          "(%ld). Please check input "
-          "value.",
-          kMaxNumExperts,
-          num_experts));
   const int64_t topk = expert_routemap_topk.dims()[1];
+  PADDLE_ENFORCE_GE(topk,
+                    1,
+                    common::errors::InvalidArgument(
+                        "topk should be > 0, received topk: (%ld)", topk));
   PADDLE_ENFORCE_LE(
       topk,
       std::numeric_limits<int32_t>::max(),
       common::errors::InvalidArgument(
           "topk should be less than INT_MAX, received topk: (%ld)", topk));
+  PADDLE_ENFORCE_LE(
+      static_cast<int64_t>(total_zipped_tokens_num),
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max()),
+      common::errors::InvalidArgument(
+          "total_zipped_tokens_num should be <= INT_MAX, but got %d.",
+          total_zipped_tokens_num));
   dev_ctx.template Alloc<T>(zipped_tokens);
   dev_ctx.template Alloc<float>(zipped_probs_topk);
-  if (unzipped_tokens.numel() == 0) return;  // 0-size tensor
+  if (unzipped_tokens.numel() == 0 || total_zipped_tokens_num == 0) return;
   void *zipped_probs_topk_ptr =
       reinterpret_cast<void *>(zipped_probs_topk->data<float>());
-  PADDLE_ENFORCE_GPU_SUCCESS(
-      cudaMemsetAsync(zipped_probs_topk_ptr,
-                      0,
-                      sizeof(float) * int64_t(total_zipped_tokens_num) * topk,
-                      dev_ctx.stream()));
+  const int64_t probs_numel =
+      static_cast<int64_t>(total_zipped_tokens_num) * topk;
+  PADDLE_ENFORCE_LE(
+      probs_numel,
+      static_cast<int64_t>(std::numeric_limits<int64_t>::max() / sizeof(float)),
+      common::errors::InvalidArgument(
+          "The zipped_probs_topk memset size overflows, got %ld elements.",
+          probs_numel));
+  PADDLE_ENFORCE_GPU_SUCCESS(cudaMemsetAsync(
+      zipped_probs_topk_ptr, 0, sizeof(float) * probs_numel, dev_ctx.stream()));
 
   dispatch_tokens_zip<T, Context>(dev_ctx,
                                   unzipped_tokens,

--- a/test/legacy_test/test_moe_permute_unpermute.py
+++ b/test/legacy_test/test_moe_permute_unpermute.py
@@ -467,6 +467,153 @@ class TestFusedMoePermuteUnpermute(unittest.TestCase):
                             err_msg="permuted_scales[{i}] is not correct",
                         )
 
+    def _build_small_permute_inputs(self):
+        seq_len = 3
+        token_len = 128
+        num_experts = 3
+        topk = 8
+        hidden_states = paddle.randn([seq_len, token_len], dtype="bfloat16")
+        expert_routemap_topk = paddle.full([seq_len, topk], -1, dtype="int32")
+        expert_routemap_topk[0, 1] = 0
+        expert_routemap_topk[1, 0] = 1
+        expert_routemap_topk[2, 6] = 1
+        expert_prob_topk = paddle.zeros([seq_len, topk], dtype="float32")
+        expert_prob_topk[0, 1] = 0.6
+        expert_prob_topk[1, 0] = 1.0
+        expert_prob_topk[2, 6] = 1.0
+        tokens_per_expert = [1, 2, 0]
+        return (
+            hidden_states,
+            expert_routemap_topk,
+            expert_prob_topk,
+            num_experts,
+            tokens_per_expert,
+        )
+
+    def _build_small_unpermute_inputs(self):
+        seq_len = 3
+        token_len = 64
+        num_experts = 3
+        topk = 8
+        unzipped_tokens = paddle.randn([4, token_len], dtype="bfloat16")
+        zipped_expertwise_rowmap = paddle.to_tensor(
+            [[1, -1, 0], [-1, 2, -1], [-1, 3, -1]], dtype="int32"
+        )
+        expert_routemap_topk = paddle.full([seq_len, topk], -1, dtype="int32")
+        expert_routemap_topk[0, 1] = 0
+        expert_routemap_topk[0, 4] = 2
+        expert_routemap_topk[1, 0] = 1
+        expert_routemap_topk[2, 6] = 1
+        token_prob_unzipped = paddle.ones([4], dtype="float32")
+        return (
+            unzipped_tokens,
+            zipped_expertwise_rowmap,
+            expert_routemap_topk,
+            token_prob_unzipped,
+            seq_len,
+            num_experts,
+        )
+
+    def test_permute_invalid_inputs(self):
+        (
+            hidden_states,
+            expert_routemap_topk,
+            expert_prob_topk,
+            num_experts,
+            tokens_per_expert,
+        ) = self._build_small_permute_inputs()
+        with self.assertRaisesRegex(Exception, "padding_alignment"):
+            moe_permute(
+                hidden_states,
+                None,
+                expert_routemap_topk,
+                expert_prob_topk,
+                num_experts,
+                tokens_per_expert,
+                0,
+            )
+        with self.assertRaisesRegex(Exception, "override_buffer_size"):
+            moe_permute(
+                hidden_states,
+                None,
+                expert_routemap_topk,
+                expert_prob_topk,
+                num_experts,
+                tokens_per_expert,
+                16,
+                override_buffer_size=-2,
+            )
+        with self.assertRaisesRegex(Exception, "expert_prob_topk"):
+            moe_permute(
+                hidden_states,
+                None,
+                expert_routemap_topk,
+                paddle.zeros([3, 7], dtype="float32"),
+                num_experts,
+                tokens_per_expert,
+                16,
+            )
+
+    def test_permute_fp8_requires_scale_when_gather(self):
+        (
+            hidden_states,
+            expert_routemap_topk,
+            expert_prob_topk,
+            num_experts,
+            tokens_per_expert,
+        ) = self._build_small_permute_inputs()
+        try:
+            hidden_states = hidden_states.astype(paddle.float8_e4m3fn)
+        except Exception as e:
+            self.skipTest(f"float8_e4m3fn is not available: {e}")
+        with self.assertRaisesRegex(Exception, "XScale"):
+            moe_permute(
+                hidden_states,
+                None,
+                expert_routemap_topk,
+                expert_prob_topk,
+                num_experts,
+                tokens_per_expert,
+                16,
+            )
+
+    def test_unpermute_invalid_inputs(self):
+        (
+            unzipped_tokens,
+            zipped_expertwise_rowmap,
+            expert_routemap_topk,
+            token_prob_unzipped,
+            seq_len,
+            num_experts,
+        ) = self._build_small_unpermute_inputs()
+        with self.assertRaisesRegex(Exception, "total_zipped_tokens_num"):
+            moe_unpermute(
+                unzipped_tokens,
+                zipped_expertwise_rowmap,
+                expert_routemap_topk,
+                token_prob_unzipped,
+                -1,
+                num_experts,
+            )
+        with self.assertRaisesRegex(Exception, "zipped_expertwise_rowmap"):
+            moe_unpermute(
+                unzipped_tokens,
+                zipped_expertwise_rowmap,
+                expert_routemap_topk,
+                token_prob_unzipped,
+                seq_len + 1,
+                num_experts,
+            )
+        with self.assertRaisesRegex(Exception, "expert_routemap_topk"):
+            moe_unpermute(
+                unzipped_tokens,
+                zipped_expertwise_rowmap,
+                expert_routemap_topk[:2, :],
+                token_prob_unzipped,
+                seq_len,
+                num_experts,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
 Improvements 

### Description
Harden permute and unpermute validation. Add targeted boundary checks for MoE permute/unpermute inputs to fail early on invalid buffer sizes, shape mismatches, and unsafe FP8 scale usage.


pcard-91067


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否 

---

Cherry-pick of #79136 (authored by @A-nnonymous) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79136 <!-- For pass CI -->