### PR TITLE
[Cpp API Compatibility] Add at::column_stack compat interface

### DIFF
--- a/paddle/phi/api/include/compat/ATen/Functions.h
+++ b/paddle/phi/api/include/compat/ATen/Functions.h
@@ -27,6 +27,7 @@
 #include <ATen/ops/chunk.h>
 #include <ATen/ops/clamp.h>
 #include <ATen/ops/coalesce.h>
+#include <ATen/ops/column_stack.h>
 #include <ATen/ops/detach.h>
 #include <ATen/ops/dsplit.h>
 #include <ATen/ops/empty.h>

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -22,6 +22,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/core/Stream.h>
 #include <c10/core/SymIntArrayRef.h>
+#include <c10/util/ArrayRef.h>
 #include <c10/util/OptionalArrayRef.h>
 #include "paddle/phi/api/include/api.h"
 #include "paddle/phi/api/include/tensor.h"
@@ -51,6 +52,7 @@ class Tensor;
 // Type aliases for ATen compatibility
 using Scalar = c10::Scalar;
 using TensorOptions = c10::TensorOptions;
+using TensorList = c10::ArrayRef<Tensor>;
 using MemoryFormat = c10::MemoryFormat;
 using IntArrayRef = c10::IntArrayRef;
 using OptionalIntArrayRef = c10::OptionalIntArrayRef;

--- a/paddle/phi/api/include/compat/ATen/ops/column_stack.h
+++ b/paddle/phi/api/include/compat/ATen/ops/column_stack.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <vector>
+
+#include "paddle/phi/api/include/api.h"
+
+namespace at {
+
+inline at::Tensor column_stack(at::TensorList tensors) {
+  PD_CHECK(!tensors.empty(), "column_stack expects a non-empty TensorList");
+
+  std::vector<paddle::Tensor> pd_tensors;
+  pd_tensors.reserve(tensors.size());
+  for (const auto& t : tensors) {
+    if (t.dim() <= 1) {
+      pd_tensors.push_back(paddle::experimental::reshape(
+          t._PD_GetInner(), phi::IntArray(std::vector<int64_t>{t.numel(), 1})));
+    } else {
+      pd_tensors.push_back(t._PD_GetInner());
+    }
+  }
+  return paddle::experimental::concat(pd_tensors, 1);
+}
+
+}  // namespace at

