### PR TITLE
【Hackathon 10th Spring No.51】update almalinux dockerfile `cmake`、cuda version、`gdrcopy`、python build - part 2

### DIFF
--- a/tools/dockerfile/manylinux/Dockerfile
+++ b/tools/dockerfile/manylinux/Dockerfile
@@ -14,7 +14,14 @@ ENV LANGUAGE en_US.UTF-8
 
 RUN yum -y update
 RUN yum -y install epel-release
-RUN yum install -y sudo wget curl perl util-linux xz bzip2 git patch which perl zlib-devel openssl-devel yum-utils autoconf automake make gcc-toolset-${DEVTOOLSET_VERSION}-toolchain unzip bison diffutils automake which file vim libffi-devel ncurses-devel sqlite-devel readline-devel tk-devel gdbm-devel glibc-devel libstdc++-devel glib2-devel libX11-devel libXext-devel libXrender-devel  mesa-libGL-devel libICE-devel libSM-devel ncurses-devel freetype-devel libpng-devel kernel-devel kmod
+RUN yum install -y \
+    sudo wget curl perl util-linux xz bzip2 git patch which zlib-devel openssl-devel \
+    yum-utils autoconf automake make gcc-toolset-${DEVTOOLSET_VERSION}-toolchain \
+    unzip bison diffutils file vim libffi-devel ncurses-devel sqlite-devel \
+    readline-devel tk-devel gdbm-devel glibc-devel libstdc++-devel glib2-devel \
+    libX11-devel libXext-devel libXrender-devel mesa-libGL-devel libICE-devel \
+    libSM-devel freetype-devel libpng-devel kernel-devel kmod \
+    rdma-core-devel libibverbs-devel
 
 # Just add everything as a safe.directory for git since these will be used in multiple places with git
 RUN git config --global --add safe.directory '*'
@@ -23,8 +30,8 @@ ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 
 # cmake-3.18.4
 WORKDIR /home
-RUN wget -q https://cmake.org/files/v3.18/cmake-3.18.0-Linux-x86_64.tar.gz && tar -zxvf cmake-3.18.0-Linux-x86_64.tar.gz && rm cmake-3.18.0-Linux-x86_64.tar.gz
-ENV PATH=/home/cmake-3.18.0-Linux-x86_64/bin:$PATH
+RUN wget -q https://cmake.org/files/v3.31/cmake-3.31.0-linux-x86_64.tar.gz && tar -zxvf cmake-3.31.0-linux-x86_64.tar.gz && rm cmake-3.31.0-linux-x86_64.tar.gz
+ENV PATH=/home/cmake-3.31.0-linux-x86_64/bin:$PATH
 
 # go-1.15.12
 WORKDIR /home
@@ -59,12 +66,14 @@ RUN bash ./install_ccache.sh && rm install_ccache.sh
 
 # Install CUDA
 FROM base as cuda
-ARG CUDA_VERSION=12.4
+ARG CUDA_VERSION
 RUN rm -rf /usr/local/cuda-*
 ENV CUDA_HOME=/usr/local/cuda-${CUDA_VERSION}
 ENV CUDA_VERSION=${CUDA_VERSION}
 ENV PATH=/usr/local/cuda-${CUDA_VERSION}/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/cuda-${CUDA_VERSION}/compat:$LD_LIBRARY_PATH
 ADD ./common/install_cuda.sh install_cuda.sh
+ADD ./common/install_gdrcopy.sh install_gdrcopy.sh
 
 FROM cuda as cuda11.8
 RUN bash ./install_cuda.sh 11.8
@@ -77,15 +86,25 @@ ENV DESIRED_CUDA=12.3
 FROM cuda as cuda12.4
 RUN bash ./install_cuda.sh 12.4
 ENV DESIRED_CUDA=12.4
-ENV DESIRED_CUDA=12.6
 
 FROM cuda as cuda12.6
 RUN bash ./install_cuda.sh 12.6
 ENV DESIRED_CUDA=12.6
 
+FROM cuda as cuda12.9
+RUN bash ./install_cuda.sh 12.9 && bash ./install_gdrcopy.sh
+ENV DESIRED_CUDA=12.9
+ENV GDRCOPY_HOME=/usr/local/gdrcopy
+
+FROM cuda as cuda13.0
+RUN bash ./install_cuda.sh 13.0 && bash ./install_gdrcopy.sh
+ENV DESIRED_CUDA=13.0
+ENV GDRCOPY_HOME=/usr/local/gdrcopy
+
 FROM cuda as cuda13.2
-RUN bash ./install_cuda.sh 13.2
+RUN bash ./install_cuda.sh 13.2 && bash ./install_gdrcopy.sh
 ENV DESIRED_CUDA=13.2
