### PR TITLE
[Typing] Upgrade mypy to 2.1.0 and target Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,8 +172,9 @@ known-first-party = ["paddle"]
 "test/dygraph_to_static/seq2seq_dygraph_model.py" = ["RUF005"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 cache_dir = ".mypy_cache"
+num_workers = 8
 # Miscellaneous strictness flags
 allow_redefinition = true
 local_partial_types = true

--- a/python/paddle/base/framework.py
+++ b/python/paddle/base/framework.py
@@ -8350,7 +8350,7 @@ def device_guard(device: str | None = None) -> Generator[None, None, None]:
             >>> support_gpu = paddle.is_compiled_with_cuda()
             >>> place = paddle.CPUPlace()
             >>> if support_gpu:
-            ...     place = paddle.CUDAPlace(0)  # type: ignore
+            ...     place = paddle.CUDAPlace(0)
 
             >>> # if GPU is supported, the three OPs below will be automatically assigned to CUDAPlace(0)
             >>> data1 = paddle.full(shape=[1, 3, 8, 8], fill_value=0.5, dtype='float32')

--- a/python/paddle/distributed/communication/recv.py
+++ b/python/paddle/distributed/communication/recv.py
@@ -142,7 +142,7 @@ def recv_object_list(
             ...     data = ["hello", {"key": 100}, [1, 2, 3]]
             ...     dist.send_object_list(data, dst=1)
             >>> else:
-            ...     data = [None] * 3  # type: ignore
+            ...     data = [None] * 3
             ...     dist.recv_object_list(data, src=0)
             >>> print(data)
             >>> # ["hello", {"key": 100}, [1, 2, 3]] (2 GPUs)

--- a/python/paddle/distributed/communication/send.py
+++ b/python/paddle/distributed/communication/send.py
@@ -141,7 +141,7 @@ def send_object_list(
             ...     data = ["hello", {"key": 100}, [1, 2, 3]]
             ...     dist.send_object_list(data, dst=1)
             >>> else:
-            ...     data = [None] * 3  # type: ignore
+            ...     data = [None] * 3
             ...     dist.recv_object_list(data, src=0)
             >>> print(data)
             >>> # ["hello", {"key": 100}, [1, 2, 3]] (2 GPUs)

--- a/python/paddle/distributed/fleet/base/topology.py
+++ b/python/paddle/distributed/fleet/base/topology.py
@@ -93,7 +93,7 @@ def create_nccl_config(
             >>> import paddle.distributed as dist
             >>> from typing import Union
             >>> dist.init_parallel_env()
-            >>> nccl_config: dict[str, Union[int, str]] = {
+            >>> raw_nccl_config: dict[str, Union[int, str]] = {
             ...     "commName": "tp_comm",
             ...     "ll_buffsize": 0,
             ...     "ll128_buffsize": 0,
@@ -104,7 +104,7 @@ def create_nccl_config(
             ...     "protoStr": "Simple",
             ... }
             >>> ranks = [0, 1, 2, 3, 4, 5, 6, 7]
-            >>> nccl_config = dist.create_nccl_config(nccl_config)
+            >>> nccl_config = dist.create_nccl_config(raw_nccl_config)
             >>> pg = dist.new_group(ranks, nccl_config=nccl_config)
             >>> m, n = 4096, 8192
             >>> local_rank = dist.get_rank(pg)

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -3143,7 +3143,7 @@ def cross_entropy(
             >>> shape = [N, C]
             >>> label_smoothing = 0.4
             >>> reduction = 'mean'
-            >>> weight: Optional[paddle.Tensor] = None
+            >>> weight = None
             >>> logits = paddle.uniform(shape, dtype='float64', min=0.1, max=1.0)
             >>> integer_labels = paddle.randint(low=0, high=C, size=[N], dtype='int64')
             >>> one_hot_labels = paddle.nn.functional.one_hot(integer_labels, C).astype('float32')

--- a/python/paddle/nn/initializer/assign.py
+++ b/python/paddle/nn/initializer/assign.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
 
     import numpy.typing as npt
 
+    from paddle._typing import NestedSequence
+
 __all__ = []
 
 
@@ -271,7 +273,9 @@ class Assign(NumpyArrayInitializer):
 
     def __init__(
         self,
-        value: npt.NDArray[Any] | Sequence[int] | paddle.Tensor,
+        value: npt.NDArray[Any]
+        | Sequence[NestedSequence[int | float | bool | complex]]
+        | paddle.Tensor,
         name: str | None = None,
     ) -> None:
         import numpy

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -405,7 +405,7 @@ class CrossEntropyLoss(Layer):
             >>> shape = [N, C]
             >>> label_smoothing = 0.4
             >>> reduction = 'mean'
-            >>> weight: Optional[paddle.Tensor] = None
+            >>> weight = None
             >>> logits = paddle.uniform(shape, dtype='float64', min=0.1, max=1.0)
             >>> integer_labels = paddle.randint(low=0, high=C, size=[N], dtype='int64')
             >>> one_hot_labels = paddle.nn.functional.one_hot(integer_labels, C).astype('float32')

--- a/python/paddle/vision/datasets/folder.py
+++ b/python/paddle/vision/datasets/folder.py
@@ -207,9 +207,14 @@ class DatasetFolder(Dataset[tuple["_ImageDataType", int]]):
             ...     ]
             ... )
 
+            >>> def cv2_loader(path: str):
+            ...     image = cv2.imread(path)
+            ...     assert image is not None
+            ...     return image
+
             >>> data_folder_2 = DatasetFolder(
             ...     fake_data_dir,
-            ...     loader=lambda x: cv2.imread(x),  # load image with OpenCV
+            ...     loader=cv2_loader,  # load image with OpenCV
             ...     extensions=(".jpg",),  # only load *.jpg files
             ...     transform=transform,  # apply transform to every image
             ... )
@@ -442,9 +447,14 @@ class ImageFolder(Dataset[list["_ImageDataType"]]):
             ...     ]
             ... )
 
+            >>> def cv2_loader(path: str):
+            ...     image = cv2.imread(path)
+            ...     assert image is not None
+            ...     return image
+
             >>> image_folder_2 = ImageFolder(
             ...     fake_data_dir,
-            ...     loader=lambda x: cv2.imread(x),  # load image with OpenCV
+            ...     loader=cv2_loader,  # load image with OpenCV
             ...     extensions=(".jpg",),  # only load *.jpg files
             ...     transform=transform,  # apply transform to every image
             ... )

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -437,12 +437,16 @@ def adjust_brightness(
             >>> fake_img = Image.fromarray(fake_img)
             >>> print(fake_img.size)
             (300, 256)
-            >>> print(fake_img.load()[1, 1])  # type: ignore[index]
+            >>> fake_img_pixels = fake_img.load()
+            >>> assert fake_img_pixels is not None
+            >>> print(fake_img_pixels[1, 1])
             (61, 155, 171)
             >>> converted_img = F.adjust_brightness(fake_img, 0.5)
             >>> print(converted_img.size)
             (300, 256)
-            >>> print(converted_img.load()[1, 1])
+            >>> converted_img_pixels = converted_img.load()
+            >>> assert converted_img_pixels is not None
+            >>> print(converted_img_pixels[1, 1])
             (30, 77, 85)
     """
     if not (

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -24,12 +24,11 @@ from typing import (
     Generic,
     Literal,
     Protocol,
-    TypeVar,
     overload,
 )
 
 import numpy as np
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, TypeVar
 
 import paddle
 
@@ -45,6 +44,7 @@ if TYPE_CHECKING:
     _TransformInputKeys: TypeAlias = Sequence[
         Literal["image", "coords", "boxes", "mask"]
     ]
+    _ImageDataType: TypeAlias = Tensor | PILImage | npt.NDArray[Any]
     from .functional import (
         _InterpolationCv2,
         _InterpolationPil,
@@ -53,11 +53,9 @@ if TYPE_CHECKING:
 
 
 _InputT = TypeVar(
-    "_InputT", "Tensor", "PILImage", "npt.NDArray[Any]", contravariant=True
+    "_InputT", bound="_ImageDataType", contravariant=True, default=Any
 )
-_RetT = TypeVar(
-    "_RetT", "Tensor", "PILImage", "npt.NDArray[Any]", covariant=True
-)
+_RetT = TypeVar("_RetT", bound="_ImageDataType", covariant=True, default=Any)
 
 
 class _Transform(Protocol, Generic[_InputT, _RetT]):
@@ -226,7 +224,7 @@ class BaseTransform(_Transform[_InputT, _RetT]):
             ...         return img.shape[:2][::-1]
             ...     else:
             ...         raise TypeError("Unexpected type {}".format(type(img)))
-            >>> class CustomRandomFlip(BaseTransform):  # type: ignore[type-arg]
+            >>> class CustomRandomFlip(BaseTransform):
             ...     def __init__(self, prob=0.5, keys=None):
             ...         super().__init__(keys)
             ...         self.prob = prob
@@ -1038,11 +1036,15 @@ class BrightnessTransform(BaseTransform[_InputT, _RetT]):
 
             >>> transform = BrightnessTransform(0.4)
             >>> fake_img = Image.fromarray((np.random.rand(224, 224, 3) * 255.0).astype(np.uint8))
-            >>> print(fake_img.load()[1, 1])  # type: ignore[index]
+            >>> fake_img_pixels = fake_img.load()
+            >>> assert fake_img_pixels is not None
+            >>> print(fake_img_pixels[1, 1])
             (60, 169, 34)
             >>> # doctest: +SKIP('random sample in Brightness function')
             >>> fake_img = transform(fake_img)
-            >>> print(fake_img.load()[1, 1])
+            >>> converted_img_pixels = fake_img.load()
+            >>> assert converted_img_pixels is not None
+            >>> print(converted_img_pixels[1, 1])
             (68, 192, 38)
 
     """

--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -17,7 +17,7 @@ wandb>=0.23.1
 xlsxwriter==3.0.9
 xdoctest==1.3.0
 ubelt==1.4.0 # just for xdoctest
-mypy==1.19.1
+mypy==2.1.0
 soundfile
 apache-tvm-ffi==0.1.11
 graphviz

--- a/tools/type_checking.py
+++ b/tools/type_checking.py
@@ -101,7 +101,9 @@ class TestResult:
     extra_info: dict[str, Any] = field(default_factory=dict)
 
 
-def pty_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+def pty_run(
+    command: list[str], env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
     """Run a command in a pseudo-terminal to capture colored output."""
     master_fd, slave_fd = pty.openpty()
     try:
@@ -113,6 +115,7 @@ def pty_run(command: list[str]) -> subprocess.CompletedProcess[str]:
             stdout=slave_fd,
             stderr=slave_fd,
             close_fds=True,
+            env=env,
         )
 
         # Parent no longer needs the slave fd — close it so the child can
@@ -206,6 +209,14 @@ class MypyChecker(TypeChecker):
         assert summary, 'No summary found in mypy output'
         return results, summary
 
+    def _mypy_env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        if 'MYPY_NUM_WORKERS' not in env:
+            num_workers = os.cpu_count()
+            if num_workers is not None:
+                env['MYPY_NUM_WORKERS'] = str(num_workers)
+        return env
+
     def run_on_directory(
         self,
         dir: pathlib.Path,
@@ -221,6 +232,7 @@ class MypyChecker(TypeChecker):
                 "--pretty",
                 str(dir),
             ],
+            env=self._mypy_env(),
         )
         if res.returncode == 0:
             print(f'No type errors found in directory {dir}')


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Devs

### Description
本 PR 升级 Paddle 的 mypy 工具链配置，并修复 mypy 2.1.0 / Python 3.10 下暴露出的示例类型检查问题。

#### 1. mypy 版本与配置升级

原因：mypy 2.0 起不再支持 `--python-version 3.9`，因此升级 mypy 时需要同步提升类型检查目标版本。

- `python/unittest_py/requirements.txt`: `mypy==1.19.1` -> `mypy==2.1.0`
- `pyproject.toml`: `[tool.mypy] python_version = "3.9"` -> `"3.10"`
- `pyproject.toml`: 设置 `num_workers = 8`，开启 mypy 2.x parallel type checking 的默认 worker 数

#### 2. mypy worker 数自动匹配

原因：mypy 配置文件中的 `num_workers` 只能写固定整数；mypy 2.1 支持通过 `MYPY_NUM_WORKERS` 覆盖配置值。因此在 `tools/type_checking.py` 中对 mypy 子进程设置 worker 数，避免在多个 shell 入口重复维护逻辑。

- `tools/type_checking.py`: 若调用方未显式设置 `MYPY_NUM_WORKERS`，则用 `os.cpu_count()` 设置 mypy 子进程的 `MYPY_NUM_WORKERS`
- 若 `os.cpu_count()` 不可用，则不设置环境变量，继续使用 `pyproject.toml` 中的默认 `num_workers = 8`

#### 3. mypy 2.1.0 / Python 3.10 暴露的 docstring sample typing 修复

原因：Static-Check 会用构建好的 wheel 对 docstring examples 做 full type checking。升级后暴露出一批示例类型问题，按最小方式修复，不新增全局 ignore。

- `CrossEntropyLoss` / `cross_entropy`: 避免同一 code block 内重复带注解定义 `weight` 导致 `no-redef`
- `Assign`: initializer 类型从一层 `Sequence[int]` 改为基于 `paddle._typing.NestedSequence` 的嵌套 sequence 类型，覆盖文档和运行时已支持的嵌套 list 初始化
- `DatasetFolder` / `ImageFolder`: `cv2.imread` loader 改为显式函数并 assert 非空，避免返回 `None` 的类型
- `create_nccl_config`: 避免示例中同名变量复用为不同类型
- `BaseTransform` / `device_guard` / object list send-recv examples / brightness examples: 删除或替换 mypy 2.1 下已不需要或过宽的 `type: ignore`
- vision transforms: 保留原泛型类结构，将 transform 输入/输出 TypeVar 改为带 `_ImageDataType` bound 与 `Any` default，避免无显式类型参数实例化时被 mypy 默认推断为只接受 `Tensor`

mypy release note 重点变化：

- mypy 2.0 不再支持 `--python-version 3.9`
- mypy 2.0 默认启用 `--local-partial-types`、`--strict-bytes`，并调整 `--allow-redefinition` 行为；Paddle 配置已显式启用 `local_partial_types = true` 和 `allow_redefinition = true`
- mypy 2.0 增加 experimental parallel type checking；本 PR 启用 parallel checking
- mypy 2.1 包含并行检查、crash、错误消息、narrowing、typeshed 和 mypyc 相关修复改进，并支持 `MYPY_NUM_WORKERS` 覆盖配置中的 `num_workers`

本地验证：

```bash
bash -n ci/static_check.sh paddle/scripts/paddle_build.sh

/Users/nyakku/.local/bin/python3.10 -m venv /tmp/paddle-mypy-2-1-py310-venv
/tmp/paddle-mypy-2-1-py310-venv/bin/python -m pip install 'mypy==2.1.0'
/tmp/paddle-mypy-2-1-py310-venv/bin/python -m mypy --version
# mypy 2.1.0 (compiled: yes)

/tmp/paddle-mypy-2-1-py310-venv/bin/python - <<'PY'
import pathlib, tomli
cfg = tomli.loads(pathlib.Path('pyproject.toml').read_text())
print('python_version=', cfg['tool']['mypy']['python_version'])
print('num_workers=', cfg['tool']['mypy']['num_workers'])
PY
# python_version= 3.10
# num_workers= 8

/tmp/paddle-mypy-2-1-py310-venv/bin/python -m mypy \
  --config-file=pyproject.toml \
  --cache-dir=/tmp/paddle-mypy-2-1-py310-typechecking-env-cache \
  -c 'x: int = 1'
# Success: no issues found in 1 source file

cd test/tools
PYTHONPATH=/path/to/Paddle/tools:/path/to/Paddle/python \
  /tmp/paddle-mypy-2-1-py310-venv/bin/python -m unittest test_type_checking
# Ran 4 tests in 2.685s, OK

git diff --check
# clean
```

说明：`tools/type_checking.py --full-test` 需要先安装当前 PR 对应的 Paddle wheel；当前本地 source-only workspace 未构建 `libpaddle`，直接运行会在导入 `paddle.base.libpaddle` 前失败。因此本地已覆盖 mypy 2.1.0 版本、配置解析、parallel smoke、shell syntax 和 `tools/type_checking.py` 的 focused unittest；完整 docstring type checking 由 CI Static-Check 使用构建 wheel 执行。

### 是否引起精度变化
否