--- a/test/cpp/compat/ATen_column_stack_test.cc
+++ b/test/cpp/compat/ATen_column_stack_test.cc
@@ -1,0 +1,144 @@
+// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ATen/Functions.h>
+#include <ATen/ops/column_stack.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+TEST(ColumnStackTest, Basic1D) {
+  at::Tensor v1 = at::arange(3, at::kFloat);
+  at::Tensor v2 = at::arange(3, 6, at::kFloat);
+  std::vector<at::Tensor> tensors = {v1, v2};
+  at::Tensor result = at::column_stack(tensors);
+
+  ASSERT_EQ(result.dim(), 2);
+  ASSERT_EQ(result.sizes()[0], 3);
+  ASSERT_EQ(result.sizes()[1], 2);
+  ASSERT_EQ(result.numel(), 6);
+
+  ASSERT_FLOAT_EQ(result[0][0].item<float>(), 0.0f);
+  ASSERT_FLOAT_EQ(result[0][1].item<float>(), 3.0f);
+  ASSERT_FLOAT_EQ(result[1][0].item<float>(), 1.0f);
+  ASSERT_FLOAT_EQ(result[1][1].item<float>(), 4.0f);
+  ASSERT_FLOAT_EQ(result[2][0].item<float>(), 2.0f);
+  ASSERT_FLOAT_EQ(result[2][1].item<float>(), 5.0f);
+}
+
+TEST(ColumnStackTest, Basic2D) {
+  at::Tensor m1 = at::ones({2, 3}, at::kFloat);
+  at::Tensor m2 = at::ones({2, 2}, at::kFloat);
+  std::vector<at::Tensor> tensors = {m1, m2};
+  at::Tensor result = at::column_stack(tensors);
+
+  ASSERT_EQ(result.dim(), 2);
+  ASSERT_EQ(result.sizes()[0], 2);
+  ASSERT_EQ(result.sizes()[1], 5);
+}
+
+TEST(ColumnStackTest, Mixed1DAnd2D) {
+  at::Tensor vec = at::zeros({3}, at::kFloat);
+  at::Tensor mat = at::zeros({3, 2}, at::kFloat);
+  std::vector<at::Tensor> tensors = {vec, mat};
+  at::Tensor result = at::column_stack(tensors);
+
+  ASSERT_EQ(result.dim(), 2);
+  ASSERT_EQ(result.sizes()[0], 3);
+  ASSERT_EQ(result.sizes()[1], 3);
+}
+
+TEST(ColumnStackTest, ScalarTensors) {
+  at::Tensor s1 = at::ones({}, at::kFloat);
+  at::Tensor s2 = at::ones({}, at::kFloat);
+  std::vector<at::Tensor> tensors = {s1, s2};
+  at::Tensor result = at::column_stack(tensors);
+
+  ASSERT_EQ(result.dim(), 2);
+  ASSERT_EQ(result.sizes()[0], 1);
+  ASSERT_EQ(result.sizes()[1], 2);
+}
+
+TEST(ColumnStackTest, ScalarMixedWithVectorThrows) {
+  at::Tensor scalar = at::ones({}, at::kFloat);
+  at::Tensor vector = at::zeros({3}, at::kFloat);
+  std::vector<at::Tensor> tensors = {scalar, vector};
+
+  ASSERT_THROW(at::column_stack(tensors), std::exception);
+}
+
+TEST(ColumnStackTest, ScalarMixedWithSingleRowMatrix) {
+  at::Tensor scalar = at::full({}, 2.0f, at::kFloat);
+  at::Tensor matrix = at::arange(2, at::kFloat).reshape({1, 2});
+  std::vector<at::Tensor> tensors = {scalar, matrix};
+  at::Tensor result = at::column_stack(tensors);
+
+  ASSERT_EQ(result.dim(), 2);
+  ASSERT_EQ(result.sizes()[0], 1);
+  ASSERT_EQ(result.sizes()[1], 3);
+  ASSERT_FLOAT_EQ(result[0][0].item<float>(), 2.0f);
+  ASSERT_FLOAT_EQ(result[0][1].item<float>(), 0.0f);
+  ASSERT_FLOAT_EQ(result[0][2].item<float>(), 1.0f);
+}
+
+TEST(ColumnStackTest, SingleTensor) {
+  at::Tensor vec = at::zeros({3}, at::kFloat);
+  std::vector<at::Tensor> tensors = {vec};
+  at::Tensor result = at::column_stack(tensors);
+
+  ASSERT_EQ(result.dim(), 2);
+  ASSERT_EQ(result.sizes()[0], 3);
+  ASSERT_EQ(result.sizes()[1], 1);
+}
+
+TEST(ColumnStackTest, DtypeDouble) {
+  at::Tensor t1 = at::zeros({3}, at::kDouble);
+  at::Tensor t2 = at::zeros({3}, at::kDouble);
+  std::vector<at::Tensor> tensors = {t1, t2};
+  at::Tensor result = at::column_stack(tensors);
+
+  ASSERT_EQ(result.scalar_type(), at::kDouble);
+  ASSERT_EQ(result.dim(), 2);
+  ASSERT_EQ(result.sizes()[0], 3);
+  ASSERT_EQ(result.sizes()[1], 2);
+}
+
+TEST(ColumnStackTest, DtypeInt) {
+  at::Tensor t1 = at::zeros({3}, at::kInt);
+  at::Tensor t2 = at::zeros({3}, at::kInt);
+  std::vector<at::Tensor> tensors = {t1, t2};
+  at::Tensor result = at::column_stack(tensors);
+
+  ASSERT_EQ(result.scalar_type(), at::kInt);
+  ASSERT_EQ(result.dim(), 2);
+  ASSERT_EQ(result.sizes()[0], 3);
+  ASSERT_EQ(result.sizes()[1], 2);
+}
+
+TEST(ColumnStackTest, DtypeLong) {
+  at::Tensor t1 = at::zeros({3}, at::kLong);
+  at::Tensor t2 = at::zeros({3}, at::kLong);
+  std::vector<at::Tensor> tensors = {t1, t2};
+  at::Tensor result = at::column_stack(tensors);
+
+  ASSERT_EQ(result.scalar_type(), at::kLong);
+  ASSERT_EQ(result.dim(), 2);
+  ASSERT_EQ(result.sizes()[0], 3);
+  ASSERT_EQ(result.sizes()[1], 2);
+}
+
+TEST(ColumnStackTest, EmptyListThrows) {
+  std::vector<at::Tensor> tensors = {};
+  ASSERT_THROW(at::column_stack(tensors), std::exception);
+}

