### PR TITLE
[Performance] Avoid repeat_interleave GPU sync when output_size is provided

### DIFF
--- a/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.cc
+++ b/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.cc
@@ -24,7 +24,11 @@ namespace funcs {
 
 template <typename Context, typename RepeatsT>
 void RepeatsTensor2IndexTensorFunctor<Context, RepeatsT>::operator()(
-    const Context &dev_ctx, const DenseTensor &repeats, DenseTensor *index) {
+    const Context &dev_ctx,
+    const DenseTensor &repeats,
+    DenseTensor *index,
+    int64_t output_size) {
+  (void)output_size;
   if (repeats.dims()[0] == 0) {
     index->Resize({0});
     dev_ctx.template Alloc<RepeatsT>(index);
@@ -61,7 +65,11 @@ void RepeatsTensor2IndexTensorFunctor<Context, RepeatsT>::operator()(
 
 template <typename RepeatsT>
 void RepeatsTensor2IndexTensorFunctor<CPUContext, RepeatsT>::operator()(
-    const CPUContext &dev_ctx, const DenseTensor &repeats, DenseTensor *index) {
+    const CPUContext &dev_ctx,
+    const DenseTensor &repeats,
+    DenseTensor *index,
+    int64_t output_size) {
+  (void)output_size;
   if (repeats.dims()[0] == 0) {
     index->Resize({0});
     dev_ctx.template Alloc<RepeatsT>(index);
@@ -95,7 +103,11 @@ template class RepeatsTensor2IndexTensorFunctor<CPUContext, int64_t>;
 #ifdef PADDLE_WITH_XPU
 template <typename RepeatsT>
 void RepeatsTensor2IndexTensorFunctor<XPUContext, RepeatsT>::operator()(
-    const XPUContext &dev_ctx, const DenseTensor &repeats, DenseTensor *index) {
+    const XPUContext &dev_ctx,
+    const DenseTensor &repeats,
+    DenseTensor *index,
+    int64_t output_size) {
+  (void)output_size;
   if (repeats.dims()[0] == 0) {
     index->Resize({0});
     dev_ctx.template Alloc<RepeatsT>(index);

--- a/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.cu
+++ b/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.cu
@@ -29,21 +29,47 @@ template <typename T>
 __global__ void fill_array_kernel(T *output,
                                   const T *prefix,
                                   const T *repeats,
-                                  int64_t n) {
-  T idx = blockIdx.x * blockDim.x + threadIdx.x;
+                                  int64_t n,
+                                  int64_t output_size) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx < n) {
-    T start = prefix[idx];
-    T count = repeats[idx];
+    int64_t start = static_cast<int64_t>(prefix[idx]);
+    int64_t end = start + static_cast<int64_t>(repeats[idx]);
+    end = end > output_size ? output_size : end;
 
-    for (T j = 0; j < count; j++) {
-      output[start + j] = idx;
+    for (int64_t j = start; j < end; j++) {
+      output[j] = static_cast<T>(idx);
     }
   }
 }
 
+template <typename T>
+__global__ void ValidateOutputSizeKernel(const T *prefix,
+                                         const T *repeats,
+                                         int64_t n,
+                                         int64_t output_size) {
+  if (blockIdx.x != 0 || threadIdx.x != 0 || n == 0) {
+    return;
+  }
+
+  const int64_t last_idx = n - 1;
+  const int64_t total_size = static_cast<int64_t>(prefix[last_idx]) +
+                             static_cast<int64_t>(repeats[last_idx]);
+  PADDLE_ENFORCE(
+      total_size == output_size,
+      "When output_size is provided, it should equal to "
+      "sum of repeats tensor. But received output_size = %ld, "
+      "sum of repeats = %ld.",
+      output_size,
+      total_size);
+}
+
 template <typename RepeatsT>
 void RepeatsTensor2IndexTensorFunctor<GPUContext, RepeatsT>::operator()(
-    const GPUContext &dev_ctx, const DenseTensor &repeats, DenseTensor *index) {
+    const GPUContext &dev_ctx,
+    const DenseTensor &repeats,
+    DenseTensor *index,
+    int64_t output_size) {
 #if defined(__NVCC__)
   const RepeatsT *repeats_ptr = repeats.data<RepeatsT>();
   int64_t num_reps = repeats.dims()[0];
@@ -69,22 +95,28 @@ void RepeatsTensor2IndexTensorFunctor<GPUContext, RepeatsT>::operator()(
       cub::Sum(),
       dev_ctx);
 
-  // get last prefix and repeat to compute total size of index tensor
-  RepeatsT last_prefix = 0;
-  RepeatsT last_repeat = 0;
-  cudaMemcpyAsync(&last_prefix,
-                  prefix_ptr + num_reps - 1,
-                  sizeof(RepeatsT),
-                  cudaMemcpyDeviceToHost,
-                  stream);
-  cudaMemcpyAsync(&last_repeat,
-                  repeats_ptr + num_reps - 1,
-                  sizeof(RepeatsT),
-                  cudaMemcpyDeviceToHost,
-                  stream);
-  cudaStreamSynchronize(stream);
-  int64_t total_size =
-      static_cast<int64_t>(last_prefix) + static_cast<int64_t>(last_repeat);
+  int64_t total_size = output_size;
+  if (total_size > 0) {
+    ValidateOutputSizeKernel<<<1, 1, 0, stream>>>(
+        prefix_ptr, repeats_ptr, num_reps, total_size);
+  } else {
+    // get last prefix and repeat to compute total size of index tensor
+    RepeatsT last_prefix = 0;
+    RepeatsT last_repeat = 0;
+    cudaMemcpyAsync(&last_prefix,
+                    prefix_ptr + num_reps - 1,
+                    sizeof(RepeatsT),
+                    cudaMemcpyDeviceToHost,
+                    stream);
+    cudaMemcpyAsync(&last_repeat,
+                    repeats_ptr + num_reps - 1,
+                    sizeof(RepeatsT),
+                    cudaMemcpyDeviceToHost,
+                    stream);
+    cudaStreamSynchronize(stream);
+    total_size =
+        static_cast<int64_t>(last_prefix) + static_cast<int64_t>(last_repeat);
+  }
 
   // resize & alloc index tensor
   index->Resize({total_size});
@@ -99,7 +131,8 @@ void RepeatsTensor2IndexTensorFunctor<GPUContext, RepeatsT>::operator()(
                           PADDLE_CUDA_NUM_THREADS,
                       PADDLE_CUDA_NUM_THREADS,
                       0,
-                      stream>>>(index_ptr, prefix_ptr, repeats_ptr, num_reps);
+                      stream>>>(
+      index_ptr, prefix_ptr, repeats_ptr, num_reps, total_size);
 #else
   DenseTensor repeats_cpu_copy;
   if (repeats.place().GetType() != AllocationType::CPU) {

--- a/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.cu
+++ b/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.cu
@@ -75,6 +75,14 @@ void RepeatsTensor2IndexTensorFunctor<GPUContext, RepeatsT>::operator()(
   int64_t num_reps = repeats.dims()[0];
 
   if (num_reps == 0) {
+    PADDLE_ENFORCE_LE(
+        output_size,
+        0,
+        common::errors::InvalidArgument(
+            "When output_size is provided, it should equal to "
+            "sum of repeats tensor. But received output_size = %ld, "
+            "sum of repeats = 0.",
+            output_size));
     index->Resize({0});
     dev_ctx.template Alloc<RepeatsT>(index);
     return;

--- a/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.h
+++ b/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.h
@@ -29,7 +29,8 @@ class RepeatsTensor2IndexTensorFunctor {
  public:
   void operator()(const Context &ctx,
                   const DenseTensor &repeats,
-                  DenseTensor *index);
+                  DenseTensor *index,
+                  int64_t output_size = -1);
 };
 
 #if defined(__NVCC__) || defined(__HIPCC__)
@@ -38,7 +39,8 @@ class RepeatsTensor2IndexTensorFunctor<GPUContext, RepeatsT> {
  public:
   void operator()(const GPUContext &ctx,
                   const DenseTensor &repeats,
-                  DenseTensor *index);
+                  DenseTensor *index,
+                  int64_t output_size = -1);
 };
 #else
 template <typename RepeatsT>
@@ -46,7 +48,8 @@ class RepeatsTensor2IndexTensorFunctor<CPUContext, RepeatsT> {
  public:
   void operator()(const CPUContext &ctx,
                   const DenseTensor &repeats,
-                  DenseTensor *index);
+                  DenseTensor *index,
+                  int64_t output_size = -1);
 };
 #endif
 
@@ -56,7 +59,8 @@ class RepeatsTensor2IndexTensorFunctor<XPUContext, RepeatsT> {
  public:
   void operator()(const XPUContext &ctx,
                   const DenseTensor &repeats,
-                  DenseTensor *index);
+                  DenseTensor *index,
+                  int64_t output_size = -1);
 };
 #endif
 

--- a/paddle/phi/kernels/gpu/repeat_interleave_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/repeat_interleave_grad_kernel.cu
@@ -164,8 +164,7 @@ void RepeatInterleaveWithTensorIndexGradKernel(
 
   if (index_type == DataType::INT64) {
     funcs::RepeatsTensor2IndexTensorFunctor<Context, int64_t>()(
-        dev_ctx, repeats_tensor, &index);
-    int64_t index_nums = index.numel();
+        dev_ctx, repeats_tensor, &index, output_size);
 
     const int64_t* index_data = index.data<int64_t>();
     index_select_grad_cuda_kernel<T, int64_t>
@@ -181,8 +180,7 @@ void RepeatInterleaveWithTensorIndexGradKernel(
                      delta);
   } else {
     funcs::RepeatsTensor2IndexTensorFunctor<Context, int>()(
-        dev_ctx, repeats_tensor, &index);
-    int64_t index_nums = index.numel();
+        dev_ctx, repeats_tensor, &index, output_size);
 
     const int* index_data = index.data<int>();
     index_select_grad_cuda_kernel<T, int>

--- a/paddle/phi/kernels/gpu/repeat_interleave_kernel.cu
+++ b/paddle/phi/kernels/gpu/repeat_interleave_kernel.cu
@@ -91,27 +91,14 @@ void RepeatInterleaveWithTensorIndexKernel(const Context& dev_ctx,
     // infer out shape
     if (index_type == DataType::INT32) {
       funcs::RepeatsTensor2IndexTensorFunctor<Context, int>()(
-          dev_ctx, repeats_tensor, &index);
+          dev_ctx, repeats_tensor, &index, output_size);
 
     } else if (index_type == DataType::INT64) {
       funcs::RepeatsTensor2IndexTensorFunctor<Context, int64_t>()(
-          dev_ctx, repeats_tensor, &index);
+          dev_ctx, repeats_tensor, &index, output_size);
     }
     auto output_dim = vectorize(x.dims());
-    if (output_size > 0) {
-      PADDLE_ENFORCE_EQ(
-          output_size,
-          index.dims()[0],
-          common::errors::InvalidArgument(
-              "When output_size is provided, it should equal to "
-              "sum of repeats tensor. But received output_size = %d, "
-              "sum of repeats = %d.",
-              output_size,
-              index.dims()[0]));
-      output_dim[dim] = output_size;
-    } else {
-      output_dim[dim] = index.dims()[0];
-    }
+    output_dim[dim] = index.dims()[0];
     out->Resize(output_dim);
     dev_ctx.template Alloc<T>(out);
     return;
@@ -123,25 +110,11 @@ void RepeatInterleaveWithTensorIndexKernel(const Context& dev_ctx,
   auto* in_data = x.data<T>();
   if (index_type == DataType::INT64) {
     funcs::RepeatsTensor2IndexTensorFunctor<Context, int64_t>()(
-        dev_ctx, repeats_tensor, &index);
+        dev_ctx, repeats_tensor, &index, output_size);
 
     const int64_t* index_data = index.data<int64_t>();
     auto output_dim = vectorize(x.dims());
-    if (output_size > 0) {
-      // Validate output_size for tensor repeats on GPU
-      PADDLE_ENFORCE_EQ(
-          output_size,
-          index.dims()[0],
-          common::errors::InvalidArgument(
-              "When output_size is provided, it should equal to "
-              "sum of repeats tensor. But received output_size = %d, "
-              "sum of repeats = %d.",
-              output_size,
-              index.dims()[0]));
-      output_dim[dim] = output_size;
-    } else {
-      output_dim[dim] = index.dims()[0];
-    }
+    output_dim[dim] = index.dims()[0];
     out->Resize(output_dim);
     T* out_data = dev_ctx.template Alloc<T>(out);
     int64_t numel = out->numel();
@@ -155,25 +128,11 @@ void RepeatInterleaveWithTensorIndexKernel(const Context& dev_ctx,
            stream>>>(in_data, out_data, index_data, numel, stride, size, delta);
   } else {
     funcs::RepeatsTensor2IndexTensorFunctor<Context, int>()(
-        dev_ctx, repeats_tensor, &index);
+        dev_ctx, repeats_tensor, &index, output_size);
 
     const int* index_data = index.data<int>();
     auto output_dim = vectorize(x.dims());
-    if (output_size > 0) {
-      // Validate output_size for tensor repeats on GPU
-      PADDLE_ENFORCE_EQ(
-          output_size,
-          index.dims()[0],
-          common::errors::InvalidArgument(
-              "When output_size is provided, it should equal to "
-              "sum of repeats tensor. But received output_size = %d, "
-              "sum of repeats = %d.",
-              output_size,
-              index.dims()[0]));
-      output_dim[dim] = output_size;
-    } else {
-      output_dim[dim] = index.dims()[0];
-    }
+    output_dim[dim] = index.dims()[0];
     out->Resize(output_dim);
     T* out_data = dev_ctx.template Alloc<T>(out);
     int64_t numel = out->numel();

--- a/test/legacy_test/test_cuda_graph.py
+++ b/test/legacy_test/test_cuda_graph.py
@@ -171,6 +171,27 @@ class TestCUDAGraphInDygraphMode(unittest.TestCase):
         y = paddle.cast(x, dtype='float16')
         graph.capture_end()
 
+    def test_repeat_interleave_tensor_repeats_with_output_size(self):
+        if not can_use_cuda_graph():
+            return
+
+        x_np = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]).astype('float32')
+        repeats_np = np.array([2, 1, 3]).astype('int32')
+
+        x = paddle.to_tensor(x_np).cuda()
+        repeats = paddle.to_tensor(repeats_np).cuda()
+
+        graph = CUDAGraph()
+        graph.capture_begin()
+        out = paddle.repeat_interleave(x, repeats, axis=1, output_size=6)
+        graph.capture_end()
+
+        graph.replay()
+        np.testing.assert_allclose(
+            out.numpy(), np.repeat(x_np, repeats_np, axis=1), rtol=1e-5
+        )
+        graph.reset()
+
     def test_cuda_graph_with_enable_replace(self):
         """Test that CUDAGraph created with enable_replace=True captures and replays correctly."""
         if not can_use_cuda_graph():

--- a/test/legacy_test/test_repeat_interleave_op.py
+++ b/test/legacy_test/test_repeat_interleave_op.py
@@ -746,5 +746,19 @@ class TestRepeatInterleave_ZeroSizeRepeatsTensor(unittest.TestCase):
         self._check(repeats_dtype="int64")
 
 
+class TestRepeatInterleaveInvalidOutputSizeForZeroRepeatsGPU(unittest.TestCase):
+    def test_invalid_positive_output_size_raises(self):
+        if not paddle.is_compiled_with_cuda() or paddle.is_compiled_with_rocm():
+            self.skipTest("CUDA-only regression test")
+
+        paddle.disable_static()
+        place = paddle.CUDAPlace(0)
+        x = paddle.to_tensor(np.zeros([0], dtype="float32"), place=place)
+        repeats = paddle.to_tensor(np.zeros([0], dtype="int32"), place=place)
+
+        with self.assertRaises(ValueError):
+            paddle.repeat_interleave(x, repeats, axis=0, output_size=1)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description
This PR optimizes the tensor-repeats GPU path of `repeat_interleave` when `output_size` is already provided.

Previously, the GPU implementation still materialized the expanded index length by copying the last prefix-sum value back to host and synchronizing the stream, even when `output_size` had already been supplied by the caller. This introduced unnecessary GPU-to-CPU synchronization in both forward and backward, and also made the `output_size` fast path less CUDA-Graph-friendly than expected.

This PR updates the related helper and GPU kernels so that:
- when `output_size` is provided, the expanded index tensor is allocated directly from that size
- the `sum(repeats) == output_size` check is performed on device
- the old host-sync fallback is kept only for the `output_size == -1` path
- the same optimization is wired into both forward and backward GPU paths

In addition, a CUDA Graph regression test is added for `repeat_interleave(..., output_size=...)` with tensor-typed `repeats`.

#### Benchmark
Benchmark was run under the same containerized build environment, comparing the patched implementation against the pre-change implementation rebuilt from the same workspace. This is not a `main`/`develop` branch comparison.

For `repeat_interleave(repeats=<Tensor>, output_size=...)`:
- shape `[128, 4096]`: forward `0.0360 ms -> 0.0250 ms` (`30.6%` faster), backward `0.1762 ms -> 0.1121 ms` (`36.4%` faster)
- shape `[512, 4096]`: forward `0.0612 ms -> 0.0483 ms` (`21.1%` faster), backward `0.3734 ms -> 0.3399 ms` (`9.0%` faster)

For the same benchmark setup, CUDA Graph capture succeeds after this change, while the pre-change implementation fails on the same `output_size` path.

### 是否引起精度变化
否