### PR TITLE
[release/3.4][Operator Mechanism] Support mm out_dtype for BF16 CUDA

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -3170,6 +3170,60 @@ void MatmulInferMeta(const MetaTensor& x,
   out->share_lod(x);
 }
 
+void MmOutDtypeInferMeta(const MetaTensor& x,
+                         const MetaTensor& y,
+                         DataType out_dtype,
+                         MetaTensor* out,
+                         MetaConfig config) {
+  PADDLE_ENFORCE_EQ(
+      out_dtype,
+      DataType::FLOAT32,
+      common::errors::InvalidArgument(
+          "The out_dtype of paddle.mm currently only supports float32."));
+  PADDLE_ENFORCE_EQ(
+      x.dtype(),
+      DataType::BFLOAT16,
+      common::errors::InvalidArgument(
+          "The out_dtype of paddle.mm currently only supports bfloat16 "
+          "Input(X)."));
+  PADDLE_ENFORCE_EQ(
+      y.dtype(),
+      DataType::BFLOAT16,
+      common::errors::InvalidArgument(
+          "The out_dtype of paddle.mm currently only supports bfloat16 "
+          "Input(Y)."));
+
+  auto dims_x = vectorize(x.dims());
+  auto dims_y = vectorize(y.dims());
+  PADDLE_ENFORCE_EQ(
+      dims_x.size(),
+      2UL,
+      common::errors::InvalidArgument(
+          "The out_dtype of paddle.mm currently only supports 2-D Input(X)."));
+  PADDLE_ENFORCE_EQ(
+      dims_y.size(),
+      2UL,
+      common::errors::InvalidArgument(
+          "The out_dtype of paddle.mm currently only supports 2-D Input(Y)."));
+  const int64_t K_lhs = dims_x[1];
+  const int64_t K_rhs = dims_y[0];
+  if (config.is_runtime || (K_lhs >= 0 && K_rhs >= 0)) {
+    PADDLE_ENFORCE_EQ(
+        K_lhs,
+        K_rhs,
+        common::errors::InvalidArgument(
+            "Input(X)'s width must equal Input(Y)'s height, but received %d "
+            "and %d.",
+            K_lhs,
+            K_rhs));
+  }
+
+  out->set_dims(make_ddim({dims_x[0], dims_y[1]}));
+  out->set_dtype(DataType::FLOAT32);
+  out->set_layout(x.layout());
+  out->share_lod(x);
+}
+
 void MatmulWithFlattenInferMeta(const MetaTensor& x,
                                 const MetaTensor& y,
                                 int x_num_col_dims,

--- a/paddle/phi/infermeta/binary.h
+++ b/paddle/phi/infermeta/binary.h
@@ -618,6 +618,12 @@ PADDLE_API void MatmulInferMeta(const MetaTensor& x,
                                 MetaTensor* out,
                                 MetaConfig config = MetaConfig());
 
+PADDLE_API void MmOutDtypeInferMeta(const MetaTensor& x,
+                                    const MetaTensor& y,
+                                    DataType out_dtype,
+                                    MetaTensor* out,
+                                    MetaConfig config = MetaConfig());
+
 PADDLE_API void MatmulWithFlattenInferMeta(const MetaTensor& x,
                                            const MetaTensor& y,
                                            int x_num_col_dims,

--- a/paddle/phi/kernels/funcs/blas/blas.h
+++ b/paddle/phi/kernels/funcs/blas/blas.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/dense_tensor.h"
 
 #ifdef PADDLE_WITH_MKLML
@@ -110,6 +111,17 @@ class Blas {
             const T* B,
             U beta,
             T* C) const;
+
+  void GEMM(CBLAS_TRANSPOSE transA,
+            CBLAS_TRANSPOSE transB,
+            int64_t M,
+            int64_t N,
+            int64_t K,
+            float alpha,
+            const phi::bfloat16* A,
+            const phi::bfloat16* B,
+            float beta,
+            float* C) const;
 
   template <typename T>
   void GEMM(bool transA,

--- a/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
@@ -1845,6 +1845,102 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
 }
 
 template <>
+inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
+                                        CBLAS_TRANSPOSE transB,
+                                        int64_t M,
+                                        int64_t N,
+                                        int64_t K,
+                                        float alpha,
+                                        const phi::bfloat16 *A,
+                                        const phi::bfloat16 *B,
+                                        float beta,
+                                        float *C) const {
+#if CUDA_VERSION >= 11000
+  // Note that cublas follows fortran order, so the order is different from
+  // the cblas convention. The int casts of lda/ldb below are safe because
+  // this branch is only reached when M, N, K <= INT_MAX_VALUE.
+  int64_t lda = (transA == CblasNoTrans) ? K : M;
+  int64_t ldb = (transB == CblasNoTrans) ? N : K;
+  cublasOperation_t cuTransA =
+      (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
+  cublasOperation_t cuTransB =
+      (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+  PADDLE_ENFORCE_GE(
+      dev_ctx_.GetComputeCapability(),
+      80,
+      common::errors::InvalidArgument(
+          "cublas bf16 gemm with fp32 output requires GPU compute capability "
+          ">= 80, but received %d",
+          dev_ctx_.GetComputeCapability()));
+
+  cublasGemmAlgo_t algo = CUBLAS_GEMM_DEFAULT;
+  bool use_tensor_op_math = dev_ctx_.tensor_core_available();
+  if (use_tensor_op_math) {
+    algo = CUBLAS_GEMM_DFALT_TENSOR_OP;
+  }
+  VLOG(5) << "use_tensor_op_math: " << (use_tensor_op_math ? "True" : "False");
+  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    cublasComputeType_t migratedComputeType = CUBLAS_COMPUTE_32F;
+    dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
+      PADDLE_ENFORCE_GPU_SUCCESS(
+          phi::dynload::cublasGemmEx_64(handle,
+                                        cuTransB,
+                                        cuTransA,
+                                        N,
+                                        M,
+                                        K,
+                                        &alpha,
+                                        B,
+                                        CUDA_R_16BF,
+                                        ldb,
+                                        A,
+                                        CUDA_R_16BF,
+                                        lda,
+                                        &beta,
+                                        C,
+                                        CUDA_R_32F,
+                                        N,
+                                        migratedComputeType,
+                                        algo));
+    });
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "cublasGemmEx_64 is not supported on cuda < 12.3"));
+#endif  // CUDA_VERSION >= 12030
+  } else {
+    CheckGEMMNSize(N);
+    dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
+      PADDLE_ENFORCE_GPU_SUCCESS(
+          phi::dynload::cublasGemmEx(handle,
+                                     cuTransB,
+                                     cuTransA,
+                                     static_cast<int>(N),
+                                     static_cast<int>(M),
+                                     static_cast<int>(K),
+                                     &alpha,
+                                     B,
+                                     CUDA_R_16BF,
+                                     static_cast<int>(ldb),
+                                     A,
+                                     CUDA_R_16BF,
+                                     static_cast<int>(lda),
+                                     &beta,
+                                     C,
+                                     CUDA_R_32F,
+                                     static_cast<int>(N),
+                                     CUDA_R_32F,
+                                     algo));
+    });
+  }
+#else
+  PADDLE_THROW(common::errors::Unimplemented(
+      "cublasGemmEx with bfloat16 is not supported on cuda <= 11"));
+#endif  // CUDA_VERSION >= 11000
+}
+
+template <>
 template <>
 inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                         CBLAS_TRANSPOSE transB,

