### PR TITLE
add Flag for layernorm forced align with Apex version

### DIFF
--- a/paddle/common/flags.cc
+++ b/paddle/common/flags.cc
@@ -2459,6 +2459,20 @@ PHI_DEFINE_EXPORTED_bool(
 PHI_DEFINE_EXPORTED_bool(use_accuracy_compatible_kernel,
                          false,
                          "Whether use torch compatible version kernel.");
+
+/**
+ * LayerNorm Apex Compatible related FLAG
+ * Name: FLAGS_use_apex_layer_norm_kernel
+ * Since Version: 3.5.0
+ * Value Range: bool, default=false
+ * Example:
+ * Note: Whether use apex compatible version LayerNorm kernel.
+ */
+PHI_DEFINE_EXPORTED_bool(
+    use_apex_layer_norm_kernel,
+    false,
+    "Whether use apex compatible version LayerNorm kernel.");
+
 /**
  * Legacy gemm related FLAG
  * Name: FLAGS_use_legacy_gemm

--- a/paddle/phi/kernels/gpu/layer_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_grad_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/layer_norm_grad_kernel.h"
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/cast_kernel.h"
@@ -26,6 +27,7 @@
 #ifdef PADDLE_WITH_CUDA
 #include "paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h"
 #endif
+COMMON_DECLARE_bool(use_apex_layer_norm_kernel);
 
 namespace phi {
 enum class LayerNormGadKernelVariant { FAST_LN_V2, GENERIC };
@@ -39,6 +41,15 @@ static inline LayerNormGadKernelVariant LayerNormGradKernelDispatch(
     const DenseTensor* scale,
     const DenseTensor* bias) {
 #if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
+  if (FLAGS_use_apex_layer_norm_kernel) {
+    if (funcs::fast_ln_v2::has_fast_ln_v2_bwd_kernel(
+            weight_type, input_type, output_type, compute_type, hidden_size)) {
+      return LayerNormGadKernelVariant::FAST_LN_V2;
+    }
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "FLAGS_use_apex_layer_norm_kernel requires inputs supported by "
+        "fast_ln_v2 backward kernel."));
+  }
   if (FLAGS_use_accuracy_compatible_kernel) {
     return LayerNormGadKernelVariant::GENERIC;
   }

--- a/paddle/phi/kernels/gpu/layer_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_kernel.cu
@@ -25,6 +25,7 @@
 #include "paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h"
 #endif
 COMMON_DECLARE_bool(use_fast_math);
+COMMON_DECLARE_bool(use_apex_layer_norm_kernel);
 
 namespace phi {
 
@@ -509,6 +510,17 @@ static inline LayerNormKernelVariant LayerNormKernelDispatch(
   if (scale == nullptr || bias == nullptr) {
     return LayerNormKernelVariant::GENERIC;
   }
+#if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
+  if (FLAGS_use_apex_layer_norm_kernel) {
+    if (funcs::fast_ln_v2::has_fast_ln_v2_fwd_kernel(
+            weight_type, input_type, output_type, compute_type, hidden_size)) {
+      return LayerNormKernelVariant::FAST_LN_V2;
+    }
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "FLAGS_use_apex_layer_norm_kernel requires inputs supported by "
+        "fast_ln_v2 forward kernel."));
+  }
+#endif
 #ifdef PADDLE_WITH_CUDA
   if (FLAGS_use_accuracy_compatible_kernel) {
     return LayerNormKernelVariant::GENERIC;


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->Operator Mechanism


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->Improvements


### Description
<!-- Describe what you’ve done -->add a flag to force layernorm op to adopt Apex version


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->否
