### PR TITLE
[BugFix] fix muon 2d param group broadcast for multi dtype in one group

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/muon_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/muon_sharding_optimizer.py
@@ -863,41 +863,46 @@ class MuonShardingOptimizer:
             if len(params) == 0:
                 continue
 
+            dtype_groups = {}
+            for p in params:
+                dtype_groups.setdefault(p.dtype, []).append(p)
+
             with framework.no_grad():
-                # Calculate total size and build param-to-offset mapping
-                param_sizes = [np.prod(p.shape) for p in params]
-                total_size = sum(param_sizes)
-                dtype = params[0].dtype
+                for dtype, group_params in dtype_groups.items():
+                    # Calculate total size and build param-to-offset mapping
+                    param_sizes = [np.prod(p.shape) for p in group_params]
+                    total_size = sum(param_sizes)
 
-                param_buffer = paddle.empty(shape=[total_size], dtype=dtype)
-                offset = 0
-                for param in params:
-                    param_shape = param.shape
-                    stop_gradient = param.stop_gradient
-                    param.stop_gradient = True
-                    param.flatten_()
+                    param_buffer = paddle.empty(shape=[total_size], dtype=dtype)
+                    offset = 0
 
-                    paddle.assign(
-                        param,
+                    for param in group_params:
+                        param_shape = param.shape
+                        stop_gradient = param.stop_gradient
+                        param.stop_gradient = True
+                        param.flatten_()
+
+                        paddle.assign(
+                            param,
+                            param_buffer._slice(
+                                offset, offset + np.prod(param_shape)
+                            ),
+                        )
+
+                        param.get_tensor()._set_dims(param_shape)
+                        param.stop_gradient = stop_gradient
                         param_buffer._slice(
                             offset, offset + np.prod(param_shape)
-                        ),
+                        )._share_buffer_to(param)
+
+                        offset += np.prod(param_shape)
+                    task = paddle.distributed.broadcast(
+                        param_buffer,
+                        src=src_rank,
+                        group=comm_group,
+                        sync_op=False,
                     )
-
-                    param.get_tensor()._set_dims(param_shape)
-                    param.stop_gradient = stop_gradient
-                    param_buffer._slice(
-                        offset, offset + np.prod(param_shape)
-                    )._share_buffer_to(param)
-
-                    offset += np.prod(param_shape)
-                task = paddle.distributed.broadcast(
-                    param_buffer,
-                    src=src_rank,
-                    group=comm_group,
-                    sync_op=False,
-                )
-                broadcast_tasks.append(task)
+                    broadcast_tasks.append(task)
         return broadcast_tasks
 
     def reorder_params(self, comm_list):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
在 MuonSharding 优化器中，在通信 2D 参数时，拟通过 fuse param 减少通信次数，但是当同一个 params list 中有不同的dtype 时，会错分配 buffer，导致错误。

```
                param_sizes = [np.prod(p.shape) for p in params]
                total_size = sum(param_sizes)
                dtype = params[0].dtype

                param_buffer = paddle.empty(shape=[total_size], dtype=dtype)
```

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否