### PR TITLE
[Security] Harden CIFAR and Flowers dataset loading

### DIFF
--- a/python/paddle/dataset/cifar.py
+++ b/python/paddle/dataset/cifar.py
@@ -44,7 +44,7 @@ CIFAR100_URL = URL_PREFIX + 'cifar-100-python.tar.gz'
 CIFAR100_MD5 = 'eb9058c3a382ffc7106e4002c42a8d85'
 
 
-def reader_creator(filename, sub_name, cycle=False):
+def reader_creator(filename, sub_name, cycle=False, md5sum=None):
     def read_batch(batch):
         data = batch[b'data']
         labels = batch.get(b'labels', batch.get(b'fine_labels', None))
@@ -53,6 +53,13 @@ def reader_creator(filename, sub_name, cycle=False):
             yield (sample / 255.0).astype(numpy.float32), int(label)
 
     def reader():
+        if md5sum is not None:
+            file_md5 = paddle.dataset.common.md5file(filename)
+            if file_md5 != md5sum:
+                raise ValueError(
+                    "Loading unverified CIFAR pickle archive disabled. "
+                    f"Please use the official MD5 {md5sum}."
+                )
         while True:
             with tarfile.open(filename, mode='r') as f:
                 names = (
@@ -90,6 +97,7 @@ def train100():
     return reader_creator(
         paddle.dataset.common.download(CIFAR100_URL, 'cifar', CIFAR100_MD5),
         'train',
+        md5sum=CIFAR100_MD5,
     )
 
 
@@ -112,6 +120,7 @@ def test100():
     return reader_creator(
         paddle.dataset.common.download(CIFAR100_URL, 'cifar', CIFAR100_MD5),
         'test',
+        md5sum=CIFAR100_MD5,
     )
 
 
@@ -137,6 +146,7 @@ def train10(cycle=False):
         paddle.dataset.common.download(CIFAR10_URL, 'cifar', CIFAR10_MD5),
         'data_batch',
         cycle=cycle,
+        md5sum=CIFAR10_MD5,
     )
 
 
@@ -162,6 +172,7 @@ def test10(cycle=False):
         paddle.dataset.common.download(CIFAR10_URL, 'cifar', CIFAR10_MD5),
         'test_batch',
         cycle=cycle,
+        md5sum=CIFAR10_MD5,
     )
 
 

--- a/python/paddle/dataset/cifar.py
+++ b/python/paddle/dataset/cifar.py
@@ -27,6 +27,7 @@ images per class.
 
 """
 
+import os
 import pickle
 import tarfile
 
@@ -52,14 +53,21 @@ def reader_creator(filename, sub_name, cycle=False, md5sum=None):
         for sample, label in zip(data, labels):
             yield (sample / 255.0).astype(numpy.float32), int(label)
 
+    verified_stat = None
+
     def reader():
+        nonlocal verified_stat
         if md5sum is not None:
-            file_md5 = paddle.dataset.common.md5file(filename)
-            if file_md5 != md5sum:
-                raise ValueError(
-                    "Loading unverified CIFAR pickle archive disabled. "
-                    f"Please use the official MD5 {md5sum}."
-                )
+            stat = os.stat(filename)
+            current_stat = (stat.st_mtime_ns, stat.st_size)
+            if verified_stat != current_stat:
+                file_md5 = paddle.dataset.common.md5file(filename)
+                if file_md5 != md5sum:
+                    raise ValueError(
+                        "Loading unverified CIFAR pickle archive disabled. "
+                        f"Please use the official MD5 {md5sum}."
+                    )
+                verified_stat = current_stat
         while True:
             with tarfile.open(filename, mode='r') as f:
                 names = (

--- a/python/paddle/utils/download.py
+++ b/python/paddle/utils/download.py
@@ -308,15 +308,20 @@ def _uncompress_file_zip(filepath):
         return uncompressed_path
 
 
-def _safe_extract_tar(tar, path, members=None):
+def _safe_extract_tar(tar, path, members=None, on_unsafe='skip'):
     """
     Safely extract tar files to prevent path traversal attacks.
 
     Security measures:
     1. Verify resolved paths are within target directory
