### PR TITLE
[CI] Increase Fleet multi-card test timeout

### DIFF
--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -694,7 +694,7 @@ jobs:
           '
 
       - name: Multi-card test
-        timeout-minutes: 30
+        timeout-minutes: 40
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -ce '
           export PYTHONPATH=$(pwd)


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description
调整 CI-H / Fleet Unit test (multi-card) 中 `Multi-card test` step 的 `timeout-minutes`：30 -> 40。

背景：参考 #79181 的 pull_request CI，该 job 已多次 rerun，其中 `Multi-card test` step 在 30 分钟限制处 timeout。此 PR 仅放宽该 step 的 timeout，不调整其它 CI 配置。

验证：
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/H-Coverage.yml'); puts 'Ruby YAML parse OK'"`
- `git diff --check`
- grep 确认 `fleet-multi-card_test` job 中 `Multi-card test` 为 40 分钟，`Download paddle.tar.gz and install paddle whl` 仍为 30 分钟

### 是否引起精度变化
否
