### PR TITLE
[API Compatibility] Add param alias for `paddle.set_rng_state`

### DIFF
--- a/python/paddle/framework/random.py
+++ b/python/paddle/framework/random.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 import paddle
 from paddle.base import core
+from paddle.utils.decorator_utils import param_one_alias
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -150,6 +151,7 @@ def get_cuda_rng_state() -> list[paddle.base.core.GeneratorState]:
     return state_list
 
 
+@param_one_alias(["state_list", "new_state"])
 def set_rng_state(
     state_list: Sequence[paddle.base.core.GeneratorState],
     device: str | None = None,

--- a/python/paddle/framework/random.py
+++ b/python/paddle/framework/random.py
@@ -162,6 +162,7 @@ def set_rng_state(
 
     Args:
         state_list(list|tuple): The device states to set back to device generators. state_list is obtained from get_rng_state().
+            Alias: ``new_state``.
         device(str): This parameter determines the specific running device.
             It can be ``cpu``, ``gpu``, ``xpu``, Default is None.
             If None, return the generators of current device (specified by ``set_device``).

--- a/test/legacy_test/test_api_compatibility_part1.py
+++ b/test/legacy_test/test_api_compatibility_part1.py
@@ -2161,5 +2161,17 @@ class TestPixelShuffleAPI(unittest.TestCase):
                 np.testing.assert_array_equal(fetches[0], out)
 
 
+# Test paddle.set_rng_state compatibility
+class TestSetRngStateAPI(unittest.TestCase):
+    def test_Compatibility(self):
+        states = paddle.get_rng_state()
+        # 1. positional argument
+        paddle.set_rng_state(states)
+        # 2. paddle-style keyword argument
+        paddle.set_rng_state(state_list=states)
+        # 3. torch-style keyword argument
+        paddle.set_rng_state(new_state=states)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Add alias `new_state` for arg `state_list` in `paddle.set_rng_state`
- Add compatibility test

**Used AI Studio**


### 是否引起精度变化
否
