### PR TITLE
[Docker] Clean up CUDA compat path and Python 3.9 image

### DIFF
--- a/tools/dockerfile/Dockerfile.centos
+++ b/tools/dockerfile/Dockerfile.centos
@@ -45,20 +45,17 @@ RUN wget --no-check-certificate -qO- https://paddle-ci.gz.bcebos.com/go1.15.12.l
 RUN wget https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/requirements.txt -O /root/requirements.txt
 
 
-RUN LD_LIBRARY_PATH=/opt/_internal/cpython-3.9.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.9.0/bin/pip3 install setuptools -U && \
-    LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.10.0/bin/pip3 install setuptools -U && \
+RUN LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.10.0/bin/pip3 install setuptools -U && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.11.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.11.0/bin/pip3 install setuptools -U && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.12.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.12.0/bin/pip3 install setuptools -U
 
-RUN LD_LIBRARY_PATH=/opt/_internal/cpython-3.9.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.9.0/bin/pip3 install -r /root/requirements.txt && \
-    LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.10.0/bin/pip3 install -r /root/requirements.txt && \
+RUN LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.10.0/bin/pip3 install -r /root/requirements.txt && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.11.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.11.0/bin/pip3 install -r /root/requirements.txt && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.12.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.12.0/bin/pip3 install -r /root/requirements.txt && \
     go get github.com/Masterminds/glide && \
     rm -rf /root/requirements.txt
 
-RUN LD_LIBRARY_PATH=/opt/_internal/cpython-3.9.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.9.0/bin/pip3 install pre-commit 'ipython==5.3.0' && \
-    LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.10.0/bin/pip3 install pre-commit 'ipython==5.3.0' && \
+RUN LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.10.0/bin/pip3 install pre-commit 'ipython==5.3.0' && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.11.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.11.0/bin/pip3 install pre-commit 'ipython==5.3.0' && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.12.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.12.0/bin/pip3 install pre-commit 'ipython==5.3.0'
 

--- a/tools/dockerfile/Dockerfile.develop.dtk
+++ b/tools/dockerfile/Dockerfile.develop.dtk
@@ -30,13 +30,7 @@ RUN rm -rf /usr/bin/cmake /usr/bin/cmake3 && \
     ln -s /opt/cmake-3.27.7/bin/cmake /usr/bin/cmake3
 ENV PATH=/opt/cmake-3.27.7/bin:${PATH}
 
-# Python 3.9\3.10
-RUN wget -q https://www.python.org/ftp/python/3.9.14/Python-3.9.14.tgz && \
-    tar xzf Python-3.9.14.tgz && cd Python-3.9.14 && \
-    CFLAGS="-Wformat" ./configure --prefix=/usr/local/ --enable-shared > /dev/null && \
-    make -j16 > /dev/null && make altinstall > /dev/null && ldconfig && \
-    cd ../ && rm -rf Python-3.9.14 && rm -rf Python-3.9.14.tgz
-
+# Python 3.10
 RUN wget -q https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz && \
     tar xzf Python-3.10.14.tgz && cd Python-3.10.14 && \
     CFLAGS="-Wformat" ./configure --prefix=/usr/local/ --enable-shared > /dev/null && \
@@ -45,30 +39,24 @@ RUN wget -q https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz && \
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
 
 # create venv and activate
-RUN /usr/local/bin/python3.10 -m venv /opt/py310 && \
-    /usr/local/bin/python3.9 -m venv /opt/py39
+RUN /usr/local/bin/python3.10 -m venv /opt/py310
 # update env
-ENV PATH=/opt/py310/bin:/opt/py39/bin:$PATH
+ENV PATH=/opt/py310/bin:$PATH
 
 # upgrade pip
-RUN pip3.10 install --upgrade pip setuptools wheel && \
-    pip3.9 install --upgrade pip setuptools wheel
+RUN pip3.10 install --upgrade pip setuptools wheel
 
 # install pylint and pre-commit
-RUN pip3.10 install pre-commit==2.17.0 pylint pytest astroid isort coverage qtconsole distro && \
-    pip3.9 install pre-commit==2.17.0 pylint pytest astroid isort coverage qtconsole distro
+RUN pip3.10 install pre-commit==2.17.0 pylint pytest astroid isort coverage qtconsole distro
 
-RUN pip3.10 install attrs pyyaml pathlib2 scipy requests psutil Cython clang-format==13.0.0 PyGithub && \
-    pip3.9 install attrs pyyaml pathlib2 scipy requests psutil Cython clang-format==13.0.0 PyGithub
+RUN pip3.10 install attrs pyyaml pathlib2 scipy requests psutil Cython clang-format==13.0.0 PyGithub
 
 # install Paddle requirement
 RUN wget https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/requirements.txt -O requirements.txt && \
-    pip3.10 install -r requirements.txt && \
-    pip3.9 install -r requirements.txt && rm -rf requirements.txt
+    pip3.10 install -r requirements.txt && rm -rf requirements.txt
 
 RUN wget https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/unittest_py/requirements.txt -O requirements.txt && \
-    pip3.10 install -r requirements.txt && \
-    pip3.9 install -r requirements.txt && rm -rf requirements.txt
+    pip3.10 install -r requirements.txt && rm -rf requirements.txt
 
 # git credential to skip password typing
 RUN git config --global credential.helper store && \

--- a/tools/dockerfile/Dockerfile.develop.npu
+++ b/tools/dockerfile/Dockerfile.develop.npu
@@ -19,14 +19,11 @@ WORKDIR /usr/local/Ascend
 RUN apt-get update -y && apt-get install -y zlib1g zlib1g-dev libsqlite3-dev openssl libssl-dev libffi-dev libbz2-dev \
     libxslt1-dev unzip pciutils net-tools libblas-dev gfortran libblas3 liblapack-dev liblapack3 libopenblas-dev zstd
 
-RUN pip3.9 install --upgrade pip setuptools wheel && \
-    pip3.10 install --upgrade pip setuptools wheel
+RUN pip3.10 install --upgrade pip setuptools wheel
 
-RUN pip3.9 install 'numpy>=1.19.2' 'decorator>=4.4.0' 'sympy>=1.5.1' 'cffi>=1.12.3' 'protobuf>=3.13.0' && \
-    pip3.10 install 'numpy>=1.19.2' 'decorator>=4.4.0' 'sympy>=1.5.1' 'cffi>=1.12.3' 'protobuf>=3.13.0'
+RUN pip3.10 install 'numpy>=1.19.2' 'decorator>=4.4.0' 'sympy>=1.5.1' 'cffi>=1.12.3' 'protobuf>=3.13.0'
 
-RUN pip3.9 install attrs pyyaml pathlib2 scipy requests psutil absl-py && \
-    pip3.10 install attrs pyyaml pathlib2 scipy requests psutil absl-py
+RUN pip3.10 install attrs pyyaml pathlib2 scipy requests psutil absl-py
 
 # update envs for driver
 ENV LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:$LD_LIBRARY_PATH

--- a/tools/dockerfile/Dockerfile.develop.xre.ubuntu22
+++ b/tools/dockerfile/Dockerfile.develop.xre.ubuntu22
@@ -38,8 +38,7 @@ RUN apt-get remove --purge cmake && apt-get install -y cmake
 RUN apt-get install -y ccache
 
 # default python version
-RUN apt-get update && apt-get install -y python3.10-distutils python3.10 python3.10-dev \
-    python3.9 python3.9-dev python3.9-distutils && \
+RUN apt-get update && apt-get install -y python3.10-distutils python3.10 python3.10-dev && \
     apt-get install python-is-python3
 # set default python
 RUN rm -rf /usr/bin/python && ln -s /usr/bin/python3.10 /usr/bin/python && \
