### PR TITLE
[CI] Fix docker image build failure handling

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -120,14 +120,15 @@ jobs:
             echo "${name}_image=${docker_image}" >> $GITHUB_OUTPUT
             set +e
             docker pull $docker_image
-            if [ $? -eq 0 ];then
+            pull_status=$?
+            set -e
+            if [ $pull_status -eq 0 ];then
               echo use docker cache
             else
               docker build -t $docker_image -f tools/dockerfile/${docker_files[$name]} .
               docker push $docker_image
               echo end docker build
             fi
-            set -e
           done
 
           # clean workspace


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->

修复 `.github/workflows/docker.yml` 中 docker 镜像构建失败不会正确抛错的问题。

原逻辑在 `docker pull` 前执行 `set +e`，并一直覆盖到 `docker build` 和 `docker push` 之后，导致 cache miss 后即使 `docker build` 或 `docker push` 失败，脚本也可能继续执行。

本 PR 将 `set +e` 的范围收窄到 `docker pull`：
- 先记录 `docker pull` 的返回码；
- 立即恢复 `set -e`；
- 仅在 pull 失败时执行 build/push，使 build 或 push 失败能正常中断 workflow。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否