### PR TITLE
[Typing] Clean up invalid `python.paddle` imports

### DIFF
--- a/python/paddle/amp/grad_scaler.py
+++ b/python/paddle/amp/grad_scaler.py
@@ -37,8 +37,8 @@ from .auto_cast import amp_global_state
 
 if TYPE_CHECKING:
     from paddle import Tensor
+    from paddle.optimizer.optimizer import Optimizer
     from paddle.static.amp.decorator import OptimizerWithMixedPrecision
-    from python.paddle.optimizer.optimizer import Optimizer
 
     class _ScaleStateDict(TypedDict):
         scale: Tensor


### PR DESCRIPTION
### PR Category
Environment Adaptation


### PR Types
Improvements


### Description
This PR cleans up the remaining invalid `python.paddle` import found on latest `develop`.

- Replace the type-checking-only import in `python/paddle/amp/grad_scaler.py` with the public `paddle.optimizer.optimizer` path.
- Verified no remaining `from python.paddle`, `import python.paddle`, or `python.paddle.` references in the repo.
- Checked that #79291 is already merged and this PR only touches a different file.

Validation:

- `PYTHONPYCACHEPREFIX=/tmp/paddle-clean-python-paddle-imports-pycache python3 -m py_compile python/paddle/amp/grad_scaler.py` ✅
- `ruff check python/paddle/amp/grad_scaler.py` ✅
- `pre-commit run --files python/paddle/amp/grad_scaler.py` ✅
- `git diff --check` ✅
- `PYTHONPATH=python python3 test/amp/test_grad_scaler_out.py` not run successfully: this source checkout does not have a built `libpaddle` extension, so importing local `paddle` fails before the test body runs.


### 是否引起精度变化
否
