### PR TITLE
[release/3.4][Operator Mechanism]Align cuBLAS workspace size for SM10 GPUs

### DIFF
--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -294,9 +294,10 @@ struct GPUContext::Impl {
 
   // Returns the cublas workspace size matching PyTorch's behavior
   // for different GPU architectures.
-  // Hopper (SM 9.0): 32 MiB, others: ~8.125 MiB
+  // Hopper (SM 9.x) and Blackwell (SM 10.x): 32 MiB, others: ~8.125 MiB
   static size_t GetCublasWorkspaceSize(int compute_capability) {
-    if (compute_capability == 90) {
+    int major = compute_capability / 10;
+    if (major >= 9) {
       return 4096 * 8 * 1024;  // 32 MiB
     }
     return 4096 * 1024 * 2 + 16 * 1024 * 8;  // ~8.125 MiB

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -330,8 +330,10 @@ struct GPUContext::Impl {
   // Returns {ptr, size}. Thread-safe via mutex for grow path.
   std::pair<void*, size_t> GetCublasLtWorkspace(size_t required_size) {
 #ifdef PADDLE_WITH_CUDA
-    required_size =
-        std::max(required_size, GetCublasWorkspaceSize(compute_capability_));
+    if (compute_capability_ / 10 >= 9) {
+      required_size =
+          std::max(required_size, GetCublasWorkspaceSize(compute_capability_));
+    }
     if (cublaslt_workspace_size_ >= required_size && cublaslt_workspace_) {
       return {cublaslt_workspace_, cublaslt_workspace_size_};
     }

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -294,7 +294,7 @@ struct GPUContext::Impl {
 
   // Returns the cublas workspace size matching PyTorch's behavior
   // for different GPU architectures.
-  // Hopper (SM 9.x) and Blackwell (SM 10.x): 32 MiB, others: ~8.125 MiB
+  // SM 9.x and later: 32 MiB, others: ~8.125 MiB.
   static size_t GetCublasWorkspaceSize(int compute_capability) {
     int major = compute_capability / 10;
     if (major >= 9) {
@@ -330,6 +330,8 @@ struct GPUContext::Impl {
   // Returns {ptr, size}. Thread-safe via mutex for grow path.
   std::pair<void*, size_t> GetCublasLtWorkspace(size_t required_size) {
 #ifdef PADDLE_WITH_CUDA
+    required_size =
+        std::max(required_size, GetCublasWorkspaceSize(compute_capability_));
     if (cublaslt_workspace_size_ >= required_size && cublaslt_workspace_) {
       return {cublaslt_workspace_, cublaslt_workspace_size_};
     }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
调整 SM10 架构 GPU 上的 cuBLAS workspace size 设置，将其与 PyTorch 在 Hopper/Blackwell 架构上的行为对齐。

  具体修改：
  - 在 `gpu_context.cc` 中更新 `GetCublasWorkspaceSize` 逻辑；
  - 对 SM9 和 SM10 架构使用 32MiB cuBLAS workspace；
  - 其他架构保持原有约 8.125MiB workspace 设置不变。

  该修改用于减少因 cuBLAS workspace size 不一致导致的算法选择差异，从而改善部分 matmul 场景下与 PyTorch
  的数值对齐表现。

devPR:https://github.com/PaddlePaddle/Paddle/pull/79373
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是