### PR TITLE
[Operator Mechanism] Add dynamic-only mm out_dtype

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -138,6 +138,7 @@ from ..common_ops_import import Variable
 from ..framework import (
     LayerHelper,
     convert_nptype_to_datatype_or_vartype,
+    convert_to_datatype,
     core,
     in_dynamic_mode,
     in_dynamic_or_pir_mode,
@@ -2118,6 +2119,7 @@ def mm(
     mat2: Tensor,
     name: str | None = None,
     *,
+    out_dtype: DTypeLike | None = None,
     out: Tensor | None = None,
 ) -> Tensor:
     """
@@ -2140,6 +2142,7 @@ def mm(
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Keywords Argument:
+        out_dtype (DTypeLike|None, optional): The output data type. This temporary feature only supports ``paddle.float32`` for dynamic-graph CUDA 2-D bfloat16 inputs. Default is None.
         out (Tensor, optional): The output Tensor. It must have the same data type and shape as the expected output. Default is None, and a new Tensor will be created to store the result.
 
     Returns:
@@ -2192,6 +2195,43 @@ def mm(
 
 
     """
+    if out_dtype is not None:
+        out_dtype = convert_to_datatype(out_dtype)
+        if not in_dynamic_mode():
+            raise NotImplementedError(
+                "The out_dtype of paddle.mm is only supported in dynamic graph mode."
+            )
+        if out_dtype != core.DataType.FLOAT32:
+            raise TypeError(
+                "The out_dtype of paddle.mm currently only supports paddle.float32."
+            )
+        if input.dtype != core.DataType.BFLOAT16:
+            raise TypeError(
+                "The out_dtype of paddle.mm currently only supports bfloat16 input."
+            )
+        if mat2.dtype != core.DataType.BFLOAT16:
+            raise TypeError(
+                "The out_dtype of paddle.mm currently only supports bfloat16 mat2."
+            )
+        if len(input.shape) != 2 or len(mat2.shape) != 2:
+            raise ValueError(
+                "The out_dtype of paddle.mm currently only supports 2-D inputs."
+            )
+        if out is not None and out.dtype != core.DataType.FLOAT32:
+            raise TypeError(
+                "The out tensor dtype must be paddle.float32 when out_dtype is paddle.float32."
+            )
+        if not input.place.is_gpu_place():
+            raise NotImplementedError(
+                "The out_dtype of paddle.mm currently only supports CUDA tensors."
+            )
+        return paddle.mm(
+            input.astype('float32'),
+            mat2.astype('float32'),
+            name=name,
+            out=out,
+        )
+
     if in_dynamic_mode():
         return _C_ops.matmul(input, mat2, False, False, out=out)
 

--- a/test/legacy_test/test_mm_out.py
+++ b/test/legacy_test/test_mm_out.py
@@ -128,6 +128,95 @@ class TestMmOutScenarios(unittest.TestCase):
         np.testing.assert_equal(o4, None)
 
 
+class TestMmOutDtypeDynamicOnly(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+
+    def _skip_if_no_bf16_cuda(self):
+        if not paddle.is_compiled_with_cuda():
+            self.skipTest("CUDA is required for mm out_dtype")
+        if paddle.device.cuda.get_device_capability()[0] < 8:
+            self.skipTest(
+                "BF16 mm out_dtype requires CUDA compute capability >= 8"
+            )
+
+    def test_bf16_to_fp32(self):
+        self._skip_if_no_bf16_cuda()
+        x = paddle.randn([3, 4], dtype='bfloat16')
+        y = paddle.randn([4, 5], dtype='bfloat16')
+        out = paddle.mm(x, y, out_dtype=paddle.float32)
+        ref = paddle.mm(x.astype('float32'), y.astype('float32'))
+        self.assertEqual(out.dtype, paddle.float32)
+        np.testing.assert_allclose(
+            out.numpy(), ref.numpy(), rtol=1e-2, atol=1e-2
+        )
+
+    def test_bf16_to_fp32_transposed_rhs(self):
+        self._skip_if_no_bf16_cuda()
+        x = paddle.randn([3, 4], dtype='bfloat16')
+        weight = paddle.randn([5, 4], dtype='bfloat16')
+        out = paddle.mm(x, weight.t(), out_dtype=paddle.float32)
+        ref = paddle.mm(x.astype('float32'), weight.t().astype('float32'))
+        self.assertEqual(out.dtype, paddle.float32)
+        np.testing.assert_allclose(
+            out.numpy(), ref.numpy(), rtol=1e-2, atol=1e-2
+        )
+
+    def test_bf16_to_fp32_out(self):
+        self._skip_if_no_bf16_cuda()
+        x = paddle.randn([3, 4], dtype='bfloat16')
+        y = paddle.randn([4, 5], dtype='bfloat16')
+        out = paddle.empty([3, 5], dtype='float32')
+        ret = paddle.mm(x, y, out_dtype=paddle.float32, out=out)
+        ref = paddle.mm(x.astype('float32'), y.astype('float32'))
+        self.assertEqual(ret.dtype, paddle.float32)
+        np.testing.assert_allclose(
+            ret.numpy(), ref.numpy(), rtol=1e-2, atol=1e-2
+        )
+        np.testing.assert_allclose(
+            out.numpy(), ref.numpy(), rtol=1e-2, atol=1e-2
+        )
+
+    def test_out_dtype_rejects_unsupported_cases(self):
+        self._skip_if_no_bf16_cuda()
+        x = paddle.randn([3, 4], dtype='float32')
+        y = paddle.randn([4, 5], dtype='float32')
+        with self.assertRaises(TypeError):
+            paddle.mm(x, y, out_dtype=paddle.float32)
+        x_bf16 = paddle.randn([3, 4], dtype='bfloat16')
+        y_bf16 = paddle.randn([4, 5], dtype='bfloat16')
+        with self.assertRaises(TypeError):
+            paddle.mm(x_bf16, y_bf16, out_dtype=paddle.bfloat16)
+        with self.assertRaises(ValueError):
+            paddle.mm(
+                x_bf16.reshape([1, 3, 4]),
+                y_bf16.reshape([1, 4, 5]),
+                out_dtype=paddle.float32,
+            )
+        with self.assertRaises(TypeError):
+            paddle.mm(
+                x_bf16,
+                y_bf16,
+                out_dtype=paddle.float32,
+                out=paddle.empty([3, 5], dtype='bfloat16'),
+            )
+
+    def test_static_rejects_out_dtype(self):
+        paddle.enable_static()
+        paddle.pir_utils._switch_to_old_ir_()
+        try:
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                x = paddle.static.data('x', [3, 4], dtype='bfloat16')
+                y = paddle.static.data('y', [4, 5], dtype='bfloat16')
+                with self.assertRaises(NotImplementedError):
+                    paddle.mm(x, y, out_dtype=paddle.float32)
+        finally:
+            paddle.pir_utils._switch_to_pir_()
+            paddle.disable_static()
+
+
 class TestMmOutBatchedAndShapes(unittest.TestCase):
     def setUp(self):
         paddle.disable_static()


### PR DESCRIPTION
Add a temporary minimal dynamic-only paddle.mm out_dtype path for CUDA 2-D BF16 inputs. Static/PIR paths fail closed to avoid legacy graph compatibility and fusion-pass corruption risks.

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
最小修改，支持动态图out_dtype

pcard-91067


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否