### PR TITLE
[SOT] fix KeyError 'self' when compiled method calls another compiled method

### DIFF
--- a/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
+++ b/python/paddle/jit/sot/opcode_translator/executor/variables/callable.py
@@ -361,9 +361,39 @@ class UserDefinedFunctionVariable(FunctionVariable):
         if isinstance(
             value, paddle.jit.dy2static.program_translator.StaticFunction
         ):
-            return UserDefinedFunctionVariable(
-                value.dygraph_function, graph, tracker
-            )
+            # Use __func__ when dygraph_function is a bound method,
+            # so that inspect.signature preserves the ``self`` parameter.
+            fn = value.dygraph_function
+            if inspect.ismethod(fn):
+                fn = fn.__func__
+            if value.class_instance is not None:
+                # StaticFunction bound to an instance (via __get__ descriptor).
+                # Wrap as MethodVariable so that load_method preserves the
+                # ``self`` binding in CALL_METHOD dispatch.
+                # Trackers use real StaticFunction attributes
+                # (class_instance, dygraph_function).  Guard evaluation is
+                # safe because method_var.tracker is a non-traceable
+                # DanglingTracker from the BuiltinVariable(getattr, ...)
+                # call in load_method — these GetAttrTracker guards are
+                # never reached.
+                fn_var = UserDefinedFunctionVariable(
+                    fn, graph, DanglingTracker()
+                )
+                instance_var = VariableFactory.from_value(
+                    value.class_instance, graph, DanglingTracker()
+                )
+                method_var = MethodVariable(
+                    instance_var,
+                    fn_var,
+                    graph=graph,
+                    tracker=tracker,
+                )
+                instance_var.tracker = GetAttrTracker(
+                    method_var, "class_instance"
+                )
+                fn_var.tracker = GetAttrTracker(method_var, "dygraph_function")
+                return method_var
+            return UserDefinedFunctionVariable(fn, graph, tracker)
         return None
 
     @property

--- a/test/sot/test_bound_static_method_call.py
+++ b/test/sot/test_bound_static_method_call.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test for SOT ``KeyError: 'self'`` when a compiled method calls
+another compiled method via ``self.xxx()``.
+
+Paddle Issue: https://github.com/PaddlePaddle/Paddle/issues/79325
+Paddle PR: https://github.com/PaddlePaddle/Paddle/pull/79326
+
+When both ``forward`` and ``step`` are wrapped with
+``paddle.jit.to_static``, and ``step`` calls ``self.forward(x)``, SOT's
+inline executor previously lost the ``self`` binding, causing
+``KeyError: 'self'``.
+
+Fix: ``UserDefinedFunctionVariable.from_value`` detects bound
+``StaticFunction`` (``class_instance is not None``) and returns a
+``MethodVariable``, so that ``load_method`` preserves the ``self``
+argument in ``CALL_METHOD`` dispatch.
+"""
+
+import unittest
+
+from test_case_base import TestCaseBase
+
+import paddle
+
+
+class ReproLayer(paddle.nn.Layer):
+    """Minimal reproduction: 1 sub-module, 2 compiled methods,
+    one calls the other."""
+
+    def __init__(self):
+        super().__init__()
+        self.dim = 8
+        self.conv = paddle.nn.Conv1D(8, 8, 3, padding=1)
+
+    def forward(self, x):
+        return self.conv(paddle.nn.functional.relu(x[:, : self.dim]))
+
+    def step(self, x):
+        out = self.forward(x)
+        return out.mean()
+
+
+class TestBoundStaticMethodCall(TestCaseBase):
+    """SOT must correctly handle ``self.method()`` when both caller
+    and callee are compiled with ``paddle.jit.to_static``."""
+
+    def _generate_input(self):
+        return paddle.randn([2, 8, 32])
+
+    def test_no_to_static(self):
+        """Sanity: dynamic execution must work."""
+        m = ReproLayer()
+        x = self._generate_input()
+        out = m.step(x)
+        self.assertIsNotNone(out)
+
+    def test_forward_only_compiled(self):
+        """Only forward compiled — should work (1 compiled method)."""
+        m = ReproLayer()
+        m.forward = paddle.jit.to_static(m.forward)
+        x = self._generate_input()
+        # step calls self.forward dynamically
+        out = m.step(x)
+        self.assertIsNotNone(out)
+
+    def test_both_compiled_no_assertion(self):
+        """Both methods compiled, assert no crash (KeyError: self)."""
+        m = ReproLayer()
+        m.forward = paddle.jit.to_static(m.forward)
+        m.step = paddle.jit.to_static(m.step)
+        x = self._generate_input()
+        try:
+            out = m.step(x)
+            self.assertIsNotNone(out)
+        except KeyError as e:
+            self.fail(f"SOT crashed with KeyError: {e}")
+
+    def test_both_compiled_valid_output(self):
+        """Both methods compiled — output must be a finite tensor."""
+        m = ReproLayer()
+        m.forward = paddle.jit.to_static(m.forward)
+        m.step = paddle.jit.to_static(m.step)
+        x = self._generate_input()
+        out = m.step(x)
+        self.assertFalse(paddle.isnan(out).any(), "Output contains NaN")
+        self.assertFalse(paddle.isinf(out).any(), "Output contains Inf")
+
+    def test_sub_module_alone(self):
+        """Regression: sub-module access (self.conv, self.dim) must
+        still work when only the callee is compiled."""
+        m = ReproLayer()
+        m.forward = paddle.jit.to_static(m.forward)
+        x = self._generate_input()
+        out = m.forward(x)
+        self.assertEqual(out.shape, [2, 8, 32])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
[used AI Studio] Fix SOT ``KeyError: 'self'`` when a compiled method calls another compiled method via ``self.xxx()``.

**Root cause**: ``VariableFactory.from_value`` creates a plain ``UserDefinedFunctionVariable`` for ``StaticFunction``, even when the ``StaticFunction`` is bound to an instance (via its ``__get__`` descriptor). ``load_method`` checks ``isinstance(method, MethodVariable)`` to decide whether to preserve the ``self`` binding in ``CALL_METHOD`` dispatch — since the Variable is not a ``MethodVariable``, the ``self`` argument is lost, causing ``KeyError: 'self'`` in the inlined callee.

**Fix**: In ``UserDefinedFunctionVariable.from_value``, detect bound ``StaticFunction`` (``class_instance is not None``) and produce a ``MethodVariable`` instead. Also handle the case where ``dygraph_function`` is itself a bound method by extracting ``__func__`` so that ``inspect.signature`` preserves the ``self`` parameter.

**Reproduction**: ``sot_bug_repro/issue_repro.py`` in the HiddenSinger project (or any code that calls ``self.forward()`` from a compiled ``training_step``).

**Related issue**: Fixes #79325

### 是否引起精度变化
否
