### PR TITLE
[CI] Experiment with sysmon for Python line coverage

### DIFF
--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -307,6 +307,8 @@ jobs:
           CCACHE_LIMIT_MULTIPLE: 0.8
           FLAGS_PIR_OPTEST: "TRUE"
           ON_INFER: "ON"
+          # coverage.py sysmon on Python 3.12 requires line-only coverage; keep branch coverage disabled.
+          COVERAGE_CORE: sysmon
           COVERAGE_FILE: ${{ github.workspace }}/build/python-coverage.data
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -349,6 +351,7 @@ jobs:
             -e CCACHE_LIMIT_MULTIPLE \
             -e FLAGS_PIR_OPTEST \
             -e ON_INFER \
+            -e COVERAGE_CORE \
             -e COVERAGE_FILE \
             -e GITHUB_TOKEN \
             -e GITHUB_API_TOKEN \

--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -292,6 +292,8 @@ jobs:
           CCACHE_LIMIT_MULTIPLE: 0.8
           FLAGS_PIR_OPTEST: "TRUE"
           ON_INFER: "ON"
+          # coverage.py sysmon on Python 3.12 requires line-only coverage; keep branch coverage disabled.
+          COVERAGE_CORE: sysmon
           COVERAGE_FILE: ${{ github.workspace }}/build/python-coverage.data
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -334,6 +336,7 @@ jobs:
             -e CCACHE_LIMIT_MULTIPLE \
             -e FLAGS_PIR_OPTEST \
             -e ON_INFER \
+            -e COVERAGE_CORE \
             -e COVERAGE_FILE \
             -e GITHUB_TOKEN \
             -e GITHUB_API_TOKEN \

--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -1208,7 +1208,7 @@ function(py_test TARGET_NAME)
           FLAGS_cudnn_deterministic=true ${FLAGS_PIR_MODE}
           PYTHONPATH=${PADDLE_BINARY_DIR}/python ${py_test_ENVS}
           COVERAGE_FILE=${PADDLE_BINARY_DIR}/python-coverage.data
-          ${PYTHON_EXECUTABLE} -m coverage run --branch -p ${py_test_SRCS}
+          ${PYTHON_EXECUTABLE} -m coverage run -p ${py_test_SRCS}
           ${py_test_ARGS}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     else()

--- a/python/paddle/distributed/auto_parallel/static/parallelizer.py
+++ b/python/paddle/distributed/auto_parallel/static/parallelizer.py
@@ -399,7 +399,7 @@ class AutoParallelizer:
                 ["--rank_mapping_path", self._rank_mapping_path]
             )
             if os.environ.get("WITH_COVERAGE", "OFF") == "ON":
-                coverage_args = ["-m", "coverage", "run", "--branch", "-p"]
+                coverage_args = ["-m", "coverage", "run", "-p"]
             else:
                 coverage_args = []
             new_cmd_args = (

--- a/python/paddle/distributed/auto_parallel/static/tuner/optimization_tuner.py
+++ b/python/paddle/distributed/auto_parallel/static/tuner/optimization_tuner.py
@@ -438,7 +438,7 @@ class OptimizationTuner:
 
     def _launch_profile(self, ctx_path, trial_dir):
         if os.environ.get("WITH_COVERAGE", "OFF") == "ON":
-            coverage_args = ["-m", "coverage", "run", "--branch", "-p"]
+            coverage_args = ["-m", "coverage", "run", "-p"]
         else:
             coverage_args = []
 

--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -544,7 +544,7 @@ def start_local_trainers(
             run_with_coverage()
             or os.environ.get("WITH_COVERAGE", "OFF") == "ON"
         ):
-            coverage_args = ["-m", "coverage", "run", "--branch", "-p"]
+            coverage_args = ["-m", "coverage", "run", "-p"]
         cmd = [
             sys.executable,
             "-u",

--- a/python/paddle/distributed/launch/controllers/controller.py
+++ b/python/paddle/distributed/launch/controllers/controller.py
@@ -217,7 +217,6 @@ class Controller(ControllerBase):
                     "-m",
                     "coverage",
                     "run",
-                    "--branch",
                     "-p",
                     self.ctx.args.training_script,
                 ]

--- a/python/paddle/distributed/launch/main.py
+++ b/python/paddle/distributed/launch/main.py
@@ -353,7 +353,6 @@ def launch() -> None:
                     "-m",
                     "coverage",
                     "run",
-                    "--branch",
                     "-p",
                     ctx.args.training_script,
                 ]

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ function(py_test_modules TARGET_NAME)
           ${CMAKE_COMMAND} -E env PYTHONPATH=${PADDLE_BINARY_DIR}/python
           ${py_test_modules_ENVS} ${FLAGS_PIR_MODE}
           COVERAGE_FILE=${PADDLE_BINARY_DIR}/python-coverage.data
