### PR TITLE
[FlexCheckpoint] add model_type/checkpoint_version/commit_id fields to Metadata

### DIFF
--- a/python/paddle/distributed/flex_checkpoint/dcp/metadata.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/metadata.py
@@ -49,3 +49,7 @@ class Metadata:
     state_dict_metadata: dict[str, list[LocalTensorMetadata]] = None
     storage_metadata: dict[LocalTensorIndex, str] = None
     flat_mapping: dict[str, tuple[str]] = None
+    model_type: str | None = None
+    checkpoint_version: str | None = None
+    erniebot_commit_id: str | None = None
+    paddle_commit_id: str | None = None


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Improvements

### Description
在 Metadata 类中新增 model_type、checkpoint_version、erniebot_commit_id、paddle_commit_id 四个字段，用于保存 checkpoint 相关的模型类型、版本号和 commit 信息，便于后续追溯和版本管理。

### 是否引起精度变化
否