-    2. Skip symlinks, hardlinks and other special files
+    2. Skip or reject symlinks, hardlinks and other special files
     3. Only extract regular files and directories
     """
+    if on_unsafe not in ('skip', 'raise'):
+        raise ValueError(
+            f"on_unsafe must be one of 'skip' or 'raise', but got {on_unsafe!r}"
+        )
+
     members_to_check = members if members is not None else tar.getmembers()
     extract_members = []
 
@@ -326,8 +331,13 @@ def _safe_extract_tar(tar, path, members=None):
                 f"Attempted path traversal in tar file: {member.name}"
             )
 
-        # Skip symlinks, hardlinks, and other special files to prevent symlink attacks
+        # Skip or reject symlinks, hardlinks, and other special files to prevent symlink attacks
         if member.issym():
+            if on_unsafe == 'raise':
+                raise ValueError(
+                    "Unsafe tar member rejected for security: "
+                    f"{member.name} (symbolic link)"
+                )
             warnings.warn(
                 f"Skipping symbolic link in tar for security: {member.name}",
                 category=UserWarning,
@@ -335,6 +345,11 @@ def _safe_extract_tar(tar, path, members=None):
             )
             continue
         elif member.islnk():
+            if on_unsafe == 'raise':
+                raise ValueError(
+                    "Unsafe tar member rejected for security: "
+                    f"{member.name} (hard link)"
+                )
             warnings.warn(
                 f"Skipping hard link in tar for security: {member.name}",
                 category=UserWarning,
@@ -342,6 +357,11 @@ def _safe_extract_tar(tar, path, members=None):
             )
             continue
         elif not (member.isfile() or member.isdir()):
+            if on_unsafe == 'raise':
+                raise ValueError(
+                    "Unsafe tar member rejected for security: "
+                    f"{member.name} (special file)"
+                )
             warnings.warn(
                 f"Skipping special file in tar for security: {member.name}",
                 category=UserWarning,

--- a/python/paddle/vision/datasets/cifar.py
+++ b/python/paddle/vision/datasets/cifar.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import os
 import pickle
 import tarfile
 from typing import TYPE_CHECKING, Any, Literal
@@ -22,7 +23,7 @@ import numpy.typing as npt
 from PIL import Image
 
 import paddle
-from paddle.dataset.common import _check_exists_and_download
+from paddle.dataset.common import _check_exists_and_download, md5file
 from paddle.io import Dataset
 
 if TYPE_CHECKING:
@@ -153,6 +154,15 @@ class Cifar10(Dataset[tuple["_ImageDataType", "npt.NDArray[Any]"]]):
             )
             self.data_file = _check_exists_and_download(
                 data_file, self.data_url, self.data_md5, 'cifar', download
+            )
+        elif not os.path.exists(self.data_file):
+            raise ValueError(
+                f"Local CIFAR archive does not exist: {self.data_file}."
+            )
+        elif md5file(self.data_file) != self.data_md5:
+            raise ValueError(
+                "Loading unverified local CIFAR pickle archive is disabled. "
+                f"Please use the official archive with MD5 {self.data_md5}."
             )
 
         self.transform = transform

--- a/python/paddle/vision/datasets/cifar.py
+++ b/python/paddle/vision/datasets/cifar.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import os
 import pickle
 import tarfile
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
@@ -50,6 +51,22 @@ MODE_FLAG_MAP = {
     'train100': 'train',
     'test100': 'test',
 }
+
+
+@lru_cache(maxsize=8)
+def _cached_md5file(path, _mtime_ns, _size):
+    return md5file(path)
+
+
+def _check_local_cifar_md5(path, expected_md5):
+    path = os.path.abspath(path)
+    stat = os.stat(path)
+    file_md5 = _cached_md5file(path, stat.st_mtime_ns, stat.st_size)
+    if file_md5 != expected_md5:
+        raise ValueError(
+            "Loading unverified local CIFAR pickle archive is disabled. "
+            f"Please use the official archive with MD5 {expected_md5}."
+        )
 
 
 class Cifar10(Dataset[tuple["_ImageDataType", "npt.NDArray[Any]"]]):
@@ -159,11 +176,8 @@ class Cifar10(Dataset[tuple["_ImageDataType", "npt.NDArray[Any]"]]):
             raise ValueError(
                 f"Local CIFAR archive does not exist: {self.data_file}."
             )
-        elif md5file(self.data_file) != self.data_md5:
-            raise ValueError(
-                "Loading unverified local CIFAR pickle archive is disabled. "
-                f"Please use the official archive with MD5 {self.data_md5}."
-            )
+        else:
+            _check_local_cifar_md5(self.data_file, self.data_md5)
 
         self.transform = transform
 

--- a/python/paddle/vision/datasets/flowers.py
+++ b/python/paddle/vision/datasets/flowers.py
@@ -51,6 +51,23 @@ SETID_MD5 = 'a5357ecc9cb78c4bef273ce3793fc85c'
 MODE_FLAG_MAP = {'train': 'tstid', 'test': 'trnid', 'valid': 'valid'}
 
 
+def _safe_extract_tar(data_tar, path):
+    abs_path = os.path.abspath(path)
+    members = data_tar.getmembers()
+    for member in members:
+        if member.name in ('', '.'):
+            raise RuntimeError(f"Unsafe tar member path: {member.name}")
+        member_path = os.path.abspath(os.path.join(path, member.name))
+        try:
+            if os.path.commonpath([abs_path, member_path]) != abs_path:
+                raise RuntimeError(f"Unsafe tar member path: {member.name}")
+        except ValueError as e:
+            raise RuntimeError(f"Unsafe tar member path: {member.name}") from e
+        if not (member.isfile() or member.isdir()):
+            raise RuntimeError(f"Unsafe tar member type: {member.name}")
+    data_tar.extractall(path, members=members)
+
+
 class Flowers(Dataset[tuple["_ImageDataType", "npt.NDArray[np.int64]"]]):
     """
     Implementation of `Flowers102 <https://www.robots.ox.ac.uk/~vgg/data/flowers/>`_
