### PR TITLE
[Sparse] Add batched CSR to COO conversion support for HIP/ROCm

### DIFF
--- a/paddle/phi/kernels/sparse/gpu/sparse_utils_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/sparse_utils_kernel.cu
@@ -359,9 +359,13 @@ void CsrToCooGPUKernel(const GPUContext& dev_ctx,
 
 #ifdef PADDLE_WITH_HIP
   DenseTensor indices = Empty<int>(dev_ctx, {sparse_dim, non_zero_num});
+  DenseTensor offsets = Empty<int>(dev_ctx, {batches});
   int* coo_indices = indices.data<int>();
-  int* coo_rows_data = coo_indices;
+  int* batch_ptr = x_dims.size() == 2 ? nullptr : coo_indices;
+  int* coo_rows_data =
+      x_dims.size() == 2 ? coo_indices : batch_ptr + non_zero_num;
   int* coo_cols_data = coo_rows_data + non_zero_num;
+  int* offsets_ptr = batches == 1 ? nullptr : offsets.data<int>();
 #else
   DenseTensor indices = Empty<IntT>(dev_ctx, {sparse_dim, non_zero_num});
   DenseTensor offsets = Empty<IntT>(dev_ctx, {batches});
@@ -377,9 +381,14 @@ void CsrToCooGPUKernel(const GPUContext& dev_ctx,
 
   if (batches > 1) {
 #ifdef PADDLE_WITH_HIP
-    PADDLE_THROW(common::errors::Unimplemented(
-        "'rocsparse_csr2coo' only supports batches "
-        "with a value of 1 currently."));
+    auto config = backends::gpu::GetGpuLaunchConfig1D(dev_ctx, batches, 1);
+    GetBatchSizes<int><<<config.block_per_grid.x, config.thread_per_block.x>>>(
+        csr_crows_data, rows, batches, offsets_ptr);
+
+    thrust::exclusive_scan(thrust::hip::par.on(dev_ctx.stream()),
+                           offsets_ptr,
+                           offsets_ptr + batches,
+                           offsets_ptr);
 #else
     auto config = backends::gpu::GetGpuLaunchConfig1D(dev_ctx, batches, 1);
     GetBatchSizes<IntT><<<config.block_per_grid.x, config.thread_per_block.x>>>(
@@ -393,14 +402,11 @@ void CsrToCooGPUKernel(const GPUContext& dev_ctx,
   }
 
 #ifdef PADDLE_WITH_HIP
-  dev_ctx.CusparseCall([&](rocsparse_handle handle) {
-    phi::dynload::rocsparse_csr2coo(handle,
-                                    csr_crows_data,
-                                    non_zero_num,
-                                    rows,
-                                    coo_rows_data,
-                                    rocsparse_index_base_zero);
-  });
+  auto config = backends::gpu::GetGpuLaunchConfig1D(dev_ctx, rows, 1);
+  config.block_per_grid.y = batches;
+  ConvertCsrCrowsToCooRows<int>
+      <<<config.block_per_grid, config.thread_per_block.x>>>(
+          csr_crows_data, offsets_ptr, coo_rows_data, batch_ptr, rows);
 #else
   auto config = backends::gpu::GetGpuLaunchConfig1D(dev_ctx, rows, 1);
   config.block_per_grid.y = batches;


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Improvements

### Description
在 ROCm/HIP 环境下，`rocsparse_csr2coo` 之前只支持 batch 值为 1 的情况。当 batch 值大于 1 时，会抛出 `NotImplementedError` 异常，导致多个稀疏算子（`sparse_mask_as_op`、`sparse_reshape_op`、`sparse_transpose_op`、`sparse_slice_op`、`sparse_sum_op`、`sparse_utils_op`）在 3D 输入时测试失败。

本次修改通过自行实现 batched CSR 转 COO 的逻辑来替代对 `rocsparse_csr2coo` 的调用：先计算各 batch 的 row 偏移量，再通过 kernel 将 CSR 格式的 crows 数据转换为 COO 格式的 row 索引，从而支持任意 batch 数量的 CSR 到 COO 转换。

### 是否引起精度变化
否
