### PR TITLE
[Security] Allow Enum/IntEnum in restricted unpickler safe class check

### DIFF
--- a/python/paddle/framework/restricted_unpickler.py
+++ b/python/paddle/framework/restricted_unpickler.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import pickle
 import types
+from enum import Enum
 
 # Whitelist of allowed modules and their allowed classes.
 # Only these classes can be instantiated during deserialization.
@@ -147,6 +148,9 @@ def _is_safe_class(cls) -> bool:
         for base in cls.__mro__:
             # Skip object - its default __reduce__ is safe for user-defined classes
             if base is object:
+                continue
+            # Enum-related stdlib base implementations are safe.
+            if base is Enum:
                 continue
             # Check if this base class defines the dangerous method
             if method in getattr(base, '__dict__', {}):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Security

### Description
<!-- Describe what you’ve done -->
This PR fixes a compatibility regression introduced by PR #79057 in `RestrictedUnpickler` safe class checks.

Previously, `_is_safe_class` traversed MRO and rejected classes if dangerous methods (e.g., `__reduce_ex__`) were found in base classes. This incorrectly blocked standard-library enum types and caused `paddle.load` to fail when loading legitimate objects saved by `paddle.save` (e.g., training args containing `Enum`/`IntEnum` fields).

Changes in this PR:
- Import `Enum` from stdlib.
- Explicitly allow `Enum` subclasses in `_is_safe_class` (covers `IntEnum` as well).
- Keep the original strict checks for other non-enum classes unchanged.

This preserves the security hardening direction while fixing false positives for common safe stdlib enum-based configs.


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否