@@ -183,7 +200,7 @@ class Flowers(Dataset[tuple["_ImageDataType", "npt.NDArray[np.int64]"]]):
             os.mkdir(self.data_path)
         jpg_path = os.path.join(self.data_path, "jpg")
         if not os.path.exists(jpg_path):
-            data_tar.extractall(self.data_path)
+            _safe_extract_tar(data_tar, self.data_path)
 
         scio = try_import('scipy.io')
         self.labels = scio.loadmat(label_file)['labels'][0]

--- a/python/paddle/vision/datasets/flowers.py
+++ b/python/paddle/vision/datasets/flowers.py
@@ -35,6 +35,7 @@ import paddle
 from paddle.dataset.common import _check_exists_and_download
 from paddle.io import Dataset
 from paddle.utils import try_import
+from paddle.utils.download import _safe_extract_tar
 
 __all__ = []
 
@@ -49,23 +50,6 @@ SETID_MD5 = 'a5357ecc9cb78c4bef273ce3793fc85c'
 # and trnid is the flag of train data. But test data is more than train data.
 # So we exchange the train data and test data.
 MODE_FLAG_MAP = {'train': 'tstid', 'test': 'trnid', 'valid': 'valid'}
-
-
-def _safe_extract_tar(data_tar, path):
-    abs_path = os.path.abspath(path)
-    members = data_tar.getmembers()
-    for member in members:
-        if member.name in ('', '.'):
-            raise RuntimeError(f"Unsafe tar member path: {member.name}")
-        member_path = os.path.abspath(os.path.join(path, member.name))
-        try:
-            if os.path.commonpath([abs_path, member_path]) != abs_path:
-                raise RuntimeError(f"Unsafe tar member path: {member.name}")
-        except ValueError as e:
-            raise RuntimeError(f"Unsafe tar member path: {member.name}") from e
-        if not (member.isfile() or member.isdir()):
-            raise RuntimeError(f"Unsafe tar member type: {member.name}")
-    data_tar.extractall(path, members=members)
 
 
 class Flowers(Dataset[tuple["_ImageDataType", "npt.NDArray[np.int64]"]]):
