### PR TITLE
[CI] Fix C++ extension JIT cache invalidation

### DIFF
--- a/.github/workflows/_Linux-CPU.yml
+++ b/.github/workflows/_Linux-CPU.yml
@@ -162,6 +162,8 @@ jobs:
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           source ${{ github.workspace }}/../../../proxy
+          echo "Cleaning stale Paddle C++ extension JIT cache"
+          rm -rf /root/.cache/paddle_extensions
           bash ${ci_scripts}/run_linux_cpu_test.sh
           EXCODE=$?
           source ${ci_scripts}/utils.sh; clean_build_files

--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -466,12 +466,12 @@ class BuildExtension(build_ext):
         else:
             cuda_dlink_post_cflags = None
 
-        # Note(Aurelius84): If already compiling source before, we should check whether
-        # cflags have changed and delete the built shared library to re-compile the source
-        # even though source file content keep unchanged.
+        # Note(Aurelius84): If already compiling source before, we should check
+        # whether sources or build arguments have changed and delete cached
+        # outputs to re-compile the source.
         so_name = self.get_ext_fullpath(self.extensions[0].name)
         clean_object_if_change_cflags(
-            os.path.abspath(so_name), self.extensions[0]
+            os.path.abspath(so_name), self.extensions[0], self.build_temp
         )
 
         # Consider .cu, .cu.cc as valid source extensions.
@@ -1123,7 +1123,7 @@ class BuildExtension(build_ext):
                     # if user set build_directory, output objects there.
                     if build_directory is not None:
                         objects = [
-                            os.path.join(build_directory, obj)
+                            _normalize_object_filename(obj, build_directory)
                             for obj in objects
                         ]
                     # ensure to use abspath
@@ -1805,6 +1805,25 @@ def _as_command_list(command: Sequence[str] | str) -> list[str]:
     if isinstance(command, str):
         return [command]
     return [str(arg) for arg in command]
+
+
+def _is_path_under_directory(path: str, directory: str) -> bool:
+    path = os.path.normcase(os.path.abspath(path))
+    directory = os.path.normcase(os.path.abspath(directory))
+    try:
+        return os.path.commonpath([path, directory]) == directory
+    except ValueError:
+        return False
+
+
+def _normalize_object_filename(
+    obj: str | os.PathLike[str], build_directory: str | os.PathLike[str]
+) -> str:
+    obj = os.fspath(obj)
+    build_directory = os.fspath(build_directory)
+    if _is_path_under_directory(obj, build_directory):
+        return os.path.abspath(obj)
+    return os.path.abspath(os.path.join(build_directory, obj))
 
 
 def _write_ninja_file(path: str, content: str) -> None:

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -285,8 +285,24 @@ VersionFields = collections.namedtuple(
         'include_dirs',
         'define_macros',
         'undef_macros',
+        'source_hashes',
     ],
 )
+
+
+def _hash_source_files(sources):
+    if not sources:
+        return []
+
+    source_hashes = []
+    for source in sources:
+        source = os.fspath(source)
+        md5 = hashlib.md5()
+        with open(source, 'rb') as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b''):
+                md5.update(chunk)
+        source_hashes.append((source, md5.hexdigest()))
+    return source_hashes
 
 
 class VersionManager:
@@ -327,11 +343,20 @@ def combine_hash(md5, value):
     return md5
 
 
-def clean_object_if_change_cflags(so_path, extension):
+def _clean_cached_objects(build_directory):
+    if build_directory is None or not os.path.isdir(build_directory):
+        return
+
+    for root, _, files in os.walk(build_directory):
+        for file in files:
+            if file.endswith(('.o', '.obj')):
+                os.remove(os.path.join(root, file))
+
+
+def clean_object_if_change_cflags(so_path, extension, build_directory=None):
     """
-    If already compiling source before, we should check whether cflags
-    have changed and delete the built object to re-compile the source
-    even though source file content keeps unchanged.
+    If sources were already compiled before, check whether the source content
+    or build arguments have changed and delete cached outputs to re-compile.
     """
 
     def serialize(path, version_info):
@@ -352,27 +377,38 @@ def clean_object_if_change_cflags(so_path, extension):
     version_file = os.path.join(base_dir, VERSION_FILE)
 
     # version info
-    args = [getattr(extension, field, None) for field in VersionFields._fields]
+    args = []
+    for field in VersionFields._fields:
+        if field == 'source_hashes':
+            args.append(_hash_source_files(getattr(extension, 'sources', None)))
+        else:
+            args.append(getattr(extension, field, None))
     version_field = VersionFields._make(args)
     versioner = VersionManager(version_field)
 
-    if os.path.exists(so_path) and os.path.exists(version_file):
+    if os.path.exists(version_file):
         old_version_info = deserialize(version_file)
         so_version = old_version_info.get(so_name, None)
