### PR TITLE
[API Compatibility] Add arg `dtype`, `out` and param aliases for `nanmean`

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1797,7 +1797,7 @@ def nanmean(
             For more information, please refer to :ref:`api_guide_Name`.
         dtype (str|paddle.dtype|np.dtype, optional): The dtype of output Tensor. The default value is None, the dtype of output is the same as input Tensor `x`.
 
-    Keywords Argument:
+    Keyword Argument:
         out (Tensor, optional): The output Tensor. If set, the result will be stored in this Tensor. Default is None, a new Tensor will be created to store the result.
 
     Returns:

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1797,12 +1797,13 @@ def nanmean(
             For more information, please refer to :ref:`api_guide_Name`.
         dtype (str|paddle.dtype|np.dtype, optional): The dtype of output Tensor. The default value is None, the dtype of output is the same as input Tensor `x`.
 
-    Keyword Argument:
+    Keyword Arguments:
         out (Tensor, optional): The output Tensor. If set, the result will be stored in this Tensor. Default is None, a new Tensor will be created to store the result.
 
     Returns:
-        Tensor, results of arithmetic mean along ``axis`` of ``x``, with the same data
-        type as ``x``.
+        Tensor, results of arithmetic mean along ``axis`` of ``x``,  with data
+        type specified by ``dtype``. If ``dtype`` is None, the data type is
+        the same as ``x``.
 
     Examples:
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1763,17 +1763,22 @@ def nansum(
     return sum(tmp_tensor, axis, dtype, keepdim, name, out=out)
 
 
+@param_two_alias(["x", "input"], ["axis", "dim"])
 def nanmean(
     x: Tensor,
     axis: int | Sequence[int] | None = None,
     keepdim: bool = False,
     name: str | None = None,
+    *,
+    dtype: DTypeLike | None = None,
+    out: Tensor | None = None,
 ) -> Tensor:
     r"""
     Compute the arithmetic mean along the specified axis, ignoring NaNs.
 
     Args:
         x (Tensor): The input Tensor with data type uint16, float16, float32, float64.
+            Alias: ``input``.
         axis (int|list|tuple, optional):The axis along which to perform nanmean
             calculations. ``axis`` should be int, list(int) or tuple(int). If
             ``axis`` is a list/tuple of dimension(s), nanmean is calculated along
@@ -1782,6 +1787,7 @@ def nanmean(
             ``axis`` or element(s) of ``axis`` is less than 0, it works the
             same way as :math:`axis + D` . If ``axis`` is None, nanmean is
             calculated over all elements of ``x``. Default is None.
+            Alias: ``dim``.
         keepdim (bool, optional): Whether to reserve the reduced dimension(s)
             in the output Tensor. If ``keepdim`` is True, the dimensions of
             the output Tensor is the same as ``x`` except in the reduced
@@ -1789,6 +1795,10 @@ def nanmean(
             the output Tensor is squeezed in ``axis`` . Default is False.
         name (str|None, optional): Name for the operation (optional, default is None).
             For more information, please refer to :ref:`api_guide_Name`.
+        dtype (str|paddle.dtype|np.dtype, optional): The dtype of output Tensor. The default value is None, the dtype of output is the same as input Tensor `x`.
+
+    Keywords Argument:
+        out (Tensor, optional): The output Tensor. If set, the result will be stored in this Tensor. Default is None, a new Tensor will be created to store the result.
 
     Returns:
         Tensor, results of arithmetic mean along ``axis`` of ``x``, with the same data
@@ -1851,11 +1861,14 @@ def nanmean(
     )
     if axis is not None:
         check_type(axis, 'axis/dim', (int, list, tuple), 'nanmean')
+    if dtype is None:
+        dtype = x.dtype
 
-    cnt = paddle.sum(~paddle.isnan(x), axis=axis, keepdim=keepdim)
+    cnt = paddle.sum(~paddle.isnan(x), axis=axis, dtype=dtype, keepdim=keepdim)
     return paddle.divide(
-        paddle.nansum(x, axis=axis, keepdim=keepdim, name=name),
-        cnt.astype(x.dtype),
+        paddle.nansum(x, axis=axis, dtype=dtype, keepdim=keepdim, name=name),
+        cnt,
+        out=out,
     )
 
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1867,7 +1867,7 @@ def nanmean(
     cnt = paddle.sum(~paddle.isnan(x), axis=axis, dtype=dtype, keepdim=keepdim)
     return paddle.divide(
         paddle.nansum(x, axis=axis, dtype=dtype, keepdim=keepdim, name=name),
-        cnt,
+        cnt.astype(dtype),
         out=out,
     )
 

--- a/test/legacy_test/test_api_compatibility_part2.py
+++ b/test/legacy_test/test_api_compatibility_part2.py
@@ -2635,9 +2635,9 @@ class TestNansumAPI(unittest.TestCase):
         # 5. Mixed arguments & out parameter
         out5 = paddle.empty([])
         out6 = paddle.nansum(input=x, axis=1, keepdim=True, out=out5)
-        # 7. Class method positional arguments
+        # 6. Class method positional arguments
         out7 = x.nansum(1, None, True)
-        # 8. Class method keyword arguments
+        # 7. Class method keyword arguments
         out8 = x.nansum(axis=1, keepdim=True)
 
         for out in [out1, out2, out3, out4, out5, out6, out7, out8]:
@@ -2693,6 +2693,75 @@ class TestNansumAPI(unittest.TestCase):
         with self.assertRaises(ValueError):
             out2 = paddle.nansum(x, dim=1, axis=1)
         paddle.enable_static()
+
+
+# Test nanmean compatibility
+class TestNanmeanAPI(unittest.TestCase):
+    def setUp(self):
+        self.np_x = np.array(
+            [[float('nan'), 0.3, 0.5, 0.9], [0.1, 0.2, float('-nan'), 0.7]]
+        ).astype('float32')
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        ref_value = np.nanmean(self.np_x, axis=1, keepdims=True)
+
+        # 1. Paddle positional arguments
+        out1 = paddle.nanmean(x, 1, True)
+        # 2. Paddle keyword arguments
+        out2 = paddle.nanmean(x=x, axis=1, keepdim=True)
+        # 3. PyTorch keyword arguments
+        out3 = paddle.nanmean(input=x, dim=1, keepdim=True)
+        # 4. Mixed arguments & out parameter
+        out4 = paddle.empty([])
+        out5 = paddle.nanmean(input=x, axis=1, keepdim=True, out=out4)
+        # 5. Class method positional arguments
+        out6 = x.nanmean(1, True)
+        # 6. Class method keyword arguments
+        out7 = x.nanmean(dim=1, keepdim=True)
+
+        for out in [out1, out2, out3, out4, out5, out6, out7]:
+            np.testing.assert_array_equal(out.numpy(), ref_value)
+
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        ref_value = np.nanmean(self.np_x, axis=1, keepdims=True)
+        with paddle.static.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=[2, 4], dtype='float32')
+
+            # 1. Paddle positional arguments
+            out1 = paddle.nanmean(x, 1, True)
+            # 2. Paddle keyword arguments
+            out2 = paddle.nanmean(x=x, axis=1, keepdim=True)
+            # 3. PyTorch keyword arguments
+            out3 = paddle.nanmean(input=x, dim=1, keepdim=True)
+            # 4. Mixed arguments
+            out4 = paddle.nanmean(input=x, axis=1, keepdim=True)
+            # 5. Class method positional arguments
+            out5 = x.nanmean(1, True)
+            # 6. Class method keyword arguments
+            out6 = x.nanmean(dim=1, keepdim=True)
+
+            exe = paddle.static.Executor()
+            fetches = exe.run(
+                main,
+                feed={"x": self.np_x},
+                fetch_list=[
+                    out1,
+                    out2,
+                    out3,
+                    out4,
+                    out5,
+                    out6,
+                ],
+            )
+            for i in range(0, len(fetches)):
+                np.testing.assert_array_equal(fetches[i], ref_value)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_api_compatibility_part2.py
+++ b/test/legacy_test/test_api_compatibility_part2.py
@@ -2612,6 +2612,75 @@ class TestTopkAPI(unittest.TestCase):
                 np.testing.assert_array_equal(fetches[i + 1], ref_indices)
 
 
+# Test nanmean compatibility
+class TestNanmeanAPI(unittest.TestCase):
+    def setUp(self):
+        self.np_x = np.array(
+            [[float('nan'), 0.3, 0.5, 0.9], [0.1, 0.2, float('-nan'), 0.7]]
+        ).astype('float32')
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        ref_value = np.nanmean(self.np_x, axis=1, keepdims=True)
+
+        # 1. Paddle positional arguments
+        out1 = paddle.nanmean(x, 1, True)
+        # 2. Paddle keyword arguments
+        out2 = paddle.nanmean(x=x, axis=1, keepdim=True)
+        # 3. PyTorch keyword arguments
+        out3 = paddle.nanmean(input=x, dim=1, keepdim=True)
+        # 4. Mixed arguments & out parameter
+        out4 = paddle.empty([])
+        out5 = paddle.nanmean(input=x, axis=1, keepdim=True, out=out4)
+        # 5. Class method positional arguments
+        out6 = x.nanmean(1, True)
+        # 6. Class method keyword arguments
+        out7 = x.nanmean(dim=1, keepdim=True)
+
+        for out in [out1, out2, out3, out4, out5, out6, out7]:
+            np.testing.assert_array_equal(out.numpy(), ref_value)
+
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        ref_value = np.nanmean(self.np_x, axis=1, keepdims=True)
+        with paddle.static.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=[2, 4], dtype='float32')
+
+            # 1. Paddle positional arguments
+            out1 = paddle.nanmean(x, 1, True)
+            # 2. Paddle keyword arguments
+            out2 = paddle.nanmean(x=x, axis=1, keepdim=True)
+            # 3. PyTorch keyword arguments
+            out3 = paddle.nanmean(input=x, dim=1, keepdim=True)
+            # 4. Mixed arguments
+            out4 = paddle.nanmean(input=x, axis=1, keepdim=True)
+            # 5. Class method positional arguments
+            out5 = x.nanmean(1, True)
+            # 6. Class method keyword arguments
+            out6 = x.nanmean(dim=1, keepdim=True)
+
+            exe = paddle.static.Executor()
+            fetches = exe.run(
+                main,
+                feed={"x": self.np_x},
+                fetch_list=[
+                    out1,
+                    out2,
+                    out3,
+                    out4,
+                    out5,
+                    out6,
+                ],
+            )
+            for i in range(0, len(fetches)):
+                np.testing.assert_array_equal(fetches[i], ref_value)
+
+
 # Test nansum compatibility
 class TestNansumAPI(unittest.TestCase):
     def setUp(self):
@@ -2693,75 +2762,6 @@ class TestNansumAPI(unittest.TestCase):
         with self.assertRaises(ValueError):
             out2 = paddle.nansum(x, dim=1, axis=1)
         paddle.enable_static()
-
-
-# Test nanmean compatibility
-class TestNanmeanAPI(unittest.TestCase):
-    def setUp(self):
-        self.np_x = np.array(
-            [[float('nan'), 0.3, 0.5, 0.9], [0.1, 0.2, float('-nan'), 0.7]]
-        ).astype('float32')
-
-    def test_dygraph_Compatibility(self):
-        paddle.disable_static()
-        x = paddle.to_tensor(self.np_x)
-        ref_value = np.nanmean(self.np_x, axis=1, keepdims=True)
-
-        # 1. Paddle positional arguments
-        out1 = paddle.nanmean(x, 1, True)
-        # 2. Paddle keyword arguments
-        out2 = paddle.nanmean(x=x, axis=1, keepdim=True)
-        # 3. PyTorch keyword arguments
-        out3 = paddle.nanmean(input=x, dim=1, keepdim=True)
-        # 4. Mixed arguments & out parameter
-        out4 = paddle.empty([])
-        out5 = paddle.nanmean(input=x, axis=1, keepdim=True, out=out4)
-        # 5. Class method positional arguments
-        out6 = x.nanmean(1, True)
-        # 6. Class method keyword arguments
-        out7 = x.nanmean(dim=1, keepdim=True)
-
-        for out in [out1, out2, out3, out4, out5, out6, out7]:
-            np.testing.assert_array_equal(out.numpy(), ref_value)
-
-        paddle.enable_static()
-
-    def test_static_Compatibility(self):
-        paddle.enable_static()
-        main = paddle.static.Program()
-        startup = paddle.static.Program()
-        ref_value = np.nanmean(self.np_x, axis=1, keepdims=True)
-        with paddle.static.program_guard(main, startup):
-            x = paddle.static.data(name="x", shape=[2, 4], dtype='float32')
-
-            # 1. Paddle positional arguments
-            out1 = paddle.nanmean(x, 1, True)
-            # 2. Paddle keyword arguments
-            out2 = paddle.nanmean(x=x, axis=1, keepdim=True)
-            # 3. PyTorch keyword arguments
-            out3 = paddle.nanmean(input=x, dim=1, keepdim=True)
-            # 4. Mixed arguments
-            out4 = paddle.nanmean(input=x, axis=1, keepdim=True)
-            # 5. Class method positional arguments
-            out5 = x.nanmean(1, True)
-            # 6. Class method keyword arguments
-            out6 = x.nanmean(dim=1, keepdim=True)
-
-            exe = paddle.static.Executor()
-            fetches = exe.run(
-                main,
-                feed={"x": self.np_x},
-                fetch_list=[
-                    out1,
-                    out2,
-                    out3,
-                    out4,
-                    out5,
-                    out6,
-                ],
-            )
-            for i in range(0, len(fetches)):
-                np.testing.assert_array_equal(fetches[i], ref_value)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_nanmean_api.py
+++ b/test/legacy_test/test_nanmean_api.py
@@ -129,6 +129,15 @@ class TestNanmeanAPI(unittest.TestCase):
         test_case(self.x_grad, (0, 1))
         paddle.enable_static()
 
+    def test_arg_dtype(self):
+        paddle.disable_static()
+        x_tensor = paddle.to_tensor(self.x)
+        out = paddle.nanmean(x_tensor, (0, 2), dtype='float64')
+        out_ref = np.nanmean(self.x, (0, 2), np.float64)
+        np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.0001)
+        self.assertTrue(out.dtype, paddle.float64)
+        paddle.enable_static()
+
 
 class TestNanmeanAPI_ZeroSize(unittest.TestCase):
     # test paddle.tensor.math.nanmean

--- a/test/legacy_test/test_nanmean_api.py
+++ b/test/legacy_test/test_nanmean_api.py
@@ -129,25 +129,33 @@ class TestNanmeanAPI(unittest.TestCase):
         test_case(self.x_grad, (0, 1))
         paddle.enable_static()
 
+    @unittest.skipIf(
+        paddle.core.is_compiled_with_xpu(),
+        "XPU does not support type float64.",
+    )
     def test_dygraph_arg_dtype(self):
         paddle.disable_static()
         x_tensor = paddle.to_tensor(self.x)
-        out = paddle.nanmean(x_tensor, (0, 2), dtype='float16')
-        out_ref = np.nanmean(self.x, (0, 2), np.float16)
+        out = paddle.nanmean(x_tensor, (0, 2), dtype='float64')
+        out_ref = np.nanmean(self.x, (0, 2), np.float64)
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.0001)
-        self.assertEqual(out.dtype, paddle.float16)
+        self.assertEqual(out.dtype, paddle.float64)
         paddle.enable_static()
 
+    @unittest.skipIf(
+        paddle.core.is_compiled_with_xpu(),
+        "XPU does not support type float64.",
+    )
     def test_static_arg_dtype(self):
         paddle.enable_static()
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', self.x_shape)
-            out = paddle.nanmean(x, (0, 2), dtype='float16')
+            out = paddle.nanmean(x, (0, 2), dtype='float64')
             exe = paddle.static.Executor(self.place)
             res = exe.run(feed={'X': self.x}, fetch_list=[out])
-        out_ref = np.nanmean(self.x, (0, 2), np.float16)
+        out_ref = np.nanmean(self.x, (0, 2), np.float64)
         np.testing.assert_allclose(res[0], out_ref, rtol=0.0001)
-        self.assertEqual(res[0].dtype, np.float16)
+        self.assertEqual(res[0].dtype, np.float64)
 
 
 class TestNanmeanAPI_ZeroSize(unittest.TestCase):

--- a/test/legacy_test/test_nanmean_api.py
+++ b/test/legacy_test/test_nanmean_api.py
@@ -129,14 +129,25 @@ class TestNanmeanAPI(unittest.TestCase):
         test_case(self.x_grad, (0, 1))
         paddle.enable_static()
 
-    def test_arg_dtype(self):
+    def test_dygraph_arg_dtype(self):
         paddle.disable_static()
         x_tensor = paddle.to_tensor(self.x)
-        out = paddle.nanmean(x_tensor, (0, 2), dtype='float64')
-        out_ref = np.nanmean(self.x, (0, 2), np.float64)
+        out = paddle.nanmean(x_tensor, (0, 2), dtype='float16')
+        out_ref = np.nanmean(self.x, (0, 2), np.float16)
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.0001)
-        self.assertEqual(out.dtype, paddle.float64)
+        self.assertEqual(out.dtype, paddle.float16)
         paddle.enable_static()
+
+    def test_static_arg_dtype(self):
+        paddle.enable_static()
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.static.data('X', self.x_shape)
+            out = paddle.nanmean(x, (0, 2), dtype='float16')
+            exe = paddle.static.Executor(self.place)
+            res = exe.run(feed={'X': self.x}, fetch_list=[out])
+        out_ref = np.nanmean(self.x, (0, 2), np.float16)
+        np.testing.assert_allclose(res[0], out_ref, rtol=0.0001)
+        self.assertEqual(res[0].dtype, np.float16)
 
 
 class TestNanmeanAPI_ZeroSize(unittest.TestCase):

--- a/test/legacy_test/test_nanmean_api.py
+++ b/test/legacy_test/test_nanmean_api.py
@@ -135,7 +135,7 @@ class TestNanmeanAPI(unittest.TestCase):
         out = paddle.nanmean(x_tensor, (0, 2), dtype='float64')
         out_ref = np.nanmean(self.x, (0, 2), np.float64)
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.0001)
-        self.assertTrue(out.dtype, paddle.float64)
+        self.assertEqual(out.dtype, paddle.float64)
         paddle.enable_static()
 
 

--- a/test/legacy_test/test_nanmean_api.py
+++ b/test/legacy_test/test_nanmean_api.py
@@ -131,31 +131,23 @@ class TestNanmeanAPI(unittest.TestCase):
 
     def test_dygraph_arg_dtype(self):
         paddle.disable_static()
-        x_np = np.random.randint(low=-10, high=11, size=self.x_shape).astype(
-            np.int16
-        )
-        x_np[0, :, :, :] = np.nan
-        x_tensor = paddle.to_tensor(x_np)
-        out = paddle.nanmean(x_tensor, (0, 2), dtype='int32')
-        out_ref = np.nanmean(x_np, (0, 2), np.int32)
+        x_tensor = paddle.to_tensor(self.x)
+        out = paddle.nanmean(x_tensor, (0, 2), dtype='float16')
+        out_ref = np.nanmean(self.x, (0, 2), np.float16)
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.0001)
-        self.assertEqual(out.dtype, paddle.int32)
+        self.assertEqual(out.dtype, paddle.float16)
         paddle.enable_static()
 
     def test_static_arg_dtype(self):
         paddle.enable_static()
-        x_np = np.random.randint(low=-10, high=11, size=self.x_shape).astype(
-            np.int16
-        )
-        x_np[0, :, :, :] = np.nan
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', self.x_shape)
-            out = paddle.nanmean(x, (0, 2), dtype='int32')
+            out = paddle.nanmean(x, (0, 2), dtype='float16')
             exe = paddle.static.Executor(self.place)
-            res = exe.run(feed={'X': x_np}, fetch_list=[out])
-        out_ref = np.nanmean(x_np, (0, 2), np.int32)
+            res = exe.run(feed={'X': self.x}, fetch_list=[out])
+        out_ref = np.nanmean(self.x, (0, 2), np.float16)
         np.testing.assert_allclose(res[0], out_ref, rtol=0.0001)
-        self.assertEqual(res[0].dtype, np.int32)
+        self.assertEqual(res[0].dtype, np.float16)
 
 
 class TestNanmeanAPI_ZeroSize(unittest.TestCase):

--- a/test/legacy_test/test_nanmean_api.py
+++ b/test/legacy_test/test_nanmean_api.py
@@ -131,23 +131,31 @@ class TestNanmeanAPI(unittest.TestCase):
 
     def test_dygraph_arg_dtype(self):
         paddle.disable_static()
-        x_tensor = paddle.to_tensor(self.x)
-        out = paddle.nanmean(x_tensor, (0, 2), dtype='float16')
-        out_ref = np.nanmean(self.x, (0, 2), np.float16)
+        x_np = np.random.randint(low=-10, high=11, size=self.x_shape).astype(
+            np.int16
+        )
+        x_np[0, :, :, :] = np.nan
+        x_tensor = paddle.to_tensor(x_np)
+        out = paddle.nanmean(x_tensor, (0, 2), dtype='int32')
+        out_ref = np.nanmean(x_np, (0, 2), np.int32)
         np.testing.assert_allclose(out.numpy(), out_ref, rtol=0.0001)
-        self.assertEqual(out.dtype, paddle.float16)
+        self.assertEqual(out.dtype, paddle.int32)
         paddle.enable_static()
 
     def test_static_arg_dtype(self):
         paddle.enable_static()
+        x_np = np.random.randint(low=-10, high=11, size=self.x_shape).astype(
+            np.int16
+        )
+        x_np[0, :, :, :] = np.nan
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data('X', self.x_shape)
-            out = paddle.nanmean(x, (0, 2), dtype='float16')
+            out = paddle.nanmean(x, (0, 2), dtype='int32')
             exe = paddle.static.Executor(self.place)
-            res = exe.run(feed={'X': self.x}, fetch_list=[out])
-        out_ref = np.nanmean(self.x, (0, 2), np.float16)
+            res = exe.run(feed={'X': x_np}, fetch_list=[out])
+        out_ref = np.nanmean(x_np, (0, 2), np.int32)
         np.testing.assert_allclose(res[0], out_ref, rtol=0.0001)
-        self.assertEqual(res[0].dtype, np.float16)
+        self.assertEqual(res[0].dtype, np.int32)
 
 
 class TestNanmeanAPI_ZeroSize(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Add kwonly arg `dtype`
- Add kwonly arg `out`
- Add param alias
- Add test for `dtype`
- Add compatibility test
- Update EN doc
- Fix wrong test case number in `nansum` test

**Used AI Studio**


### 是否引起精度变化
否
