### PR TITLE
[CodeStyle][Typos] Bump `typos` to `v1.47.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
             paddle/cinn/utils/registry.h
           )$
   - repo: https://github.com/PFCCLab/typos-pre-commit-mirror.git
-    rev: v1.46.2
+    rev: v1.47.0
     hooks:
       - id: typos
         args: [--force-exclude]


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Devs
### Description
Bump the `typos` pre-commit hook from `v1.46.2` to `v1.47.0`.

Validation:
- `pre-commit run typos --all-files`
- `pre-commit validate-config .pre-commit-config.yaml`
- `pre-commit run yamlfmt --files .pre-commit-config.yaml`
- `git diff --check`

@SigureMo Please review this PR when you have time. Thanks!

### 是否引起精度变化
否
