### PR TITLE
[PHI] Fix local index in strided elementwise kernel

### DIFF
--- a/paddle/phi/kernels/stride/elementwise_stride_base.cu.h
+++ b/paddle/phi/kernels/stride/elementwise_stride_base.cu.h
@@ -63,10 +63,10 @@ __global__ void BinaryElementwiseKernel(
       using ArgsT = typename Traits::ArgsTuple;
       __simd__ ArgsT args[VecSize];
       __simd__ ConditionalT<OutT, NumOuts> result[VecSize];
-      std::get<0>(args[idx]) =
+      std::get<0>(args[0]) =
           *(reinterpret_cast<const _ptr_ std::tuple_element_t<0, ArgsT> *>(
               reinterpret_cast<const _ptr_ char *>(ins[0]) + offsets[1]));
-      std::get<1>(args[idx]) =
+      std::get<1>(args[0]) =
           *(reinterpret_cast<const _ptr_ std::tuple_element_t<1, ArgsT> *>(
               reinterpret_cast<const _ptr_ char *>(ins[1]) + offsets[2]));
       funcs::SameDimsElementwisePrimitiveCaller<ConditionalT<OutT, NumOuts>,
@@ -108,7 +108,7 @@ __global__ void UnaryElementwiseKernel(
       using ArgsT = typename Traits::ArgsTuple;
       __simd__ ArgsT args[VecSize];
       __simd__ ConditionalT<OutT, NumOuts> result[VecSize];
-      std::get<0>(args[idx]) =
+      std::get<0>(args[0]) =
           *(reinterpret_cast<const _ptr_ std::tuple_element_t<0, ArgsT> *>(
               reinterpret_cast<const _ptr_ char *>(ins[0]) + offsets[1]));
       funcs::SameDimsElementwisePrimitiveCaller<ConditionalT<OutT, NumOuts>,

--- a/test/legacy_test/test_compare_op_stride.py
+++ b/test/legacy_test/test_compare_op_stride.py
@@ -42,7 +42,6 @@ class TestBinaryElementwiseOp_Stride(unittest.TestCase):
         self.x_trans = np.transpose(self.x, self.perm)
 
     def test_dygraph_api_arithmetic(self):
-        paddle.disable_static()
         x_trans = paddle.to_tensor(self.x_trans, place=self.place)
         y = paddle.to_tensor(self.y, place=self.place)
         if self.strided_input_type == "transpose":
@@ -56,7 +55,6 @@ class TestBinaryElementwiseOp_Stride(unittest.TestCase):
         out = self.paddle_api(x_non_conti, y)
         out_ref = self.numpy_api(self.x, self.y)
         np.testing.assert_allclose(out_ref, out.numpy())
-        paddle.enable_static()
 
 
 def create_test_act_stride_class(base_class, api_name, paddle_api, numpy_api):
@@ -202,6 +200,38 @@ create_test_act_stride_class(
 create_test_act_stride_class(
     TestBinaryElementwiseOp_Stride, "Notequal", paddle.not_equal, np.not_equal
 )
+
+
+class TestCompareStridedSliceWithScalar(unittest.TestCase):
+    def setUp(self):
+        self.place = get_device_place()
+
+    def _make_label(self):
+        base = paddle.to_tensor(
+            np.arange(64, dtype=np.int64).reshape([1, 64, 1]),
+            place=self.place,
+        )
+        return base[:, :63, :]
+
+    def test_not_equal_with_size_one_dim_stride(self):
+        label = self._make_label()
+
+        self.assertEqual(list(label.shape), [1, 63, 1])
+        self.assertEqual(label.strides, [64, 1, 1])
+        self.assertFalse(label.is_contiguous())
+
+        out = label != -100
+        np.testing.assert_array_equal(
+            out.numpy(), np.ones([1, 63, 1], dtype=np.bool_)
+        )
+
+    def test_equal_with_size_one_dim_stride(self):
+        label = self._make_label()
+
+        out = label == 1
+        expected = np.arange(63, dtype=np.int64).reshape([1, 63, 1]) == 1
+        np.testing.assert_array_equal(out.numpy(), expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/legacy_test/test_compare_op_stride.py
+++ b/test/legacy_test/test_compare_op_stride.py
@@ -202,6 +202,10 @@ create_test_act_stride_class(
 )
 
 
+@unittest.skipIf(
+    not (paddle.core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
+)
 class TestCompareStridedSliceWithScalar(unittest.TestCase):
     def setUp(self):
         self.place = get_device_place()


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description

修复 stride elementwise CUDA kernel 中线程本地数组索引错误的问题。

最小复现样例如下：

```python
import paddle
base = paddle.arange(64, dtype="int64").reshape([1, 64, 1])
label = base[:, :63, :]
label != -100  # CUDA 719
```

在 `BinaryElementwiseKernel` / `UnaryElementwiseKernel` 中，线程本地数组 `args` 的长度为 `STRIDE_VEC_SIZE`，当前为 1，但原实现使用全局线性下标 `idx` 写入 `args[idx]`。当处理非 contiguous 输入的 compare/logical/elementwise stride kernel 时，线程号大于 0 会写越线程本地数组边界，在 CUDA 13.2 / sm_103 环境中可由 `label != -100` 触发 illegal memory access。

本 PR 将本地输入缓存写入改为 `args[0]`，并补充 `base[:, :63, :]` 形成 shape `[1, 63, 1]`、stride `[64, 1, 1]` 后执行 `!=` / `==` 的 CUDA 回归用例。

### 是否引起精度变化
否。该修复只更正 stride elementwise kernel 的线程本地数组索引，不改变数学计算逻辑。

<div align="right">
   <sup>This PR is authored by @codex (gpt-5.5 xhigh)</sup>
</div>