--- a/paddle/phi/kernels/gpu/matmul_kernel.cu
+++ b/paddle/phi/kernels/gpu/matmul_kernel.cu
@@ -116,3 +116,8 @@ PD_REGISTER_KERNEL(legacy_matmul,
     kernel->OutputAt(0).SetDataType(phi::DataType::INT32);
   }
 }
+
+PD_REGISTER_KERNEL(
+    mm_out_dtype, GPU, ALL_LAYOUT, phi::MmOutDtypeKernel, phi::bfloat16) {
+  kernel->OutputAt(0).SetDataType(phi::DataType::FLOAT32);
+}

--- a/paddle/phi/kernels/impl/matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_kernel_impl.h
@@ -20,6 +20,7 @@ limitations under the License. */
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/autotune/cache_base.h"
 #include "paddle/phi/kernels/cast_kernel.h"
+#include "paddle/phi/kernels/contiguous_kernel.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #ifdef PADDLE_WITH_HIP
 #include "paddle/phi/kernels/funcs/blas/blaslt_impl.hip.h"
@@ -2052,6 +2053,94 @@ MatmulJudgeDtypeKernel(const Context& dev_ctx,
                        bool transpose_y) {
   DispatchMatmulKernel<Context, T>(
       dev_ctx, x, y, x_dims, y_dims, out, transpose_x, transpose_y);
+}
+
+template <typename T, typename Context>
+void MmOutDtypeKernel(const Context& dev_ctx,
+                      const DenseTensor& x,
+                      const DenseTensor& y,
+                      DataType out_dtype,
+                      DenseTensor* out) {
+  PADDLE_ENFORCE_EQ(
+      out_dtype,
+      DataType::FLOAT32,
+      common::errors::InvalidArgument(
+          "The out_dtype of paddle.mm currently only supports float32."));
+  PADDLE_ENFORCE_EQ(
+      x.dtype(),
+      DataType::BFLOAT16,
+      common::errors::InvalidArgument(
+          "The out_dtype of paddle.mm currently only supports bfloat16 "
+          "Input(X)."));
+  PADDLE_ENFORCE_EQ(
+      y.dtype(),
+      DataType::BFLOAT16,
+      common::errors::InvalidArgument(
+          "The out_dtype of paddle.mm currently only supports bfloat16 "
+          "Input(Y)."));
+  const std::vector<std::int64_t> x_dims = vectorize(x.dims());
+  const std::vector<std::int64_t> y_dims = vectorize(y.dims());
+  PADDLE_ENFORCE_EQ(
+      x_dims.size(),
+      2UL,
+      common::errors::InvalidArgument(
+          "The out_dtype of paddle.mm currently only supports 2-D Input(X)."));
+  PADDLE_ENFORCE_EQ(
+      y_dims.size(),
+      2UL,
+      common::errors::InvalidArgument(
+          "The out_dtype of paddle.mm currently only supports 2-D Input(Y)."));
+#if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP)
+  if constexpr (std::is_same<Context, phi::GPUContext>::value &&
+                std::is_same<T, phi::bfloat16>::value) {
+    const int64_t M = x_dims[0];
+    const int64_t K = x_dims[1];
+    const int64_t N = y_dims[1];
+    PADDLE_ENFORCE_EQ(
+        K,
+        y_dims[0],
+        common::errors::InvalidArgument(
+            "Input(X)'s width must equal Input(Y)'s height, but received %d "
+            "and %d.",
+            K,
+            y_dims[0]));
+    if (x.numel() == 0 || y.numel() == 0) {
+      Full<float, Context>(dev_ctx, out->dims(), 0, out);
+      return;
+    }
+    DenseTensor x_contiguous;
+    DenseTensor y_contiguous;
+    const DenseTensor* x_ptr = &x;
+    const DenseTensor* y_ptr = &y;
+    if (!x.meta().is_contiguous()) {
+      ContiguousKernel<T, Context>(dev_ctx, x, &x_contiguous);
+      x_ptr = &x_contiguous;
+    }
+    if (!y.meta().is_contiguous()) {
+      ContiguousKernel<T, Context>(dev_ctx, y, &y_contiguous);
+      y_ptr = &y_contiguous;
+    }
+    dev_ctx.template Alloc<float>(out);
+    funcs::Blas<Context> blas(dev_ctx);
+    blas.GEMM(CblasNoTrans,
+              CblasNoTrans,
+              M,
+              N,
+              K,
+              1.0f,
+              x_ptr->data<phi::bfloat16>(),
+              y_ptr->data<phi::bfloat16>(),
+              0.0f,
+              out->data<float>());
+  } else {
+    PADDLE_THROW(common::errors::Unimplemented(
+        "The out_dtype of paddle.mm currently only supports CUDA bfloat16 "
+        "inputs."));
+  }
+#else
+  PADDLE_THROW(common::errors::Unimplemented(
+      "The out_dtype of paddle.mm currently only supports CUDA."));
+#endif
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/matmul_kernel.h
+++ b/paddle/phi/kernels/matmul_kernel.h
@@ -28,6 +28,13 @@ void MatmulKernel(const Context& dev_ctx,
                   bool transpose_y,
                   DenseTensor* out);
 
+template <typename T, typename Context>
+void MmOutDtypeKernel(const Context& dev_ctx,
+                      const DenseTensor& x,
+                      const DenseTensor& y,
+                      DataType out_dtype,
+                      DenseTensor* out);
+
 // In order to be compatible with `mul` op in fluid,
 // it is no longer used in 2.x API
 template <typename T, typename Context>

--- a/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
@@ -285,6 +285,16 @@
   backward : minimum_grad
   traits : pir::BinaryElementWiseTrait
 
+- op : mm_out_dtype
+  args : (Tensor x, Tensor y, DataType out_dtype)
+  output : Tensor(out)
+  infer_meta :
+    func : MmOutDtypeInferMeta
+  kernel :
+    func : mm_out_dtype
+    data_type : x
+  traits : paddle::dialect::ForwardOnlyTrait
+
 - op : multiply
   args : (Tensor x, Tensor y)
   output : Tensor

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2088,6 +2088,7 @@ def mm(
     mat2: Tensor,
     name: str | None = None,
     *,
+    out_dtype: DTypeLike | None = None,
     out: Tensor | None = None,
 ) -> Tensor:
     """
@@ -2110,10 +2111,11 @@ def mm(
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Keywords Argument:
+        out_dtype (paddle.dtype|None, optional): The desired output data type. Currently only supports ``paddle.float32`` for CUDA bfloat16 2-D inputs in dynamic graph. Default: None.
         out (Tensor, optional): The output Tensor. It must have the same data type and shape as the expected output. Default is None, and a new Tensor will be created to store the result.
 
     Returns:
-        Tensor: The product Tensor, with same data type of the input Tensor.
+        Tensor: The product Tensor. Its data type is the same as input unless ``out_dtype`` is specified.
 
     ::
 
@@ -2162,6 +2164,36 @@ def mm(
 
 
     """
+    if out_dtype is not None:
+        out_dtype = convert_nptype_to_datatype_or_vartype(out_dtype)
+        float32_dtypes = (core.DataType.FLOAT32, core.VarDesc.VarType.FP32)
+        bf16_dtypes = (core.DataType.BFLOAT16, core.VarDesc.VarType.BF16)
+        if out_dtype not in float32_dtypes:
+            raise TypeError(
+                "The out_dtype of paddle.mm currently only supports paddle.float32."
+            )
+        if input.dtype not in bf16_dtypes:
+            raise TypeError(
+                "The out_dtype of paddle.mm currently only supports bfloat16 input."
+            )
+        if mat2.dtype not in bf16_dtypes:
+            raise TypeError(
+                "The out_dtype of paddle.mm currently only supports bfloat16 mat2."
+            )
+        if len(input.shape) != 2 or len(mat2.shape) != 2:
+            raise ValueError(
+                "The out_dtype of paddle.mm currently only supports 2-D inputs."
+            )
+        if out is not None and out.dtype not in float32_dtypes:
+            raise TypeError(
+                "The out tensor dtype must be paddle.float32 when out_dtype is paddle.float32."
+            )
+        if not in_dynamic_mode():
+            raise NotImplementedError(
+                "The out_dtype of paddle.mm currently only supports dynamic graph."
+            )
+        return _C_ops.mm_out_dtype(input, mat2, out_dtype, out=out)
+
     if in_dynamic_mode():
         return _C_ops.matmul(input, mat2, False, False, out=out)
 

--- a/test/legacy_test/test_mm_out.py
+++ b/test/legacy_test/test_mm_out.py
@@ -174,5 +174,92 @@ class TestMmOutBatchedAndShapes(unittest.TestCase):
         )
 
 
