### PR TITLE
[Environment Adaptation] fix libflashattn.so loading on ROCm by pre-loading libamdhip64.so

### DIFF
--- a/paddle/phi/backends/dynload/dynamic_loader.cc
+++ b/paddle/phi/backends/dynload/dynamic_loader.cc
@@ -885,6 +885,15 @@ void* GetFlashAttnDsoHandle() {
   return GetDsoHandleFromSearchPath(flashattn_dir, "flashattn.dll");
 #elif defined(PADDLE_WITH_CUSTOM_DEVICE)
   return GetDsoHandleFromSearchPath(flashattn_dir, FLASHATTN_LIB_NAME);
+#elif defined(PADDLE_WITH_HIP)
+  // Pre-load the ROCm HIP runtime so that transitive dependencies
+  // (e.g., libgalaxyhip.so.5) are resolvable when libflashattn.so is
+  // loaded via dlopen.
+  if (!FLAGS_rocm_dir.empty()) {
+    dlopen((FLAGS_rocm_dir + "/libamdhip64.so").c_str(),
+           RTLD_LAZY | RTLD_GLOBAL);
+  }
+  return GetDsoHandleFromSearchPath(flashattn_dir, "libflashattn.so");
 #else
   return GetDsoHandleFromSearchPath(flashattn_dir, "libflashattn.so");
 #endif


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
在 ROCm 环境下，加载 libflashattn.so 时因动态库间接依赖 libgalaxyhip.so.5 未在 LD_LIBRARY_PATH 中而导致加载失败，引发 RuntimeError。

根本原因是 libflashattn.so 在 dlopen 加载时，其传递依赖（如 libgalaxyhip.so.5）无法被动态链接器解析。本修复通过在加载 libflashattn.so 之前，先以 RTLD_GLOBAL 模式预加载 libamdhip64.so，使得所有 ROCm HIP 运行时符号对后续加载的动态库可见，从而正确解析传递依赖。

改动仅涉及 paddle/phi/backends/dynload/dynamic_loader.cc 文件，在 PADDLE_WITH_HIP 条件下增加了预加载 libamdhip64.so 的逻辑。

### 是否引起精度变化
否
