### PR TITLE
[Operator Mechanism] fix swiglu_grad: add shape validation for dz input

### DIFF
--- a/paddle/phi/kernels/swiglu_grad_kernel.h
+++ b/paddle/phi/kernels/swiglu_grad_kernel.h
@@ -95,6 +95,14 @@ void SwiGLUGradKernel(const Context &dev_ctx,
                           "by 2 when Input(Y) is None, but got %d",
                           n));
     const auto &dz_dims = dz.dims();
+    PADDLE_ENFORCE_EQ(
+        dz_dims.size(),
+        dims.size(),
+        common::errors::InvalidArgument(
+            "The rank of Input(dz):[%d] must be equal to the rank of "
+            "Input(X):[%d] when Input(Y) is None.",
+            dz_dims.size(),
+            dims.size()));
     for (int i = 0; i < dims.size() - 1; ++i) {
       PADDLE_ENFORCE_EQ(dz_dims[i],
                         dims[i],
@@ -105,14 +113,6 @@ void SwiGLUGradKernel(const Context &dev_ctx,
                             dz_dims,
                             dims));
     }
-    PADDLE_ENFORCE_EQ(
-        dz_dims.size(),
-        dims.size(),
-        common::errors::InvalidArgument(
-            "The rank of Input(dz):[%d] must be equal to the rank of "
-            "Input(X):[%d] when Input(Y) is None.",
-            dz_dims.size(),
-            dims.size()));
     PADDLE_ENFORCE_EQ(
         dz_dims[dz_dims.size() - 1],
         n / 2,

--- a/paddle/phi/kernels/swiglu_grad_kernel.h
+++ b/paddle/phi/kernels/swiglu_grad_kernel.h
@@ -62,12 +62,20 @@ void SwiGLUGradKernel(const Context &dev_ctx,
   if (y) {
     const auto &y_tensor = y.get();
     const auto &y_dims = y_tensor.dims();
+    const auto &dz_dims = dz.dims();
     PADDLE_ENFORCE_EQ(y_dims,
                       dims,
                       common::errors::InvalidArgument(
                           "The shape of Input(Y):[%s] must be equal "
                           "to the shape of Input(X):[%s].",
                           y_dims,
+                          dims));
+    PADDLE_ENFORCE_EQ(dz_dims,
+                      dims,
+                      common::errors::InvalidArgument(
+                          "The shape of Input(dz):[%s] must be equal "
+                          "to the shape of Input(X):[%s].",
+                          dz_dims,
                           dims));
     SwiGLUGradKernelImpl<T, Context>(dev_ctx,
                                      x_ptr,
@@ -86,6 +94,33 @@ void SwiGLUGradKernel(const Context &dev_ctx,
                           "The last dim of Input(X) should be exactly divided "
                           "by 2 when Input(Y) is None, but got %d",
                           n));
+    const auto &dz_dims = dz.dims();
+    for (int i = 0; i < dims.size() - 1; ++i) {
+      PADDLE_ENFORCE_EQ(dz_dims[i],
+                        dims[i],
+                        common::errors::InvalidArgument(
+                            "The shape of Input(dz):[%s] must be equal to "
+                            "the shape of Input(X):[%s] except the last dim "
+                            "when Input(Y) is None.",
+                            dz_dims,
+                            dims));
+    }
+    PADDLE_ENFORCE_EQ(
+        dz_dims.size(),
+        dims.size(),
+        common::errors::InvalidArgument(
+            "The rank of Input(dz):[%d] must be equal to the rank of "
+            "Input(X):[%d] when Input(Y) is None.",
+            dz_dims.size(),
+            dims.size()));
+    PADDLE_ENFORCE_EQ(
+        dz_dims[dz_dims.size() - 1],
+        n / 2,
+        common::errors::InvalidArgument(
+            "The last dim of Input(dz):[%d] must be equal to half of the "
+            "last dim of Input(X):[%d] when Input(Y) is None.",
+            dz_dims[dz_dims.size() - 1],
+            n));
     SwiGLUGradKernelImpl<T, Context>(
         dev_ctx, x_ptr, nullptr, dz_ptr, dx_ptr, nullptr, m, n / 2);
   }

--- a/test/legacy_test/test_swiglu.py
+++ b/test/legacy_test/test_swiglu.py
@@ -355,7 +355,7 @@ class TestSwigluOp_ZeroSize3(TestSwigluOp_ZeroSize):
 class TestSwigluGradOp(unittest.TestCase):
     def test_swiglu_grad(self):
         x = paddle.randn([10, 2]).astype("float32")
-        out_grad = paddle.randn([10, 2]).astype("float32")
+        out_grad = paddle.randn([10, 1]).astype("float32")
         x_grad, y_grad = paddle._C_ops.swiglu_grad(x, None, out_grad)
         self.assertFalse(
             paddle.all(x_grad == 0).item(), "x_grad should not be all zero"


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you've done -->
在 `SwiGLUGradKernel` 中为反向梯度输入 `dz` 增加形状校验：
- 当 `y` 存在时，校验 `dz.dims() == x.dims()`
- 当 `y` 为 None 时，校验 `dz` 与 `x` 的 rank 相等、除最后一维外各维相等、最后一维等于 `x` 最后一维的一半

修复了 0-size 或 shape 不匹配场景下缺少明确错误信息的问题。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否