### PR TITLE
[Cpp API Compatibility] add at::vstack compat interface

### DIFF
--- a/paddle/phi/api/include/compat/ATen/Functions.h
+++ b/paddle/phi/api/include/compat/ATen/Functions.h
@@ -78,5 +78,6 @@
 #include <ATen/ops/view.h>
 #include <ATen/ops/view_as.h>
 #include <ATen/ops/vsplit.h>
+#include <ATen/ops/vstack.h>
 #include <ATen/ops/zeros.h>
 #include <ATen/ops/zeros_like.h>

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -22,6 +22,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/core/Stream.h>
 #include <c10/core/SymIntArrayRef.h>
+#include <c10/util/ArrayRef.h>
 #include <c10/util/OptionalArrayRef.h>
 #include "paddle/phi/api/include/api.h"
 #include "paddle/phi/api/include/tensor.h"
@@ -51,6 +52,7 @@ class Tensor;
 // Type aliases for ATen compatibility
 using Scalar = c10::Scalar;
 using TensorOptions = c10::TensorOptions;
+using TensorList = c10::ArrayRef<Tensor>;
 using MemoryFormat = c10::MemoryFormat;
 using IntArrayRef = c10::IntArrayRef;
 using OptionalIntArrayRef = c10::OptionalIntArrayRef;

--- a/paddle/phi/api/include/compat/ATen/ops/vstack.h
+++ b/paddle/phi/api/include/compat/ATen/ops/vstack.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <ATen/ops/cat.h>
+#include <ATen/ops/reshape.h>
+#include <ATen/ops/unsqueeze.h>
+#include <c10/util/Exception.h>
+#include <vector>
+
+namespace at {
+
+inline at::Tensor vstack(at::TensorList tensors) {
+  TORCH_CHECK(!tensors.empty(), "vstack expects a non-empty TensorList");
+
+  std::vector<at::Tensor> processed;
+  processed.reserve(tensors.size());
+
+  for (const auto& t : tensors) {
+    if (t.dim() == 0) {
+      processed.push_back(t.reshape({1, 1}));
+    } else if (t.dim() == 1) {
+      processed.push_back(t.unsqueeze(0));
+    } else {
+      processed.push_back(t);
+    }
+  }
+
+  return at::cat(processed, 0);
+}
+
+}  // namespace at

