### PR TITLE
[ThirdParty] Update `gloo` submodule to PFCCLab paddle branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,8 @@
 	ignore = dirty
 [submodule "third_party/gloo"]
 	path = third_party/gloo
-	url = https://github.com/ziyoujiyi/gloo.git
+	url = https://github.com/PFCCLab/gloo.git
+	branch = paddle
 	ignore = dirty
 [submodule "third_party/dlpack"]
 	path = third_party/dlpack

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,6 @@
 [submodule "third_party/gloo"]
 	path = third_party/gloo
 	url = https://github.com/PFCCLab/gloo.git
-	branch = paddle
 	ignore = dirty
 [submodule "third_party/dlpack"]
 	path = third_party/dlpack


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->

* 将 `third_party/gloo` 子模块地址切换为 `https://github.com/PFCCLab/gloo.git` 并设置分支为 paddle
* gloo 支持 gcc15

相关链接：
* PFCCLab/gloo#1

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否