### PR TITLE
[CodeStyle] Clean up Python 3.9 SOT C++ compatibility code

### DIFF
--- a/ci/coverage_info.sh
+++ b/ci/coverage_info.sh
@@ -111,7 +111,6 @@ function gen_full_report() {
         "${PADDLE_ROOT}/paddle/fluid/inference/*" \
         "${PADDLE_ROOT}/paddle/fluid/memory/*" \
         "${PADDLE_ROOT}/paddle/fluid/operators/*" \
-        "${PADDLE_ROOT}/paddle/fluid/pybind/*" \
         "${PADDLE_ROOT}/paddle/fluid/eager/*" \
         "${PADDLE_ROOT}/paddle/fluid/pir/*" \
         "${PADDLE_ROOT}/paddle/fluid/ir_adaptor/*" \

--- a/ci/coverage_info.sh
+++ b/ci/coverage_info.sh
@@ -159,6 +159,7 @@ function gen_full_report() {
         "${PADDLE_ROOT}/paddle/fluid/inference/*" \
         "${PADDLE_ROOT}/paddle/fluid/memory/*" \
         "${PADDLE_ROOT}/paddle/fluid/operators/*" \
+        "${PADDLE_ROOT}/paddle/fluid/pybind/*" \
         "${PADDLE_ROOT}/paddle/fluid/eager/*" \
         "${PADDLE_ROOT}/paddle/fluid/pir/*" \
         "${PADDLE_ROOT}/paddle/fluid/ir_adaptor/*" \

--- a/paddle/fluid/pybind/sot/guards.cc
+++ b/paddle/fluid/pybind/sot/guards.cc
@@ -27,10 +27,6 @@ limitations under the License. */
 #include <internal/pycore_interpframe.h>
 #endif
 
-#if !PY_3_10_PLUS
-#define Py_IsNone(x) ((x) == Py_None)
-#endif
-
 // check if the tensor is null, tensor is std::optional<paddle::Tensor>
 #define HANDLE_NULL_TENSOR(tensor) \
   {                                \

--- a/paddle/fluid/pybind/sot/macros.h
+++ b/paddle/fluid/pybind/sot/macros.h
@@ -20,16 +20,12 @@ extern "C" {
 
 #include <Python.h>
 
-#define PY_3_9_0_HEX 0x03090000
-#define PY_3_10_0_HEX 0x030A0000
 #define PY_3_11_0_HEX 0x030B0000
 #define PY_3_12_0_HEX 0x030C0000
 #define PY_3_13_0_HEX 0x030D0000
 #define PY_3_14_0_HEX 0x030E0000
 #define PY_3_15_0_HEX 0x030F0000
 
-#define PY_3_9_PLUS (PY_VERSION_HEX >= PY_3_9_0_HEX)
-#define PY_3_10_PLUS (PY_VERSION_HEX >= PY_3_10_0_HEX)
 #define PY_3_11_PLUS (PY_VERSION_HEX >= PY_3_11_0_HEX)
 #define PY_3_12_PLUS (PY_VERSION_HEX >= PY_3_12_0_HEX)
 #define PY_3_13_PLUS (PY_VERSION_HEX >= PY_3_13_0_HEX)


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description
Paddle now requires Python >= 3.10, so the SOT C++ pybind code no longer needs Python 3.9 compatibility helpers.

This PR cleans up `paddle/fluid/pybind/sot` by:
- removing the unused `PY_3_9_0_HEX` and `PY_3_9_PLUS` macros;
- simplifying the now-dead Python < 3.10 `Py_IsNone` fallback guarded by `PY_3_10_PLUS`;
- removing the now-unused `PY_3_10_0_HEX` and `PY_3_10_PLUS` macros while keeping Python 3.11+ version branches unchanged.

Review update:
- Merged latest `develop` after #79300 and restored the temporary `ci/coverage_info.sh` coverage allowlist change. The final PR diff is back to SOT cleanup only.

Validation:
- `rg -n 'PY_3_9_PLUS|PY_3_10_PLUS|PY_3_9_0_HEX|PY_3_10_0_HEX' paddle/fluid/pybind/sot` (no matches)
- `git diff --check upstream/develop...HEAD`
- `git diff --check`
- `pre-commit run --files paddle/fluid/pybind/sot/guards.cc paddle/fluid/pybind/sot/macros.h`

Not run:
- `PYTHONPATH=python:. python3 test/sot/test_guard_tree.py -q` could not run in this checkout because there is no local built `libpaddle` available for importing `paddle.framework.core`.
- Full C++ build was not run locally due to the large Paddle build footprint.

### 是否引起精度变化
否
