### PR TITLE
[Execute Infrastructure] Fix HasKernel to return false instead of throwing when kernel not found

### DIFF
--- a/paddle/phi/core/kernel_factory.cc
+++ b/paddle/phi/core/kernel_factory.cc
@@ -167,10 +167,9 @@ KernelKeyMap KernelFactory::SelectKernelMap(
 bool KernelFactory::HasKernel(const std::string& kernel_name,
                               const KernelKey& kernel_key) const {
   auto iter = kernels_.find(kernel_name);
-  PADDLE_ENFORCE_NE(iter,
-                    kernels_.end(),
-                    common::errors::NotFound(
-                        "The kernel `%s` is not registered.", kernel_name));
+  if (iter == kernels_.end()) {
+    return false;
+  }
 
   auto kernel_iter = iter->second.find(kernel_key);
   if (kernel_iter == iter->second.end() &&


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
修复 `KernelFactory::HasKernel` 方法在查询未注册的 kernel 名称时抛出 `NotFound` 异常的问题。

`HasKernel` 的所有调用者均将其作为布尔谓词使用，但原有实现在 `kernel_name` 未注册时通过 `PADDLE_ENFORCE_NE` 抛出异常，导致 fused_conv2d_add_act 等 fusion kernel 在执行 conv2d_add_fuse_pass / conv2d_add_act_fuse_pass 等 PIR pass 时因 kernel 未注册而直接崩溃。

本次修改将该行为改为返回 `false`，与 `SelectKernel` 的语义保持一致。

### 是否引起精度变化
否