-        # delete shared library file if version is changed to re-compile it.
-        if so_version is not None and so_version != versioner.version:
-            log_v(
-                f"Re-Compiling {so_name}, because specified cflags have been changed. New signature {versioner.version} has been saved into {version_file}."
-            )
+        if so_version == versioner.version:
+            return
+
+        log_v(
+            f"Re-Compiling {so_name}, because specified source files or build arguments have been changed. New signature {versioner.version} has been saved into {version_file}."
+        )
+        if os.path.exists(so_path):
             os.remove(so_path)
-            # update new version information
-            new_version_info = versioner.details
-            new_version_info[so_name] = versioner.version
-            serialize(version_file, new_version_info)
+        _clean_cached_objects(build_directory)
+        # update new version information
+        new_version_info = versioner.details
+        new_version_info[so_name] = versioner.version
+        serialize(version_file, new_version_info)
     else:
         # If compile at first time, save compiling detail information for debug.
         if not os.path.exists(base_dir):
             os.makedirs(base_dir)
+        if os.path.exists(so_path):
+            os.remove(so_path)
+            _clean_cached_objects(build_directory)
         details = versioner.details
         details[so_name] = versioner.version
         serialize(version_file, details)

--- a/test/cpp_extension/test_cpp_extension_ninja.py
+++ b/test/cpp_extension/test_cpp_extension_ninja.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import shlex
 import subprocess
@@ -30,11 +31,16 @@ from paddle.utils.cpp_extension.cpp_extension import (
     _is_ninja_available,
     _join_ninja_shell_list,
     _ninja_escape_path,
+    _normalize_object_filename,
     _run_ninja_build,
     _write_ninja_file,
 )
 from paddle.utils.cpp_extension.extension_utils import (
+    VersionFields,
+    VersionManager,
+    _hash_source_files,
     _write_setup_file,
+    clean_object_if_change_cflags,
 )
 
 
@@ -84,6 +90,48 @@ class TestNinjaHelperFunctions(unittest.TestCase):
         self.assertEqual(_as_command_list("gcc"), ["gcc"])
         self.assertEqual(_as_command_list(["gcc", "-c"]), ["gcc", "-c"])
         self.assertEqual(_as_command_list(("gcc", "-c")), ["gcc", "-c"])