+class TestMmOutDtypeDynamicOnly(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+
+    def _skip_if_no_bf16_cuda(self):
+        if not paddle.is_compiled_with_cuda() or paddle.is_compiled_with_rocm():
+            self.skipTest("CUDA is required for mm out_dtype")
+        if paddle.device.cuda.get_device_capability()[0] < 8:
+            self.skipTest(
+                "BF16 mm out_dtype requires CUDA compute capability >= 8"
+            )
+
+    def test_bf16_to_fp32(self):
+        self._skip_if_no_bf16_cuda()
+        x = paddle.randn([3, 4], dtype='bfloat16')
+        y = paddle.randn([4, 5], dtype='bfloat16')
+        out = paddle.mm(x, y, out_dtype=paddle.float32)
+        ref = paddle.mm(x.astype('float32'), y.astype('float32'))
+        self.assertEqual(out.dtype, paddle.float32)
+        np.testing.assert_allclose(
+            out.numpy(), ref.numpy(), rtol=1e-2, atol=1e-2
+        )
+
+    def test_bf16_to_fp32_transposed_rhs(self):
+        self._skip_if_no_bf16_cuda()
+        x = paddle.randn([3, 4], dtype='bfloat16')
+        weight = paddle.randn([5, 4], dtype='bfloat16')
+        out = paddle.mm(x, weight.t(), out_dtype=paddle.float32)
+        ref = paddle.mm(x.astype('float32'), weight.t().astype('float32'))
+        self.assertEqual(out.dtype, paddle.float32)
+        np.testing.assert_allclose(
+            out.numpy(), ref.numpy(), rtol=1e-2, atol=1e-2
+        )
+
+    def test_bf16_to_fp32_out(self):
+        self._skip_if_no_bf16_cuda()
+        x = paddle.randn([3, 4], dtype='bfloat16')
+        y = paddle.randn([4, 5], dtype='bfloat16')
+        out = paddle.empty([3, 5], dtype='float32')
+        ret = paddle.mm(x, y, out_dtype=paddle.float32, out=out)
+        ref = paddle.mm(x.astype('float32'), y.astype('float32'))
+        self.assertEqual(ret.dtype, paddle.float32)
+        np.testing.assert_allclose(
+            ret.numpy(), ref.numpy(), rtol=1e-2, atol=1e-2
+        )
+        np.testing.assert_allclose(
+            out.numpy(), ref.numpy(), rtol=1e-2, atol=1e-2
+        )
+
+    def test_out_dtype_rejects_unsupported_cases(self):
+        self._skip_if_no_bf16_cuda()
+        x = paddle.randn([3, 4], dtype='float32')
+        y = paddle.randn([4, 5], dtype='float32')
+        with self.assertRaises(TypeError):
+            paddle.mm(x, y, out_dtype=paddle.float32)
+        x_bf16 = paddle.randn([3, 4], dtype='bfloat16')
+        y_bf16 = paddle.randn([4, 5], dtype='bfloat16')
+        with self.assertRaises(TypeError):
+            paddle.mm(x_bf16, y_bf16, out_dtype=paddle.bfloat16)
+        with self.assertRaises(ValueError):
+            paddle.mm(
+                x_bf16.reshape([1, 3, 4]),
+                y_bf16.reshape([1, 4, 5]),
+                out_dtype=paddle.float32,
+            )
+        with self.assertRaises(TypeError):
+            paddle.mm(
+                x_bf16,
+                y_bf16,
+                out_dtype=paddle.float32,
+                out=paddle.empty([3, 5], dtype='bfloat16'),
+            )
+
+    def test_static_out_dtype_fails_closed(self):
+        paddle.enable_static()
+        try:
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                x = paddle.static.data('x', [3, 4], dtype='bfloat16')
+                y = paddle.static.data('y', [4, 5], dtype='bfloat16')
+                with self.assertRaises(NotImplementedError):
+                    paddle.mm(x, y, out_dtype=paddle.float32)
+        finally:
+            paddle.disable_static()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION


<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
Temporary add a narrow CUDA BF16 x BF16 -> FP32 path for paddle.mm(out_dtype=paddle.float32), including schema, infermeta, stride dispatch, fused cuBLAS GEMM, and focused tests.

pcard-91067


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

---

Cherry-pick of #79252 (authored by @A-nnonymous) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79252 <!-- For pass CI -->