### PR TITLE
[CUDAGraph] Guard float(paddle.version.cuda()) against non-numeric return

### DIFF
--- a/test/legacy_test/test_cuda_graph_static_mode.py
+++ b/test/legacy_test/test_cuda_graph_static_mode.py
@@ -52,7 +52,7 @@ def build_program(main, startup, batch_size, class_num):
 
 @unittest.skipIf(
     not (paddle.is_compiled_with_cuda() or is_custom_device())
-    or float(paddle.version.cuda()) < 11.0,
+    or (paddle.is_compiled_with_cuda() and float(paddle.version.cuda()) < 11.0),
     "only support cuda >= 11.0",
 )
 class TestCUDAGraphInStaticMode(unittest.TestCase):

--- a/test/legacy_test/test_cuda_graph_static_mode_error.py
+++ b/test/legacy_test/test_cuda_graph_static_mode_error.py
@@ -24,7 +24,7 @@ from paddle.device.cuda.graphs import CUDAGraph
 
 @unittest.skipIf(
     not (paddle.is_compiled_with_cuda() or is_custom_device())
-    or float(paddle.version.cuda()) < 11.0,
+    or (paddle.is_compiled_with_cuda() and float(paddle.version.cuda()) < 11.0),
     "only support cuda >= 11.0",
 )
 class TestCUDAGraphInFirstBatch(unittest.TestCase):


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
修复 test_cuda_graph_static_mode 和 test_cuda_graph_static_mode_error 测试中因 `paddle.version.cuda()` 返回非数字字符串（如 'False'）导致 `float()` 转换失败抛出 ValueError 的问题。

当 Paddle 编译了 CUDA 但未正确设置 CUDA 版本时，`paddle.version.cuda()` 可能返回 `'False'`，直接调用 `float('False')` 会触发 `could not convert string to float: 'False'` 错误。

通过在 `float()` 转换前增加 `paddle.is_compiled_with_cuda()` 检查，确保仅在确实编译了 CUDA 的情况下才进行版本比较，避免异常。

### 是否引起精度变化
否
