### PR TITLE
Add CUDA arch compatibility check at import time

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -95,7 +95,64 @@ if __is_metainfo_generated:
 
 # NOTE(SigureMo): We should place the import of base.core before other modules,
 # because there are some initialization codes in base/core/__init__.py.
-from .base import core  # noqa: F401
+from .base import core
+
+
+def _normalize_cuda_arch(arch):
+    if isinstance(arch, str):
+        arch = arch.replace('sm_', '').replace('compute_', '')
+    return int(arch)
+
+
+def _check_cuda_arch_compatible():
+    if not core.is_compiled_with_cuda():
+        return
+
+    device_count = core.get_cuda_device_count()
+
+    if device_count == 0:
+        return
+
+    from .version import compiled_cuda_archs
+
+    supported_archs = {
+        _normalize_cuda_arch(arch) for arch in compiled_cuda_archs
+    }
+    if not supported_archs:
+        return
+
+    unsupported_devices = []
+    for device_id in range(device_count):
+        prop = core.get_device_properties(device_id)
+        device_arch = prop.major * 10 + prop.minor
+        if device_arch not in supported_archs:
+            unsupported_devices.append(
+                f"gpu:{device_id} {prop.name}, compute capability sm_{device_arch}"
+            )
+
+    if not unsupported_devices:
+        return
+
+    supported_archs_str = ', '.join(
+        f"sm_{arch}" for arch in sorted(supported_archs)
+    )
+    unsupported_devices_str = '\n  '.join(unsupported_devices)
+    raise RuntimeError(
+        "The installed PaddlePaddle GPU package is not compatible with "
+        "the current CUDA device.\n"
+        f"Current unsupported CUDA device(s):\n  {unsupported_devices_str}\n\n"
+        "Paddle CUDA kernels in this package support:\n"
+        f"  {supported_archs_str}\n\n"
+        "This mismatch can cause CUDA kernels to fail or produce incorrect "
+        "results. Please install a PaddlePaddle package built with the "
+        "current GPU compute capability, or rebuild PaddlePaddle with the "
+        "required CUDA architecture enabled."
+    )
+
+
+_check_cuda_arch_compatible()
+
+
 from .base.dygraph.generated_tensor_methods_patch import (
     monkey_patch_generated_methods_for_tensor,
 )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

本 PR 在 `import paddle` 初始化阶段增加 CUDA 架构兼容性检查：

- 在 `paddle.base.core` 加载完成后，获取当前机器上的 CUDA device 信息。
- 读取 Paddle 包编译时包含的 `compiled_cuda_archs`。
- 对比当前 GPU 的 compute capability 是否在编译支持列表中。
- 如果存在不支持的 GPU 架构，则在 `import paddle` 阶段直接抛出清晰的 `RuntimeError`，错误信息包含：
  - 当前不兼容的 GPU 列表
  - 每张 GPU 的 compute capability
  - 当前 Paddle 包支持的 CUDA 架构列表
  - 重新安装或重新编译 Paddle 的提示

对于以下场景会跳过检查，不影响原有行为：

- Paddle 非 CUDA 编译包
- 当前环境没有 CUDA device


![Uploading ad5acb53e0e766eb3726ffa5de3e1974.png…]()

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否