### PR TITLE
[CI] Skip oversized randperm large-n test under Coverage

### DIFF
--- a/test/legacy_test/test_randperm_op.py
+++ b/test/legacy_test/test_randperm_op.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 from itertools import product
 
@@ -28,6 +29,12 @@ from utils import dygraph_guard
 
 import paddle
 from paddle.base import core
+
+
+def is_coverage_run():
+    return os.getenv("COVERAGE_FILE") is not None or (
+        os.getenv("WITH_COVERAGE", "OFF") == "ON"
+    )
 
 
 def check_randperm_out(n, data_np):
@@ -557,6 +564,12 @@ class TestRandperm_compatible(unittest.TestCase):
             self.assertEqual(data_np.max(), n - 1)
             self.assertEqual(len(np.unique(data_np)), n)
 
+    # Coverage CI runs under coverage.py, where this 214M-element
+    # allocation/check dominates test_randperm_op runtime.
+    @unittest.skipIf(
+        is_coverage_run(),
+        "Skip oversized CPU randperm large-n test under Coverage CI.",
+    )
     def test_large_n_cpu(self):
         paddle.set_flags({'FLAGS_use_accuracy_compatible_kernel': 1})
         # uint32_max // 20 + 1 = 214748365, just exceeds the threshold

--- a/test/legacy_test/test_randperm_op.py
+++ b/test/legacy_test/test_randperm_op.py
@@ -564,8 +564,15 @@ class TestRandperm_compatible(unittest.TestCase):
             self.assertEqual(data_np.max(), n - 1)
             self.assertEqual(len(np.unique(data_np)), n)
 
-    # Coverage CI runs under coverage.py, where this 214M-element
-    # allocation/check dominates test_randperm_op runtime.
+    # Coverage jobs are slower than ordinary CPU jobs: WITH_COVERAGE=ON
+    # builds C++ with gcov instrumentation (-O0, -fprofile-arcs,
+    # -ftest-coverage), and Python tests also run under coverage.py with
+    # COVERAGE_FILE set.
+    # test_large_n_cpu intentionally uses the real large-n threshold,
+    # n=214748365, which drives a 214M-iteration CPU randperm loop and
+    # materializes about 0.8 GiB of int32 data before NumPy uniqueness
+    # checks. Keep ordinary Linux CPU running it so the non-instrumented
+    # large-n branch stays covered.
     @unittest.skipIf(
         is_coverage_run(),
         "Skip oversized CPU randperm large-n test under Coverage CI.",


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
修复 Coverage CI 中 `test_randperm_op` 容易因 `TestRandperm_compatible.test_large_n_cpu` 超时的问题。

该 large-n 用例使用 `n = 214748365` 来触发 CPU `randperm` 的 large-n 分支，会执行 214M 级别的 CPU loop，产生约 0.8 GiB 的 int32 tensor，并在 `x.numpy()` 后继续执行 `np.unique` 校验；Coverage CI 同时使用 `WITH_COVERAGE=ON` 的 C/C++ gcov instrumentation（`-O0 -fprofile-arcs -ftest-coverage`）和 Python `coverage run`，即使当前 timeout 提高到 500s 也不稳定。

本 PR：
- 在检测到 `COVERAGE_FILE` 或 `WITH_COVERAGE=ON` 时，仅跳过 oversized 的 `test_large_n_cpu`；
- 保留普通非 Coverage CI 中的 large-n 分支测试；
- 不影响 `test_small_n_cpu` 和其它 `test_randperm_op` 用例。

验证：
- `python3 -m py_compile test/legacy_test/test_randperm_op.py`
- stubbed unittest metadata check：Coverage env 下仅 `test_large_n_cpu` 标记 skip，普通 env 下不 skip
- `pre-commit run --files test/legacy_test/test_randperm_op.py`

关联：#79337 follow-up。


Coverage build size gate：
- 当前 Coverage build size gate 日志显示 develop baseline 152G、PR build 158G（`Coverage build` job 82289491529）。
- 本 PR 相对 `develop` 只修改 `test/legacy_test/test_randperm_op.py`（20 行插入，增加 Coverage skip/helper 注释），不修改 CMake/workflow/编译产物配置，因此不预期由本 PR 引入真实的 6G release build size 增长。
- 该项按 Coverage build-size approval gate 处理；不盲目 rerun，等待所需 RD approval。


### 是否引起精度变化
否


