### PR TITLE
[Bug Fix] Fix DataLoader to support non-Tensor data by returning bool from ReadNext

### DIFF
--- a/paddle/fluid/operators/reader/read_op.cc
+++ b/paddle/fluid/operators/reader/read_op.cc
@@ -111,8 +111,7 @@ class ReadOp : public framework::OperatorBase {
     phi::RecordEvent record_event(
         Type().c_str(), phi::TracerEventType::UserDefined, 1);
 
-    reader->ReadNext(&ins);
-    if (ins.empty()) {
+    if (!reader->ReadNext(&ins)) {
       VLOG(3) << "throw_eof_exp";
       PADDLE_THROW_EOF();
     }

--- a/paddle/fluid/pybind/reader_py.cc
+++ b/paddle/fluid/pybind/reader_py.cc
@@ -241,7 +241,10 @@ class MultiDeviceFeedReader {
     ResultList result;
     result.reserve(ret_.size());
     for (size_t i = 0; i < ret_.size(); ++i) {
-      if (ret_status_[i] != Status::kSuccess) continue;
+      if (ret_status_[i] != Status::kSuccess) {
+        if (!kKeepOrder) result.emplace_back();
+        continue;
+      }
       result.emplace_back(std::move(ret_[i]));
     }
     ReadAsync();

--- a/paddle/fluid/pybind/reader_py.cc
+++ b/paddle/fluid/pybind/reader_py.cc
@@ -199,6 +199,7 @@ class MultiDeviceFeedReader {
 
     futures_.resize(dst_places.size());
     ret_.resize(dst_places.size());
+    ret_status_.resize(dst_places.size());
     exceptions_.assign(dst_places.size(), nullptr);
     ReadAsync();
   }
@@ -209,8 +210,9 @@ class MultiDeviceFeedReader {
     CheckNextStatus();
     ResultDictList result;
     result.reserve(ret_.size());
-    for (auto &item : ret_) {
-      if (item.empty()) {
+    for (size_t i = 0; i < ret_.size(); ++i) {
+      auto &item = ret_[i];
+      if (ret_status_[i] != Status::kSuccess) {
         if (!kKeepOrder) result.emplace_back();
         continue;
       }
@@ -238,9 +240,9 @@ class MultiDeviceFeedReader {
     CheckNextStatus();
     ResultList result;
     result.reserve(ret_.size());
-    for (auto &item : ret_) {
-      if (kKeepOrder && item.empty()) continue;
-      result.emplace_back(std::move(item));
+    for (size_t i = 0; i < ret_.size(); ++i) {
+      if (ret_status_[i] != Status::kSuccess) continue;
+      result.emplace_back(std::move(ret_[i]));
     }
     ReadAsync();
     return result;
@@ -273,6 +275,7 @@ class MultiDeviceFeedReader {
     size_t success_num = 0;
     for (size_t i = 0; i < futures_.size(); ++i) {
       auto each_status = futures_[i].get();
+      ret_status_[i] = each_status;
       if (UNLIKELY(each_status != Status::kSuccess)) {
         if (UNLIKELY(each_status == Status::kException)) {
           PADDLE_ENFORCE_NOT_NULL(
@@ -307,8 +310,8 @@ class MultiDeviceFeedReader {
     for (size_t i = 0; i < readers_.size(); ++i) {
       futures_[i] = pool_->enqueue([this, i] {
         try {
-          readers_[i]->ReadNext(&ret_[i]);
-          return ret_[i].empty() ? Status::kEOF : Status::kSuccess;
+          bool success = readers_[i]->ReadNext(&ret_[i]);
+          return success ? Status::kSuccess : Status::kEOF;
         } catch (...) {
           exceptions_[i] = std::current_exception();
           return Status::kException;
@@ -353,6 +356,7 @@ class MultiDeviceFeedReader {
   std::vector<std::exception_ptr> exceptions_;
 
   std::vector<phi::TensorArray> ret_;
+  std::vector<Status> ret_status_;
   bool drop_last_;
   bool pin_memory_;
   int reader_buffer_size_;

--- a/paddle/phi/core/framework/reader.cc
+++ b/paddle/phi/core/framework/reader.cc
@@ -18,14 +18,14 @@
 
 namespace paddle::framework {
 
-void ReaderBase::ReadNext(phi::TensorArray *out) {
+bool ReaderBase::ReadNext(phi::TensorArray *out) {
   std::lock_guard<std::mutex> lock(mu_);
   PADDLE_ENFORCE_EQ(status_,
                     ReaderStatus::kRunning,
                     common::errors::Unavailable(
                         "The current reader has stopped running and cannot "
                         "continue to read the next batch of data."));
-  ReadNextImpl(out);
+  return ReadNextImpl(out);
 }
 
 void ReaderBase::InsertDecoratedReader(

--- a/paddle/phi/core/framework/reader.h
+++ b/paddle/phi/core/framework/reader.h
@@ -48,7 +48,7 @@ class ReaderBase {
             "and need_check_feed"));
   }
 
-  PADDLE_API virtual void ReadNext(phi::TensorArray* out);
+  PADDLE_API virtual bool ReadNext(phi::TensorArray* out);
 
   PADDLE_API virtual void Shutdown();
 
@@ -73,7 +73,7 @@ class ReaderBase {
   PADDLE_API virtual ~ReaderBase();
 
  protected:
-  virtual void ReadNextImpl(phi::TensorArray* out UNUSED) {}
+  virtual bool ReadNextImpl(phi::TensorArray* out UNUSED) { return false; }
 
   virtual void ShutdownImpl() {}
 
@@ -162,12 +162,12 @@ class ReaderHolder {
 
   const std::shared_ptr<ReaderBase>& Get() const { return reader_; }
 
-  void ReadNext(phi::TensorArray* out) {
+  bool ReadNext(phi::TensorArray* out) {
     PADDLE_ENFORCE_NOT_NULL(
         reader_,
         common::errors::InvalidArgument(
             "The underlying reader of ReaderHolder should not be null"));
-    reader_->ReadNext(out);
+    return reader_->ReadNext(out);
   }
 
   void ResetAll() {

--- a/paddle/phi/core/operators/reader/buffered_reader.cc
+++ b/paddle/phi/core/operators/reader/buffered_reader.cc
@@ -118,9 +118,9 @@ void BufferedReader::ReadTillBufferFullAsync() {
 void BufferedReader::ReadAsync(size_t i) {
   position_.emplace(thread_pool_.enqueue([this, i]() -> size_t {
     TensorVec &cpu = cpu_buffer_[i];
-    reader_->ReadNext(&cpu);
+    bool success = reader_->ReadNext(&cpu);
 
-    if (cpu.empty()) {
+    if (!success) {
       return -1UL;
     }
 
@@ -382,17 +382,17 @@ void BufferedReader::StartImpl() {
   ReadTillBufferFullAsync();
 }
 
-void BufferedReader::ReadNextImpl(phi::TensorArray *out) {
+bool BufferedReader::ReadNextImpl(phi::TensorArray *out) {
   if (position_.empty()) {
     out->clear();
-    return;
+    return false;
   }
   size_t i = position_.front().get();
   position_.pop();
 
   if (i == -1UL) {
-    ReadNextImpl(out);
-    return;
+    out->clear();
+    return false;
   }
 
   if (place_.GetType() == AllocationType::GPU) {  // NOLINT
@@ -412,6 +412,7 @@ void BufferedReader::ReadNextImpl(phi::TensorArray *out) {
     ReadAsync(prev_pos_);
   }
   prev_pos_ = i;
+  return true;
 }
 
 }  // namespace paddle::operators::reader

--- a/paddle/phi/core/operators/reader/buffered_reader.h
+++ b/paddle/phi/core/operators/reader/buffered_reader.h
@@ -60,7 +60,7 @@ class PADDLE_API BufferedReader : public framework::DecoratedReader {
  protected:
   void ShutdownImpl() override;
   void StartImpl() override;
-  void ReadNextImpl(phi::TensorArray* out) override;
+  bool ReadNextImpl(phi::TensorArray* out) override;
 
  private:
   ThreadPool thread_pool_;

--- a/paddle/phi/core/operators/reader/py_reader.cc
+++ b/paddle/phi/core/operators/reader/py_reader.cc
@@ -28,10 +28,11 @@ PyReader::PyReader(
   queue_ = queue;
 }
 
-void PyReader::ReadNext(phi::TensorArray* out) {
+bool PyReader::ReadNext(phi::TensorArray* out) {
   bool success = false;
   *out = queue_->Pop(&success);
   if (!success) out->clear();
+  return success;
 }
 
 PyReader::~PyReader() {  // NOLINT

--- a/paddle/phi/core/operators/reader/py_reader.h
+++ b/paddle/phi/core/operators/reader/py_reader.h
@@ -35,7 +35,7 @@ class PADDLE_API PyReader : public framework::FileReader {
       const std::vector<framework::proto::VarType::Type>& var_types,
       const std::vector<bool>& need_check_feed);
 
-  void ReadNext(phi::TensorArray* out) override;
+  bool ReadNext(phi::TensorArray* out) override;
 
   ~PyReader();
 

--- a/test/cpp/fluid/framework/reader_test.cc
+++ b/test/cpp/fluid/framework/reader_test.cc
@@ -24,7 +24,7 @@ class StubDecoratedReader : public paddle::framework::DecoratedReader {
   explicit StubDecoratedReader(const std::shared_ptr<ReaderBase> &reader)
       : DecoratedReader(reader) {}
 
-  void ReadNextImpl(phi::TensorArray *out) override {}
+  bool ReadNextImpl(phi::TensorArray *out) override { return false; }
 };
 
 class StubRootReader : public paddle::framework::ReaderBase {
@@ -34,7 +34,7 @@ class StubRootReader : public paddle::framework::ReaderBase {
       const std::vector<paddle::framework::proto::VarType::Type> &var_types,
       const std::vector<bool> &need_check_feed)
       : paddle::framework::ReaderBase(dims, var_types, need_check_feed) {}
-  void ReadNextImpl(phi::TensorArray *out) override {}
+  bool ReadNextImpl(phi::TensorArray *out) override { return false; }
 };
 
 TEST(READER, decorate_chain) {

--- a/test/legacy_test/test_dataloader_non_tensor.py
+++ b/test/legacy_test/test_dataloader_non_tensor.py
@@ -168,10 +168,11 @@ class TestNonTensorDataLoader(unittest.TestCase):
         batches = []
         for batch in loader:
             batches.append(batch)
-        self.assertEqual(len(batches), 2)
-        for batch in batches:
-            for item in batch:
-                self.assertEqual(item, "a")
+        # 20 samples / batch_size=10 / 2 places = 1 Python iteration
+        self.assertEqual(len(batches), 1)
+        self.assertEqual(len(batches[0]), 10)
+        for item in batches[0]:
+            self.assertEqual(item, "a")
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_dataloader_non_tensor.py
+++ b/test/legacy_test/test_dataloader_non_tensor.py
@@ -142,34 +142,36 @@ class TestNonTensorDataLoader(unittest.TestCase):
         item.empty() to filter EOF, so empty TensorArrays from non-Tensor
         batches are preserved in multi-place (kKeepOrder) mode.
         """
-        import numpy as np
-
         import paddle
 
-        class TensorDS(Dataset):
+        class NonTensorDS(Dataset):
             def __init__(self, n):
                 self.n = n
 
             def __getitem__(self, idx):
-                return np.array([idx], dtype="float32")
+                return "a"
 
             def __len__(self):
                 return self.n
 
-        # Multi-place with Tensor data — regression check
-        dataset = TensorDS(20)
+        # Multi-place with non-Tensor data — regression for ordered reader
+        dataset = NonTensorDS(20)
         loader = DataLoader(
             dataset,
             batch_size=10,
             shuffle=False,
             drop_last=True,
+            collate_fn=identity_collate,
             num_workers=0,
             places=[paddle.CPUPlace(), paddle.CPUPlace()],
         )
-        batch_count = 0
+        batches = []
         for batch in loader:
-            batch_count += 1
-        self.assertEqual(batch_count, 1)
+            batches.append(batch)
+        self.assertEqual(len(batches), 2)
+        for batch in batches:
+            for item in batch:
+                self.assertEqual(item, "a")
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_dataloader_non_tensor.py
+++ b/test/legacy_test/test_dataloader_non_tensor.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test that DataLoader supports returning non-Tensor data (Issue #77754)."""
+
+import unittest
+
+from paddle.io import DataLoader, Dataset
+
+
+class NonTensorDataset(Dataset):
+    """Dataset that returns only non-Tensor data (strings)."""
+
+    def __init__(self, num_samples):
+        self.num_samples = num_samples
+
+    def __getitem__(self, idx):
+        return "a"
+
+    def __len__(self):
+        return self.num_samples
+
+
+class MixedDataset(Dataset):
+    """Dataset that returns a mix of Tensor and non-Tensor data."""
+
+    def __init__(self, num_samples):
+        self.num_samples = num_samples
+
+    def __getitem__(self, idx):
+        import numpy as np
+
+        return "item_" + str(idx), np.array([idx], dtype="float32")
+
+    def __len__(self):
+        return self.num_samples
+
+
+def identity_collate(batch):
+    return batch
+
+
+class TestNonTensorDataLoader(unittest.TestCase):
+    """Test DataLoader with non-Tensor return values (Issue #77754)."""
+
+    def test_single_process_non_tensor(self):
+        """Single-process DataLoader should iterate all batches for non-Tensor data."""
+        dataset = NonTensorDataset(20)
+        loader = DataLoader(
+            dataset,
+            batch_size=10,
+            shuffle=True,
+            drop_last=True,
+            collate_fn=identity_collate,
+            num_workers=0,
+        )
+        batches = []
+        for batch in loader:
+            batches.append(batch)
+
+        # With drop_last=True, 20 samples / batch_size=10 = 2 full batches
+        self.assertEqual(len(batches), 2)
+        for batch in batches:
+            self.assertEqual(len(batch), 10)
+            for item in batch:
+                self.assertEqual(item, "a")
+
+    def test_single_process_non_tensor_no_drop_last(self):
+        """Single-process DataLoader without drop_last for non-Tensor data."""
+        dataset = NonTensorDataset(25)
+        loader = DataLoader(
+            dataset,
+            batch_size=10,
+            shuffle=False,
+            drop_last=False,
+            collate_fn=identity_collate,
+            num_workers=0,
+        )
+        batches = []
+        for batch in loader:
+            batches.append(batch)
+
+        # 25 samples / batch_size=10 = 2 full + 1 partial (5 items)
+        self.assertEqual(len(batches), 3)
+        self.assertEqual(len(batches[0]), 10)
+        self.assertEqual(len(batches[1]), 10)
+        self.assertEqual(len(batches[2]), 5)
+
+    def test_multi_process_non_tensor(self):
+        """Multi-process DataLoader should iterate all batches for non-Tensor data."""
+        dataset = NonTensorDataset(20)
+        loader = DataLoader(
+            dataset,
+            batch_size=10,
+            shuffle=True,
+            drop_last=True,
+            collate_fn=identity_collate,
+            num_workers=2,
+        )
+        batches = []
+        for batch in loader:
+            batches.append(batch)
+
+        self.assertEqual(len(batches), 2)
+        for batch in batches:
+            self.assertEqual(len(batch), 10)
+
+    def test_mixed_tensor_and_non_tensor(self):
+        """DataLoader with mixed Tensor and non-Tensor data should work correctly."""
+        dataset = MixedDataset(20)
+        loader = DataLoader(
+            dataset,
+            batch_size=10,
+            shuffle=False,
+            drop_last=True,
+            collate_fn=identity_collate,
+            num_workers=0,
+        )
+        batches = []
+        for batch in loader:
+            batches.append(batch)
+
+        self.assertEqual(len(batches), 2)
+        for batch in batches:
+            self.assertEqual(len(batch), 10)
+
+    def test_multi_place_non_tensor(self):
+        """Multi-place DataLoader handles all-non-Tensor batches.
+
+        Verifies that ReadNextList() uses per-reader status instead of
+        item.empty() to filter EOF, so empty TensorArrays from non-Tensor
+        batches are preserved in multi-place (kKeepOrder) mode.
+        """
+        import numpy as np
+
+        import paddle
+
+        class TensorDS(Dataset):
+            def __init__(self, n):
+                self.n = n
+
+            def __getitem__(self, idx):
+                return np.array([idx], dtype="float32")
+
+            def __len__(self):
+                return self.n
+
+        # Multi-place with Tensor data — regression check
+        dataset = TensorDS(20)
+        loader = DataLoader(
+            dataset,
+            batch_size=10,
+            shuffle=False,
+            drop_last=True,
+            num_workers=0,
+            places=[paddle.CPUPlace(), paddle.CPUPlace()],
+        )
+        batch_count = 0
+        for batch in loader:
+            batch_count += 1
+        self.assertEqual(batch_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description

Fixes #77754.

Previously, `DataLoader` would silently stop iteration when a batch contained no `Tensor`s (e.g., all strings). The root cause was that `PyReader::ReadNext` lost the success flag from `DenseTensorBlockingQueue::Pop()`, and callers used `TensorArray::empty()` to detect EOF — conflating "empty batch" with "queue closed".

This PR changes `ReadNext` / `ReadNextImpl` to return `bool` (true = data available, false = EOF) across the reader hierarchy:
- `ReaderBase`, `PyReader`, `BufferedReader`, `ReaderHolder`
- `read_op.cc` and `reader_py.cc` now check the return value correctly.

### 是否引起精度变化
否