### PR TITLE
[WIP][CI] update coverage CI to CUDA 13.2

### DIFF
--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -98,7 +98,7 @@ jobs:
           FLAGS_fraction_of_gpu_memory_to_use: 0.15
           CTEST_PARALLEL_LEVEL: 2
           WITH_GPU: "ON"
-          CUDA_ARCH_NAME: Volta
+          CUDA_ARCH_NAME: Hopper
           WITH_AVX: "ON"
           WITH_COVERAGE: "ON"
           COVERALLS_UPLOAD: "ON"
@@ -282,7 +282,7 @@ jobs:
     needs: [build, build-docker]
     if: needs.build.outputs.can-skip != 'true'
     runs-on:
-      group: BD_BJ-V100
+      group: H-Coverage
     timeout-minutes: 240
     steps:
       - name: Check docker image and run container
@@ -292,7 +292,7 @@ jobs:
           FLAGS_fraction_of_gpu_memory_to_use: 0.15
           CTEST_PARALLEL_LEVEL: 2
           WITH_GPU: "ON"
-          CUDA_ARCH_NAME: Auto
+          CUDA_ARCH_NAME: Hopper
           WITH_AVX: "ON"
           WITH_COVERAGE: "ON"
           COVERALLS_UPLOAD: "ON"

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -282,7 +282,7 @@ jobs:
     needs: [build, build-docker]
     if: needs.build.outputs.can-skip != 'true'
     runs-on:
-      group: H-Coverage
+      group: BD_BJ-V100
     timeout-minutes: 240
     steps:
       - name: Check docker image and run container

