### PR TITLE
[CI] Upload latest night coverage build size

### DIFF
--- a/.github/workflows/Night_ALL_Coverage.yml
+++ b/.github/workflows/Night_ALL_Coverage.yml
@@ -214,6 +214,7 @@ jobs:
           mkdir -p ${CFS_DIR}/coverage_night/${coverage_tag}
           echo "Uploading coverage build size"
           python ${{ env.bos_file }} coverage_build_size paddle-github-action/night/coverage/${coverage_tag}
+          python ${{ env.bos_file }} coverage_build_size paddle-github-action/night/coverage
           echo "Uploading coverage wheel"
           python ${{ env.bos_file }} ${{ env.paddle_whl }} paddle-github-action/night/coverage/${coverage_tag}
           cd /

--- a/ci/coverage_build_size_approval.sh
+++ b/ci/coverage_build_size_approval.sh
@@ -16,13 +16,24 @@ if [ ${BRANCH} != 'develop' ];then
     exit 0
 fi
 
-rm -f build_size
-curl --noproxy '*' -O https://paddle-docker-tar.bj.bcebos.com/paddle_ci_index/build_size
-dev_coverage_build_size=`cat build_size|sed 's#G##g'`
+rm -f coverage_build_size
+coverage_build_size_url="https://paddle-github-action.bj.bcebos.com/night/coverage/coverage_build_size"
+if ! curl --noproxy '*' -fsSL -o coverage_build_size "${coverage_build_size_url}"; then
+    echo "develop coverage build size not found: ${coverage_build_size_url}"
+    exit 1
+fi
+
+dev_coverage_build_size=`grep -Eo '[0-9]+G' coverage_build_size | head -n1 | sed 's#G##g'`
+if [ -z "${dev_coverage_build_size}" ]; then
+    echo "invalid develop coverage build size: $(cat coverage_build_size | tr -d '\n')"
+    exit 1
+fi
+
 pr_coverage_build_size=`echo $buildSize |sed 's#G##g'`
 
 echo "========================================================"
-echo "The develop coverage build size is $(cat build_size | tr -d '\n')"
+echo "The develop coverage build size is ${dev_coverage_build_size}G"
+echo "The develop coverage build size source is ${coverage_build_size_url}"
 echo "The pr coverage build size is $buildSize"
 echo "========================================================"
 


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
Night-Coverage 原本只会将 `coverage_build_size` 上传到 `paddle-github-action/night/coverage/<date>/coverage_build_size`，用于按日期保留 nightly 产物；Coverage approval gate 则只读取 `paddle-docker-tar/paddle_ci_index/build_size`。

关键证据：

- `ci/coverage_build_size_approval.sh` 原先固定读取 `https://paddle-docker-tar.bj.bcebos.com/paddle_ci_index/build_size`。
- #40749 在 2022 年引入 Coverage build size check 时就使用了 `paddle_ci_index/build_size` 作为 develop 基线。
- #72031 在 2025 年将 Coverage 迁到 GitHub Actions 后，仍然保留 `paddle_ci_index/build_size` 作为 approval gate 的基线来源。
- #75348 在 2025 年新增 Night-Coverage，初始设计就是将 nightly 产物写入 `paddle-github-action/night/coverage/<date>/...`；#75535 只是把日期格式从 `%m-%d` 调整为 `%Y-%m-%d`。
- 仓库内没有找到把 `paddle-github-action/night/coverage/<date>/coverage_build_size` 同步到 `paddle-docker-tar/paddle_ci_index/build_size` 的代码，因此这两个 URL 不是同一条链路。

这次 Coverage build size approval 的问题是：#79337 合入后，最新 Night-Coverage 已经在带日期路径写出了新的基线 `Build_Size=158G`，但旧固定基线仍停留在 `152G`，导致 PR Coverage gate 继续用旧基线比较，误判为 `158G - 152G > 3G`，从而要求额外 approval。

这个 PR 做两件事：

- Night-Coverage 在保留原日期路径上传的基础上，额外上传同一份 `coverage_build_size` 到 `paddle-github-action/night/coverage/coverage_build_size`，提供 stable latest 路径。
- `ci/coverage_build_size_approval.sh` 改为读取 `https://paddle-github-action.bj.bcebos.com/night/coverage/coverage_build_size`，并兼容 Night-Coverage 产物里的 `Build_Size=158G` 格式。

stable latest 是固定 key；如果某一天 Night-Coverage 没有成功上传新的 `coverage_build_size`，这个 key 仍会保留上一次成功上传的基线，不需要在 approval 脚本里再 fallback 到日期路径。

可复现验证方式：

```bash
# 最新 Night-Coverage 日期路径已经写入新基线
curl -fsSL https://paddle-github-action.bj.bcebos.com/night/coverage/2026-06-20/coverage_build_size
# Build_Size=158G

# 旧固定基线仍是 152G，这是误判来源
curl -fsSL https://paddle-docker-tar.bj.bcebos.com/paddle_ci_index/build_size
# 152G

# 新脚本的解析逻辑可从 Night-Coverage 产物中提取 158
curl -fsSL https://paddle-github-action.bj.bcebos.com/night/coverage/2026-06-20/coverage_build_size | grep -Eo '[0-9]+G' | head -n1 | sed 's#G##g'
# 158

# 合入并等待下一次 Night-Coverage 后，stable latest 应该可用
curl -fsSL https://paddle-github-action.bj.bcebos.com/night/coverage/coverage_build_size
# Build_Size=<latest>
```

本地校验：

```bash
bash -n ci/coverage_build_size_approval.sh
git diff --check -- .github/workflows/Night_ALL_Coverage.yml ci/coverage_build_size_approval.sh
prek --files .github/workflows/Night_ALL_Coverage.yml ci/coverage_build_size_approval.sh
prek
```

Related: https://github.com/PaddlePaddle/Paddle/pull/79337

### 是否引起精度变化
否。仅修改 CI 产物上传和 Coverage build size approval 的基线读取逻辑，不影响框架功能和模型精度。
