### PR TITLE
[API Compatibility] Return `_IncompatibleKeys` for `set_state_dict`

### DIFF
--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -3004,7 +3004,7 @@ class Layer:
         state_dict: _StateDict,
         use_structured_name: bool = True,
         assign: bool = False,
-    ) -> tuple[list[str], list[str]]:
+    ) -> _IncompatibleKeys:
         '''
         Set parameters and persistable buffers from state_dict. All the parameters and buffers will be reset by the tensor in the state_dict
 
@@ -3015,9 +3015,13 @@ class Layer:
             assign(bool, optional): When set to ``False``, the properties of the tensors
                 in the current layer are preserved whereas setting it to ``True`` preserves
                 properties of the tensors in the state dict. Default: ``False``.
+
         Returns:
-            missing_keys(list):A list of str containing the missing keys
-            unexpected_keys(list):A list of str containing the unexpected keys
+            ``NamedTuple`` with ``missing_keys`` and ``unexpected_keys`` fields:
+                * ``missing_keys`` is a list of str containing any keys that are expected
+                    by this module but missing from the provided ``state_dict``.
+                * ``unexpected_keys`` is a list of str containing the keys that are not
+                    expected by this module but present in the provided ``state_dict``.
 
         Examples:
             .. code-block:: pycon
@@ -3147,14 +3151,14 @@ class Layer:
                     "This error might happens in dy2static, while calling 'set_state_dict' dynamically in 'forward', which is not supported. If you only need call 'set_state_dict' once, move it to '__init__'."
                 )
 
-        return missing_keys, unexpected_keys
+        return _IncompatibleKeys(missing_keys, unexpected_keys)
 
     def load_state_dict(
         self,
         state_dict: Mapping[str, Any],
         strict: bool = True,
         assign: bool = False,
-    ):
+    ) -> _IncompatibleKeys:
         """
         Copy parameters and buffers from :attr:`state_dict` into this module and its descendants.
 

--- a/test/legacy_test/test_state_dict_convert.py
+++ b/test/legacy_test/test_state_dict_convert.py
@@ -109,6 +109,15 @@ class TestStateDictReturn(unittest.TestCase):
         self.assertEqual(len(unexpected_keys), 1)
         self.assertEqual(unexpected_keys[0], "unexpected_keys")
 
+    def test_missing_keys_and_unexpected_keys_attr(self):
+        model1 = MyModel2()
+        tmp_dict = {}
+        tmp_dict["unexpected_keys"] = paddle.to_tensor([1])
+        result = model1.set_state_dict(tmp_dict)
+        self.assertIsInstance(result, tuple)
+        self.assertIs(result[0], result.missing_keys)
+        self.assertIs(result[1], result.unexpected_keys)
+
 
 class TestStateKeepVars(unittest.TestCase):
     def test_true(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
User Experience


### PR Types
Improvements


### Description
<!-- Describe what you’ve done -->
- Set return type to `_IncompatibleKeys` for `set_state_dict`
- Update EN doc
- Add test for `_IncompatibleKeys`

**Used AI Studio**


### 是否引起精度变化
否
