### PR TITLE
[CI] Store night coverage build size before cleanup

### DIFF
--- a/.github/workflows/Night_ALL_Coverage.yml
+++ b/.github/workflows/Night_ALL_Coverage.yml
@@ -175,8 +175,8 @@ jobs:
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           source ~/.bashrc
-          source ${ci_scripts}/utils.sh; clean_build_files
           Build_Size=$(du -h --max-depth=0 ${work_dir}/build |awk '"'"'{print $1}'"'"')
+          source ${ci_scripts}/utils.sh; clean_build_files
           echo "Build_Size=${Build_Size}" > ${work_dir}/dist/coverage_build_size
           find ./ -type f -size +200M | xargs du -lh
           rm -rf $(find . -name "*.a")


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
Night-Coverage 当前在 `clean_build_files` 之后重新计算并上传 `coverage_build_size`，而 PR Coverage 的 build size approval gate 使用的是构建完成时记录的 `/paddle/build` 大小。两者口径不一致时，develop baseline 会偏小，导致后续 PR 即使继承了已合入变更，也仍可能反复触发 coverage build size approval。

本 PR 将 Night-Coverage 中 `coverage_build_size` 的计算提前到 `clean_build_files` 之前，使 nightly 上传的 develop baseline 与 PR approval gate 使用的构建后大小保持一致。

验证：
- `prek --files .github/workflows/Night_ALL_Coverage.yml`
- `git diff --check -- .github/workflows/Night_ALL_Coverage.yml .github/workflows/Coverage.yml ci/coverage_build_size_approval.sh`
- `bash -n ci/coverage_build_size_approval.sh`

### 是否引起精度变化
否
