### PR TITLE
【Hackathon 10th Spring No.51】Apply yaml-cpp GCC 15 compatibility patch - part 5

### DIFF
--- a/cmake/external/yaml.cmake
+++ b/cmake/external/yaml.cmake
@@ -23,6 +23,12 @@ set(SOURCE_INCLUDE_DIR ${SOURCE_DIR}/include)
 
 include_directories(${YAML_INCLUDE_DIR})
 
+file(TO_NATIVE_PATH
+     ${PADDLE_SOURCE_DIR}/patches/yaml-cpp/emitterutils.cpp.patch
+     YAML_CPP_EMITTERUTILS_PATCH)
+set(YAML_PATCH_COMMAND git checkout -- . && git apply
+                       ${YAML_CPP_EMITTERUTILS_PATCH})
+
 set(YAML_BuildTests
     OFF
     CACHE INTERNAL "")
@@ -86,6 +92,7 @@ ExternalProject_Add(
   SOURCE_DIR ${SOURCE_DIR}
   PREFIX ${YAML_PREFIX_DIR}
   UPDATE_COMMAND ""
+  PATCH_COMMAND ${YAML_PATCH_COMMAND}
   CMAKE_ARGS -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
              -DYAML_BUILD_SHARED_LIBS=OFF
              -DYAML_MSVC_SHARED_RT=${YAML_MSVC_SHARED_RT}

--- a/patches/yaml-cpp/emitterutils.cpp.patch
+++ b/patches/yaml-cpp/emitterutils.cpp.patch
@@ -1,0 +1,9 @@
+diff --git a/src/emitterutils.cpp b/src/emitterutils.cpp
+index fc41011a5..f801b1d0c 100644
+--- a/src/emitterutils.cpp
++++ b/src/emitterutils.cpp
+@@ -1,3 +1,4 @@
+ #include <algorithm>
++#include <cstdint>
+ #include <iomanip>
+ #include <sstream>


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->

* 解决 gcc 15 编译问题
* 为什么不更新 yaml-cpp 可以看一下 PaddlePaddle/Paddle#79229，看起来是 yaml-cpp 的 bug 所以先打 patch，后续再更新

相关链接：
* https://github.com/jbeder/yaml-cpp/issues/1307
* https://gcc.gnu.org/cgit/gcc/commit/?id=3a817a4a5a6d94da9127af3be9f84a74e3076ee2
* https://gcc.gnu.org/pipermail/gcc-cvs/2024-August/407124.html
* PaddlePaddle/Paddle#79229

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否