### PR TITLE
[ROCm] Handle degenerate spatial size in instance norm kernel for MIOpen compatibility

### DIFF
--- a/paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu
@@ -397,6 +397,32 @@ void InstanceNormGradKernel(const Context &dev_ctx,
   } else {
     set_constant(dev_ctx, &scale_tmp, static_cast<AccT>(1));
   }
+
+  // MIOpen/cuDNN batch norm backward also requires N*spatial_size > 1.
+  // When H*W*D <= 1, gradients simplify: d_x=0, d_scale=0,
+  // d_bias[c]=sum_n d_y[n,c] (sum over N for each channel).
+  if (H * W * D <= 1) {
+    {
+      funcs::SetConstant<GPUContext, T> set_zero_t;
+      set_zero_t(dev_ctx, d_x, static_cast<T>(0));
+    }
+    if (d_scale) {
+      dev_ctx.template Alloc<AccT>(d_scale);
+      set_constant(dev_ctx, d_scale, static_cast<AccT>(0));
+    }
+    if (d_bias) {
+      dev_ctx.template Alloc<AccT>(d_bias);
+      DenseTensor db_tmp;
+      db_tmp.Resize({NxC});
+      dev_ctx.template Alloc<AccT>(&db_tmp);
+      convert_data_type<T, AccT><<<grid, block, 0, dev_ctx.stream()>>>(
+          d_y.data<T>(), db_tmp.data<AccT>(), NxC);
+      add_param<AccT, block, false><<<grid1, block, 0, dev_ctx.stream()>>>(
+          db_tmp.data<AccT>(), d_bias->data<AccT>(), N, C);
+    }
+    return;
+  }
+
   std::vector<int> dims;
   std::vector<int> strides;
   dims = {1, NxC, H, W, D};

--- a/paddle/phi/kernels/gpu/instance_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/instance_norm_kernel.cu
@@ -182,6 +182,33 @@ void InstanceNormKernel(const Context &dev_ctx,
       saved_variance ? saved_variance->data<BatchNormParamType<T>>()
                      : saved_variance_tmp.data<BatchNormParamType<T>>();
 
+  // MIOpen/cuDNN batch norm requires N*spatial_size > 1.  Instance norm
+  // reshapes to {1, N*C, H, W, D} so the effective N is 1.  When H*W*D <= 1
+  // the library call fails.  Handle the degenerate case: output = bias
+  // (x-mean=0, variance=0), saved_mean=0, saved_variance=1/sqrt(eps).
+  if (H * W * D <= 1) {
+    convert_data_type<AccT, T><<<grid, block, 0, dev_ctx.stream()>>>(
+        bias_tmp.template data<AccT>(), y->template data<T>(), NxC);
+    if (saved_variance) {
+      functor(dev_ctx,
+              saved_variance,
+              static_cast<BatchNormParamType<T>>(
+                  1.0 / std::sqrt(static_cast<double>(epsilon))));
+    }
+#ifdef PADDLE_WITH_HIP
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        dynload::miopenDestroyTensorDescriptor(data_desc_));
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        dynload::miopenDestroyTensorDescriptor(in_param_desc_));
+#else
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        dynload::cudnnDestroyTensorDescriptor(data_desc_));
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        dynload::cudnnDestroyTensorDescriptor(in_param_desc_));
+#endif
+    return;
+  }
+
 #ifdef PADDLE_WITH_HIP
   PADDLE_ENFORCE_GPU_SUCCESS(dynload::miopenBatchNormalizationForwardTraining(
       handle,

--- a/paddle/phi/kernels/gpu/instance_norm_utils.h
+++ b/paddle/phi/kernels/gpu/instance_norm_utils.h
@@ -40,6 +40,13 @@ static __global__ void repeat_param(const T *input,
   }
 }
 
+template <typename InT, typename OutT>
+static __global__ void convert_data_type(const InT *input,
+                                         OutT *output,
+                                         const int size) {
+  CUDA_KERNEL_LOOP(i, size) { output[i] = static_cast<OutT>(input[i]); }
+}
+
 template <typename T, int BlockDim, bool AVG>
 static __global__ void add_param(const T *input,
                                  T *output,


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
在 ROCm 平台下，MIOpen 的 miopenBatchNormalizationForwardTraining 要求 N*spatial_size > 1。Instance norm 在实现中将输入 {N, C, H, W} reshape 为 {1, N*C, H, W, D}，当 H*W*D <= 1 时 MIOpen 调用会失败并返回 MIOPEN_STATUS_BAD_PARAM，导致 test_eager_trace_op 和 test_instance_norm_op_v2 测试报错。

本 PR 在 H*W*D <= 1 的退化情况下跳过 MIOpen/cuDNN 调用，直接手动处理：
- 前向：输出直接设置为 bias（x-mean=0, variance=0），saved_mean=0，saved_variance=1/sqrt(eps)
- 反向：梯度简化为 d_x=0, d_scale=0, d_bias 在 N 维度求和

涉及文件：
- paddle/phi/kernels/gpu/instance_norm_kernel.cu
- paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu
- paddle/phi/kernels/gpu/instance_norm_utils.h

### 是否引起精度变化
否