-          ${PYTHON_EXECUTABLE} -m coverage run --branch -p
+          ${PYTHON_EXECUTABLE} -m coverage run -p
           ${PADDLE_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     else()

--- a/test/amp/CMakeLists.txt
+++ b/test/amp/CMakeLists.txt
@@ -32,7 +32,7 @@ function(py_test_modules TARGET_NAME)
           ${CMAKE_COMMAND} -E env PYTHONPATH=${PADDLE_BINARY_DIR}/python
           ${py_test_modules_ENVS} ${FLAGS_PIR_MODE}
           COVERAGE_FILE=${PADDLE_BINARY_DIR}/python-coverage.data
-          ${PYTHON_EXECUTABLE} -m coverage run --branch -p
+          ${PYTHON_EXECUTABLE} -m coverage run -p
           ${PADDLE_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     else()

--- a/test/auto_parallel/test_converter.py
+++ b/test/auto_parallel/test_converter.py
@@ -27,7 +27,7 @@ class TestConverter(unittest.TestCase):
         launch_model_path = os.path.join(file_dir, "converter.py")
 
         if os.environ.get("WITH_COVERAGE", "OFF") == "ON":
-            coverage_args = ["-m", "coverage", "run", "--branch", "-p"]
+            coverage_args = ["-m", "coverage", "run", "-p"]
         else:
             coverage_args = []
 

--- a/test/auto_parallel/test_high_order_grad.py
+++ b/test/auto_parallel/test_high_order_grad.py
@@ -25,7 +25,7 @@ class TestHighOrderGrad(unittest.TestCase):
         launch_model_path = os.path.join(file_dir, "high_order_grad.py")
 
         if os.environ.get("WITH_COVERAGE", "OFF") == "ON":
-            coverage_args = ["-m", "coverage", "run", "--branch", "-p"]
+            coverage_args = ["-m", "coverage", "run", "-p"]
         else:
             coverage_args = []
 

--- a/test/auto_parallel/test_iterable_dataset.py
+++ b/test/auto_parallel/test_iterable_dataset.py
@@ -27,7 +27,7 @@ class TestEngineAPI(unittest.TestCase):
         launch_model_path = os.path.join(file_dir, "iterable_dataset.py")
 
         if os.environ.get("WITH_COVERAGE", "OFF") == "ON":
-            coverage_args = ["-m", "coverage", "run", "--branch", "-p"]
+            coverage_args = ["-m", "coverage", "run", "-p"]
         else:
             coverage_args = []
 

--- a/test/collective/fleet/test_parallel_dygraph_qat.py
+++ b/test/collective/fleet/test_parallel_dygraph_qat.py
@@ -85,7 +85,7 @@ def start_local_trainers(
         print(f"trainer proc env:{current_env}")
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
-            cmd = "python -m coverage run --branch -p " + training_script
+            cmd = "python -m coverage run -p " + training_script
         else:
             cmd = "python -u " + training_script
 

--- a/test/collective/multinode/multinode_dist_test.sh
+++ b/test/collective/multinode/multinode_dist_test.sh
@@ -41,7 +41,7 @@ run_time=$(( $TEST_TIMEOUT - 10 ))
 echo "run_time: ${run_time}"
 
 if [[ ${WITH_COVERAGE} == "ON" ]]; then
-    PYTHON_EXEC="python3 -u -m coverage run --branch -p "
+    PYTHON_EXEC="python3 -u -m coverage run -p "
 else
     PYTHON_EXEC="python3 -u "
 fi

--- a/test/custom_runtime/test_collective_process_group_xccl.py
+++ b/test/custom_runtime/test_collective_process_group_xccl.py
@@ -64,7 +64,7 @@ def start_local_trainers(
         print(f"trainer proc env:{current_env}")
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
-            cmd = "python -m coverage run --branch -p " + training_script
+            cmd = "python -m coverage run -p " + training_script
         else:
             cmd = "python -u " + training_script
 

--- a/test/distributed_passes/dist_pass_test_base.py
+++ b/test/distributed_passes/dist_pass_test_base.py
@@ -199,7 +199,7 @@ class DistPassTestBase(unittest.TestCase):
 
         if os.environ.get("WITH_COVERAGE", "OFF") == "ON":
             run_with_coverage(True)
-            coverage_args = ["-m", "coverage", "run", "--branch", "-p"]
+            coverage_args = ["-m", "coverage", "run", "-p"]
         else:
             coverage_args = []
 

--- a/test/legacy_test/CMakeLists.txt
+++ b/test/legacy_test/CMakeLists.txt
@@ -343,7 +343,7 @@ function(py_test_modules TARGET_NAME)
             PYTHONPATH=${PADDLE_BINARY_DIR}/python:$ENV{PYTHONPATH}
             ${py_test_modules_ENVS} ${FLAGS_PIR_MODE}
             COVERAGE_FILE=${PADDLE_BINARY_DIR}/python-coverage.data
-            ${PYTHON_EXECUTABLE} -m coverage run --branch -p
+            ${PYTHON_EXECUTABLE} -m coverage run -p
             ${PADDLE_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
       else()
@@ -353,7 +353,7 @@ function(py_test_modules TARGET_NAME)
             ${CMAKE_COMMAND} -E env PYTHONPATH=${PADDLE_BINARY_DIR}/python
             ${py_test_modules_ENVS} ${FLAGS_PIR_MODE}
             COVERAGE_FILE=${PADDLE_BINARY_DIR}/python-coverage.data
-            ${PYTHON_EXECUTABLE} -m coverage run --branch -p
+            ${PYTHON_EXECUTABLE} -m coverage run -p
             ${PADDLE_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
       endif()

--- a/test/legacy_test/dist_test.sh
+++ b/test/legacy_test/dist_test.sh
@@ -39,7 +39,7 @@ run_time=$(( $TEST_TIMEOUT - 10 ))
 echo "run_time: ${run_time}"
 
 if [[ ${WITH_COVERAGE} == "ON" ]]; then
-    PYTHON_EXEC="python -u -m coverage run --branch -p "
+    PYTHON_EXEC="python -u -m coverage run -p "
 else
     PYTHON_EXEC="python -u "
 fi

--- a/test/legacy_test/parallel_test.sh
+++ b/test/legacy_test/parallel_test.sh
@@ -37,7 +37,7 @@ if [[ ${TEST_TIMEOUT}"x" == "x" ]]; then
 fi
 
 if [[ ${WITH_COVERAGE} == "ON" ]]; then
-    PYTHON_EXEC="python -u -m coverage run --branch -p "
+    PYTHON_EXEC="python -u -m coverage run -p "
 else
     PYTHON_EXEC="python -u "
 fi

--- a/test/legacy_test/test_collective_api_base.py
+++ b/test/legacy_test/test_collective_api_base.py
@@ -274,7 +274,7 @@ class TestDistBase(unittest.TestCase):
         env1['DUMP_FILE'] = dump_file_1
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
-            tr_cmd = "%s -m coverage run --branch -p %s"
+            tr_cmd = "%s -m coverage run -p %s"
         else:
             tr_cmd = "%s %s"
         tr0_cmd = tr_cmd % (self._python_interp, model_file)

--- a/test/legacy_test/test_dist_base.py
+++ b/test/legacy_test/test_dist_base.py
@@ -1063,7 +1063,7 @@ class TestDistBase(unittest.TestCase):
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
             required_envs['COVERAGE_FILE'] = os.getenv('COVERAGE_FILE', '')
-            ps_cmd += " -m coverage run --branch -p"
+            ps_cmd += " -m coverage run -p"
 
         ps_cmd += " %s --role pserver --endpoints %s --trainer_id 0 --current_endpoint %s --trainers %d --update_method pserver"
 
@@ -1121,7 +1121,7 @@ class TestDistBase(unittest.TestCase):
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
             envs['COVERAGE_FILE'] = os.getenv('COVERAGE_FILE', '')
-            cmd += " -m coverage run --branch -p"
+            cmd += " -m coverage run -p"
 
         cmd += (
             f" {model} --role trainer --update_method local --lr {self._lr:f}"
@@ -1218,7 +1218,7 @@ class TestDistBase(unittest.TestCase):
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
             envs['COVERAGE_FILE'] = os.getenv('COVERAGE_FILE', '')
-            tr_cmd += " -m coverage run --branch -p"
+            tr_cmd += " -m coverage run -p"
 
         tr_cmd += " %s --role trainer --endpoints %s --trainer_id %d --current_endpoint %s --trainers %d --update_method pserver --lr %f"
 
@@ -1321,7 +1321,7 @@ class TestDistBase(unittest.TestCase):
         tr_cmd = "%s -u"
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
-            tr_cmd += " -m coverage run --branch -p"
+            tr_cmd += " -m coverage run -p"
 
         tr_cmd += " %s --role trainer --endpoints %s --trainer_id %d --current_endpoint %s --update_method %s --lr %f"
 
@@ -1388,7 +1388,7 @@ class TestDistBase(unittest.TestCase):
         tr_cmd = "%s -u"
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
-            tr_cmd += " -m coverage run --branch -p"
+            tr_cmd += " -m coverage run -p"
 
         tr_cmd += " %s --role trainer --endpoints %s --trainer_id %d --current_endpoint %s --update_method %s --lr %f"
 

--- a/test/legacy_test/test_dist_fleet_base.py
+++ b/test/legacy_test/test_dist_fleet_base.py
@@ -329,7 +329,7 @@ class TestFleetBase(unittest.TestCase):
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
             envs['COVERAGE_FILE'] = os.getenv('COVERAGE_FILE', '')
-            python_path += " -m coverage run --branch -p"
+            python_path += " -m coverage run -p"
         env.update(envs)
 
         tr_cmd = f"{python_path} {model} --role trainer --endpoints {self._ps_endpoints} --trainer_endpoints {self._tr_endpoints} --current_id {{}} --trainers {self._trainers} --mode {self._mode} --geo_sgd_need_push_nums {self._geo_sgd_need_push_nums} --reader {self._reader} --gloo_path {gloo_path} --test {self._need_test}"

--- a/test/legacy_test/test_dist_fleet_gloo.py
+++ b/test/legacy_test/test_dist_fleet_gloo.py
@@ -99,7 +99,7 @@ class TestDistGloo_2x2(TestFleetBase):
         python_path = self._python_interp
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
             envs['COVERAGE_FILE'] = os.getenv('COVERAGE_FILE', '')
-            python_path += " -m coverage run --branch -p"
+            python_path += " -m coverage run -p"
         env.update(envs)
 
         tr_cmd = f"{python_path} {model}"

--- a/test/legacy_test/test_dist_fleet_heter_base.py
+++ b/test/legacy_test/test_dist_fleet_heter_base.py
@@ -354,7 +354,7 @@ class TestFleetHeterBase(unittest.TestCase):
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
             envs['COVERAGE_FILE'] = os.getenv('COVERAGE_FILE', '')
-            python_path += " -m coverage run --branch -p"
+            python_path += " -m coverage run -p"
         env.update(envs)
         self._all_heter_endpoints = ";".join(
             (self._heter_endpoints, self._heter_endpoints_2)

--- a/test/legacy_test/test_dist_hapi_model.py
+++ b/test/legacy_test/test_dist_hapi_model.py
@@ -84,7 +84,7 @@ def start_local_trainers(
         print(f"trainer proc env:{current_env}")
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
-            cmd = "python -m coverage run --branch -p " + training_script
+            cmd = "python -m coverage run -p " + training_script
         else:
             cmd = "python -u " + training_script
 

--- a/test/legacy_test/test_nan_inf.py
+++ b/test/legacy_test/test_nan_inf.py
@@ -28,7 +28,7 @@ class TestNanInfBase(unittest.TestCase):
     def setUp(self):
         self._python_interp = sys.executable
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
-            self._python_interp += " -m coverage run --branch -p"
+            self._python_interp += " -m coverage run -p"
 
         self.env = os.environ.copy()
         paddle.disable_static()

--- a/test/legacy_test/test_parallel_dygraph_dataparallel.py
+++ b/test/legacy_test/test_parallel_dygraph_dataparallel.py
@@ -137,7 +137,7 @@ def start_local_trainers(
         print(f"trainer proc env:{current_env}")
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
-            cmd = "python -m coverage run --branch -p " + training_script
+            cmd = "python -m coverage run -p " + training_script
         else:
             cmd = "python -u " + training_script
 

--- a/test/legacy_test/test_parallel_dygraph_dataparallel_cpuonly.py
+++ b/test/legacy_test/test_parallel_dygraph_dataparallel_cpuonly.py
@@ -80,7 +80,7 @@ def start_local_trainers(
         print(f"trainer proc env:{current_env}")
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
-            cmd = "python -m coverage run --branch -p " + training_script
+            cmd = "python -m coverage run -p " + training_script
         else:
             cmd = "python -u " + training_script
 

--- a/test/xpu/test_collective_api_base.py
+++ b/test/xpu/test_collective_api_base.py
@@ -265,7 +265,7 @@ class TestDistBase(unittest.TestCase):
         env1['DUMP_FILE'] = dump_file_1
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
-            tr_cmd = "%s -m coverage run --branch -p %s"
+            tr_cmd = "%s -m coverage run -p %s"
         else:
             tr_cmd = "%s %s"
         tr0_cmd = tr_cmd % (self._python_interp, model_file)

--- a/test/xpu/test_parallel_dygraph_dataparallel.py
+++ b/test/xpu/test_parallel_dygraph_dataparallel.py
@@ -87,7 +87,7 @@ def start_local_trainers(
         print(f"trainer proc env:{current_env}")
 
         if os.getenv('WITH_COVERAGE', 'OFF') == 'ON':
-            cmd = "python -m coverage run --branch -p " + training_script
+            cmd = "python -m coverage run -p " + training_script
         else:
             cmd = "python -u " + training_script
 


### PR DESCRIPTION
### PR Category

Environment Adaptation

### PR Types

Performance

### Description

This is an experimental CI coverage acceleration PR.

- Request `COVERAGE_CORE=sysmon` for the PR Coverage and CI-H coverage test containers.
- Drop Python branch coverage collection from all `coverage run` launch sites, keeping parallel data mode (`-p`) for line coverage.
- Keep the final coverage report line-focused; Paddle currently consumes line coverage and does not use branch coverage data.

Why this differs from #72183:

- #72183 requested `COVERAGE_CORE=sysmon`, but the CI still ran `coverage run --branch -p`.
- On Python 3.12, coverage.py cannot measure branches with `sys.monitoring`, so `--branch` makes coverage.py fall back to the default C tracer.
- This PR removes the branch collection flag so coverage.py can actually use the sysmon core for line coverage.

Local validation:

- `COVERAGE_CORE=sysmon COVERAGE_DEBUG=sys python3.12 -m coverage run -p ...` with coverage==7.10.7 reports `core: SysMonitor`.
- The same command with `--branch` reports `sys.monitoring can't measure branches in this version` and `core: CTracer`, confirming the prior fallback mode.
- Targeted grep for `coverage run --branch`, `"--branch"`, and `'--branch'`: no remaining coverage command matches.
- Changed Python files pass `py_compile`; changed shell scripts pass `bash -n`; changed workflow files parse as YAML; `git diff --check` passes.
- Pre-commit hooks run during commit passed.

Timing baseline to compare after this PR runs:

- Recent successful `Coverage` workflow (last 5 before this PR): `Coverage test` avg ~132m37s, median ~128m25s; `Coverage build` avg ~52m50s.
- Recent full `CI-H` successful examples: `Coverage test` ~25m27s / ~27m59s; `Coverage build` varies with cache (~24m29s to ~104m08s).

I will compare the Coverage / CI-H job durations from this PR against the above baseline after CI data is available.

### 是否引起精度变化

否
