### PR TITLE
[CI] Check C++ coverage before diff filtering

### DIFF
--- a/ci/coverage_info.sh
+++ b/ci/coverage_info.sh
@@ -107,12 +107,12 @@ function pr_has_cpp_source_changes() {
     ' "${diff_file}"
 }
 
-function ensure_cpp_diff_coverage_data() {
+function ensure_cpp_extracted_coverage_data() {
     local info_file="$1"
     local diff_file="$2"
 
     if pr_has_cpp_source_changes "${diff_file}" && ! grep -q '^DA:' "${info_file}" 2>/dev/null; then
-        echo "ERROR: ${info_file} has no C++ line coverage data for compiled C++ source changes"
+        echo "ERROR: ${info_file} has no extracted C++ line coverage data for compiled C++ source changes"
         echo "This usually means lcov/gcov failed before producing a valid diff report."
         exit 101
     fi
@@ -230,11 +230,11 @@ lcov --extract coverage-full.info \
     -o coverage-diff.info \
     --rc lcov_branch_coverage=0
 
+ensure_cpp_extracted_coverage_data coverage-diff.info git-diff.out
+
 python ${PADDLE_ROOT}/ci/coverage_diff.py coverage-diff.info git-diff.out > coverage-diff.tmp
 
 mv -f coverage-diff.tmp coverage-diff.info
-
-ensure_cpp_diff_coverage_data coverage-diff.info git-diff.out
 
 cp coverage-diff.info coverage_files
 

--- a/ci/coverage_info.sh
+++ b/ci/coverage_info.sh
@@ -123,6 +123,7 @@ function filter_coverage_diff_if_available() {
     local diff_file="$2"
     local tmp_file="$3"
 
+    # Temporary smoke-test marker for CI-only coverage changes.
     if [ ! -f "${info_file}" ]; then
         echo "Skip coverage diff filtering because ${info_file} was not generated."
         : > "${info_file}"

--- a/ci/coverage_info.sh
+++ b/ci/coverage_info.sh
@@ -123,7 +123,6 @@ function filter_coverage_diff_if_available() {
     local diff_file="$2"
     local tmp_file="$3"
 
-    # Temporary smoke-test marker for CI-only coverage changes.
     if [ ! -f "${info_file}" ]; then
         echo "Skip coverage diff filtering because ${info_file} was not generated."
         : > "${info_file}"

--- a/ci/coverage_info.sh
+++ b/ci/coverage_info.sh
@@ -232,7 +232,7 @@ lcov --extract coverage-full.info \
 
 ensure_cpp_extracted_coverage_data coverage-diff.info git-diff.out
 
-python ${PADDLE_ROOT}/ci/coverage_diff.py coverage-diff.info git-diff.out > coverage-diff.tmp
+python ${PADDLE_ROOT}/ci/coverage_diff.py coverage-diff.info git-diff.out > coverage-diff.tmp || exit 101
 
 mv -f coverage-diff.tmp coverage-diff.info
 
@@ -279,7 +279,7 @@ lcov --extract python-coverage-full.info \
     -o python-coverage-diff.info \
     --rc lcov_branch_coverage=0
 
-python ${PADDLE_ROOT}/ci/coverage_diff.py python-coverage-diff.info python-git-diff.out > python-coverage-diff.tmp
+python ${PADDLE_ROOT}/ci/coverage_diff.py python-coverage-diff.info python-git-diff.out > python-coverage-diff.tmp || exit 101
 
 mv -f python-coverage-diff.tmp python-coverage-diff.info
 

--- a/ci/coverage_info.sh
+++ b/ci/coverage_info.sh
@@ -118,6 +118,26 @@ function ensure_cpp_extracted_coverage_data() {
     fi
 }
 
+function filter_coverage_diff_if_available() {
+    local info_file="$1"
+    local diff_file="$2"
+    local tmp_file="$3"
+
+    if [ ! -f "${info_file}" ]; then
+        echo "Skip coverage diff filtering because ${info_file} was not generated."
+        : > "${info_file}"
+        return
+    fi
+
+    if [ ! -f "${diff_file}" ]; then
+        echo "ERROR: ${diff_file} was not generated for ${info_file}"
+        exit 101
+    fi
+
+    python ${PADDLE_ROOT}/ci/coverage_diff.py "${info_file}" "${diff_file}" > "${tmp_file}" || exit 101
+    mv -f "${tmp_file}" "${info_file}"
+}
+
 # NOTE: This gcda pre-cleaning step keeps/removes files by mapping PR
 # changed files to "*.gcda" paths. That is not always correct: for header-only
 # changes, or changes whose coverage is recorded in other translation units,
@@ -220,9 +240,9 @@ fi
 
 if [ "${PR_ID}" != "" ]; then
 
-    COVERAGE_DIFF_PATTERN="`python ${PADDLE_ROOT}/ci/coverage_pull_request.py files ${PR_ID}`"
+    COVERAGE_DIFF_PATTERN="`python ${PADDLE_ROOT}/ci/coverage_pull_request.py files ${PR_ID}`" || exit 101
 
-    python ${PADDLE_ROOT}/ci/coverage_pull_request.py diff ${PR_ID} > git-diff.out
+    python ${PADDLE_ROOT}/ci/coverage_pull_request.py diff ${PR_ID} > git-diff.out || exit 101
 fi
 
 lcov --extract coverage-full.info \
@@ -232,9 +252,7 @@ lcov --extract coverage-full.info \
 
 ensure_cpp_extracted_coverage_data coverage-diff.info git-diff.out
 
-python ${PADDLE_ROOT}/ci/coverage_diff.py coverage-diff.info git-diff.out > coverage-diff.tmp || exit 101
-
-mv -f coverage-diff.tmp coverage-diff.info
+filter_coverage_diff_if_available coverage-diff.info git-diff.out coverage-diff.tmp
 
 cp coverage-diff.info coverage_files
 
@@ -269,9 +287,9 @@ gen_python_full_report || true  # python-coverage-full.info
 
 
 if [ "${GIT_PR_ID}" != "" ]; then
-    COVERAGE_DIFF_PATTERN="`python ${PADDLE_ROOT}/ci/coverage_pull_request.py files ${GIT_PR_ID}`"
+    COVERAGE_DIFF_PATTERN="`python ${PADDLE_ROOT}/ci/coverage_pull_request.py files ${GIT_PR_ID}`" || exit 101
 
-    python ${PADDLE_ROOT}/ci/coverage_pull_request.py diff ${GIT_PR_ID} > python-git-diff.out
+    python ${PADDLE_ROOT}/ci/coverage_pull_request.py diff ${GIT_PR_ID} > python-git-diff.out || exit 101
 fi
 
 lcov --extract python-coverage-full.info \
@@ -279,8 +297,6 @@ lcov --extract python-coverage-full.info \
     -o python-coverage-diff.info \
     --rc lcov_branch_coverage=0
 
-python ${PADDLE_ROOT}/ci/coverage_diff.py python-coverage-diff.info python-git-diff.out > python-coverage-diff.tmp || exit 101
-
-mv -f python-coverage-diff.tmp python-coverage-diff.info
+filter_coverage_diff_if_available python-coverage-diff.info python-git-diff.out python-coverage-diff.tmp
 
 cp python-coverage-diff.info coverage_files

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -747,7 +747,6 @@ void Backward(const std::vector<paddle::Tensor>& tensors,  // outputs
               const std::vector<paddle::Tensor>& grad_tensors,
               bool retain_graph,
               std::string dump_backward_graph_path) {
-  // Coverage guard smoke test: non-executable source diff.
   VLOG(3) << "Run in Backward";
   phi::RecordEvent backward_record_event(
       "backward", phi::TracerEventType::UserDefined, 1);

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -747,6 +747,7 @@ void Backward(const std::vector<paddle::Tensor>& tensors,  // outputs
               const std::vector<paddle::Tensor>& grad_tensors,
               bool retain_graph,
               std::string dump_backward_graph_path) {
+  // Coverage guard smoke test: non-executable source diff.
   VLOG(3) << "Run in Backward";
   phi::RecordEvent backward_record_event(
       "backward", phi::TracerEventType::UserDefined, 1);


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
修复 Coverage C++ 空数据 guard 在 diff 行过滤后误伤 PR 的问题，并补上 diff filtering 失败时的临时文件保护。

背景：#79263 合入后，`ci/coverage_info.sh` 会在 `coverage_diff.py` 过滤 PR diff 行之后检查 `coverage-diff.info` 是否仍有 `DA:` 行。这个检查可以发现 gcov/lcov 采集失败导致的空报告，但也会误伤一种正常场景：C++ coverage 提取阶段已有有效行覆盖率数据，但 PR 修改行本身不是 lcov 可统计执行行（例如函数签名、参数声明、参数透传换行等），经过 `coverage_diff.py` 过滤后没有 `DA:`。

#79267 的 Coverage 失败就是这个场景：job 日志显示 `lcov --extract` 已提取到 `paddle/fluid/eager/backward.cc`，并给出有效 line coverage；但 diff 行过滤后没有 `DA:`，最终被 guard 以 `ERROR: coverage-diff.info has no C++ line coverage data for compiled C++ source changes` 拦截。

本 PR 的处理：

- 将 C++ 空数据检查点前移到 `lcov --extract ... -o coverage-diff.info` 之后、`coverage_diff.py` 之前。
- 如果 extract 阶段对编译型 C++ 源码变更完全没有 `DA:`，仍然 fail fast，继续防止 gcov/lcov 采集失败产生空报告。
- 如果 extract 阶段已有 C++ 行覆盖率数据，只是 diff 行过滤后没有 `DA:`，不再误判为采集失败。
- `coverage_diff.py > *.tmp` 失败时不再继续 `mv -f` 覆盖原 report。
- 对没有 C++/Python coverage input 的 PR（例如仅修改 CI shell），跳过 diff filtering 并生成空 diff info，避免因输入文件不存在误失败。

关联失败示例：

- #79267 Coverage test: https://github.com/PaddlePaddle/Paddle/actions/runs/27086928359/job/80016269502?pr=79267

本地验证：

- bash -n ci/coverage_info.sh
- git diff --check -- ci/coverage_info.sh
- shellcheck -S error -s bash -e SC2328 ci/coverage_info.sh
- prek
- 手工样本验证：extract 有 `DA:` 时不失败；extract 无 `DA:` 且存在编译型 C++ 变更时仍会失败；缺少 coverage input 时会生成空 diff info 并跳过；已有 coverage input 但 `coverage_diff.py` 异常时会 `exit 101` 且不覆盖原 info。

CI 验证：

- 临时提交 `f9187c9124` 在 `paddle/fluid/eager/backward.cc` 增加一行非可执行注释，用来模拟编译型 C++ 源文件有 diff、但 diff 行本身不会产生 `DA:` 的场景。standard Coverage 已通过：https://github.com/PaddlePaddle/Paddle/actions/runs/27120351538/job/80043628335 。日志显示 `backward.cc` 被 `lcov --extract` 提取，`ensure_cpp_extracted_coverage_data` 在 `coverage_diff.py` 前检查到 `DA:` 后继续执行，最终 `Coverage passed`。验证完成后已通过 `624ac78da7` 回滚临时测试提交。
- 临时提交 `eaad8e571c` 在 `ci/coverage_info.sh` 增加一行注释，用来模拟仅修改 CI shell、没有 C++ coverage input 的场景。两条 Coverage test 均已通过：https://github.com/PaddlePaddle/Paddle/actions/runs/27175585527/job/80226927009 和 https://github.com/PaddlePaddle/Paddle/actions/runs/27175585565/job/80230022603 。验证完成后已通过 `e76b8bf329` 回滚临时测试提交。

### 是否引起精度变化
否