### PR TITLE
[release/3.4] Inplace api not set unique name

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -2186,7 +2186,10 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
             set_tensor_name_str += f'{indent}{indent}egr::SetTensorName(unique_api_name, "{name}", &{name});\n'
             save_md5_checksum_str += f"{indent}{indent}egr::SaveTensorMD5CheckSumToFile(FLAGS_tensor_md5_checksum_output_path, {name});\n"
 
-        get_outputs_str += SET_TENSOR_NAME_TEMPLATE.format(set_tensor_name_str)
+        if not is_inplaced:
+            get_outputs_str += SET_TENSOR_NAME_TEMPLATE.format(
+                set_tensor_name_str
+            )
         get_outputs_str += SAVE_TENSOR_MD5_CHECKSUM_TEMPLATE.format(
             save_md5_checksum_str
         )


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements 

### Description
<!-- Describe what you’ve done -->
业务中会存储Tensor的name用于索引。因此不能改变已有name的Tensor name。因此inplace API不得修改output name。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

---

Cherry-pick of #79206 (authored by @wanghuancoder) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79206 <!-- For pass CI -->