### PR TITLE
[CI] Fix Night-Coverage gcov tool selection

### DIFF
--- a/ci/coverage_all_info.sh
+++ b/ci/coverage_all_info.sh
@@ -32,8 +32,67 @@ echo "::endgroup::"
 
 cd ${PADDLE_ROOT}/build
 
+function init_gcov_tool() {
+    local cxx_compiler=""
+    local compiler_version=""
+    local compiler_major=""
+    local gcov_version=""
+    local gcov_major=""
+    local candidate=""
+    local cxx_compiler_for_version=""
+    local gcov_candidates=()
+
+    GCOV_TOOL=""
+
+    if [ -f CMakeCache.txt ]; then
+        cxx_compiler=$(awk -F= '/^CMAKE_CXX_COMPILER:FILEPATH=/ {print $2; exit}' CMakeCache.txt)
+    fi
+
+    if [ -n "${cxx_compiler}" ] && [ -x "${cxx_compiler}" ]; then
+        cxx_compiler_for_version="${cxx_compiler}"
+    elif command -v c++ >/dev/null 2>&1; then
+        cxx_compiler_for_version=$(command -v c++)
+    fi
+
+    if [ -n "${cxx_compiler_for_version}" ]; then
+        compiler_version=$("${cxx_compiler_for_version}" -dumpfullversion -dumpversion 2>/dev/null | head -n 1)
+        compiler_major=${compiler_version%%.*}
+        gcov_candidates+=("gcov-${compiler_version}" "gcov-${compiler_major}")
+    fi
+    gcov_candidates+=(gcov)
+
+    for candidate in "${gcov_candidates[@]}"; do
+        if [ -n "${candidate}" ] && command -v "${candidate}" >/dev/null 2>&1; then
+            GCOV_TOOL=$(command -v "${candidate}")
+            break
+        fi
+    done
+
+    if [ -z "${GCOV_TOOL}" ]; then
+        echo "ERROR: no gcov executable found for coverage collection"
+        exit 101
+    fi
+
+    gcov_version=$("${GCOV_TOOL}" --version 2>/dev/null | head -n 1 | grep -oE '[0-9]+([.][0-9]+)+' | tail -n 1)
+    gcov_major=${gcov_version%%.*}
+
+    echo "CXX compiler for coverage: ${cxx_compiler_for_version:-unknown}"
+    if [ -n "${cxx_compiler}" ] && [ "${cxx_compiler}" != "${cxx_compiler_for_version}" ]; then
+        echo "CMake CXX compiler from cache: ${cxx_compiler}"
+    fi
+    echo "CXX compiler version for coverage: ${compiler_version:-unknown}"
+    echo "GCOV tool for coverage: ${GCOV_TOOL}"
+    "${GCOV_TOOL}" --version
+
+    if [ -n "${compiler_major}" ] && [ -n "${gcov_major}" ] && [ "${compiler_major}" != "${gcov_major}" ]; then
+        echo "ERROR: gcov major version ${gcov_major} does not match CXX compiler major version ${compiler_major}"
+        exit 101
+    fi
+}
+
 echo "::group::Run lcov"
-lcov --ignore-errors gcov --capture -d ./ -o coverage.info --rc lcov_branch_coverage=0
+init_gcov_tool
+lcov --gcov-tool "${GCOV_TOOL}" --ignore-errors gcov --capture -d ./ -o coverage.info --rc lcov_branch_coverage=0
 echo "::endgroup::"
 
 mkdir coverage_files


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
Night-Coverage 在 `WITH_ALL_COVERAGE=ON` 时会走 `ci/coverage_all_info.sh` 生成全量覆盖率报告。该路径此前直接执行 `lcov --ignore-errors gcov --capture ...`，没有像普通 Coverage 路径一样根据 `CMakeCache.txt` 中的 C++ 编译器选择匹配版本的 gcov。

在 Night-Coverage 日志中，build 阶段使用 GCC 12.3.0 生成 `.gcno/.gcda`，但 coverage 采集阶段默认 gcov 是 11.4.0，导致大量 `*.gcno:version 'B23*', prefer 'B14*'` 和 `geninfo: WARNING: GCOV failed for ...`。

本 PR 将普通 Coverage 路径已有的 gcov 选择逻辑补到 `ci/coverage_all_info.sh`：
- 从 `CMakeCache.txt` 读取 `CMAKE_CXX_COMPILER`
- 优先查找 `gcov-${compiler_version}` / `gcov-${compiler_major}`
- 通过 `lcov --gcov-tool "${GCOV_TOOL}"` 显式使用匹配的 gcov
- 当 compiler/gcov major 不一致时提前报错，避免静默生成不完整覆盖率

验证：
- `bash -n ci/coverage_all_info.sh ci/coverage_info.sh`
- `git diff --check --cached`
- `prek`

### 是否引起精度变化
否。该改动只影响 CI 覆盖率采集脚本，不改变训练、推理或算子行为。
