### PR TITLE
[Operator Mechanism] Harden MoE permute/unpermute boundary cases

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -6583,6 +6583,17 @@ void MoeUnpermuteInferMeta(const MetaTensor& unzipped_tokens,
                           "but got %ld.",
                           cols));
   }
+  if (!common::contain_unknown_dim(unzipped_tokens.dims()) &&
+      !common::contain_unknown_dim(unzipped_token_probs.dims())) {
+    PADDLE_ENFORCE_EQ(
+        unzipped_token_probs.numel(),
+        unzipped_tokens.dims()[0],
+        common::errors::InvalidArgument(
+            "Input unzipped_token_probs's number of elements should be equal "
+            "to unzipped_tokens.dims()[0], but got %ld and %ld.",
+            unzipped_token_probs.numel(),
+            unzipped_tokens.dims()[0]));
+  }
   if (!common::contain_unknown_dim(expert_routemap_topk.dims())) {
     PADDLE_ENFORCE_GE(topk,
                       1,

--- a/paddle/phi/kernels/gpu/moe_permute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_permute_kernel.cu
@@ -202,8 +202,8 @@ __global__ __launch_bounds__(BLOCK_DIM_X) void permute_kernel(
         expert = shared_routemap[lane_id * topk + col];
         prob = shared_probs[lane_id * topk + col];
       } else {
-        expert = routemap_topk[global_row * topk + col];
-        prob = probs_topk[global_row * topk + col];
+        expert = routemap_topk[static_cast<int64_t>(global_row) * topk + col];
+        prob = probs_topk[static_cast<int64_t>(global_row) * topk + col];
       }
     }
     if (expert >= 0 && expert < num_experts) {
@@ -267,8 +267,9 @@ __global__ __launch_bounds__(BLOCK_DIM_X) void permute_kernel(
                       __popc((lane_id < 31) ? (mask >> (lane_id + 1)) : 0u);
         }
 
-        zipped_expertwise_rowmap[global_row * num_experts + expert_id] =
-            final_pos;
+        zipped_expertwise_rowmap[static_cast<int64_t>(global_row) *
+                                     num_experts +
+                                 expert_id] = final_pos;
 #pragma unroll
         for (int k = 0; k < TOPK; k++) {
           if (reg_expert[k] == expert_id) {
@@ -731,11 +732,6 @@ void MoePermuteKernel(const Context &dev_ctx,
           "X.dims()[0], but got %ld and %ld.",
           expert_routemap_topk.dims()[0],
           rows));
-  PADDLE_ENFORCE_GE(
-      rows,
-      0,
-      common::errors::InvalidArgument(
-          "X.dims()[0] should be non-negative, received: (%ld)", rows));
   PADDLE_ENFORCE_LE(
       rows,
       static_cast<int64_t>(std::numeric_limits<int32_t>::max()) -
@@ -744,11 +740,6 @@ void MoePermuteKernel(const Context &dev_ctx,
           "X.dims()[0] should be <= INT_MAX - %d, received: (%ld)",
           kPermuteBlockSize,
           rows));
-  PADDLE_ENFORCE_GE(
-      cols,
-      0,
-      common::errors::InvalidArgument(
-          "X.dims()[1] should be non-negative, received: (%ld)", cols));
   PADDLE_ENFORCE_LE(
       cols,
       std::numeric_limits<int32_t>::max(),
@@ -811,6 +802,16 @@ void MoePermuteKernel(const Context &dev_ctx,
                       common::errors::InvalidArgument(
                           "Input XScale's dims should be 2, but got %u.",
                           XScale.get_ptr()->dims().size()));
+    if (do_gather) {
+      PADDLE_ENFORCE_EQ(
+          XScale.get_ptr()->dims()[0],
+          rows,
+          common::errors::InvalidArgument(
+              "Input XScale's first dimension should be equal to X.dims()[0], "
+              "but got %ld and %ld.",
+              XScale.get_ptr()->dims()[0],
+              rows));
+    }
   }
   const int64_t quanted_cols =
       (XScale.get_ptr() != nullptr) ? XScale.get_ptr()->dims()[1] : 0;

--- a/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
+++ b/paddle/phi/kernels/gpu/moe_unpermute_kernel.cu
@@ -52,7 +52,9 @@ __global__ __launch_bounds__(256) void tokens_zip_kernel(
   // Strided load: blockDim.x may be < num_experts, so each thread
   // handles multiple slots to cover the full [0, num_experts) range.
   for (int i = threadIdx.x; i < num_experts; i += blockDim.x) {
-    const int fetch_row = zipped_expertwise_rowmap[this_row * num_experts + i];
+    const int fetch_row =
+        zipped_expertwise_rowmap[static_cast<int64_t>(this_row) * num_experts +
+                                 i];
     local_row_fetchlist[i] = fetch_row;
     if constexpr (WEIGHTED_TOKEN) {
       local_row_weight[i] =
@@ -64,11 +66,12 @@ __global__ __launch_bounds__(256) void tokens_zip_kernel(
 
 #pragma unroll
   for (int k = 0; k < topk; ++k) {
-    const int expert_idx = expert_routemap_topk[this_row * topk + k];
+    const int expert_idx =
+        expert_routemap_topk[static_cast<int64_t>(this_row) * topk + k];
     if (expert_idx < 0) [[likely]]
       continue;
     const int expert_fetch_row = local_row_fetchlist[expert_idx];
-    zipped_probs_topk[this_row * topk + k] =
+    zipped_probs_topk[static_cast<int64_t>(this_row) * topk + k] =
         unzipped_token_probs[expert_fetch_row];
   }
 
@@ -303,13 +306,15 @@ void MoeUnpermuteKernel(const Context &dev_ctx,
           "total_zipped_tokens_num, but got %ld and %d.",
           expert_routemap_topk.dims()[0],
           total_zipped_tokens_num));
-  const int64_t cols = unzipped_tokens.dims()[1];
-  PADDLE_ENFORCE_GE(
-      cols,
-      0,
+  PADDLE_ENFORCE_EQ(
+      unzipped_token_probs.numel(),
+      unzipped_tokens.dims()[0],
       common::errors::InvalidArgument(
-          "unzipped_tokens.dims()[1] should be non-negative, but got %ld.",
-          cols));
+          "Input unzipped_token_probs's number of elements should be equal to "
+          "unzipped_tokens.dims()[0], but got %ld and %ld.",
+          unzipped_token_probs.numel(),
+          unzipped_tokens.dims()[0]));
+  const int64_t cols = unzipped_tokens.dims()[1];
   PADDLE_ENFORCE_LE(cols,
                     std::numeric_limits<int32_t>::max(),
                     common::errors::InvalidArgument(

--- a/test/legacy_test/test_moe_permute_unpermute.py
+++ b/test/legacy_test/test_moe_permute_unpermute.py
@@ -614,6 +614,58 @@ class TestFusedMoePermuteUnpermute(unittest.TestCase):
                 num_experts,
             )
 
+    def test_unpermute_invalid_token_probs(self):
+        (
+            unzipped_tokens,
+            zipped_expertwise_rowmap,
+            expert_routemap_topk,
+            token_prob_unzipped,
+            seq_len,
+            num_experts,
+        ) = self._build_small_unpermute_inputs()
+        # unzipped_token_probs must hold one probability per unzipped token row.
+        with self.assertRaisesRegex(Exception, "unzipped_token_probs"):
+            moe_unpermute(
+                unzipped_tokens,
+                zipped_expertwise_rowmap,
+                expert_routemap_topk,
+                paddle.zeros([0], dtype="float32"),
+                seq_len,
+                num_experts,
+            )
+        with self.assertRaisesRegex(Exception, "unzipped_token_probs"):
+            moe_unpermute(
+                unzipped_tokens,
+                zipped_expertwise_rowmap,
+                expert_routemap_topk,
+                token_prob_unzipped[:-1],
+                seq_len,
+                num_experts,
+            )
+
+    def test_permute_invalid_scale_rows(self):
+        (
+            hidden_states,
+            expert_routemap_topk,
+            expert_prob_topk,
+            num_experts,
+            tokens_per_expert,
+        ) = self._build_small_permute_inputs()
+        # XScale's first dimension must match X.dims()[0].
+        mismatched_scale = paddle.zeros(
+            [hidden_states.shape[0] + 1, 1], dtype="float32"
+        )
+        with self.assertRaisesRegex(Exception, "XScale"):
+            moe_permute(
+                hidden_states,
+                mismatched_scale,
+                expert_routemap_topk,
+                expert_prob_topk,
+                num_experts,
+                tokens_per_expert,
+                16,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION


<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
Extend the validation added in #79136 to cover additional boundary inputs surfaced by compute-sanitizer:

- moe_unpermute: enforce unzipped_token_probs holds one probability per unzipped token row (numel == unzipped_tokens.dims()[0]), both in MoeUnpermuteInferMeta and MoeUnpermuteKernel. This rejects the zero-size / mismatched probs buffer that previously caused an out-of-bounds read of unzipped_token_probs.
- moe_permute: enforce XScale.dims()[0] == X.dims()[0] when do_gather is set, mirroring the InferMeta check so the FP8 scale gather path fails early on a mismatched scale buffer.
- Make the row-major index arithmetic in tokens_zip_kernel and permute_kernel int64-safe so a valid (each dim <= INT32) input whose row*topk / row*num_experts product exceeds INT32 does not silently overflow into an out-of-bounds access.

pcard-91067

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否 