### PR TITLE
[Fix] issue #79160 paddle.isin 在动态图与静态图下对 bool 输入行为不一致的问题

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -7105,6 +7105,29 @@ def isin(
     if not isinstance(test_x, (paddle.Tensor, Variable, paddle.pir.Value)):
         raise TypeError(f"x must be tensor type, but got {type(test_x)}")
 
+    # ``check_variable_and_dtype`` below is skipped in dygraph (see NOTE
+    # [ Why skip dynamic graph check ] in data_feeder.py), so bool/other
+    # unsupported dtypes would silently slip through in eager mode while being
+    # rejected in static mode (issue #79160). This mode-agnostic guard enforces
+    # the documented dtype contract consistently in eager, static and to_static.
+    # It matches ``torch.isin``, which also rejects bool, and reflects the fact
+    # that ``argsort``/``sort``/``searchsorted`` have no bool kernel.
+    supported_dtypes = [
+        'uint16',
+        'float16',
+        'float32',
+        'float64',
+        'int32',
+        'int64',
+    ]
+    for var, var_name in ((x, 'x'), (test_x, 'test_x')):
+        if convert_dtype(var.dtype) not in supported_dtypes:
+            raise TypeError(
+                f"The data type of '{var_name}' in isin must be "
+                f'{supported_dtypes}, but received '
+                f'{convert_dtype(var.dtype)}.'
+            )
+
     check_variable_and_dtype(
         x,
         "x",

--- a/test/legacy_test/test_isin.py
+++ b/test/legacy_test/test_isin.py
@@ -243,6 +243,55 @@ class TestIsInError(unittest.TestCase):
             paddle.isin(np.array([1, 2]), np.array([1, 2]))
 
 
+class TestIsInDtypeReject(unittest.TestCase):
+    # Regression test for issue #79160: paddle.isin used to accept bool tensors
+    # in eager mode (the static-only dtype checker is skipped in dygraph) while
+    # rejecting them in static mode. bool is excluded by the documented dtype
+    # contract and unsupported by torch.isin, so it must be rejected
+    # consistently in eager, static and to_static.
+    def _check(self, np_dtype, want_substr):
+        # Force dynamic mode before building the tensors so they are eager
+        # tensors regardless of the mode a previously-run test left behind.
+        paddle.disable_static()
+        x = paddle.to_tensor([1, 0, 1]).astype(np_dtype)
+        t = paddle.to_tensor([1]).astype(np_dtype)
+
+        # eager
+        with self.assertRaises(TypeError) as cm:
+            paddle.isin(x, t)
+        self.assertIn(want_substr, str(cm.exception))
+
+        # to_static (the exact failing path reported in the issue)
+        static_fn = paddle.jit.to_static(
+            paddle.isin,
+            input_spec=[
+                paddle.static.InputSpec([3], dtype=np_dtype),
+                paddle.static.InputSpec([1], dtype=np_dtype),
+            ],
+            full_graph=True,
+        )
+        with self.assertRaises(TypeError):
+            static_fn(x, t)
+
+        # static
+        paddle.enable_static()
+        try:
+            with paddle.static.program_guard(paddle.static.Program()):
+                sx = paddle.static.data('x', [3], np_dtype)
+                st = paddle.static.data('t', [1], np_dtype)
+                with self.assertRaises(TypeError) as cm2:
+                    paddle.isin(sx, st)
+                self.assertIn(want_substr, str(cm2.exception))
+        finally:
+            paddle.disable_static()
+
+    def test_bool_rejected(self):
+        self._check('bool', 'received bool')
+
+    def test_complex_rejected(self):
+        self._check('complex64', 'received complex')
+
+
 class TestIsIn(unittest.TestCase):
     def test_without_gpu(self):
         test(DATA_CASES, DATA_TYPE)


### PR DESCRIPTION
### PR Category
User Experience


### PR Types
Bug fixes


### Description

**问题描述**

`paddle.isin` 对 `bool` 类型输入在动态图与静态图下行为不一致：

- 动态图（`eager`）：可以接受 `bool` 输入并返回结果；
- 静态图 / 组网（`to_static, full_graph=True`）：报错
```bash
The data type of 'x' in isin must be ['uint16', 'float16', 'float32', 'float64', 'int32', 'int64'], but received bool.
```
相关 issue：
- https://github.com/paddlepaddle/paddle/issues/79160

根因：`isin`（`python/paddle/tensor/math.py`）通过两次 `check_variable_and_dtype` 做 `dtype 校验`，而  `check_variable_and_dtype` / `check_dtype` 在动态图下会直接跳过（`data_feeder.py` 中 `if in_dygraph_mode(): return`，见 NOTE [ Why skip dynamic graph check ]）。因此动态图下白名单校验不生效，`bool` 被放行；静态图下才会被拦截，导致两种模式行为不一致。

**解决方案**

统一为两种模式都拒绝 `bool`，理由：

1. `torch.isin` 同样不支持 `bool`（`RuntimeError: Unsupported input type encountered for isin(): Bool`），本项目以对齐 PyTorch 为目标；
2. `paddle.isin` 文档（docstring）本就只声明支持 `bfloat16/float16/float32/float64/int32/int64`，并不包含 `bool`，本次修改是让代码与已声明契约一致；
3. 动态图下对 `bool` 的“支持”本身并不可靠——仅在 `test_x` 较小走暴力比较分支时可用；一旦走 `argsort/sort/searchsorted` 分支，因缺少 `bool kernel` 会抛出底层 `NotFound` 报错。给出清晰的 `TypeError` 比“小输入可用、大输入崩溃”体验更好。

**修改内容**

- `python/paddle/tensor/math.py`：在 `isin` 入参类型检查之后，新增一段与运行模式无关的 `dtype` 校验（使用 `convert_dtype`，已在文件内导入），在 `eager / static / to_static` 下都会执行，对不在白名单内的 `dtype`（如 `bool`、`complex`）抛出 `TypeError`，报错信息与原静态图保持完全一致。保留原有 `check_variable_and_dtype` 调用不变。
  - 说明：`convert_dtype(bfloat16) == 'uint16'`，仍在白名单内，`bfloat16` 不受影响；`convert_dtype(bool) == 'bool'`，被正确拦截。
- `test/legacy_test/test_isin.py`：新增 `TestIsInDtypeReject`，覆盖 `bool` 与 `complex64` 在 `eager / to_static(full_graph=True) / static` 三种路径下均抛出 `TypeError`。


### 是否引起精度变化
否
