### PR TITLE
[Eager] Fix segfault in unstack_grad when some forward outputs are unused

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/codegen_utils.py
@@ -67,6 +67,7 @@ ops_to_fill_zero_for_empty_grads = {
     "divide_grad",
     "matmul_grad",
     "unbind_grad",
+    "unstack_grad",
 }
 
 # For API dispatch used at python-level

--- a/test/legacy_test/test_unstack_op.py
+++ b/test/legacy_test/test_unstack_op.py
@@ -340,5 +340,51 @@ class TestUnstackEmptyTensorInput(unittest.TestCase):
             self._test_unstack_with_static_empty_tensor_input(place)
 
 
+class TestUnstackGradPartiallyUsedOutputs(unittest.TestCase):
+    """When only part of unstack's outputs feed the loss, the gradients of the
+    unused outputs are undefined (null-impl) tensors. ``unstack_grad`` must
+    zero-fill them instead of dereferencing them (previously a SIGSEGV)."""
+
+    def _get_places(self):
+        places = [paddle.base.CPUPlace()]
+        if paddle.is_compiled_with_cuda() or is_custom_device():
+            places.append(get_device_place())
+        return places
+
+    def _run_case(self, shape, axis, used_indices, place):
+        x = (
+            paddle.arange(int(np.prod(shape)), dtype='float32')
+            .reshape(shape)
+            .to(place)
+        )
+        x.stop_gradient = False
+        parts = paddle.unstack(x, axis=axis)
+        # loss = sum(part ** 2)
+        loss = paddle.add_n([parts[i] * parts[i] for i in used_indices]).sum()
+        dx = paddle.grad(loss, x)[0]
+
+        # grad is 2 * x on the used slices, and zero
+        # everywhere else (unused outputs contribute no gradient).
+        part_grads = [
+            (2.0 * p.numpy() if i in used_indices else np.zeros_like(p.numpy()))
+            for i, p in enumerate(parts)
+        ]
+        expected = np.stack(part_grads, axis=axis)
+        np.testing.assert_allclose(dx.numpy(), expected, rtol=1e-6, atol=1e-6)
+
+    def test_partially_used_outputs(self):
+        with dygraph_guard():
+            for place in self._get_places():
+                # Original repro: only the middle output of axis 0 is used.
+                self._run_case((3, 4), axis=0, used_indices=[1], place=place)
+                # First / last output unused.
+                self._run_case((3, 4), axis=0, used_indices=[0, 2], place=place)
+                # Non-zero / negative axis.
+                self._run_case((2, 3, 4), axis=1, used_indices=[1], place=place)
+                self._run_case(
+                    (2, 3, 4), axis=-1, used_indices=[0, 3], place=place
+                )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description

**Problem**

Fixes #79188. In dygraph mode, calling backward through `paddle.unstack` crashes with a segfault when only a subset of its outputs feed the loss, e.g.:

```python
parts = paddle.unstack(x, axis=0)   # multiple outputs
loss = (parts[1] * parts[1]).sum()  # only parts[1] is used
paddle.grad(loss, x)                # SIGSEGV
```

The gradients of the unused outputs are undefined (null-`impl`) tensors. `UnstackGradNode` passed this gradient list straight to `unstack_grad`, and `UnStackGradKernel` unconditionally reads `x[i]->data<T>()` / `memcpy`s from every entry, dereferencing the null tensors and crashing.

**Root cause**

`unstack` is effectively the twin of `unbind` (both slice a tensor along an axis into a list). `unbind_grad` already zero-fills empty gradient inputs via `ops_to_fill_zero_for_empty_grads`, but `unstack_grad` was omitted from that set, so the eager code generator never emitted `FillZeroForEmptyGradInput` for it.

**Fix**

Add `unstack_grad` to `ops_to_fill_zero_for_empty_grads` in the eager code generator. The generated `UnstackGradNode` now zero-fills the empty entries of the gradient list before invoking the kernel, so unused outputs contribute a correct zero slice to `x_grad` instead of crashing.

**Test**

Added `TestUnstackGradPartiallyUsedOutputs` to `test/legacy_test/test_unstack_op.py`, covering the partially-used-outputs case across `axis=0`, a positive axis and a negative axis (CPU, and GPU when available). It verifies the backward runs without crashing and that unused-output slices get a zero gradient while used ones get the correct gradient. Verified locally on a CPU build: the test fails (segfault) without the fix and passes with it.

### 是否引起精度变化
否
