### PR TITLE
[CodeStyle][Typos] Fix `keeped` typos in comments

### DIFF
--- a/python/paddle/distributed/spawn.py
+++ b/python/paddle/distributed/spawn.py
@@ -84,7 +84,7 @@ class ParallelEnvArgs:
 
 
 def _options_valid_check(options):
-    # `print_config` keeped as a debug options, not show to users
+    # `print_config` kept as a debug options, not show to users
     supported_options = [
         'start_method',
         'ips',

--- a/python/paddle/nn/decode.py
+++ b/python/paddle/nn/decode.py
@@ -143,7 +143,7 @@ class Decoder:
         `decoder.step()` would emit a bool `finished` value at each decoding
         step. The emitted `finished` can be used to determine whether every
         batch entries is finished directly, or it can be combined with the
-        finished tracker keeped in `dynamic_decode` by performing a logical OR
+        finished tracker kept in `dynamic_decode` by performing a logical OR
         to take the already finished into account.
 
         If `False`, the latter would be took when performing `dynamic_decode`,


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Docs

### Description
Fix two `keeped` typos reported by the `typos` hook:

- `python/paddle/nn/decode.py`: `keeped` -> `kept`
- `python/paddle/distributed/spawn.py`: `keeped` -> `kept`

This is split from the discussion in #79247.

Validation:

```bash
prek run typos --files python/paddle/nn/decode.py python/paddle/distributed/spawn.py
git diff --check
```

### 是否引起精度变化
否
