### PR TITLE
[Test] Fix adam_step array-to-scalar conversion in test_adam_op.py

### DIFF
--- a/test/legacy_test/test_adam_op.py
+++ b/test/legacy_test/test_adam_op.py
@@ -359,7 +359,7 @@ def adam_step(inputs, attributes, weight_decay=False):
     moment1 = inputs['Moment1']
     moment2 = inputs['Moment2']
     moment2_max = inputs['Moment2Max']
-    lr = float(inputs['LearningRate'])
+    lr = inputs['LearningRate'].item()
     beta1_pow = inputs['Beta1Pow']
     beta2_pow = inputs['Beta2Pow']
 


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
test_adam_op.py 中的 adam_step 函数在将 LearningRate 从数组转换为标量时使用了 `float(inputs['LearningRate'])`。当 `inputs['LearningRate']` 为多维数组时，该转换会抛出 `TypeError: only 0-dimensional arrays can be converted to Python scalars`，导致 test_adam_op 和 test_adam_op_multi_thread 等多个测试用例失败。本 PR 将转换方式改为 `.item()`，使其兼容任意维度的数组，从而修复该问题。

### 是否引起精度变化
否