@@ -200,7 +184,7 @@ class Flowers(Dataset[tuple["_ImageDataType", "npt.NDArray[np.int64]"]]):
             os.mkdir(self.data_path)
         jpg_path = os.path.join(self.data_path, "jpg")
         if not os.path.exists(jpg_path):
-            _safe_extract_tar(data_tar, self.data_path)
+            _safe_extract_tar(data_tar, self.data_path, on_unsafe='raise')
 
         scio = try_import('scipy.io')
         self.labels = scio.loadmat(label_file)['labels'][0]

--- a/test/legacy_test/test_dataset_security.py
+++ b/test/legacy_test/test_dataset_security.py
@@ -254,7 +254,3 @@ class TestFlowersSafeExtractTar(unittest.TestCase):
             extracted_file = os.path.join(extract_dir, member_name)
             with open(extracted_file, 'rb') as f:
                 self.assertEqual(f.read(), content)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/legacy_test/test_dataset_security.py
+++ b/test/legacy_test/test_dataset_security.py
@@ -1,0 +1,260 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import os
+import tarfile
+import tempfile
+import unittest
+from unittest import mock
+
+import paddle.vision.datasets.cifar as vision_cifar
+from paddle.dataset.cifar import CIFAR10_MD5, reader_creator
+from paddle.utils.download import _safe_extract_tar
+from paddle.vision.datasets import Cifar10
+
+
+class TestCifarSecurity(unittest.TestCase):
+    def _write_tar(self, data_file):
+        with tarfile.open(data_file, 'w:gz') as data_tar:
+            content = b'not an official CIFAR archive'
+            info = tarfile.TarInfo('cifar-10-batches-py/data_batch_1')
+            info.size = len(content)
+            data_tar.addfile(info, io.BytesIO(content))
+
+    def test_reject_unverified_local_archive(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'cifar-10-python.tar.gz')
+            self._write_tar(data_file)
+
+            with self.assertRaisesRegex(
+                ValueError,
+                'unverified local CIFAR pickle archive|official archive|MD5',
+            ):
+                Cifar10(data_file=data_file, download=False)
+
+    def test_reject_missing_local_archive(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'missing.tar.gz')
+
+            with self.assertRaisesRegex(
+                ValueError, 'Local CIFAR archive does not exist'
+            ):
+                Cifar10(data_file=data_file, download=False)
+
+    def test_legacy_reader_rechecks_archive_md5(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'cifar-10-python.tar.gz')
+            self._write_tar(data_file)
+            reader = reader_creator(
+                data_file,
+                'data_batch',
+                md5sum=CIFAR10_MD5,
+            )
+
+            with self.assertRaisesRegex(
+                ValueError, 'unverified CIFAR pickle archive|official MD5'
+            ):
+                list(reader())
+
+    def _count_local_cifar_md5_calls(self, data_file, mutate=None):
+        md5_calls = []
+
+        def fake_md5file(path):
+            md5_calls.append(path)
+            return CIFAR10_MD5
+
+        vision_cifar._cached_md5file.cache_clear()
+        try:
+            with (
+                mock.patch.object(vision_cifar, 'md5file', fake_md5file),
+                mock.patch.object(
+                    Cifar10,
+                    '_load_data',
+                    lambda dataset: setattr(dataset, 'data', []),
+                ),
+            ):
+                Cifar10(data_file=data_file, download=False)
+                if mutate is not None:
+                    mutate()
+                Cifar10(data_file=data_file, download=False)
+        finally:
+            vision_cifar._cached_md5file.cache_clear()
+
+        return len(md5_calls)
+
+    def test_local_archive_md5_cache_reuses_unchanged_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'cifar-10-python.tar.gz')
+            self._write_tar(data_file)
+
+            self.assertEqual(self._count_local_cifar_md5_calls(data_file), 1)
+
+    def test_local_archive_md5_cache_refreshes_changed_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'cifar-10-python.tar.gz')
+            self._write_tar(data_file)
+
+            def mutate():
+                with open(data_file, 'ab') as f:
+                    f.write(b'changed')
+
+            self.assertEqual(
+                self._count_local_cifar_md5_calls(data_file, mutate), 2
+            )
+
+
+class TestFlowersSafeExtractTar(unittest.TestCase):
+    def _write_tar_members(self, data_file, members):
+        with tarfile.open(data_file, 'w:gz') as data_tar:
+            for info, content in members:
+                fileobj = io.BytesIO(content) if content is not None else None
+                data_tar.addfile(info, fileobj)
+
+    def test_reject_path_traversal_member(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'flowers.tgz')
+            extract_dir = os.path.join(tmpdir, 'flowers')
+            outside_file = os.path.join(tmpdir, 'evil.txt')
+            os.mkdir(extract_dir)
+
+            with tarfile.open(data_file, 'w:gz') as data_tar:
+                content = b'evil'
+                info = tarfile.TarInfo('../evil.txt')
+                info.size = len(content)
+                data_tar.addfile(info, io.BytesIO(content))
+
+            with (
+                tarfile.open(data_file) as data_tar,
+                self.assertRaises(ValueError),
+            ):
+                _safe_extract_tar(data_tar, extract_dir)
+
+            self.assertFalse(os.path.exists(outside_file))
+
+    def test_reject_invalid_on_unsafe(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'flowers.tgz')
+            extract_dir = os.path.join(tmpdir, 'flowers')
+            os.mkdir(extract_dir)
+
+            with tarfile.open(data_file, 'w:gz'):
+                pass
+
+            with (
+                tarfile.open(data_file) as data_tar,
+                self.assertRaisesRegex(
+                    ValueError, "on_unsafe must be one of 'skip' or 'raise'"
+                ),
+            ):
+                _safe_extract_tar(data_tar, extract_dir, on_unsafe='bad')
+
+    def test_raise_on_symlink_member(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'flowers.tgz')
+            extract_dir = os.path.join(tmpdir, 'flowers')
+            os.mkdir(extract_dir)
+
+            symlink_info = tarfile.TarInfo('jpg/link.jpg')
+            symlink_info.type = tarfile.SYMTYPE
+            symlink_info.linkname = 'image_00001.jpg'
+            self._write_tar_members(data_file, [(symlink_info, None)])
+
+            with (
+                tarfile.open(data_file) as data_tar,
+                self.assertRaisesRegex(ValueError, 'symbolic link'),
+            ):
+                _safe_extract_tar(data_tar, extract_dir, on_unsafe='raise')
+
+    def test_raise_on_hardlink_member(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'flowers.tgz')
+            extract_dir = os.path.join(tmpdir, 'flowers')
+            os.mkdir(extract_dir)
+
+            hardlink_info = tarfile.TarInfo('jpg/hardlink.jpg')
+            hardlink_info.type = tarfile.LNKTYPE
+            hardlink_info.linkname = 'jpg/image_00001.jpg'
+            self._write_tar_members(data_file, [(hardlink_info, None)])
+
+            with (
+                tarfile.open(data_file) as data_tar,
+                self.assertRaisesRegex(ValueError, 'hard link'),
+            ):
+                _safe_extract_tar(data_tar, extract_dir, on_unsafe='raise')
+
+    def test_raise_on_special_file_member(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'flowers.tgz')
+            extract_dir = os.path.join(tmpdir, 'flowers')
+            os.mkdir(extract_dir)
+
+            special_info = tarfile.TarInfo('jpg/special')
+            special_info.type = tarfile.FIFOTYPE
+            self._write_tar_members(data_file, [(special_info, None)])
+
+            with (
+                tarfile.open(data_file) as data_tar,
+                self.assertRaisesRegex(ValueError, 'special file'),
+            ):
+                _safe_extract_tar(data_tar, extract_dir, on_unsafe='raise')
+
+    def test_skip_unsafe_member_by_default(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'flowers.tgz')
+            extract_dir = os.path.join(tmpdir, 'flowers')
+            os.mkdir(extract_dir)
+
+            symlink_info = tarfile.TarInfo('jpg/link.jpg')
+            symlink_info.type = tarfile.SYMTYPE
+            symlink_info.linkname = 'image_00001.jpg'
+            self._write_tar_members(data_file, [(symlink_info, None)])
+
+            with (
+                tarfile.open(data_file) as data_tar,
+                self.assertWarnsRegex(UserWarning, 'symbolic link'),
+            ):
+                _safe_extract_tar(data_tar, extract_dir)
+
+            self.assertFalse(os.path.exists(os.path.join(extract_dir, 'jpg')))
+
+    def test_extract_regular_member(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'flowers.tgz')
+            extract_dir = os.path.join(tmpdir, 'flowers')
+            member_name = 'jpg/image_00001.jpg'
+            content = b'image content'
+            os.mkdir(extract_dir)
+
+            with tarfile.open(data_file, 'w:gz') as data_tar:
+                dir_info = tarfile.TarInfo('jpg')
+                dir_info.type = tarfile.DIRTYPE
+                dir_info.mode = 0o755
+                data_tar.addfile(dir_info)
+
+                file_info = tarfile.TarInfo(member_name)
+                file_info.mode = 0o644
+                file_info.size = len(content)
+                data_tar.addfile(file_info, io.BytesIO(content))
+
+            with tarfile.open(data_file) as data_tar:
+                _safe_extract_tar(data_tar, extract_dir)
+
+            extracted_file = os.path.join(extract_dir, member_name)
+            with open(extracted_file, 'rb') as f:
+                self.assertEqual(f.read(), content)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/legacy_test/test_dataset_security.py
+++ b/test/legacy_test/test_dataset_security.py
@@ -20,9 +20,9 @@ import unittest
 from unittest import mock
 
 import paddle.vision.datasets.cifar as vision_cifar
