### PR TITLE
[Cpp API Compatibility] Add at::take compat interface

### DIFF
--- a/paddle/phi/api/include/compat/ATen/Functions.h
+++ b/paddle/phi/api/include/compat/ATen/Functions.h
@@ -68,6 +68,7 @@
 #include <ATen/ops/std.h>
 #include <ATen/ops/sum.h>
 #include <ATen/ops/t.h>
+#include <ATen/ops/take.h>
 #include <ATen/ops/tensor_split.h>
 #include <ATen/ops/to.h>
 #include <ATen/ops/transpose.h>

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -485,6 +485,9 @@ class Tensor : public TensorBase {
 
   at::Tensor masked_select(const at::Tensor& mask) const;
 
+  // take: Returns a new tensor with the elements of input at the given indices.
+  at::Tensor take(const at::Tensor& index) const;
+
   std::vector<at::Tensor> tensor_split(int64_t sections, int64_t dim) const;
   std::vector<at::Tensor> tensor_split_symint(c10::SymInt sections,
                                               int64_t dim) const;

--- a/paddle/phi/api/include/compat/ATen/ops/take.h
+++ b/paddle/phi/api/include/compat/ATen/ops/take.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <ATen/core/Tensor.h>
+#include <vector>
+
+#include "paddle/phi/api/include/api.h"
+
+namespace at {
+
+// take - Returns a new tensor with the elements of input at the given indices.
+// The input tensor is treated as if it were viewed as a 1-D tensor.
+// The result takes the same shape as the indices.
+//
+// PyTorch behavior:
+// - index must be a Long tensor
+// - output dtype matches input dtype
+// - output shape matches index shape
+inline at::Tensor take(const at::Tensor& self, const at::Tensor& index) {
+  // PyTorch requires index to be a Long (INT64) tensor
+  TORCH_CHECK(index.scalar_type() == at::ScalarType::Long,
+              "take(): Expected a long tensor for index, but got ",
+              index.scalar_type());
+
+  TORCH_CHECK(self.numel() > 0 || index.numel() == 0,
+              "take(): cannot take from an empty tensor with non-empty index");
+
+  // Flatten self to 1D (treat as 1-D tensor for indexing).
+  auto flattened =
+      paddle::experimental::reshape(self._PD_GetInner(), phi::IntArray({-1}));
+
+  // Record the original index shape for reshaping the result
+  auto index_sizes = index.sizes();
+  std::vector<int64_t> index_shape_vec(index_sizes.begin(), index_sizes.end());
+
+  // Flatten index to 1D. take_along_axis performs unified CPU/GPU bounds
+  // checking and normalizes legal negative indices on device.
+  auto flattened_index =
+      paddle::experimental::reshape(index._PD_GetInner(), phi::IntArray({-1}));
+
+  // Use take_along_axis along axis 0 to pick elements by index.
+  auto selected =
+      paddle::experimental::take_along_axis(flattened, flattened_index, 0);
+
+  // Reshape result to match original index shape
+  if (index_shape_vec.empty()) {
+    // Scalar index: return scalar (0-D tensor)
+    return Tensor(paddle::experimental::reshape(
+        selected, phi::IntArray(std::vector<int64_t>{})));
+  }
+  return Tensor(
+      paddle::experimental::reshape(selected, phi::IntArray(index_shape_vec)));
+}
+
+inline at::Tensor Tensor::take(const at::Tensor& index) const {
+  return at::take(*this, index);
+}
+
+}  // namespace at

--- a/paddle/phi/api/include/compat/ATen/ops/take.h
+++ b/paddle/phi/api/include/compat/ATen/ops/take.h
@@ -46,14 +46,24 @@ inline at::Tensor take(const at::Tensor& self, const at::Tensor& index) {
   auto index_sizes = index.sizes();
   std::vector<int64_t> index_shape_vec(index_sizes.begin(), index_sizes.end());
 
-  // Flatten index to 1D. take_along_axis performs unified CPU/GPU bounds
-  // checking and normalizes legal negative indices on device.
+  // Flatten index to 1D. gather performs unified CPU/GPU bounds checking and
+  // normalizes legal negative indices on device.
   auto flattened_index =
       paddle::experimental::reshape(index._PD_GetInner(), phi::IntArray({-1}));
 
-  // Use take_along_axis along axis 0 to pick elements by index.
+  // gather covers a wider dtype surface than take_along_axis. CPU Half is the
+  // only exposed take dtype missing from gather, so gather through Float32 and
+  // cast back to preserve the public ATen dtype.
   auto selected =
-      paddle::experimental::take_along_axis(flattened, flattened_index, 0);
+      self.is_cpu() && self.scalar_type() == at::kHalf
+          ? paddle::experimental::cast(
+                paddle::experimental::gather(
+                    paddle::experimental::cast(flattened,
+                                               phi::DataType::FLOAT32),
+                    flattened_index,
+                    0),
+                phi::DataType::FLOAT16)
+          : paddle::experimental::gather(flattened, flattened_index, 0);
 
   // Reshape result to match original index shape
   if (index_shape_vec.empty()) {

--- a/paddle/phi/api/include/compat/ATen/ops/take.h
+++ b/paddle/phi/api/include/compat/ATen/ops/take.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <ATen/core/Tensor.h>
+#include <utils/scalar_type_conversion.h>
 #include <vector>
 
 #include "paddle/phi/api/include/api.h"
@@ -38,9 +39,12 @@ inline at::Tensor take(const at::Tensor& self, const at::Tensor& index) {
   TORCH_CHECK(self.numel() > 0 || index.numel() == 0,
               "take(): cannot take from an empty tensor with non-empty index");
 
+  auto contiguous_self = self.contiguous();
+  auto contiguous_index = index.contiguous();
+
   // Flatten self to 1D (treat as 1-D tensor for indexing).
-  auto flattened =
-      paddle::experimental::reshape(self._PD_GetInner(), phi::IntArray({-1}));
+  auto flattened = paddle::experimental::reshape(contiguous_self._PD_GetInner(),
+                                                 phi::IntArray({-1}));
 
   // Record the original index shape for reshaping the result
   auto index_sizes = index.sizes();
@@ -48,21 +52,28 @@ inline at::Tensor take(const at::Tensor& self, const at::Tensor& index) {
 
   // Flatten index to 1D. gather performs unified CPU/GPU bounds checking and
   // normalizes legal negative indices on device.
-  auto flattened_index =
-      paddle::experimental::reshape(index._PD_GetInner(), phi::IntArray({-1}));
+  auto flattened_index = paddle::experimental::reshape(
+      contiguous_index._PD_GetInner(), phi::IntArray({-1}));
 
-  // gather covers a wider dtype surface than take_along_axis. CPU Half is the
-  // only exposed take dtype missing from gather, so gather through Float32 and
-  // cast back to preserve the public ATen dtype.
+  auto self_dtype = self.scalar_type();
+  TORCH_CHECK(!(self.is_cpu() && (self_dtype == at::kFloat8_e5m2 ||
+                                  self_dtype == at::kFloat8_e4m3fn)),
+              "\"take_cpu\" not implemented for '",
+              self_dtype,
+              "'");
+  bool need_cast_gather =
+      (self.is_cpu() && self_dtype == at::kHalf) ||
+      (!self.is_cpu() &&
+       (self_dtype == at::kFloat8_e5m2 || self_dtype == at::kFloat8_e4m3fn));
   auto selected =
-      self.is_cpu() && self.scalar_type() == at::kHalf
+      need_cast_gather
           ? paddle::experimental::cast(
                 paddle::experimental::gather(
                     paddle::experimental::cast(flattened,
                                                phi::DataType::FLOAT32),
                     flattened_index,
                     0),
-                phi::DataType::FLOAT16)
+                compat::_PD_AtenScalarTypeToPhiDataType(self_dtype))
           : paddle::experimental::gather(flattened, flattened_index, 0);
 
   // Reshape result to match original index shape

--- a/paddle/phi/api/include/compat/ATen/ops/take.h
+++ b/paddle/phi/api/include/compat/ATen/ops/take.h
@@ -39,6 +39,16 @@ inline at::Tensor take(const at::Tensor& self, const at::Tensor& index) {
   TORCH_CHECK(self.numel() > 0 || index.numel() == 0,
               "take(): cannot take from an empty tensor with non-empty index");
 
+  auto self_dtype = self.scalar_type();
+  TORCH_CHECK(!(self_dtype == at::kUInt16 || self_dtype == at::kUInt32 ||
+                (self.is_cpu() && (self_dtype == at::kFloat8_e5m2 ||
+                                   self_dtype == at::kFloat8_e4m3fn))),
+              "\"",
+              self.is_cpu() ? "take_cpu" : "take_cuda",
+              "\" not implemented for '",
+              self_dtype,
+              "'");
+
   auto contiguous_self = self.contiguous();
   auto contiguous_index = index.contiguous();
 
@@ -55,12 +65,6 @@ inline at::Tensor take(const at::Tensor& self, const at::Tensor& index) {
   auto flattened_index = paddle::experimental::reshape(
       contiguous_index._PD_GetInner(), phi::IntArray({-1}));
 
-  auto self_dtype = self.scalar_type();
-  TORCH_CHECK(!(self.is_cpu() && (self_dtype == at::kFloat8_e5m2 ||
-                                  self_dtype == at::kFloat8_e4m3fn)),
-              "\"take_cpu\" not implemented for '",
-              self_dtype,
-              "'");
   bool need_cast_gather =
       (self.is_cpu() && self_dtype == at::kHalf) ||
       (!self.is_cpu() &&

--- a/test/cpp/compat/ATen_take_test.cc
+++ b/test/cpp/compat/ATen_take_test.cc
@@ -19,6 +19,9 @@
 #include "ATen/ATen.h"
 #include "ATen/Functions.h"
 #include "ATen/core/TensorBody.h"
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#include "ATen/cuda/CUDAContext.h"
+#endif
 #include "ATen/ops/as_strided.h"
 #include "ATen/ops/full.h"
 #include "ATen/ops/take.h"
@@ -346,6 +349,10 @@ TEST(TakeTest, TakeMemberFunction) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 // Test for take on CUDA
 TEST(TakeTest, TakeCUDA) {
+  if (!at::cuda::is_available()) {
+    return;
+  }
+
   auto tensor =
       at::arange(10, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
 
@@ -363,6 +370,10 @@ TEST(TakeTest, TakeCUDA) {
 }
 
 TEST(TakeTest, TakeCUDAUIntDtypesThrow) {
+  if (!at::cuda::is_available()) {
+    return;
+  }
+
   auto index = make_long_index({0, 3, 1}).cuda();
 
   auto tensor_uint16 = make_long_index({2, 2, 2, 2}).to(at::kUInt16).cuda();
@@ -373,6 +384,10 @@ TEST(TakeTest, TakeCUDAUIntDtypesThrow) {
 }
 
 TEST(TakeTest, TakeCUDANegativeIndexAndOutOfRange) {
+  if (!at::cuda::is_available()) {
+    return;
+  }
+
   auto tensor =
       at::arange(10, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
 

--- a/test/cpp/compat/ATen_take_test.cc
+++ b/test/cpp/compat/ATen_take_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <complex>
+#include <cstdint>
 #include <vector>
 
 #include "ATen/ATen.h"
@@ -20,6 +22,7 @@
 #include "ATen/ops/full.h"
 #include "ATen/ops/take.h"
 #include "ATen/ops/tensor.h"
+#include "c10/util/complex.h"
 #include "gtest/gtest.h"
 #include "torch/all.h"
 
@@ -28,6 +31,11 @@
 static at::Tensor make_long_index(const std::vector<int64_t>& values) {
   return at::tensor(at::ArrayRef<int64_t>(values),
                     at::TensorOptions().dtype(at::kLong));
+}
+
+static at::Tensor make_float_tensor(const std::vector<float>& values) {
+  return at::tensor(at::ArrayRef<float>(values),
+                    at::TensorOptions().dtype(at::kFloat));
 }
 
 // Test for take on 1D tensor
@@ -128,6 +136,87 @@ TEST(TakeTest, TakeDifferentDtypes) {
   EXPECT_DOUBLE_EQ(result_double[0].item<double>(), 1.0);
   EXPECT_DOUBLE_EQ(result_double[1].item<double>(), 3.0);
   EXPECT_DOUBLE_EQ(result_double[2].item<double>(), 8.0);
+}
+
+TEST(TakeTest, TakeExtendedDtypes) {
+  auto index = make_long_index({0, 3, 1});
+
+  auto tensor_bool = make_long_index({0, 1, 0, 1}).to(at::kBool);
+  auto result_bool = at::take(tensor_bool, index);
+  EXPECT_EQ(result_bool.scalar_type(), at::kBool);
+  EXPECT_FALSE(result_bool.data_ptr<bool>()[0]);
+  EXPECT_TRUE(result_bool.data_ptr<bool>()[1]);
+  EXPECT_TRUE(result_bool.data_ptr<bool>()[2]);
+
+  std::vector<int8_t> char_values = {-4, -2, 3, 7};
+  auto tensor_char = at::tensor(at::ArrayRef<int8_t>(char_values),
+                                at::TensorOptions().dtype(at::kChar));
+  auto result_char = at::take(tensor_char, index);
+  EXPECT_EQ(result_char.scalar_type(), at::kChar);
+  EXPECT_EQ(result_char.data_ptr<int8_t>()[0], static_cast<int8_t>(-4));
+  EXPECT_EQ(result_char.data_ptr<int8_t>()[1], static_cast<int8_t>(7));
+  EXPECT_EQ(result_char.data_ptr<int8_t>()[2], static_cast<int8_t>(-2));
+
+  auto tensor_half = make_float_tensor({1.5f, -2.0f, 0.5f, 4.0f}).to(at::kHalf);
+  auto result_half = at::take(tensor_half, index);
+  EXPECT_EQ(result_half.scalar_type(), at::kHalf);
+  auto result_half_float = result_half.to(at::kFloat);
+  EXPECT_FLOAT_EQ(result_half_float.data_ptr<float>()[0], 1.5f);
+  EXPECT_FLOAT_EQ(result_half_float.data_ptr<float>()[1], 4.0f);
+  EXPECT_FLOAT_EQ(result_half_float.data_ptr<float>()[2], -2.0f);
+
+  auto tensor_bfloat =
+      make_float_tensor({1.25f, -3.5f, 2.0f, 8.0f}).to(at::kBFloat16);
+  auto result_bfloat = at::take(tensor_bfloat, index);
+  EXPECT_EQ(result_bfloat.scalar_type(), at::kBFloat16);
+  auto result_bfloat_float = result_bfloat.to(at::kFloat);
+  EXPECT_FLOAT_EQ(result_bfloat_float.data_ptr<float>()[0], 1.25f);
+  EXPECT_FLOAT_EQ(result_bfloat_float.data_ptr<float>()[1], 8.0f);
+  EXPECT_FLOAT_EQ(result_bfloat_float.data_ptr<float>()[2], -3.5f);
+
+  std::vector<c10::complex<float>> complex_float_values = {
+      {1.0f, 2.0f}, {3.0f, -4.0f}, {-5.0f, 6.0f}, {7.0f, 8.0f}};
+  auto tensor_complex_float =
+      at::tensor(at::ArrayRef<c10::complex<float>>(complex_float_values),
+                 at::TensorOptions().dtype(at::kComplexFloat));
+  auto result_complex_float = at::take(tensor_complex_float, index);
+  EXPECT_EQ(result_complex_float.scalar_type(), at::kComplexFloat);
+  auto* complex_float_data =
+      result_complex_float.data_ptr<c10::complex<float>>();
+  auto complex_float_0 =
+      static_cast<std::complex<float>>(complex_float_data[0]);
+  auto complex_float_1 =
+      static_cast<std::complex<float>>(complex_float_data[1]);
+  auto complex_float_2 =
+      static_cast<std::complex<float>>(complex_float_data[2]);
+  EXPECT_FLOAT_EQ(complex_float_0.real(), 1.0f);
+  EXPECT_FLOAT_EQ(complex_float_0.imag(), 2.0f);
+  EXPECT_FLOAT_EQ(complex_float_1.real(), 7.0f);
+  EXPECT_FLOAT_EQ(complex_float_1.imag(), 8.0f);
+  EXPECT_FLOAT_EQ(complex_float_2.real(), 3.0f);
+  EXPECT_FLOAT_EQ(complex_float_2.imag(), -4.0f);
+
+  std::vector<c10::complex<double>> complex_double_values = {
+      {1.0, -2.0}, {-3.0, 4.0}, {5.0, -6.0}, {-7.0, -8.0}};
+  auto tensor_complex_double =
+      at::tensor(at::ArrayRef<c10::complex<double>>(complex_double_values),
+                 at::TensorOptions().dtype(at::kComplexDouble));
+  auto result_complex_double = at::take(tensor_complex_double, index);
+  EXPECT_EQ(result_complex_double.scalar_type(), at::kComplexDouble);
+  auto* complex_double_data =
+      result_complex_double.data_ptr<c10::complex<double>>();
+  auto complex_double_0 =
+      static_cast<std::complex<double>>(complex_double_data[0]);
+  auto complex_double_1 =
+      static_cast<std::complex<double>>(complex_double_data[1]);
+  auto complex_double_2 =
+      static_cast<std::complex<double>>(complex_double_data[2]);
+  EXPECT_DOUBLE_EQ(complex_double_0.real(), 1.0);
+  EXPECT_DOUBLE_EQ(complex_double_0.imag(), -2.0);
+  EXPECT_DOUBLE_EQ(complex_double_1.real(), -7.0);
+  EXPECT_DOUBLE_EQ(complex_double_1.imag(), -8.0);
+  EXPECT_DOUBLE_EQ(complex_double_2.real(), -3.0);
+  EXPECT_DOUBLE_EQ(complex_double_2.imag(), 4.0);
 }
 
 // Test for take on empty index

--- a/test/cpp/compat/ATen_take_test.cc
+++ b/test/cpp/compat/ATen_take_test.cc
@@ -19,6 +19,7 @@
 #include "ATen/ATen.h"
 #include "ATen/Functions.h"
 #include "ATen/core/TensorBody.h"
+#include "ATen/ops/as_strided.h"
 #include "ATen/ops/full.h"
 #include "ATen/ops/take.h"
 #include "ATen/ops/tensor.h"
@@ -217,6 +218,44 @@ TEST(TakeTest, TakeExtendedDtypes) {
   EXPECT_DOUBLE_EQ(complex_double_1.imag(), -8.0);
   EXPECT_DOUBLE_EQ(complex_double_2.real(), -3.0);
   EXPECT_DOUBLE_EQ(complex_double_2.imag(), 4.0);
+}
+
+TEST(TakeTest, TakeCpuFloat8Throws) {
+  auto index = make_long_index({0, 3, 1});
+
+  auto tensor_float8_e5m2 =
+      make_float_tensor({1.0f, 2.0f, 4.0f, 8.0f}).to(at::kFloat8_e5m2);
+  EXPECT_THROW(at::take(tensor_float8_e5m2, index), std::exception);
+
+  auto tensor_float8_e4m3fn =
+      make_float_tensor({1.0f, 2.0f, 4.0f, 8.0f}).to(at::kFloat8_e4m3fn);
+  EXPECT_THROW(at::take(tensor_float8_e4m3fn, index), std::exception);
+}
+
+TEST(TakeTest, TakeNonContiguousInput) {
+  auto base = at::arange(6, at::TensorOptions().dtype(at::kFloat));
+  auto tensor = base.as_strided({3}, {2});
+  auto index = make_long_index({1});
+
+  auto result = at::take(tensor, index);
+
+  EXPECT_EQ(result.dim(), 1);
+  EXPECT_EQ(result.size(0), 1);
+  EXPECT_FLOAT_EQ(result[0].item<float>(), 2.0f);
+}
+
+TEST(TakeTest, TakeNonContiguousIndex) {
+  auto tensor = at::arange(6, at::TensorOptions().dtype(at::kFloat));
+  auto index_base = make_long_index({0, 1, 2, 3, 4, 5});
+  auto index = index_base.as_strided({3}, {2});
+
+  auto result = at::take(tensor, index);
+
+  EXPECT_EQ(result.dim(), 1);
+  EXPECT_EQ(result.size(0), 3);
+  EXPECT_FLOAT_EQ(result[0].item<float>(), 0.0f);
+  EXPECT_FLOAT_EQ(result[1].item<float>(), 2.0f);
+  EXPECT_FLOAT_EQ(result[2].item<float>(), 4.0f);
 }
 
 // Test for take on empty index

--- a/test/cpp/compat/ATen_take_test.cc
+++ b/test/cpp/compat/ATen_take_test.cc
@@ -25,7 +25,10 @@
 #include "ATen/ops/tensor.h"
 #include "c10/util/complex.h"
 #include "gtest/gtest.h"
+#include "paddle/common/macros.h"
 #include "torch/all.h"
+
+COMMON_DECLARE_bool(use_stride_kernel);
 
 // ==================== take tests ====================
 
@@ -232,7 +235,20 @@ TEST(TakeTest, TakeCpuFloat8Throws) {
   EXPECT_THROW(at::take(tensor_float8_e4m3fn, index), std::exception);
 }
 
+TEST(TakeTest, TakeUIntDtypesThrow) {
+  auto index = make_long_index({0, 3, 1});
+
+  auto tensor_uint16 = make_long_index({2, 2, 2, 2}).to(at::kUInt16);
+  EXPECT_THROW(at::take(tensor_uint16, index), std::exception);
+
+  auto tensor_uint32 = make_long_index({2, 2, 2, 2}).to(at::kUInt32);
+  EXPECT_THROW(at::take(tensor_uint32, index), std::exception);
+}
+
 TEST(TakeTest, TakeNonContiguousInput) {
+  if (!FLAGS_use_stride_kernel) {
+    return;
+  }
   auto base = at::arange(6, at::TensorOptions().dtype(at::kFloat));
   auto tensor = base.as_strided({3}, {2});
   auto index = make_long_index({1});
@@ -245,6 +261,9 @@ TEST(TakeTest, TakeNonContiguousInput) {
 }
 
 TEST(TakeTest, TakeNonContiguousIndex) {
+  if (!FLAGS_use_stride_kernel) {
+    return;
+  }
   auto tensor = at::arange(6, at::TensorOptions().dtype(at::kFloat));
   auto index_base = make_long_index({0, 1, 2, 3, 4, 5});
   auto index = index_base.as_strided({3}, {2});
@@ -341,6 +360,16 @@ TEST(TakeTest, TakeCUDA) {
   EXPECT_FLOAT_EQ(cpu_result[0].item<float>(), 1.0f);
   EXPECT_FLOAT_EQ(cpu_result[1].item<float>(), 3.0f);
   EXPECT_FLOAT_EQ(cpu_result[2].item<float>(), 7.0f);
+}
+
+TEST(TakeTest, TakeCUDAUIntDtypesThrow) {
+  auto index = make_long_index({0, 3, 1}).cuda();
+
+  auto tensor_uint16 = make_long_index({2, 2, 2, 2}).to(at::kUInt16).cuda();
+  EXPECT_THROW((void)at::take(tensor_uint16, index).cpu(), std::exception);
+
+  auto tensor_uint32 = make_long_index({2, 2, 2, 2}).to(at::kUInt32).cuda();
+  EXPECT_THROW((void)at::take(tensor_uint32, index).cpu(), std::exception);
 }
 
 TEST(TakeTest, TakeCUDANegativeIndexAndOutOfRange) {

--- a/test/cpp/compat/ATen_take_test.cc
+++ b/test/cpp/compat/ATen_take_test.cc
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "ATen/ATen.h"
+#include "ATen/Functions.h"
+#include "ATen/core/TensorBody.h"
+#include "ATen/ops/full.h"
+#include "ATen/ops/take.h"
+#include "ATen/ops/tensor.h"
+#include "gtest/gtest.h"
+#include "torch/all.h"
+
+// ==================== take tests ====================
+
+static at::Tensor make_long_index(const std::vector<int64_t>& values) {
+  return at::tensor(at::ArrayRef<int64_t>(values),
+                    at::TensorOptions().dtype(at::kLong));
+}
+
+// Test for take on 1D tensor
+TEST(TakeTest, Take1D) {
+  auto tensor = at::arange(10, at::TensorOptions().dtype(at::kFloat));
+  auto index = make_long_index({2, 5, 7});
+
+  auto result = at::take(tensor, index);
+
+  EXPECT_EQ(result.dim(), 1);
+  EXPECT_EQ(result.size(0), 3);
+  EXPECT_FLOAT_EQ(result[0].item<float>(), 2.0f);
+  EXPECT_FLOAT_EQ(result[1].item<float>(), 5.0f);
+  EXPECT_FLOAT_EQ(result[2].item<float>(), 7.0f);
+}
+
+// Test for take on 2D tensor (treated as flattened)
+TEST(TakeTest, Take2DFlattened) {
+  auto tensor =
+      at::arange(12, at::TensorOptions().dtype(at::kFloat)).reshape({3, 4});
+
+  // Flattened indices: element at flattened position 0 is 0, position 5 is 5,
+  // position 11 is 11
+  auto index = make_long_index({0, 5, 11});
+
+  auto result = at::take(tensor, index);
+
+  EXPECT_EQ(result.dim(), 1);
+  EXPECT_EQ(result.size(0), 3);
+  EXPECT_FLOAT_EQ(result[0].item<float>(), 0.0f);
+  EXPECT_FLOAT_EQ(result[1].item<float>(), 5.0f);
+  EXPECT_FLOAT_EQ(result[2].item<float>(), 11.0f);
+}
+
+// Test for take with multi-dimensional index
+TEST(TakeTest, TakeMultiDimIndex) {
+  auto tensor = at::arange(12, at::TensorOptions().dtype(at::kFloat));
+
+  auto index = make_long_index({0, 3, 7, 10}).reshape({2, 2});
+
+  auto result = at::take(tensor, index);
+
+  EXPECT_EQ(result.dim(), 2);
+  EXPECT_EQ(result.size(0), 2);
+  EXPECT_EQ(result.size(1), 2);
+  EXPECT_FLOAT_EQ(result[0][0].item<float>(), 0.0f);
+  EXPECT_FLOAT_EQ(result[0][1].item<float>(), 3.0f);
+  EXPECT_FLOAT_EQ(result[1][0].item<float>(), 7.0f);
+  EXPECT_FLOAT_EQ(result[1][1].item<float>(), 10.0f);
+}
+
+// Test for take with duplicate indices
+TEST(TakeTest, TakeDuplicateIndices) {
+  auto tensor = at::arange(5, at::TensorOptions().dtype(at::kFloat));
+
+  auto index = make_long_index({1, 1, 3, 1});
+
+  auto result = at::take(tensor, index);
+
+  EXPECT_EQ(result.size(0), 4);
+  EXPECT_FLOAT_EQ(result[0].item<float>(), 1.0f);
+  EXPECT_FLOAT_EQ(result[1].item<float>(), 1.0f);
+  EXPECT_FLOAT_EQ(result[2].item<float>(), 3.0f);
+  EXPECT_FLOAT_EQ(result[3].item<float>(), 1.0f);
+}
+
+// Test for take with scalar tensor (0-dim index)
+TEST(TakeTest, TakeScalarIndex) {
+  auto tensor = at::arange(10, at::TensorOptions().dtype(at::kFloat));
+
+  auto index = at::full({}, 7, at::kLong);
+
+  auto result = at::take(tensor, index);
+
+  // Result should be scalar (0-dim tensor)
+  EXPECT_EQ(result.dim(), 0);
+  EXPECT_FLOAT_EQ(result.item<float>(), 7.0f);
+}
+
+// Test for take with different dtypes
+TEST(TakeTest, TakeDifferentDtypes) {
+  // Test with int64
+  auto tensor_int = at::arange(10, at::TensorOptions().dtype(at::kLong));
+  auto index = make_long_index({1, 3, 8});
+
+  auto result = at::take(tensor_int, index);
+
+  EXPECT_EQ(result.scalar_type(), at::kLong);
+  EXPECT_EQ(result[0].item<int64_t>(), 1);
+  EXPECT_EQ(result[1].item<int64_t>(), 3);
+  EXPECT_EQ(result[2].item<int64_t>(), 8);
+
+  // Test with double
+  auto tensor_double = at::arange(10, at::TensorOptions().dtype(at::kDouble));
+  auto result_double = at::take(tensor_double, index);
+
+  EXPECT_EQ(result_double.scalar_type(), at::kDouble);
+  EXPECT_DOUBLE_EQ(result_double[0].item<double>(), 1.0);
+  EXPECT_DOUBLE_EQ(result_double[1].item<double>(), 3.0);
+  EXPECT_DOUBLE_EQ(result_double[2].item<double>(), 8.0);
+}
+
+// Test for take on empty index
+TEST(TakeTest, TakeEmptyIndex) {
+  auto tensor = at::arange(10, at::TensorOptions().dtype(at::kFloat));
+
+  // Empty index
+  auto index = at::empty({0}, at::TensorOptions().dtype(at::kLong));
+
+  auto result = at::take(tensor, index);
+
+  EXPECT_EQ(result.numel(), 0);
+}
+
+TEST(TakeTest, TakeEmptyInputNonEmptyIndexThrows) {
+  auto tensor = at::empty({0}, at::TensorOptions().dtype(at::kFloat));
+  auto index = make_long_index({0});
+
+  EXPECT_THROW(at::take(tensor, index), std::exception);
+}
+
+// Test for take with non-Long index dtype (should throw)
+TEST(TakeTest, TakeNonLongIndexThrows) {
+  auto tensor = at::arange(10, at::TensorOptions().dtype(at::kFloat));
+
+  // INT32 index should be rejected
+  auto index_int32 = at::tensor({0, 1, 2}, at::TensorOptions().dtype(at::kInt));
+  EXPECT_THROW(at::take(tensor, index_int32), std::exception);
+
+  // FLOAT index should be rejected
+  auto index_float =
+      at::tensor({0.0f, 1.0f, 2.0f}, at::TensorOptions().dtype(at::kFloat));
+  EXPECT_THROW(at::take(tensor, index_float), std::exception);
+}
+
+TEST(TakeTest, TakeNegativeIndexWraps) {
+  auto tensor = at::arange(10, at::TensorOptions().dtype(at::kFloat));
+  auto index = make_long_index({-1, -10});
+
+  auto result = at::take(tensor, index);
+
+  EXPECT_FLOAT_EQ(result[0].item<float>(), 9.0f);
+  EXPECT_FLOAT_EQ(result[1].item<float>(), 0.0f);
+}
+
+TEST(TakeTest, TakeOutOfRangeThrows) {
+  auto tensor = at::arange(10, at::TensorOptions().dtype(at::kFloat));
+
+  auto positive_oob = make_long_index({10});
+  EXPECT_THROW(at::take(tensor, positive_oob), std::exception);
+
+  auto negative_oob = make_long_index({-11});
+  EXPECT_THROW(at::take(tensor, negative_oob), std::exception);
+}
+
+// Test for take member function
+TEST(TakeTest, TakeMemberFunction) {
+  auto tensor = at::arange(10, at::TensorOptions().dtype(at::kFloat));
+
+  auto index = make_long_index({4, 6});
+
+  auto result = tensor.take(index);
+
+  EXPECT_EQ(result.size(0), 2);
+  EXPECT_FLOAT_EQ(result[0].item<float>(), 4.0f);
+  EXPECT_FLOAT_EQ(result[1].item<float>(), 6.0f);
+}
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+// Test for take on CUDA
+TEST(TakeTest, TakeCUDA) {
+  auto tensor =
+      at::arange(10, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+
+  auto index = make_long_index({1, 3, 7}).cuda();
+
+  auto result = at::take(tensor, index);
+
+  EXPECT_TRUE(result.is_cuda());
+  EXPECT_EQ(result.size(0), 3);
+
+  auto cpu_result = result.cpu();
+  EXPECT_FLOAT_EQ(cpu_result[0].item<float>(), 1.0f);
+  EXPECT_FLOAT_EQ(cpu_result[1].item<float>(), 3.0f);
+  EXPECT_FLOAT_EQ(cpu_result[2].item<float>(), 7.0f);
+}
+
+TEST(TakeTest, TakeCUDANegativeIndexAndOutOfRange) {
+  auto tensor =
+      at::arange(10, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+
+  auto index = make_long_index({-1}).cuda();
+  auto result = at::take(tensor, index).cpu();
+  EXPECT_FLOAT_EQ(result[0].item<float>(), 9.0f);
+
+  index = make_long_index({10}).cuda();
+  EXPECT_THROW((void)at::take(tensor, index).cpu(), std::exception);
+}
+#endif

--- a/test/cpp/compat/CMakeLists.txt
+++ b/test/cpp/compat/CMakeLists.txt
@@ -72,6 +72,7 @@ else()
   cc_test(ATen_record_stream_test SRCS ATen_record_stream_test.cc)
   cc_test(ATen_select_test SRCS ATen_select_test.cc)
   cc_test(ATen_split_test SRCS ATen_split_test.cc)
+  cc_test(ATen_take_test SRCS ATen_take_test.cc)
 
   cc_test(ATen_CUDAContext_test SRCS ATen_CUDAContext_test.cc)
   cc_test(ATen_philox_test SRCS ATen_philox_test.cc)

--- a/test/cpp/compat/CMakeLists.txt
+++ b/test/cpp/compat/CMakeLists.txt
@@ -72,13 +72,14 @@ else()
   cc_test(ATen_record_stream_test SRCS ATen_record_stream_test.cc)
   cc_test(ATen_select_test SRCS ATen_select_test.cc)
   cc_test(ATen_split_test SRCS ATen_split_test.cc)
-  cc_test(ATen_take_test SRCS ATen_take_test.cc)
 
   cc_test(ATen_CUDAContext_test SRCS ATen_CUDAContext_test.cc)
   cc_test(ATen_philox_test SRCS ATen_philox_test.cc)
   cc_test(c10_Event_test SRCS c10_Event_test.cc)
   cc_test(c10_Stream_test SRCS c10_Stream_test.cc)
 endif()
+
+cc_test(ATen_take_test SRCS ATen_take_test.cc)
 
 if(WITH_GPU)
   nv_test(ATen_CUDABlas_test SRCS ATen_CUDABlas_test.cc)

--- a/test/cpp/fluid/fused/CMakeLists.txt
+++ b/test/cpp/fluid/fused/CMakeLists.txt
@@ -7,11 +7,25 @@ if(WITH_GPU OR WITH_ROCM)
     nv_test(
       test_fused_residual_dropout_bias
       SRCS fused_residual_dropout_bias_test.cu
-      DEPS tensor op_registry dropout_op generated_op phi common)
+      DEPS tensor
+           op_registry
+           dropout_op
+           generated_op
+           phi
+           common
+           conditional_block_op
+           executor)
     nv_test(
       test_fused_dropout_act_bias
       SRCS fused_dropout_act_bias_test.cu
-      DEPS tensor op_registry dropout_op generated_op phi common)
+      DEPS tensor
+           op_registry
+           dropout_op
+           generated_op
+           phi
+           common
+           conditional_block_op
+           executor)
     nv_test(
       test_fused_layernorm_residual_dropout_bias
       SRCS fused_layernorm_residual_dropout_bias_test.cu
@@ -21,11 +35,19 @@ if(WITH_GPU OR WITH_ROCM)
            generated_op
            phi
            common
+           conditional_block_op
+           executor
            ${CINN_DEPS})
     nv_test(
       test_cudnn_norm_conv
       SRCS cudnn_norm_conv_test.cc
-      DEPS generated_op tensor op_registry phi common)
+      DEPS generated_op
+           tensor
+           op_registry
+           phi
+           common
+           conditional_block_op
+           executor)
     paddle_test(test_cudnn_bn_add_relu SRCS cudnn_bn_add_relu_test.cc)
   endif()
 endif()


### PR DESCRIPTION
### PR Category
Execute Infrastructure


### PR Types
New features


### Description
Add `at::take` compat interface in Paddle C++ API compatibility layer.

**Changes:**
- Add `paddle/phi/api/include/compat/ATen/ops/take.h` - compat implementation using `contiguous` + `reshape` + `gather`
- Add `Tensor::take()` member function declaration in `ATen/core/TensorBody.h`
- Add `ATen_take_test.cc` coverage for flattened take semantics, scalar/multi-dimensional index, negative/OOB index, extended dtypes, non-contiguous input/index, and CUDA behavior
- Update fused C++ test CMake dependencies to satisfy full `ninja -j16` link requirements for existing fused CUDA tests touched by this branch validation

**Implementation:**
PyTorch's `take(self, index)` treats `self` as a flattened 1-D tensor in logical order and returns elements at the given indices. The output shape matches the index shape.

Paddle compat implementation:
1. Require `index` to be `Long`, matching ATen C++ behavior.
2. Materialize `self` and `index` with `contiguous()` before flattening, so strided tensors are gathered in logical order.
3. Flatten `self` and `index` with `reshape({-1})`.
4. Use `gather` along axis 0 for unified CPU/GPU negative-index and OOB handling.
5. Use a Float32 gather fallback for CPU Half and non-CPU Float8 where Paddle gather dtype coverage is narrower; CPU Float8 keeps libtorch 2.12.1 behavior and throws.
6. Reshape the result back to the original index shape.

**Test Results:**
- `python tools/check_aten_ops_signature.py --paddle-root . --torch-include-dir /home/may/libtorch/include`: pass
- `bash -n ci/static_check.sh`: pass
- `cd build && ninja -j16 ATen_take_test && ctest -R '^ATen_take_test$' --output-on-failure`: pass
- `cd build && ninja -j16`: pass, wheel packaged
- Installed `build/python/dist/paddlepaddle_gpu-3.5.0.dev20260629-cp313-cp313-linux_x86_64.whl`
- PCAT `test/take-20260528`: `ninja -j16 torch_TakeTest paddle_TakeTest`: pass
- PCAT `torch_TakeTest` vs `paddle_TakeTest` result diff: no diff


### 是否引起精度变化
否
