### PR TITLE
【Hackathon 10th Spring No.52】[Inference] Avoid rpath link flag on Windows

### DIFF
--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -142,9 +142,12 @@ if(WIN32)
                PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
   target_link_libraries(paddle_inference_shared phi common)
 endif()
-set(INFERENCE_SHARED_LINKFLAGS "-Wl,-rpath,'$ORIGIN'")
-set_target_properties(paddle_inference_shared
-                      PROPERTIES LINK_FLAGS "${INFERENCE_SHARED_LINKFLAGS}")
+set(INFERENCE_SHARED_LINKFLAGS "")
+if(NOT WIN32)
+  set(INFERENCE_SHARED_LINKFLAGS "-Wl,-rpath,'$ORIGIN'")
+  set_target_properties(paddle_inference_shared
+                        PROPERTIES LINK_FLAGS "${INFERENCE_SHARED_LINKFLAGS}")
+endif()
 set_target_properties(paddle_inference_shared PROPERTIES OUTPUT_NAME
                                                          paddle_inference)
 if(NOT APPLE


### PR DESCRIPTION
### PR Category
Inference

### PR Types
Bug fixes

### Description
Windows MSVC `link.exe` 不支持 GNU ld 风格的 `-Wl,-rpath,'$ORIGIN'` 参数。此前 `paddle_inference_shared` 会无条件设置该 rpath link flag，导致 Windows 构建 `paddle_inference.dll` 时也会把这个无效参数传给 MSVC linker，并产生 `LNK4044` 警告。

本 PR 将该 rpath link flag 限定为仅在非 Windows 平台使用，Windows 下不再向 `link.exe` 传递该参数。改动范围仅限 inference shared library 的链接参数生成，不涉及算子、kernel 或运行时计算逻辑。

验证：
- `git diff --check -- paddle/fluid/inference/CMakeLists.txt`
- `prek --files paddle/fluid/inference/CMakeLists.txt`

### 是否引起精度变化
否