### PR TITLE
[Fix] issue #79238 paddle.bincount output consumed by paddle.scatter_reduce fails under to_static full_graph

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -7648,9 +7648,15 @@ def put_along_axis(
                     "`indices` and `values` must have the same number of dimensions!"
                 )
             for i in range(len(arr.shape)):
+                indices_shape_i = indices.shape[i]
+                values_shape_i = values.shape[i]
+                arr_shape_i = arr.shape[i]
+                # Skip check for dynamic shapes (negative values in static graph)
+                if indices_shape_i < 0 or values_shape_i < 0 or arr_shape_i < 0:
+                    continue
                 if (
-                    i != axis and arr.shape[i] < indices.shape[i]
-                ) or indices.shape[i] > values.shape[i]:
+                    i != axis and arr_shape_i < indices_shape_i
+                ) or indices_shape_i > values_shape_i:
                     raise RuntimeError(
                         f"Size does not match at dimension {i} expected index {indices.shape} to be smaller than self {arr.shape} apart from dimension {axis} and to be smaller size than values {values.shape}"
                     )


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Bug fixes

### Description
**错误原因**
在静态图模式（`paddle.jit.to_static`）下，`paddle.scatter_reduce` 配合 `paddle.bincount` 使用时抛出 RuntimeError
```bash
RuntimeError: Size does not match at dimension 0 expected index paddle.Size([5]) 
to be smaller than self paddle.Size([3]) apart from dimension 0 and to be smaller 
size than values paddle.Size([-1])
```

在静态图下，`paddle.bincount` 的输出 `counts` 的 `shape` 被推断为 [-1]（动态 `shape`，表示长度在运行时才能确定）。此时检查条件 `indices.shape[i] > values.shape[I]` 即 `5 > -1`，在 Python 中该比较返回 `True`，导致错误地抛出 RuntimeError。

根本问题：`shape` 检查逻辑没有处理静态图中的动态 `shape`（用负数表示），将 -1 当作实际长度进行比较。


**修复点**
在 `python/paddle/tensor/manipulation.py` 第 7650-7656 行，`put_along_axis` 函数的 `shape` 检查逻辑中，增加了对动态 shape（值为负数）的跳过处理。这样在静态图下遇到 `paddle.Size([-1])` 这样的动态 `shape` 时，不会错误地触发 `shape` 不匹配报错。

重新编译后 `issue` 中的代码能够通过
```bash
λ /workspace python3.10 test.py 
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
RuntimeError: module compiled against ABI version 0x1000009 but this version of numpy is 0x2000000
paddle 3.5.0.dev20260609
W0609 13:12:59.821501 19576 gpu_resources.cc:116] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.6, Runtime API Version: 11.8
eager: [7.0, -2.0, 1.0]
I0609 13:12:59.964815 19576 pir_interpreter.cc:1605] New Executor is Running ...
I0609 13:12:59.965278 19576 pir_interpreter.cc:1629] pir interpreter is running by multi-thread mode ...
static: [7.0, -2.0, 1.0]
```

相关 issue：
- https://github.com/paddlepaddle/paddle/issues/79238

### 是否引起精度变化
否
