### PR TITLE
【FlexCheckpoint】fix missing key and unexpected key log 

### DIFF
--- a/python/paddle/distributed/flex_checkpoint/dcp/key_validation.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/key_validation.py
@@ -328,15 +328,21 @@ def _print_standard_report(
 ) -> None:
     lines = [_SEP, f"FlexCheckpoint Load Report (Checkpoint: {path})", _SEP]
 
-    if not result.missing_keys and not result.unexpected_keys:
+    if (
+        not result.missing_keys
+        and not result.unexpected_keys
+        and not result.shape_mismatches
+    ):
         lines.append(
             _C.green(
                 f"[OK] All {total_keys} keys matched successfully. "
-                f"(missing: 0, unexpected: 0, shape_mismatch: {len(result.shape_mismatches)})"
+                f"(missing: 0, unexpected: 0, shape_mismatch: 0)"
             )
         )
     else:
-        matched = total_keys - len(result.missing_keys)
+        matched = (
+            total_keys - len(result.missing_keys) - len(result.shape_mismatches)
+        )
         lines.append(
             f"Matched: {matched}/{total_keys} keys | "
             f"Missing: {len(result.missing_keys)} | "

--- a/python/paddle/distributed/flex_checkpoint/dcp/key_validation.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/key_validation.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import paddle
+from paddle.distributed import get_rank as _get_rank
 from paddle.distributed.fleet.utils.log_util import logger
 
 if TYPE_CHECKING:
@@ -203,7 +204,7 @@ def validate_and_report_keys_standard(
     )
 
     # 5. Print on rank 0 (or always when not using dist)
-    if not use_dist or paddle.distributed.get_rank() == 0:
+    if not use_dist or _get_rank() == 0:
         _print_standard_report(result, checkpoint_path, len(global_dst_keys))
 
     return result
@@ -261,7 +262,7 @@ def validate_and_report_keys_aoa(
     )
 
     # 6. Print on rank 0 (or always when not using dist)
-    if not use_dist or paddle.distributed.get_rank() == 0:
+    if not use_dist or _get_rank() == 0:
         _print_aoa_report(
             result, aoa_mappings, explicitly_removed, checkpoint_path
         )

--- a/python/paddle/distributed/flex_checkpoint/dcp/key_validation.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/key_validation.py
@@ -20,7 +20,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import paddle
-from paddle.distributed import get_rank as _get_rank
 from paddle.distributed.fleet.utils.log_util import logger
 
 if TYPE_CHECKING:
@@ -39,6 +38,11 @@ _MAX_SHAPE_MISMATCHES = 20
 _MAX_PATTERNS_SHOWN = 30
 _SRC_FOLD_THRESHOLD = 5
 _MAX_SLICE_DETAIL_KEYS = 5
+
+
+def _get_rank() -> int:
+    return paddle.distributed.get_rank()
+
 
 # ---------------------------------------------------------------------------
 # Color support (disabled by default)
@@ -340,9 +344,7 @@ def _print_standard_report(
             )
         )
     else:
