### PR TITLE
[CodeStyle] Remove dead activation codegen helpers

### DIFF
--- a/python/paddle/tensor/layer_function_generator.py
+++ b/python/paddle/tensor/layer_function_generator.py
@@ -16,17 +16,12 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from paddle import _C_ops, _legacy_C_ops
-
-from ..base.data_feeder import check_variable_and_dtype
 from ..common_ops_import import Variable
 from ..framework import (
     LayerHelper,
     OpProtoHolder,
     convert_nptype_to_datatype_or_vartype,
     core,
-    in_dynamic_mode,
-    in_dynamic_or_pir_mode,
 )
 
 if TYPE_CHECKING:
@@ -162,87 +157,4 @@ def generate_layer_fn(op_type: str):
         return helper.append_activation(out_var)
 
     func.__name__ = op_type
-    return func
-
-
-def generate_activation_fn(op_type: str):
-    """Register the Python layer for an Operator without Attribute.
-
-    Args:
-       op_type: The name of the operator to be created.
-
-    This function takes in the operator type (sigmoid, exp , tanh etc) and
-    creates the operator functionality.
-
-    """
-
-    def func(x, name: str | None = None) -> Tensor:
-        if in_dynamic_or_pir_mode():
-            if hasattr(_C_ops, op_type):
-                op = getattr(_C_ops, op_type)
-                return op(x)
-            else:
-                # TODO(dev): Because some ops' yaml has not been migrated.
-                # Replace it with _C_ops while all yaml work is done.
-                op = getattr(_legacy_C_ops, op_type)
-                return op(x)
-        else:
-            if op_type not in ["abs", "exp", "square"]:
-                check_variable_and_dtype(
-                    x, 'x', ['float16', 'float32', 'float64'], op_type
-                )
-            else:
-                # abs exp square ops support dtype(int32, int64, float16, float32, float64)
-                check_variable_and_dtype(
-                    x,
-                    'x',
-                    [
-                        'int32',
-                        'int64',
-                        'float16',
-                        'float32',
-                        'float64',
-                        'complex64',
-                        'complex128',
-                        'uint16',
-                    ],
-                    op_type,
-                )
-
-            helper = LayerHelper(op_type, **locals())
-
-            output = helper.create_variable_for_type_inference(dtype=x.dtype)
-            helper.append_op(
-                type=op_type, inputs={"X": x}, outputs={"Out": output}
-            )
-            return output
-
-    return func
-
-
-def generate_inplace_fn(inplace_op_type):
-    """Register the Python layer for an Inplace Operator without Attribute.
-
-    Args:
-       inplace_op_type: The name of the inplace operator to be created.
-
-    This function takes in the inplace operator type (exp_ , ceil_ etc) and
-    creates the operator functionality.
-    """
-    origin_op_type = inplace_op_type[:-1]
-
-    def func(x, name=None):
-        if in_dynamic_mode():
-            if hasattr(_C_ops, inplace_op_type):
-                op = getattr(_C_ops, inplace_op_type)
-                return op(x)
-            else:
-                op = getattr(_legacy_C_ops, inplace_op_type)
-                return op(x)
-
-    func.__name__ = inplace_op_type
-    func.__doc__ = f"""
-Inplace version of ``{origin_op_type}`` API, the output Tensor will be inplaced with input ``x``.
-Please refer to :ref:`api_paddle_{origin_op_type}`.
-"""
     return func

--- a/test/ai_edited_test/test_ai_layer_gen.py
+++ b/test/ai_edited_test/test_ai_layer_gen.py
@@ -25,8 +25,6 @@ Test Module: paddle.tensor.layer_function_generator
 This test covers the following functions:
 1. _convert_ - CamelCase 转 snake_case / CamelCase to snake_case conversion
 2. generate_layer_fn - 生成算子层函数 / Generate operator layer function
-3. generate_activation_fn - 生成激活函数 / Generate activation function
-4. generate_inplace_fn - 生成就地操作函数 / Generate inplace operation function
 """
 
 import unittest
@@ -36,8 +34,6 @@ import numpy as np
 import paddle
 from paddle.tensor.layer_function_generator import (
     _convert_,
-    generate_activation_fn,
-    generate_inplace_fn,
     generate_layer_fn,
 )
 
@@ -105,165 +101,6 @@ class TestConvert(unittest.TestCase):
         Test GELU -> gelu conversion"""
         result = _convert_("GELU")
         self.assertEqual(result, "gelu")
