### PR TITLE
[CI] Keep gcov tool selection only

### DIFF
--- a/ci/coverage_info.sh
+++ b/ci/coverage_info.sh
@@ -90,54 +90,6 @@ function init_gcov_tool() {
     fi
 }
 
-function pr_has_cpp_source_changes() {
-    local diff_file="$1"
-
-    awk '
-        index($0, "+++ ") == 1 {
-            path = substr($0, 5)
-            if (path ~ /^paddle\// &&
-                path ~ /\.(c|cc|cpp|cxx|cu)$/ &&
-                path !~ /(^|\/)(test|tests)\// &&
-                path !~ /(^|\/)[^\/]*(test_|_test|unittest)[^\/]*\./) {
-                found = 1
-            }
-        }
-        END { exit(found ? 0 : 1) }
-    ' "${diff_file}"
-}
-
-function ensure_cpp_extracted_coverage_data() {
-    local info_file="$1"
-    local diff_file="$2"
-
-    if pr_has_cpp_source_changes "${diff_file}" && ! grep -q '^DA:' "${info_file}" 2>/dev/null; then
-        echo "ERROR: ${info_file} has no extracted C++ line coverage data for compiled C++ source changes"
-        echo "This usually means lcov/gcov failed before producing a valid diff report."
-        exit 101
-    fi
-}
-
-function filter_coverage_diff_if_available() {
-    local info_file="$1"
-    local diff_file="$2"
-    local tmp_file="$3"
-
-    if [ ! -f "${info_file}" ]; then
-        echo "Skip coverage diff filtering because ${info_file} was not generated."
-        : > "${info_file}"
-        return
-    fi
-
-    if [ ! -f "${diff_file}" ]; then
-        echo "ERROR: ${diff_file} was not generated for ${info_file}"
-        exit 101
-    fi
-
-    python ${PADDLE_ROOT}/ci/coverage_diff.py "${info_file}" "${diff_file}" > "${tmp_file}" || exit 101
-    mv -f "${tmp_file}" "${info_file}"
-}
-
 # NOTE: This gcda pre-cleaning step keeps/removes files by mapping PR
 # changed files to "*.gcda" paths. That is not always correct: for header-only
 # changes, or changes whose coverage is recorded in other translation units,
@@ -240,9 +192,9 @@ fi
 
 if [ "${PR_ID}" != "" ]; then
 
-    COVERAGE_DIFF_PATTERN="`python ${PADDLE_ROOT}/ci/coverage_pull_request.py files ${PR_ID}`" || exit 101
+    COVERAGE_DIFF_PATTERN="`python ${PADDLE_ROOT}/ci/coverage_pull_request.py files ${PR_ID}`"
 
-    python ${PADDLE_ROOT}/ci/coverage_pull_request.py diff ${PR_ID} > git-diff.out || exit 101
+    python ${PADDLE_ROOT}/ci/coverage_pull_request.py diff ${PR_ID} > git-diff.out
 fi
 
 lcov --extract coverage-full.info \
@@ -250,9 +202,9 @@ lcov --extract coverage-full.info \
     -o coverage-diff.info \
     --rc lcov_branch_coverage=0
 
-ensure_cpp_extracted_coverage_data coverage-diff.info git-diff.out
+python ${PADDLE_ROOT}/ci/coverage_diff.py coverage-diff.info git-diff.out > coverage-diff.tmp
 
-filter_coverage_diff_if_available coverage-diff.info git-diff.out coverage-diff.tmp
+mv -f coverage-diff.tmp coverage-diff.info
 
 cp coverage-diff.info coverage_files
 
@@ -287,9 +239,9 @@ gen_python_full_report || true  # python-coverage-full.info
 
 
 if [ "${GIT_PR_ID}" != "" ]; then
-    COVERAGE_DIFF_PATTERN="`python ${PADDLE_ROOT}/ci/coverage_pull_request.py files ${GIT_PR_ID}`" || exit 101
+    COVERAGE_DIFF_PATTERN="`python ${PADDLE_ROOT}/ci/coverage_pull_request.py files ${GIT_PR_ID}`"
 
-    python ${PADDLE_ROOT}/ci/coverage_pull_request.py diff ${GIT_PR_ID} > python-git-diff.out || exit 101
+    python ${PADDLE_ROOT}/ci/coverage_pull_request.py diff ${GIT_PR_ID} > python-git-diff.out
 fi
 
 lcov --extract python-coverage-full.info \
@@ -297,6 +249,8 @@ lcov --extract python-coverage-full.info \
     -o python-coverage-diff.info \
     --rc lcov_branch_coverage=0
 
-filter_coverage_diff_if_available python-coverage-diff.info python-git-diff.out python-coverage-diff.tmp
+python ${PADDLE_ROOT}/ci/coverage_diff.py python-coverage-diff.info python-git-diff.out > python-coverage-diff.tmp
+
+mv -f python-coverage-diff.tmp python-coverage-diff.info
 
 cp python-coverage-diff.info coverage_files


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
本 PR 调整 Coverage 脚本，保留 #79263 中用于解决 GCC/gcov 主版本不一致的 `GCOV_TOOL` 搜索和 `lcov --gcov-tool` 显式选择逻辑，但撤回基于 `.c/.cc/.cpp/.cxx/.cu` 文件变更强制要求 C++ `coverage-diff.info`/`DA:` 的检查，以及 #79274 为该检查补充的 diff filtering wrapper。

现阶段不适合继续加这个校验：Coverage CI 跑的是有限测试集合，并不保证每个修改的编译型 C++/CUDA 文件都会被该 job 中的测试覆盖到；部分回归测试可能只在其他 CI 或专用测试入口中执行。仅凭 PR 修改了 `.cc/.cu` 文件就要求 standard Coverage job 一定生成对应 C++ coverage input，会把“测试未在 Coverage job 中执行、未产生 `.gcda` 或未生成 `coverage-diff.info`”的场景误判为脚本失败，导致正常 PR 被 blocking。文件后缀只能说明有编译型源码变更，不能证明本 Coverage job 应该能产生有效 diff coverage。

修改后 Coverage 流程回到 #79263 前的文件变更无关逻辑：如果上游 lcov/extract/filter 生成了报告就继续正常处理，不再按源码后缀 fail fast；但 gcov 工具选择仍会优先匹配 CMake C++ compiler 版本，继续避免 GCC/gcov 版本不一致导致的采集问题。

本地验证：

- `bash -n ci/coverage_info.sh`
- `git diff --check -- ci/coverage_info.sh`
- `prek`

### 是否引起精度变化
否