--- a/test/cpp/compat/CMakeLists.txt
+++ b/test/cpp/compat/CMakeLists.txt
@@ -21,6 +21,7 @@ cc_test(ATen_autograd_test SRCS ATen_autograd_test.cc)
 cc_test(ATen_chunk_test SRCS ATen_chunk_test.cc)
 cc_test(ATen_clamp_test SRCS ATen_clamp_test.cc)
 cc_test(ATen_coalesce_test SRCS ATen_coalesce_test.cc)
+cc_test(ATen_column_stack_test SRCS ATen_column_stack_test.cc)
 cc_test(ATen_dense_sparse_conversion_test
         SRCS ATen_dense_sparse_conversion_test.cc)
 cc_test(ATen_empty_test SRCS ATen_empty_test.cc)

--- a/test/cpp/fluid/fused/CMakeLists.txt
+++ b/test/cpp/fluid/fused/CMakeLists.txt
@@ -7,25 +7,11 @@ if(WITH_GPU OR WITH_ROCM)
     nv_test(
       test_fused_residual_dropout_bias
       SRCS fused_residual_dropout_bias_test.cu
-      DEPS tensor
-           op_registry
-           dropout_op
-           generated_op
-           phi
-           common
-           conditional_block_op
-           executor)
+      DEPS tensor op_registry dropout_op generated_op phi common)
     nv_test(
       test_fused_dropout_act_bias
       SRCS fused_dropout_act_bias_test.cu
-      DEPS tensor
-           op_registry
-           dropout_op
-           generated_op
-           phi
-           common
-           conditional_block_op
-           executor)
+      DEPS tensor op_registry dropout_op generated_op phi common)
     nv_test(
       test_fused_layernorm_residual_dropout_bias
       SRCS fused_layernorm_residual_dropout_bias_test.cu
@@ -35,19 +21,11 @@ if(WITH_GPU OR WITH_ROCM)
            generated_op
            phi
            common
-           conditional_block_op
-           executor
            ${CINN_DEPS})
     nv_test(
       test_cudnn_norm_conv
       SRCS cudnn_norm_conv_test.cc
-      DEPS generated_op
-           tensor
-           op_registry
-           phi
-           common
-           conditional_block_op
-           executor)
+      DEPS generated_op tensor op_registry phi common)
     paddle_test(test_cudnn_bn_add_relu SRCS cudnn_bn_add_relu_test.cc)
   endif()
 endif()

--- a/test/cpp/fluid/fused/CMakeLists.txt
+++ b/test/cpp/fluid/fused/CMakeLists.txt
@@ -7,11 +7,25 @@ if(WITH_GPU OR WITH_ROCM)
     nv_test(
       test_fused_residual_dropout_bias
       SRCS fused_residual_dropout_bias_test.cu
-      DEPS tensor op_registry dropout_op generated_op phi common)
+      DEPS tensor
+           op_registry
+           dropout_op
+           generated_op
+           phi
+           common
+           conditional_block_op
+           executor)
     nv_test(
       test_fused_dropout_act_bias
       SRCS fused_dropout_act_bias_test.cu
-      DEPS tensor op_registry dropout_op generated_op phi common)
+      DEPS tensor
+           op_registry
+           dropout_op
+           generated_op
+           phi
+           common
+           conditional_block_op
+           executor)
     nv_test(
       test_fused_layernorm_residual_dropout_bias
       SRCS fused_layernorm_residual_dropout_bias_test.cu
@@ -21,11 +35,19 @@ if(WITH_GPU OR WITH_ROCM)
            generated_op
            phi
            common
+           conditional_block_op
+           executor
            ${CINN_DEPS})
     nv_test(
       test_cudnn_norm_conv
       SRCS cudnn_norm_conv_test.cc
-      DEPS generated_op tensor op_registry phi common)
+      DEPS generated_op
+           tensor
+           op_registry
+           phi
+           common
+           conditional_block_op
+           executor)
     paddle_test(test_cudnn_bn_add_relu SRCS cudnn_bn_add_relu_test.cc)
   endif()
 endif()


### PR DESCRIPTION
### PR Category
Execute Infrastructure


### PR Types
New features


### Description
<!-- Describe what you've done -->
Add `at::column_stack` compatible interface in Paddle C++ compat layer.

- Add `paddle/phi/api/include/compat/ATen/ops/column_stack.h`
- Update `ATen/Functions.h` to include the new header
- Add `ATen_column_stack_test.cc` compat test
- Update `test/cpp/compat/CMakeLists.txt`

### 是否引起精度变化
否