--- a/test/cpp/compat/ATen_vstack_test.cc
+++ b/test/cpp/compat/ATen_vstack_test.cc
@@ -1,0 +1,139 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ATen/Functions.h>
+#include <ATen/core/TensorBody.h>
+#include <ATen/ops/vstack.h>
+#include <c10/core/ScalarType.h>
+#include <c10/core/TensorOptions.h>
+#include <vector>
+
+#include "ATen/ATen.h"
+#include "gtest/gtest.h"
+#include "torch/all.h"
+
+TEST(ATenVStackTest, Basic2D) {
+  auto t1 = at::ones({2, 3}, at::kFloat);
+  auto t2 = at::zeros({2, 3}, at::kFloat);
+  std::vector<at::Tensor> tensors = {t1, t2};
+  auto result = at::vstack(tensors);
+
+  EXPECT_EQ(result.dim(), 2);
+  EXPECT_EQ(result.size(0), 4);
+  EXPECT_EQ(result.size(1), 3);
+
+  auto slice0 = result.slice(0, 0, 2);
+  auto slice1 = result.slice(0, 2, 4);
+  EXPECT_TRUE(at::allclose(slice0, t1));
+  EXPECT_TRUE(at::allclose(slice1, t2));
+}
+
+TEST(ATenVStackTest, Basic1D) {
+  auto t1 = at::ones({3}, at::kFloat);
+  auto t2 = at::zeros({3}, at::kFloat);
+  std::vector<at::Tensor> tensors = {t1, t2};
+  auto result = at::vstack(tensors);
+
+  EXPECT_EQ(result.dim(), 2);
+  EXPECT_EQ(result.size(0), 2);
+  EXPECT_EQ(result.size(1), 3);
+
+  auto slice0 = result[0];
+  auto slice1 = result[1];
+  EXPECT_TRUE(at::allclose(slice0, t1));
+  EXPECT_TRUE(at::allclose(slice1, t2));
+}
+
+TEST(ATenVStackTest, ScalarTo2D) {
+  auto t1 = at::full({}, 1.0f, at::kFloat);
+  auto t2 = at::full({}, 2.0f, at::kFloat);
+  std::vector<at::Tensor> tensors = {t1, t2};
+  auto result = at::vstack(tensors);
+
+  EXPECT_EQ(result.dim(), 2);
+  EXPECT_EQ(result.size(0), 2);
+  EXPECT_EQ(result.size(1), 1);
+
+  EXPECT_FLOAT_EQ(result[0][0].item<float>(), 1.0f);
+  EXPECT_FLOAT_EQ(result[1][0].item<float>(), 2.0f);
+}
+
+TEST(ATenVStackTest, MixedDims) {
+  auto t1 = at::ones({3}, at::kFloat);
+  auto t2 = at::zeros({1, 3}, at::kFloat);
+  std::vector<at::Tensor> tensors = {t1, t2};
+  auto result = at::vstack(tensors);
+
+  EXPECT_EQ(result.dim(), 2);
+  EXPECT_EQ(result.size(0), 2);
+  EXPECT_EQ(result.size(1), 3);
+
+  auto slice0 = result[0];
+  auto slice1 = result[1];
+  EXPECT_TRUE(at::allclose(slice0, t1));
+  EXPECT_TRUE(at::allclose(slice1, t2.squeeze(0)));
+}
+
+TEST(ATenVStackTest, EmptyListThrows) {
+  std::vector<at::Tensor> tensors = {};
+  ASSERT_THROW(at::vstack(tensors), std::exception);
+}
+
+TEST(ATenVStackTest, DtypeFloat64) {
+  auto t1 = at::ones({2, 3}, at::kDouble);
+  auto t2 = at::zeros({2, 3}, at::kDouble);
+  std::vector<at::Tensor> tensors = {t1, t2};
+  auto result = at::vstack(tensors);
+
+  EXPECT_EQ(result.scalar_type(), at::kDouble);
+  EXPECT_EQ(result.size(0), 4);
+  EXPECT_EQ(result.size(1), 3);
+
+  auto slice0 = result.slice(0, 0, 2);
+  auto slice1 = result.slice(0, 2, 4);
+  EXPECT_TRUE(at::allclose(slice0, t1));
+  EXPECT_TRUE(at::allclose(slice1, t2));
+}
+
+TEST(ATenVStackTest, DtypeInt32) {
+  auto t1 = at::ones({2, 3}, at::kInt);
+  auto t2 = at::zeros({2, 3}, at::kInt);
+  std::vector<at::Tensor> tensors = {t1, t2};
+  auto result = at::vstack(tensors);
+
+  EXPECT_EQ(result.scalar_type(), at::kInt);
+  EXPECT_EQ(result.size(0), 4);
+  EXPECT_EQ(result.size(1), 3);
+
+  auto slice0 = result.slice(0, 0, 2);
+  auto slice1 = result.slice(0, 2, 4);
+  EXPECT_TRUE(at::equal(slice0, t1));
+  EXPECT_TRUE(at::equal(slice1, t2));
+}
+
+TEST(ATenVStackTest, DtypeInt64) {
+  auto t1 = at::ones({2, 3}, at::kLong);
+  auto t2 = at::zeros({2, 3}, at::kLong);
+  std::vector<at::Tensor> tensors = {t1, t2};
+  auto result = at::vstack(tensors);
+
+  EXPECT_EQ(result.scalar_type(), at::kLong);
+  EXPECT_EQ(result.size(0), 4);
+  EXPECT_EQ(result.size(1), 3);
+
+  auto slice0 = result.slice(0, 0, 2);
+  auto slice1 = result.slice(0, 2, 4);
+  EXPECT_TRUE(at::equal(slice0, t1));
+  EXPECT_TRUE(at::equal(slice1, t2));
+}

--- a/test/cpp/compat/CMakeLists.txt
+++ b/test/cpp/compat/CMakeLists.txt
@@ -51,6 +51,7 @@ cc_test(ATen_transpose_test SRCS ATen_transpose_test.cc)
 cc_test(ATen_Utils_test SRCS ATen_Utils_test.cc)
 cc_test(ATen_values_test SRCS ATen_values_test.cc)
 cc_test(ATen_viewAs_test SRCS ATen_viewAs_test.cc)
+cc_test(ATen_vstack_test SRCS ATen_vstack_test.cc)
 
 # torch library tests (CPU compatible)
 cc_test(torch_library_test SRCS torch_library_test.cc)


### PR DESCRIPTION
### PR Category
Execute Infrastructure


### PR Types
New features


### Description
为 Paddle C++ 兼容层新增 `at::vstack` 接口，用于将张量序列沿垂直方向（第 0 维）堆叠。

- 新增接口声明：`paddle/phi/api/include/compat/ATen/ops/vstack.h`
- 新增单测：`test/cpp/compat/ATen_vstack_test.cc`（8 个用例）
- 行为与 PyTorch 保持一致：
  - 0D 张量 → reshape 为 (1, 1)
  - 1D 张量 → unsqueeze(0) 为 (1, N)
  - 2D+ 张量 → 直接沿 dim 0 concat
  - 空输入 → TORCH_CHECK 抛异常
- 覆盖 Shape：标量、1D、2D 小 shape、2D 大 shape (50x100)、含零维度、全一维度、混合维度
- 覆盖 Dtype：kFloat、kDouble、kInt、kLong

PCAT 跨框架对比测试同步新增 12 个用例，Paddle / PyTorch 双端均通过，`result_cmp` 无差异。PR: PFCCLab/PaddleCppAPITest#65


### 是否引起精度变化
否