-
-
-class TestGenerateActivationFn(unittest.TestCase):
-    """测试 generate_activation_fn 函数
-    Test generate_activation_fn function"""
-
-    def setUp(self):
-        """设置测试环境 / Set up test environment"""
-        paddle.disable_static()
-
-    def test_relu_activation(self):
-        """测试生成 relu 激活函数
-        Test generated relu activation function"""
-        relu_fn = generate_activation_fn("relu")
-        x = paddle.to_tensor([[-1.0, 0.0, 1.0], [2.0, -0.5, 0.5]])
-        out = relu_fn(x)
-        expected = np.array([[0.0, 0.0, 1.0], [2.0, 0.0, 0.5]])
-        np.testing.assert_allclose(out.numpy(), expected, atol=1e-6)
-
-    def test_sigmoid_activation(self):
-        """测试生成 sigmoid 激活函数
-        Test generated sigmoid activation function"""
-        sigmoid_fn = generate_activation_fn("sigmoid")
-        x = paddle.to_tensor([[0.0, 1.0], [-1.0, 2.0]])
-        out = sigmoid_fn(x)
-        expected = 1.0 / (1.0 + np.exp(-np.array([[0.0, 1.0], [-1.0, 2.0]])))
-        np.testing.assert_allclose(out.numpy(), expected, atol=1e-6)
-
-    def test_tanh_activation(self):
-        """测试生成 tanh 激活函数
-        Test generated tanh activation function"""
-        tanh_fn = generate_activation_fn("tanh")
-        x = paddle.to_tensor([[0.0, 1.0], [-1.0, 0.5]])
-        out = tanh_fn(x)
-        expected = np.tanh(np.array([[0.0, 1.0], [-1.0, 0.5]]))
-        np.testing.assert_allclose(out.numpy(), expected, atol=1e-6)
-
-    def test_abs_activation(self):
-        """测试生成 abs 激活函数
-        Test generated abs activation function"""
-        abs_fn = generate_activation_fn("abs")
-        x = paddle.to_tensor([[-1.0, -2.0], [3.0, -0.5]])
-        out = abs_fn(x)
-        expected = np.array([[1.0, 2.0], [3.0, 0.5]])
-        np.testing.assert_allclose(out.numpy(), expected, atol=1e-6)
-
-    def test_exp_activation(self):
-        """测试生成 exp 激活函数
-        Test generated exp activation function"""
-        exp_fn = generate_activation_fn("exp")
-        x = paddle.to_tensor([[0.0, 1.0], [-1.0, 2.0]])
-        out = exp_fn(x)
-        expected = np.exp(np.array([[0.0, 1.0], [-1.0, 2.0]]))
-        np.testing.assert_allclose(out.numpy(), expected, atol=1e-5)
-
-    def test_square_activation(self):
-        """测试生成 square 激活函数
-        Test generated square activation function"""
-        square_fn = generate_activation_fn("square")
-        x = paddle.to_tensor([[1.0, 2.0], [3.0, -2.0]])
-        out = square_fn(x)
-        expected = np.array([[1.0, 4.0], [9.0, 4.0]])
-        np.testing.assert_allclose(out.numpy(), expected, atol=1e-6)
-
-    def test_gelu_activation(self):
-        """测试生成 gelu 激活函数
-        Test generated gelu activation function"""
-        gelu_fn = generate_activation_fn("gelu")
-        x = paddle.to_tensor([[0.0, 1.0], [-1.0, 0.5]])
-        out = gelu_fn(x)
-        self.assertEqual(list(out.shape), [2, 2])
-        # GELU(0) 应接近 0 / GELU(0) should be close to 0
-        self.assertAlmostEqual(out.numpy()[0, 0], 0.0, places=5)
-
-    def test_relu6_activation(self):
-        """测试生成 relu6 激活函数
-        Test generated relu6 activation function"""
-        try:
-            relu6_fn = generate_activation_fn("relu6")
-            x = paddle.to_tensor([[7.0, 3.0], [-1.0, 5.0]])
-            out = relu6_fn(x)
-            # relu6 裁剪到 [0, 6]
-            expected = np.array([[6.0, 3.0], [0.0, 5.0]])
-            np.testing.assert_allclose(out.numpy(), expected, atol=1e-5)
-        except Exception:
-            # relu6 可能不存在于某些版本中
-            # relu6 may not exist in some versions
-            pass
-
-    def test_activation_with_float64(self):
-        """测试激活函数使用 float64 输入
-        Test activation function with float64 input"""
-        relu_fn = generate_activation_fn("relu")
-        x = paddle.to_tensor([[-1.0, 0.0, 1.0]], dtype='float64')
-        out = relu_fn(x)
-        self.assertEqual(out.dtype, paddle.float64)
-        np.testing.assert_allclose(out.numpy(), [[0.0, 0.0, 1.0]], atol=1e-10)
-
-
-class TestGenerateInplaceFn(unittest.TestCase):
-    """测试 generate_inplace_fn 函数
-    Test generate_inplace_fn function"""
-
-    def setUp(self):
-        """设置测试环境 / Set up test environment"""
-        paddle.disable_static()
-
-    def test_exp_inplace(self):
-        """测试生成 exp_ 就地操作函数
-        Test generated exp_ inplace function"""
-        exp_inplace_fn = generate_inplace_fn("exp_")
-        x = paddle.to_tensor([1.0, 2.0, 3.0])
-        original_id = id(x)
-        out = exp_inplace_fn(x)
-        expected = np.exp(np.array([1.0, 2.0, 3.0]))
-        np.testing.assert_allclose(x.numpy(), expected, atol=1e-5)
-        # 就地操作应该修改原张量 / Inplace should modify original tensor
-        np.testing.assert_allclose(out.numpy(), expected, atol=1e-5)
-
-    def test_abs_inplace(self):
-        """测试生成 abs_ 就地操作函数
-        Test generated abs_ inplace function"""
-        abs_inplace_fn = generate_inplace_fn("abs_")
-        x = paddle.to_tensor([-1.0, 2.0, -3.0])
-        out = abs_inplace_fn(x)
-        np.testing.assert_allclose(x.numpy(), [1.0, 2.0, 3.0], atol=1e-6)
-
-    def test_inplace_fn_name(self):
-        """测试生成的就地函数名称
-        Test generated inplace function name"""
-        exp_inplace_fn = generate_inplace_fn("exp_")
-        self.assertEqual(exp_inplace_fn.__name__, "exp_")
-
-    def test_inplace_fn_docstring(self):
-        """测试生成的就地函数文档字符串
-        Test generated inplace function docstring"""
-        relu_inplace_fn = generate_inplace_fn("relu_")
-        self.assertIn("relu", relu_inplace_fn.__doc__)
-
-    def test_square_inplace(self):
-        """测试生成 square_ 就地操作函数
-        Test generated square_ inplace function"""
-        square_inplace_fn = generate_inplace_fn("square_")
-        x = paddle.to_tensor([1.0, 2.0, 3.0])
-        out = square_inplace_fn(x)
-        np.testing.assert_allclose(x.numpy(), [1.0, 4.0, 9.0], atol=1e-6)
-
-    def test_ceil_inplace(self):
-        """测试生成 ceil_ 就地操作函数
-        Test generated ceil_ inplace function"""
-        try:
-            ceil_inplace_fn = generate_inplace_fn("ceil_")
-            x = paddle.to_tensor([1.2, 2.7, -0.5])
-            out = ceil_inplace_fn(x)
-            np.testing.assert_allclose(x.numpy(), [2.0, 3.0, 0.0], atol=1e-6)
-        except Exception:
-            # ceil_ 可能在某些版本中不可用
-            # ceil_ may not be available in some versions
-            pass
 
 
 class TestGenerateLayerFn(unittest.TestCase):


### PR DESCRIPTION
### PR Category
Execute Infrastructure


### PR Types
Devs


### Description
Remove unused `generate_activation_fn` and `generate_inplace_fn` helpers from `python/paddle/tensor/layer_function_generator.py`.

Full-tree searches for `generate_activation_fn` / `generate_inplace_fn` only found their definitions and AI-generated tests under `test/ai_edited_test/test_ai_layer_gen.py`, so this also deletes those corresponding test-only cases and cleans their now-unused imports/doc entries.

Validation:
- `python3 -m py_compile python/paddle/tensor/layer_function_generator.py test/ai_edited_test/test_ai_layer_gen.py`
- `ruff check python/paddle/tensor/layer_function_generator.py test/ai_edited_test/test_ai_layer_gen.py`
- `pre-commit run --files python/paddle/tensor/layer_function_generator.py test/ai_edited_test/test_ai_layer_gen.py`
- `git diff --check`

Remaining related test note:
- `python3 test/ai_edited_test/test_ai_layer_gen.py` could not run in this local environment because `numpy` is not installed for the available Python 3.14 interpreter.


### 是否引起精度变化
否