-from paddle.dataset.cifar import CIFAR10_MD5, reader_creator
+from paddle.dataset.cifar import CIFAR10_MD5, CIFAR100_MD5, reader_creator
 from paddle.utils.download import _safe_extract_tar
-from paddle.vision.datasets import Cifar10
+from paddle.vision.datasets import Cifar10, Cifar100
 
 
 class TestCifarSecurity(unittest.TestCase):
@@ -68,27 +68,33 @@ class TestCifarSecurity(unittest.TestCase):
             ):
                 list(reader())
 
-    def _count_local_cifar_md5_calls(self, data_file, mutate=None):
+    def _count_local_cifar_md5_calls(
+        self,
+        data_file,
+        dataset_cls=Cifar10,
+        md5sum=CIFAR10_MD5,
+        mutate=None,
+    ):
         md5_calls = []
 
         def fake_md5file(path):
             md5_calls.append(path)
-            return CIFAR10_MD5
+            return md5sum
 
         vision_cifar._cached_md5file.cache_clear()
         try:
             with (
                 mock.patch.object(vision_cifar, 'md5file', fake_md5file),
                 mock.patch.object(
-                    Cifar10,
+                    dataset_cls,
                     '_load_data',
                     lambda dataset: setattr(dataset, 'data', []),
                 ),
             ):
