### PR TITLE
[Execute Infrastructure] Fix Linux CPU custom op JIT test source paths

### DIFF
--- a/test/custom_op/test_custom_extend_attrs_jit.py
+++ b/test/custom_op/test_custom_extend_attrs_jit.py
@@ -32,7 +32,11 @@ if os.name == 'nt' and os.path.isfile(file):
 # Compile and load custom op Just-In-Time.
 extend_custom_attrs = load(
     name='custom_extend_attrs_jit',
-    sources=['extend_attr_test_op.cc'],
+    sources=[
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "extend_attr_test_op.cc"
+        )
+    ],
     extra_include_paths=paddle_includes,  # add for Coverage CI
     extra_cxx_cflags=extra_cc_args,  # test for cflags
     extra_cuda_cflags=extra_nvcc_args,  # test for cflags

--- a/test/custom_op/test_custom_inplace.py
+++ b/test/custom_op/test_custom_inplace.py
@@ -39,7 +39,11 @@ if os.name == 'nt' and os.path.isfile(file):
 # Compile and load custom op Just-In-Time.
 custom_inplace = load(
     name='custom_inplace',
-    sources=['custom_inplace.cc'],
+    sources=[
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), 'custom_inplace.cc'
+        )
+    ],
     extra_include_paths=paddle_includes,  # add for Coverage CI
     extra_cxx_cflags=extra_cc_args,  # test for cflags
     extra_cuda_cflags=extra_nvcc_args,  # test for cflags

--- a/test/custom_op/test_custom_simple_slice.py
+++ b/test/custom_op/test_custom_simple_slice.py
@@ -31,7 +31,12 @@ if os.name == 'nt' and os.path.isfile(file):
 
 custom_ops = load(
     name='custom_simple_slice_jit',
-    sources=['custom_simple_slice_op.cc'],
+    sources=[
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            'custom_simple_slice_op.cc',
+        )
+    ],
     extra_include_paths=paddle_includes,  # add for Coverage CI
     extra_cxx_cflags=extra_cc_args,  # test for cc flags
     extra_cuda_cflags=extra_nvcc_args,  # test for nvcc flags


### PR DESCRIPTION
### PR Category
User Experience


### PR Types
Bug fixes


### Description

The Linux CPU CI has the following errors:
```bash
  ========================================
  There are failed tests, which have been executed re-run,but success rate is less than 50%:
  Summary Failed Tests... 
  ========================================
  The following tests FAILED: 
  	246 - test_custom_simple_slice (Failed)
  	247 - test_custom_inplace (Failed)
  	259 - test_custom_simple_slice (Failed)
  	261 - test_custom_inplace (Failed)
              	245 - test_custom_extend_attrs_jit (Failed)
              	255 - test_custom_extend_attrs_jit (Failed)
```

Test on dev machine, all three tests have the same issue: `error: [Errno 2] No such file or directory`

This is because the file route is fixed, not dynamically determined. e.g.,

***before***
```python
    sources=['custom_simple_slice_op.cc']
```

***After***
```python
    sources=[
        os.path.join(
            os.path.dirname(os.path.abspath(__file__)),
            'custom_simple_slice_op.cc',
        )
    ],
```

Which resolve the problem.

### 是否引起精度变化
否


pure test file change version of this pr:
- https://github.com/PaddlePaddle/Paddle/pull/79298