### PR TITLE
[release/3.4] fix add_n 0-size bug

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -406,6 +406,7 @@ void AddNInferMeta(const std::vector<const MetaTensor*>& x,
   }
   bool is_all_0d_tensor = true;
   DDim in_dim({0});
+  bool has_in_dim = false;
   for (size_t i = 0; i < x.size(); ++i) {
     auto x_dim = x[i]->dims();
     // x_dim.size() == 1 means the real dim of selected rows is [0]
@@ -418,8 +419,9 @@ void AddNInferMeta(const std::vector<const MetaTensor*>& x,
     }
     is_all_0d_tensor = false;
     // use the first dimension
-    if (common::product(in_dim) == 0) {
+    if (!has_in_dim) {
       in_dim = x_dim;
+      has_in_dim = true;
     } else {
       if (config.is_runtime) {
         PADDLE_ENFORCE_EQ(in_dim,

--- a/test/legacy_test/test_add_n_op.py
+++ b/test/legacy_test/test_add_n_op.py
@@ -119,5 +119,17 @@ class TestAddnOp_ZeroSize(unittest.TestCase):
             np.testing.assert_allclose(x_g_np_32[i].shape, [0, 256])
 
 
+class TestAddnOpZeroSizeAndNonZeroSize(unittest.TestCase):
+    def test_add_n_zero_size_and_non_zero_size(self):
+        paddle.disable_static()
+        try:
+            with self.assertRaises(ValueError):
+                x0 = paddle.to_tensor([], dtype='float32')
+                x1 = paddle.to_tensor([1], dtype='float32')
+                out = paddle.add_n([x0, x1])
+        finally:
+            paddle.enable_static()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复add_n首个Tensor为0-Size时不能检查shape全相等的bug。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

---

Cherry-pick of #79276 (authored by @wanghuancoder) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79276 <!-- For pass CI -->