### PR TITLE
[Test] add multinomial std debug logs

### DIFF
--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -109,7 +109,7 @@ jobs:
           WITH_FLAGCX: "ON"
           LITE_GIT_TAG: develop
           WITH_UNITY_BUILD: "ON"
-          PY_VERSION: 3.9
+          PY_VERSION: "3.12"
           WITH_SHARED_PHI: "ON"
           WITH_CINN: "ON"
           INFERENCE_DEMO_INSTALL_DIR: /root/.cache/coverage
@@ -299,7 +299,7 @@ jobs:
           PADDLE_VERSION: 0.0.0
           WITH_DISTRIBUTE: "ON"
           WITH_UNITY_BUILD: "ON"
-          PY_VERSION: 3.9
+          PY_VERSION: "3.12"
           WITH_SHARED_PHI: "ON"
           WITH_CINN: "ON"
           INFERENCE_DEMO_INSTALL_DIR: /root/.cache/coverage

--- a/ci/coverage_test.sh
+++ b/ci/coverage_test.sh
@@ -52,8 +52,9 @@ unset GREP_OPTIONS
 source $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/utils.sh
 init
 
-ln -sf $(which python3.9) /usr/local/bin/python
-ln -sf $(which pip3.9) /usr/local/bin/pip
+PY_VERSION=${PY_VERSION:-3.12}
+ln -sf $(which python${PY_VERSION}) /usr/local/bin/python
+ln -sf $(which pip${PY_VERSION}) /usr/local/bin/pip
 
 echo "::group::Install zstd"
 apt install zstd -y
@@ -65,6 +66,8 @@ echo "::group::Install dependencies"
 
 pip install -r "${work_dir}/python/requirements.txt"
 pip install -r "${work_dir}/python/unittest_py/requirements.txt"
+pip install --force-reinstall --no-cache-dir numpy==2.4.6
+python -c "import numpy as np; print('coverage numpy version:', np.__version__, np.__file__)"
 pip install PyGithub
 
 echo "::endgroup::"

--- a/test/legacy_test/test_multinomial_op.py
+++ b/test/legacy_test/test_multinomial_op.py
@@ -53,6 +53,61 @@ def sample_output_two_dimension(out, shape):
     return sample_prob
 
 
+def log_multinomial_std_debug(case_name, y, expected_std):
+    actual_std = np.std(y)
+    actual_std_float = float(actual_std)
+    expected_std_float = float(expected_std)
+    std_abs_diff = actual_std_float - expected_std_float
+    std_ulp = float(np.spacing(expected_std_float))
+    std_ulp_diff = abs(std_abs_diff) / std_ulp if std_ulp != 0 else float("inf")
+
+    cpu_features = []
+    try:
+        np_core = getattr(np, "_core", None)
+        if np_core is None:
+            np_core = np.core
+        features = np_core._multiarray_umath.__cpu_features__
+        cpu_features = sorted(
+            name for name, enabled in features.items() if enabled
+        )
+    except Exception as exc:
+        cpu_features = [f"unavailable: {exc}"]
+
+    print(f"[multinomial_std_debug] case={case_name}")
+    print(
+        "[multinomial_std_debug] "
+        f"python_version={sys.version.split()[0]} "
+        f"numpy_version={np.__version__} numpy_file={np.__file__} "
+        f"paddle_version={paddle.__version__}"
+    )
+    print(
+        "[multinomial_std_debug] "
+        f"device={paddle.device.get_device()} "
+        f"cuda_device_name={paddle.device.cuda.get_device_name()}"
+    )
+    print(
+        "[multinomial_std_debug] "
+        f"y.dtype={y.dtype} y.shape={y.shape} y.strides={y.strides} "
+        f"c_contiguous={y.flags.c_contiguous}"
+    )
+    print(
+        "[multinomial_std_debug] "
+        f"sum={np.sum(y)!r} mean={np.mean(y)!r} var={np.var(y)!r} "
+        f"std={actual_std!r} expected_std={expected_std!r}"
+    )
+    print(
+        "[multinomial_std_debug] "
+        f"std_abs_diff={std_abs_diff:.17g} "
+        f"std_ulp={std_ulp:.17g} std_ulp_diff={std_ulp_diff:.17g}"
+    )
+    print(
+        "[multinomial_std_debug] "
+        f"min={np.min(y)!r} max={np.max(y)!r} "
+        f"numpy_cpu_features={cpu_features}"
+    )
+    return actual_std
+
+
 class TestMultinomialOp(OpTest):
     def setUp(self):
         paddle.enable_static()
@@ -533,7 +588,14 @@ class TestMultinomialAlias(unittest.TestCase):
         ).numpy()
         self.assertEqual(np.sum(y), 102371362581)
         self.assertEqual(np.mean(y), 4998.60168852539)
-        self.assertEqual(np.std(y), 2886.316308500771)
+        self.assertEqual(
+            log_multinomial_std_debug(
+                "TestMultinomialAlias.test_alias_torch.replacement_true_1",
+                y,
+                2886.316308500771,
+            ),
+            2886.316308500771,
+        )
         expect = [7630, 8235, 8445, 3275, 5580, 4591, 1331, 342, 1662, 7156]
         np.testing.assert_array_equal(y[100, 0:10], expect)
 
@@ -613,14 +675,28 @@ class TestRandomValue(unittest.TestCase):
         y = paddle.multinomial(x, 20000, replacement=True).numpy()
         self.assertEqual(np.sum(y), 102371362581)
         self.assertEqual(np.mean(y), 4998.60168852539)
-        self.assertEqual(np.std(y), 2886.316308500771)
+        self.assertEqual(
+            log_multinomial_std_debug(
+                "TestRandomValue.test_fixed_random_number.replacement_true_1",
+                y,
+                2886.316308500771,
+            ),
+            2886.316308500771,
+        )
         expect = [7630, 8235, 8445, 3275, 5580, 4591, 1331, 342, 1662, 7156]
         np.testing.assert_array_equal(y[100, 0:10], expect)
 
         y = paddle.multinomial(x, 20000, replacement=True).numpy()
         self.assertEqual(np.sum(y), 102400672117)
         self.assertEqual(np.mean(y), 5000.032818212891)
-        self.assertEqual(np.std(y), 2886.913426124017)
+        self.assertEqual(
+            log_multinomial_std_debug(
+                "TestRandomValue.test_fixed_random_number.replacement_true_2",
+                y,
+                2886.913426124017,
+            ),
+            2886.913426124017,
+        )
         expect = [4159, 7849, 9305, 5759, 4422, 122, 345, 2897, 5200, 5911]
         np.testing.assert_array_equal(y[100, 0:10], expect)
 


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Devs

### Description
该 PR 将 `test_multinomial_op` 中 `np.std(y)` 的调试观测点拆到独立分支，用于在 CI 单测机上直接查看当前环境下的标准差计算结果。

主要输出内容包括 Python / NumPy / Paddle 版本、NumPy 加载路径、CUDA device、输出数组 dtype/shape/strides、sum/mean/var/std、std 与期望值的差值、ULP 差异以及 NumPy CPU feature dispatch 信息。

为复现 Python 3.12 环境下的 NumPy 行为，本 PR 临时将 Coverage build/test 的 `PY_VERSION` 切到 3.12，并在 Coverage test 阶段强制重装 `numpy==2.4.6`，同时打印实际加载的 NumPy 版本和路径。

原有严格相等断言保持不变，便于失败时在测试日志中暴露当前实际值。

### 是否引起精度变化
否。仅为单测诊断日志和临时 CI 诊断配置，不改变算子实现或计算逻辑。