+ENV GDRCOPY_HOME=/usr/local/gdrcopy
 
 
 # Install paddle

--- a/tools/dockerfile/manylinux/Dockerfile
+++ b/tools/dockerfile/manylinux/Dockerfile
@@ -28,7 +28,7 @@ RUN git config --global --add safe.directory '*'
 RUN ln -s /opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib/gcc/x86_64-redhat-linux/${DEVTOOLSET_VERSION} /usr/lib/gcc/x86_64-redhat-linux/${DEVTOOLSET_VERSION}
 ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
 
-# cmake-3.18.4
+# cmake-3.31.0
 WORKDIR /home
 RUN wget -q https://cmake.org/files/v3.31/cmake-3.31.0-linux-x86_64.tar.gz && tar -zxvf cmake-3.31.0-linux-x86_64.tar.gz && rm cmake-3.31.0-linux-x86_64.tar.gz
 ENV PATH=/home/cmake-3.31.0-linux-x86_64/bin:$PATH

--- a/tools/dockerfile/manylinux/common/install_cuda.sh
+++ b/tools/dockerfile/manylinux/common/install_cuda.sh
@@ -74,6 +74,17 @@ function install_cusparselt_090_cuda13 {
     rm -rf tmp_cusparselt
 }
 
+function install_cusparselt_081 {
+    # cuSparseLt license: https://docs.nvidia.com/cuda/cusparselt/license.html
+    mkdir tmp_cusparselt && pushd tmp_cusparselt
+    wget -q https://developer.download.nvidia.com/compute/cusparselt/redist/libcusparse_lt/linux-x86_64/libcusparse_lt-linux-x86_64-0.8.1.1_cuda13-archive.tar.xz
+    tar xf libcusparse_lt-linux-x86_64-0.8.1.1_cuda13-archive.tar.xz
+    cp -a libcusparse_lt-linux-x86_64-0.8.1.1_cuda13-archive/include/* /usr/local/cuda/include/
+    cp -a libcusparse_lt-linux-x86_64-0.8.1.1_cuda13-archive/lib/* /usr/local/cuda/lib64/
+    popd
+    rm -rf tmp_cusparselt
+}
+
 function install_nccl_2162 {
     wget -q https://nccl2-deb.cdn.bcebos.com/nccl_2.16.2-1+cuda11.8_x86_64.txz --no-check-certificate --no-proxy
     tar xf nccl_2.16.2-1+cuda11.8_x86_64.txz
@@ -108,10 +119,21 @@ function install_nccl_2234 {
 
 function install_nccl_2297_cuda132 {
     yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
+    # `install_132` uses toolkit-only installation, so install the official
+    # forward-compat driver libraries to provide /usr/local/cuda-13.2/compat/libcuda.so.1.
     yum install -y \
+        cuda-compat-13-2 \
         libnccl-2.29.7-1+cuda13.2 \
         libnccl-devel-2.29.7-1+cuda13.2 \
         libnccl-static-2.29.7-1+cuda13.2
+}
+
+function install_nccl_2283 {
+    wget -q https://nccl2-deb.cdn.bcebos.com/nccl_2.28.3-1+cuda13.0_x86_64.txz --no-check-certificate --no-proxy
+    tar xf nccl_2.28.3-1+cuda13.0_x86_64.txz
+    cp -a nccl_2.28.3-1+cuda13.0_x86_64/include/* /usr/include/
+    cp -a nccl_2.28.3-1+cuda13.0_x86_64/lib/* /usr/lib64
+    rm -rf nccl_2.28.3-1+cuda13.0_x86_64 nccl_2.28.3-1+cuda13.0_x86_64.txz
 }
 
 function install_trt_8616 {
@@ -133,6 +155,13 @@ function install_trt_1016111 {
     tar -zxf TensorRT-10.16.1.11.Linux.x86_64-gnu.cuda-13.2.tar.gz -C /usr/local
     cp -rf /usr/local/TensorRT-10.16.1.11/include/* /usr/include/ && cp -rf /usr/local/TensorRT-10.16.1.11/lib/* /usr/lib/
     rm -f TensorRT-10.16.1.11.Linux.x86_64-gnu.cuda-13.2.tar.gz
+}
+
+function install_trt_101339 {
+    wget -q https://paddle-ci.gz.bcebos.com/TRT/TensorRT-10.13.3.9.Linux.x86_64-gnu.cuda-13.0.tar.gz --no-check-certificate --no-proxy
+    tar -zxf TensorRT-10.13.3.9.Linux.x86_64-gnu.cuda-13.0.tar.gz -C /usr/local
+    cp -rf /usr/local/TensorRT-10.13.3.9/include/* /usr/include/ && cp -rf /usr/local/TensorRT-10.13.3.9/lib/* /usr/lib/
+    rm -f TensorRT-10.13.3.9.Linux.x86_64-gnu.cuda-13.0.tar.gz
 }
 
 function install_118 {
@@ -283,9 +312,35 @@ function install_129 {
     install_trt_105018
     install_cusparselt_063
 
-    # install gdrcopy
-    cd /usr/local
-    wget -q https://paddle-ci.gz.bcebos.com/gdrcopy.tar && tar xf gdrcopy.tar && rm -rf gdrcopy.tar
+    ldconfig
+}
+
+function install_130 {
+    CUDNN_VERSION=9.13.0.50
+    NCCL_VERSION=2.28.3
+    TensorRT_VERSION=10.13
+    echo "Installing CUDA 13.0.1 and cuDNN ${CUDNN_VERSION} and NCCL ${NCCL_VERSION} and TensorRT ${TensorRT_VERSION} and cuSparseLt-0.8.1"
+    rm -rf /usr/local/cuda-13.0 /usr/local/cuda
+    # install CUDA 13.0.1 in the same container
+    wget -q https://developer.download.nvidia.com/compute/cuda/13.0.1/local_installers/cuda_13.0.1_580.82.07_linux.run
+    chmod +x cuda_13.0.1_580.82.07_linux.run
+    ./cuda_13.0.1_580.82.07_linux.run --toolkit --driver --silent --kernel-source-path=/usr/src/kernels/4.18.0-553.76.1.el8_10.x86_64
+    rm -f cuda_13.0.1_580.82.07_linux.run
+    rm -f /usr/local/cuda && ln -s /usr/local/cuda-13.0 /usr/local/cuda
+    rm -rf /usr/bin/nvidia-smi
+
+    # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
+    mkdir tmp_cudnn && cd tmp_cudnn
+    wget -q https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-${CUDNN_VERSION}_cuda13-archive.tar.xz -O cudnn-linux-x86_64-${CUDNN_VERSION}_cuda13-archive.tar.xz
+    tar xf cudnn-linux-x86_64-${CUDNN_VERSION}_cuda13-archive.tar.xz
+    cp -a cudnn-linux-x86_64-${CUDNN_VERSION}_cuda13-archive/include/* /usr/local/cuda/include/
+    cp -a cudnn-linux-x86_64-${CUDNN_VERSION}_cuda13-archive/lib/* /usr/local/cuda/lib64/
+    cd ..
+    rm -rf tmp_cudnn
+
+    install_nccl_2283
+    install_trt_101339
+    install_cusparselt_081
 
     ldconfig
 }
@@ -463,6 +518,8 @@ do
     12.6) install_126; prune_126
         ;;
     12.9) install_129
+        ;;
+    13.0) install_130
         ;;
     13.2) install_132
         ;;

--- a/tools/dockerfile/manylinux/common/install_gdrcopy.sh
+++ b/tools/dockerfile/manylinux/common/install_gdrcopy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# install gdrcopy
+cd /usr/local
+wget -q https://paddle-ci.gz.bcebos.com/gdrcopy.tar && tar xf gdrcopy.tar && rm -rf gdrcopy.tar
+ldconfig

--- a/tools/dockerfile/manylinux/common/install_gdrcopy.sh
+++ b/tools/dockerfile/manylinux/common/install_gdrcopy.sh
@@ -14,7 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 # install gdrcopy
 cd /usr/local
-wget -q https://paddle-ci.gz.bcebos.com/gdrcopy.tar && tar xf gdrcopy.tar && rm -rf gdrcopy.tar
+wget -q https://paddle-ci.gz.bcebos.com/gdrcopy.tar
+tar xf gdrcopy.tar
+rm -f gdrcopy.tar
 ldconfig

--- a/tools/dockerfile/manylinux/common/install_python.sh
+++ b/tools/dockerfile/manylinux/common/install_python.sh
@@ -49,7 +49,7 @@ function do_cpython_build {
     #    GIL='--disable-gil'
     #fi
 
-    LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH} CFLAGS="-Wformat" ./configure --prefix=${prefix} --enable-shared $unicode_flags > /dev/null
+    LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH} CFLAGS="-Wformat" LDFLAGS="-Wl,-rpath,${prefix}/lib" ./configure --prefix=${prefix} --enable-shared $unicode_flags > /dev/null
     LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH} make -j8 > /dev/null
     LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH} make install > /dev/null
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation 


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
* almalinux 添加 cuda 12.9、cuda 13.0、cuda 13.2（只验证了 cuda 13.2）
* almalinux 添加 gdrcopy
* almalinux 更新 cmake 到 3.31.0
* almalinux 修复 python 编译选项（原先的选项会找不到 .so）

相关链接：
* https://github.com/PaddlePaddle/Paddle/issues/77429

close: #75447
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否