### PR TITLE
[API Compatibility] Add torch-compatible NVTX range context manager

### DIFF
--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -16,7 +16,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Union
 
 import paddle
 from paddle import base, core, device as paddle_device, framework
@@ -53,6 +54,8 @@ from paddle.tensor.creation import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     DeviceLike = Union[paddle.core.Place, int, str, None]
 
 
@@ -345,6 +348,25 @@ def set_rng_state(
 
 class nvtx:
     """Namespace for NVTX marker operations."""
+
+    @staticmethod
+    @contextmanager
+    def range(
+        msg: str, *args: Any, **kwargs: Any
+    ) -> Generator[None, None, None]:
+        """
+        Context manager/decorator that pushes and pops an NVTX range.
+
+        Args:
+            msg (str): The name of the NVTX range.
+            *args: Arguments used to format ``msg``.
+            **kwargs: Keyword arguments used to format ``msg``.
+        """
+        nvtx.range_push(msg.format(*args, **kwargs))
+        try:
+            yield
+        finally:
+            nvtx.range_pop()
 
     @staticmethod
     def range_push(msg: str):

--- a/python/paddle/device/__init__.py
+++ b/python/paddle/device/__init__.py
@@ -21,7 +21,8 @@ import os
 import re
 import sys
 import types
-from typing import TYPE_CHECKING, Union, overload
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Union, overload
 
 from typing_extensions import TypeAlias
 
@@ -54,6 +55,7 @@ from . import (  # noqa: F401
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from contextlib import AbstractContextManager
     from types import TracebackType
 
@@ -2011,6 +2013,25 @@ class amp:
 
 class nvtx:
     """Namespace for NVTX marker operations."""
+
+    @staticmethod
+    @contextmanager
+    def range(
+        msg: str, *args: Any, **kwargs: Any
+    ) -> Generator[None, None, None]:
+        """
+        Context manager/decorator that pushes and pops an NVTX range.
+
+        Args:
+            msg (str): The name of the NVTX range.
+            *args: Arguments used to format ``msg``.
+            **kwargs: Keyword arguments used to format ``msg``.
+        """
+        nvtx.range_push(msg.format(*args, **kwargs))
+        try:
+            yield
+        finally:
+            nvtx.range_pop()
 
     @staticmethod
     def range_push(msg: str):

--- a/test/legacy_test/test_cuda_unittest.py
+++ b/test/legacy_test/test_cuda_unittest.py
@@ -17,6 +17,7 @@ import platform
 import types
 import unittest
 import warnings
+from unittest import mock
 
 import numpy as np
 from op_test import get_device, is_custom_device
@@ -448,6 +449,86 @@ class TestExternalStream(unittest.TestCase):
 
 
 class TestNvtx(unittest.TestCase):
+    def _test_nvtx_range_context_manager_and_decorator(self, nvtx):
+        events = []
+
+        def range_push(msg):
+            events.append(("push", msg))
+
+        def range_pop():
+            events.append(("pop", None))
+
+        with (
+            mock.patch.object(nvtx, "range_push", range_push),
+            mock.patch.object(nvtx, "range_pop", range_pop),
+        ):
+            with nvtx.range("context-{name}", name="formatted"):
+                events.append(("body", "context"))
+            self.assertEqual(
+                events,
+                [
+                    ("push", "context-formatted"),
+                    ("body", "context"),
+                    ("pop", None),
+                ],
+            )
+
+            events.clear()
+
+            @nvtx.range("decorator-{}", "formatted")
+            def decorated(value):
+                events.append(("body", value))
+                return value + 1
+
+            self.assertEqual(decorated(41), 42)
+            self.assertEqual(
+                events,
+                [
+                    ("push", "decorator-formatted"),
+                    ("body", 41),
+                    ("pop", None),
+                ],
+            )
+
+            events.clear()
+            with nvtx.range("outer"):
+                events.append(("body", "outer"))
+                with nvtx.range("inner"):
+                    events.append(("body", "inner"))
+                events.append(("body", "after-inner"))
+            self.assertEqual(
+                events,
+                [
+                    ("push", "outer"),
+                    ("body", "outer"),
+                    ("push", "inner"),
+                    ("body", "inner"),
+                    ("pop", None),
+                    ("body", "after-inner"),
+                    ("pop", None),
+                ],
+            )
+
+            events.clear()
+            with (
+                self.assertRaisesRegex(RuntimeError, "boom"),
+                nvtx.range("exception"),
+            ):
+                events.append(("body", "exception"))
+                raise RuntimeError("boom")
+            self.assertEqual(
+                events,
+                [
+                    ("push", "exception"),
+                    ("body", "exception"),
+                    ("pop", None),
+                ],
+            )
+
+    def test_range_context_manager_and_decorator(self):
+        self._test_nvtx_range_context_manager_and_decorator(paddle.cuda.nvtx)
+        self._test_nvtx_range_context_manager_and_decorator(paddle.device.nvtx)
+
     def test_range_push_pop(self):
         if platform.system().lower() == "windows":
             return
@@ -466,6 +547,10 @@ class TestNvtx(unittest.TestCase):
             paddle.cuda.nvtx.range_pop()
             paddle.device.nvtx.range_push("test_push")
             paddle.device.nvtx.range_pop()
+            with paddle.cuda.nvtx.range("test_{}", "range"):
+                pass
+            with paddle.device.nvtx.range("test_{}", "range"):
+                pass
         except Exception as e:
             self.fail(f"nvtx test failed: {e}")
 


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Improvements

### Description
This PR adds a torch-compatible NVTX range context manager to Paddle's existing NVTX namespace:

- `paddle.cuda.nvtx.range(msg, *args, **kwargs)`
- `paddle.device.nvtx.range(msg, *args, **kwargs)`

The wrapper follows `torch.cuda.nvtx.range` behavior: it formats `msg`, calls the existing `range_push`, yields as a context manager/decorator, and always calls `range_pop` in `finally`. It does not introduce a torch dependency and preserves Paddle's current CUDA/NVTX availability behavior by reusing the existing `range_push` / `range_pop` APIs.

Background: in NVIDIA/cudnn-frontend's Paddle adaptation, `with torch.cuda.nvtx.range(...)` call sites had to be replaced by a local context manager wrapping `paddle.cuda.nvtx.range_push/pop`. Adding this compatibility wrapper lets such external projects keep the torch-style call shape when using `import paddle as torch`.

Validation:

- `pre-commit run --files python/paddle/cuda/__init__.py python/paddle/device/__init__.py test/legacy_test/test_cuda_unittest.py`
- `git diff --check`
- `python3 - <<'PY' ... compile edited files ... PY`
- Targeted `TestNvtx` runtime was not runnable in this source checkout because there is no built `libpaddle`; CUDA/NVTX runtime behavior remains covered by the existing guarded CUDA test path plus the new monkeypatched no-CUDA behavior test.

### 是否引起精度变化
否