@@ -51,11 +50,9 @@ RUN wget -q https://bootstrap.pypa.io/get-pip.py
 RUN sed -i 's#"install", "--upgrade", "--force-reinstall"#"install", "--upgrade", "--force-reinstall", "--break-system-packages"#' get-pip.py
 
 RUN python3.10 get-pip.py && \
-    python3.9 get-pip.py && \
     rm -rf /opt/get-pip.py
 
-RUN python3.10 -m pip install setuptools==68.2.0 && \
-    python3.9 -m pip install setuptools==50.3.2
+RUN python3.10 -m pip install setuptools==68.2.0
 
 
 # binutils >= 2.27
@@ -73,14 +70,10 @@ RUN rm -f /usr/local/bin/pip && ln -s /usr/local/bin/pip3.10 /usr/local/bin/pip 
     rm -f /usr/local/bin/pip3 && ln -s /usr/local/bin/pip3.10 /usr/local/bin/pip3
 
 RUN python3.10 -m pip --no-cache-dir install ipython==5.3.0 && \
-    python3.10 -m pip --no-cache-dir install ipykernel==4.6.0 wheel && \
-    python3.9 -m pip --no-cache-dir install ipython==5.3.0 && \
-    python3.9 -m pip --no-cache-dir install ipykernel==4.6.0 wheel
+    python3.10 -m pip --no-cache-dir install ipykernel==4.6.0 wheel
 
 # install pylint and pre-commit
 RUN python3.10 -m pip --no-cache-dir install pre-commit==2.17.0 pylint pytest astroid isort coverage qtconsole distro \
-    attrs pyyaml pathlib2 scipy requests psutil Cython clang-format==13.0.0 && \
-    python3.9 -m pip --no-cache-dir install pre-commit==2.17.0 pylint pytest astroid isort coverage qtconsole distro \
     attrs pyyaml pathlib2 scipy requests psutil Cython clang-format==13.0.0
 
 
@@ -92,12 +85,10 @@ RUN apt-get update && apt-get install libprotobuf-dev protobuf-compiler libproto
 # install Paddle requirement
 RUN wget --no-check-certificate https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/requirements.txt -O requirements.txt && \
     python3.10 -m pip --no-cache-dir install -r requirements.txt -i https://pypi.org/simple && \
-    python3.9 -m pip --no-cache-dir install -r requirements.txt -i https://pypi.org/simple && \
     rm -rf requirements.txt
 
 RUN wget --no-check-certificate https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/unittest_py/requirements.txt -O requirements.txt && \
     python3.10 -m pip --no-cache-dir install -r requirements.txt --ignore-installed -i https://pypi.org/simple && \
-    python3.9 -m pip --no-cache-dir install -r requirements.txt --ignore-installed -i https://pypi.org/simple && \
     rm -rf requirements.txt
 
 # Install XRE 5.0.21.21

--- a/tools/dockerfile/Dockerfile.ubuntu20
+++ b/tools/dockerfile/Dockerfile.ubuntu20
@@ -94,8 +94,8 @@ RUN set -eux; \
   build_python 3.13.0 --disable-gil --with-mimalloc; \
   build_python 3.13.0
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
-RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python && \
-    ln -sf /usr/local/bin/python3.10 /usr/bin/python3
+# Keep Ubuntu's /usr/bin/python3 for system scripts such as lsb_release.
+RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python
 
 RUN for py in 3.10 3.11 3.12 3.13 3.13t; do \
       printf '#!/bin/sh\nexec /usr/local/bin/python%s -m pip "$@"\n' "$py" > "/usr/local/bin/pip${py}" && \

--- a/tools/dockerfile/Dockerfile.ubuntu20
+++ b/tools/dockerfile/Dockerfile.ubuntu20
@@ -59,6 +59,7 @@ WORKDIR /home
 RUN wget -q https://cmake.org/files/v3.18/cmake-3.18.0-Linux-x86_64.tar.gz && tar -zxvf cmake-3.18.0-Linux-x86_64.tar.gz && rm cmake-3.18.0-Linux-x86_64.tar.gz
 ENV PATH=/home/cmake-3.18.0-Linux-x86_64/bin:$PATH
 
