### PR TITLE
[Paddle TensorRT] Fix int64 shape tensor in stack/arange converters breaking TRT>=10.8 engine build

### DIFF
--- a/python/paddle/tensorrt/impls/creation.py
+++ b/python/paddle/tensorrt/impls/creation.py
@@ -129,7 +129,14 @@ def arange_converter(network, paddle_op, inputs):
             name=[paddle_op.name(), 'quotient_tensor'],
         )
     else:
-        quotient_tensor = f_quotient_tensor
+        # zero_tensor (above) is int32; on TRT>=10 the integer quotient is int64,
+        # which would mismatch in the trt_sub below. Cast it to int32 too.
+        quotient_tensor = trt_cast(
+            network,
+            f_quotient_tensor,
+            trt.int32,
+            name=[paddle_op.name(), 'quotient_tensor'],
+        )
 
     delta_1 = trt_sub(
         network,

--- a/python/paddle/tensorrt/impls/manipulation.py
+++ b/python/paddle/tensorrt/impls/manipulation.py
@@ -947,9 +947,13 @@ def stack_converter(network, paddle_op, inputs):
     if axis < 0:
         axis += output_rank
 
-    shape_tensor = network.add_shape(input_tensors[0])
-    set_layer_name(shape_tensor, paddle_op)
-    shape_tensor = shape_tensor.get_output(0)
+    # Use trt_shape() instead of raw add_shape: TRT 10.8 changed Shape's output
+    # to int64, which then collides with the int32 add_1D_constant_layer below in
+    # add_concatenation ("Error Code 4: incompatible types Int32 and Int64").
+    # trt_shape() casts the shape tensor back to int32 on TRT>=10.
+    shape_tensor = trt_shape(
+        network, input_tensors[0], name=[paddle_op.name(), 'shape_tensor']
+    )
     shape_tensor_vec = []
     for i in range(output_rank):
         if i < axis:


### PR DESCRIPTION
### PR Category

Inference

### PR Types

Bug fixes

### Description

**Problem.** On **TensorRT ≥ 10.8** the `Shape` op returns **int64** (it returned int32 up to 10.0.1).
The `pd_op.stack` converter builds its output-shape subgraph from a **raw `network.add_shape(...)`** and
then concatenates that int64 tensor with the int32 `add_1D_constant_layer(network, 1)`, which breaks the
TensorRT engine build. Paddle already handles this elsewhere via `converter_utils.py::trt_shape()` (which
casts the `Shape` result back to int32 on TRT ≥ 10, per its docstring); `stack_converter` simply wasn't
routed through it. `arange_converter` has the analogous gap — only its float branch casts the quotient.

**Fix (2 files):**
- `python/paddle/tensorrt/impls/manipulation.py` — `stack_converter`: replace raw
  `network.add_shape(...)` with `trt_shape(...)` so the shape tensor is int32 before the
  `add_concatenation` with the int32 constant.
- `python/paddle/tensorrt/impls/creation.py` — `arange_converter`: cast the integer-branch quotient to
  int32 (mirroring the existing float branch).

**Verification — the repo's own tests go FAIL → PASS, on Turing *and* Blackwell.** Built the released
`paddlepaddle-gpu==3.3.0` (cu129) + `tensorrt==10.15.1.29` and ran `test/tensorrt/test_converter_*.py`:

```
[Tesla T4, sm_75]  and  [RTX PRO 6000, sm_120]  — identical:

BEFORE this fix:
  test_converter_manipulation.py::TestStackTRTPattern::test_trt_result       FAILED
  test_converter_manipulation.py::TestStackCase2TRTPattern::test_trt_result  FAILED
    [TRT] [E] Error Code 2: graphShapeAnalyzer ... Assertion !isInFlight(p.second.symbolicRep) failed
    E  AttributeError: 'NoneType' object has no attribute 'axis'  (manipulation.py:999)
  => 2 failed, 2 passed

AFTER this fix (same tests):
  test_converter_manipulation.py::TestStackTRTPattern::test_trt_result       PASSED
  test_converter_manipulation.py::TestStackCase2TRTPattern::test_trt_result  PASSED
  => 4 passed
```

The existing `TestStackTRTPattern` / `TestStackCase2TRTPattern` already cover the path, so **no new test
is needed** — they fail on TRT ≥ 10.8 without this change and pass with it (and pass on TRT < 10.8 either
way, where `Shape` still returns int32, which is why this regressed silently on CI). In larger graphs the
same int64 shape tensor instead trips `Error Code 4: ... incompatible types Int32 and Int64` (observed
with `PP-FormulaNet_plus-L`).

**Note on `arange`:** the existing arange tests use *constant* inputs and pass before and after, so they
don't independently exercise this; the integer-branch cast is included as the obvious consistency fix
matching the float branch (the same issue surfaces at the model level, e.g. `PP-DocLayout-L`). Happy to
split it into a follow-up if preferred.

Regression sources: `pd_op.stack` (#68839), `pd_op.arange` (#68757). Good cherry-pick candidate for
`release/3.3` / `release/3.4`.

Fixes #79319.

### 是否引起精度变化 (Does this change precision?)

否 (No). Shape/index tensors are bounded well within int32 range; the change only makes the TensorRT
operand dtype consistent so the engine builds, and is numerically equivalent.