-        matched = (
-            total_keys - len(result.missing_keys) - len(result.shape_mismatches)
-        )
+        matched = total_keys - len(result.missing_keys)
         lines.append(
             f"Matched: {matched}/{total_keys} keys | "
             f"Missing: {len(result.missing_keys)} | "

--- a/python/paddle/distributed/flex_checkpoint/dcp/key_validation.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/key_validation.py
@@ -1,0 +1,741 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import paddle
+from paddle.distributed.fleet.utils.log_util import logger
+
+if TYPE_CHECKING:
+    from paddle.distributed.communication.group import Group
+
+    from ..aoa.aoa_engine import AOAEngine
+    from .metadata import Metadata
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_MAX_TOTAL_LINES = 500
+_MAX_KEYS_SHOWN = 50
+_MAX_SHAPE_MISMATCHES = 20
+_MAX_PATTERNS_SHOWN = 30
+_SRC_FOLD_THRESHOLD = 5
+_MAX_SLICE_DETAIL_KEYS = 5
+
+# ---------------------------------------------------------------------------
+# Color support (disabled by default)
+# ---------------------------------------------------------------------------
+
+
+class _C:
+    """No-op color helpers. Colors are disabled by default."""
+
+    @staticmethod
+    def green(t):
+        return t
+
+    @staticmethod
+    def yellow(t):
+        return t
+
+    @staticmethod
+    def red(t):
+        return t
+
+    @staticmethod
+    def cyan(t):
+        return t
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ShapeMismatchInfo:
+    key: str
+    src_global_shape: tuple[int, ...]
+    dst_global_shape: tuple[int, ...]
+    src_dtype: str | None = None
+    dst_dtype: str | None = None
+
+
+@dataclass
+class KeyValidationResult:
+    missing_keys: set[str] = field(default_factory=set)
+    unexpected_keys: set[str] = field(default_factory=set)
+    shape_mismatches: list[ShapeMismatchInfo] = field(default_factory=list)
+    randomly_initialized_keys: set[str] = field(default_factory=set)
+
+
+@dataclass
+class AOASliceMapping:
+    src_key: str
+    src_slice: tuple[slice, ...]
+    dst_slice: tuple[slice, ...]
+    postprocess: list[str] | None = None
+
+
+@dataclass
+class AOAMappingEntry:
+    dst_key: str
+    dst_global_shape: tuple[int, ...]
+    slice_mappings: list[AOASliceMapping] = field(default_factory=list)
+    is_identity: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Public API: Standard (non-AOA) validation
+# ---------------------------------------------------------------------------
+
+
+def validate_and_report_keys_standard(
+    metadata_list: list[Metadata],
+    state_dict_param_names: set[str],
+    process_group: Group | None,
+    use_dist: bool,
+    checkpoint_path: str,
+    state_dict: dict,
+) -> KeyValidationResult:
+    """Validate keys for the standard (non-AOA) loading path.
+
+    Gathers global dst keys across all ranks, compares with global src keys,
+    checks shape mismatches. Prints report on rank 0 only.
+    """
+    # 1. Gather global dst keys
+    if use_dist:
+        global_dst_key_list = []
+        paddle.distributed.all_gather_object(
+            global_dst_key_list, list(state_dict_param_names), process_group
+        )
+        global_dst_keys = {
+            k for sublist in global_dst_key_list for k in sublist
+        }
+    else:
+        global_dst_keys = state_dict_param_names
+
+    # 2. Collect global src keys from metadata
+    global_src_keys = set()
+    for metadata in metadata_list:
+        for local_tensor_index in metadata.storage_metadata:
+            if (
+                local_tensor_index.replica_id is not None
+                and local_tensor_index.replica_id != 0
+            ):
+                continue
+            global_src_keys.add(local_tensor_index.tensor_key)
+
+    # 3. Compute missing / unexpected
+    missing_keys = global_dst_keys - global_src_keys
+    unexpected_keys = global_src_keys - global_dst_keys
+
+    # 4. Check shape mismatches for matching keys
+    shape_mismatches = []
+    assert state_dict is not None, "state_dict must not be None"
+    # Gather dst global shapes: {key: global_shape}
+    local_dst_shapes = {}
+    for key, val in state_dict.items():
+        k = key if isinstance(key, str) else key[0]
+        if hasattr(val, "global_shape"):
+            local_dst_shapes[k] = tuple(val.global_shape)
+        else:
+            local_dst_shapes[k] = tuple(val.shape)
+
+    if use_dist:
+        all_dst_shapes_list = []
+        paddle.distributed.all_gather_object(
+            all_dst_shapes_list, local_dst_shapes, process_group
+        )
+        global_dst_shapes = {}
+        for d in all_dst_shapes_list:
+            global_dst_shapes.update(d)
+    else:
+        global_dst_shapes = local_dst_shapes
+
+    # Build src global shapes from metadata
+    src_global_shapes: dict[str, tuple[int, ...]] = {}
+    for metadata in metadata_list:
+        if not metadata.state_dict_metadata:
+            continue
+        for key, src_metas in metadata.state_dict_metadata.items():
+            if not src_metas or src_metas[0].global_shape is None:
+                continue
+            src_global_shapes[key] = tuple(src_metas[0].global_shape)
+
+    matching_keys = global_dst_keys & global_src_keys
+    for key in sorted(matching_keys):
+        src_shape = src_global_shapes.get(key)
+        dst_shape = global_dst_shapes.get(key)
+        if src_shape is None or dst_shape is None:
+            continue
+        if src_shape != dst_shape:
+            shape_mismatches.append(
+                ShapeMismatchInfo(
+                    key=key,
+                    src_global_shape=src_shape,
+                    dst_global_shape=dst_shape,
+                )
+            )
+
+    result = KeyValidationResult(
+        missing_keys=missing_keys,
+        unexpected_keys=unexpected_keys,
+        shape_mismatches=shape_mismatches,
+        randomly_initialized_keys=set(),
+    )
+
+    # 5. Print on rank 0
+    if paddle.distributed.get_rank() == 0:
+        _print_standard_report(result, checkpoint_path, len(global_dst_keys))
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API: AOA validation
+# ---------------------------------------------------------------------------
+
+
+def validate_and_report_keys_aoa(
+    aoa_engine: AOAEngine,
+    metadata: Metadata,
+    checkpoint_path: str,
+) -> KeyValidationResult:
+    """Validate keys for the AOA loading path.
+
+    Called AFTER AOAEngine is initialized. Uses output_vars/input_vars to
+    compute truly missing/unexpected keys and builds the mapping table.
+    """
+    # 1. Covered dst keys
+    aoa_covered_dst_keys = {
+        k for k, v in aoa_engine.output_vars.items() if v is not None
+    }
+    randomly_initialized_keys = set(aoa_engine.need_add_output_vars)
+
+    # 2. Consumed src keys
+    consumed_src_keys = set()
+    for tensor_desc in aoa_engine.output_vars.values():
+        if tensor_desc is None:
+            continue
+        for src_key, _, _, _ in tensor_desc.slices:
+            consumed_src_keys.add(src_key)
+
+    # 3. Explicitly removed / all src keys
+    explicitly_removed = set(aoa_engine.need_remove_input_vars)
+    all_src_keys = set(aoa_engine.input_vars.keys())
+
+    # 4. Compute truly missing / unexpected
+    dst_state_keys = aoa_engine.context.get_all_dst_state_keys()
+    truly_missing = (
+        dst_state_keys - aoa_covered_dst_keys - randomly_initialized_keys
+    )
+    truly_unexpected = all_src_keys - consumed_src_keys - explicitly_removed
+
+    # 5. Build AOA mapping entries
+    aoa_mappings = _build_aoa_mappings(aoa_engine)
+
+    result = KeyValidationResult(
+        missing_keys=truly_missing,
+        unexpected_keys=truly_unexpected,
+        shape_mismatches=[],
+        randomly_initialized_keys=randomly_initialized_keys,
+    )
+
+    # 6. Print on rank 0
+    if paddle.distributed.get_rank() == 0:
+        _print_aoa_report(
+            result, aoa_mappings, explicitly_removed, checkpoint_path
+        )
+
+    return result
+
+
+def _build_aoa_mappings(aoa_engine: AOAEngine) -> list[AOAMappingEntry]:
+    """Extract mapping entries from AOA engine's output_vars."""
+    entries = []
+    for dst_key, tensor_desc in sorted(aoa_engine.output_vars.items()):
+        if tensor_desc is None:
+            continue
+        shape = tuple(tensor_desc.shape)
+        slice_mappings = []
+        for src_key, src_sl, dst_sl, pp_list in tensor_desc.slices:
+            slice_mappings.append(
+                AOASliceMapping(
+                    src_key=src_key,
+                    src_slice=src_sl,
+                    dst_slice=dst_sl,
+                    postprocess=pp_list,
+                )
+            )
+        # Determine if identity
+        is_identity = (
+            len(slice_mappings) == 1
+            and slice_mappings[0].src_key == dst_key
+            and slice_mappings[0].postprocess is None
+            and _slice_covers_full(slice_mappings[0].dst_slice, shape)
+        )
+        entries.append(
+            AOAMappingEntry(
+                dst_key=dst_key,
+                dst_global_shape=shape,
+                slice_mappings=slice_mappings,
+                is_identity=is_identity,
+            )
+        )
+    return entries
+
+
+def _slice_covers_full(sl: tuple[slice, ...], shape: tuple[int, ...]) -> bool:
+    """Check if a slice tuple covers the full tensor."""
+    if len(sl) != len(shape):
+        return False
+    for s, dim in zip(sl, shape):
+        if s.start != 0 or s.stop != dim:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Printing: Standard report
+# ---------------------------------------------------------------------------
+
+_SEP = "=" * 70
+_THIN_SEP = "-" * 70
+
+
+def _print_standard_report(
+    result: KeyValidationResult, path: str, total_keys: int
+) -> None:
+    lines = [_SEP, f"FlexCheckpoint Load Report (Checkpoint: {path})", _SEP]
+
+    if not result.missing_keys and not result.unexpected_keys:
+        lines.append(
+            _C.green(
+                f"[OK] All {total_keys} keys matched successfully. "
+                f"(missing: 0, unexpected: 0, shape_mismatch: {len(result.shape_mismatches)})"
+            )
+        )
+    else:
+        matched = total_keys - len(result.missing_keys)
+        lines.append(
+            f"Matched: {matched}/{total_keys} keys | "
+            f"Missing: {len(result.missing_keys)} | "
+            f"Unexpected: {len(result.unexpected_keys)} | "
+            f"Shape mismatch: {len(result.shape_mismatches)}"
+        )
+        if result.missing_keys:
+            lines.append("")
+            lines.append(
+                _C.yellow(
+                    f"[WARNING] Missing keys ({len(result.missing_keys)} total) "
+                    f"- model expects but not in checkpoint:"
+                )
+            )
+            lines.extend(_format_key_list(result.missing_keys))
+        if result.unexpected_keys:
+            lines.append("")
+            lines.append(
+                _C.yellow(
+                    f"[WARNING] Unexpected keys ({len(result.unexpected_keys)} total) "
+                    f"- in checkpoint but not used:"
+                )
+            )
+            lines.extend(_format_key_list(result.unexpected_keys))
+        if result.shape_mismatches:
+            lines.append("")
+            lines.append(
+                _C.yellow(
+                    f"[WARNING] Shape mismatches ({len(result.shape_mismatches)} total):"
+                )
+            )
+            for m in result.shape_mismatches[:_MAX_SHAPE_MISMATCHES]:
+                lines.append(
+                    f"    {m.key}: ckpt={list(m.src_global_shape)} vs model={list(m.dst_global_shape)}"
+                )
+            remaining = len(result.shape_mismatches) - _MAX_SHAPE_MISMATCHES
+            if remaining > 0:
+                lines.append(f"    ... and {remaining} more")
+
+    lines.append(_SEP)
+    _emit(lines)
+
+
+# ---------------------------------------------------------------------------
+# Printing: AOA report
+# ---------------------------------------------------------------------------
+
+
+def _print_aoa_report(
+    result: KeyValidationResult,
+    aoa_mappings: list[AOAMappingEntry],
+    explicitly_removed: set[str],
+    path: str,
+) -> None:
+    lines = [
+        _SEP,
+        f"FlexCheckpoint Load Report (Checkpoint: {path}, AOA enabled)",
+        _SEP,
+    ]
+
+    # Status
+    total_dst = (
+        len(aoa_mappings)
+        + len(result.missing_keys)
+        + len(result.randomly_initialized_keys)
+    )
+    if not result.missing_keys and not result.unexpected_keys:
+        lines.append(
+            _C.green(
+                f"[OK] All {total_dst} keys resolved via AOA mapping. "
+                f"(missing: 0, unexpected: 0)"
+            )
+        )
+    else:
+        matched = total_dst - len(result.missing_keys)
+        lines.append(
+            f"Matched: {matched}/{total_dst} keys | "
+            f"Missing: {len(result.missing_keys)} | "
+            f"Unexpected: {len(result.unexpected_keys)}"
+        )
+        if result.missing_keys:
+            lines.append("")
+            lines.append(
+                _C.yellow(
+                    f"[WARNING] Missing keys ({len(result.missing_keys)} total) "
+                    f"- no AOA source mapping:"
+                )
+            )
+            lines.extend(_format_key_list(result.missing_keys))
+        if result.unexpected_keys:
+            lines.append("")
+            lines.append(
+                _C.yellow(
+                    f"[WARNING] Unexpected keys ({len(result.unexpected_keys)} total) "
+                    f"- in checkpoint but not consumed by any AOA mapping:"
+                )
+            )
+            lines.extend(_format_key_list(result.unexpected_keys))
+
+    # AOA mapping table
+    lines.append("")
+    lines.append(_C.cyan(_THIN_SEP))
+
+    # Classify mappings
+    non_identity = [m for m in aoa_mappings if not m.is_identity]
+    rename_only, with_transform, structural = _classify_mappings(non_identity)
+
+    total_dst = len(aoa_mappings)
+    total_src = len(
+        {sm.src_key for m in aoa_mappings for sm in m.slice_mappings}
+    )
+    lines.append(
+        _C.cyan(f"AOA Key Mapping ({total_dst} dst keys, {total_src} src keys)")
+    )
+    lines.append(_C.cyan(_THIN_SEP))
+
+    # Summary
+    lines.append("Summary:")
+    lines.append(
+        f"  1-to-1 rename (same shape, no transform):  {len(rename_only)} keys (not shown)"
+    )
+    lines.append(
+        f"  1-to-1 with transform:                     {len(with_transform)} keys "
+        f"({min(len(_group_by_signature(with_transform)), _MAX_PATTERNS_SHOWN)} pattern(s) below)"
+    )
+    lines.append(
+        f"  Structural (N-to-1 / 1-to-N / reshape):    {len(structural)} keys "
+        f"({min(len(_group_by_signature(structural)), _MAX_PATTERNS_SHOWN)} pattern(s) below)"
+    )
+
+    # Print transform patterns
+    next_index = 1
+    if with_transform:
+        lines.append("")
+        result_lines, next_index = _format_pattern_groups(
+            _group_by_signature(with_transform), "1-to-1 transform", next_index
+        )
+        lines.extend(result_lines)
+
+    # Print structural patterns
+    if structural:
+        lines.append("")
+        result_lines, next_index = _format_pattern_groups(
+            _group_by_signature(structural), "structural", next_index
+        )
+        lines.extend(result_lines)
+
+    # Removed / Initialized
+    lines.append("")
+    removed_str = ", ".join(sorted(explicitly_removed)[:5])
+    if len(explicitly_removed) > 5:
+        removed_str += f" ... +{len(explicitly_removed) - 5} more"
+    lines.append(f"Removed ({len(explicitly_removed)}): {removed_str or '-'}")
+    init_keys = result.randomly_initialized_keys
+    init_str = ", ".join(sorted(init_keys)[:5])
+    if len(init_keys) > 5:
+        init_str += f" ... +{len(init_keys) - 5} more"
+    lines.append(f"Initialized ({len(init_keys)}): {init_str or '-'}")
+
+    lines.append("")
+    lines.append(_THIN_SEP)
+    lines.append(_SEP)
+    _emit(lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: Classification & Pattern Merging
+# ---------------------------------------------------------------------------
+
+
+def _classify_mappings(
+    non_identity: list[AOAMappingEntry],
+) -> tuple[list[AOAMappingEntry], list[AOAMappingEntry], list[AOAMappingEntry]]:
+    """Classify non-identity mappings into rename_only, with_transform, structural."""
+    rename_only = []
+    with_transform = []
+    structural = []
+    for entry in non_identity:
+        if len(entry.slice_mappings) != 1:
+            structural.append(entry)
+            continue
+        sm = entry.slice_mappings[0]
+        src_norm = re.sub(r"\d+", "{N}", sm.src_key)
+        dst_norm = re.sub(r"\d+", "{N}", entry.dst_key)
+        if src_norm != dst_norm:
+            structural.append(entry)
+        elif sm.postprocess is None:
+            rename_only.append(entry)
+        else:
+            with_transform.append(entry)
+    return rename_only, with_transform, structural
+
+
+def _get_signature(entry: AOAMappingEntry) -> str:
+    """Compute a structure signature for pattern grouping."""
+    dst_norm = re.sub(r"\d+", "{N}", entry.dst_key)
+    parts = [dst_norm, str(len(entry.slice_mappings))]
+    for sm in entry.slice_mappings:
+        src_norm = re.sub(r"\d+", "{N}", sm.src_key)
+        pp = "|".join(sm.postprocess) if sm.postprocess else ""
+        parts.append(f"{src_norm}:{pp}")
+    return "@@".join(parts)
+
+
+def _group_by_signature(
+    entries: list[AOAMappingEntry],
+) -> dict[str, list[AOAMappingEntry]]:
+    """Group entries by structure signature."""
+    groups: dict[str, list[AOAMappingEntry]] = defaultdict(list)
+    for entry in entries:
+        groups[_get_signature(entry)].append(entry)
+    return groups
+
+
+def _format_pattern_groups(
+    groups: dict[str, list[AOAMappingEntry]], label: str, start_index: int = 1
+) -> tuple[list[str], int]:
+    """Format grouped patterns with box-drawing style. Returns (lines, next_index)."""
+    lines = []
+    shown = 0
+    idx = start_index
+    for _sig, entries in sorted(groups.items(), key=lambda x: -len(x[1])):
+        if shown >= _MAX_PATTERNS_SHOWN:
+            remaining = len(groups) - shown
+            lines.append(f"  ... and {remaining} more {label} pattern(s)")
+            break
+        shown += 1
+        representative = entries[0]
+        count = len(entries)
+
+        # Build pattern title
+        dst_pattern = re.sub(r"\d+", "*", representative.dst_key)
+        lines.append(f"[Pattern #{idx}] {dst_pattern}  ({count} keys, {label})")
+        lines.append("\u250c" + "\u2500" * 69)
+        # DST line
+        shape_str = list(representative.dst_global_shape)
+        lines.append(f"\u2502 DST: {representative.dst_key}  {shape_str}")
+        # SRC lines (with folding)
+        _append_src_lines(lines, representative.slice_mappings)
+        # OP line
+        ops = _describe_ops(representative)
+        if ops:
+            lines.append(f"\u2502 OP:  {ops}")
+        lines.append("\u2514" + "\u2500" * 69)
+        lines.append("")
+        idx += 1
+    return lines, idx
+
+
+def _append_src_lines(
+    lines: list[str], slice_mappings: list[AOASliceMapping]
+) -> None:
+    """Append SRC lines, folding consecutive numeric patterns."""
+    if len(slice_mappings) <= _SRC_FOLD_THRESHOLD:
+        for i, sm in enumerate(slice_mappings):
+            prefix = "\u2502 SRC:" if i == 0 else "\u2502    +"
+            slice_info = _format_slice_range(sm.src_slice, sm.dst_slice)
+            lines.append(f"{prefix} {sm.src_key}{slice_info}")
+        return
+
+    # Try to fold: find common pattern
+    src_keys = [sm.src_key for sm in slice_mappings]
+    folded = _try_fold_src_keys(src_keys)
+    if folded:
+        lines.append(f"\u2502 SRC: {folded}  (\u00d7{len(slice_mappings)})")
+    else:
+        # Show first 2 and last 1
+        lines.append(f"\u2502 SRC: {src_keys[0]}")
+        lines.append(f"\u2502    + {src_keys[1]}")
+        lines.append(f"\u2502    + ... ({len(src_keys) - 3} more)")
+        lines.append(f"\u2502    + {src_keys[-1]}")
+
+
+def _format_slice_range(
+    src_slice: tuple[slice, ...], dst_slice: tuple[slice, ...]
+) -> str:
+    """Format slice info when same src_key appears multiple times."""
+    src_str = ",".join(f"{s.start}:{s.stop}" for s in src_slice)
+    dst_str = ",".join(f"{s.start}:{s.stop}" for s in dst_slice)
+    return f"  [{src_str}] -> dst[{dst_str}]"
+
+
+def _try_fold_src_keys(keys: list[str]) -> str | None:
+    """Try to fold src keys like experts.0, experts.1, ..., experts.255 into a pattern."""
+    if len(keys) < 2:
+        return None
+    # Find varying digit segments
+    pattern = re.sub(r"\d+", "{}", keys[0])
+    for k in keys[1:]:
+        if re.sub(r"\d+", "{}", k) != pattern:
+            return None
+    # Extract the varying numbers
+    nums_per_key = [re.findall(r"\d+", k) for k in keys]
+    num_positions = len(nums_per_key[0])
+    # Find which position varies
+    varying_pos = []
+    for pos in range(num_positions):
+        vals = [int(n[pos]) for n in nums_per_key]
+        if len(set(vals)) > 1:
+            varying_pos.append(pos)
+    if len(varying_pos) != 1:
+        return None
+    vpos = varying_pos[0]
+    vals = [int(n[vpos]) for n in nums_per_key]
+    lo, hi = min(vals), max(vals)
+    # Reconstruct pattern with {lo..hi}
+    segments = re.split(r"\d+", keys[0])
+    digits = re.findall(r"\d+", keys[0])
+    result_parts = []
+    for i, seg in enumerate(segments):
+        result_parts.append(seg)
+        if i < len(digits):
+            if i == vpos:
+                result_parts.append(f"{{{lo}..{hi}}}")
+            else:
+                result_parts.append(digits[i])
+    return "".join(result_parts)
+
+
+def _describe_ops(entry: AOAMappingEntry) -> str:
+    """Describe the operations for a mapping entry."""
+    ops = []
+    if len(entry.slice_mappings) > 1:
+        ops.append("concat")
+    # Collect postprocess from first slice (representative)
+    if entry.slice_mappings:
+        pp = entry.slice_mappings[0].postprocess
+        if pp:
+            for p in pp:
+                if p.startswith("["):
+                    ops.append(f"permute({p})")
+                else:
+                    ops.append(f"cast({p})")
+    return " + ".join(ops)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: Key list formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_key_list(keys: set[str]) -> list[str]:
+    """Format a set of keys with prefix grouping and truncation."""
+    if not keys:
+        return []
+    sorted_keys = sorted(keys)
+    if len(sorted_keys) <= _MAX_KEYS_SHOWN:
+        return [f"    {k}" for k in sorted_keys]
+
+    # Adaptive grouping: find the prefix depth that gives reasonable group sizes
+    groups = _group_keys_adaptive(sorted_keys)
+
+    lines = []
+    groups_shown = 0
+    for prefix, group_keys in sorted(groups.items(), key=lambda x: -len(x[1])):
+        if groups_shown >= _MAX_KEYS_SHOWN:
+            remaining_groups = len(groups) - groups_shown
+            remaining_keys = sum(
+                len(v)
+                for i, v in enumerate(
+                    sorted(groups.values(), key=len, reverse=True)
+                )
+                if i >= groups_shown
+            )
+            lines.append(
+                f"    ... and {remaining_groups} more groups ({remaining_keys} keys)"
+            )
+            break
+        groups_shown += 1
+        if len(group_keys) > 3:
+            lines.append(f"    [{prefix}] ({len(group_keys)} keys):")
+            for k in group_keys[:3]:
+                lines.append(f"      {k}")
+            lines.append(f"      ... +{len(group_keys) - 3} more")
+        else:
+            for k in group_keys:
+                lines.append(f"    {k}")
+    return lines
+
+
+def _group_keys_adaptive(keys: list[str]) -> dict[str, list[str]]:
+    """Group keys by normalized pattern (digits replaced with *)."""
+    groups: dict[str, list[str]] = defaultdict(list)
+    for k in keys:
+        # Replace all digit segments with * to get the pattern
+        pattern = re.sub(r"(?<=\.)\d+(?=\.)|(?<=\.)\d+$", "*", k)
+        groups[pattern].append(k)
+    return dict(groups)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: Output
+# ---------------------------------------------------------------------------
+
+
+def _emit(lines: list[str]) -> None:
+    """Output lines via logger, respecting total line limit."""
+    for i, line in enumerate(lines):
+        if i >= _MAX_TOTAL_LINES:
+            logger.info(
+                f"... output truncated ({len(lines) - i} lines omitted)"
+            )
+            break
+        logger.info(line)

--- a/python/paddle/distributed/flex_checkpoint/dcp/key_validation.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/key_validation.py
@@ -202,8 +202,8 @@ def validate_and_report_keys_standard(
         randomly_initialized_keys=set(),
     )
 
-    # 5. Print on rank 0
-    if paddle.distributed.get_rank() == 0:
+    # 5. Print on rank 0 (or always when not using dist)
+    if not use_dist or paddle.distributed.get_rank() == 0:
         _print_standard_report(result, checkpoint_path, len(global_dst_keys))
 
     return result

--- a/python/paddle/distributed/flex_checkpoint/dcp/key_validation.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/key_validation.py
@@ -218,6 +218,7 @@ def validate_and_report_keys_aoa(
     aoa_engine: AOAEngine,
     metadata: Metadata,
     checkpoint_path: str,
+    use_dist: bool = True,
 ) -> KeyValidationResult:
     """Validate keys for the AOA loading path.
 
@@ -259,8 +260,8 @@ def validate_and_report_keys_aoa(
         randomly_initialized_keys=randomly_initialized_keys,
     )
 
-    # 6. Print on rank 0
-    if paddle.distributed.get_rank() == 0:
+    # 6. Print on rank 0 (or always when not using dist)
+    if not use_dist or paddle.distributed.get_rank() == 0:
         _print_aoa_report(
             result, aoa_mappings, explicitly_removed, checkpoint_path
         )

--- a/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
@@ -280,8 +280,7 @@ def get_rank_to_files(
         logger.warning(
             "No necessary data files found in the checkpoint directory. Please check the metadata."
         )
-        missing_keys = set(state_dict.keys())
-        return {}, missing_keys, mw_name_compatibility_mapping
+        return {}, mw_name_compatibility_mapping
 
     # allgather all accessible files
     global_data_files = []
@@ -311,20 +310,6 @@ def get_rank_to_files(
             mw_name_compatibility_mapping = _modify_mw_name_for_compatibility(
                 state_dict, missing_keys, tensor_key_list
             )
-            if len(missing_keys) > 0:
-                logger.warning(
-                    f"Missing keys:{missing_keys}, check whether the checkpoint is complete."
-                )
-        else:
-            logger.warning(
-                f"Missing keys:{missing_keys}, check whether the checkpoint is complete."
-            )
-
-    unexpected_keys = set(tensor_key_list) - set(state_dict_param_names)
-    if len(unexpected_keys) > 0:
-        logger.warning(
-            f"Unexpected keys:{unexpected_keys}, these keys exist in checkpoint but not in state_dict."
-        )
 
     rank_to_files = {}
     for rank, need_files in enumerate(all_necessary_files):
@@ -334,7 +319,7 @@ def get_rank_to_files(
         ]
         rank_to_files[rank] = unique_need_files
     logger.debug(f"mapping rank_to_files:{rank_to_files}")
-    return rank_to_files, missing_keys, mw_name_compatibility_mapping
+    return rank_to_files, mw_name_compatibility_mapping
 
 
 def _modify_mw_name_for_compatibility(
@@ -632,14 +617,16 @@ def _handle_aoa(
         ]
         for param_name, local_tensor_metas in state_dict_metadata.items()
     }
-    logger_missing_key_and_unexpected_keys_before_aoa(
-        metadata, load_dict, process_group, safetensors, use_dist
-    )
     aoa_engine = AOAEngine(
         source_state_shard_info=source_state_shard_info,
         destination_state_shard_info=destination_state_shard_info,
         aoa_config=aoa_config,
     )
+
+    # AOA key validation (after engine init)
+    from .key_validation import validate_and_report_keys_aoa
+
+    validate_and_report_keys_aoa(aoa_engine, metadata, path)
 
     src_desc_to_sharded_tensor = {}
     dst_to_src_desc_mapping = {}
@@ -711,6 +698,7 @@ def _handle_aoa(
         safetensors=safetensors,
         worker_groups=worker_groups,
         comm_method=comm_method,
+        skip_validation=True,
     )
 
     for dst_desc, src_desc in dst_to_src_desc_mapping.items():
@@ -1201,6 +1189,7 @@ def load_state_dict_impl(
     safetensors: bool = False,
     worker_groups: list[Group] | None = None,
     comm_method: str = 'broadcast',
+    skip_validation: bool = False,
 ) -> None:
     with paddle.base.dygraph.guard():
         global _metadata_manager
@@ -1248,19 +1237,30 @@ def load_state_dict_impl(
                 metadata_list.append(paddle.load(os.path.join(path, file)))
             _metadata_manager.set_metadata_list(metadata_list)
 
-        rank_to_files, missing_keys, mw_name_compatibility_mapping = (
-            get_rank_to_files(
+        rank_to_files, mw_name_compatibility_mapping = get_rank_to_files(
+            _metadata_manager.get_metadata_list(),
+            local_data_files,
+            flat_state_dict,
+            process_group,
+            use_dist,
+            mw_name_compatibility,
+        )
+
+        # Key validation (global)
+        if not skip_validation:
+            from .key_validation import validate_and_report_keys_standard
+
+            state_dict_param_names = {
+                key if isinstance(key, str) else key[0]
+                for key in flat_state_dict.keys()
+            }
+            validate_and_report_keys_standard(
                 _metadata_manager.get_metadata_list(),
-                local_data_files,
-                flat_state_dict,
+                state_dict_param_names,
                 process_group,
                 use_dist,
-                mw_name_compatibility,
-            )
-        )
-        if len(missing_keys) > 0:
-            logger.warning(
-                f"The following keys:{missing_keys} are not found in checkpoint path: {path}."
+                path,
+                state_dict=flat_state_dict,
             )
 
         cur_rank = paddle.distributed.get_rank()
@@ -1789,57 +1789,6 @@ def merge_sharded_state_dict(
     SaveSafetensor.save_single_safetenors(
         local_state_dict_to_save, paddle.distributed.get_rank()
     )
-
-
-def logger_missing_key_and_unexpected_keys_before_aoa(
-    metadata: Metadata,
-    state_dict: dict[str, Tensor] | dict[str, ShardedWeight],
-    process_group: Group | None = None,
-    safetensors: bool = False,
-    use_dist: bool = False,
-):
-    first_key = next(iter(state_dict), None)
-    if isinstance(first_key, tuple):
-        flat_state_dict = state_dict
-    else:
-        flat_state_dict, mapping = flatten_state_dict(state_dict)
-
-    global_src_key_list = []
-    dst_key_list = [
-        key if isinstance(key, str) else key[0]
-        for key in flat_state_dict.keys()
-    ]
-    global_dst_key_list = []
-    if use_dist:
-        paddle.distributed.all_gather_object(
-            global_dst_key_list, dst_key_list, process_group
-        )
-        flatten_global_dst_key_list = [
-            item for sublist in global_dst_key_list for item in sublist
-        ]
-    else:
-        global_dst_key_list.extend(dst_key_list)
-        flatten_global_dst_key_list = global_dst_key_list
-
-    for local_tensor_index, file_name in metadata.storage_metadata.items():
-        if (
-            local_tensor_index.replica_id is not None
-            and local_tensor_index.replica_id != 0
-        ):
-            continue
-        global_src_key_list.append(local_tensor_index.tensor_key)
-    missing_keys = set(flatten_global_dst_key_list) - set(global_src_key_list)
-    unexpected_keys = set(global_src_key_list) - set(
-        flatten_global_dst_key_list
-    )
-    if len(missing_keys) > 0:
-        logger.warning(
-            f"Missing keys:{missing_keys}, check whether the checkpoint is complete and note whether the aoa_statements is complete."
-        )
-    if len(unexpected_keys) > 0:
-        logger.warning(
-            f"Unexpected keys:{unexpected_keys}, check whether the model is complete and note whether the aoa_statements is complete."
-        )
 
 
 class SavePartialSafetensors:

--- a/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
@@ -626,7 +626,7 @@ def _handle_aoa(
     # AOA key validation (after engine init)
     from .key_validation import validate_and_report_keys_aoa
 
-    validate_and_report_keys_aoa(aoa_engine, metadata, path)
+    validate_and_report_keys_aoa(aoa_engine, metadata, path, use_dist=use_dist)
 
     src_desc_to_sharded_tensor = {}
     dst_to_src_desc_mapping = {}

--- a/test/auto_parallel/test_dist_checkpoint_utils.py
+++ b/test/auto_parallel/test_dist_checkpoint_utils.py
@@ -133,7 +133,6 @@ class TestDistCheckpointUtils(test_base.CommunicationTestDistBase):
         }
         (
             rank_to_files,
-            missing_keys,
             mw_name_compatibility_mapping,
         ) = get_rank_to_files(
             metadata_list,
@@ -144,7 +143,6 @@ class TestDistCheckpointUtils(test_base.CommunicationTestDistBase):
         )
         self.assertTrue(len(rank_to_files) == 1 and 0 in rank_to_files)
         self.assertTrue(rank_to_files[0] == ["0_0.distcp"])
-        self.assertTrue(len(missing_keys) == 0)
         self.assertTrue(len(mw_name_compatibility_mapping) == 0)
 
         new_state_dict = {
@@ -153,7 +151,6 @@ class TestDistCheckpointUtils(test_base.CommunicationTestDistBase):
         }
         (
             rank_to_files,
-            missing_keys,
             mw_name_compatibility_mapping,
         ) = get_rank_to_files(
             metadata_list,
@@ -164,9 +161,7 @@ class TestDistCheckpointUtils(test_base.CommunicationTestDistBase):
         )
         self.assertTrue(len(rank_to_files) == 1 and 0 in rank_to_files)
         self.assertTrue(rank_to_files[0] == ["0_0.distcp"])
-        self.assertTrue(len(missing_keys) == 1)
         self.assertTrue(len(mw_name_compatibility_mapping) == 0)
-        self.assertTrue("w3" in missing_keys)
 
         new_state_dict = {
             "w3": paddle.to_tensor([3, 4]),
@@ -174,7 +169,6 @@ class TestDistCheckpointUtils(test_base.CommunicationTestDistBase):
         }
         (
             rank_to_files,
-            missing_keys,
             mw_name_compatibility_mapping,
         ) = get_rank_to_files(
             metadata_list,
@@ -184,10 +178,7 @@ class TestDistCheckpointUtils(test_base.CommunicationTestDistBase):
             use_dist,
         )
         self.assertTrue(len(rank_to_files) == 0)
-        self.assertTrue(len(missing_keys) == 2)
         self.assertTrue(len(mw_name_compatibility_mapping) == 0)
-        self.assertTrue("w3" in missing_keys)
-        self.assertTrue("w4" in missing_keys)
 
         ckpt_dir_tmp.cleanup()
 

--- a/test/flex_checkpoint/test_key_validation.py
+++ b/test/flex_checkpoint/test_key_validation.py
@@ -731,13 +731,23 @@ class TestValidateAndReportKeysStandard(unittest.TestCase):
         )
         self.assertEqual(len(result.unexpected_keys), 0)
 
-    @patch("paddle.distributed.get_rank", return_value=1)
+    @patch(
+        "paddle.distributed.flex_checkpoint.dcp.key_validation._get_rank",
+        return_value=1,
+    )
     @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
-    def test_non_rank0_no_print(self, mock_emit, mock_rank):
+    @patch("paddle.distributed.all_gather_object")
+    def test_non_rank0_no_print(self, mock_gather, mock_emit, mock_rank):
         metadata = self._make_metadata({"w1": (4,)})
         state_dict = {"w1": paddle.zeros([4])}
+
+        def gather_side_effect(out_list, obj, group=None):
+            out_list.clear()
+            out_list.append(obj)
+
+        mock_gather.side_effect = gather_side_effect
         validate_and_report_keys_standard(
-            [metadata], {"w1"}, None, False, "/tmp/ckpt", state_dict
+            [metadata], {"w1"}, None, True, "/tmp/ckpt", state_dict
         )
         mock_emit.assert_not_called()
 

--- a/test/flex_checkpoint/test_key_validation.py
+++ b/test/flex_checkpoint/test_key_validation.py
@@ -1,0 +1,846 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import paddle
+from paddle.distributed.flex_checkpoint.dcp.key_validation import (
+    AOAMappingEntry,
+    AOASliceMapping,
+    KeyValidationResult,
+    ShapeMismatchInfo,
+    _append_src_lines,
+    _build_aoa_mappings,
+    _classify_mappings,
+    _describe_ops,
+    _emit,
+    _format_key_list,
+    _format_pattern_groups,
+    _format_slice_range,
+    _get_signature,
+    _group_by_signature,
+    _group_keys_adaptive,
+    _print_aoa_report,
+    _print_standard_report,
+    _slice_covers_full,
+    _try_fold_src_keys,
+    validate_and_report_keys_aoa,
+    validate_and_report_keys_standard,
+)
+from paddle.distributed.flex_checkpoint.dcp.metadata import (
+    LocalTensorIndex,
+    LocalTensorMetadata,
+    Metadata,
+)
+
+
+class TestSliceCoversFull(unittest.TestCase):
+    def test_covers_full(self):
+        sl = (slice(0, 4), slice(0, 8))
+        self.assertTrue(_slice_covers_full(sl, (4, 8)))
+
+    def test_not_covers_partial(self):
+        sl = (slice(0, 2), slice(0, 8))
+        self.assertFalse(_slice_covers_full(sl, (4, 8)))
+
+    def test_not_covers_mismatched_dims(self):
+        sl = (slice(0, 4),)
+        self.assertFalse(_slice_covers_full(sl, (4, 8)))
+
+    def test_non_zero_start(self):
+        sl = (slice(1, 4), slice(0, 8))
+        self.assertFalse(_slice_covers_full(sl, (4, 8)))
+
+
+class TestFormatSliceRange(unittest.TestCase):
+    def test_basic(self):
+        src_sl = (slice(0, 4), slice(0, 8))
+        dst_sl = (slice(0, 4), slice(0, 8))
+        result = _format_slice_range(src_sl, dst_sl)
+        self.assertIn("0:4", result)
+        self.assertIn("0:8", result)
+        self.assertIn("->", result)
+
+    def test_partial_slices(self):
+        src_sl = (slice(2, 6),)
+        dst_sl = (slice(0, 4),)
+        result = _format_slice_range(src_sl, dst_sl)
+        self.assertIn("2:6", result)
+        self.assertIn("0:4", result)
+
+
+class TestTryFoldSrcKeys(unittest.TestCase):
+    def test_fold_consecutive(self):
+        keys = [f"model.experts.{i}.weight" for i in range(8)]
+        result = _try_fold_src_keys(keys)
+        self.assertIsNotNone(result)
+        self.assertIn("{0..7}", result)
+
+    def test_no_fold_different_patterns(self):
+        keys = ["model.a.weight", "model.b.weight"]
+        result = _try_fold_src_keys(keys)
+        self.assertIsNone(result)
+
+    def test_no_fold_multiple_varying_positions(self):
+        keys = ["layer.0.expert.0.w", "layer.1.expert.1.w"]
+        result = _try_fold_src_keys(keys)
+        self.assertIsNone(result)
+
+    def test_single_key(self):
+        result = _try_fold_src_keys(["a.0.b"])
+        self.assertIsNone(result)
+
+    def test_empty(self):
+        result = _try_fold_src_keys([])
+        self.assertIsNone(result)
+
+
+class TestDescribeOps(unittest.TestCase):
+    def test_single_with_permute(self):
+        entry = AOAMappingEntry(
+            dst_key="a.weight",
+            dst_global_shape=(4, 8),
+            slice_mappings=[
+                AOASliceMapping(
+                    "b.weight",
+                    (slice(0, 4), slice(0, 8)),
+                    (slice(0, 4), slice(0, 8)),
+                    ["[1, 0]"],
+                )
+            ],
+        )
+        result = _describe_ops(entry)
+        self.assertIn("permute([1, 0])", result)
+
+    def test_concat_with_cast(self):
+        entry = AOAMappingEntry(
+            dst_key="a.weight",
+            dst_global_shape=(8, 4),
+            slice_mappings=[
+                AOASliceMapping(
+                    "b.weight",
+                    (slice(0, 4), slice(0, 4)),
+                    (slice(0, 4), slice(0, 4)),
+                    ["bfloat16"],
+                ),
+                AOASliceMapping(
+                    "c.weight",
+                    (slice(0, 4), slice(0, 4)),
+                    (slice(4, 8), slice(0, 4)),
+                    ["bfloat16"],
+                ),
+            ],
+        )
+        result = _describe_ops(entry)
+        self.assertIn("concat", result)
+        self.assertIn("cast(bfloat16)", result)
+
+    def test_no_ops(self):
+        entry = AOAMappingEntry(
+            dst_key="a.weight",
+            dst_global_shape=(4, 8),
+            slice_mappings=[
+                AOASliceMapping(
+                    "b.weight",
+                    (slice(0, 4), slice(0, 8)),
+                    (slice(0, 4), slice(0, 8)),
+                    None,
+                )
+            ],
+        )
+        result = _describe_ops(entry)
+        self.assertEqual(result, "")
+
+    def test_empty_slice_mappings(self):
+        entry = AOAMappingEntry(
+            dst_key="a.weight", dst_global_shape=(4,), slice_mappings=[]
+        )
+        result = _describe_ops(entry)
+        self.assertEqual(result, "")
+
+
+class TestClassifyMappings(unittest.TestCase):
+    def _make_entry(self, dst_key, src_key, pp=None, multi_src=False):
+        if multi_src:
+            sms = [
+                AOASliceMapping(src_key, (slice(0, 4),), (slice(0, 4),), pp),
+                AOASliceMapping(
+                    src_key + ".2", (slice(0, 4),), (slice(4, 8),), pp
+                ),
+            ]
+        else:
+            sms = [AOASliceMapping(src_key, (slice(0, 4),), (slice(0, 4),), pp)]
+        return AOAMappingEntry(
+            dst_key=dst_key, dst_global_shape=(8,), slice_mappings=sms
+        )
+
+    def test_rename_only(self):
+        entry = self._make_entry("model.layers.2.w", "model.layers.0.w")
+        rename, transform, struct = _classify_mappings([entry])
+        self.assertEqual(len(rename), 1)
+        self.assertEqual(len(transform), 0)
+        self.assertEqual(len(struct), 0)
+
+    def test_with_transform(self):
+        entry = self._make_entry(
+            "model.layers.2.w", "model.layers.0.w", ["[1, 0]"]
+        )
+        rename, transform, struct = _classify_mappings([entry])
+        self.assertEqual(len(rename), 0)
+        self.assertEqual(len(transform), 1)
+        self.assertEqual(len(struct), 0)
+
+    def test_structural_multi_src(self):
+        entry = self._make_entry(
+            "model.layers.2.qkv", "model.layers.0.q", multi_src=True
+        )
+        rename, transform, struct = _classify_mappings([entry])
+        self.assertEqual(len(rename), 0)
+        self.assertEqual(len(transform), 0)
+        self.assertEqual(len(struct), 1)
+
+    def test_structural_different_pattern(self):
+        entry = self._make_entry("model.decoder.0.w", "model.encoder.0.w")
+        rename, transform, struct = _classify_mappings([entry])
+        self.assertEqual(len(struct), 1)
+
+
+class TestGroupBySignature(unittest.TestCase):
+    def test_same_signature_grouped(self):
+        entries = []
+        for i in range(4):
+            entries.append(
+                AOAMappingEntry(
+                    dst_key=f"model.layers.{i}.w",
+                    dst_global_shape=(4,),
+                    slice_mappings=[
+                        AOASliceMapping(
+                            f"src.layers.{i}.w",
+                            (slice(0, 4),),
+                            (slice(0, 4),),
+                            ["[1, 0]"],
+                        )
+                    ],
+                )
+            )
+        groups = _group_by_signature(entries)
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(len(next(iter(groups.values()))), 4)
+
+    def test_different_signatures(self):
+        e1 = AOAMappingEntry(
+            dst_key="model.layers.0.w",
+            dst_global_shape=(4,),
+            slice_mappings=[
+                AOASliceMapping(
+                    "src.layers.0.w", (slice(0, 4),), (slice(0, 4),), None
+                )
+            ],
+        )
+        e2 = AOAMappingEntry(
+            dst_key="model.layers.0.qkv",
+            dst_global_shape=(12,),
+            slice_mappings=[
+                AOASliceMapping(
+                    "src.layers.0.q", (slice(0, 4),), (slice(0, 4),), None
+                ),
+                AOASliceMapping(
+                    "src.layers.0.k", (slice(0, 4),), (slice(4, 8),), None
+                ),
+            ],
+        )
+        groups = _group_by_signature([e1, e2])
+        self.assertEqual(len(groups), 2)
+
+
+class TestGetSignature(unittest.TestCase):
+    def test_digits_normalized(self):
+        entry = AOAMappingEntry(
+            dst_key="model.layers.5.weight",
+            dst_global_shape=(4,),
+            slice_mappings=[
+                AOASliceMapping(
+                    "src.layers.5.weight", (slice(0, 4),), (slice(0, 4),), None
+                )
+            ],
+        )
+        sig = _get_signature(entry)
+        self.assertIn("{N}", sig)
+        self.assertNotIn("5", sig)
+
+
+class TestFormatPatternGroups(unittest.TestCase):
+    def test_basic_output(self):
+        entries = [
+            AOAMappingEntry(
+                dst_key="model.layers.0.w",
+                dst_global_shape=(4, 8),
+                slice_mappings=[
+                    AOASliceMapping(
+                        "src.layers.0.w",
+                        (slice(0, 4), slice(0, 8)),
+                        (slice(0, 4), slice(0, 8)),
+                        ["[1, 0]"],
+                    )
+                ],
+            )
+        ]
+        groups = {"sig1": entries}
+        lines, next_idx = _format_pattern_groups(groups, "test", 1)
+        self.assertTrue(any("Pattern #1" in l for l in lines))
+        self.assertEqual(next_idx, 2)
+
+    def test_numbering_continues(self):
+        e1 = [
+            AOAMappingEntry(
+                dst_key="a.0.w",
+                dst_global_shape=(4,),
+                slice_mappings=[
+                    AOASliceMapping(
+                        "b.0.w", (slice(0, 4),), (slice(0, 4),), None
+                    )
+                ],
+            )
+        ]
+        e2 = [
+            AOAMappingEntry(
+                dst_key="c.0.w",
+                dst_global_shape=(4,),
+                slice_mappings=[
+                    AOASliceMapping(
+                        "d.0.w", (slice(0, 4),), (slice(0, 4),), None
+                    )
+                ],
+            )
+        ]
+        groups = {"sig1": e1, "sig2": e2}
+        lines, next_idx = _format_pattern_groups(groups, "test", 5)
+        self.assertEqual(next_idx, 7)
+
+    def test_max_patterns_truncation(self):
+        import paddle.distributed.flex_checkpoint.dcp.key_validation as kv
+
+        old = kv._MAX_PATTERNS_SHOWN
+        kv._MAX_PATTERNS_SHOWN = 2
+        try:
+            groups = {}
+            for i in range(5):
+                groups[f"sig{i}"] = [
+                    AOAMappingEntry(
+                        dst_key=f"x.{i}.w",
+                        dst_global_shape=(4,),
+                        slice_mappings=[
+                            AOASliceMapping(
+                                f"y.{i}.w", (slice(0, 4),), (slice(0, 4),), None
+                            )
+                        ],
+                    )
+                ]
+            lines, _ = _format_pattern_groups(groups, "test", 1)
+            self.assertTrue(any("more" in l for l in lines))
+        finally:
+            kv._MAX_PATTERNS_SHOWN = old
+
+
+class TestAppendSrcLines(unittest.TestCase):
+    def test_few_srcs(self):
+        sms = [
+            AOASliceMapping("a.w", (slice(0, 4),), (slice(0, 4),), None),
+            AOASliceMapping("b.w", (slice(0, 4),), (slice(4, 8),), None),
+        ]
+        lines = []
+        _append_src_lines(lines, sms)
+        self.assertEqual(len(lines), 2)
+        self.assertIn("SRC:", lines[0])
+        self.assertIn("+", lines[1])
+
+    def test_many_srcs_foldable(self):
+        sms = [
+            AOASliceMapping(
+                f"experts.{i}.w",
+                (slice(0, 4),),
+                (slice(i * 4, (i + 1) * 4),),
+                None,
+            )
+            for i in range(10)
+        ]
+        lines = []
+        _append_src_lines(lines, sms)
+        # Should fold into single line with ×N
+        self.assertTrue(any("\u00d7" in l for l in lines))
+
+    def test_many_srcs_not_foldable(self):
+        sms = [
+            AOASliceMapping(
+                "src_alpha.w", (slice(0, 4),), (slice(0, 4),), None
+            ),
+            AOASliceMapping("src_beta.w", (slice(0, 4),), (slice(4, 8),), None),
+            AOASliceMapping(
+                "src_gamma.w", (slice(0, 4),), (slice(8, 12),), None
+            ),
+            AOASliceMapping(
+                "src_delta.w", (slice(0, 4),), (slice(12, 16),), None
+            ),
+            AOASliceMapping(
+                "src_epsilon.w", (slice(0, 4),), (slice(16, 20),), None
+            ),
+            AOASliceMapping(
+                "src_zeta.w", (slice(0, 4),), (slice(20, 24),), None
+            ),
+        ]
+        lines = []
+        _append_src_lines(lines, sms)
+        # Should show first 2, ..., last 1
+        self.assertTrue(any("more" in l for l in lines))
+
+
+class TestGroupKeysAdaptive(unittest.TestCase):
+    def test_basic_grouping(self):
+        keys = [
+            "model.layers.0.weight",
+            "model.layers.1.weight",
+            "model.layers.2.weight",
+            "model.embed.weight",
+        ]
+        groups = _group_keys_adaptive(keys)
+        self.assertEqual(len(groups), 2)
+        # layers.* grouped together
+        layer_group = [g for g in groups.values() if len(g) == 3]
+        self.assertEqual(len(layer_group), 1)
+
+    def test_no_digits(self):
+        keys = ["model.weight", "model.bias"]
+        groups = _group_keys_adaptive(keys)
+        self.assertEqual(len(groups), 2)
+
+
+class TestFormatKeyList(unittest.TestCase):
+    def test_few_keys(self):
+        keys = {"a.w", "b.w", "c.w"}
+        lines = _format_key_list(keys)
+        self.assertEqual(len(lines), 3)
+
+    def test_many_keys_grouped(self):
+        keys = {f"model.layers.{i}.weight" for i in range(100)}
+        lines = _format_key_list(keys)
+        # Should be grouped and folded
+        self.assertTrue(len(lines) < 100)
+        self.assertTrue(any("[" in l for l in lines))
+
+    def test_empty(self):
+        lines = _format_key_list(set())
+        self.assertEqual(lines, [])
+
+
+class TestEmit(unittest.TestCase):
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation.logger")
+    def test_normal_output(self, mock_logger):
+        lines = ["line1", "line2", "line3"]
+        _emit(lines)
+        self.assertEqual(mock_logger.info.call_count, 3)
+
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation.logger")
+    def test_truncation(self, mock_logger):
+        import paddle.distributed.flex_checkpoint.dcp.key_validation as kv
+
+        old_max = kv._MAX_TOTAL_LINES
+        kv._MAX_TOTAL_LINES = 5
+        try:
+            lines = ["x"] * 20
+            _emit(lines)
+            # 5 lines + 1 truncation msg = 6
+            self.assertEqual(mock_logger.info.call_count, 6)
+        finally:
+            kv._MAX_TOTAL_LINES = old_max
+
+
+class TestPrintStandardReport(unittest.TestCase):
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_all_matched(self, mock_emit):
+        result = KeyValidationResult()
+        _print_standard_report(result, "/tmp/ckpt", 100)
+        lines = mock_emit.call_args[0][0]
+        self.assertTrue(any("[OK]" in l for l in lines))
+
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_with_missing_and_unexpected(self, mock_emit):
+        result = KeyValidationResult(
+            missing_keys={"a.w", "b.w"},
+            unexpected_keys={"c.w"},
+            shape_mismatches=[ShapeMismatchInfo("d.w", (4, 8), (4, 16))],
+        )
+        _print_standard_report(result, "/tmp/ckpt", 100)
+        lines = mock_emit.call_args[0][0]
+        self.assertTrue(any("Missing" in l for l in lines))
+        self.assertTrue(any("Unexpected" in l for l in lines))
+        self.assertTrue(any("Shape" in l for l in lines))
+        self.assertTrue(any("Matched: 98/100" in l for l in lines))
+
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_shape_mismatch_truncation(self, mock_emit):
+        import paddle.distributed.flex_checkpoint.dcp.key_validation as kv
+
+        old = kv._MAX_SHAPE_MISMATCHES
+        kv._MAX_SHAPE_MISMATCHES = 2
+        try:
+            mismatches = [
+                ShapeMismatchInfo(f"k{i}", (4,), (8,)) for i in range(5)
+            ]
+            result = KeyValidationResult(
+                missing_keys={"x"}, shape_mismatches=mismatches
+            )
+            _print_standard_report(result, "/tmp/ckpt", 10)
+            lines = mock_emit.call_args[0][0]
+            self.assertTrue(any("and 3 more" in l for l in lines))
+        finally:
+            kv._MAX_SHAPE_MISMATCHES = old
+
+
+class TestPrintAoaReport(unittest.TestCase):
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_all_resolved(self, mock_emit):
+        mappings = [
+            AOAMappingEntry(
+                dst_key="a.w",
+                dst_global_shape=(4,),
+                slice_mappings=[
+                    AOASliceMapping("b.w", (slice(0, 4),), (slice(0, 4),), None)
+                ],
+                is_identity=False,
+            ),
+        ]
+        result = KeyValidationResult()
+        _print_aoa_report(result, mappings, set(), "/tmp/ckpt")
+        lines = mock_emit.call_args[0][0]
+        self.assertTrue(any("[OK]" in l for l in lines))
+
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_with_missing(self, mock_emit):
+        mappings = [
+            AOAMappingEntry(
+                "a.w",
+                (4,),
+                [AOASliceMapping("b.w", (slice(0, 4),), (slice(0, 4),), None)],
+            )
+        ]
+        result = KeyValidationResult(
+            missing_keys={"c.w"}, unexpected_keys={"d.w"}
+        )
+        _print_aoa_report(result, mappings, {"removed.w"}, "/tmp/ckpt")
+        lines = mock_emit.call_args[0][0]
+        self.assertTrue(any("Missing" in l for l in lines))
+        self.assertTrue(any("Unexpected" in l for l in lines))
+        self.assertTrue(any("Removed" in l for l in lines))
+
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_randomly_initialized_keys(self, mock_emit):
+        mappings = []
+        result = KeyValidationResult(
+            randomly_initialized_keys={"init.w", "init.b"}
+        )
+        _print_aoa_report(result, mappings, set(), "/tmp/ckpt")
+        lines = mock_emit.call_args[0][0]
+        self.assertTrue(any("Initialized (2)" in l for l in lines))
+
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_removed_keys_truncation(self, mock_emit):
+        mappings = []
+        removed = {f"removed.key.{i}" for i in range(10)}
+        result = KeyValidationResult()
+        _print_aoa_report(result, mappings, removed, "/tmp/ckpt")
+        lines = mock_emit.call_args[0][0]
+        self.assertTrue(any("more" in l for l in lines))
+
+
+class TestBuildAoaMappings(unittest.TestCase):
+    def test_basic(self):
+        engine = MagicMock()
+        td1 = MagicMock()
+        td1.shape = [4, 8]
+        td1.slices = [
+            (
+                "src.w",
+                (slice(0, 4), slice(0, 8)),
+                (slice(0, 4), slice(0, 8)),
+                None,
+            )
+        ]
+        td2 = MagicMock()
+        td2.shape = [8, 8]
+        td2.slices = [
+            (
+                "src.q",
+                (slice(0, 4), slice(0, 8)),
+                (slice(0, 4), slice(0, 8)),
+                ["[1, 0]"],
+            ),
+            (
+                "src.k",
+                (slice(0, 4), slice(0, 8)),
+                (slice(4, 8), slice(0, 8)),
+                ["[1, 0]"],
+            ),
+        ]
+        ov = MagicMock()
+        ov.items.return_value = sorted({"dst.qkv": td2, "dst.w": td1}.items())
+        engine.output_vars = ov
+
+        results = _build_aoa_mappings(engine)
+        self.assertEqual(len(results), 2)
+        qkv = next(r for r in results if r.dst_key == "dst.qkv")
+        self.assertFalse(qkv.is_identity)
+        self.assertEqual(len(qkv.slice_mappings), 2)
+
+    def test_identity_detection(self):
+        engine = MagicMock()
+        td = MagicMock()
+        td.shape = [4, 8]
+        td.slices = [
+            (
+                "same.key",
+                (slice(0, 4), slice(0, 8)),
+                (slice(0, 4), slice(0, 8)),
+                None,
+            )
+        ]
+        ov = MagicMock()
+        ov.items.return_value = [("same.key", td)]
+        engine.output_vars = ov
+
+        results = _build_aoa_mappings(engine)
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].is_identity)
+
+    def test_none_tensor_desc_skipped(self):
+        engine = MagicMock()
+        ov = MagicMock()
+        ov.items.return_value = [("a", None), ("b", None)]
+        engine.output_vars = ov
+        results = _build_aoa_mappings(engine)
+        self.assertEqual(len(results), 0)
+
+
+class TestValidateAndReportKeysStandard(unittest.TestCase):
+    def _make_metadata(self, keys_shapes):
+        """keys_shapes: dict of {key: shape_tuple}"""
+        storage_metadata = {}
+        state_dict_metadata = {}
+        for key, shape in keys_shapes.items():
+            idx = LocalTensorIndex(
+                tensor_key=key,
+                global_offset=tuple([0] * len(shape)),
+                replica_id=0,
+            )
+            storage_metadata[idx] = f"{key}.distcp"
+            state_dict_metadata[key] = [
+                LocalTensorMetadata(
+                    global_offset=tuple([0] * len(shape)),
+                    local_shape=shape,
+                    dtype="float32",
+                    global_shape=shape,
+                )
+            ]
+        return Metadata(
+            state_dict_metadata=state_dict_metadata,
+            storage_metadata=storage_metadata,
+        )
+
+    @patch("paddle.distributed.get_rank", return_value=0)
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_all_match(self, mock_emit, mock_rank):
+        metadata = self._make_metadata({"w1": (4, 8), "w2": (4, 8)})
+        state_dict = {
+            "w1": paddle.zeros([4, 8]),
+            "w2": paddle.zeros([4, 8]),
+        }
+        result = validate_and_report_keys_standard(
+            [metadata], {"w1", "w2"}, None, False, "/tmp/ckpt", state_dict
+        )
+        self.assertEqual(len(result.missing_keys), 0)
+        self.assertEqual(len(result.unexpected_keys), 0)
+
+    @patch("paddle.distributed.get_rank", return_value=0)
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_missing_keys(self, mock_emit, mock_rank):
+        metadata = self._make_metadata({"w1": (4,)})
+        state_dict = {
+            "w1": paddle.zeros([4]),
+            "w2": paddle.zeros([4]),
+        }
+        result = validate_and_report_keys_standard(
+            [metadata], {"w1", "w2"}, None, False, "/tmp/ckpt", state_dict
+        )
+        self.assertIn("w2", result.missing_keys)
+
+    @patch("paddle.distributed.get_rank", return_value=0)
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_unexpected_keys(self, mock_emit, mock_rank):
+        metadata = self._make_metadata({"w1": (4,), "w2": (4,), "w3": (4,)})
+        state_dict = {"w1": paddle.zeros([4])}
+        result = validate_and_report_keys_standard(
+            [metadata], {"w1"}, None, False, "/tmp/ckpt", state_dict
+        )
+        self.assertIn("w2", result.unexpected_keys)
+        self.assertIn("w3", result.unexpected_keys)
+
+    @patch("paddle.distributed.get_rank", return_value=0)
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_shape_mismatch(self, mock_emit, mock_rank):
+        metadata = self._make_metadata({"w1": (4, 8)})
+        state_dict = {"w1": paddle.zeros([4, 16])}
+        result = validate_and_report_keys_standard(
+            [metadata], {"w1"}, None, False, "/tmp/ckpt", state_dict
+        )
+        self.assertEqual(len(result.shape_mismatches), 1)
+        self.assertEqual(result.shape_mismatches[0].src_global_shape, (4, 8))
+        self.assertEqual(result.shape_mismatches[0].dst_global_shape, (4, 16))
+
+    @patch("paddle.distributed.get_rank", return_value=0)
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_replica_id_filtered(self, mock_emit, mock_rank):
+        """Keys with replica_id != 0 should be filtered out."""
+        storage_metadata = {
+            LocalTensorIndex(
+                tensor_key="w1", global_offset=(0,), replica_id=0
+            ): "f1",
+            LocalTensorIndex(
+                tensor_key="w2", global_offset=(0,), replica_id=1
+            ): "f2",
+        }
+        metadata = Metadata(
+            state_dict_metadata={
+                "w1": [LocalTensorMetadata((0,), (4,), "float32", (4,))]
+            },
+            storage_metadata=storage_metadata,
+        )
+        state_dict = {"w1": paddle.zeros([4])}
+        result = validate_and_report_keys_standard(
+            [metadata], {"w1"}, None, False, "/tmp/ckpt", state_dict
+        )
+        self.assertEqual(len(result.unexpected_keys), 0)
+
+    @patch("paddle.distributed.get_rank", return_value=1)
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_non_rank0_no_print(self, mock_emit, mock_rank):
+        metadata = self._make_metadata({"w1": (4,)})
+        state_dict = {"w1": paddle.zeros([4])}
+        validate_and_report_keys_standard(
+            [metadata], {"w1"}, None, False, "/tmp/ckpt", state_dict
+        )
+        mock_emit.assert_not_called()
+
+
+class TestValidateAndReportKeysAoa(unittest.TestCase):
+    def _make_mock_engine(self):
+        engine = MagicMock()
+        td1 = MagicMock()
+        td1.shape = [4, 8]
+        td1.slices = [
+            (
+                "src.w1",
+                (slice(0, 4), slice(0, 8)),
+                (slice(0, 4), slice(0, 8)),
+                None,
+            )
+        ]
+        td2 = MagicMock()
+        td2.shape = [8, 8]
+        td2.slices = [
+            (
+                "src.q",
+                (slice(0, 4), slice(0, 8)),
+                (slice(0, 4), slice(0, 8)),
+                ["[1, 0]"],
+            ),
+            (
+                "src.k",
+                (slice(0, 4), slice(0, 8)),
+                (slice(4, 8), slice(0, 8)),
+                ["[1, 0]"],
+            ),
+        ]
+        # output_vars: need .items() for _build_aoa_mappings and iteration for values()
+        ov = MagicMock()
+        ov.items.return_value = sorted({"dst.w1": td1, "dst.qkv": td2}.items())
+        ov.values.return_value = [td1, td2]
+        ov.__iter__ = lambda self: iter({"dst.w1": td1, "dst.qkv": td2})
+        ov.__getitem__ = lambda self, k: {"dst.w1": td1, "dst.qkv": td2}[k]
+        engine.output_vars = ov
+        engine.need_add_output_vars = ["dst.init"]
+        engine.need_remove_input_vars = ["src.removed"]
+        engine.input_vars = MagicMock()
+        engine.input_vars.keys.return_value = [
+            "src.w1",
+            "src.q",
+            "src.k",
+            "src.removed",
+            "src.leftover",
+        ]
+        engine.context = MagicMock()
+        engine.context.get_all_dst_state_keys.return_value = {
+            "dst.w1",
+            "dst.qkv",
+            "dst.init",
+        }
+        return engine
+
+    @patch("paddle.distributed.get_rank", return_value=0)
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_all_resolved(self, mock_emit, mock_rank):
+        engine = self._make_mock_engine()
+        metadata = MagicMock()
+        result = validate_and_report_keys_aoa(engine, metadata, "/tmp/ckpt")
+        # dst.w1 and dst.qkv are covered; dst.init is randomly initialized
+        self.assertEqual(len(result.missing_keys), 0)
+        # src.leftover not consumed and not removed
+        self.assertIn("src.leftover", result.unexpected_keys)
+        self.assertIn("dst.init", result.randomly_initialized_keys)
+
+    @patch("paddle.distributed.get_rank", return_value=0)
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_truly_missing(self, mock_emit, mock_rank):
+        engine = self._make_mock_engine()
+        # Add a dst key that is NOT covered
+        engine.context.get_all_dst_state_keys = lambda: {
+            "dst.w1",
+            "dst.qkv",
+            "dst.init",
+            "dst.missing",
+        }
+        metadata = MagicMock()
+        result = validate_and_report_keys_aoa(engine, metadata, "/tmp/ckpt")
+        self.assertIn("dst.missing", result.missing_keys)
+
+    @patch("paddle.distributed.get_rank", return_value=1)
+    @patch("paddle.distributed.flex_checkpoint.dcp.key_validation._emit")
+    def test_non_rank0_no_print(self, mock_emit, mock_rank):
+        engine = self._make_mock_engine()
+        metadata = MagicMock()
+        validate_and_report_keys_aoa(engine, metadata, "/tmp/ckpt")
+        mock_emit.assert_not_called()
+
+
+class TestColorHelpers(unittest.TestCase):
+    def test_no_color(self):
+        from paddle.distributed.flex_checkpoint.dcp.key_validation import _C
+
+        self.assertEqual(_C.green("test"), "test")
+        self.assertEqual(_C.yellow("test"), "test")
+        self.assertEqual(_C.red("test"), "test")
+        self.assertEqual(_C.cyan("test"), "test")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
优化FlexCheckpoint对missing key、unexpected key的打印、展示AOA映射定义的映射关系，各个字段含义如下：
1. **Matched**: 名称匹配。通过AOA指定的自定义映射关系或恒等映射。
2. **Missing**: 模型需要的权重名称（可能通过AOA映射）但是该权重未出现在Checkpoint中。
3. **Unexpected**: 模型不需要的权重名称但是该权重出现在Checkpoint中。
4. **AOA Mapping**打印：总结三种映射类型，并将每种映射pattern打印出。**DST**指的是模型权重名称，**SRC**指的是Checkpoint中的权重名称，**OP** 指的是映射关系（SRC经过何种变换后赋值给DST），即**DST = OP(SRC)**。
```
======================================================================
FlexCheckpoint Load Report (Checkpoint: /path/to/ckpt, AOA enabled)
======================================================================
Matched: 440/440 keys | Missing: 0 | Unexpected: 4847

[WARNING] Unexpected keys (4847 total) - in checkpoint but not consumed by any AOA mapping:
    [model.layers.*.block_sparse_moe.experts.*.w1.weight] (1472 keys):
      model.layers.23.block_sparse_moe.experts.0.w1.weight
      ... +1469 more
    [model.layers.*.block_sparse_moe.experts.*.w2.weight] (1472 keys):
      ... +1469 more
    (... 更多分组)

----------------------------------------------------------------------
AOA Key Mapping (440 dst keys, 4833 src keys)
----------------------------------------------------------------------
Summary:
  1-to-1 rename (same shape, no transform):  92 keys (not shown)
  1-to-1 with transform:                     138 keys (6 pattern(s) below)
  Structural (N-to-1 / 1-to-N / reshape):    209 keys (10 pattern(s) below)

[Pattern #1] model.layers.*.self_attn.gate_proj.weight  (23 keys, 1-to-1 transform)
┌─────────────────────────────────────────────────────────────────────
│ DST: model.layers.1.self_attn.gate_proj.weight  [2048, 8192]
│ SRC: model.layers.0.self_attn.gate_proj.weight  [0:8192,0:2048] -> dst[0:2048,0:8192]
│ OP:  permute([1, 0])
└─────────────────────────────────────────────────────────────────────
........
[Pattern #10] model.layers.*.mlp.grouped_gemm_experts.weight*  (23 keys, structural)
┌─────────────────────────────────────────────────────────────────────
│ DST: model.layers.1.mlp.grouped_gemm_experts.weight1  [65536, 2048]
│ SRC: model.layers.0.block_sparse_moe.experts.{0..63}.w2.weight  (×64)
│ OP:  concat + permute([1, 0])
└─────────────────────────────────────────────────────────────────────

Removed (0): -
Initialized (0): -

----------------------------------------------------------------------
======================================================================
```
**NOTE**: 上述报告打印依赖AOA成功解析，如果AOA解析失败没有报告。
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否