+
+    def test_normalize_object_filename_avoids_duplicate_build_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            build_dir = os.path.join(tmpdir, "build", "temp")
+            obj = os.path.join(build_dir, "paddle", "op.o")
+
+            self.assertEqual(
+                _normalize_object_filename(obj, build_dir),
+                os.path.abspath(obj),
+            )
+
+    def test_normalize_object_filename_avoids_duplicate_relative_build_directory(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                build_dir = os.path.join("build", "temp")
+                obj = os.path.join(build_dir, "paddle", "op.o")
+
+                self.assertEqual(
+                    _normalize_object_filename(obj, build_dir),
+                    os.path.abspath(obj),
+                )
+            finally:
+                os.chdir(old_cwd)
+
+    def test_normalize_object_filename_keeps_existing_outside_behavior(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            build_dir = os.path.join(tmpdir, "build", "temp")
+            relative_obj = os.path.join("paddle", "op.o")
+            outside_obj = os.path.join(tmpdir, "outside", "op.o")
+
+            self.assertEqual(
+                _normalize_object_filename(relative_obj, build_dir),
+                os.path.abspath(os.path.join(build_dir, relative_obj)),
+            )
+            self.assertEqual(
+                _normalize_object_filename(outside_obj, build_dir),
+                os.path.abspath(outside_obj),
+            )
 
     def test_write_ninja_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1178,6 +1226,111 @@ class TestBuildExtension(unittest.TestCase):
         self.assertIn('--prepared --use-local-env', content)
         self.assertIn('/DPADDLE_WITH_CUDA', content)
         self.assertNotIn(invalid_extra_args, content)
+
+
+class TestExtensionVersioning(unittest.TestCase):
+    def _extension(self, sources):
+        return SimpleNamespace(
+            sources=sources,
+            extra_compile_args=[],
+            extra_link_args=[],
+            library_dirs=[],
+            runtime_library_dirs=[],
+            include_dirs=[],
+            define_macros=[],
+            undef_macros=[],
+        )
+
+    def test_source_content_hash_participates_in_version(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "custom_op.cc")
+            Path(source).write_text("int value = 1;\n", encoding='utf-8')
+            first_hashes = _hash_source_files([source])
+            first_version = VersionManager(
+                VersionFields(
+                    [source],
+                    [],
+                    [],
+                    [],
+                    [],
+                    [],
+                    [],
+                    [],
+                    first_hashes,
+                )
+            ).version
+
+            Path(source).write_text("int value = 2;\n", encoding='utf-8')
+            second_hashes = _hash_source_files([source])
+            second_version = VersionManager(
+                VersionFields(
+                    [source],
+                    [],
+                    [],
+                    [],
+                    [],
+                    [],
+                    [],
+                    [],
+                    second_hashes,
+                )
+            ).version
+
+        self.assertNotEqual(first_hashes, second_hashes)
+        self.assertNotEqual(first_version, second_version)
+        json.dumps({'source_hashes': second_hashes})
+
+    def test_source_content_change_removes_stale_outputs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "custom_op.cc")
+            so_path = os.path.join(tmpdir, "custom_op.so")
+            build_dir = os.path.join(tmpdir, "build")
+            obj_path = os.path.join(build_dir, "custom_op.o")
+            os.makedirs(build_dir)
+            Path(source).write_text("int value = 1;\n", encoding='utf-8')
+            Path(so_path).write_bytes(b"so")
+            Path(obj_path).write_bytes(b"obj")
+
+            extension = self._extension([source])
+            clean_object_if_change_cflags(so_path, extension, build_dir)
+            version_path = os.path.join(tmpdir, "version.txt")
+            first_version = json.loads(
+                Path(version_path).read_text(encoding='utf-8')
+            )[os.path.basename(so_path)]
+
+            Path(so_path).write_bytes(b"so")
+            Path(obj_path).write_bytes(b"obj")
+            Path(source).write_text("int value = 2;\n", encoding='utf-8')
+            clean_object_if_change_cflags(so_path, extension, build_dir)
+            version_info = json.loads(
+                Path(version_path).read_text(encoding='utf-8')
+            )
+
+        self.assertFalse(os.path.exists(so_path))
+        self.assertFalse(os.path.exists(obj_path))
+        self.assertIn('source_hashes', version_info)
+        self.assertNotEqual(
+            first_version, version_info[os.path.basename(so_path)]
+        )
+
+    def test_source_content_change_removes_stale_objects_without_shared_library(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "custom_op.cc")
+            so_path = os.path.join(tmpdir, "custom_op.so")
+            build_dir = os.path.join(tmpdir, "build")
+            obj_path = os.path.join(build_dir, "custom_op.o")
+            os.makedirs(build_dir)
+            Path(source).write_text("int value = 1;\n", encoding='utf-8')
+
+            extension = self._extension([source])
+            clean_object_if_change_cflags(so_path, extension, build_dir)
+            Path(obj_path).write_bytes(b"obj")
+            Path(source).write_text("int value = 2;\n", encoding='utf-8')
+            clean_object_if_change_cflags(so_path, extension, build_dir)
+
+        self.assertFalse(os.path.exists(obj_path))
 
 
 class TestNinjaGeneratedSetupFile(unittest.TestCase):


### PR DESCRIPTION
### PR Category

Execute Infrastructure

### PR Types

Bug fixes

### Description

修复 Linux-CPU custom op JIT 在共享 `/root/.cache/paddle_extensions` 下可能命中陈旧缓存的问题，并保留一个 CI 侧的临时/防御性 cache cleanup。

背景来自 PaddlePaddle/Paddle#79289 的 Linux-CPU 排查：

- 最近通过样例 `80404721798` 与失败样例 `80467139736` 使用相同 Linux-CPU docker image `ccr-2vdh3abv-pub.cnc.bj.baidubce.com/ci/paddle:19d3669ca5ff0b19144a785bb3126d7e`，且均安装 `apache-tvm-ffi==0.1.11`，所以 CPU 失败不指向 `tvm-ffi==0.1.12`。
- 失败集中在 `test_custom_extend_attrs_jit` / `test_custom_simple_slice` / `test_custom_inplace`，日志显示 `paddle.utils.cpp_extension` 调用 `ninja -v -f /root/.cache/paddle_extensions/.../build.ninja` 时 `ninja` 进程收到 `SIGSEGV`。
- Linux-CPU workflow 将 `/home/data/cfs/.cache/python35-cpu` 挂载为容器内 `/root/.cache`，`paddle_extensions` 位于该共享 cache 下。

本 PR 做两类修复：

1. `BuildExtension` 生成 object path 时，避免对已经位于 `build_temp` 下的 object 再次拼接 `build_temp`，修正类似 `.../temp.../build/.../temp.../build.ninja` 的重复路径。
2. `version.txt` 的扩展版本签名加入 source file content hash；source 或 build args 变化时，删除 stale `.so` 以及 `build_temp` 下的 `.o/.obj`，避免共享 cache 中旧 object 被 ninja/distutils 复用。
3. Linux-CPU workflow 在 Test step 进入 `run_linux_cpu_test.sh` 前，仅清理 `/root/.cache/paddle_extensions`；不清理整个 `/root/.cache`，也不动 pip cache / ccache。

本地验证：

```bash
python3 -m py_compile python/paddle/utils/cpp_extension/cpp_extension.py python/paddle/utils/cpp_extension/extension_utils.py test/cpp_extension/test_cpp_extension_ninja.py
git diff --check
```

另外跑了一个 isolated helper validation（stub 掉最小 Paddle import），覆盖：

- relative object path 已在 `build_temp` 下时不会重复拼接；
- source content 变化会改变 version signature；
- source content 变化时会清理 stale `.so` 和 `.o`；
- `.so` 不存在但 stale `.o` 存在时也会清理 stale `.o`。

完整 unittest 在本地源码 checkout 中因未构建 `paddle.base.libpaddle` 无法导入运行，留给 CI 验证。

### 是否引起精度变化

否