-                Cifar10(data_file=data_file, download=False)
+                dataset_cls(data_file=data_file, download=False)
                 if mutate is not None:
                     mutate()
-                Cifar10(data_file=data_file, download=False)
+                dataset_cls(data_file=data_file, download=False)
         finally:
             vision_cifar._cached_md5file.cache_clear()
 
@@ -101,6 +107,20 @@ class TestCifarSecurity(unittest.TestCase):
 
             self.assertEqual(self._count_local_cifar_md5_calls(data_file), 1)
 
+    def test_cifar100_local_archive_md5_cache_reuses_unchanged_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'cifar-100-python.tar.gz')
+            self._write_tar(data_file)
+
+            self.assertEqual(
+                self._count_local_cifar_md5_calls(
+                    data_file,
+                    dataset_cls=Cifar100,
+                    md5sum=CIFAR100_MD5,
+                ),
+                1,
+            )
+
     def test_local_archive_md5_cache_refreshes_changed_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             data_file = os.path.join(tmpdir, 'cifar-10-python.tar.gz')
@@ -111,7 +131,7 @@ class TestCifarSecurity(unittest.TestCase):
                     f.write(b'changed')
 
             self.assertEqual(
-                self._count_local_cifar_md5_calls(data_file, mutate), 2
+                self._count_local_cifar_md5_calls(data_file, mutate=mutate), 2
             )
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category