+# Build free-threaded 3.13 before normal 3.13 so python3.13 stays non-free-threaded.
 RUN set -eux; \
   build_python() { \
     py_ver="$1"; \
@@ -76,8 +77,8 @@ RUN set -eux; \
   build_python 3.10.0; \
   build_python 3.11.0; \
   build_python 3.12.0; \
-  build_python 3.13.0; \
-  build_python 3.13.0 --disable-gil --with-mimalloc
+  build_python 3.13.0 --disable-gil --with-mimalloc; \
+  build_python 3.13.0
 ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
 RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python && \
     ln -sf /usr/local/bin/python3.10 /usr/bin/python3
@@ -137,7 +138,7 @@ RUN pip3.10 --no-cache-dir install ipython==5.3.0 && \
     python3.13 -m pip --no-cache-dir install ipython==5.3.0 && \
     python3.13 -m pip --no-cache-dir install ipykernel==4.6.0 wheel && \
     python3.13t -m pip --no-cache-dir install ipython==5.3.0 && \
-    python3.13 -m pip --no-cache-dir install ipykernel==4.6.0 wheel
+    python3.13t -m pip --no-cache-dir install ipykernel==4.6.0 wheel
 
 # For PaddleTest CE
 RUN pip3.10 --no-cache-dir install pytest && \

--- a/tools/dockerfile/Dockerfile.ubuntu20
+++ b/tools/dockerfile/Dockerfile.ubuntu20
@@ -25,11 +25,11 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.cn/compute/cuda/r
 
 RUN apt-get update --allow-unauthenticated && \
   apt-get install -y software-properties-common && \
-  add-apt-repository ppa:deadsnakes/ppa && \
-  apt-get update && \
   apt-get install -y curl wget vim git unzip pigz zstd unrar tar xz-utils libssl-dev bzip2 gzip \
     coreutils ntp language-pack-zh-hans libsm6 libxext6 libxrender-dev libgl1-mesa-glx \
-    bison graphviz libjpeg-dev zlib1g-dev automake locales swig net-tools libtool kmod
+    bison graphviz libjpeg-dev zlib1g-dev automake locales swig net-tools libtool kmod \
+    libbz2-dev libffi-dev libgdbm-dev liblzma-dev libncursesw5-dev libreadline-dev \
+    libsqlite3-dev pkg-config tk-dev uuid-dev
 <install_cpu_package>
 
 # Downgrade gcc&&g++
@@ -59,14 +59,28 @@ WORKDIR /home
 RUN wget -q https://cmake.org/files/v3.18/cmake-3.18.0-Linux-x86_64.tar.gz && tar -zxvf cmake-3.18.0-Linux-x86_64.tar.gz && rm cmake-3.18.0-Linux-x86_64.tar.gz
 ENV PATH=/home/cmake-3.18.0-Linux-x86_64/bin:$PATH
 
-RUN apt-get update && \
-  apt-get install -y python3.10 python3.10-dev python3.10-distutils \
-  python3.11 python3.11-dev python3.11-distutils \
-  python3.12 python3.12-dev \
-  python3.13 python3.13-dev python3.13-nogil && \
-  apt-get install python-is-python3
-RUN rm /usr/bin/python && ln -s /usr/bin/python3.10 /usr/bin/python && \
-    rm /usr/bin/python3 && ln -s /usr/bin/python3.10 /usr/bin/python3
+RUN set -eux; \
+  build_python() { \
+    py_ver="$1"; \
+    shift; \
+    wget -q "https://www.python.org/ftp/python/${py_ver}/Python-${py_ver}.tgz"; \
+    tar -xzf "Python-${py_ver}.tgz"; \
+    cd "Python-${py_ver}"; \
+    CFLAGS="-Wformat" ./configure --prefix=/usr/local --enable-shared "$@" > /dev/null; \
+    make -j"$(nproc)" > /dev/null; \
+    make altinstall > /dev/null; \
+    cd ..; \
+    rm -rf "Python-${py_ver}" "Python-${py_ver}.tgz"; \
+    ldconfig; \
+  }; \
+  build_python 3.10.0; \
+  build_python 3.11.0; \
+  build_python 3.12.0; \
+  build_python 3.13.0; \
+  build_python 3.13.0 --disable-gil --with-mimalloc
+ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
+RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python && \
+    ln -sf /usr/local/bin/python3.10 /usr/bin/python3
 
 WORKDIR /home
 RUN wget -q https://bootstrap.pypa.io/get-pip.py
@@ -156,9 +170,6 @@ RUN pip3.10 --no-cache-dir install -r /root/requirements.txt && \
     python3.13t -m pip --no-cache-dir install -r /root/requirements.txt && \
     python3.13t -m pip --no-cache-dir install -r /home/compile_requirements.txt
     # python3.13t -m pip --no-cache-dir install -r /home/requirements.txt
-
-
-RUN apt-get install pkg-config -y
 
 # clang12
 RUN apt-get update &&\

--- a/tools/dockerfile/Dockerfile.ubuntu20
+++ b/tools/dockerfile/Dockerfile.ubuntu20
@@ -60,19 +60,17 @@ RUN wget -q https://cmake.org/files/v3.18/cmake-3.18.0-Linux-x86_64.tar.gz && ta
 ENV PATH=/home/cmake-3.18.0-Linux-x86_64/bin:$PATH
 
 RUN apt-get update && \
-  apt-get install -y python3.9 python3.9-dev python3.9-distutils \
-  python3.10 python3.10-dev python3.10-distutils \
+  apt-get install -y python3.10 python3.10-dev python3.10-distutils \
   python3.11 python3.11-dev python3.11-distutils \
   python3.12 python3.12-dev \
   python3.13 python3.13-dev python3.13-nogil && \
   apt-get install python-is-python3
-RUN rm /usr/bin/python && ln -s /usr/bin/python3.9 /usr/bin/python && \
-    rm /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
+RUN rm /usr/bin/python && ln -s /usr/bin/python3.10 /usr/bin/python && \
+    rm /usr/bin/python3 && ln -s /usr/bin/python3.10 /usr/bin/python3
 
 WORKDIR /home
 RUN wget -q https://bootstrap.pypa.io/get-pip.py
-RUN python3.9 get-pip.py && \
-  python3.10 get-pip.py && \
+RUN python3.10 get-pip.py && \
   python3.11 get-pip.py && \
   python3.12 get-pip.py
 
@@ -80,8 +78,7 @@ RUN python3.13t get-pip.py && \
   mv /usr/local/bin/pip3.13 /usr/local/bin/pip3.13t && \
   python3.13 get-pip.py
 
-RUN python3.9 -m pip install setuptools==69.5.1 && \
-  python3.10 -m pip install setuptools==69.5.1 && \
+RUN python3.10 -m pip install setuptools==69.5.1 && \
   python3.11 -m pip install setuptools==69.5.1 && \
   python3.12 -m pip install --break-system-packages setuptools==69.5.1 && \
   python3.13 -m pip install setuptools==69.5.1 && \
@@ -112,12 +109,10 @@ RUN git config --global credential.helper store
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 #For pre-commit
-RUN rm -f /usr/local/bin/pip && ln -s /usr/local/bin/pip3.9 /usr/local/bin/pip && \
-    rm -f /usr/local/bin/pip3 && ln -s /usr/local/bin/pip3.9 /usr/local/bin/pip3
+RUN rm -f /usr/local/bin/pip && ln -s /usr/local/bin/pip3.10 /usr/local/bin/pip && \
+    rm -f /usr/local/bin/pip3 && ln -s /usr/local/bin/pip3.10 /usr/local/bin/pip3
 
-RUN pip3.9 --no-cache-dir install ipython==5.3.0 && \
-    pip3.9 --no-cache-dir install ipykernel==4.6.0 wheel && \
-    pip3.10 --no-cache-dir install ipython==5.3.0 && \
+RUN pip3.10 --no-cache-dir install ipython==5.3.0 && \
     pip3.10 --no-cache-dir install ipykernel==4.6.0 wheel && \
     pip3.11 --no-cache-dir install ipython==5.3.0 && \
     pip3.11 --no-cache-dir install ipykernel==4.6.0 wheel && \
@@ -129,16 +124,13 @@ RUN pip3.9 --no-cache-dir install ipython==5.3.0 && \
     python3.13 -m pip --no-cache-dir install ipykernel==4.6.0 wheel
 
 # For PaddleTest CE
-RUN pip3.9 --no-cache-dir install pytest && \
-    pip3.10 --no-cache-dir install pytest && \
+RUN pip3.10 --no-cache-dir install pytest && \
     pip3.11 --no-cache-dir install pytest && \
     pip3.12 --no-cache-dir install pytest && \
     python3.13 -m pip --no-cache-dir install pytest && \
     python3.13t -m pip --no-cache-dir install pytest
 
-RUN pip3.9 --no-cache-dir install pre-commit==2.17.0 && \
-    pip3.9 --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
-    pip3.10 --no-cache-dir install pre-commit==2.17.0 && \
+RUN pip3.10 --no-cache-dir install pre-commit==2.17.0 && \
     pip3.10 --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
     pip3.11 --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
     pip3.12 --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
@@ -149,10 +141,7 @@ COPY ./python/requirements.txt  /root/
 COPY ./python/unittest_py/requirements.txt /home/
 COPY ./paddle/scripts/compile_requirements.txt /home/
 
-RUN pip3.9 --no-cache-dir install -r /root/requirements.txt && \
-    pip3.9 --no-cache-dir install -r  /home/requirements.txt && \
-    pip3.9 --no-cache-dir install -r /home/compile_requirements.txt && \
-    pip3.10 --no-cache-dir install -r /root/requirements.txt && \
+RUN pip3.10 --no-cache-dir install -r /root/requirements.txt && \
     pip3.10 --no-cache-dir install -r /home/requirements.txt && \
     pip3.10 --no-cache-dir install -r /home/compile_requirements.txt && \
     pip3.11 --no-cache-dir install -r /root/requirements.txt && \

--- a/tools/dockerfile/Dockerfile.ubuntu20
+++ b/tools/dockerfile/Dockerfile.ubuntu20
@@ -163,6 +163,8 @@ COPY ./python/requirements.txt  /root/
 COPY ./python/unittest_py/requirements.txt /home/
 COPY ./paddle/scripts/compile_requirements.txt /home/
 
+# Free-threaded Python 3.13 only installs compile helpers because broader
+# requirements currently pull packages without cp313t wheels.
 RUN pip3.10 --no-cache-dir install -r /root/requirements.txt && \
     pip3.10 --no-cache-dir install -r /home/requirements.txt && \
     pip3.10 --no-cache-dir install -r /home/compile_requirements.txt && \
@@ -175,9 +177,7 @@ RUN pip3.10 --no-cache-dir install -r /root/requirements.txt && \
     python3.13 -m pip --no-cache-dir install -r /root/requirements.txt && \
     python3.13 -m pip --no-cache-dir install -r /home/requirements.txt && \
     python3.13 -m pip --no-cache-dir install -r /home/compile_requirements.txt && \
-    python3.13t -m pip --no-cache-dir install -r /root/requirements.txt && \
     python3.13t -m pip --no-cache-dir install -r /home/compile_requirements.txt
-    # python3.13t -m pip --no-cache-dir install -r /home/requirements.txt
 
 # clang12
 RUN apt-get update &&\

--- a/tools/dockerfile/Dockerfile.ubuntu20
+++ b/tools/dockerfile/Dockerfile.ubuntu20
@@ -98,18 +98,17 @@ ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
 RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python
 
 RUN for py in 3.10 3.11 3.12 3.13 3.13t; do \
-      printf '#!/bin/sh\nexec /usr/local/bin/python%s -m pip "$@"\n' "$py" > "/usr/local/bin/pip${py}" && \
-      chmod +x "/usr/local/bin/pip${py}"; \
-    done && \
-    ln -sf /usr/local/bin/pip3.10 /usr/local/bin/pip && \
-    ln -sf /usr/local/bin/pip3.10 /usr/local/bin/pip3
-
-RUN for py in 3.10 3.11 3.12 3.13 3.13t; do \
       python${py} -m pip install --no-cache-dir --upgrade pip; \
     done && \
   python3.10 -m pip install setuptools==69.5.1 && \
   python3.11 -m pip install setuptools==69.5.1 && \
   python3.12 -m pip install --break-system-packages setuptools==69.5.1 && \
+  for py in 3.10 3.11 3.12 3.13 3.13t; do \
+    printf '#!/bin/sh\nexec /usr/local/bin/python%s -m pip "$@"\n' "$py" > "/usr/local/bin/pip${py}" && \
+    chmod +x "/usr/local/bin/pip${py}"; \
+  done && \
+  ln -sf /usr/local/bin/pip3.10 /usr/local/bin/pip && \
+  ln -sf /usr/local/bin/pip3.10 /usr/local/bin/pip3 && \
   python3.13 -m pip install setuptools==69.5.1 && \
   python3.13t -m pip install setuptools==69.5.1
 

--- a/tools/dockerfile/Dockerfile.ubuntu20
+++ b/tools/dockerfile/Dockerfile.ubuntu20
@@ -28,7 +28,7 @@ RUN apt-get update --allow-unauthenticated && \
   apt-get install -y curl wget vim git unzip pigz zstd unrar tar xz-utils libssl-dev bzip2 gzip \
     coreutils ntp language-pack-zh-hans libsm6 libxext6 libxrender-dev libgl1-mesa-glx \
     bison graphviz libjpeg-dev zlib1g-dev automake locales swig net-tools libtool kmod \
-    libbz2-dev libffi-dev libgdbm-dev liblzma-dev libncursesw5-dev libreadline-dev \
+    libbz2-dev libexpat1-dev libffi-dev libgdbm-dev liblzma-dev libmpdec-dev libncursesw5-dev libreadline-dev \
     libsqlite3-dev pkg-config tk-dev uuid-dev
 <install_cpu_package>
 
@@ -67,7 +67,11 @@ RUN set -eux; \
     wget -q "https://www.python.org/ftp/python/${py_ver}/Python-${py_ver}.tgz"; \
     tar -xzf "Python-${py_ver}.tgz"; \
     cd "Python-${py_ver}"; \
-    CFLAGS="-Wformat" ./configure --prefix=/usr/local --enable-shared "$@" > /dev/null; \
+    configure_opts="--prefix=/usr/local --enable-shared --enable-optimizations --with-lto --with-system-expat --with-system-libmpdec --with-ensurepip=install"; \
+    if ./configure --help | grep -q -- "--with-system-ffi"; then \
+      configure_opts="${configure_opts} --with-system-ffi"; \
+    fi; \
+    CFLAGS="-Wformat" ./configure ${configure_opts} "$@" > /dev/null; \
     make -j"$(nproc)" > /dev/null; \
     make altinstall > /dev/null; \
     cd ..; \
@@ -83,15 +87,6 @@ ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
 RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python && \
     ln -sf /usr/local/bin/python3.10 /usr/bin/python3
 
-WORKDIR /home
-RUN wget -q https://bootstrap.pypa.io/get-pip.py
-RUN python3.10 get-pip.py && \
-  python3.11 get-pip.py && \
-  python3.12 get-pip.py
-
-RUN python3.13t get-pip.py && \
-  mv /usr/local/bin/pip3.13 /usr/local/bin/pip3.13t && \
-  python3.13 get-pip.py
 RUN for py in 3.10 3.11 3.12 3.13 3.13t; do \
       printf '#!/bin/sh\nexec /usr/local/bin/python%s -m pip "$@"\n' "$py" > "/usr/local/bin/pip${py}" && \
       chmod +x "/usr/local/bin/pip${py}"; \

--- a/tools/dockerfile/Dockerfile.ubuntu20
+++ b/tools/dockerfile/Dockerfile.ubuntu20
@@ -91,6 +91,12 @@ RUN python3.10 get-pip.py && \
 RUN python3.13t get-pip.py && \
   mv /usr/local/bin/pip3.13 /usr/local/bin/pip3.13t && \
   python3.13 get-pip.py
+RUN for py in 3.10 3.11 3.12 3.13 3.13t; do \
+      printf '#!/bin/sh\nexec /usr/local/bin/python%s -m pip "$@"\n' "$py" > "/usr/local/bin/pip${py}" && \
+      chmod +x "/usr/local/bin/pip${py}"; \
+    done && \
+    ln -sf /usr/local/bin/pip3.10 /usr/local/bin/pip && \
+    ln -sf /usr/local/bin/pip3.10 /usr/local/bin/pip3
 
 RUN python3.10 -m pip install setuptools==69.5.1 && \
   python3.11 -m pip install setuptools==69.5.1 && \
@@ -121,10 +127,6 @@ RUN git config --global credential.helper store
 
 # Fix locales to en_US.UTF-8
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
-
-#For pre-commit
-RUN rm -f /usr/local/bin/pip && ln -s /usr/local/bin/pip3.10 /usr/local/bin/pip && \
-    rm -f /usr/local/bin/pip3 && ln -s /usr/local/bin/pip3.10 /usr/local/bin/pip3
 
 RUN pip3.10 --no-cache-dir install ipython==5.3.0 && \
     pip3.10 --no-cache-dir install ipykernel==4.6.0 wheel && \

--- a/tools/dockerfile/Dockerfile.ubuntu20
+++ b/tools/dockerfile/Dockerfile.ubuntu20
@@ -28,7 +28,7 @@ RUN apt-get update --allow-unauthenticated && \
   apt-get install -y curl wget vim git unzip pigz zstd unrar tar xz-utils libssl-dev bzip2 gzip \
     coreutils ntp language-pack-zh-hans libsm6 libxext6 libxrender-dev libgl1-mesa-glx \
     bison graphviz libjpeg-dev zlib1g-dev automake locales swig net-tools libtool kmod \
-    libbz2-dev libexpat1-dev libffi-dev libgdbm-dev liblzma-dev libmpdec-dev libncursesw5-dev libreadline-dev \
+    libbz2-dev libexpat1-dev libffi-dev libgdbm-dev liblzma-dev libncursesw5-dev libreadline-dev \
     libsqlite3-dev pkg-config tk-dev uuid-dev
 <install_cpu_package>
 
@@ -59,6 +59,16 @@ WORKDIR /home
 RUN wget -q https://cmake.org/files/v3.18/cmake-3.18.0-Linux-x86_64.tar.gz && tar -zxvf cmake-3.18.0-Linux-x86_64.tar.gz && rm cmake-3.18.0-Linux-x86_64.tar.gz
 ENV PATH=/home/cmake-3.18.0-Linux-x86_64/bin:$PATH
 
+RUN wget -q https://www.bytereef.org/software/mpdecimal/releases/mpdecimal-2.5.1.tar.gz && \
+    tar -xzf mpdecimal-2.5.1.tar.gz && \
+    cd mpdecimal-2.5.1 && \
+    ./configure --prefix=/usr/local > /dev/null && \
+    make -j"$(nproc)" > /dev/null && \
+    make install > /dev/null && \
+    cd .. && \
+    rm -rf mpdecimal-2.5.1 mpdecimal-2.5.1.tar.gz && \
+    ldconfig
+
 # Build free-threaded 3.13 before normal 3.13 so python3.13 stays non-free-threaded.
 RUN set -eux; \
   build_python() { \
@@ -71,7 +81,7 @@ RUN set -eux; \
     if ./configure --help | grep -q -- "--with-system-ffi"; then \
       configure_opts="${configure_opts} --with-system-ffi"; \
     fi; \
-    CFLAGS="-Wformat" ./configure ${configure_opts} "$@" > /dev/null; \
+    CPPFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib" CFLAGS="-Wformat" ./configure ${configure_opts} "$@" > /dev/null; \
     make -j"$(nproc)" > /dev/null; \
     make altinstall > /dev/null; \
     cd ..; \

--- a/tools/dockerfile/Dockerfile.ubuntu20
+++ b/tools/dockerfile/Dockerfile.ubuntu20
@@ -104,7 +104,10 @@ RUN for py in 3.10 3.11 3.12 3.13 3.13t; do \
     ln -sf /usr/local/bin/pip3.10 /usr/local/bin/pip && \
     ln -sf /usr/local/bin/pip3.10 /usr/local/bin/pip3
 
-RUN python3.10 -m pip install setuptools==69.5.1 && \
+RUN for py in 3.10 3.11 3.12 3.13 3.13t; do \
+      python${py} -m pip install --no-cache-dir --upgrade pip; \
+    done && \
+  python3.10 -m pip install setuptools==69.5.1 && \
   python3.11 -m pip install setuptools==69.5.1 && \
   python3.12 -m pip install --break-system-packages setuptools==69.5.1 && \
   python3.13 -m pip install setuptools==69.5.1 && \

--- a/tools/dockerfile/Dockerfile.ubuntu22
+++ b/tools/dockerfile/Dockerfile.ubuntu22
@@ -58,23 +58,19 @@ RUN apt-get remove --purge cmake && apt-get install -y cmake
 RUN apt-get install -y ccache
 
 RUN apt-get update && \
-  apt-get install -y python3.9 python3.9-dev python3.9-distutils \
-  python3.10 python3.10-dev python3.10-distutils \
+  apt-get install -y python3.10 python3.10-dev python3.10-distutils \
   python3.11 python3.11-dev python3.11-distutils \
   python3.12 python3.12-dev \
   python3.13 python3.13-dev python3.13-nogil && \
   apt-get install python-is-python3
-RUN rm /usr/bin/python && ln -s /usr/bin/python3.9 /usr/bin/python && \
-    rm /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
+RUN rm /usr/bin/python && ln -s /usr/bin/python3.10 /usr/bin/python && \
+    rm /usr/bin/python3 && ln -s /usr/bin/python3.10 /usr/bin/python3
 
 WORKDIR /home
-RUN wget -q https://bootstrap.pypa.io/get-pip.py && \
-    wget -q https://bootstrap.pypa.io/pip/3.9/get-pip.py -O get-pip-3.9.py
-RUN sed -i 's#"install", "--upgrade", "--force-reinstall"#"install", "--upgrade", "--force-reinstall", "--break-system-packages"#' get-pip.py && \
-    sed -i 's#"install", "--upgrade", "--force-reinstall"#"install", "--upgrade", "--force-reinstall", "--break-system-packages"#' get-pip-3.9.py
+RUN wget -q https://bootstrap.pypa.io/get-pip.py
+RUN sed -i 's#"install", "--upgrade", "--force-reinstall"#"install", "--upgrade", "--force-reinstall", "--break-system-packages"#' get-pip.py
 
-RUN python3.9 get-pip-3.9.py && \
-  python3.10 get-pip.py && \
+RUN python3.10 get-pip.py && \
   python3.11 get-pip.py && \
   python3.12 get-pip.py
 
@@ -82,8 +78,7 @@ RUN python3.13t get-pip.py && \
   mv /usr/local/bin/pip3.13 /usr/local/bin/pip3.13t && \
   python3.13 get-pip.py
 
-RUN python3.9 -m pip install setuptools==50.3.2 && \
-  python3.10 -m pip install setuptools==68.2.0 && \
+RUN python3.10 -m pip install setuptools==68.2.0 && \
   python3.11 -m pip install setuptools==68.2.0 && \
   python3.12 -m pip install --break-system-packages setuptools==68.2.0 && \
   python3.13 -m pip install setuptools==69.5.0 && \
@@ -111,12 +106,10 @@ RUN git config --global credential.helper store
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 #For pre-commit
-RUN rm -f /usr/local/bin/pip && ln -s /usr/local/bin/pip3.9 /usr/local/bin/pip && \
-    rm -f /usr/local/bin/pip3 && ln -s /usr/local/bin/pip3.9 /usr/local/bin/pip3
+RUN rm -f /usr/local/bin/pip && ln -s /usr/local/bin/pip3.10 /usr/local/bin/pip && \
+    rm -f /usr/local/bin/pip3 && ln -s /usr/local/bin/pip3.10 /usr/local/bin/pip3
 
-RUN python3.9 -m pip --no-cache-dir install ipython==5.3.0 && \
-    python3.9 -m pip --no-cache-dir install ipykernel==4.6.0 wheel && \
-    python3.10 -m pip --no-cache-dir install ipython==5.3.0 && \
+RUN python3.10 -m pip --no-cache-dir install ipython==5.3.0 && \
     python3.10 -m pip --no-cache-dir install ipykernel==4.6.0 wheel && \
     python3.11 -m pip --no-cache-dir install ipython==5.3.0 && \
     python3.11 -m pip --no-cache-dir install ipykernel==4.6.0 wheel && \
@@ -128,16 +121,13 @@ RUN python3.9 -m pip --no-cache-dir install ipython==5.3.0 && \
     python3.13t -m pip --no-cache-dir install ipykernel==4.6.0 wheel
 
 # For PaddleTest CE
-RUN python3.9  -m pip --no-cache-dir install pytest && \
-    python3.10 -m pip --no-cache-dir install pytest && \
+RUN python3.10 -m pip --no-cache-dir install pytest && \
     python3.11 -m pip --no-cache-dir install pytest && \
     python3.12 -m pip --no-cache-dir install --break-system-packages pytest && \
     python3.13 -m pip --no-cache-dir install pytest && \
     python3.13t -m pip --no-cache-dir install pytest
 
-RUN python3.9  -m pip --no-cache-dir install pre-commit==2.17.0 && \
-    python3.10 -m pip --no-cache-dir install pre-commit==2.17.0 && \
-    python3.9  -m pip --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
+RUN python3.10 -m pip --no-cache-dir install pre-commit==2.17.0 && \
     python3.10 -m pip --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
     python3.11 -m pip --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
     python3.12 -m pip --no-cache-dir install --break-system-packages cpplint==1.6.0 clang-format==13.0.0 && \
@@ -147,9 +137,7 @@ RUN python3.9  -m pip --no-cache-dir install pre-commit==2.17.0 && \
 COPY ./python/requirements.txt /root/
 COPY ./python/unittest_py/requirements.txt /home/
 
-RUN python3.9  -m pip --no-cache-dir install -r /root/requirements.txt && \
-    python3.9  -m pip --no-cache-dir install --break-system-packages --ignore-installed -r /home/requirements.txt && \
-    python3.10 -m pip --no-cache-dir install -r /root/requirements.txt && \
+RUN python3.10 -m pip --no-cache-dir install -r /root/requirements.txt && \
     python3.10 -m pip --no-cache-dir install --break-system-packages --ignore-installed -r /home/requirements.txt && \
     python3.11 -m pip --no-cache-dir install -r /root/requirements.txt && \
     python3.11 -m pip --no-cache-dir install --break-system-packages --ignore-installed -r /home/requirements.txt && \

--- a/tools/dockerfile/Dockerfile.ubuntu24
+++ b/tools/dockerfile/Dockerfile.ubuntu24
@@ -51,22 +51,20 @@ RUN apt-get remove --purge cmake && apt-get install -y cmake=3.28.3-1build7
 RUN apt-get install -y ccache
 
 RUN apt-get update && \
-  apt-get install -y python3.9 python3.9-dev python3.9-distutils \
-  python3.10 python3.10-dev python3.10-distutils \
+  apt-get install -y python3.10 python3.10-dev python3.10-distutils \
   python3.11 python3.11-dev python3.11-distutils \
   python3.12 python3.12-dev \
   python3.13 python3.13-dev python3.13-nogil \
   python3.14 python3.14-dev python3.14-nogil && \
   apt-get install python-is-python3
-RUN rm /usr/bin/python && ln -s /usr/bin/python3.9 /usr/bin/python && \
-    rm /usr/bin/python3 && ln -s /usr/bin/python3.9 /usr/bin/python3
+RUN rm /usr/bin/python && ln -s /usr/bin/python3.10 /usr/bin/python && \
+    rm /usr/bin/python3 && ln -s /usr/bin/python3.10 /usr/bin/python3
 
 WORKDIR /home
 RUN wget -q https://bootstrap.pypa.io/get-pip.py
 RUN sed -i 's#"install", "--upgrade", "--force-reinstall"#"install", "--upgrade", "--force-reinstall", "--break-system-packages"#' get-pip.py
 
-RUN python3.9 get-pip.py && \
-  python3.10 get-pip.py && \
+RUN python3.10 get-pip.py && \
   python3.11 get-pip.py && \
   python3.12 get-pip.py
 
@@ -80,8 +78,7 @@ RUN python3.14t get-pip.py && \
 
 RUN python -m pip config set global.break-system-packages true
 
-RUN python3.9 -m pip install setuptools==50.3.2 && \
-    python3.10 -m pip install setuptools==68.2.0 && \
+RUN python3.10 -m pip install setuptools==68.2.0 && \
     python3.11 -m pip install setuptools==68.2.0 && \
     python3.12 -m pip install --break-system-packages setuptools==68.2.0 && \
     python3.13 -m pip install setuptools==69.5.0 && \
@@ -111,12 +108,10 @@ RUN git config --global credential.helper store
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 #For pre-commit
-RUN rm -f /usr/local/bin/pip && ln -s /usr/local/bin/pip3.9 /usr/local/bin/pip && \
-    rm -f /usr/local/bin/pip3 && ln -s /usr/local/bin/pip3.9 /usr/local/bin/pip3
+RUN rm -f /usr/local/bin/pip && ln -s /usr/local/bin/pip3.10 /usr/local/bin/pip && \
+    rm -f /usr/local/bin/pip3 && ln -s /usr/local/bin/pip3.10 /usr/local/bin/pip3
 
-RUN python3.9 -m pip --no-cache-dir install ipython==5.3.0 && \
-    python3.9 -m pip --no-cache-dir install ipykernel==4.6.0 wheel && \
-    python3.10 -m pip --no-cache-dir install ipython==5.3.0 && \
+RUN python3.10 -m pip --no-cache-dir install ipython==5.3.0 && \
     python3.10 -m pip --no-cache-dir install ipykernel==4.6.0 wheel && \
     python3.11 -m pip --no-cache-dir install ipython==5.3.0 && \
     python3.11 -m pip --no-cache-dir install ipykernel==4.6.0 wheel && \
@@ -130,8 +125,7 @@ RUN python3.9 -m pip --no-cache-dir install ipython==5.3.0 && \
     python3.14t -m pip --no-cache-dir install ipython==5.3.0 ipykernel==4.6.0 wheel
 
 # For PaddleTest CE
-RUN python3.9  -m pip --no-cache-dir install pytest && \
-    python3.10 -m pip --no-cache-dir install pytest && \
+RUN python3.10 -m pip --no-cache-dir install pytest && \
     python3.11 -m pip --no-cache-dir install pytest && \
     python3.12 -m pip --no-cache-dir install --break-system-packages pytest && \
     python3.13 -m pip --no-cache-dir install pytest && \
@@ -139,9 +133,7 @@ RUN python3.9  -m pip --no-cache-dir install pytest && \
     python3.14 -m pip --no-cache-dir install pytest && \
     python3.14t -m pip --no-cache-dir install pytest
 
-RUN python3.9  -m pip --no-cache-dir install pre-commit==2.17.0 && \
-    python3.10 -m pip --no-cache-dir install pre-commit==2.17.0 && \
-    python3.9  -m pip --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
+RUN python3.10 -m pip --no-cache-dir install pre-commit==2.17.0 && \
     python3.10 -m pip --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
     python3.11 -m pip --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
     python3.12 -m pip --no-cache-dir install --break-system-packages cpplint==1.6.0 clang-format==13.0.0 && \
@@ -153,9 +145,7 @@ RUN python3.9  -m pip --no-cache-dir install pre-commit==2.17.0 && \
 COPY ./python/requirements.txt /root/
 COPY ./python/unittest_py/requirements.txt /home/
 
-RUN python3.9  -m pip --no-cache-dir install -r /root/requirements.txt && \
-    python3.9  -m pip --no-cache-dir install --break-system-packages --ignore-installed -r /home/requirements.txt && \
-    python3.10 -m pip --no-cache-dir install -r /root/requirements.txt && \
+RUN python3.10 -m pip --no-cache-dir install -r /root/requirements.txt && \
     python3.10 -m pip --no-cache-dir install --break-system-packages --ignore-installed -r /home/requirements.txt && \
     python3.11 -m pip --no-cache-dir install -r /root/requirements.txt && \
     python3.11 -m pip --no-cache-dir install --break-system-packages --ignore-installed -r /home/requirements.txt && \

--- a/tools/dockerfile/build_scripts/build.sh
+++ b/tools/dockerfile/build_scripts/build.sh
@@ -24,7 +24,7 @@ set -ex
 # remove others to expedite build and reduce docker image size. The original
 # manylinux docker image project builds many python versions.
 # NOTE We added back 3.5.1, since auditwheel requires python 3.3+
-CPYTHON_VERSIONS="3.12.0 3.11.0 3.10.0 3.9.0"
+CPYTHON_VERSIONS="3.12.0 3.11.0 3.10.0"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive
@@ -76,7 +76,6 @@ build_cpythons $CPYTHON_VERSIONS
 
 #PY37_BIN=/opt/python/cp37-cp37m/bin
 PY38_BIN=/opt/python/cp38-cp38/bin
-PY39_BIN=/opt/python/cp39-cp39/bin
 PY310_BIN=/opt/python/cp310-cp310/bin
 PY311_BIN=/opt/python/cp311-cp311/bin
 PY312_BIN=/opt/python/cp312-cp312/bin
@@ -84,7 +83,7 @@ PY312_BIN=/opt/python/cp312-cp312/bin
 # libpython, we need to add libpython's dir to LD_LIBRARY_PATH before running
 # python.
 ORIGINAL_LD_LIBRARY_PATH="${LD_LIBRARY_PATH}"
-LD_LIBRARY_PATH="${ORIGINAL_LD_LIBRARY_PATH}:$(dirname ${PY38_BIN})/lib:$(dirname ${PY39_BIN})/lib:$(dirname ${PY310_BIN})/lib:$(dirname ${PY311_BIN})/lib"
+LD_LIBRARY_PATH="${ORIGINAL_LD_LIBRARY_PATH}:$(dirname ${PY38_BIN})/lib:$(dirname ${PY310_BIN})/lib:$(dirname ${PY311_BIN})/lib"
 
 # Our openssl doesn't know how to find the system CA trust store
 #   (https://github.com/pypa/manylinux/issues/53)

--- a/tools/dockerfile/build_scripts/build_utils.sh
+++ b/tools/dockerfile/build_scripts/build_utils.sh
@@ -83,9 +83,6 @@ function do_cpython_build {
     rm -rf Python-$py_ver
     # Some python's install as bin/python3. Make them available as
     # bin/python.
-    if [ -e ${prefix}/bin/python3.9 ]; then
-        ln -s python3.9 ${prefix}/bin/python
-    fi
     if [ -e ${prefix}/bin/python3.10 ]; then
         ln -s python3.10 ${prefix}/bin/python
     fi

--- a/tools/dockerfile/ci_dockerfile.sh
+++ b/tools/dockerfile/ci_dockerfile.sh
@@ -123,14 +123,6 @@ function make_ubuntu20_cu123_dockerfile(){
   sed -i 's#/usr/local/gcc-8.2/bin/g++#/usr/local/gcc-12.1/bin/g++#g' ${dockerfile_name}
   sed -i 's#/usr/local/gcc-8.2/bin/g++#/usr/local/gcc-12.1/bin/g++#g' ${dockerfile_name}
   sed -i 's#PATH=/usr/local/gcc-8.2/bin:$PATH#PATH=/usr/local/gcc-12.1/bin:$PATH#g' ${dockerfile_name}
-
-  sed -i "${dockerfile_line}i WORKDIR /home \n \
-    RUN git clone --depth=1 https://github.com/PaddlePaddle/PaddleNLP.git -b stable/paddle-ci \&\& cd PaddleNLP \&\& \
-    pip3.10 install -r requirements.txt \&\& \
-    pip3.10 install -r scripts/regression/requirements_ci.txt \&\& \
-    pip3.10 install -r csrc/requirements.txt \&\& \
-    pip3.10 install pytest-timeout \&\& \
-    cd /home \&\& rm -rf PaddleNLP" ${dockerfile_name}
 }
 
 function main() {

--- a/tools/dockerfile/manylinux/Dockerfile
+++ b/tools/dockerfile/manylinux/Dockerfile
@@ -111,15 +111,13 @@ ENV GDRCOPY_HOME=/usr/local/gdrcopy
 FROM python as paddle
 RUN wget https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/requirements.txt -O /root/requirements.txt
 
-RUN LD_LIBRARY_PATH=/opt/_internal/cpython-3.9.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.9.0/bin/pip3 install setuptools pyyaml wheel -U && \
-    LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.10.0/bin/pip3 install setuptools pyyaml wheel -U && \
+RUN LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.10.0/bin/pip3 install setuptools pyyaml wheel -U && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.11.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.11.0/bin/pip3 install setuptools pyyaml wheel -U && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.12.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.12.0/bin/pip3 install setuptools pyyaml wheel -U && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.13.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.13.0/bin/pip3 install setuptools pyyaml wheel -U && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.14.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.14.0/bin/pip3 install setuptools pyyaml wheel -U
 
-RUN LD_LIBRARY_PATH=/opt/_internal/cpython-3.9.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.9.0/bin/pip3 install -r /root/requirements.txt && \
-    LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.10.0/bin/pip3 install -r /root/requirements.txt && \
+RUN LD_LIBRARY_PATH=/opt/_internal/cpython-3.10.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.10.0/bin/pip3 install -r /root/requirements.txt && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.11.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.11.0/bin/pip3 install -r /root/requirements.txt && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.12.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.12.0/bin/pip3 install -r /root/requirements.txt && \
     LD_LIBRARY_PATH=/opt/_internal/cpython-3.13.0/lib/:${LD_LIBRARY_PATH} /opt/_internal/cpython-3.13.0/bin/pip3 install -r /root/requirements.txt && \

--- a/tools/dockerfile/manylinux/Dockerfile-130
+++ b/tools/dockerfile/manylinux/Dockerfile-130
@@ -16,6 +16,7 @@ ARG PYTHON_VERSION=3.10
 ENV WITH_GPU=${WITH_GPU:-ON}
 ENV WITH_AVX=${WITH_AVX:-ON}
 ENV DEBIAN_FRONTEND=noninteractive
+ENV LD_LIBRARY_PATH=/usr/local/cuda-${CUDA_VERSION}/compat:/usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux/lib:$LD_LIBRARY_PATH
 
 ENV HOME /root
 

--- a/tools/dockerfile/manylinux/Dockerfile-130
+++ b/tools/dockerfile/manylinux/Dockerfile-130
@@ -16,7 +16,6 @@ ARG PYTHON_VERSION=3.10
 ENV WITH_GPU=${WITH_GPU:-ON}
 ENV WITH_AVX=${WITH_AVX:-ON}
 ENV DEBIAN_FRONTEND=noninteractive
-ENV LD_LIBRARY_PATH=/usr/local/cuda-${CUDA_VERSION}/compat:/usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux/lib:$LD_LIBRARY_PATH
 
 ENV HOME /root
 

--- a/tools/dockerfile/manylinux/Dockerfile-132
+++ b/tools/dockerfile/manylinux/Dockerfile-132
@@ -18,7 +18,6 @@ ARG TMP_DIR=patchelf_tmp
 ENV WITH_GPU=${WITH_GPU:-ON}
 ENV WITH_AVX=${WITH_AVX:-ON}
 ENV DEBIAN_FRONTEND=noninteractive
-ENV LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat:$LD_LIBRARY_PATH
 ENV GDRCOPY_HOME=/usr/local/gdrcopy
 
 ENV HOME /root

--- a/tools/dockerfile/manylinux/common/install_python.sh
+++ b/tools/dockerfile/manylinux/common/install_python.sh
@@ -122,39 +122,3 @@ CPYTHON_VERSIONS="3.14.0 3.13.0 3.12.0 3.11.0 3.10.0 3.9.0"
 
 mkdir -p /opt/python
 build_cpythons $CPYTHON_VERSIONS
-
-
-mkdir -p /opt/python
-build_cpythons $CPYTHON_VERSIONS
-#PY39_BIN=/opt/python/cp39-cp39/bin
-#PY310_BIN=/opt/python/cp310-cp310/bin
-#PY311_BIN=/opt/python/cp311-cp311/bin
-#PY312_BIN=/opt/python/cp312-cp312/bin
-#PY313_BIN=/opt/python/cp313-cp313/bin
-#PY313T_BIN=/opt/python/cp313-cp313t/bin
-#
-#LD_LIBRARY_PATH="${ORIGINAL_LD_LIBRARY_PATH}:$(dirname ${PY38_BIN})/lib" $PY38_BIN/pip install certifi
-#ln -s $($PY38_BIN/python -c 'import certifi; print(certifi.where())') \
-#      /opt/_internal/certs.pem
-#
-#find /opt/_internal -name '*.a' -print0 | xargs -0 rm -f
-#find /opt/_internal -type f -print0 \
-#    | xargs -0 -n1 strip --strip-unneeded 2>/dev/null || true
-#
-#find /opt/_internal \
-#     \( -type d -a -name test -o -name tests \) \
-#  -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
-#  -print0 | xargs -0 rm -f
-#
-#for PYTHON in /opt/python/*/bin/python; do
-#    # Add matching directory of libpython shared library to library lookup path
-#    LD_LIBRARY_PATH="${ORIGINAL_LD_LIBRARY_PATH}:$(dirname $(dirname ${PYTHON}))/lib"
-#
-#    if [ "$(dirname $(dirname ${PYTHON}))" != "/opt/python/cp310-cp310" -a "$(dirname $(dirname ${PYTHON}))" != "/opt/python/cp311-cp311" ]; then
-#        # Smoke test to make sure that our Pythons work, and do indeed detect as
-#        # being manylinux compatible:
-#        LD_LIBRARY_PATH="${ORIGINAL_LD_LIBRARY_PATH}:$(dirname $(dirname ${PYTHON}))/lib" $PYTHON $MY_DIR/manylinux1-check.py
-#        # Make sure that SSL cert checking works
-#        LD_LIBRARY_PATH="${ORIGINAL_LD_LIBRARY_PATH}:$(dirname $(dirname ${PYTHON}))/lib"
-#    fi
-#done

--- a/tools/dockerfile/manylinux/common/install_python.sh
+++ b/tools/dockerfile/manylinux/common/install_python.sh
@@ -58,9 +58,6 @@ function do_cpython_build {
     find / -name 'libpython*.so*'
     rm -rf Python-$py_ver
     # Some python's install as bin/python3. Make them available as bin/python.
-    if [ -e ${prefix}/bin/python3.9 ]; then
-        ln -s python3.9 ${prefix}/bin/python
-    fi
     if [ -e ${prefix}/bin/python3.10 ]; then
         ln -s python3.10 ${prefix}/bin/python
     fi
@@ -118,7 +115,7 @@ function build_cpythons {
 
 PYTHON_DOWNLOAD_URL=https://www.python.org/ftp/python
 GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
-CPYTHON_VERSIONS="3.14.0 3.13.0 3.12.0 3.11.0 3.10.0 3.9.0"
+CPYTHON_VERSIONS="3.14.0 3.13.0 3.12.0 3.11.0 3.10.0"
 
 mkdir -p /opt/python
 build_cpythons $CPYTHON_VERSIONS


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Improvements

### Description
本 PR 清理 Docker 构建镜像中的两类历史配置：

- 移除 CUDA 13.2 manylinux 镜像中全局启用的 CUDA compat `LD_LIBRARY_PATH`，避免容器默认优先加载 compat 包里的 driver libraries。
- 清理 `tools/dockerfile` 下仍保留的 Python 3.9 安装、默认链接、构建矩阵和依赖安装路径，让构建镜像统一收敛到 Python 3.10+。

#### 背景
CUDA forward compatibility package 只应在需要跨 major release forward compatibility 时显式启用。`cuda-compat-*` 包会提供 `libcuda.so.*` 等 driver user-mode libraries，但不应该在基础镜像中默认压过容器运行环境注入的真实 NVIDIA driver library。对 CUDA 13.2 manylinux 镜像全局设置 `/usr/local/cuda-13.2/compat` 到 `LD_LIBRARY_PATH`，会增加运行时误加载 compat driver library 的风险。

Python 3.9 已从本次 Docker 构建矩阵中退场后，继续在 Dockerfile、manylinux 构建脚本和 build scripts 中安装 `python3.9`、构建 `cpython-3.9.0`、创建 `py39` venv，或把默认 `python` / `pip` 指向 3.9，会让废弃运行时继续进入构建镜像并增加维护成本。

Ubuntu20 build 镜像原本依赖 deadsnakes apt 包安装 Python 3.10+，但当前 Docker CI 已无法稳定安装对应的 dev/distutils/nogil 包。因此 `Dockerfile.ubuntu20` 改为从 CPython 官方源码构建 Python 3.10、3.11、3.12、3.13 和 free-threaded 3.13，并补齐源码构建所需的 system library 配置。

#### 主要改动
- 删除 `tools/dockerfile/manylinux/Dockerfile-132` 中全局 `/usr/local/cuda-13.2/compat` `LD_LIBRARY_PATH` 配置。
- 保持 `tools/dockerfile/manylinux/Dockerfile-130` 与 `develop` 一致，不在本 PR 中修改 CUDA 13.0 镜像。
- 清理 `tools/dockerfile` 下的 Python 3.9 路径，包括 Dockerfile、manylinux `install_python.sh`、`build_scripts/build.sh` 和 `build_scripts/build_utils.sh` 中的 `python3.9` / `pip3.9` / `cpython-3.9.0` / `py39` / `cp39`。
- 将 `Dockerfile.ubuntu20` 的 Python 3.10+ 安装从 deadsnakes apt 包切换为源码构建。
- CPython 源码构建显式开启 `--enable-optimizations`、`--with-lto`、`--with-system-expat`、`--with-system-libmpdec`、`--with-ensurepip=install`，并在版本支持时追加 `--with-system-ffi`。
- 在 Ubuntu20 Python 源码构建前安装 `mpdecimal-2.5.1` 到 `/usr/local`，避免 focal 自带 `libmpdec` 2.4.2 不满足 CPython 3.11+ `_decimal` 的版本要求。
- 删除 Ubuntu20 源码构建路径中的 `get-pip.py`，改由 CPython `ensurepip` 安装 pip，并保留 `pip3.10`、`pip3.11`、`pip3.12`、`pip3.13`、`pip3.13t` wrapper。
- 先构建 free-threaded Python 3.13，再构建普通 Python 3.13，确保 `/usr/local/bin/python3.13` 仍指向普通解释器。
- Ubuntu20 保留系统 `/usr/bin/python3`，只将 `/usr/bin/python` 指向源码编译的 Python 3.10，避免 `lsb_release` 等系统脚本被非系统 Python 运行。
- 收敛 Ubuntu20 中 free-threaded Python 3.13 的依赖安装范围：跳过会拉取 numpy 等包源码构建的通用 requirements，只保留 `compile_requirements.txt`。

#### 影响范围
该 PR 只影响 Docker 镜像定义和镜像构建脚本，不修改 Paddle Python API、算子逻辑或运行时数值路径。

CUDA 13.2 manylinux 镜像不再默认启用 CUDA compat driver libraries。若某些运行环境确实需要 forward compatibility，应在具体任务中显式配置 `LD_LIBRARY_PATH` 或 loader，而不是在基础镜像中全局打开。

Ubuntu20 build 镜像改为源码构建 Python 后，镜像构建时间会比 apt 安装更长；显式开启 PGO 和 LTO 后构建时间也会增加。这样可以避免继续依赖 deadsnakes 是否提供 focal 上的 Python dev/distutils 包，并让源码构建产物明确使用 system expat、system libffi、mpdecimal 2.5.1 和 CPython `ensurepip`。

free-threaded Python 3.13 目前不安装通用 runtime/test requirements，避免在 GCC 8.2 的 Ubuntu20 build image 中触发 numpy 等缺少 `cp313t` wheel 的包源码构建。

#### 验证
- 下载并检查 CI-Build 失败日志，确认最新失败点为 `python3.13t` 安装 `/root/requirements.txt` 时 numpy 回退源码构建，并因当前 GCC 8.2 低于 NumPy 2.5.0 要求的 GCC >= 9.3 失败。
- 使用 `gsed` 临时生成 `Dockerfile.cuda11.2_cudnn8_gcc82_trt8`，确认生成文件中 `python3.13t` 只安装 `/home/compile_requirements.txt`，不再安装 `/root/requirements.txt` 或 `/home/requirements.txt`。
- 使用 `gsed` 临时生成 Ubuntu20 相关 Dockerfile，确认 free-threaded 3.13 先于普通 3.13 构建，源码编译参数包含 PGO、LTO、system expat、system libmpdec、ensurepip，并且不再包含 `get-pip.py`。
- `rg -n "python3\\.9|pip3\\.9|cpython-3\\.9|Python-3\\.9|Python 3\\.9|py39|cp39|pip/3\\.9|3\\.9\\.0" tools/dockerfile` 无 Python 3.9 相关命中。
- `bash -n tools/dockerfile/ci_dockerfile.sh tools/dockerfile/build_scripts/build_utils.sh tools/dockerfile/build_scripts/build.sh tools/dockerfile/manylinux/common/install_python.sh`
- `git diff --check -- tools/dockerfile/Dockerfile.ubuntu20`
- `docker build --check` 可读入生成的 Ubuntu20 build Dockerfile；当前仅报告模板既有的 `MAINTAINER` 和 legacy `ENV HOME /root` warning。
- `prek`

参考：
- https://docs.nvidia.com/deploy/cuda-compatibility/forward-compatibility.html
- https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html

### 是否引起精度变化
否