--- a/tools/dockerfile/ci_dockerfile.sh
+++ b/tools/dockerfile/ci_dockerfile.sh
@@ -77,6 +77,9 @@ function make_ubuntu24_cu132_dockerfile(){
   dockerfile_name="Dockerfile.cuda117_cudnn8_gcc82_ubuntu18_coverage"
   sed "s#<baseimg>#nvcr.io/nvidia/cuda:13.2.0-cudnn-devel-ubuntu24.04#g" ./Dockerfile.ubuntu24 >${dockerfile_name}
   sed -i "s#<setcuda>#ENV LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat:/usr/local/cuda-13.2/targets/x86_64-linux/lib:\$LD_LIBRARY_PATH #g" ${dockerfile_name}
+  sed -i '/RUN mv \/etc\/apt\/sources.list.d\/cuda.list \/etc\/apt\/sources.list.d\/cuda.list.bak/d' ${dockerfile_name}
+  sed -i '/RUN mv \/etc\/apt\/sources.list.d\/cuda.list.bak \/etc\/apt\/sources.list.d\/cuda.list/d' ${dockerfile_name}
+  sed -i '/RUN sed -i .*\/etc\/apt\/sources.list.d\/cuda.list/d' ${dockerfile_name}
   sed -i 's#<install_cpu_package>##g' ${dockerfile_name}
   sed -i "7i ENV TZ=Asia/Beijing" ${dockerfile_name}
   sed -i "8i RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone" ${dockerfile_name}

--- a/tools/dockerfile/ci_dockerfile.sh
+++ b/tools/dockerfile/ci_dockerfile.sh
@@ -73,10 +73,10 @@ function make_ce_framework_dockerfile(){
 }
 
 
-function make_ubuntu20_cu12_dockerfile(){
+function make_ubuntu24_cu132_dockerfile(){
   dockerfile_name="Dockerfile.cuda117_cudnn8_gcc82_ubuntu18_coverage"
-  sed "s#<baseimg>#nvidia/cuda:12.0.1-cudnn8-devel-ubuntu22.04#g" ./Dockerfile.ubuntu22 >${dockerfile_name}
-  sed -i "s#<setcuda>#ENV LD_LIBRARY_PATH=/usr/local/cuda-12.0/targets/x86_64-linux/lib:\$LD_LIBRARY_PATH #g" ${dockerfile_name}
+  sed "s#<baseimg>#nvcr.io/nvidia/cuda:13.2.0-cudnn-devel-ubuntu24.04#g" ./Dockerfile.ubuntu24 >${dockerfile_name}
+  sed -i "s#<setcuda>#ENV LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat:/usr/local/cuda-13.2/targets/x86_64-linux/lib:\$LD_LIBRARY_PATH #g" ${dockerfile_name}
   sed -i 's#<install_cpu_package>##g' ${dockerfile_name}
   sed -i "7i ENV TZ=Asia/Beijing" ${dockerfile_name}
   sed -i "8i RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone" ${dockerfile_name}
@@ -84,15 +84,14 @@ function make_ubuntu20_cu12_dockerfile(){
   dockerfile_line=$(wc -l ${dockerfile_name}|awk '{print $1}')
   sed -i "${dockerfile_line}i RUN wget --no-check-certificate -q https://paddle-edl.bj.bcebos.com/hadoop-2.7.7.tar.gz \&\& \
      tar -xzf  hadoop-2.7.7.tar.gz && mv hadoop-2.7.7 /usr/local/" ${dockerfile_name}
+  sed -i "${dockerfile_line}i RUN apt-get update \&\& apt-get install -y libnccl2=2.29.7-1+cuda13.2 libnccl-dev=2.29.7-1+cuda13.2" ${dockerfile_name}
   sed -i "${dockerfile_line}i RUN apt remove git -y \&\& apt update \&\& apt install -y libcurl4-openssl-dev gettext pigz zstd ninja-build  \&\& wget -q https://paddle-ci.gz.bcebos.com/git-2.17.1.tar.gz \&\& \
     tar -xvf git-2.17.1.tar.gz \&\& \
     cd git-2.17.1 \&\& \
     ./configure --with-openssl --with-curl --prefix=/usr/local \&\& \
     make -j8 \&\& make install " ${dockerfile_name}
   sed -i "${dockerfile_line}i RUN pip install wheel \&\& pip3.12 install PyGithub wheel distro jinja2" ${dockerfile_name}
-  sed -i 's# && rm /etc/apt/sources.list.d/nvidia-ml.list##g' ${dockerfile_name}
   sed -i 's#RUN bash /build_scripts/install_trt.sh##g' ${dockerfile_name}
-  sed -i 's#<install_cudnn>#RUN bash /build_scripts/install_cudnn.sh cudnn896 #g' ${dockerfile_name}
 }
 
 
@@ -137,7 +136,7 @@ function main() {
   make_cpu_dockerfile
   make_sot_dockerfile
   make_ce_framework_dockerfile
-  make_ubuntu20_cu12_dockerfile
+  make_ubuntu24_cu132_dockerfile
   make_ubuntu20_cu123_dockerfile
 }
 


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Improvements

### Description
该 PR 将标准 Coverage CI 的 coverage 镜像生成逻辑切到 CUDA 13.2 / Ubuntu 24.04，并将 coverage build / test 的 CUDA 架构目标调整为 Hopper。

主要改动：
- 更新 coverage Dockerfile 生成函数，使用 `nvcr.io/nvidia/cuda:13.2.0-cudnn-devel-ubuntu24.04` 作为基础镜像。
- 为生成的 coverage 镜像安装 CUDA 13.2 对应的 NCCL 包。
- 保持 coverage 镜像不安装 TensorRT，延续原 coverage 镜像逻辑。
- 删除从 `Dockerfile.ubuntu24` 继承来的 `cuda.list` 重写步骤，避免 CUDA 13.2 NGC base 镜像中不存在 `/etc/apt/sources.list.d/cuda.list` 时 docker build 失败。
- 保持 Coverage test runner group 为原来的 `BD_BJ-V100`。

本地验证：
- `prek --files .github/workflows/Coverage.yml tools/dockerfile/ci_dockerfile.sh`
- `git diff --check -- .github/workflows/Coverage.yml tools/dockerfile/ci_dockerfile.sh`
- `bash -n tools/dockerfile/ci_dockerfile.sh`
- 使用 GNU sed 生成 `Dockerfile.cuda117_cudnn8_gcc82_ubuntu18_coverage`，确认基础镜像为 CUDA 13.2 / Ubuntu 24.04，包含 cuda13.2 NCCL 包，没有 TensorRT 安装行，也不再包含对 `/etc/apt/sources.list.d/cuda.list` 的 `mv` / `sed` 操作。

### 是否引起精度变化
否