User Experience

### PR Types

Security

### Description

本 PR 对 CIFAR 和 Flowers 数据集加载流程进行安全加固，降低非官方或被篡改数据文件带来的反序列化和解压风险。
   
                                                            
  #### CIFAR 数据集                                                                                                 
                                                            
  CIFAR 数据集仍保持使用官方 Python pickle 数据包，不改变默认下载和加载行为，仅在进入 `pickle.load`                 
  前增加官方数据包校验：                                    
                                                                                                                    
  - `paddle.vision.datasets.Cifar10/Cifar100` 在用户传入本地 `data_file` 时，会校验文件是否存在；                   
  - 对不存在的本地 `data_file`，抛出更明确的 `ValueError`；
  - 对 MD5 与官方数据包不一致的本地 CIFAR archive，直接拒绝加载，避免未验证的 pickle 数据进入反序列化流程；         
  - 旧接口 `paddle.dataset.cifar.train10/test10/train100/test100` 在 reader 执行 `pickle.load` 前，会再次校验       
  archive MD5，避免缓存文件在下载校验后被替换；                                                                     
  - 默认官方下载路径、官方数据包以及原有 MD5 校验逻辑保持不变。                                                     
                                                                                                                    
  #### Flowers 数据集                                                                                               
                                                                                                                    
  Flowers 数据集解压流程复用 `paddle.utils.download._safe_extract_tar` 进行安全解压，避免维护两套相近实现：         
                                                            
  - 将 Flowers 中直接调用 `tar.extractall()` 的逻辑替换为安全解压；                                                 
  - 解压前校验 tar 成员路径，确保最终解压路径仍位于目标目录内；
  - 对路径穿越、绝对路径等异常成员直接拒绝；                                                                        
  - 对 symlink、hardlink、device、fifo 等非普通文件/目录成员，在 Flowers 场景下使用 `on_unsafe='raise'` 直接报错；  
  - `paddle.utils.download._safe_extract_tar` 默认仍保持原有 `skip + warning` 行为，通过 `on_unsafe='skip'|'raise'` 
  支持不同调用场景。                                                                                                
                                                                                                                    
  本次修改不改变官方数据集的默认下载和正常加载流程，主要限制用户显式传入的非官方 CIFAR pickle archive，以及不安全的Flowers tar 成员。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否