### PR TITLE
[Cpp API Compatibility] Add ATen ops signature static check

### DIFF
--- a/ci/static_check.sh
+++ b/ci/static_check.sh
@@ -193,11 +193,13 @@ if [ -z "${aten_ops_signature_base_ref}" ]; then
     exit 1
 fi
 
-aten_ops_signature_headers=$(
-    git -C "${PADDLE_ROOT}" diff --name-only --diff-filter=A "${aten_ops_signature_base_ref}" -- \
-        paddle/phi/api/include/compat/ATen/ops | grep -E '\.h$' || true
+aten_ops_signature_inputs=$(
+    git -C "${PADDLE_ROOT}" diff --name-only --diff-filter=AM "${aten_ops_signature_base_ref}" -- \
+        paddle/phi/api/include/compat/ATen/ops \
+        paddle/phi/api/include/compat/ATen/core/TensorBody.h |
+        grep -E '(^paddle/phi/api/include/compat/ATen/ops/.*\.h$|^paddle/phi/api/include/compat/ATen/core/TensorBody\.h$)' || true
 )
-if [ -n "${aten_ops_signature_headers}" ]; then
+if [ -n "${aten_ops_signature_inputs}" ]; then
     aten_ops_signature_torch_target=$(mktemp -d)
     pip install --target "${aten_ops_signature_torch_target}" \
         torch==2.9.1 --index-url https://download.pytorch.org/whl/cpu 1>nul
@@ -215,7 +217,7 @@ if [ -n "${aten_ops_signature_headers}" ]; then
         exit $torch_cleanup_error
     fi
 else
-    echo "No newly added compat ATen ops headers found; skip ATen ops signature check."
+    echo "No changed compat ATen ops headers or TensorBody.h found; skip ATen ops signature check."
 fi
 
 exec_samplecode_checking

--- a/ci/static_check.sh
+++ b/ci/static_check.sh
@@ -202,7 +202,7 @@ aten_ops_signature_inputs=$(
 if [ -n "${aten_ops_signature_inputs}" ]; then
     aten_ops_signature_torch_target=$(mktemp -d)
     pip install --target "${aten_ops_signature_torch_target}" \
-        torch==2.9.1 --index-url https://download.pytorch.org/whl/cpu 1>nul
+        torch==2.12.1 --index-url https://download.pytorch.org/whl/cpu 1>nul
 
     PYTHONPATH="${aten_ops_signature_torch_target}${PYTHONPATH:+:${PYTHONPATH}}" \
         python ${PADDLE_ROOT}/tools/check_aten_ops_signature.py \

--- a/ci/static_check.sh
+++ b/ci/static_check.sh
@@ -180,4 +180,42 @@ pip install --upgrade pip 1>nul
 pip install -r "${work_dir}/python/requirements.txt" 1>nul
 pip install -r "${work_dir}/python/unittest_py/requirements.txt" 1>nul
 
+aten_ops_signature_base_branch="${BRANCH:-develop}"
+aten_ops_signature_base_ref=""
+for ref in "upstream/${aten_ops_signature_base_branch}" "origin/${aten_ops_signature_base_branch}" "${aten_ops_signature_base_branch}"; do
+    if git -C "${PADDLE_ROOT}" rev-parse --verify --quiet "${ref}" >/dev/null; then
+        aten_ops_signature_base_ref="${ref}"
+        break
+    fi
+done
+if [ -z "${aten_ops_signature_base_ref}" ]; then
+    echo "Cannot find a base ref for ATen ops signature check." >&2
+    exit 1
+fi
+
+aten_ops_signature_headers=$(
+    git -C "${PADDLE_ROOT}" diff --name-only --diff-filter=A "${aten_ops_signature_base_ref}" -- \
+        paddle/phi/api/include/compat/ATen/ops | grep -E '\.h$' || true
+)
+if [ -n "${aten_ops_signature_headers}" ]; then
+    aten_ops_signature_torch_target=$(mktemp -d)
+    pip install --target "${aten_ops_signature_torch_target}" \
+        torch==2.9.1 --index-url https://download.pytorch.org/whl/cpu 1>nul
+
+    PYTHONPATH="${aten_ops_signature_torch_target}${PYTHONPATH:+:${PYTHONPATH}}" \
+        python ${PADDLE_ROOT}/tools/check_aten_ops_signature.py \
+        --paddle-root ${PADDLE_ROOT}
+    aten_ops_signature_error=$?
+    rm -rf "${aten_ops_signature_torch_target}"
+    torch_cleanup_error=$?
+    if [ "$aten_ops_signature_error" != "0" ]; then
+        exit $aten_ops_signature_error
+    fi
+    if [ "$torch_cleanup_error" != "0" ]; then
+        exit $torch_cleanup_error
+    fi
+else
+    echo "No newly added compat ATen ops headers found; skip ATen ops signature check."
+fi
+
 exec_samplecode_checking

--- a/ci/static_check.sh
+++ b/ci/static_check.sh
@@ -196,8 +196,9 @@ fi
 aten_ops_signature_inputs=$(
     git -C "${PADDLE_ROOT}" diff --name-only --diff-filter=AM "${aten_ops_signature_base_ref}" -- \
         paddle/phi/api/include/compat/ATen/ops \
-        paddle/phi/api/include/compat/ATen/core/TensorBody.h |
-        grep -E '(^paddle/phi/api/include/compat/ATen/ops/.*\.h$|^paddle/phi/api/include/compat/ATen/core/TensorBody\.h$)' || true
+        paddle/phi/api/include/compat/ATen/core/TensorBody.h \
+        paddle/phi/api/include/compat/ATen/core/TensorBase.h |
+        grep -E '(^paddle/phi/api/include/compat/ATen/ops/.*\.h$|^paddle/phi/api/include/compat/ATen/core/TensorBody\.h$|^paddle/phi/api/include/compat/ATen/core/TensorBase\.h$)' || true
 )
 if [ -n "${aten_ops_signature_inputs}" ]; then
     aten_ops_signature_torch_target=$(mktemp -d)
@@ -217,7 +218,7 @@ if [ -n "${aten_ops_signature_inputs}" ]; then
         exit $torch_cleanup_error
     fi
 else
-    echo "No changed compat ATen ops headers or TensorBody.h found; skip ATen ops signature check."
+    echo "No changed compat ATen ops headers, TensorBody.h, or TensorBase.h found; skip ATen ops signature check."
 fi
 
 exec_samplecode_checking

--- a/paddle/phi/api/include/compat/ATen/Functions.h
+++ b/paddle/phi/api/include/compat/ATen/Functions.h
@@ -34,6 +34,7 @@
 #include <ATen/ops/empty_strided.h>
 #include <ATen/ops/equal.h>
 #include <ATen/ops/expand.h>
+#include <ATen/ops/expand_as.h>
 #include <ATen/ops/eye.h>
 #include <ATen/ops/flatten.h>
 #include <ATen/ops/from_blob.h>

--- a/paddle/phi/api/include/compat/ATen/core/TensorBase.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBase.h
@@ -126,11 +126,8 @@ class PADDLE_API TensorBase {
 
   const void* const_data_ptr() const { return data_ptr(); }
 
-  template <typename T, std::enable_if_t<!std::is_const_v<T>, int> = 0>
+  template <typename T>
   const T* const_data_ptr() const;
-
-  template <typename T, std::enable_if_t<std::is_const_v<T>, int> = 0>
-  const std::remove_const_t<T>* const_data_ptr() const;
 
   void* mutable_data_ptr() const { return data_ptr(); }
 

--- a/paddle/phi/api/include/compat/ATen/core/TensorBase.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBase.h
@@ -71,11 +71,11 @@ class PADDLE_API TensorBase {
   TensorBase& operator=(const TensorBase&) && = delete;
   TensorBase& operator=(TensorBase&&) && noexcept = delete;
 
-  bool is_same(const TensorBase& other) const {
+  bool is_same(const TensorBase& other) const noexcept {
     return tensor_.impl().get() == other.tensor_.impl().get();
   }
-  size_t use_count() const { return tensor_.impl().use_count(); }
-  size_t weak_use_count() const {
+  size_t use_count() const noexcept { return tensor_.impl().use_count(); }
+  size_t weak_use_count() const noexcept {
     // PyTorch exposes an internal self weak-reference on live TensorImpls, so
     // the observable weak count starts at 1 even without user-created refs.
     return tensor_.defined() ? 1 : 0;
@@ -312,27 +312,6 @@ class PADDLE_API TensorBase {
   }
 
   bool is_sparse_csr() const { return tensor_.is_sparse_csr_tensor(); }
-
-  at::TensorBase reshape(at::IntArrayRef shape) const {
-    return TensorBase(
-        paddle::experimental::reshape(tensor_, shape._PD_ToPaddleIntArray()));
-  }
-
-  at::TensorBase& copy_(const at::TensorBase& src,
-                        bool non_blocking = false) const {
-    const_cast<PaddleTensor&>(tensor_).copy_(
-        src._PD_GetInner(), tensor_.place(), /*blocking=*/!non_blocking);
-    return const_cast<at::TensorBase&>(*this);
-  }
-
-  at::TensorBase view(at::IntArrayRef size) const {
-    return TensorBase(paddle::experimental::view_shape(tensor_, size.vec()));
-  }
-
-  at::TensorBase view(at::ScalarType dtype) const {
-    return TensorBase(paddle::experimental::view_dtype(
-        tensor_, compat::_PD_AtenScalarTypeToPhiDataType(dtype)));
-  }
 
   inline size_t nbytes() const {
     PD_CHECK(

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -36,17 +36,6 @@
 #include <cuda_runtime_api.h>
 #endif
 
-// Forward declaration to allow record_stream(at::cuda::CUDAStream) overload
-// without pulling in the full CUDAStream header here.
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-namespace c10::cuda {
-class CUDAStream;
-}  // namespace c10::cuda
-namespace at::cuda {
-using c10::cuda::CUDAStream;
-}  // namespace at::cuda
-#endif
-
 #include <limits>
 #include <optional>
 #include <utility>
@@ -292,13 +281,12 @@ class Tensor : public TensorBase {
       ::std::optional<int64_t> storage_offset = ::std::nullopt) const;
 
   // Standard deviation functions
-  Tensor std(int dim) const;
-  Tensor std(bool unbiased = true) const;
+  Tensor std(bool unbiased) const;
   Tensor std(at::OptionalIntArrayRef dim,
-             bool unbiased = true,
+             bool unbiased,
              bool keepdim = false) const;
-  Tensor std(at::OptionalIntArrayRef dim,
-             const ::std::optional<at::Scalar>& correction,
+  Tensor std(at::OptionalIntArrayRef dim = ::std::nullopt,
+             const ::std::optional<at::Scalar>& correction = ::std::nullopt,
              bool keepdim = false) const;
 
   Tensor tensor_data() const {
@@ -349,11 +337,6 @@ class Tensor : public TensorBase {
                          const at::Tensor& values,
                          bool accumulate = false) const;
 
-  // index_put_: Set scalar value at specified indices in-place
-  at::Tensor& index_put_(const c10::List<::std::optional<at::Tensor>>& indices,
-                         const at::Scalar& v,
-                         bool accumulate = false) const;
-
   // index_put: Non-inplace version of index_put_
   at::Tensor index_put(const c10::List<::std::optional<at::Tensor>>& indices,
                        const at::Tensor& values,
@@ -399,7 +382,7 @@ class Tensor : public TensorBase {
     return compat::_PD_PhiDataTypeToAtenScalarType(tensor_.dtype());
   }
 
-  at::Tensor flatten(int64_t start_dim, int64_t end_dim) const;
+  at::Tensor flatten(int64_t start_dim = 0, int64_t end_dim = -1) const;
   at::Tensor unflatten(int64_t dim, at::IntArrayRef sizes) const;
   at::Tensor unflatten_symint(int64_t dim, c10::SymIntArrayRef sizes) const;
 
@@ -535,12 +518,8 @@ class Tensor : public TensorBase {
   at::Tensor& squeeze_(int64_t dim) const;
   at::Tensor& squeeze_(at::IntArrayRef dim) const;
 
-  at::Tensor unsqueeze() const;
   at::Tensor unsqueeze(int64_t dim) const;
-  at::Tensor unsqueeze(at::IntArrayRef dim) const;
-  at::Tensor& unsqueeze_() const;
   at::Tensor& unsqueeze_(int64_t dim) const;
-  at::Tensor& unsqueeze_(at::IntArrayRef dim) const;
 
   at::Tensor sum(::std::optional<at::ScalarType> dtype = ::std::nullopt) const;
   at::Tensor sum(at::OptionalIntArrayRef dim,
@@ -584,19 +563,20 @@ class Tensor : public TensorBase {
   std::vector<at::Tensor> split_symint(c10::SymIntArrayRef split_sizes,
                                        int64_t dim) const;
 
-  std::vector<at::Tensor> unsafe_split(int64_t split_size, int64_t dim) const;
+  std::vector<at::Tensor> unsafe_split(int64_t split_size,
+                                       int64_t dim = 0) const;
   std::vector<at::Tensor> unsafe_split_symint(c10::SymInt split_size,
-                                              int64_t dim) const;
+                                              int64_t dim = 0) const;
 
   std::vector<at::Tensor> split_with_sizes(at::IntArrayRef split_sizes,
-                                           int64_t dim) const;
+                                           int64_t dim = 0) const;
   std::vector<at::Tensor> split_with_sizes_symint(
-      c10::SymIntArrayRef split_sizes, int64_t dim) const;
+      c10::SymIntArrayRef split_sizes, int64_t dim = 0) const;
 
   std::vector<at::Tensor> unsafe_split_with_sizes(at::IntArrayRef split_sizes,
-                                                  int64_t dim) const;
+                                                  int64_t dim = 0) const;
   std::vector<at::Tensor> unsafe_split_with_sizes_symint(
-      c10::SymIntArrayRef split_sizes, int64_t dim) const;
+      c10::SymIntArrayRef split_sizes, int64_t dim = 0) const;
 
   std::vector<at::Tensor> hsplit(int64_t sections) const;
   std::vector<at::Tensor> hsplit(at::IntArrayRef indices) const;
@@ -615,13 +595,21 @@ class Tensor : public TensorBase {
   at::Tensor slice(int64_t dim = 0,
                    ::std::optional<int64_t> start = ::std::nullopt,
                    ::std::optional<int64_t> end = ::std::nullopt,
-                   int64_t step = 1);
+                   int64_t step = 1) const;
 
   at::Tensor index(ArrayRef<at::indexing::TensorIndex> indices) const;
   inline at::Tensor index(
       std::initializer_list<at::indexing::TensorIndex> indices) const {
     return index(ArrayRef<at::indexing::TensorIndex>(indices));
   }
+  Tensor& index_put_(ArrayRef<at::indexing::TensorIndex> indices,
+                     Tensor const& rhs);
+  Tensor& index_put_(ArrayRef<at::indexing::TensorIndex> indices,
+                     const Scalar& v);
+  Tensor& index_put_(std::initializer_list<at::indexing::TensorIndex> indices,
+                     Tensor const& rhs);
+  Tensor& index_put_(std::initializer_list<at::indexing::TensorIndex> indices,
+                     const Scalar& v);
 
   at::Tensor& floor_divide_(const at::Scalar& other) const {
     paddle::experimental::floor_divide_(
@@ -721,9 +709,6 @@ class Tensor : public TensorBase {
   }
 
   void record_stream(at::Stream s) const;
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-  void record_stream(at::cuda::CUDAStream s) const;
-#endif
 
   Tensor var(int dim) const { return var(at::IntArrayRef{dim}, true, false); }
 

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -38,6 +38,7 @@
 
 #include <limits>
 #include <optional>
+#include <type_traits>
 #include <utility>
 #include <vector>
 #include "paddle/common/ddim.h"
@@ -124,7 +125,7 @@ class Tensor : public TensorBase {
   }
 
   template <typename T>
-  void* data() const {
+  T* data() const {
     return data_ptr<T>();
   }
 
@@ -643,7 +644,9 @@ class Tensor : public TensorBase {
     return static_cast<int64_t>(SizeOf(tensor_.dtype()));
   }
 
-  inline Tensor clone() const {
+  inline Tensor clone(
+      ::std::optional<at::MemoryFormat> memory_format = ::std::nullopt) const {
+    (void)memory_format;
     PaddleTensor cloned_tensor = paddle::experimental::assign(tensor_);
     return Tensor(cloned_tensor);
   }
@@ -715,14 +718,14 @@ class Tensor : public TensorBase {
 
   Tensor var(int dim) const { return var(at::IntArrayRef{dim}, true, false); }
 
-  Tensor var(bool unbiased = true) const {
+  Tensor var(bool unbiased) const {
     std::vector<int64_t> empty_dims;
     double correction = unbiased ? 1.0 : 0.0;
     return var_impl(empty_dims, correction, false);
   }
 
   Tensor var(at::OptionalIntArrayRef dim,
-             bool unbiased = true,
+             bool unbiased,
              bool keepdim = false) const {
     // Convert unbiased to correction: unbiased=True means correction=1
     double correction = unbiased ? 1.0 : 0.0;
@@ -733,8 +736,8 @@ class Tensor : public TensorBase {
     return var_impl(dims_vec, correction, keepdim);
   }
 
-  Tensor var(at::OptionalIntArrayRef dim,
-             const ::std::optional<at::Scalar>& correction,
+  Tensor var(at::OptionalIntArrayRef dim = ::std::nullopt,
+             const ::std::optional<at::Scalar>& correction = ::std::nullopt,
              bool keepdim = false) const {
     double correction_value = 1.0;
     if (correction.has_value()) {
@@ -838,10 +841,26 @@ class Tensor : public TensorBase {
                                                                  index_t>
   packed_accessor() && = delete;
 
+  template <typename T>
+  using hook_return_void_t =
+      std::enable_if_t<std::is_void_v<std::invoke_result_t<T&, Tensor>>,
+                       unsigned>;
+  template <typename T>
+  using hook_return_var_t =
+      std::enable_if_t<std::is_same_v<std::invoke_result_t<T&, Tensor>, Tensor>,
+                       unsigned>;
+
   // register_hook - throws exception for Paddle compatibility
   // Paddle does not support gradient hooks
   template <typename T>
-  unsigned register_hook(T&&) const {
+  hook_return_void_t<T> register_hook(T&&) const {
+    throw std::runtime_error(
+        "register_hook is not supported in Paddle, this is an ATen "
+        "compatibility API that is not available");
+  }
+
+  template <typename T>
+  hook_return_var_t<T> register_hook(T&&) const {
     throw std::runtime_error(
         "register_hook is not supported in Paddle, this is an ATen "
         "compatibility API that is not available");

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -54,6 +54,8 @@ using MemoryFormat = c10::MemoryFormat;
 using IntArrayRef = c10::IntArrayRef;
 using OptionalIntArrayRef = c10::OptionalIntArrayRef;
 using ScalarType = c10::ScalarType;
+using TensorList = c10::ArrayRef<Tensor>;
+using ITensorListRef = c10::ArrayRef<Tensor>;
 }  // namespace at
 
 namespace at {  // NOLINT(build/namespaces)
@@ -288,6 +290,7 @@ class Tensor : public TensorBase {
   Tensor std(at::OptionalIntArrayRef dim = ::std::nullopt,
              const ::std::optional<at::Scalar>& correction = ::std::nullopt,
              bool keepdim = false) const;
+  Tensor std(int dim) const { return std(at::IntArrayRef{dim}); }
 
   Tensor tensor_data() const {
     PaddleTensor result;

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -169,13 +169,8 @@ class Tensor : public TensorBase {
     return const_cast<void*>(tensor_.data());
   }
 
-  template <typename T, std::enable_if_t<!std::is_const_v<T>, int> = 0>
+  template <typename T>
   const T* const_data_ptr() const {
-    return TensorBase::const_data_ptr<T>();
-  }
-
-  template <typename T, std::enable_if_t<std::is_const_v<T>, int> = 0>
-  const std::remove_const_t<T>* const_data_ptr() const {
     return TensorBase::const_data_ptr<T>();
   }
 

--- a/paddle/phi/api/include/compat/ATen/core/TensorBody.h
+++ b/paddle/phi/api/include/compat/ATen/core/TensorBody.h
@@ -118,12 +118,6 @@ class Tensor : public TensorBase {
     return *this;
   }
 
-  void* data_ptr() const { return const_cast<void*>(tensor_.data()); }
-  template <typename T>
-  T* data_ptr() const {
-    return const_cast<T*>(tensor_.data<T>());
-  }
-
   template <typename T>
   T* data() const {
     return data_ptr<T>();
@@ -165,33 +159,9 @@ class Tensor : public TensorBase {
 #endif
   }
 
-  const void* const_data_ptr() const {
-    return const_cast<void*>(tensor_.data());
-  }
-
-  template <typename T>
-  const T* const_data_ptr() const {
-    return TensorBase::const_data_ptr<T>();
-  }
-
-  void* mutable_data_ptr() const { return const_cast<void*>(tensor_.data()); }
-
-  template <typename T>
-  T* mutable_data_ptr() const {
-    return TensorBase::mutable_data_ptr<T>();
-  }
-
   using TensorBase::stride;
 
-  c10::IntArrayRef strides() const {
-    return compat::_PD_PhiDDimToIntArrayRef(tensor_.strides());
-  }
-
   using TensorBase::size;
-
-  c10::IntArrayRef sizes() const {
-    return compat::_PD_PhiDDimToIntArrayRef(tensor_.dims());
-  }
 
   at::Tensor to(
       at::TensorOptions options = {},
@@ -346,39 +316,12 @@ class Tensor : public TensorBase {
         tensor_, compat::_PD_AtenScalarTypeToPhiDataType(t)));
   }
 
-  int64_t numel() const { return tensor_.numel(); }
-
-  caffe2::TypeMeta dtype() const {
-    return caffe2::TypeMeta::fromScalarType(
-        compat::_PD_PhiDataTypeToAtenScalarType(tensor_.dtype()));
-  }
-
-  c10::Device device() const { return c10::Device(tensor_.place()); }
-  c10::DeviceIndex get_device() const {
-    return c10::Device(tensor_.place()).index();
-  }
-
-  int64_t dim() const { return tensor_.dims().size(); }
-  int64_t ndimension() const { return dim(); }
-
   at::Tensor contiguous(
       c10::MemoryFormat memory_format = c10::MemoryFormat::Contiguous) const {
     PD_CHECK(memory_format == c10::MemoryFormat::Contiguous,
              "`MemoryFormat` other than Contiguous");
 
     return tensor_.contiguous();
-  }
-
-  bool is_contiguous(
-      at::MemoryFormat memory_format = at::MemoryFormat::Contiguous) const {
-    PD_CHECK(memory_format == c10::MemoryFormat::Contiguous,
-             "`MemoryFormat` other than Contiguous");
-
-    return tensor_.is_contiguous();
-  }
-
-  c10::ScalarType scalar_type() const {
-    return compat::_PD_PhiDataTypeToAtenScalarType(tensor_.dtype());
   }
 
   at::Tensor flatten(int64_t start_dim = 0, int64_t end_dim = -1) const;
@@ -394,9 +337,6 @@ class Tensor : public TensorBase {
     paddle::experimental::fill_(const_cast<PaddleTensor&>(tensor_), 0.0);
     return const_cast<at::Tensor&>(*this);
   }
-
-  bool is_cpu() const { return phi::is_cpu_place(tensor_.place()); }
-  bool is_cuda() const { return phi::is_gpu_place(tensor_.place()); }
 
   bool is_pinned(::std::optional<c10::Device> device = ::std::nullopt) const {
     if (device.has_value()) {
@@ -620,24 +560,6 @@ class Tensor : public TensorBase {
   // Paddle Tensor has no storage_offset, so we add it here, and it is always
   // 0.
   //   int64_t storage_offset() const { return storage_offset_; }
-
-  inline size_t nbytes() const {
-    PD_CHECK(
-        ((tensor_.layout() != common::DataLayout::SPARSE_COO) &&
-         (tensor_.layout() != common::DataLayout::SPARSE_CSR)),
-        "nbytes is not defined for sparse tensors.  If you want the size of "
-        "the constituent "
-        "tensors, add the nbytes of the indices and values.  If you want the "
-        "size of the  "
-        "equivalent dense tensor, multiply numel() by element_size()");
-    return tensor_.numel() * SizeOf(tensor_.dtype());
-  }
-
-  size_t itemsize() const { return SizeOf(tensor_.dtype()); }
-
-  int64_t element_size() const {
-    return static_cast<int64_t>(SizeOf(tensor_.dtype()));
-  }
 
   inline Tensor clone(
       ::std::optional<at::MemoryFormat> memory_format = ::std::nullopt) const {

--- a/paddle/phi/api/include/compat/ATen/ops/as_strided.h
+++ b/paddle/phi/api/include/compat/ATen/ops/as_strided.h
@@ -107,7 +107,7 @@ inline at::Tensor Tensor::as_strided_scatter(
   at::Tensor strided_view =
       copy_tensor.as_strided(size, stride, storage_offset);
   strided_view.copy_(src);
-  return strided_view;
+  return copy_tensor;
 }
 
 }  // namespace at

--- a/paddle/phi/api/include/compat/ATen/ops/cat.h
+++ b/paddle/phi/api/include/compat/ATen/ops/cat.h
@@ -22,9 +22,7 @@
 
 namespace at {
 
-// TODO(dev): The signature in PyTorch should be `at::Tensor cat(const
-// at::ITensorListRef & tensors, int64_t dim=0)`
-inline at::Tensor cat(const std::vector<at::Tensor>& tensors, int64_t dim = 0) {
+inline at::Tensor cat(const at::ITensorListRef& tensors, int64_t dim = 0) {
   std::vector<paddle::Tensor> pd_tensors;
   pd_tensors.reserve(tensors.size());
   for (const auto& t : tensors) {

--- a/paddle/phi/api/include/compat/ATen/ops/expand.h
+++ b/paddle/phi/api/include/compat/ATen/ops/expand.h
@@ -134,7 +134,4 @@ inline Tensor Tensor::expand(at::IntArrayRef size, bool implicit) const {
   return at::expand(*this, size, implicit);
 }
 
-// Member function: Tensor::expand_as
 }  // namespace at
-
-#include "paddle/phi/api/include/compat/ATen/ops/expand_as.h"

--- a/paddle/phi/api/include/compat/ATen/ops/expand.h
+++ b/paddle/phi/api/include/compat/ATen/ops/expand.h
@@ -125,11 +125,6 @@ inline Tensor expand(const Tensor& self,
   }
 }
 
-// expand_as - expands to same size as another tensor
-inline Tensor expand_as(const Tensor& self, const Tensor& other) {
-  return expand(self, other.sizes());
-}
-
 }  // namespace at
 
 namespace at {
@@ -140,8 +135,6 @@ inline Tensor Tensor::expand(at::IntArrayRef size, bool implicit) const {
 }
 
 // Member function: Tensor::expand_as
-inline Tensor Tensor::expand_as(const Tensor& other) const {
-  return at::expand_as(*this, other);
-}
-
 }  // namespace at
+
+#include "paddle/phi/api/include/compat/ATen/ops/expand_as.h"

--- a/paddle/phi/api/include/compat/ATen/ops/expand_as.h
+++ b/paddle/phi/api/include/compat/ATen/ops/expand_as.h
@@ -15,21 +15,12 @@
 #pragma once
 
 #include <ATen/core/Tensor.h>
+#include <ATen/ops/expand.h>
 
 namespace at {
 
-inline at::Tensor masked_select(const at::Tensor& self,
-                                const at::Tensor& mask) {
-  return Tensor(paddle::experimental::masked_select(self._PD_GetInner(),
-                                                    mask._PD_GetInner()));
-}
-
-}  // namespace at
-
-namespace at {
-
-inline at::Tensor Tensor::masked_select(const at::Tensor& mask) const {
-  return at::masked_select(*this, mask);
+inline Tensor Tensor::expand_as(const Tensor& other) const {
+  return at::expand(*this, other.sizes());
 }
 
 }  // namespace at

--- a/paddle/phi/api/include/compat/ATen/ops/flatten.h
+++ b/paddle/phi/api/include/compat/ATen/ops/flatten.h
@@ -19,8 +19,8 @@
 namespace at {
 
 inline at::Tensor flatten(const at::Tensor& self,
-                          int64_t start_dim,
-                          int64_t end_dim) {
+                          int64_t start_dim = 0,
+                          int64_t end_dim = -1) {
   return Tensor(paddle::experimental::flatten(self._PD_GetInner(),
                                               static_cast<int>(start_dim),
                                               static_cast<int>(end_dim)));

--- a/paddle/phi/api/include/compat/ATen/ops/index.h
+++ b/paddle/phi/api/include/compat/ATen/ops/index.h
@@ -16,6 +16,7 @@
 
 #include <ATen/TensorIndexing.h>
 #include <ATen/core/Tensor.h>
+#include <c10/core/List.h>
 
 namespace at::indexing {
 
@@ -27,10 +28,10 @@ inline const at::Tensor& TensorIndex::tensor() const { return *tensor_; }
 
 }  // namespace at::indexing
 
-namespace at {
+namespace at::detail {
 
-inline at::Tensor index(const at::Tensor& self,
-                        ArrayRef<at::indexing::TensorIndex> indices) {
+inline at::Tensor _PD_index_tensor_indices(
+    const at::Tensor& self, ArrayRef<at::indexing::TensorIndex> indices) {
   if (indices.size() == 0) {
     PD_THROW("index() cannot be called with an empty index list");
   }
@@ -81,10 +82,74 @@ inline at::Tensor index(const at::Tensor& self,
   return self.index(tensor_indices);
 }
 
-inline at::Tensor index(
-    const at::Tensor& self,
-    std::initializer_list<at::indexing::TensorIndex> indices) {
-  return at::index(self, ArrayRef<at::indexing::TensorIndex>(indices));
+}  // namespace at::detail
+
+namespace at {
+
+inline at::Tensor index(const at::Tensor& self,
+                        const c10::List<::std::optional<at::Tensor>>& indices) {
+  if (indices.empty()) {
+    return self;
+  }
+
+  bool all_none = true;
+  for (const auto& idx : indices) {
+    if (idx.has_value()) {
+      all_none = false;
+      break;
+    }
+  }
+  if (all_none) {
+    return self;
+  }
+
+  std::vector<paddle::Tensor> pd_indices;
+  std::vector<bool> has_index(indices.size(), false);
+  pd_indices.reserve(indices.size());
+
+  for (size_t i = 0; i < indices.size(); ++i) {
+    if (indices[i].has_value()) {
+      pd_indices.push_back(indices[i].value()._PD_GetInner());
+      has_index[i] = true;
+    } else {
+      pd_indices.push_back(paddle::Tensor());
+    }
+  }
+
+  int non_none_count = 0;
+  size_t first_non_none = 0;
+  for (size_t i = 0; i < has_index.size(); ++i) {
+    if (has_index[i]) {
+      non_none_count++;
+      first_non_none = i;
+    }
+  }
+
+  if (non_none_count == 1 && first_non_none == 0) {
+    return paddle::experimental::index_select(
+        self._PD_GetInner(), pd_indices[0], 0);
+  }
+
+  if (non_none_count == static_cast<int>(indices.size())) {
+    auto stacked_indices = paddle::experimental::stack(pd_indices, -1);
+    return paddle::experimental::gather_nd(self._PD_GetInner(),
+                                           stacked_indices);
+  }
+
+  auto self_dims = self._PD_GetInner().dims();
+  int self_rank = self_dims.size();
+  at::Tensor result = self;
+
+  for (size_t i = 0; i < indices.size() && i < static_cast<size_t>(self_rank);
+       ++i) {
+    if (has_index[i]) {
+      paddle::Tensor pd_result = result._PD_GetInner();
+      result = paddle::experimental::index_select(
+          pd_result, pd_indices[i], static_cast<int>(i));
+    }
+  }
+
+  return result;
 }
 
 }  // namespace at
@@ -93,7 +158,7 @@ namespace at {
 
 inline at::Tensor Tensor::index(
     ArrayRef<at::indexing::TensorIndex> indices) const {
-  return at::index(*this, indices);
+  return at::detail::_PD_index_tensor_indices(*this, indices);
 }
 
 }  // namespace at

--- a/paddle/phi/api/include/compat/ATen/ops/index.h
+++ b/paddle/phi/api/include/compat/ATen/ops/index.h
@@ -30,6 +30,43 @@ inline const at::Tensor& TensorIndex::tensor() const { return *tensor_; }
 
 namespace at::detail {
 
+inline bool _PD_is_full_slice(const at::indexing::Slice& slice) {
+  return static_cast<int64_t>(slice.start()) == 0 &&
+         static_cast<int64_t>(slice.stop()) == at::indexing::INDEX_MAX &&
+         static_cast<int64_t>(slice.step()) == 1;
+}
+
+inline at::Tensor _PD_apply_tensor_index(
+    const at::Tensor& self, ArrayRef<at::indexing::TensorIndex> indices) {
+  int64_t output_dim = 0;
+  int tensor_index_count = 0;
+  at::Tensor result = self;
+
+  for (const auto& index : indices) {
+    if (index.is_tensor()) {
+      ++tensor_index_count;
+      PD_CHECK(tensor_index_count == 1,
+               "Multiple tensor indices mixed with None/Slice are not "
+               "supported yet.");
+      result = paddle::experimental::index_select(
+          result._PD_GetInner(), index.tensor()._PD_GetInner(), output_dim);
+      ++output_dim;
+    } else if (index.is_none()) {
+      result =
+          paddle::experimental::unsqueeze(result._PD_GetInner(), {output_dim});
+      ++output_dim;
+    } else if (index.is_slice()) {
+      const auto& slice = index.slice();
+      PD_CHECK(_PD_is_full_slice(slice),
+               "Only full Slice() is supported when mixed with tensor/None "
+               "indices.");
+      ++output_dim;
+    }
+  }
+
+  return result;
+}
+
 inline at::Tensor _PD_index_tensor_indices(
     const at::Tensor& self, ArrayRef<at::indexing::TensorIndex> indices) {
   if (indices.size() == 0) {
@@ -69,8 +106,10 @@ inline at::Tensor _PD_index_tensor_indices(
         self._PD_GetInner(), axes, starts, ends, strides, {});
   }
 
-  PD_CHECK(!has_slice,
-           "Mixed slice and tensor/None indexing is not supported yet.");
+  if (has_slice) {
+    return _PD_apply_tensor_index(self, indices);
+  }
+
   c10::List<::std::optional<at::Tensor>> tensor_indices;
   for (const auto& index : indices) {
     if (index.is_none()) {

--- a/paddle/phi/api/include/compat/ATen/ops/index_put.h
+++ b/paddle/phi/api/include/compat/ATen/ops/index_put.h
@@ -15,15 +15,15 @@
 #pragma once
 
 #include <ATen/core/Tensor.h>
+#include <ATen/ops/index.h>
 #include <c10/core/List.h>
 #include <c10/core/Scalar.h>
 
 #include "paddle/phi/api/include/api.h"
 
-namespace at {
+namespace at::detail {
 
-// Helper function to convert c10::List<optional<Tensor>> to vector<Tensor>
-inline std::vector<at::Tensor> convert_indices_list(
+inline std::vector<at::Tensor> _PD_convert_indices_list(
     const c10::List<::std::optional<at::Tensor>>& indices) {
   std::vector<at::Tensor> result;
   result.reserve(indices.size());
@@ -35,95 +35,33 @@ inline std::vector<at::Tensor> convert_indices_list(
   return result;
 }
 
-// index: Get values at specified indices
-inline at::Tensor index(const at::Tensor& self,
-                        const c10::List<::std::optional<at::Tensor>>& indices) {
-  // Handle empty indices - return self
-  if (indices.empty()) {
-    return self;
-  }
-
-  // Check if all indices are None (select all)
-  bool all_none = true;
-  for (const auto& idx : indices) {
-    if (idx.has_value()) {
-      all_none = false;
-      break;
+inline c10::List<::std::optional<at::Tensor>> _PD_convert_tensor_index_list(
+    ArrayRef<at::indexing::TensorIndex> indices) {
+  c10::List<::std::optional<at::Tensor>> result;
+  for (const auto& index : indices) {
+    PD_CHECK(!index.is_ellipsis(), "Ellipsis index is not supported yet.");
+    PD_CHECK(!index.is_integer(), "Integer index is not supported yet.");
+    PD_CHECK(!index.is_boolean(), "Boolean index is not supported yet.");
+    PD_CHECK(!index.is_slice(), "Slice index is not supported yet.");
+    if (index.is_none()) {
+      result.push_back(::std::nullopt);
+    } else if (index.is_tensor()) {
+      result.push_back(index.tensor());
     }
   }
-  if (all_none) {
-    return self;
-  }
-
-  // Build vector of indices while tracking which dimensions have None
-  std::vector<paddle::Tensor> pd_indices;
-  std::vector<bool> has_index(indices.size(), false);
-  pd_indices.reserve(indices.size());
-
-  for (size_t i = 0; i < indices.size(); ++i) {
-    if (indices[i].has_value()) {
-      pd_indices.push_back(indices[i].value()._PD_GetInner());
-      has_index[i] = true;
-    } else {
-      // None - will be handled as "select all"
-      pd_indices.push_back(paddle::Tensor());
-      has_index[i] = false;
-    }
-  }
-
-  // If only one non-None index at position 0, use index_select
-  int non_none_count = 0;
-  size_t first_non_none = 0;
-  for (size_t i = 0; i < has_index.size(); ++i) {
-    if (has_index[i]) {
-      non_none_count++;
-      first_non_none = i;
-    }
-  }
-
-  // Simple case: single index tensor
-  if (non_none_count == 1 && first_non_none == 0) {
-    return paddle::experimental::index_select(
-        self._PD_GetInner(), pd_indices[0], 0);
-  }
-
-  // Case: All indices are tensors (no None) - use gather_nd
-  if (non_none_count == static_cast<int>(indices.size())) {
-    auto stacked_indices = paddle::experimental::stack(pd_indices, -1);
-    return paddle::experimental::gather_nd(self._PD_GetInner(),
-                                           stacked_indices);
-  }
-
-  // Mixed case: some indices are None (select all) and some are tensors
-  // Handle by using a combination of operations
-  auto self_dims = self._PD_GetInner().dims();
-  int self_rank = self_dims.size();
-
-  // Build result by iterating over dimensions
-  // For dimensions with None, we select all; for dimensions with tensor, we use
-  // the index
-  at::Tensor result = self;
-
-  for (size_t i = 0; i < indices.size() && i < static_cast<size_t>(self_rank);
-       ++i) {
-    if (has_index[i]) {
-      // Use the index tensor for this dimension
-      paddle::Tensor pd_result = result._PD_GetInner();
-      result = paddle::experimental::index_select(
-          pd_result, pd_indices[i], static_cast<int>(i));
-    }
-    // If None, we select all along this dimension (do nothing)
-  }
-
   return result;
 }
+
+}  // namespace at::detail
+
+namespace at {
 
 // index_put_: Set values at specified indices (in-place)
 inline at::Tensor& index_put_(
     at::Tensor& self,  // NOLINT(runtime/references)
     const c10::List<::std::optional<at::Tensor>>& indices,
     const at::Tensor& values,
-    bool accumulate) {
+    bool accumulate = false) {
   std::vector<paddle::Tensor> pd_indices;
   pd_indices.reserve(indices.size());
   for (const auto& idx : indices) {
@@ -137,34 +75,12 @@ inline at::Tensor& index_put_(
   return self;
 }
 
-// index_put_: Set scalar value at specified indices (in-place)
-inline at::Tensor& index_put_(
-    at::Tensor& self,  // NOLINT(runtime/references)
-    const c10::List<::std::optional<at::Tensor>>& indices,
-    const at::Scalar& v,
-    bool accumulate) {
-  std::vector<paddle::Tensor> pd_indices;
-  pd_indices.reserve(indices.size());
-  for (const auto& idx : indices) {
-    if (idx.has_value()) {
-      pd_indices.push_back(idx.value()._PD_GetInner());
-    }
-  }
-
-  auto scalar_tensor = paddle::experimental::full(
-      {}, phi::Scalar(v.to<double>()), self._PD_GetInner().dtype());
-
-  paddle::experimental::index_put_(
-      self._PD_GetInner(), pd_indices, scalar_tensor, accumulate);
-  return self;
-}
-
 // index_put: Non-inplace version
 inline at::Tensor index_put(
     const at::Tensor& self,
     const c10::List<::std::optional<at::Tensor>>& indices,
     const at::Tensor& values,
-    bool accumulate) {
+    bool accumulate = false) {
   std::vector<paddle::Tensor> pd_indices;
   pd_indices.reserve(indices.size());
   for (const auto& idx : indices) {
@@ -195,10 +111,26 @@ inline at::Tensor& Tensor::index_put_(
 }
 
 inline at::Tensor& Tensor::index_put_(
-    const c10::List<::std::optional<at::Tensor>>& indices,
-    const at::Scalar& v,
-    bool accumulate) const {
-  return at::index_put_(const_cast<at::Tensor&>(*this), indices, v, accumulate);
+    ArrayRef<at::indexing::TensorIndex> indices, Tensor const& rhs) {
+  return index_put_(detail::_PD_convert_tensor_index_list(indices), rhs);
+}
+
+inline at::Tensor& Tensor::index_put_(
+    ArrayRef<at::indexing::TensorIndex> indices, const Scalar& v) {
+  auto scalar_tensor = at::Tensor(paddle::experimental::full(
+      {}, phi::Scalar(v.to<double>()), this->_PD_GetInner().dtype()));
+  return index_put_(indices, scalar_tensor);
+}
+
+inline at::Tensor& Tensor::index_put_(
+    std::initializer_list<at::indexing::TensorIndex> indices,
+    Tensor const& rhs) {
+  return index_put_(ArrayRef<at::indexing::TensorIndex>(indices), rhs);
+}
+
+inline at::Tensor& Tensor::index_put_(
+    std::initializer_list<at::indexing::TensorIndex> indices, const Scalar& v) {
+  return index_put_(ArrayRef<at::indexing::TensorIndex>(indices), v);
 }
 
 inline at::Tensor Tensor::index_put(

--- a/paddle/phi/api/include/compat/ATen/ops/index_put.h
+++ b/paddle/phi/api/include/compat/ATen/ops/index_put.h
@@ -18,6 +18,7 @@
 #include <ATen/ops/index.h>
 #include <c10/core/List.h>
 #include <c10/core/Scalar.h>
+#include <vector>
 
 #include "paddle/phi/api/include/api.h"
 
@@ -42,14 +43,60 @@ inline c10::List<::std::optional<at::Tensor>> _PD_convert_tensor_index_list(
     PD_CHECK(!index.is_ellipsis(), "Ellipsis index is not supported yet.");
     PD_CHECK(!index.is_integer(), "Integer index is not supported yet.");
     PD_CHECK(!index.is_boolean(), "Boolean index is not supported yet.");
-    PD_CHECK(!index.is_slice(), "Slice index is not supported yet.");
-    if (index.is_none()) {
-      result.push_back(::std::nullopt);
+    if (index.is_slice()) {
+      PD_CHECK(_PD_is_full_slice(index.slice()),
+               "Only full Slice() is supported in index_put_ TensorIndex "
+               "paths.");
     } else if (index.is_tensor()) {
       result.push_back(index.tensor());
     }
   }
   return result;
+}
+
+inline at::Tensor _PD_squeeze_newaxis_value(
+    const at::Tensor& values, ArrayRef<at::indexing::TensorIndex> indices) {
+  std::vector<int64_t> value_shape(values.sizes().begin(),
+                                   values.sizes().end());
+  size_t value_dim = 0;
+  bool changed = false;
+
+  for (const auto& index : indices) {
+    if (index.is_none()) {
+      if (!value_shape.empty()) {
+        PD_CHECK(value_dim < value_shape.size(),
+                 "index_put_ value rank is too small for None index.");
+        PD_CHECK(value_shape[value_dim] == 1,
+                 "index_put_ expected value dimension inserted by None to "
+                 "have size 1, but got ",
+                 value_shape[value_dim],
+                 ".");
+        value_shape.erase(value_shape.begin() + value_dim);
+        changed = true;
+      }
+    } else if (index.is_tensor()) {
+      if (!value_shape.empty()) {
+        ++value_dim;
+      }
+    } else if (index.is_slice()) {
+      PD_CHECK(_PD_is_full_slice(index.slice()),
+               "Only full Slice() is supported in index_put_ TensorIndex "
+               "paths.");
+      if (!value_shape.empty()) {
+        ++value_dim;
+      }
+    } else {
+      PD_CHECK(!index.is_ellipsis(), "Ellipsis index is not supported yet.");
+      PD_CHECK(!index.is_integer(), "Integer index is not supported yet.");
+      PD_CHECK(!index.is_boolean(), "Boolean index is not supported yet.");
+    }
+  }
+
+  if (!changed) {
+    return values;
+  }
+  return paddle::experimental::reshape(values._PD_GetInner(),
+                                       phi::IntArray(value_shape));
 }
 
 }  // namespace at::detail
@@ -112,11 +159,26 @@ inline at::Tensor& Tensor::index_put_(
 
 inline at::Tensor& Tensor::index_put_(
     ArrayRef<at::indexing::TensorIndex> indices, Tensor const& rhs) {
-  return index_put_(detail::_PD_convert_tensor_index_list(indices), rhs);
+  auto tensor_indices = detail::_PD_convert_tensor_index_list(indices);
+  at::Tensor values = detail::_PD_squeeze_newaxis_value(rhs, indices);
+  if (tensor_indices.empty()) {
+    return copy_(values);
+  }
+  return index_put_(tensor_indices, values);
 }
 
 inline at::Tensor& Tensor::index_put_(
     ArrayRef<at::indexing::TensorIndex> indices, const Scalar& v) {
+  auto tensor_indices = detail::_PD_convert_tensor_index_list(indices);
+  if (tensor_indices.empty()) {
+    std::vector<int64_t> value_shape(this->sizes().begin(),
+                                     this->sizes().end());
+    auto scalar_tensor =
+        at::Tensor(paddle::experimental::full(phi::IntArray(value_shape),
+                                              phi::Scalar(v.to<double>()),
+                                              this->_PD_GetInner().dtype()));
+    return copy_(scalar_tensor);
+  }
   auto scalar_tensor = at::Tensor(paddle::experimental::full(
       {}, phi::Scalar(v.to<double>()), this->_PD_GetInner().dtype()));
   return index_put_(indices, scalar_tensor);

--- a/paddle/phi/api/include/compat/ATen/ops/record_stream.h
+++ b/paddle/phi/api/include/compat/ATen/ops/record_stream.h
@@ -49,9 +49,4 @@ inline void Tensor::record_stream(at::Stream s) const {
 #endif
 }
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-inline void Tensor::record_stream(at::cuda::CUDAStream s) const {
-  record_stream(static_cast<at::Stream>(s));
-}
-#endif
 }  // namespace at

--- a/paddle/phi/api/include/compat/ATen/ops/rename.h
+++ b/paddle/phi/api/include/compat/ATen/ops/rename.h
@@ -18,15 +18,6 @@
 
 namespace at {
 
-// rename - stub implementation for Paddle (Dimname not supported)
-inline Tensor rename(const Tensor& self, ::std::optional<at::DimnameList>) {
-  return self;
-}
-
-}  // namespace at
-
-namespace at {
-
 // Member function: Tensor::rename
 inline Tensor Tensor::rename(::std::optional<at::DimnameList>) const {
   return *this;

--- a/paddle/phi/api/include/compat/ATen/ops/slice.h
+++ b/paddle/phi/api/include/compat/ATen/ops/slice.h
@@ -44,7 +44,7 @@ namespace at {
 inline at::Tensor Tensor::slice(int64_t dim,
                                 ::std::optional<int64_t> start,
                                 ::std::optional<int64_t> end,
-                                int64_t step) {
+                                int64_t step) const {
   return at::slice(*this, dim, start, end, step);
 }
 

--- a/paddle/phi/api/include/compat/ATen/ops/sparse_coo_tensor.h
+++ b/paddle/phi/api/include/compat/ATen/ops/sparse_coo_tensor.h
@@ -18,15 +18,18 @@
 #include <c10/core/TensorOptions.h>
 #include <utils/pinned_place.h>
 #include <algorithm>
+#include <memory>
 #include <optional>
 
 #include "paddle/phi/api/include/api.h"
 #include "paddle/phi/api/include/sparse_api.h"
 #include "paddle/phi/common/place.h"
+#include "paddle/phi/core/sparse_coo_tensor.h"
 
-namespace at {
+namespace at::detail {
 
-inline std::vector<int64_t> infer_sparse_coo_size(const at::Tensor& indices) {
+inline std::vector<int64_t> _PD_infer_sparse_coo_size(
+    const at::Tensor& indices) {
   auto host_indices = indices.cpu().to(at::kLong);
   int64_t sparse_dim = host_indices.dim() > 0 ? host_indices.size(0) : 0;
   int64_t nnz = host_indices.dim() > 1 ? host_indices.size(1) : 0;
@@ -42,10 +45,28 @@ inline std::vector<int64_t> infer_sparse_coo_size(const at::Tensor& indices) {
   return inferred_size;
 }
 
-inline at::Tensor sparse_coo_tensor(const at::Tensor& indices,
-                                    const at::Tensor& values,
-                                    at::IntArrayRef size,
-                                    at::TensorOptions options = {}) {
+inline void _PD_set_sparse_coo_coalesced(at::Tensor* tensor,
+                                         ::std::optional<bool> is_coalesced) {
+  if (!is_coalesced.has_value()) {
+    return;
+  }
+  auto sparse_tensor = std::dynamic_pointer_cast<phi::SparseCooTensor>(
+      tensor->_PD_GetInner().impl());
+  PD_CHECK(sparse_tensor,
+           "Expected SparseCooTensor result from sparse_coo_tensor.");
+  sparse_tensor->SetCoalesced(is_coalesced.value());
+}
+
+}  // namespace at::detail
+
+namespace at {
+
+inline at::Tensor sparse_coo_tensor(
+    const at::Tensor& indices,
+    const at::Tensor& values,
+    at::IntArrayRef size,
+    at::TensorOptions options = {},
+    ::std::optional<bool> is_coalesced = ::std::nullopt) {
   paddle::Tensor idx = indices._PD_GetInner();
   paddle::Tensor vals = values._PD_GetInner();
 
@@ -62,8 +83,10 @@ inline at::Tensor sparse_coo_tensor(const at::Tensor& indices,
 
   // PyTorch: sparse_coo_tensor(indices, values, size)
   // Paddle:  sparse_coo_tensor(values, indices, shape)
-  return paddle::experimental::sparse::sparse_coo_tensor(
+  at::Tensor result = paddle::experimental::sparse::sparse_coo_tensor(
       vals, idx, std::vector<int64_t>(size.begin(), size.end()));
+  detail::_PD_set_sparse_coo_coalesced(&result, is_coalesced);
+  return result;
 }
 
 inline at::Tensor sparse_coo_tensor(const at::Tensor& indices,
@@ -72,19 +95,25 @@ inline at::Tensor sparse_coo_tensor(const at::Tensor& indices,
                                     ::std::optional<at::ScalarType> dtype,
                                     ::std::optional<at::Layout> layout,
                                     ::std::optional<at::Device> device,
-                                    ::std::optional<bool> pin_memory) {
+                                    ::std::optional<bool> pin_memory,
+                                    ::std::optional<bool> is_coalesced) {
   PD_CHECK(!layout.has_value() || layout.value() == c10::kSparse,
            "`layout` must be Sparse for sparse_coo_tensor.");
   auto options =
       at::TensorOptions().dtype(dtype).device(device).pinned_memory(pin_memory);
-  return sparse_coo_tensor(indices, values, size, options);
+  return sparse_coo_tensor(indices, values, size, options, is_coalesced);
 }
 
-inline at::Tensor sparse_coo_tensor(const at::Tensor& indices,
-                                    const at::Tensor& values,
-                                    at::TensorOptions options = {}) {
-  return sparse_coo_tensor(
-      indices, values, infer_sparse_coo_size(indices), options);
+inline at::Tensor sparse_coo_tensor(
+    const at::Tensor& indices,
+    const at::Tensor& values,
+    at::TensorOptions options = {},
+    ::std::optional<bool> is_coalesced = ::std::nullopt) {
+  return sparse_coo_tensor(indices,
+                           values,
+                           detail::_PD_infer_sparse_coo_size(indices),
+                           options,
+                           is_coalesced);
 }
 
 }  // namespace at

--- a/paddle/phi/api/include/compat/ATen/ops/sparse_csr_tensor.h
+++ b/paddle/phi/api/include/compat/ATen/ops/sparse_csr_tensor.h
@@ -31,7 +31,7 @@ inline at::Tensor sparse_csr_tensor(const at::Tensor& crow_indices,
                                     const at::Tensor& col_indices,
                                     const at::Tensor& values,
                                     at::IntArrayRef size,
-                                    at::TensorOptions options = {}) {
+                                    at::TensorOptions options) {
   paddle::Tensor crows = crow_indices._PD_GetInner();
   paddle::Tensor cols = col_indices._PD_GetInner();
   paddle::Tensor vals = values._PD_GetInner();
@@ -92,7 +92,7 @@ inline at::Tensor sparse_csr_tensor(const at::Tensor& crow_indices,
 inline at::Tensor sparse_csr_tensor(const at::Tensor& crow_indices,
                                     const at::Tensor& col_indices,
                                     const at::Tensor& values,
-                                    at::TensorOptions options = {}) {
+                                    at::TensorOptions options) {
   // Infer size from crow_indices and col_indices:
   //   nrows = crow_indices.size(0) - 1
   //   ncols = max(col_indices) + 1

--- a/paddle/phi/api/include/compat/ATen/ops/split_with_sizes.h
+++ b/paddle/phi/api/include/compat/ATen/ops/split_with_sizes.h
@@ -21,12 +21,12 @@ namespace at {
 
 inline std::vector<at::Tensor> split_with_sizes(const at::Tensor& self,
                                                 at::IntArrayRef split_sizes,
-                                                int64_t dim) {
+                                                int64_t dim = 0) {
   return at::split(self, split_sizes, dim);
 }
 
 inline std::vector<at::Tensor> split_with_sizes_symint(
-    const at::Tensor& self, c10::SymIntArrayRef split_sizes, int64_t dim) {
+    const at::Tensor& self, c10::SymIntArrayRef split_sizes, int64_t dim = 0) {
   return at::split_symint(self, split_sizes, dim);
 }
 

--- a/paddle/phi/api/include/compat/ATen/ops/std.h
+++ b/paddle/phi/api/include/compat/ATen/ops/std.h
@@ -25,13 +25,13 @@
 #include "paddle/phi/common/int_array.h"
 #include "paddle/phi/common/scalar.h"
 
-namespace at {
+namespace at::detail {
 
 // Internal implementation for std (standard deviation = sqrt(variance))
-inline Tensor std_impl(const Tensor& self,
-                       const std::vector<int64_t>& dims_vec,
-                       double correction_value,
-                       bool keepdim) {
+inline Tensor _PD_std_impl(const Tensor& self,
+                           const std::vector<int64_t>& dims_vec,
+                           double correction_value,
+                           bool keepdim) {
   // Validate dimensions before processing
   int64_t ndim = self.dim();
   for (int64_t d : dims_vec) {
@@ -107,19 +107,14 @@ inline Tensor std_impl(const Tensor& self,
   return Tensor(result);
 }
 
-}  // namespace at
+}  // namespace at::detail
 
 namespace at {
-
-inline Tensor Tensor::std(int dim) const {
-  // Call the OptionalIntArrayRef version
-  return std(at::OptionalIntArrayRef(dim), true, false);
-}
 
 inline Tensor Tensor::std(bool unbiased) const {
   std::vector<int64_t> empty_dims;
   double correction = unbiased ? 1.0 : 0.0;
-  return std_impl(*this, empty_dims, correction, false);
+  return detail::_PD_std_impl(*this, empty_dims, correction, false);
 }
 
 inline Tensor Tensor::std(at::OptionalIntArrayRef dim,
@@ -130,7 +125,7 @@ inline Tensor Tensor::std(at::OptionalIntArrayRef dim,
   if (dim.has_value() && dim.value().size() > 0) {
     dims_vec.assign(dim.value().begin(), dim.value().end());
   }
-  return std_impl(*this, dims_vec, correction, keepdim);
+  return detail::_PD_std_impl(*this, dims_vec, correction, keepdim);
 }
 
 inline Tensor Tensor::std(at::OptionalIntArrayRef dim,
@@ -145,7 +140,7 @@ inline Tensor Tensor::std(at::OptionalIntArrayRef dim,
   if (dim.has_value() && dim.value().size() > 0) {
     dims_vec.assign(dim.value().begin(), dim.value().end());
   }
-  return std_impl(*this, dims_vec, correction_value, keepdim);
+  return detail::_PD_std_impl(*this, dims_vec, correction_value, keepdim);
 }
 
 }  // namespace at

--- a/paddle/phi/api/include/compat/ATen/ops/transpose.h
+++ b/paddle/phi/api/include/compat/ATen/ops/transpose.h
@@ -24,10 +24,10 @@
 namespace at {
 
 inline at::Tensor transpose(const at::Tensor& self,
-                            const at::Scalar& dim0,
-                            const at::Scalar& dim1) {
-  int d0 = dim0.to<int>();
-  int d1 = dim1.to<int>();
+                            int64_t dim0,
+                            int64_t dim1) {
+  int d0 = static_cast<int>(dim0);
+  int d1 = static_cast<int>(dim1);
   int64_t ndim = self.dim();
 
   if (d0 < 0) d0 += ndim;
@@ -42,20 +42,6 @@ inline at::Tensor transpose(const at::Tensor& self,
   }
   std::swap(perm[d0], perm[d1]);
 
-  return paddle::experimental::transpose(self._PD_GetInner(), perm);
-}
-
-inline at::Tensor transpose(const at::Tensor& self,
-                            int64_t dim0,
-                            int64_t dim1) {
-  int64_t ndim = self.dim();
-  if (dim0 < 0) dim0 += ndim;
-  if (dim1 < 0) dim1 += ndim;
-  std::vector<int> perm(self.dim());
-  for (size_t i = 0; i < perm.size(); i++) {
-    perm[i] = static_cast<int>(i);
-  }
-  std::swap(perm[dim0], perm[dim1]);
   return paddle::experimental::transpose(self._PD_GetInner(), perm);
 }
 

--- a/paddle/phi/api/include/compat/ATen/ops/transpose.h
+++ b/paddle/phi/api/include/compat/ATen/ops/transpose.h
@@ -16,31 +16,53 @@
 
 #include <ATen/core/Tensor.h>
 #include <c10/core/TensorOptions.h>
+#include <limits>
 #include <optional>
 #include <string_view>
+#include <vector>
 
 #include "paddle/phi/api/include/api.h"
+
+namespace at::detail {
+
+inline int _PD_normalize_transpose_dim(int64_t dim,
+                                       int64_t ndim,
+                                       const char* name) {
+  int64_t normalized = dim;
+  if (normalized < 0) {
+    normalized += ndim;
+  }
+
+  PD_CHECK(normalized >= 0 && normalized < ndim, name, " out of range");
+  PD_CHECK(normalized <= static_cast<int64_t>(std::numeric_limits<int>::max()),
+           name,
+           " out of int range");
+  return static_cast<int>(normalized);
+}
+
+inline std::vector<int> _PD_make_transpose_perm(int64_t ndim, int d0, int d1) {
+  PD_CHECK(ndim <= static_cast<int64_t>(std::numeric_limits<int>::max()),
+           "tensor rank out of int range");
+
+  std::vector<int> perm(static_cast<size_t>(ndim));
+  for (int64_t i = 0; i < ndim; ++i) {
+    perm[static_cast<size_t>(i)] = static_cast<int>(i);
+  }
+  std::swap(perm[d0], perm[d1]);
+  return perm;
+}
+
+}  // namespace at::detail
 
 namespace at {
 
 inline at::Tensor transpose(const at::Tensor& self,
                             int64_t dim0,
                             int64_t dim1) {
-  int d0 = static_cast<int>(dim0);
-  int d1 = static_cast<int>(dim1);
   int64_t ndim = self.dim();
-
-  if (d0 < 0) d0 += ndim;
-  if (d1 < 0) d1 += ndim;
-
-  PD_CHECK(d0 >= 0 && d0 < ndim, "dim0 out of range");
-  PD_CHECK(d1 >= 0 && d1 < ndim, "dim1 out of range");
-
-  std::vector<int> perm(ndim);
-  for (int i = 0; i < ndim; ++i) {
-    perm[i] = i;
-  }
-  std::swap(perm[d0], perm[d1]);
+  int d0 = at::detail::_PD_normalize_transpose_dim(dim0, ndim, "dim0");
+  int d1 = at::detail::_PD_normalize_transpose_dim(dim1, ndim, "dim1");
+  auto perm = at::detail::_PD_make_transpose_perm(ndim, d0, d1);
 
   return paddle::experimental::transpose(self._PD_GetInner(), perm);
 }
@@ -55,13 +77,9 @@ inline at::Tensor Tensor::transpose(int64_t dim0, int64_t dim1) const {
 
 inline at::Tensor& Tensor::transpose_(int64_t dim0, int64_t dim1) const {
   int64_t ndim = this->dim();
-  if (dim0 < 0) dim0 += ndim;
-  if (dim1 < 0) dim1 += ndim;
-  std::vector<int> perm(this->dim());
-  for (size_t i = 0; i < perm.size(); i++) {
-    perm[i] = static_cast<int>(i);
-  }
-  std::swap(perm[dim0], perm[dim1]);
+  int d0 = at::detail::_PD_normalize_transpose_dim(dim0, ndim, "dim0");
+  int d1 = at::detail::_PD_normalize_transpose_dim(dim1, ndim, "dim1");
+  auto perm = at::detail::_PD_make_transpose_perm(ndim, d0, d1);
   PaddleTensor& inner = const_cast<PaddleTensor&>(tensor_);
   paddle::experimental::transpose_(inner, perm);
   return const_cast<at::Tensor&>(*this);

--- a/paddle/phi/api/include/compat/ATen/ops/unflatten.h
+++ b/paddle/phi/api/include/compat/ATen/ops/unflatten.h
@@ -38,7 +38,7 @@ inline at::Tensor unflatten(const at::Tensor& self,
 }
 
 inline at::Tensor unflatten_symint(const at::Tensor& self,
-                                   const int64_t dim,
+                                   int64_t dim,
                                    c10::SymIntArrayRef sizes) {
   return unflatten(
       self,

--- a/paddle/phi/api/include/compat/ATen/ops/unsafe_split.h
+++ b/paddle/phi/api/include/compat/ATen/ops/unsafe_split.h
@@ -21,13 +21,13 @@ namespace at {
 
 inline std::vector<at::Tensor> unsafe_split(const at::Tensor& self,
                                             int64_t split_size,
-                                            int64_t dim) {
+                                            int64_t dim = 0) {
   return at::split(self, split_size, dim);
 }
 
 inline std::vector<at::Tensor> unsafe_split_symint(const at::Tensor& self,
                                                    c10::SymInt split_size,
-                                                   int64_t dim) {
+                                                   int64_t dim = 0) {
   return at::split(self, static_cast<int64_t>(split_size), dim);
 }
 

--- a/paddle/phi/api/include/compat/ATen/ops/unsafe_split_with_sizes.h
+++ b/paddle/phi/api/include/compat/ATen/ops/unsafe_split_with_sizes.h
@@ -20,12 +20,12 @@
 namespace at {
 
 inline std::vector<at::Tensor> unsafe_split_with_sizes(
-    const at::Tensor& self, at::IntArrayRef split_sizes, int64_t dim) {
+    const at::Tensor& self, at::IntArrayRef split_sizes, int64_t dim = 0) {
   return at::split(self, split_sizes, dim);
 }
 
 inline std::vector<at::Tensor> unsafe_split_with_sizes_symint(
-    const at::Tensor& self, c10::SymIntArrayRef split_sizes, int64_t dim) {
+    const at::Tensor& self, c10::SymIntArrayRef split_sizes, int64_t dim = 0) {
   return at::split_symint(self, split_sizes, dim);
 }
 

--- a/paddle/phi/api/include/compat/ATen/ops/unsqueeze.h
+++ b/paddle/phi/api/include/compat/ATen/ops/unsqueeze.h
@@ -18,48 +18,21 @@
 
 namespace at {
 
-inline at::Tensor unsqueeze(const at::Tensor& self) {
-  return paddle::experimental::unsqueeze(self._PD_GetInner(), {});
-}
-
 inline at::Tensor unsqueeze(const at::Tensor& self, int64_t dim) {
   return paddle::experimental::unsqueeze(self._PD_GetInner(), {dim});
-}
-
-inline at::Tensor unsqueeze(const at::Tensor& self, at::IntArrayRef dim) {
-  return paddle::experimental::unsqueeze(self._PD_GetInner(),
-                                         dim._PD_ToPaddleIntArray());
 }
 
 }  // namespace at
 
 namespace at {
 
-inline at::Tensor Tensor::unsqueeze() const { return at::unsqueeze(*this); }
-
 inline at::Tensor Tensor::unsqueeze(int64_t dim) const {
   return at::unsqueeze(*this, dim);
-}
-
-inline at::Tensor Tensor::unsqueeze(at::IntArrayRef dim) const {
-  return at::unsqueeze(*this, dim);
-}
-
-inline at::Tensor& Tensor::unsqueeze_() const {
-  PaddleTensor& inner = const_cast<PaddleTensor&>(tensor_);
-  paddle::experimental::unsqueeze_(inner, {});
-  return const_cast<at::Tensor&>(*this);
 }
 
 inline at::Tensor& Tensor::unsqueeze_(int64_t dim) const {
   PaddleTensor& inner = const_cast<PaddleTensor&>(tensor_);
   paddle::experimental::unsqueeze_(inner, {dim});
-  return const_cast<at::Tensor&>(*this);
-}
-
-inline at::Tensor& Tensor::unsqueeze_(at::IntArrayRef dim) const {
-  PaddleTensor& inner = const_cast<PaddleTensor&>(tensor_);
-  paddle::experimental::unsqueeze_(inner, dim._PD_ToPaddleIntArray());
   return const_cast<at::Tensor&>(*this);
 }
 

--- a/paddle/phi/api/include/compat/ATen/ops/view.h
+++ b/paddle/phi/api/include/compat/ATen/ops/view.h
@@ -22,11 +22,6 @@ inline at::Tensor view(const at::Tensor& self, at::IntArrayRef size) {
   return paddle::experimental::view_shape(self._PD_GetInner(), size.vec());
 }
 
-inline at::Tensor view(const at::Tensor& self, at::ScalarType dtype) {
-  return paddle::experimental::view_dtype(
-      self._PD_GetInner(), compat::_PD_AtenScalarTypeToPhiDataType(dtype));
-}
-
 }  // namespace at
 
 namespace at {
@@ -36,7 +31,8 @@ inline at::Tensor Tensor::view(at::IntArrayRef size) const {
 }
 
 inline at::Tensor Tensor::view(at::ScalarType dtype) const {
-  return at::view(*this, dtype);
+  return paddle::experimental::view_dtype(
+      this->_PD_GetInner(), compat::_PD_AtenScalarTypeToPhiDataType(dtype));
 }
 
 }  // namespace at

--- a/test/cpp/compat/ATen_as_strided_test.cc
+++ b/test/cpp/compat/ATen_as_strided_test.cc
@@ -109,7 +109,7 @@ TEST_F(TensorAsStridedTest, AsStridedScatterBasic) {
   at::Tensor src = at::full({2, 3}, 99.0f, at::kFloat);
   at::Tensor result = t.as_strided_scatter(src, {2, 3}, {3, 1});
 
-  ASSERT_EQ(result.sizes(), c10::IntArrayRef({2, 3}));
+  ASSERT_EQ(result.sizes(), c10::IntArrayRef({12}));
   float* data = result.data_ptr<float>();
   for (int i = 0; i < 6; ++i) {
     ASSERT_FLOAT_EQ(data[i], 99.0f);
@@ -131,10 +131,10 @@ TEST_F(TensorAsStridedTest, AsStridedScatterWithOffset) {
   at::Tensor src = at::full({2, 2}, 88.0f, at::kFloat);
   at::Tensor result = t.as_strided_scatter(src, {2, 2}, {2, 1}, 2);
 
-  ASSERT_EQ(result.sizes(), c10::IntArrayRef({2, 2}));
+  ASSERT_EQ(result.sizes(), c10::IntArrayRef({12}));
   float* data = result.data_ptr<float>();
-  ASSERT_FLOAT_EQ(data[0], 88.0f);
-  ASSERT_FLOAT_EQ(data[3], 88.0f);
+  ASSERT_FLOAT_EQ(data[2], 88.0f);
+  ASSERT_FLOAT_EQ(data[5], 88.0f);
 }
 
 TEST_F(TensorAsStridedTest, AsStridedTranspose) {

--- a/test/cpp/compat/ATen_basic_test.cc
+++ b/test/cpp/compat/ATen_basic_test.cc
@@ -39,7 +39,7 @@ COMMON_DECLARE_bool(use_stride_kernel);
 
 TEST(TensorBaseTest, DataPtrAPIs) {
   // Test data_ptr() and const_data_ptr() APIs
-  at::TensorBase tensor = at::ones({2, 3}, at::kFloat);
+  at::Tensor tensor = at::ones({2, 3}, at::kFloat);
 
   // Test void* data_ptr()
   void* void_ptr = tensor.data_ptr();
@@ -88,7 +88,7 @@ TEST(TensorBaseTest, ModifyOperationAPIs) {
     return;
   }
   // Test modify operation related APIs
-  at::TensorBase tensor = at::ones({2, 3}, at::kFloat);
+  at::Tensor tensor = at::ones({2, 3}, at::kFloat);
 
   // Test is_contiguous()
   ASSERT_TRUE(tensor.is_contiguous());
@@ -110,7 +110,7 @@ TEST(TensorBaseTest, ModifyOperationAPIs) {
   }
 
   // Test copy_()
-  at::TensorBase src = at::ones({2, 3}, at::kFloat);
+  at::Tensor src = at::ones({2, 3}, at::kFloat);
   tensor.copy_(src);
   for (int i = 0; i < tensor.numel(); i++) {
     ASSERT_EQ(data[i], 1.0f);

--- a/test/cpp/compat/ATen_expand_test.cc
+++ b/test/cpp/compat/ATen_expand_test.cc
@@ -164,12 +164,11 @@ TEST_F(TensorExpandTest, ExpandFunction) {
   ASSERT_FLOAT_EQ(result.data_ptr<float>()[0], 7.0f);
 }
 
-// Test expand_as function (not member function)
-TEST_F(TensorExpandTest, ExpandAsFunction) {
+TEST_F(TensorExpandTest, ExpandAsMemberFunction) {
   at::Tensor t = at::full({1, 2}, 4.0f, at::kFloat);
   at::Tensor other = at::zeros({3, 2}, at::kFloat);
 
-  at::Tensor result = at::expand_as(t, other);
+  at::Tensor result = t.expand_as(other);
 
   ASSERT_EQ(result.sizes()[0], 3);
   ASSERT_EQ(result.sizes()[1], 2);

--- a/test/cpp/compat/ATen_index_test.cc
+++ b/test/cpp/compat/ATen_index_test.cc
@@ -77,7 +77,7 @@ TEST(TensorIndexTest, IndexWithEmptyInitializerListReturnsSelf) {
   at::Tensor t = at::arange(5, at::kFloat);
 
   // PyTorch throws for empty index list
-  ASSERT_THROW(at::index(t, std::initializer_list<at::indexing::TensorIndex>{}),
+  ASSERT_THROW(t.index(std::initializer_list<at::indexing::TensorIndex>{}),
                std::exception);
 }
 
@@ -90,7 +90,7 @@ TEST(TensorIndexTest, IndexWithTensorInitializerList) {
   idx_data[1] = 2;
   idx_data[2] = 4;
 
-  at::Tensor result = at::index(t, {idx});
+  at::Tensor result = t.index({idx});
 
   ASSERT_EQ(result.numel(), 3);
   float* result_data = result.data_ptr<float>();
@@ -121,7 +121,7 @@ TEST(TensorIndexTest, MixedSliceAndTensorIndicesThrows) {
   idx.data_ptr<int64_t>()[0] = 0;
   idx.data_ptr<int64_t>()[1] = 2;
 
-  ASSERT_THROW(at::index(t, {at::indexing::Slice(0, 2), idx}), std::exception);
+  ASSERT_THROW(t.index({at::indexing::Slice(0, 2), idx}), std::exception);
 }
 
 // ======================== index_put_ tests ========================
@@ -164,10 +164,7 @@ TEST(TensorIndexPutTest, IndexPutInplaceWithScalar) {
   idx_data[0] = 0;
   idx_data[1] = 4;
 
-  c10::List<::std::optional<at::Tensor>> indices;
-  indices.push_back(idx);
-
-  t.index_put_(indices, at::Scalar(7.0));
+  t.index_put_({idx}, at::Scalar(7.0));
 
   // Verify data pointer unchanged (inplace)
   ASSERT_EQ(t.data_ptr<float>(), original_data_ptr);

--- a/test/cpp/compat/ATen_index_test.cc
+++ b/test/cpp/compat/ATen_index_test.cc
@@ -403,3 +403,45 @@ TEST(TensorIndexPutTest, IndexPutArrayRefWithTensorValue) {
   ASSERT_FLOAT_EQ(t.data_ptr<float>()[2], 0.0f);
   ASSERT_FLOAT_EQ(t.data_ptr<float>()[4], 13.0f);
 }
+
+TEST(TensorIndexPutTest, IndexPutArrayRefWithNoneValue) {
+  at::Tensor t = at::zeros({2, 3}, at::kFloat);
+  at::Tensor values = at::full({1, 2, 3}, 6.0f, at::kFloat);
+
+  t.index_put_({at::indexing::None}, values);
+
+  ASSERT_EQ(t.sizes(), c10::IntArrayRef({2, 3}));
+  for (int i = 0; i < 6; ++i) {
+    ASSERT_FLOAT_EQ(t.data_ptr<float>()[i], 6.0f);
+  }
+}
+
+TEST(TensorIndexPutTest, IndexPutArrayRefWithTensorNoneAndSlice) {
+  at::Tensor t = at::zeros({3, 4}, at::kFloat);
+  at::Tensor idx = at::empty({2}, at::kLong);
+  idx.data_ptr<int64_t>()[0] = 2;
+  idx.data_ptr<int64_t>()[1] = 0;
+  at::Tensor values = at::full({2, 1, 4}, 8.0f, at::kFloat);
+
+  t.index_put_({idx, at::indexing::None, at::indexing::Slice()}, values);
+
+  ASSERT_EQ(t.sizes(), c10::IntArrayRef({3, 4}));
+  for (int i = 0; i < 4; ++i) {
+    ASSERT_FLOAT_EQ(t.data_ptr<float>()[i], 8.0f);
+    ASSERT_FLOAT_EQ(t.data_ptr<float>()[8 + i], 8.0f);
+  }
+  for (int i = 4; i < 8; ++i) {
+    ASSERT_FLOAT_EQ(t.data_ptr<float>()[i], 0.0f);
+  }
+}
+
+TEST(TensorIndexPutTest, IndexPutArrayRefWithNoneScalarValue) {
+  at::Tensor t = at::zeros({2, 3}, at::kFloat);
+
+  t.index_put_({at::indexing::None}, at::Scalar(4.0));
+
+  ASSERT_EQ(t.sizes(), c10::IntArrayRef({2, 3}));
+  for (int i = 0; i < 6; ++i) {
+    ASSERT_FLOAT_EQ(t.data_ptr<float>()[i], 4.0f);
+  }
+}

--- a/test/cpp/compat/ATen_index_test.cc
+++ b/test/cpp/compat/ATen_index_test.cc
@@ -252,6 +252,69 @@ TEST(TensorIndexTest, IndexWithOptionalNone) {
   ASSERT_EQ(result.numel(), 6);
 }
 
+TEST(TensorIndexTest, FreeIndexWithAllNoneReturnsSelf) {
+  at::Tensor t = at::arange(6, at::kFloat).reshape({2, 3});
+  c10::List<::std::optional<at::Tensor>> indices;
+  indices.push_back(::std::nullopt);
+  indices.push_back(::std::nullopt);
+
+  at::Tensor result = at::index(t, indices);
+
+  ASSERT_EQ(result.sizes(), c10::IntArrayRef({2, 3}));
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[0], 0.0f);
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[5], 5.0f);
+}
+
+TEST(TensorIndexTest, FreeIndexWithSingleLeadingTensor) {
+  at::Tensor t = at::arange(9, at::kFloat).reshape({3, 3});
+  at::Tensor idx = at::empty({2}, at::kLong);
+  idx.data_ptr<int64_t>()[0] = 2;
+  idx.data_ptr<int64_t>()[1] = 0;
+
+  c10::List<::std::optional<at::Tensor>> indices;
+  indices.push_back(idx);
+
+  at::Tensor result = at::index(t, indices);
+
+  ASSERT_EQ(result.sizes(), c10::IntArrayRef({2, 3}));
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[0], 6.0f);
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[1], 7.0f);
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[2], 8.0f);
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[3], 0.0f);
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[4], 1.0f);
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[5], 2.0f);
+}
+
+TEST(TensorIndexTest, MixedTensorNoneFullSliceIndex) {
+  at::Tensor base = at::arange(12, at::kFloat).reshape({3, 4});
+  at::Tensor idx = at::empty({2}, at::kLong);
+  idx.data_ptr<int64_t>()[0] = 2;
+  idx.data_ptr<int64_t>()[1] = 0;
+
+  at::Tensor result =
+      base.index({idx, at::indexing::None, at::indexing::Slice()});
+
+  ASSERT_EQ(result.sizes(), c10::IntArrayRef({2, 1, 4}));
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[0], 8.0f);
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[1], 9.0f);
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[2], 10.0f);
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[3], 11.0f);
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[4], 0.0f);
+  ASSERT_FLOAT_EQ(result.data_ptr<float>()[7], 3.0f);
+}
+
+TEST(TensorIndexTest, MixedFullSliceWithMultipleTensorIndicesThrows) {
+  at::Tensor base = at::arange(12, at::kFloat).reshape({3, 4});
+  at::Tensor idx0 = at::empty({2}, at::kLong);
+  idx0.data_ptr<int64_t>()[0] = 0;
+  idx0.data_ptr<int64_t>()[1] = 1;
+  at::Tensor idx1 = at::empty({2}, at::kLong);
+  idx1.data_ptr<int64_t>()[0] = 0;
+  idx1.data_ptr<int64_t>()[1] = 1;
+
+  ASSERT_THROW(base.index({idx0, at::indexing::Slice(), idx1}), std::exception);
+}
+
 TEST(TensorIndexPutTest, IndexPutAccumulate) {
   // Test index_put_ with accumulate=true
   at::Tensor t = at::zeros({5}, at::kFloat);
@@ -323,4 +386,20 @@ TEST(TensorIndexPutTest, IndexPutNonInplaceAccumulate) {
   ASSERT_FLOAT_EQ(t.data_ptr<float>()[1], 0.0f);
   // Result has accumulated
   ASSERT_FLOAT_EQ(result.data_ptr<float>()[1], 6.0f);
+}
+
+TEST(TensorIndexPutTest, IndexPutArrayRefWithTensorValue) {
+  at::Tensor t = at::zeros({5}, at::kFloat);
+  at::Tensor idx = at::empty({2}, at::kLong);
+  idx.data_ptr<int64_t>()[0] = 1;
+  idx.data_ptr<int64_t>()[1] = 4;
+  at::Tensor values = at::full({2}, 13.0f, at::kFloat);
+
+  std::vector<at::indexing::TensorIndex> tensor_indices = {idx};
+  t.index_put_(at::ArrayRef<at::indexing::TensorIndex>(tensor_indices), values);
+
+  ASSERT_FLOAT_EQ(t.data_ptr<float>()[0], 0.0f);
+  ASSERT_FLOAT_EQ(t.data_ptr<float>()[1], 13.0f);
+  ASSERT_FLOAT_EQ(t.data_ptr<float>()[2], 0.0f);
+  ASSERT_FLOAT_EQ(t.data_ptr<float>()[4], 13.0f);
 }

--- a/test/cpp/compat/ATen_memory_test.cc
+++ b/test/cpp/compat/ATen_memory_test.cc
@@ -53,6 +53,22 @@ TEST(IsPinnedTest, MultiDimTensorNotPinned) {
   EXPECT_FALSE(tensor.is_pinned());
 }
 
+// ==================== data pointer tests ====================
+
+TEST(TensorDataPtrTest, ConstDataPtrSupportsConstAndNonConstElementTypes) {
+  auto tensor = at::ones({2, 3}, at::TensorOptions().dtype(at::kFloat));
+
+  const void* void_ptr = tensor.const_data_ptr();
+  const float* float_ptr = tensor.const_data_ptr<float>();
+  const float* const_float_ptr = tensor.const_data_ptr<const float>();
+
+  EXPECT_NE(void_ptr, nullptr);
+  EXPECT_EQ(static_cast<const void*>(float_ptr), void_ptr);
+  EXPECT_EQ(static_cast<const void*>(const_float_ptr), void_ptr);
+  EXPECT_FLOAT_EQ(float_ptr[0], 1.0f);
+  EXPECT_FLOAT_EQ(const_float_ptr[0], 1.0f);
+}
+
 // ==================== reciprocal tests ====================
 
 // Test reciprocal for simple values

--- a/test/cpp/compat/ATen_nnz_test.cc
+++ b/test/cpp/compat/ATen_nnz_test.cc
@@ -72,7 +72,8 @@ TEST(TensorNNZTest, SparseCsr_NNZ_Correct) {
   at::Tensor crow = at::tensor({0, 1, 2, 3}, at::kInt);
   at::Tensor col = at::tensor({0, 1, 2}, at::kInt);
   at::Tensor vals = at::tensor({1.0f, 1.0f, 1.0f}, at::kFloat);
-  at::Tensor sparse_csr = at::sparse_csr_tensor(crow, col, vals, {3, 3});
+  at::Tensor sparse_csr =
+      at::sparse_csr_tensor(crow, col, vals, {3, 3}, at::TensorOptions());
 
   ASSERT_EQ(sparse_csr._nnz(), 3);
 }
@@ -82,7 +83,8 @@ TEST(TensorNNZTest, SparseCsr_NNZ_SingleRow) {
   at::Tensor crow = at::tensor({0, 2}, at::kInt);
   at::Tensor col = at::tensor({0, 2}, at::kInt);
   at::Tensor vals = at::tensor({5.0f, 7.0f}, at::kFloat);
-  at::Tensor sparse_csr = at::sparse_csr_tensor(crow, col, vals, {1, 3});
+  at::Tensor sparse_csr =
+      at::sparse_csr_tensor(crow, col, vals, {1, 3}, at::TensorOptions());
 
   ASSERT_EQ(sparse_csr._nnz(), 2);
 }

--- a/test/cpp/compat/ATen_record_stream_test.cc
+++ b/test/cpp/compat/ATen_record_stream_test.cc
@@ -47,8 +47,8 @@ class RecordStreamTest : public ::testing::Test {
 
 // --- Happy path: CUDA tensor + current CUDA stream should succeed ---
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-using RecordCudaStreamMethod = void (at::Tensor::*)(at::cuda::CUDAStream) const;
-[[maybe_unused]] static RecordCudaStreamMethod g_record_cuda_stream_method =
+using RecordStreamMethod = void (at::Tensor::*)(at::Stream) const;
+[[maybe_unused]] static RecordStreamMethod g_record_stream_method =
     &at::Tensor::record_stream;
 
 TEST_F(RecordStreamTest, CudaTensorCurrentCudaStream) {

--- a/test/cpp/compat/ATen_squeeze_test.cc
+++ b/test/cpp/compat/ATen_squeeze_test.cc
@@ -101,13 +101,11 @@ TEST(TestSqueeze, SqueezeInplaceMultipleDims) {
   ASSERT_EQ(tensor.data_ptr(), original_ptr);
 }
 
-TEST(TestUnsqueeze, UnsqueezeNoArg) {
-  // Test unsqueeze() without arguments
+TEST(TestUnsqueeze, UnsqueezeLeadingDim) {
   at::Tensor tensor = at::ones({3, 4}, at::kFloat);
-  at::Tensor unsqueezed = tensor.unsqueeze();
+  at::Tensor unsqueezed = tensor.unsqueeze(0);
 
-  // The behavior depends on the implementation
-  ASSERT_EQ(unsqueezed.numel(), tensor.numel());
+  ASSERT_EQ(unsqueezed.sizes(), c10::IntArrayRef({1, 3, 4}));
 }
 
 TEST(TestUnsqueeze, UnsqueezeSingleDim) {
@@ -131,23 +129,21 @@ TEST(TestUnsqueeze, UnsqueezeSingleDim) {
   ASSERT_EQ(unsqueezed_neg.sizes(), c10::IntArrayRef({3, 4, 1}));
 }
 
-TEST(TestUnsqueeze, UnsqueezeMultipleDims) {
-  // Test unsqueeze(IntArrayRef dim) - adds dimensions at specified positions
+TEST(TestUnsqueeze, UnsqueezeChainedDims) {
   at::Tensor tensor = at::ones({3, 4}, at::kFloat);
 
-  // Unsqueeze at dimensions 0 and 2
-  at::Tensor unsqueezed = tensor.unsqueeze(c10::IntArrayRef({0, 2}));
+  at::Tensor unsqueezed = tensor.unsqueeze(0).unsqueeze(2);
+  ASSERT_EQ(unsqueezed.sizes(), c10::IntArrayRef({1, 3, 1, 4}));
   ASSERT_EQ(unsqueezed.numel(), tensor.numel());
 }
 
-TEST(TestUnsqueeze, UnsqueezeInplaceNoArg) {
-  // Test unsqueeze_() without arguments - in-place operation
+TEST(TestUnsqueeze, UnsqueezeInplaceLeadingDim) {
   at::Tensor tensor = at::ones({3, 4}, at::kFloat);
   void* original_ptr = tensor.data_ptr();
 
-  tensor.unsqueeze_();
+  tensor.unsqueeze_(0);
 
-  ASSERT_EQ(tensor.numel(), 12);  // 3 * 4
+  ASSERT_EQ(tensor.sizes(), c10::IntArrayRef({1, 3, 4}));
   ASSERT_EQ(tensor.data_ptr(), original_ptr);
 }
 
@@ -162,14 +158,14 @@ TEST(TestUnsqueeze, UnsqueezeInplaceSingleDim) {
   ASSERT_EQ(tensor.data_ptr(), original_ptr);
 }
 
-TEST(TestUnsqueeze, UnsqueezeInplaceMultipleDims) {
-  // Test unsqueeze_(IntArrayRef dim) - in-place operation on multiple
-  // dimensions
+TEST(TestUnsqueeze, UnsqueezeInplaceChainedDims) {
   at::Tensor tensor = at::ones({3, 4}, at::kFloat);
   void* original_ptr = tensor.data_ptr();
 
-  tensor.unsqueeze_(c10::IntArrayRef({0, 2}));
+  tensor.unsqueeze_(0);
+  tensor.unsqueeze_(2);
 
+  ASSERT_EQ(tensor.sizes(), c10::IntArrayRef({1, 3, 1, 4}));
   ASSERT_EQ(tensor.numel(), 12);
   ASSERT_EQ(tensor.data_ptr(), original_ptr);
 }

--- a/test/cpp/compat/ATen_transpose_test.cc
+++ b/test/cpp/compat/ATen_transpose_test.cc
@@ -107,3 +107,28 @@ TEST(TensorTransposeInplaceTest,
   t.transpose_(0, 1);
   ASSERT_EQ(t.sizes(), c10::IntArrayRef({5, 7}));
 }
+
+TEST(TensorTransposeTest, TransposeLargePositiveDimThrows) {
+  at::Tensor t = at::ones({2, 3}, at::kFloat);
+  ASSERT_ANY_THROW((void)at::transpose(t, 1LL << 32, 1));
+}
+
+TEST(TensorTransposeTest, TransposeLargeNegativeDimThrows) {
+  at::Tensor t = at::ones({2, 3}, at::kFloat);
+  ASSERT_ANY_THROW((void)t.transpose(0, -(1LL << 32)));
+}
+
+TEST(TensorTransposeInplaceTest, TransposeInplaceLargeDimThrowsUnchanged) {
+  at::Tensor t = at::ones({2, 3}, at::kFloat);
+  ASSERT_ANY_THROW((void)t.transpose_(1LL << 32, 1));
+  ASSERT_EQ(t.sizes(), c10::IntArrayRef({2, 3}));
+}
+
+TEST(TensorTransposeTest, TransposeLegalNegativeDims) {
+  at::Tensor t = at::ones({2, 3}, at::kFloat);
+  at::Tensor result = at::transpose(t, -1, -2);
+  ASSERT_EQ(result.sizes(), c10::IntArrayRef({3, 2}));
+
+  t.transpose_(-1, -2);
+  ASSERT_EQ(t.sizes(), c10::IntArrayRef({3, 2}));
+}

--- a/test/cpp/compat/ATen_values_test.cc
+++ b/test/cpp/compat/ATen_values_test.cc
@@ -103,7 +103,8 @@ TEST(TensorValuesTest, SparseCsr_ValuesCorrect) {
   at::Tensor crow = at::tensor({0, 1, 2, 3}, at::kInt);
   at::Tensor col = at::tensor({0, 1, 2}, at::kInt);
   at::Tensor vals_in = at::tensor({1.0f, 1.0f, 1.0f}, at::kFloat);
-  at::Tensor sparse_csr = at::sparse_csr_tensor(crow, col, vals_in, {3, 3});
+  at::Tensor sparse_csr =
+      at::sparse_csr_tensor(crow, col, vals_in, {3, 3}, at::TensorOptions());
 
   // PyTorch does not dispatch _values for SparseCsr tensors
   ASSERT_THROW(sparse_csr._values(), std::exception);

--- a/test/cpp/compat/c10_MemoryFormat_test.cc
+++ b/test/cpp/compat/c10_MemoryFormat_test.cc
@@ -32,7 +32,7 @@
 
 TEST(TensorBaseTest, IsContiguousOrFalseAPI) {
   // Test with regular contiguous tensor
-  at::TensorBase contiguous_tensor = at::ones({2, 3, 4}, at::kFloat);
+  at::Tensor contiguous_tensor = at::ones({2, 3, 4}, at::kFloat);
   ASSERT_TRUE(contiguous_tensor.is_contiguous_or_false());
   ASSERT_EQ(contiguous_tensor.is_contiguous_or_false(),
             contiguous_tensor.is_contiguous());

--- a/test/cpp/compat/c10_layout_test.cc
+++ b/test/cpp/compat/c10_layout_test.cc
@@ -267,6 +267,46 @@ TEST(SparseConstructorTest, SparseCooTensorWithOptions) {
   ASSERT_EQ(sparse.layout(), c10::kSparse);
 }
 
+TEST(SparseConstructorTest, SparseCooTensorWithCoalescedOptionTrue) {
+  at::Tensor indices = at::empty({2, 2}, c10::TensorOptions().dtype(at::kLong));
+  int64_t* indices_ptr = indices.data_ptr<int64_t>();
+  indices_ptr[0] = 0;
+  indices_ptr[1] = 1;
+  indices_ptr[2] = 0;
+  indices_ptr[3] = 1;
+
+  at::Tensor values = at::empty({2}, c10::TensorOptions().dtype(at::kFloat));
+  values.data_ptr<float>()[0] = 3.0f;
+  values.data_ptr<float>()[1] = 4.0f;
+
+  at::Tensor sparse =
+      at::sparse_coo_tensor(indices, values, {2, 2}, at::TensorOptions(), true);
+
+  ASSERT_TRUE(sparse.is_sparse());
+  ASSERT_EQ(sparse.layout(), c10::kSparse);
+  ASSERT_TRUE(sparse.is_coalesced());
+}
+
+TEST(SparseConstructorTest, SparseCooTensorWithCoalescedOptionFalse) {
+  at::Tensor indices = at::empty({2, 2}, c10::TensorOptions().dtype(at::kLong));
+  int64_t* indices_ptr = indices.data_ptr<int64_t>();
+  indices_ptr[0] = 0;
+  indices_ptr[1] = 1;
+  indices_ptr[2] = 0;
+  indices_ptr[3] = 1;
+
+  at::Tensor values = at::empty({2}, c10::TensorOptions().dtype(at::kFloat));
+  values.data_ptr<float>()[0] = 3.0f;
+  values.data_ptr<float>()[1] = 4.0f;
+
+  at::Tensor sparse = at::sparse_coo_tensor(
+      indices, values, {2, 2}, at::TensorOptions(), false);
+
+  ASSERT_TRUE(sparse.is_sparse());
+  ASSERT_EQ(sparse.layout(), c10::kSparse);
+  ASSERT_FALSE(sparse.is_coalesced());
+}
+
 // ============== at::sparse_csr_tensor tests ==============
 
 TEST(SparseConstructorTest, SparseCsrTensorBasic) {
@@ -404,6 +444,28 @@ TEST(SparseConstructorTest, SparseCooTensorInferSize) {
   ASSERT_EQ(sparse.dim(), 2);
   ASSERT_EQ(sparse.size(0), 3);
   ASSERT_EQ(sparse.size(1), 3);
+}
+
+TEST(SparseConstructorTest, SparseCooTensorInferSizeWithCoalescedOption) {
+  at::Tensor indices = at::empty({2, 2}, c10::TensorOptions().dtype(at::kLong));
+  int64_t* indices_ptr = indices.data_ptr<int64_t>();
+  indices_ptr[0] = 0;
+  indices_ptr[1] = 2;
+  indices_ptr[2] = 1;
+  indices_ptr[3] = 3;
+
+  at::Tensor values = at::empty({2}, c10::TensorOptions().dtype(at::kFloat));
+  values.data_ptr<float>()[0] = 1.0f;
+  values.data_ptr<float>()[1] = 2.0f;
+
+  at::Tensor sparse =
+      at::sparse_coo_tensor(indices, values, at::TensorOptions(), true);
+
+  ASSERT_TRUE(sparse.is_sparse());
+  ASSERT_EQ(sparse.layout(), c10::kSparse);
+  ASSERT_EQ(sparse.size(0), 3);
+  ASSERT_EQ(sparse.size(1), 4);
+  ASSERT_TRUE(sparse.is_coalesced());
 }
 
 TEST(SparseConstructorTest, SparseCooTensorDouble) {

--- a/test/cpp/compat/c10_layout_test.cc
+++ b/test/cpp/compat/c10_layout_test.cc
@@ -260,7 +260,8 @@ TEST(SparseConstructorTest, SparseCooTensorWithOptions) {
                                             at::kFloat,
                                             at::kSparse,
                                             at::kCPU,
-                                            /*pin_memory=*/false);
+                                            /*pin_memory=*/false,
+                                            std::nullopt);
 
   ASSERT_TRUE(sparse.is_sparse());
   ASSERT_EQ(sparse.layout(), c10::kSparse);
@@ -301,8 +302,8 @@ TEST(SparseConstructorTest, SparseCsrTensorBasic) {
   values_ptr[3] = 4.0f;
 
   // Create sparse CSR tensor
-  at::Tensor sparse =
-      at::sparse_csr_tensor(crow_indices, col_indices, values, {3, 4});
+  at::Tensor sparse = at::sparse_csr_tensor(
+      crow_indices, col_indices, values, {3, 4}, at::TensorOptions());
 
   ASSERT_TRUE(sparse.is_sparse_csr());
   ASSERT_TRUE(sparse.is_sparse());
@@ -470,8 +471,8 @@ TEST(SparseConstructorTest, SparseCsrTensorDouble) {
   values_ptr[0] = 1.5;
   values_ptr[1] = 2.5;
 
-  at::Tensor sparse =
-      at::sparse_csr_tensor(crow_indices, col_indices, values, {2, 2});
+  at::Tensor sparse = at::sparse_csr_tensor(
+      crow_indices, col_indices, values, {2, 2}, at::TensorOptions());
 
   ASSERT_TRUE(sparse.is_sparse_csr());
   ASSERT_TRUE(sparse.is_sparse());
@@ -513,8 +514,8 @@ TEST(SparseConstructorTest, SparseCsrTensorLarger) {
   values_ptr[4] = 5.0f;
   values_ptr[5] = 6.0f;
 
-  at::Tensor sparse =
-      at::sparse_csr_tensor(crow_indices, col_indices, values, {4, 5});
+  at::Tensor sparse = at::sparse_csr_tensor(
+      crow_indices, col_indices, values, {4, 5}, at::TensorOptions());
 
   ASSERT_TRUE(sparse.is_sparse_csr());
   ASSERT_TRUE(sparse.is_sparse());
@@ -536,8 +537,8 @@ TEST(SparseConstructorTest, SparseCsrTensorEmpty) {
 
   at::Tensor values = at::empty({0}, c10::TensorOptions().dtype(at::kFloat));
 
-  at::Tensor sparse =
-      at::sparse_csr_tensor(crow_indices, col_indices, values, {3, 3});
+  at::Tensor sparse = at::sparse_csr_tensor(
+      crow_indices, col_indices, values, {3, 3}, at::TensorOptions());
 
   ASSERT_TRUE(sparse.is_sparse_csr());
   ASSERT_TRUE(sparse.is_sparse());

--- a/test/cpp/compat/c10_ptr_test.cc
+++ b/test/cpp/compat/c10_ptr_test.cc
@@ -32,7 +32,7 @@
 
 TEST(TensorBaseTest, IsSameAPI) {
   // Test is_same() API - checks if two tensors share the same underlying data
-  at::TensorBase tensor1 = at::ones({2, 3}, at::kFloat);
+  at::Tensor tensor1 = at::ones({2, 3}, at::kFloat);
   at::TensorBase tensor2 = tensor1;                       // Same tensor
   at::TensorBase tensor3 = at::ones({2, 3}, at::kFloat);  // Different tensor
 
@@ -61,7 +61,7 @@ TEST(TensorBaseTest, IsSameAPI) {
 
 TEST(TensorBaseTest, UseCountAPI) {
   // Test use_count() API - returns reference count of underlying tensor
-  at::TensorBase tensor1 = at::ones({2, 3}, at::kFloat);
+  at::Tensor tensor1 = at::ones({2, 3}, at::kFloat);
 
   // Initial reference count should be 1
   ASSERT_EQ(tensor1.use_count(), 1);

--- a/test/cpp/compat/c10_storage_test.cc
+++ b/test/cpp/compat/c10_storage_test.cc
@@ -347,7 +347,7 @@ TEST(StorageTest, IsSharedStorageAliasFunction) {
 
 TEST(StorageTest, StorageIsAliasOfMethod) {
   // Test Storage::is_alias_of() method
-  at::TensorBase tensor1 = at::ones({2, 3}, at::kFloat);
+  at::Tensor tensor1 = at::ones({2, 3}, at::kFloat);
   at::TensorBase tensor2 = tensor1.view({3, 2});
   at::TensorBase tensor3 = at::ones({2, 3}, at::kFloat);
 
@@ -1009,7 +1009,7 @@ TEST(StorageTest, AliasWrapperDoesNotIncreaseTensorOwnedStorageCount) {
 }
 
 TEST(StorageTest, ViewTensorWrappersShareStorageImpl) {
-  at::TensorBase tensor = at::ones({2, 3}, at::kFloat);
+  at::Tensor tensor = at::ones({2, 3}, at::kFloat);
   at::TensorBase alias = tensor.view({3, 2});
 
   c10::Storage tensor_storage = tensor.storage();

--- a/test/tools/test_check_aten_ops_signature.py
+++ b/test/tools/test_check_aten_ops_signature.py
@@ -1180,6 +1180,100 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
         self.assertFalse(run_check_mock.call_args.kwargs["check_tensor_body"])
         self.assertTrue(run_check_mock.call_args.kwargs["check_tensor_base"])
 
+    def test_tensor_body_change_runs_all_ops_headers(self):
+        foo = self.write_paddle_op("foo.h", "namespace at {}\n")
+        bar = self.write_paddle_op("bar.h", "namespace at {}\n")
+        with (
+            mock.patch(
+                "check_aten_ops_signature.tensor_body_changed",
+                return_value=True,
+            ),
+            mock.patch(
+                "check_aten_ops_signature.tensor_base_changed",
+                return_value=False,
+            ),
+            mock.patch(
+                "check_aten_ops_signature.changed_aten_ops_headers",
+                side_effect=AssertionError(
+                    "TensorBody changes must scan all ops headers"
+                ),
+            ),
+            mock.patch(
+                "check_aten_ops_signature.all_aten_ops_headers",
+                return_value=[foo, bar],
+            ),
+            mock.patch(
+                "check_aten_ops_signature.discover_torch_include_dir",
+                return_value=self.torch_include,
+            ),
+            mock.patch(
+                "check_aten_ops_signature.run_check",
+                return_value=[],
+            ) as run_check_mock,
+            mock.patch(
+                "sys.argv",
+                [
+                    "check_aten_ops_signature.py",
+                    "--paddle-root",
+                    str(self.paddle_root),
+                ],
+            ),
+        ):
+            self.assertEqual(main(), 0)
+        run_check_mock.assert_called_once()
+        self.assertEqual(run_check_mock.call_args.args[2], [foo, bar])
+        self.assertTrue(run_check_mock.call_args.kwargs["check_tensor_body"])
+        self.assertFalse(run_check_mock.call_args.kwargs["check_tensor_base"])
+
+    def test_existing_ops_member_mismatch_fails_when_scanned(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline at::Tensor Tensor::foo(bool dim) const {
+              return at::Tensor();
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor foo(int64_t dim) const;
+            };
+            }  // namespace at
+            """
+        )
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor foo(int64_t dim) const;
+            };
+            }  // namespace at
+            """,
+        )
+
+        errors = run_check(
+            self.paddle_root,
+            self.torch_include,
+            [header],
+            check_tensor_body=True,
+            check_tensor_base=False,
+        )
+
+        self.assertTrue(errors)
+        self.assertTrue(
+            any(
+                "member function implementation is missing" in error.message
+                for error in errors
+            )
+        )
+
     def test_no_changed_signature_inputs_skips_torch_discovery(self):
         with (
             mock.patch(

--- a/tools/check_aten_ops_signature.py
+++ b/tools/check_aten_ops_signature.py
@@ -146,13 +146,38 @@ def strip_comments_and_literals(text: str) -> str:
 
 def find_matching(text: str, open_pos: int, open_ch: str, close_ch: str) -> int:
     depth = 0
-    for pos in range(open_pos, len(text)):
-        if text[pos] == open_ch:
+    pos = open_pos
+    state = "normal"
+    while pos < len(text):
+        ch = text[pos]
+        nxt = text[pos + 1] if pos + 1 < len(text) else ""
+        if state == "normal":
+            if ch == '"':
+                state = "string"
+                pos += 1
+                continue
+            if ch == "'":
+                state = "char"
+                pos += 1
+                continue
+        elif state in ("string", "char"):
+            if ch == "\\" and nxt:
+                pos += 2
+                continue
+            if (state == "string" and ch == '"') or (
+                state == "char" and ch == "'"
+            ):
+                state = "normal"
+            pos += 1
+            continue
+
+        if ch == open_ch:
             depth += 1
-        elif text[pos] == close_ch:
+        elif ch == close_ch:
             depth -= 1
             if depth == 0:
                 return pos
+        pos += 1
     raise SignatureParseError(
         f"unmatched {open_ch!r} at character offset {open_pos}"
     )
@@ -213,7 +238,31 @@ def split_top_level(text: str, separator: str) -> list[str]:
     pieces: list[str] = []
     start = 0
     angle = paren = bracket = brace = 0
-    for pos, ch in enumerate(text):
+    pos = 0
+    state = "normal"
+    while pos < len(text):
+        ch = text[pos]
+        nxt = text[pos + 1] if pos + 1 < len(text) else ""
+        if state == "normal":
+            if ch == '"':
+                state = "string"
+                pos += 1
+                continue
+            if ch == "'":
+                state = "char"
+                pos += 1
+                continue
+        elif state in ("string", "char"):
+            if ch == "\\" and nxt:
+                pos += 2
+                continue
+            if (state == "string" and ch == '"') or (
+                state == "char" and ch == "'"
+            ):
+                state = "normal"
+            pos += 1
+            continue
+
         if ch == "<":
             angle += 1
         elif ch == ">" and angle > 0:
@@ -239,13 +288,38 @@ def split_top_level(text: str, separator: str) -> list[str]:
         ):
             pieces.append(text[start:pos])
             start = pos + 1
+        pos += 1
     pieces.append(text[start:])
     return pieces
 
 
 def split_default_value(param: str) -> tuple[str, str | None]:
     angle = paren = bracket = brace = 0
-    for pos, ch in enumerate(param):
+    pos = 0
+    state = "normal"
+    while pos < len(param):
+        ch = param[pos]
+        nxt = param[pos + 1] if pos + 1 < len(param) else ""
+        if state == "normal":
+            if ch == '"':
+                state = "string"
+                pos += 1
+                continue
+            if ch == "'":
+                state = "char"
+                pos += 1
+                continue
+        elif state in ("string", "char"):
+            if ch == "\\" and nxt:
+                pos += 2
+                continue
+            if (state == "string" and ch == '"') or (
+                state == "char" and ch == "'"
+            ):
+                state = "normal"
+            pos += 1
+            continue
+
         if ch == "<":
             angle += 1
         elif ch == ">" and angle > 0:
@@ -270,6 +344,7 @@ def split_default_value(param: str) -> tuple[str, str | None]:
             and brace == 0
         ):
             return param[:pos], param[pos + 1 :]
+        pos += 1
     return param, None
 
 
@@ -386,29 +461,69 @@ def top_level_function_definitions(
     signatures: list[CppSignature] = []
     start = 0
     pos = 0
+    angle = paren = bracket = brace = 0
+    state = "normal"
     while pos < len(block):
         ch = block[pos]
-        if ch == "{":
-            candidate = block[start:pos]
-            signature = parse_cpp_signature(
-                candidate,
-                include_member_defaults=include_member_defaults,
-            )
-            if signature is not None:
-                signatures.append(signature)
-            end = find_matching(block, pos, "{", "}")
-            pos = end + 1
-            start = pos
+        nxt = block[pos + 1] if pos + 1 < len(block) else ""
+        if state == "normal":
+            if ch == '"':
+                state = "string"
+                pos += 1
+                continue
+            if ch == "'":
+                state = "char"
+                pos += 1
+                continue
+        elif state in ("string", "char"):
+            if ch == "\\" and nxt:
+                pos += 2
+                continue
+            if (state == "string" and ch == '"') or (
+                state == "char" and ch == "'"
+            ):
+                state = "normal"
+            pos += 1
             continue
+
+        if ch == "<":
+            angle += 1
+        elif ch == ">" and angle > 0:
+            angle -= 1
+        elif ch == "(":
+            paren += 1
+        elif ch == ")" and paren > 0:
+            paren -= 1
+        elif ch == "[":
+            bracket += 1
+        elif ch == "]" and bracket > 0:
+            bracket -= 1
+        elif ch == "{":
+            if angle == 0 and paren == 0 and bracket == 0 and brace == 0:
+                candidate = block[start:pos]
+                signature = parse_cpp_signature(
+                    candidate,
+                    include_member_defaults=include_member_defaults,
+                )
+                if signature is not None:
+                    signatures.append(signature)
+                end = find_matching(block, pos, "{", "}")
+                pos = end + 1
+                start = pos
+                continue
+            brace += 1
+        elif ch == "}" and brace > 0:
+            brace -= 1
         if ch == ";":
-            candidate = block[start:pos]
-            signature = parse_cpp_signature(
-                candidate,
-                include_member_defaults=include_member_defaults,
-            )
-            if signature is not None:
-                signatures.append(signature)
-            start = pos + 1
+            if angle == 0 and paren == 0 and bracket == 0 and brace == 0:
+                candidate = block[start:pos]
+                signature = parse_cpp_signature(
+                    candidate,
+                    include_member_defaults=include_member_defaults,
+                )
+                if signature is not None:
+                    signatures.append(signature)
+                start = pos + 1
         pos += 1
     return signatures
 
@@ -482,23 +597,63 @@ def tensor_class_declarations(
     signatures: list[CppSignature] = []
     start = 0
     pos = 0
+    angle = paren = bracket = brace = 0
+    state = "normal"
     while pos < len(body):
         ch = body[pos]
-        if ch == "{":
-            end = find_matching(body, pos, "{", "}")
-            pos = end + 1
-            start = pos
+        nxt = body[pos + 1] if pos + 1 < len(body) else ""
+        if state == "normal":
+            if ch == '"':
+                state = "string"
+                pos += 1
+                continue
+            if ch == "'":
+                state = "char"
+                pos += 1
+                continue
+        elif state in ("string", "char"):
+            if ch == "\\" and nxt:
+                pos += 2
+                continue
+            if (state == "string" and ch == '"') or (
+                state == "char" and ch == "'"
+            ):
+                state = "normal"
+            pos += 1
             continue
+
+        if ch == "<":
+            angle += 1
+        elif ch == ">" and angle > 0:
+            angle -= 1
+        elif ch == "(":
+            paren += 1
+        elif ch == ")" and paren > 0:
+            paren -= 1
+        elif ch == "[":
+            bracket += 1
+        elif ch == "]" and bracket > 0:
+            bracket -= 1
+        elif ch == "{":
+            if angle == 0 and paren == 0 and bracket == 0 and brace == 0:
+                end = find_matching(body, pos, "{", "}")
+                pos = end + 1
+                start = pos
+                continue
+            brace += 1
+        elif ch == "}" and brace > 0:
+            brace -= 1
         if ch == ";":
-            candidate = body[start:pos]
-            signature = parse_cpp_signature(
-                candidate,
-                class_member=True,
-                include_member_defaults=include_member_defaults,
-            )
-            if signature is not None:
-                signatures.append(signature)
-            start = pos + 1
+            if angle == 0 and paren == 0 and bracket == 0 and brace == 0:
+                candidate = body[start:pos]
+                signature = parse_cpp_signature(
+                    candidate,
+                    class_member=True,
+                    include_member_defaults=include_member_defaults,
+                )
+                if signature is not None:
+                    signatures.append(signature)
+                start = pos + 1
         pos += 1
     return signatures
 

--- a/tools/check_aten_ops_signature.py
+++ b/tools/check_aten_ops_signature.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 ATEN_OPS_DIR = Path("paddle/phi/api/include/compat/ATen/ops")
+ATEN_TENSOR_BODY = Path("paddle/phi/api/include/compat/ATen/core/TensorBody.h")
 TORCH_INSTALL_HINT = (
     "pip install torch==2.9.1 --index-url https://download.pytorch.org/whl/cpu"
 )
@@ -185,6 +186,8 @@ def find_matching(text: str, open_pos: int, open_ch: str, close_ch: str) -> int:
 
 def normalize_punctuation(text: str) -> str:
     text = re.sub(r"\bat::", "", text)
+    text = re.sub(r"\bc10::", "", text)
+    text = re.sub(r"\bcaffe2::", "", text)
     text = text.replace("::std::", "std::")
     text = re.sub(r"\s+", " ", text.strip())
     text = re.sub(r"\s*::\s*", "::", text)
@@ -391,7 +394,10 @@ def parse_cpp_signature(
     templates, text = strip_leading_templates(text)
     export_macro_pattern = "|".join(re.escape(macro) for macro in EXPORT_MACROS)
     text = re.sub(rf"\b(?:{export_macro_pattern})\b\s*", "", text)
+    text = strip_leading_signature_annotations(text)
     text = re.sub(r"\binline\s+", "", text).strip()
+    if class_member and re.match(r"(?:explicit\s+)?~?Tensor\s*\(", text):
+        return None
     try:
         open_pos = find_function_paren(text)
         close_pos = find_matching(text, open_pos, "(", ")")
@@ -438,6 +444,28 @@ def parse_cpp_signature(
         name=name,
         is_member=is_member,
     )
+
+
+def strip_leading_signature_annotations(text: str) -> str:
+    rest = text.strip()
+    while True:
+        original = rest
+        while rest.startswith("[["):
+            end = rest.find("]]")
+            if end < 0:
+                break
+            rest = rest[end + 2 :].lstrip()
+        for macro in ("C10_DEPRECATED_MESSAGE", "C10_DEPRECATED"):
+            macro_match = re.match(rf"{macro}\b", rest)
+            if not macro_match:
+                continue
+            rest = rest[macro_match.end() :].lstrip()
+            if rest.startswith("("):
+                close_pos = find_matching(rest, 0, "(", ")")
+                rest = rest[close_pos + 1 :].lstrip()
+            break
+        if rest == original:
+            return rest
 
 
 def namespace_at_blocks(text: str) -> list[str]:
@@ -575,10 +603,10 @@ def signature_without_templates(signature: CppSignature) -> CppSignature:
     )
 
 
-def find_tensor_class_body(text: str) -> str | None:
+def find_tensor_class_body(text: str, class_name: str = "Tensor") -> str | None:
     clean = strip_comments_and_literals(text)
     match = re.search(
-        r"\bclass\s+(?:[A-Za-z_]\w*\s+)*Tensor\b[^;{]*\{",
+        rf"\bclass\s+(?:[A-Za-z_]\w*\s+)*{re.escape(class_name)}\b[^;{{]*\{{",
         clean,
     )
     if not match:
@@ -589,9 +617,11 @@ def find_tensor_class_body(text: str) -> str | None:
 
 
 def tensor_class_declarations(
-    text: str, include_member_defaults: bool = False
+    text: str,
+    include_member_defaults: bool = False,
+    class_name: str = "Tensor",
 ) -> list[CppSignature]:
-    body = find_tensor_class_body(text)
+    body = find_tensor_class_body(text, class_name)
     if body is None:
         return []
     signatures: list[CppSignature] = []
@@ -636,6 +666,14 @@ def tensor_class_declarations(
             bracket -= 1
         elif ch == "{":
             if angle == 0 and paren == 0 and bracket == 0 and brace == 0:
+                candidate = body[start:pos]
+                signature = parse_cpp_signature(
+                    candidate,
+                    class_member=True,
+                    include_member_defaults=include_member_defaults,
+                )
+                if signature is not None:
+                    signatures.append(signature)
                 end = find_matching(body, pos, "{", "}")
                 pos = end + 1
                 start = pos
@@ -673,6 +711,15 @@ def parse_torch_tensor_body(path: Path) -> list[CppSignature]:
                 block, include_member_defaults=True
             )
             if sig.is_member
+        )
+    tensor_base = path.with_name("TensorBase.h")
+    if tensor_base.is_file():
+        signatures.extend(
+            tensor_class_declarations(
+                tensor_base.read_text(),
+                include_member_defaults=True,
+                class_name="TensorBase",
+            )
         )
     deduped: dict[str, CppSignature] = {}
     for sig in signatures:
@@ -753,16 +800,22 @@ def choose_base_ref(paddle_root: Path, branch: str) -> str:
 
 
 def added_aten_ops_headers(paddle_root: Path, branch: str) -> list[Path]:
+    return changed_aten_ops_headers(paddle_root, branch)
+
+
+def changed_paths(
+    paddle_root: Path, branch: str, paths: Iterable[Path | str]
+) -> list[Path]:
     base_ref = choose_base_ref(paddle_root, branch)
     result = subprocess.run(
         [
             "git",
             "diff",
             "--name-only",
-            "--diff-filter=A",
+            "--diff-filter=AM",
             base_ref,
             "--",
-            str(ATEN_OPS_DIR),
+            *(str(path) for path in paths),
         ],
         cwd=paddle_root,
         text=True,
@@ -771,11 +824,22 @@ def added_aten_ops_headers(paddle_root: Path, branch: str) -> list[Path]:
     )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip())
+    return [paddle_root / line.strip() for line in result.stdout.splitlines()]
+
+
+def changed_aten_ops_headers(paddle_root: Path, branch: str) -> list[Path]:
     return [
-        paddle_root / line.strip()
-        for line in result.stdout.splitlines()
-        if line.strip().endswith(".h")
+        path
+        for path in changed_paths(paddle_root, branch, [ATEN_OPS_DIR])
+        if path.suffix == ".h"
     ]
+
+
+def tensor_body_changed(paddle_root: Path, branch: str) -> bool:
+    return any(
+        path == paddle_root / ATEN_TENSOR_BODY
+        for path in changed_paths(paddle_root, branch, [ATEN_TENSOR_BODY])
+    )
 
 
 def all_aten_ops_headers(paddle_root: Path) -> list[Path]:
@@ -852,6 +916,41 @@ def check_header(
     return errors
 
 
+def check_tensor_body_members(
+    paddle_root: Path,
+    torch_include_dir: Path,
+    torch_member_signatures: list[CppSignature],
+    paddle_member_signatures: dict[str, CppSignature],
+) -> list[CheckError]:
+    tensor_body = paddle_root / ATEN_TENSOR_BODY
+    torch_header = torch_include_dir / "ATen/core/TensorBody.h"
+    torch_canonicals = {
+        signature.canonical for signature in torch_member_signatures
+    }
+    errors: list[CheckError] = []
+    for signature in paddle_member_signatures.values():
+        if is_paddle_internal_member(signature):
+            continue
+        if signature.canonical in torch_canonicals:
+            continue
+        errors.append(
+            CheckError(
+                header=tensor_body,
+                message="TensorBody member signature does not match libtorch",
+                signature=signature,
+                torch_header=torch_header,
+                candidates=same_name_candidates(
+                    torch_member_signatures, signature
+                ),
+            )
+        )
+    return errors
+
+
+def is_paddle_internal_member(signature: CppSignature) -> bool:
+    return signature.name.startswith("_PD_") or signature.name.endswith("_impl")
+
+
 def format_errors(errors: list[CheckError], paddle_root: Path) -> str:
     lines = ["ATen ops signature check failed:"]
     for idx, error in enumerate(errors, start=1):
@@ -878,11 +977,14 @@ def run_check(
 ) -> list[CheckError]:
     tensor_body = torch_include_dir / "ATen/core/TensorBody.h"
     torch_member_signatures = parse_torch_tensor_body(tensor_body)
-    paddle_tensor_body = (
-        paddle_root / "paddle/phi/api/include/compat/ATen/core/TensorBody.h"
-    )
+    paddle_tensor_body = paddle_root / ATEN_TENSOR_BODY
     paddle_member_signatures = parse_paddle_tensor_body(paddle_tensor_body)
-    errors: list[CheckError] = []
+    errors: list[CheckError] = check_tensor_body_members(
+        paddle_root=paddle_root,
+        torch_include_dir=torch_include_dir,
+        torch_member_signatures=torch_member_signatures,
+        paddle_member_signatures=paddle_member_signatures,
+    )
     for header in headers:
         errors.extend(
             check_header(
@@ -899,7 +1001,7 @@ def run_check(
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Check newly added Paddle compat ATen ops signatures against "
+            "Check changed Paddle compat ATen signatures against "
             "libtorch headers."
         )
     )
@@ -916,12 +1018,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--branch",
         default=os.environ.get("BRANCH", "develop"),
-        help="Base branch name used when collecting newly added files.",
+        help="Base branch name used when collecting changed files.",
     )
     parser.add_argument(
         "--all",
         action="store_true",
-        help="Check all compat ATen ops headers instead of only added files.",
+        help=(
+            "Check all compat ATen ops headers and TensorBody members instead "
+            "of only changed files."
+        ),
     )
     return parser.parse_args()
 
@@ -933,10 +1038,16 @@ def main() -> int:
         headers = (
             all_aten_ops_headers(paddle_root)
             if args.all
-            else added_aten_ops_headers(paddle_root, args.branch)
+            else changed_aten_ops_headers(paddle_root, args.branch)
         )
-        if not headers:
-            print("No newly added compat ATen ops headers found; skip check.")
+        check_tensor_body = args.all or tensor_body_changed(
+            paddle_root, args.branch
+        )
+        if not headers and not check_tensor_body:
+            print(
+                "No changed compat ATen ops headers or TensorBody.h found; "
+                "skip check."
+            )
             return 0
         torch_include_dir = discover_torch_include_dir(args.torch_include_dir)
         errors = run_check(paddle_root, torch_include_dir, headers)

--- a/tools/check_aten_ops_signature.py
+++ b/tools/check_aten_ops_signature.py
@@ -974,17 +974,22 @@ def run_check(
     paddle_root: Path,
     torch_include_dir: Path,
     headers: list[Path],
+    check_tensor_body: bool = True,
 ) -> list[CheckError]:
     tensor_body = torch_include_dir / "ATen/core/TensorBody.h"
     torch_member_signatures = parse_torch_tensor_body(tensor_body)
     paddle_tensor_body = paddle_root / ATEN_TENSOR_BODY
     paddle_member_signatures = parse_paddle_tensor_body(paddle_tensor_body)
-    errors: list[CheckError] = check_tensor_body_members(
-        paddle_root=paddle_root,
-        torch_include_dir=torch_include_dir,
-        torch_member_signatures=torch_member_signatures,
-        paddle_member_signatures=paddle_member_signatures,
-    )
+    errors: list[CheckError] = []
+    if check_tensor_body:
+        errors.extend(
+            check_tensor_body_members(
+                paddle_root=paddle_root,
+                torch_include_dir=torch_include_dir,
+                torch_member_signatures=torch_member_signatures,
+                paddle_member_signatures=paddle_member_signatures,
+            )
+        )
     for header in headers:
         errors.extend(
             check_header(
@@ -1050,7 +1055,12 @@ def main() -> int:
             )
             return 0
         torch_include_dir = discover_torch_include_dir(args.torch_include_dir)
-        errors = run_check(paddle_root, torch_include_dir, headers)
+        errors = run_check(
+            paddle_root,
+            torch_include_dir,
+            headers,
+            check_tensor_body=check_tensor_body,
+        )
     except Exception as exc:
         print(f"ATen ops signature check error: {exc}", file=sys.stderr)
         return 1

--- a/tools/check_aten_ops_signature.py
+++ b/tools/check_aten_ops_signature.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 ATEN_OPS_DIR = Path("paddle/phi/api/include/compat/ATen/ops")
 ATEN_TENSOR_BODY = Path("paddle/phi/api/include/compat/ATen/core/TensorBody.h")
 TORCH_INSTALL_HINT = (
-    "pip install torch==2.9.1 --index-url https://download.pytorch.org/whl/cpu"
+    "pip install torch==2.12.1 --index-url https://download.pytorch.org/whl/cpu"
 )
 
 BUILTIN_TYPE_WORDS = {

--- a/tools/check_aten_ops_signature.py
+++ b/tools/check_aten_ops_signature.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 ATEN_OPS_DIR = Path("paddle/phi/api/include/compat/ATen/ops")
 ATEN_TENSOR_BODY = Path("paddle/phi/api/include/compat/ATen/core/TensorBody.h")
+ATEN_TENSOR_BASE = Path("paddle/phi/api/include/compat/ATen/core/TensorBase.h")
 TORCH_INSTALL_HINT = (
     "pip install torch==2.12.1 --index-url https://download.pytorch.org/whl/cpu"
 )
@@ -387,6 +388,7 @@ def parse_cpp_signature(
     raw: str,
     class_member: bool = False,
     include_member_defaults: bool = False,
+    class_name: str = "Tensor",
 ) -> CppSignature | None:
     text = clean_signature_text(raw)
     if not text or "(" not in text or ")" not in text:
@@ -396,7 +398,9 @@ def parse_cpp_signature(
     text = re.sub(rf"\b(?:{export_macro_pattern})\b\s*", "", text)
     text = strip_leading_signature_annotations(text)
     text = re.sub(r"\binline\s+", "", text).strip()
-    if class_member and re.match(r"(?:explicit\s+)?~?Tensor\s*\(", text):
+    if class_member and re.match(
+        rf"(?:explicit\s+)?~?{re.escape(class_name)}\s*\(", text
+    ):
         return None
     try:
         open_pos = find_function_paren(text)
@@ -415,11 +419,14 @@ def parse_cpp_signature(
     return_type = before[: name_match.start()].strip()
     if not return_type:
         return None
-    if "::" in qualified_name and not qualified_name.startswith("Tensor::"):
+    member_prefixes = ("Tensor::", "TensorBase::")
+    if "::" in qualified_name and not qualified_name.startswith(
+        member_prefixes
+    ):
         return None
-    is_member = class_member or qualified_name.startswith("Tensor::")
+    is_member = class_member or qualified_name.startswith(member_prefixes)
     if class_member and "::" not in qualified_name:
-        qualified_name = f"Tensor::{qualified_name}"
+        qualified_name = f"{class_name}::{qualified_name}"
     name = qualified_name.split("::")[-1]
     include_default = include_member_defaults or not is_member
     param_items = []
@@ -603,6 +610,23 @@ def signature_without_templates(signature: CppSignature) -> CppSignature:
     )
 
 
+def signature_with_class_name(
+    signature: CppSignature, class_name: str
+) -> CppSignature:
+    canonical = re.sub(
+        r"\b(?:Tensor|TensorBase)::",
+        f"{class_name}::",
+        signature.canonical,
+        count=1,
+    )
+    return CppSignature(
+        raw=signature.raw,
+        canonical=canonical,
+        name=signature.name,
+        is_member=signature.is_member,
+    )
+
+
 def find_tensor_class_body(text: str, class_name: str = "Tensor") -> str | None:
     clean = strip_comments_and_literals(text)
     match = re.search(
@@ -616,14 +640,93 @@ def find_tensor_class_body(text: str, class_name: str = "Tensor") -> str | None:
     return clean[open_pos + 1 : close_pos]
 
 
+def public_class_sections(text: str, class_name: str = "Tensor") -> list[str]:
+    body = find_tensor_class_body(text, class_name)
+    if body is None:
+        return []
+    sections: list[str] = []
+    access = "private"
+    start = 0
+    pos = 0
+    angle = paren = bracket = brace = 0
+    state = "normal"
+    while pos < len(body):
+        ch = body[pos]
+        nxt = body[pos + 1] if pos + 1 < len(body) else ""
+        if state == "normal":
+            if ch == '"':
+                state = "string"
+                pos += 1
+                continue
+            if ch == "'":
+                state = "char"
+                pos += 1
+                continue
+        elif state in ("string", "char"):
+            if ch == "\\" and nxt:
+                pos += 2
+                continue
+            if (state == "string" and ch == '"') or (
+                state == "char" and ch == "'"
+            ):
+                state = "normal"
+            pos += 1
+            continue
+
+        if ch == "<":
+            angle += 1
+        elif ch == ">" and angle > 0:
+            angle -= 1
+        elif ch == "(":
+            paren += 1
+        elif ch == ")" and paren > 0:
+            paren -= 1
+        elif ch == "[":
+            bracket += 1
+        elif ch == "]" and bracket > 0:
+            bracket -= 1
+        elif ch == "{":
+            brace += 1
+        elif ch == "}" and brace > 0:
+            brace -= 1
+
+        if paren == 0 and bracket == 0 and brace == 0:
+            match = re.match(r"\s*(public|protected|private)\s*:", body[pos:])
+            if match:
+                if access == "public":
+                    sections.append(body[start:pos])
+                access = match.group(1)
+                pos += match.end()
+                start = pos
+                continue
+        pos += 1
+    if access == "public":
+        sections.append(body[start:])
+    return sections
+
+
 def tensor_class_declarations(
     text: str,
     include_member_defaults: bool = False,
     class_name: str = "Tensor",
 ) -> list[CppSignature]:
-    body = find_tensor_class_body(text, class_name)
-    if body is None:
-        return []
+    signatures: list[CppSignature] = []
+    for body in public_class_sections(text, class_name):
+        signatures.extend(
+            class_section_declarations(
+                body,
+                include_member_defaults=include_member_defaults,
+                class_name=class_name,
+            )
+        )
+    return signatures
+
+
+def class_section_declarations(
+    body: str,
+    include_member_defaults: bool = False,
+    class_name: str = "Tensor",
+) -> list[CppSignature]:
     signatures: list[CppSignature] = []
     start = 0
     pos = 0
@@ -671,6 +774,7 @@ def tensor_class_declarations(
                     candidate,
                     class_member=True,
                     include_member_defaults=include_member_defaults,
+                    class_name=class_name,
                 )
                 if signature is not None:
                     signatures.append(signature)
@@ -688,6 +792,7 @@ def tensor_class_declarations(
                     candidate,
                     class_member=True,
                     include_member_defaults=include_member_defaults,
+                    class_name=class_name,
                 )
                 if signature is not None:
                     signatures.append(signature)
@@ -715,7 +820,8 @@ def parse_torch_tensor_body(path: Path) -> list[CppSignature]:
     tensor_base = path.with_name("TensorBase.h")
     if tensor_base.is_file():
         signatures.extend(
-            tensor_class_declarations(
+            signature_with_class_name(signature, "Tensor")
+            for signature in tensor_class_declarations(
                 tensor_base.read_text(),
                 include_member_defaults=True,
                 class_name="TensorBase",
@@ -727,15 +833,25 @@ def parse_torch_tensor_body(path: Path) -> list[CppSignature]:
     return list(deduped.values())
 
 
-def parse_paddle_tensor_body(path: Path) -> dict[str, CppSignature]:
+def parse_torch_tensor_base(path: Path) -> list[CppSignature]:
+    if not path.is_file():
+        return []
+    return tensor_class_declarations(
+        path.read_text(), include_member_defaults=True, class_name="TensorBase"
+    )
+
+
+def parse_paddle_class_members(
+    path: Path, class_name: str
+) -> dict[str, CppSignature]:
     if not path.is_file():
         return {}
     text = path.read_text()
     declarations_with_defaults = tensor_class_declarations(
-        text, include_member_defaults=True
+        text, include_member_defaults=True, class_name=class_name
     )
     declarations_without_defaults = tensor_class_declarations(
-        text, include_member_defaults=False
+        text, include_member_defaults=False, class_name=class_name
     )
     declarations: dict[str, CppSignature] = {}
     for no_default, with_default in zip(
@@ -743,6 +859,14 @@ def parse_paddle_tensor_body(path: Path) -> dict[str, CppSignature]:
     ):
         declarations.setdefault(no_default.canonical, with_default)
     return declarations
+
+
+def parse_paddle_tensor_body(path: Path) -> dict[str, CppSignature]:
+    return parse_paddle_class_members(path, "Tensor")
+
+
+def parse_paddle_tensor_base(path: Path) -> dict[str, CppSignature]:
+    return parse_paddle_class_members(path, "TensorBase")
 
 
 def valid_torch_include_dir(path: Path) -> bool:
@@ -839,6 +963,13 @@ def tensor_body_changed(paddle_root: Path, branch: str) -> bool:
     return any(
         path == paddle_root / ATEN_TENSOR_BODY
         for path in changed_paths(paddle_root, branch, [ATEN_TENSOR_BODY])
+    )
+
+
+def tensor_base_changed(paddle_root: Path, branch: str) -> bool:
+    return any(
+        path == paddle_root / ATEN_TENSOR_BASE
+        for path in changed_paths(paddle_root, branch, [ATEN_TENSOR_BASE])
     )
 
 
@@ -947,6 +1078,37 @@ def check_tensor_body_members(
     return errors
 
 
+def check_tensor_base_members(
+    paddle_root: Path,
+    torch_include_dir: Path,
+    torch_base_signatures: list[CppSignature],
+    paddle_base_signatures: dict[str, CppSignature],
+) -> list[CheckError]:
+    tensor_base = paddle_root / ATEN_TENSOR_BASE
+    torch_header = torch_include_dir / "ATen/core/TensorBase.h"
+    torch_canonicals = {
+        signature.canonical for signature in torch_base_signatures
+    }
+    errors: list[CheckError] = []
+    for signature in paddle_base_signatures.values():
+        if is_paddle_internal_member(signature):
+            continue
+        if signature.canonical in torch_canonicals:
+            continue
+        errors.append(
+            CheckError(
+                header=tensor_base,
+                message="TensorBase member signature does not match libtorch",
+                signature=signature,
+                torch_header=torch_header,
+                candidates=same_name_candidates(
+                    torch_base_signatures, signature
+                ),
+            )
+        )
+    return errors
+
+
 def is_paddle_internal_member(signature: CppSignature) -> bool:
     return signature.name.startswith("_PD_") or signature.name.endswith("_impl")
 
@@ -975,11 +1137,17 @@ def run_check(
     torch_include_dir: Path,
     headers: list[Path],
     check_tensor_body: bool = True,
+    check_tensor_base: bool = True,
 ) -> list[CheckError]:
     tensor_body = torch_include_dir / "ATen/core/TensorBody.h"
     torch_member_signatures = parse_torch_tensor_body(tensor_body)
+    torch_base_signatures = parse_torch_tensor_base(
+        torch_include_dir / "ATen/core/TensorBase.h"
+    )
     paddle_tensor_body = paddle_root / ATEN_TENSOR_BODY
     paddle_member_signatures = parse_paddle_tensor_body(paddle_tensor_body)
+    paddle_tensor_base = paddle_root / ATEN_TENSOR_BASE
+    paddle_base_signatures = parse_paddle_tensor_base(paddle_tensor_base)
     errors: list[CheckError] = []
     if check_tensor_body:
         errors.extend(
@@ -988,6 +1156,15 @@ def run_check(
                 torch_include_dir=torch_include_dir,
                 torch_member_signatures=torch_member_signatures,
                 paddle_member_signatures=paddle_member_signatures,
+            )
+        )
+    if check_tensor_base:
+        errors.extend(
+            check_tensor_base_members(
+                paddle_root=paddle_root,
+                torch_include_dir=torch_include_dir,
+                torch_base_signatures=torch_base_signatures,
+                paddle_base_signatures=paddle_base_signatures,
             )
         )
     for header in headers:
@@ -1048,10 +1225,13 @@ def main() -> int:
         check_tensor_body = args.all or tensor_body_changed(
             paddle_root, args.branch
         )
-        if not headers and not check_tensor_body:
+        check_tensor_base = args.all or tensor_base_changed(
+            paddle_root, args.branch
+        )
+        if not headers and not check_tensor_body and not check_tensor_base:
             print(
-                "No changed compat ATen ops headers or TensorBody.h found; "
-                "skip check."
+                "No changed compat ATen ops headers, TensorBody.h, or "
+                "TensorBase.h found; skip check."
             )
             return 0
         torch_include_dir = discover_torch_include_dir(args.torch_include_dir)
@@ -1060,6 +1240,7 @@ def main() -> int:
             torch_include_dir,
             headers,
             check_tensor_body=check_tensor_body,
+            check_tensor_base=check_tensor_base,
         )
     except Exception as exc:
         print(f"ATen ops signature check error: {exc}", file=sys.stderr)

--- a/tools/check_aten_ops_signature.py
+++ b/tools/check_aten_ops_signature.py
@@ -610,23 +610,6 @@ def signature_without_templates(signature: CppSignature) -> CppSignature:
     )
 
 
-def signature_with_class_name(
-    signature: CppSignature, class_name: str
-) -> CppSignature:
-    canonical = re.sub(
-        r"\b(?:Tensor|TensorBase)::",
-        f"{class_name}::",
-        signature.canonical,
-        count=1,
-    )
-    return CppSignature(
-        raw=signature.raw,
-        canonical=canonical,
-        name=signature.name,
-        is_member=signature.is_member,
-    )
-
-
 def find_tensor_class_body(text: str, class_name: str = "Tensor") -> str | None:
     clean = strip_comments_and_literals(text)
     match = re.search(
@@ -816,16 +799,6 @@ def parse_torch_tensor_body(path: Path) -> list[CppSignature]:
                 block, include_member_defaults=True
             )
             if sig.is_member
-        )
-    tensor_base = path.with_name("TensorBase.h")
-    if tensor_base.is_file():
-        signatures.extend(
-            signature_with_class_name(signature, "Tensor")
-            for signature in tensor_class_declarations(
-                tensor_base.read_text(),
-                include_member_defaults=True,
-                class_name="TensorBase",
-            )
         )
     deduped: dict[str, CppSignature] = {}
     for sig in signatures:

--- a/tools/check_aten_ops_signature.py
+++ b/tools/check_aten_ops_signature.py
@@ -1179,8 +1179,8 @@ def parse_args() -> argparse.Namespace:
         "--all",
         action="store_true",
         help=(
-            "Check all compat ATen ops headers and TensorBody members instead "
-            "of only changed files."
+            "Check all compat ATen ops headers, TensorBody members, and "
+            "TensorBase members instead of only changed files."
         ),
     )
     return parser.parse_args()
@@ -1190,16 +1190,16 @@ def main() -> int:
     args = parse_args()
     paddle_root = Path(args.paddle_root).resolve()
     try:
-        headers = (
-            all_aten_ops_headers(paddle_root)
-            if args.all
-            else changed_aten_ops_headers(paddle_root, args.branch)
-        )
         check_tensor_body = args.all or tensor_body_changed(
             paddle_root, args.branch
         )
         check_tensor_base = args.all or tensor_base_changed(
             paddle_root, args.branch
+        )
+        headers = (
+            all_aten_ops_headers(paddle_root)
+            if args.all or check_tensor_body
+            else changed_aten_ops_headers(paddle_root, args.branch)
         )
         if not headers and not check_tensor_body and not check_tensor_base:
             print(

--- a/tools/check_aten_ops_signature.py
+++ b/tools/check_aten_ops_signature.py
@@ -1,0 +1,799 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+ATEN_OPS_DIR = Path("paddle/phi/api/include/compat/ATen/ops")
+TORCH_INSTALL_HINT = (
+    "pip install torch==2.9.1 --index-url https://download.pytorch.org/whl/cpu"
+)
+
+BUILTIN_TYPE_WORDS = {
+    "auto",
+    "bool",
+    "char",
+    "double",
+    "float",
+    "int",
+    "int8_t",
+    "int16_t",
+    "int32_t",
+    "int64_t",
+    "long",
+    "short",
+    "size_t",
+    "uint8_t",
+    "uint16_t",
+    "uint32_t",
+    "uint64_t",
+    "void",
+}
+
+
+@dataclass(frozen=True)
+class CppSignature:
+    raw: str
+    canonical: str
+    name: str
+    is_member: bool
+
+
+@dataclass(frozen=True)
+class CheckError:
+    header: Path
+    message: str
+    signature: CppSignature | None = None
+    torch_header: Path | None = None
+    candidates: tuple[CppSignature, ...] = ()
+
+
+class SignatureParseError(ValueError):
+    pass
+
+
+EXPORT_MACROS = (
+    "AT_API",
+    "C10_API",
+    "CAFFE2_API",
+    "TORCH_API",
+)
+
+
+def strip_comments_and_literals(text: str) -> str:
+    result: list[str] = []
+    i = 0
+    state = "normal"
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        if state == "normal":
+            if ch == "/" and nxt == "/":
+                result.extend((" ", " "))
+                i += 2
+                state = "line_comment"
+                continue
+            if ch == "/" and nxt == "*":
+                result.extend((" ", " "))
+                i += 2
+                state = "block_comment"
+                continue
+            if ch == '"':
+                result.append(ch)
+                i += 1
+                state = "string"
+                continue
+            if ch == "'":
+                result.append(ch)
+                i += 1
+                state = "char"
+                continue
+            result.append(ch)
+            i += 1
+            continue
+        if state == "line_comment":
+            result.append("\n" if ch == "\n" else " ")
+            i += 1
+            if ch == "\n":
+                state = "normal"
+            continue
+        if state == "block_comment":
+            if ch == "*" and nxt == "/":
+                result.extend((" ", " "))
+                i += 2
+                state = "normal"
+                continue
+            result.append("\n" if ch == "\n" else " ")
+            i += 1
+            continue
+        if state in ("string", "char"):
+            result.append(ch)
+            if ch == "\\" and nxt:
+                result.append(nxt)
+                i += 2
+                continue
+            if (state == "string" and ch == '"') or (
+                state == "char" and ch == "'"
+            ):
+                state = "normal"
+            i += 1
+            continue
+    return "".join(result)
+
+
+def find_matching(text: str, open_pos: int, open_ch: str, close_ch: str) -> int:
+    depth = 0
+    for pos in range(open_pos, len(text)):
+        if text[pos] == open_ch:
+            depth += 1
+        elif text[pos] == close_ch:
+            depth -= 1
+            if depth == 0:
+                return pos
+    raise SignatureParseError(
+        f"unmatched {open_ch!r} at character offset {open_pos}"
+    )
+
+
+def normalize_punctuation(text: str) -> str:
+    text = re.sub(r"\bat::", "", text)
+    text = text.replace("::std::", "std::")
+    text = re.sub(r"\s+", " ", text.strip())
+    text = re.sub(r"\s*::\s*", "::", text)
+    text = re.sub(r"\s*([<>,()=\[\]])\s*", r"\1", text)
+    text = re.sub(r"\s*([&*])\s*", r"\1", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def clean_signature_text(raw: str) -> str:
+    raw = re.sub(r"\\\s*\n", " ", raw)
+    lines = [
+        line for line in raw.splitlines() if not line.lstrip().startswith("#")
+    ]
+    text = " ".join(lines)
+    text = re.sub(r"\b(public|protected|private)\s*:\s*", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text.rstrip(";").strip()
+
+
+def strip_leading_templates(text: str) -> tuple[tuple[str, ...], str]:
+    templates: list[str] = []
+    rest = text.strip()
+    while rest.startswith("template"):
+        match = re.match(r"template\s*<", rest)
+        if not match:
+            break
+        open_pos = rest.find("<", match.start())
+        close_pos = find_matching(rest, open_pos, "<", ">")
+        templates.append(normalize_punctuation(rest[: close_pos + 1]))
+        rest = rest[close_pos + 1 :].strip()
+    return tuple(templates), rest
+
+
+def find_function_paren(text: str) -> int:
+    depth_angle = 0
+    positions: list[int] = []
+    for pos, ch in enumerate(text):
+        if ch == "<":
+            depth_angle += 1
+        elif ch == ">" and depth_angle > 0:
+            depth_angle -= 1
+        elif ch == "(" and depth_angle == 0:
+            positions.append(pos)
+    if not positions:
+        raise SignatureParseError("function signature has no parameter list")
+    return positions[-1]
+
+
+def split_top_level(text: str, separator: str) -> list[str]:
+    pieces: list[str] = []
+    start = 0
+    angle = paren = bracket = brace = 0
+    for pos, ch in enumerate(text):
+        if ch == "<":
+            angle += 1
+        elif ch == ">" and angle > 0:
+            angle -= 1
+        elif ch == "(":
+            paren += 1
+        elif ch == ")" and paren > 0:
+            paren -= 1
+        elif ch == "[":
+            bracket += 1
+        elif ch == "]" and bracket > 0:
+            bracket -= 1
+        elif ch == "{":
+            brace += 1
+        elif ch == "}" and brace > 0:
+            brace -= 1
+        elif (
+            ch == separator
+            and angle == 0
+            and paren == 0
+            and bracket == 0
+            and brace == 0
+        ):
+            pieces.append(text[start:pos])
+            start = pos + 1
+    pieces.append(text[start:])
+    return pieces
+
+
+def split_default_value(param: str) -> tuple[str, str | None]:
+    angle = paren = bracket = brace = 0
+    for pos, ch in enumerate(param):
+        if ch == "<":
+            angle += 1
+        elif ch == ">" and angle > 0:
+            angle -= 1
+        elif ch == "(":
+            paren += 1
+        elif ch == ")" and paren > 0:
+            paren -= 1
+        elif ch == "[":
+            bracket += 1
+        elif ch == "]" and bracket > 0:
+            bracket -= 1
+        elif ch == "{":
+            brace += 1
+        elif ch == "}" and brace > 0:
+            brace -= 1
+        elif (
+            ch == "="
+            and angle == 0
+            and paren == 0
+            and bracket == 0
+            and brace == 0
+        ):
+            return param[:pos], param[pos + 1 :]
+    return param, None
+
+
+def strip_parameter_name(param_type: str) -> str:
+    text = normalize_punctuation(param_type)
+    if not text or text == "void":
+        return text
+    match = re.match(
+        r"(?P<prefix>.+?)(?:\s+|(?<=[&*]))"
+        r"(?P<name>[A-Za-z_]\w*)\s*(?P<array>(?:\[[^\]]*\])*)$",
+        text,
+    )
+    if not match:
+        match = re.match(
+            r"(?P<prefix>.+?>)(?P<name>[A-Za-z_]\w*)"
+            r"\s*(?P<array>(?:\[[^\]]*\])*)$",
+            text,
+        )
+    if not match:
+        return text
+    prefix = match.group("prefix").rstrip()
+    name = match.group("name")
+    if name in BUILTIN_TYPE_WORDS or prefix.endswith("::"):
+        return text
+    return normalize_punctuation(prefix + match.group("array"))
+
+
+def normalize_parameter(param: str, include_default: bool) -> str:
+    left, default = split_default_value(param)
+    normalized_type = strip_parameter_name(left)
+    if include_default and default is not None:
+        return f"{normalized_type}={normalize_punctuation(default)}"
+    return normalized_type
+
+
+def parse_cpp_signature(
+    raw: str,
+    class_member: bool = False,
+    include_member_defaults: bool = False,
+) -> CppSignature | None:
+    text = clean_signature_text(raw)
+    if not text or "(" not in text or ")" not in text:
+        return None
+    templates, text = strip_leading_templates(text)
+    export_macro_pattern = "|".join(re.escape(macro) for macro in EXPORT_MACROS)
+    text = re.sub(rf"\b(?:{export_macro_pattern})\b\s*", "", text)
+    text = re.sub(r"\binline\s+", "", text).strip()
+    try:
+        open_pos = find_function_paren(text)
+        close_pos = find_matching(text, open_pos, "(", ")")
+    except SignatureParseError:
+        return None
+    before = text[:open_pos].strip()
+    params = text[open_pos + 1 : close_pos]
+    suffix = text[close_pos + 1 :].strip()
+    name_match = re.search(
+        r"(?P<name>(?:[A-Za-z_]\w*::)*[A-Za-z_]\w*)$", before
+    )
+    if not name_match:
+        return None
+    qualified_name = name_match.group("name")
+    return_type = before[: name_match.start()].strip()
+    if not return_type:
+        return None
+    if "::" in qualified_name and not qualified_name.startswith("Tensor::"):
+        return None
+    is_member = class_member or qualified_name.startswith("Tensor::")
+    if class_member and "::" not in qualified_name:
+        qualified_name = f"Tensor::{qualified_name}"
+    name = qualified_name.split("::")[-1]
+    include_default = include_member_defaults or not is_member
+    param_items = []
+    if params.strip() and params.strip() != "void":
+        param_items = [
+            normalize_parameter(param, include_default)
+            for param in split_top_level(params, ",")
+            if param.strip()
+        ]
+    canonical_return = normalize_punctuation(return_type)
+    canonical_suffix = normalize_punctuation(suffix)
+    canonical_templates = "".join(templates)
+    canonical = (
+        f"{canonical_templates}{canonical_return} "
+        f"{qualified_name}({','.join(param_items)})"
+    )
+    if canonical_suffix:
+        canonical = f"{canonical}{canonical_suffix}"
+    return CppSignature(
+        raw=normalize_punctuation(text),
+        canonical=canonical,
+        name=name,
+        is_member=is_member,
+    )
+
+
+def namespace_at_blocks(text: str) -> list[str]:
+    return namespace_blocks(text, "at")
+
+
+def namespace_blocks(text: str, namespace_name: str) -> list[str]:
+    clean = strip_comments_and_literals(text)
+    blocks: list[str] = []
+    pattern = rf"\bnamespace\s+{re.escape(namespace_name)}\s*\{{"
+    for match in re.finditer(pattern, clean):
+        open_pos = clean.find("{", match.start())
+        close_pos = find_matching(clean, open_pos, "{", "}")
+        blocks.append(clean[open_pos + 1 : close_pos])
+    return blocks
+
+
+def top_level_function_definitions(
+    block: str, include_member_defaults: bool = False
+) -> list[CppSignature]:
+    signatures: list[CppSignature] = []
+    start = 0
+    pos = 0
+    while pos < len(block):
+        ch = block[pos]
+        if ch == "{":
+            candidate = block[start:pos]
+            signature = parse_cpp_signature(
+                candidate,
+                include_member_defaults=include_member_defaults,
+            )
+            if signature is not None:
+                signatures.append(signature)
+            end = find_matching(block, pos, "{", "}")
+            pos = end + 1
+            start = pos
+            continue
+        if ch == ";":
+            candidate = block[start:pos]
+            signature = parse_cpp_signature(
+                candidate,
+                include_member_defaults=include_member_defaults,
+            )
+            if signature is not None:
+                signatures.append(signature)
+            start = pos + 1
+        pos += 1
+    return signatures
+
+
+def parse_paddle_header(path: Path) -> tuple[list[CppSignature], list[str]]:
+    blocks = namespace_at_blocks(path.read_text())
+    errors: list[str] = []
+    if len(blocks) not in (1, 2):
+        errors.append(
+            "expected one or two exact 'namespace at' blocks, "
+            f"got {len(blocks)}"
+        )
+        return [], errors
+    signatures: list[CppSignature] = []
+    for block in blocks:
+        signatures.extend(top_level_function_definitions(block))
+    return signatures, errors
+
+
+def parse_torch_ops_header(path: Path) -> list[CppSignature]:
+    if not path.is_file():
+        return []
+    signatures: list[CppSignature] = []
+    for block in namespace_at_blocks(path.read_text()):
+        signatures.extend(
+            sig
+            for sig in top_level_function_definitions(block)
+            if not sig.is_member
+        )
+        for symint_block in namespace_blocks(block, "symint"):
+            signatures.extend(
+                signature_without_templates(sig)
+                for sig in top_level_function_definitions(symint_block)
+                if not sig.is_member
+            )
+    return signatures
+
+
+def signature_without_templates(signature: CppSignature) -> CppSignature:
+    canonical = signature.canonical
+    while canonical.startswith("template<"):
+        close_pos = find_matching(canonical, canonical.find("<"), "<", ">")
+        canonical = canonical[close_pos + 1 :]
+    return CppSignature(
+        raw=signature.raw,
+        canonical=canonical,
+        name=signature.name,
+        is_member=signature.is_member,
+    )
+
+
+def find_tensor_class_body(text: str) -> str | None:
+    clean = strip_comments_and_literals(text)
+    match = re.search(
+        r"\bclass\s+(?:[A-Za-z_]\w*\s+)*Tensor\b[^;{]*\{",
+        clean,
+    )
+    if not match:
+        return None
+    open_pos = clean.find("{", match.start())
+    close_pos = find_matching(clean, open_pos, "{", "}")
+    return clean[open_pos + 1 : close_pos]
+
+
+def tensor_class_declarations(
+    text: str, include_member_defaults: bool = False
+) -> list[CppSignature]:
+    body = find_tensor_class_body(text)
+    if body is None:
+        return []
+    signatures: list[CppSignature] = []
+    start = 0
+    pos = 0
+    while pos < len(body):
+        ch = body[pos]
+        if ch == "{":
+            end = find_matching(body, pos, "{", "}")
+            pos = end + 1
+            start = pos
+            continue
+        if ch == ";":
+            candidate = body[start:pos]
+            signature = parse_cpp_signature(
+                candidate,
+                class_member=True,
+                include_member_defaults=include_member_defaults,
+            )
+            if signature is not None:
+                signatures.append(signature)
+            start = pos + 1
+        pos += 1
+    return signatures
+
+
+def parse_torch_tensor_body(path: Path) -> list[CppSignature]:
+    if not path.is_file():
+        return []
+    text = path.read_text()
+    signatures: list[CppSignature] = []
+    signatures.extend(
+        tensor_class_declarations(text, include_member_defaults=True)
+    )
+    for block in namespace_at_blocks(text):
+        signatures.extend(
+            sig
+            for sig in top_level_function_definitions(
+                block, include_member_defaults=True
+            )
+            if sig.is_member
+        )
+    deduped: dict[str, CppSignature] = {}
+    for sig in signatures:
+        deduped.setdefault(sig.canonical, sig)
+    return list(deduped.values())
+
+
+def parse_paddle_tensor_body(path: Path) -> dict[str, CppSignature]:
+    if not path.is_file():
+        return {}
+    text = path.read_text()
+    declarations_with_defaults = tensor_class_declarations(
+        text, include_member_defaults=True
+    )
+    declarations_without_defaults = tensor_class_declarations(
+        text, include_member_defaults=False
+    )
+    declarations: dict[str, CppSignature] = {}
+    for no_default, with_default in zip(
+        declarations_without_defaults, declarations_with_defaults
+    ):
+        declarations.setdefault(no_default.canonical, with_default)
+    return declarations
+
+
+def valid_torch_include_dir(path: Path) -> bool:
+    return (path / "ATen/core/TensorBody.h").is_file() and (
+        path / "ATen/ops"
+    ).is_dir()
+
+
+def torch_include_dirs_from_python() -> list[Path]:
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            from torch.utils.cpp_extension import include_paths
+    except Exception:
+        return []
+    return [Path(path) for path in include_paths()]
+
+
+def discover_torch_include_dir(torch_include_dir: str | None) -> Path:
+    candidates: list[Path] = []
+    if torch_include_dir:
+        candidates.append(Path(torch_include_dir))
+    else:
+        candidates.extend(torch_include_dirs_from_python())
+    for candidate in candidates:
+        if valid_torch_include_dir(candidate):
+            return candidate
+    searched = ", ".join(str(path) for path in candidates) or "<none>"
+    raise FileNotFoundError(
+        "Cannot find libtorch headers. Searched: "
+        f"{searched}. Install CPU PyTorch with: {TORCH_INSTALL_HINT}"
+    )
+
+
+def git_ref_exists(paddle_root: Path, ref: str) -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", ref],
+        cwd=paddle_root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def choose_base_ref(paddle_root: Path, branch: str) -> str:
+    refs = [f"upstream/{branch}", f"origin/{branch}", branch]
+    for ref in refs:
+        if git_ref_exists(paddle_root, ref):
+            return ref
+    raise RuntimeError(
+        "Cannot find a base ref for ATen ops signature check. Tried: "
+        + ", ".join(refs)
+    )
+
+
+def added_aten_ops_headers(paddle_root: Path, branch: str) -> list[Path]:
+    base_ref = choose_base_ref(paddle_root, branch)
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=A",
+            base_ref,
+            "--",
+            str(ATEN_OPS_DIR),
+        ],
+        cwd=paddle_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip())
+    return [
+        paddle_root / line.strip()
+        for line in result.stdout.splitlines()
+        if line.strip().endswith(".h")
+    ]
+
+
+def all_aten_ops_headers(paddle_root: Path) -> list[Path]:
+    return sorted((paddle_root / ATEN_OPS_DIR).glob("*.h"))
+
+
+def same_name_candidates(
+    candidates: Iterable[CppSignature], signature: CppSignature
+) -> tuple[CppSignature, ...]:
+    return tuple(
+        candidate
+        for candidate in candidates
+        if candidate.name == signature.name
+        and candidate.is_member == signature.is_member
+    )
+
+
+def check_header(
+    paddle_header: Path,
+    paddle_root: Path,
+    torch_include_dir: Path,
+    torch_member_signatures: list[CppSignature],
+    paddle_member_signatures: dict[str, CppSignature],
+) -> list[CheckError]:
+    signatures, parse_errors = parse_paddle_header(paddle_header)
+    errors = [
+        CheckError(header=paddle_header, message=message)
+        for message in parse_errors
+    ]
+    if parse_errors:
+        return errors
+    ops_name = paddle_header.name
+    torch_ops_header = torch_include_dir / "ATen/ops" / ops_name
+    torch_free_signatures = parse_torch_ops_header(torch_ops_header)
+    for signature in signatures:
+        if signature.is_member:
+            torch_header = torch_include_dir / "ATen/core/TensorBody.h"
+            candidates = torch_member_signatures
+            comparison_signature = paddle_member_signatures.get(
+                signature.canonical
+            )
+            if comparison_signature is None:
+                errors.append(
+                    CheckError(
+                        header=paddle_header,
+                        message=(
+                            "member function implementation is missing a "
+                            "matching Paddle TensorBody declaration"
+                        ),
+                        signature=signature,
+                        torch_header=torch_header,
+                        candidates=same_name_candidates(candidates, signature),
+                    )
+                )
+                continue
+        else:
+            torch_header = torch_ops_header
+            candidates = torch_free_signatures
+            comparison_signature = signature
+        if any(
+            candidate.canonical == comparison_signature.canonical
+            for candidate in candidates
+        ):
+            continue
+        errors.append(
+            CheckError(
+                header=paddle_header,
+                message="signature does not match libtorch",
+                signature=comparison_signature,
+                torch_header=torch_header,
+                candidates=same_name_candidates(candidates, signature),
+            )
+        )
+    return errors
+
+
+def format_errors(errors: list[CheckError], paddle_root: Path) -> str:
+    lines = ["ATen ops signature check failed:"]
+    for idx, error in enumerate(errors, start=1):
+        rel_header = error.header.relative_to(paddle_root)
+        lines.append(f"{idx}. {rel_header}: {error.message}")
+        if error.signature is None:
+            continue
+        lines.append(f"   Paddle signature: {error.signature.raw}")
+        if error.torch_header is not None:
+            lines.append(f"   Libtorch header: {error.torch_header}")
+        if error.candidates:
+            lines.append("   Libtorch candidates with the same name:")
+            for candidate in error.candidates:
+                lines.append(f"     - {candidate.raw}")
+        else:
+            lines.append("   Libtorch candidates with the same name: <none>")
+    return "\n".join(lines)
+
+
+def run_check(
+    paddle_root: Path,
+    torch_include_dir: Path,
+    headers: list[Path],
+) -> list[CheckError]:
+    tensor_body = torch_include_dir / "ATen/core/TensorBody.h"
+    torch_member_signatures = parse_torch_tensor_body(tensor_body)
+    paddle_tensor_body = (
+        paddle_root / "paddle/phi/api/include/compat/ATen/core/TensorBody.h"
+    )
+    paddle_member_signatures = parse_paddle_tensor_body(paddle_tensor_body)
+    errors: list[CheckError] = []
+    for header in headers:
+        errors.extend(
+            check_header(
+                paddle_header=header,
+                paddle_root=paddle_root,
+                torch_include_dir=torch_include_dir,
+                torch_member_signatures=torch_member_signatures,
+                paddle_member_signatures=paddle_member_signatures,
+            )
+        )
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check newly added Paddle compat ATen ops signatures against "
+            "libtorch headers."
+        )
+    )
+    parser.add_argument(
+        "--paddle-root",
+        default=".",
+        help="Path to Paddle repository root.",
+    )
+    parser.add_argument(
+        "--torch-include-dir",
+        default=None,
+        help="Path to libtorch include directory.",
+    )
+    parser.add_argument(
+        "--branch",
+        default=os.environ.get("BRANCH", "develop"),
+        help="Base branch name used when collecting newly added files.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Check all compat ATen ops headers instead of only added files.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    paddle_root = Path(args.paddle_root).resolve()
+    try:
+        headers = (
+            all_aten_ops_headers(paddle_root)
+            if args.all
+            else added_aten_ops_headers(paddle_root, args.branch)
+        )
+        if not headers:
+            print("No newly added compat ATen ops headers found; skip check.")
+            return 0
+        torch_include_dir = discover_torch_include_dir(args.torch_include_dir)
+        errors = run_check(paddle_root, torch_include_dir, headers)
+    except Exception as exc:
+        print(f"ATen ops signature check error: {exc}", file=sys.stderr)
+        return 1
+    if errors:
+        print(format_errors(errors, paddle_root), file=sys.stderr)
+        return 1
+    print(f"ATen ops signature check passed for {len(headers)} header(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_check_aten_ops_signature.py
+++ b/tools/test_check_aten_ops_signature.py
@@ -21,6 +21,7 @@ from check_aten_ops_signature import (
     discover_torch_include_dir,
     main,
     parse_paddle_header,
+    parse_paddle_tensor_body,
     run_check,
 )
 
@@ -117,6 +118,147 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             TORCH_API Tensor foo(const Tensor& input, int64_t axis = 0);
             }  // namespace at
             """,
+        )
+        self.assertEqual(self.check(header), [])
+
+    def test_free_function_braced_default_value_match(self):
+        header = self.write_paddle_op(
+            "empty_strided.h",
+            """
+            namespace at {
+            inline Tensor empty_strided(IntArrayRef size,
+                                        IntArrayRef stride,
+                                        TensorOptions options = {}) {
+              return Tensor();
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/empty_strided.h",
+            """
+            namespace at {
+            inline Tensor empty_strided(IntArrayRef size,
+                                        IntArrayRef stride,
+                                        TensorOptions options = {}) {
+              return Tensor();
+            }
+            }  // namespace at
+            """,
+        )
+        self.assertEqual(self.check(header), [])
+
+    def test_member_declaration_braced_default_value_match(self):
+        header = self.write_paddle_op(
+            "new_empty.h",
+            """
+            namespace at {
+            inline Tensor Tensor::new_empty(IntArrayRef size,
+                                            TensorOptions options) const {
+              return Tensor();
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              Tensor new_empty(IntArrayRef size,
+                               TensorOptions options = {}) const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            """
+            namespace at {
+            class Tensor {
+             public:
+              Tensor new_empty(IntArrayRef size,
+                               TensorOptions options = {}) const;
+            };
+            }  // namespace at
+            """,
+        )
+        declarations = parse_paddle_tensor_body(
+            self.paddle_root
+            / "paddle/phi/api/include/compat/ATen/core/TensorBody.h"
+        )
+        self.assertTrue(
+            any(
+                "TensorOptions={}" in sig.canonical
+                for sig in declarations.values()
+            )
+        )
+        self.assertEqual(self.check(header), [])
+
+    def test_multiple_defaults_after_braced_default_value_match(self):
+        header = self.write_paddle_op(
+            "sparse_coo_tensor.h",
+            """
+            namespace at {
+            inline Tensor sparse_coo_tensor(
+                const Tensor& indices,
+                const Tensor& values,
+                IntArrayRef size,
+                TensorOptions options = {},
+                std::optional<bool> is_coalesced = std::nullopt) {
+              return Tensor();
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/sparse_coo_tensor.h",
+            """
+            namespace at {
+            inline Tensor sparse_coo_tensor(
+                const Tensor& indices,
+                const Tensor& values,
+                IntArrayRef size,
+                TensorOptions options = {},
+                std::optional<bool> is_coalesced = std::nullopt) {
+              return Tensor();
+            }
+            }  // namespace at
+            """,
+        )
+        self.assertEqual(self.check(header), [])
+
+    def test_from_blob_overloads_with_braced_defaults_are_collected(self):
+        header = self.write_paddle_op(
+            "from_blob.h",
+            """
+            namespace at {
+            inline TensorMaker for_blob(void* data, IntArrayRef sizes) noexcept {
+              return TensorMaker();
+            }
+            inline Tensor from_blob(void* data,
+                                    IntArrayRef sizes,
+                                    IntArrayRef strides,
+                                    const TensorOptions& options = {}) {
+              return Tensor();
+            }
+            inline Tensor from_blob(void* data,
+                                    IntArrayRef sizes,
+                                    const TensorOptions& options = {}) {
+              return Tensor();
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/from_blob.h",
+            header.read_text(),
+        )
+        signatures, errors = parse_paddle_header(header)
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            sum(sig.name == "from_blob" for sig in signatures),
+            2,
         )
         self.assertEqual(self.check(header), [])
 

--- a/tools/test_check_aten_ops_signature.py
+++ b/tools/test_check_aten_ops_signature.py
@@ -74,6 +74,14 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             [header],
         )
 
+    def check_changed_headers_only(self, header):
+        return run_check(
+            self.paddle_root,
+            self.torch_include,
+            [header],
+            check_tensor_body=False,
+        )
+
     def test_free_function_signature_match(self):
         header = self.write_paddle_op(
             "foo.h",
@@ -558,6 +566,107 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             """,
         )
         errors = self.check(header)
+        self.assertTrue(
+            any(
+                "TensorBody member signature" in error.message
+                for error in errors
+            )
+        )
+
+    def test_changed_ops_header_does_not_check_unchanged_tensor_body(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline at::Tensor foo(const at::Tensor& self) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor stale_member(int64_t dim = 1) const {
+                return at::Tensor();
+              }
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor stale_member(int64_t dim = 0) const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/foo.h",
+            """
+            namespace at {
+            inline at::Tensor foo(const at::Tensor& self) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+
+        self.assertEqual(self.check_changed_headers_only(header), [])
+
+    def test_tensor_body_check_still_fails_when_requested(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline at::Tensor foo(const at::Tensor& self) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor stale_member(int64_t dim = 1) const {
+                return at::Tensor();
+              }
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor stale_member(int64_t dim = 0) const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/foo.h",
+            """
+            namespace at {
+            inline at::Tensor foo(const at::Tensor& self) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+
+        errors = self.check(header)
+
         self.assertTrue(
             any(
                 "TensorBody member signature" in error.message

--- a/tools/test_check_aten_ops_signature.py
+++ b/tools/test_check_aten_ops_signature.py
@@ -782,6 +782,86 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             declarations,
         )
 
+    def test_tensor_body_does_not_match_inherited_tensor_base_member(self):
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              const void* const_data_ptr() const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            """
+            namespace at {
+            class Tensor {};
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBase.h",
+            """
+            namespace at {
+            class TensorBase {
+             public:
+              const void* const_data_ptr() const;
+            };
+            }  // namespace at
+            """,
+        )
+
+        errors = run_check(
+            self.paddle_root,
+            self.torch_include,
+            [],
+            check_tensor_body=True,
+            check_tensor_base=False,
+        )
+
+        self.assertTrue(
+            any(
+                "TensorBody member signature" in error.message
+                for error in errors
+            )
+        )
+
+    def test_tensor_base_member_still_matches_tensor_base(self):
+        self.write_paddle_tensor_base(
+            """
+            namespace at {
+            class TensorBase {
+             public:
+              const void* const_data_ptr() const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBase.h",
+            """
+            namespace at {
+            class TensorBase {
+             public:
+              const void* const_data_ptr() const;
+            };
+            }  // namespace at
+            """,
+        )
+
+        self.assertEqual(
+            run_check(
+                self.paddle_root,
+                self.torch_include,
+                [],
+                check_tensor_body=False,
+                check_tensor_base=True,
+            ),
+            [],
+        )
+
     def test_deprecated_attribute_and_macro_are_equivalent(self):
         header = self.write_paddle_op("packed_accessor.h", "namespace at {}")
         self.write_paddle_tensor_body(

--- a/tools/test_check_aten_ops_signature.py
+++ b/tools/test_check_aten_ops_signature.py
@@ -23,8 +23,10 @@ from check_aten_ops_signature import (
     discover_torch_include_dir,
     main,
     parse_paddle_header,
+    parse_paddle_tensor_base,
     parse_paddle_tensor_body,
     run_check,
+    tensor_base_changed,
     tensor_body_changed,
 )
 
@@ -61,6 +63,15 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
         path.write_text(content)
         return path
 
+    def write_paddle_tensor_base(self, content):
+        path = (
+            self.paddle_root
+            / "paddle/phi/api/include/compat/ATen/core/TensorBase.h"
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
     def write_torch(self, relpath, content):
         path = self.torch_include / relpath
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -80,6 +91,7 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             self.torch_include,
             [header],
             check_tensor_body=False,
+            check_tensor_base=False,
         )
 
     def test_free_function_signature_match(self):
@@ -674,6 +686,102 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             )
         )
 
+    def test_tensor_base_public_member_mismatch_fails_when_requested(self):
+        self.write_paddle_tensor_base(
+            """
+            namespace at {
+            class TensorBase {
+             public:
+              bool use_count() const noexcept;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBase.h",
+            """
+            namespace at {
+            class TensorBase {
+             public:
+              size_t use_count() const noexcept;
+            };
+            }  // namespace at
+            """,
+        )
+
+        errors = run_check(
+            self.paddle_root,
+            self.torch_include,
+            [],
+            check_tensor_body=False,
+            check_tensor_base=True,
+        )
+
+        self.assertTrue(
+            any(
+                "TensorBase member signature" in error.message
+                for error in errors
+            )
+        )
+
+    def test_tensor_base_private_helper_is_not_checked(self):
+        self.write_paddle_tensor_base(
+            """
+            namespace at {
+            class TensorBase {
+             public:
+              size_t use_count() const noexcept;
+             private:
+              void MaybeResetHolder();
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBase.h",
+            """
+            namespace at {
+            class TensorBase {
+             public:
+              size_t use_count() const noexcept;
+            };
+            }  // namespace at
+            """,
+        )
+
+        self.assertEqual(
+            run_check(
+                self.paddle_root,
+                self.torch_include,
+                [],
+                check_tensor_body=False,
+                check_tensor_base=True,
+            ),
+            [],
+        )
+
+    def test_tensor_base_owner_is_preserved(self):
+        self.write_paddle_tensor_base(
+            """
+            namespace at {
+            class TensorBase {
+             public:
+              const void* const_data_ptr() const;
+            };
+            }  // namespace at
+            """,
+        )
+
+        declarations = parse_paddle_tensor_base(
+            self.paddle_root
+            / "paddle/phi/api/include/compat/ATen/core/TensorBase.h"
+        )
+
+        self.assertIn(
+            "const void* TensorBase::const_data_ptr()const",
+            declarations,
+        )
+
     def test_deprecated_attribute_and_macro_are_equivalent(self):
         header = self.write_paddle_op("packed_accessor.h", "namespace at {}")
         self.write_paddle_tensor_body(
@@ -925,6 +1033,73 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
 
         self.assertTrue(tensor_body_changed(self.paddle_root, "develop"))
 
+    def test_tensor_base_changed_detects_modified_tensor_base(self):
+        tensor_base = self.write_paddle_tensor_base(
+            "namespace at { class TensorBase {}; }\n"
+        )
+        subprocess.run(["git", "init"], cwd=self.paddle_root, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=self.paddle_root,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "test"],
+            cwd=self.paddle_root,
+            check=True,
+        )
+        subprocess.run(["git", "add", "."], cwd=self.paddle_root, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "base"],
+            cwd=self.paddle_root,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "branch", "develop"], cwd=self.paddle_root, check=True
+        )
+        tensor_base.write_text(
+            "namespace at { class TensorBase { public: size_t use_count() const; }; }\n"
+        )
+
+        self.assertTrue(tensor_base_changed(self.paddle_root, "develop"))
+
+    def test_tensor_base_only_change_runs_tensor_base_check(self):
+        with (
+            mock.patch(
+                "check_aten_ops_signature.changed_aten_ops_headers",
+                return_value=[],
+            ),
+            mock.patch(
+                "check_aten_ops_signature.tensor_body_changed",
+                return_value=False,
+            ),
+            mock.patch(
+                "check_aten_ops_signature.tensor_base_changed",
+                return_value=True,
+            ),
+            mock.patch(
+                "check_aten_ops_signature.discover_torch_include_dir",
+                return_value=self.torch_include,
+            ),
+            mock.patch(
+                "check_aten_ops_signature.run_check",
+                return_value=[],
+            ) as run_check_mock,
+            mock.patch(
+                "sys.argv",
+                [
+                    "check_aten_ops_signature.py",
+                    "--paddle-root",
+                    str(self.paddle_root),
+                ],
+            ),
+        ):
+            self.assertEqual(main(), 0)
+        run_check_mock.assert_called_once()
+        self.assertFalse(run_check_mock.call_args.kwargs["check_tensor_body"])
+        self.assertTrue(run_check_mock.call_args.kwargs["check_tensor_base"])
+
     def test_no_changed_signature_inputs_skips_torch_discovery(self):
         with (
             mock.patch(
@@ -933,6 +1108,10 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             ),
             mock.patch(
                 "check_aten_ops_signature.tensor_body_changed",
+                return_value=False,
+            ),
+            mock.patch(
+                "check_aten_ops_signature.tensor_base_changed",
                 return_value=False,
             ),
             mock.patch(

--- a/tools/test_check_aten_ops_signature.py
+++ b/tools/test_check_aten_ops_signature.py
@@ -1,0 +1,501 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from check_aten_ops_signature import (
+    discover_torch_include_dir,
+    main,
+    parse_paddle_header,
+    run_check,
+)
+
+
+class TestAtenOpsSignatureCheck(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.paddle_root = self.root / "Paddle"
+        self.torch_include = self.root / "torch" / "include"
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            "namespace at { class Tensor {}; }",
+        )
+        (self.torch_include / "ATen/ops").mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write_paddle_op(self, name, content):
+        path = (
+            self.paddle_root / "paddle/phi/api/include/compat/ATen/ops" / name
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+    def write_paddle_tensor_body(self, content):
+        path = (
+            self.paddle_root
+            / "paddle/phi/api/include/compat/ATen/core/TensorBody.h"
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+    def write_torch(self, relpath, content):
+        path = self.torch_include / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+    def check(self, header):
+        return run_check(
+            self.paddle_root,
+            self.torch_include,
+            [header],
+        )
+
+    def test_free_function_signature_match(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline std::vector<at::Tensor> foo(
+                const at::Tensor& self,
+                ::std::optional<at::Layout>,
+                int64_t dim = 0) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/foo.h",
+            """
+            namespace at {
+            inline ::std::vector<Tensor> foo(
+                const Tensor & input,
+                std::optional<Layout> layout,
+                int64_t axis=0) {
+              return {};
+            }
+            }  // namespace at
+            """,
+        )
+        self.assertEqual(self.check(header), [])
+
+    def test_torch_api_free_function_declaration_match(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline at::Tensor foo(const at::Tensor& self, int64_t dim = 0) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/foo.h",
+            """
+            namespace at {
+            TORCH_API Tensor foo(const Tensor& input, int64_t axis = 0);
+            }  // namespace at
+            """,
+        )
+        self.assertEqual(self.check(header), [])
+
+    def test_symint_free_function_signature_match(self):
+        header = self.write_paddle_op(
+            "view.h",
+            """
+            namespace at {
+            inline at::Tensor view(const at::Tensor& self,
+                                   at::IntArrayRef size) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/view.h",
+            """
+            namespace at {
+            namespace symint {
+            template <typename T,
+                      typename = std::enable_if_t<std::is_same_v<T, int64_t>>>
+            at::Tensor view(const at::Tensor& self, at::IntArrayRef size) {
+              return self;
+            }
+            }  // namespace symint
+            }  // namespace at
+            """,
+        )
+        self.assertEqual(self.check(header), [])
+
+    def test_missing_torch_overload_not_present_in_compat_is_ignored(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline at::Tensor foo(const at::Tensor& self) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/foo.h",
+            """
+            namespace at {
+            inline Tensor foo(const Tensor& input) {
+              return input;
+            }
+            inline Tensor foo(const Tensor& input, int64_t dim) {
+              return input;
+            }
+            }  // namespace at
+            """,
+        )
+        self.assertEqual(self.check(header), [])
+
+    def test_free_function_does_not_match_tensor_member_function(self):
+        header = self.write_paddle_op(
+            "view.h",
+            """
+            namespace at {
+            inline at::Tensor view(const at::Tensor& self,
+                                   at::ScalarType dtype) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor foo(int64_t dim=0) const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor view(at::ScalarType dtype) const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/view.h",
+            """
+            namespace at {}
+            """,
+        )
+        errors = self.check(header)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("signature does not match", errors[0].message)
+
+    def test_member_function_signature_match_from_tensor_body_declaration(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {}
+            namespace at {
+            inline at::Tensor Tensor::foo(int64_t dim) const {
+              return at::Tensor();
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor foo(int64_t dim=0) const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor foo(int64_t dim=0) const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.assertEqual(self.check(header), [])
+
+    def test_template_member_signature_match_from_tensor_body_declaration(self):
+        header = self.write_paddle_op(
+            "item.h",
+            """
+            namespace at {}
+            namespace at {
+            template <typename T>
+            T Tensor::item() const {
+              return T();
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              template <typename T>
+              T item() const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            """
+            namespace at {
+            class Tensor {
+             public:
+              template <typename T>
+              T item() const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.assertEqual(self.check(header), [])
+
+    def test_free_function_default_value_mismatch_fails(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline at::Tensor foo(const at::Tensor& self, int64_t dim = 1) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/foo.h",
+            """
+            namespace at {
+            inline Tensor foo(const Tensor & input, int64_t axis=0) {
+              return input;
+            }
+            }  // namespace at
+            """,
+        )
+        errors = self.check(header)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("signature does not match", errors[0].message)
+
+    def test_free_function_string_default_value_mismatch_fails(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline at::Tensor foo(const at::Tensor& self,
+                                  std::string mode = "sum") {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/foo.h",
+            """
+            namespace at {
+            TORCH_API Tensor foo(const Tensor& self,
+                                 std::string mode = "mean");
+            }  // namespace at
+            """,
+        )
+        errors = self.check(header)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("signature does not match", errors[0].message)
+
+    def test_member_default_value_mismatch_fails(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline at::Tensor Tensor::foo(bool upper) const {
+              return at::Tensor();
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor foo(bool upper=true) const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor foo(bool upper=false) const;
+            };
+            }  // namespace at
+            """,
+        )
+        errors = self.check(header)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("signature does not match", errors[0].message)
+
+    def test_member_return_type_mismatch_fails(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline at::Scalar Tensor::foo(int64_t dim) const {
+              return at::Scalar();
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Scalar foo(int64_t dim) const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor foo(int64_t dim) const;
+            };
+            }  // namespace at
+            """,
+        )
+        errors = self.check(header)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("signature does not match", errors[0].message)
+
+    def test_missing_torch_function_fails(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline at::Tensor bar(const at::Tensor& self) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_torch("ATen/ops/foo.h", "namespace at {}")
+        errors = self.check(header)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].candidates, ())
+
+    def test_helper_function_in_namespace_at_is_checked(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline std::vector<at::Tensor> convert_indices_list(
+                const c10::List<std::optional<at::Tensor>>& indices) {
+              return {};
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_torch("ATen/ops/foo.h", "namespace at {}")
+        errors = self.check(header)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].signature.name, "convert_indices_list")
+
+    def test_namespace_count_must_be_one_or_two(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {}
+            namespace at {}
+            namespace at {}
+            """,
+        )
+        signatures, errors = parse_paddle_header(header)
+        self.assertEqual(signatures, [])
+        self.assertEqual(len(errors), 1)
+        self.assertIn("expected one or two", errors[0])
+
+    def test_discover_torch_include_dir_argument(self):
+        self.assertEqual(
+            discover_torch_include_dir(str(self.torch_include)),
+            self.torch_include,
+        )
+
+    def test_discover_torch_include_dir_from_python_helper(self):
+        bad = self.root / "bad"
+        with mock.patch(
+            "check_aten_ops_signature.torch_include_dirs_from_python",
+            return_value=[bad, self.torch_include],
+        ):
+            self.assertEqual(
+                discover_torch_include_dir(None), self.torch_include
+            )
+
+    def test_no_added_headers_skips_torch_discovery(self):
+        with (
+            mock.patch(
+                "check_aten_ops_signature.added_aten_ops_headers",
+                return_value=[],
+            ),
+            mock.patch(
+                "check_aten_ops_signature.discover_torch_include_dir",
+                side_effect=AssertionError("should not discover torch"),
+            ),
+            mock.patch(
+                "sys.argv",
+                [
+                    "check_aten_ops_signature.py",
+                    "--paddle-root",
+                    str(self.paddle_root),
+                ],
+            ),
+        ):
+            self.assertEqual(main(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_check_aten_ops_signature.py
+++ b/tools/test_check_aten_ops_signature.py
@@ -12,17 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
 
 from check_aten_ops_signature import (
+    changed_aten_ops_headers,
     discover_torch_include_dir,
     main,
     parse_paddle_header,
     parse_paddle_tensor_body,
     run_check,
+    tensor_body_changed,
 )
 
 
@@ -333,7 +336,7 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             namespace at {
             class Tensor {
              public:
-              at::Tensor foo(int64_t dim=0) const;
+              at::Tensor view(at::ScalarType dtype) const;
             };
             }  // namespace at
             """,
@@ -356,8 +359,32 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             """,
         )
         errors = self.check(header)
-        self.assertEqual(len(errors), 1)
-        self.assertIn("signature does not match", errors[0].message)
+        self.assertTrue(errors)
+        self.assertTrue(
+            any("signature does not match" in error.message for error in errors)
+        )
+
+    def test_inline_member_declaration_is_collected_from_tensor_body(self):
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              Tensor std(int dim) const { return Tensor(); }
+            };
+            }  // namespace at
+            """,
+        )
+        declarations = parse_paddle_tensor_body(
+            self.paddle_root
+            / "paddle/phi/api/include/compat/ATen/core/TensorBody.h"
+        )
+        self.assertTrue(
+            any(
+                signature.canonical == "Tensor Tensor::std(int)const"
+                for signature in declarations.values()
+            )
+        )
 
     def test_member_function_signature_match_from_tensor_body_declaration(self):
         header = self.write_paddle_op(
@@ -454,8 +481,10 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             """,
         )
         errors = self.check(header)
-        self.assertEqual(len(errors), 1)
-        self.assertIn("signature does not match", errors[0].message)
+        self.assertTrue(errors)
+        self.assertTrue(
+            any("signature does not match" in error.message for error in errors)
+        )
 
     def test_free_function_string_default_value_mismatch_fails(self):
         header = self.write_paddle_op(
@@ -479,8 +508,102 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             """,
         )
         errors = self.check(header)
-        self.assertEqual(len(errors), 1)
-        self.assertIn("signature does not match", errors[0].message)
+        self.assertTrue(errors)
+        self.assertTrue(
+            any("signature does not match" in error.message for error in errors)
+        )
+
+    def test_tensor_body_inline_member_mismatch_fails(self):
+        header = self.write_paddle_op(
+            "foo.h",
+            """
+            namespace at {
+            inline at::Tensor foo(const at::Tensor& self) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor foo(int64_t dim = 1) const {
+                return at::Tensor();
+              }
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            """
+            namespace at {
+            class Tensor {
+             public:
+              at::Tensor foo(int64_t dim = 0) const;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/ops/foo.h",
+            """
+            namespace at {
+            inline at::Tensor foo(const at::Tensor& self) {
+              return self;
+            }
+            }  // namespace at
+            """,
+        )
+        errors = self.check(header)
+        self.assertTrue(
+            any(
+                "TensorBody member signature" in error.message
+                for error in errors
+            )
+        )
+
+    def test_deprecated_attribute_and_macro_are_equivalent(self):
+        header = self.write_paddle_op("packed_accessor.h", "namespace at {}")
+        self.write_paddle_tensor_body(
+            """
+            namespace at {
+            class Tensor {
+             public:
+              template <typename T,
+                        size_t N,
+                        template <typename U> class PtrTraits = DefaultPtrTraits,
+                        typename index_t = int64_t>
+              [[deprecated("packed_accessor is deprecated,use packed_accessor32 "
+                           "or packed_accessor64 instead")]]
+              GenericPackedTensorAccessor<T, N, PtrTraits, index_t>
+              packed_accessor() && = delete;
+            };
+            }  // namespace at
+            """,
+        )
+        self.write_torch(
+            "ATen/core/TensorBody.h",
+            """
+            namespace at {
+            class Tensor {
+             public:
+              template <typename T,
+                        size_t N,
+                        template <typename U> class PtrTraits = DefaultPtrTraits,
+                        typename index_t = int64_t>
+              C10_DEPRECATED_MESSAGE(
+                  "packed_accessor is deprecated,use packed_accessor32 or "
+                  "packed_accessor64 instead")
+              GenericPackedTensorAccessor<T, N, PtrTraits, index_t>
+              packed_accessor() && = delete;
+            };
+            }  // namespace at
+            """,
+        )
+        self.assertEqual(self.check(header), [])
 
     def test_member_default_value_mismatch_fails(self):
         header = self.write_paddle_op(
@@ -515,8 +638,10 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             """,
         )
         errors = self.check(header)
-        self.assertEqual(len(errors), 1)
-        self.assertIn("signature does not match", errors[0].message)
+        self.assertTrue(errors)
+        self.assertTrue(
+            any("signature does not match" in error.message for error in errors)
+        )
 
     def test_member_return_type_mismatch_fails(self):
         header = self.write_paddle_op(
@@ -551,8 +676,10 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
             """,
         )
         errors = self.check(header)
-        self.assertEqual(len(errors), 1)
-        self.assertIn("signature does not match", errors[0].message)
+        self.assertTrue(errors)
+        self.assertTrue(
+            any("signature does not match" in error.message for error in errors)
+        )
 
     def test_missing_torch_function_fails(self):
         header = self.write_paddle_op(
@@ -617,11 +744,87 @@ class TestAtenOpsSignatureCheck(unittest.TestCase):
                 discover_torch_include_dir(None), self.torch_include
             )
 
-    def test_no_added_headers_skips_torch_discovery(self):
+    def test_changed_aten_ops_headers_includes_modified_headers(self):
+        ops_dir = self.paddle_root / "paddle/phi/api/include/compat/ATen/ops"
+        ops_dir.mkdir(parents=True, exist_ok=True)
+        foo = ops_dir / "foo.h"
+        bar = ops_dir / "bar.h"
+        foo.write_text("namespace at {}\n")
+        subprocess.run(["git", "init"], cwd=self.paddle_root, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=self.paddle_root,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "test"],
+            cwd=self.paddle_root,
+            check=True,
+        )
+        subprocess.run(["git", "add", "."], cwd=self.paddle_root, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "base"],
+            cwd=self.paddle_root,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "branch", "develop"], cwd=self.paddle_root, check=True
+        )
+        foo.write_text(
+            "namespace at { inline Tensor foo() { return Tensor(); } }\n"
+        )
+        bar.write_text("namespace at {}\n")
+        subprocess.run(
+            ["git", "add", str(foo), str(bar)],
+            cwd=self.paddle_root,
+            check=True,
+        )
+
+        headers = changed_aten_ops_headers(self.paddle_root, "develop")
+
+        self.assertEqual(set(headers), {foo, bar})
+
+    def test_tensor_body_changed_detects_modified_tensor_body(self):
+        tensor_body = self.write_paddle_tensor_body(
+            "namespace at { class Tensor {}; }\n"
+        )
+        subprocess.run(["git", "init"], cwd=self.paddle_root, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=self.paddle_root,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "test"],
+            cwd=self.paddle_root,
+            check=True,
+        )
+        subprocess.run(["git", "add", "."], cwd=self.paddle_root, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "base"],
+            cwd=self.paddle_root,
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "branch", "develop"], cwd=self.paddle_root, check=True
+        )
+        tensor_body.write_text(
+            "namespace at { class Tensor { public: Tensor foo() const; }; }\n"
+        )
+
+        self.assertTrue(tensor_body_changed(self.paddle_root, "develop"))
+
+    def test_no_changed_signature_inputs_skips_torch_discovery(self):
         with (
             mock.patch(
-                "check_aten_ops_signature.added_aten_ops_headers",
+                "check_aten_ops_signature.changed_aten_ops_headers",
                 return_value=[],
+            ),
+            mock.patch(
+                "check_aten_ops_signature.tensor_body_changed",
+                return_value=False,
             ),
             mock.patch(
                 "check_aten_ops_signature.discover_torch_include_dir",


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description
本 PR 新增 ATen ops 兼容头文件函数签名静态检查，并修复现有 compat ATen ops 头文件中与 libtorch 2.12.1 public API 不一致的签名。

主要改动：
- 新增 tools/check_aten_ops_signature.py 和单测，并在 ci/static_check.sh 中安装 torch==2.12.1 CPU wheel 后执行检查。
- 对齐现有 compat ATen ops 头文件的 public 签名，包括默认参数、const/ref 修饰、TensorList 相关类型和 sparse_coo_tensor is_coalesced 参数。
- 将非 libtorch public 的 helper 或扩展入口移出 public namespace at top-level，保留必要内部实现逻辑。
- 更新相关 C++ compat 测试，改为使用 libtorch 公开签名入口。

本地验证：
- python tools/test_check_aten_ops_signature.py
- python -m py_compile tools/check_aten_ops_signature.py tools/test_check_aten_ops_signature.py
- python tools/check_aten_ops_signature.py --paddle-root . --torch-include-dir /home/may/libtorch/include --all
- pre-commit run --files <changed files>
- ninja -C build ATen_index_test ATen_squeeze_test ATen_std_var_test ATen_expand_test ATen_split_test ATen_record_stream_test ATen_rename_test c10_layout_test -j16
- ctest -R '^(ATen_index_test|ATen_squeeze_test|ATen_std_var_test|ATen_expand_test|ATen_split_test|ATen_record_stream_test|ATen_rename_test|c10_layout_test)$' --output-on-failure -j16
- python -m pip install --dry-run torch==2.12.1 --index-url https://download.pytorch.org/whl/cpu

### 是否引起精度变化
否
