### PR TITLE
[Operator Mechanism]Fix cuda launch dimension checks for elementwise and fusion kernels

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
+++ b/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
@@ -293,21 +293,20 @@ static __global__ void FusedElemwiseAndActBroadcast2CUDAKernel(
     const T *x,
     const T *y,
     CompoundFunctor compound_functor,
-    int pre,
-    int n,
-    int post,
+    int64_t pre,
+    int64_t n,
+    int64_t post,
     T *out,
     T *intermediate_out) {
-  int tid = threadIdx.x;
-  int j = blockIdx.x;
+  int64_t tid = threadIdx.x;
+  int64_t j = blockIdx.x;
 
   while (true) {
-    int i = tid / post;
-    int k = tid % post;
+    int64_t i = tid / post;
+    int64_t k = tid % post;
     if (i >= pre) break;
 
-    int64_t offset =
-        static_cast<int64_t>(i) * n * post + static_cast<int64_t>(j) * post + k;
+    int64_t offset = i * n * post + j * post + k;
 
     T y_val = BcastY ? y[j] : y[offset];
     T x_val = BcastY ? x[offset] : x[j];
@@ -991,9 +990,9 @@ static __global__ void FusedElemwiseAndActGradBroadcast2CUDAKernel(
     const T *intermediate_out,
     const T *out,
     const T *dout,
-    int pre,
-    int n,
-    int post,
+    int64_t pre,
+    int64_t n,
+    int64_t post,
     DX_OP dx_op,
     DY_OP dy_op,
     DIntermediate_OP dintermediate_op,
@@ -1001,19 +1000,18 @@ static __global__ void FusedElemwiseAndActGradBroadcast2CUDAKernel(
     T *dy,
     T *d_intermediate) {
   int tid = threadIdx.x;
-  int j = blockIdx.x;
+  int64_t j = blockIdx.x;
 
   T val(0), inter_val(0);
-  int ttid = tid;
+  int64_t ttid = tid;
   int64_t tmp_out_idx, x_idx, y_idx;
   T zero = static_cast<T>(0);
   while (true) {
-    int i = ttid / post;
-    int k = ttid % post;
+    int64_t i = ttid / post;
+    int64_t k = ttid % post;
     if (i >= pre) break;
 
-    int64_t offset =
-        static_cast<int64_t>(i) * n * post + static_cast<int64_t>(j) * post + k;
+    int64_t offset = i * n * post + j * post + k;
 
     tmp_out_idx = BcastY ? j : offset;
     y_idx = BcastY ? j : offset;
@@ -1071,8 +1069,8 @@ static __global__ void FusedElemwiseAndActGradBroadcast2CUDAKernel(
     ttid += ELEMWISE_MAX_BLOCK_DIM;
   }
 
-  int h = pre * post;
-  h = h > ELEMWISE_MAX_BLOCK_DIM ? ELEMWISE_MAX_BLOCK_DIM : h;
+  int h = static_cast<int>(
+      std::min(pre * post, static_cast<int64_t>(ELEMWISE_MAX_BLOCK_DIM)));
   if (BcastY) {
     if (dy) {
       val = phi::backends::gpu::reduceSum(val, tid, h);

--- a/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
+++ b/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
@@ -21,6 +21,7 @@
 #include <iterator>
 #include <vector>
 
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/common/transform.h"
 #include "paddle/phi/core/dense_tensor.h"
@@ -39,6 +40,7 @@
 #endif
 #include <thrust/iterator/iterator_adaptor.h>
 
+#include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/kernels/funcs/elementwise/elementwise_op_broadcast.cu.h"
@@ -117,13 +119,13 @@ template <typename T,
 static void FusedElemwiseAndActBroadcast1CPU(const T *x,
                                              const T *y,
                                              CompoundFunctor compound_functor,
-                                             int h,
-                                             int w,
+                                             int64_t h,
+                                             int64_t w,
                                              T *out,
                                              T *intermediate_out) {
-  for (int i = 0; i < h; ++i) {
-    for (int j = 0; j < w; ++j) {
-      int64_t offset = static_cast<int64_t>(i) * w + j;
+  for (int64_t i = 0; i < h; ++i) {
+    for (int64_t j = 0; j < w; ++j) {
+      int64_t offset = i * w + j;
 
       T y_val = BcastY ? y[j] : y[offset];
       T x_val = BcastY ? x[offset] : x[j];
@@ -211,16 +213,16 @@ template <typename T,
 static __global__ void FusedElemwiseAndActBroadcast1CUDAKernel(
     const T *x,
     const T *y,
-    int h,
-    int w,
+    int64_t h,
+    int64_t w,
     CompoundFunctor compound_functor,
     T *out,
     T *intermediate_out) {
-  int i = blockIdx.x;
-  int j = threadIdx.x;
+  int64_t i = blockIdx.x;
+  int64_t j = threadIdx.x;
 
   while (j < w) {
-    int64_t offset = static_cast<int64_t>(i) * w + j;
+    int64_t offset = i * w + j;
 
     T y_val = BcastY ? y[j] : y[offset];
     T x_val = BcastY ? x[offset] : x[j];
@@ -254,7 +256,7 @@ template <typename T,
           bool BcastY,
           bool KeepIntermediateOut,
           bool SameShapeOfIntermediateOutAndOut>
-static void FusedElemwiseAndActBroadcast1CUDA(gpuStream_t stream,
+static void FusedElemwiseAndActBroadcast1CUDA(const GPUContext &dev_ctx,
                                               const T *x,
                                               const T *y,
                                               CompoundFunctor compound_functor,
@@ -264,13 +266,21 @@ static void FusedElemwiseAndActBroadcast1CUDA(gpuStream_t stream,
                                               T *intermediate_out) {
   int64_t block_size =
       std::min(static_cast<int64_t>(ELEMWISE_MAX_BLOCK_DIM), w);
-  int64_t gird_size = h;
+  PADDLE_ENFORCE_LE(
+      h,
+      dev_ctx.GetCUDAMaxGridDimSize()[0],
+      common::errors::InvalidArgument(
+          "fused elemwise activation grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(h, "fused elemwise activation grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(block_size, "fused elemwise activation block.x");
+  uint32_t grid_size = static_cast<uint32_t>(h);
+  gpuStream_t stream = dev_ctx.stream();
   FusedElemwiseAndActBroadcast1CUDAKernel<T,
                                           CompoundFunctor,
                                           BcastY,
                                           KeepIntermediateOut,
                                           SameShapeOfIntermediateOutAndOut>
-      <<<gird_size, block_size, 0, stream>>>(
+      <<<grid_size, static_cast<uint32_t>(block_size), 0, stream>>>(
           x, y, h, w, compound_functor, out, intermediate_out);
 }
 
@@ -331,7 +341,7 @@ template <typename T,
           bool BcastY,
           bool KeepIntermediateOut,
           bool SameShapeOfIntermediateOutAndOut>
-static void FusedElemwiseAndActBroadcast2CUDA(gpuStream_t stream,
+static void FusedElemwiseAndActBroadcast2CUDA(const GPUContext &dev_ctx,
                                               const T *x,
                                               const T *y,
                                               int64_t pre,
@@ -342,14 +352,22 @@ static void FusedElemwiseAndActBroadcast2CUDA(gpuStream_t stream,
                                               T *intermediate_out) {
   int64_t block_size =
       std::min(static_cast<int64_t>(ELEMWISE_MAX_BLOCK_DIM), pre * post);
-  int64_t gird_size = n;
+  PADDLE_ENFORCE_LE(
+      n,
+      dev_ctx.GetCUDAMaxGridDimSize()[0],
+      common::errors::InvalidArgument(
+          "fused elemwise activation grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(n, "fused elemwise activation grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(block_size, "fused elemwise activation block.x");
+  uint32_t grid_size = static_cast<uint32_t>(n);
+  gpuStream_t stream = dev_ctx.stream();
 
   FusedElemwiseAndActBroadcast2CUDAKernel<T,
                                           CompoundFunctor,
                                           BcastY,
                                           KeepIntermediateOut,
                                           SameShapeOfIntermediateOutAndOut>
-      <<<gird_size, block_size, 0, stream>>>(
+      <<<grid_size, static_cast<uint32_t>(block_size), 0, stream>>>(
           x, y, compound_functor, pre, n, post, out, intermediate_out);
 }
 
@@ -405,8 +423,8 @@ void FusedElemwiseAndActComputeWithBroadcast(const DeviceContext &dev_ctx,
   funcs::GetMidDims(
       x_dim, y_dim, axis, &pre, &n, &post, &is_run_common_broadcast);
   if (post == 1) {
-    int h = pre;
-    int w = n;
+    int64_t h = static_cast<int64_t>(pre);
+    int64_t w = static_cast<int64_t>(n);
     if (dev_ctx.GetPlace().GetType() == AllocationType::GPU) {
 #if defined(__NVCC__) || defined(__HIPCC__)
       FusedElemwiseAndActBroadcast1CUDA<T,
@@ -414,7 +432,7 @@ void FusedElemwiseAndActComputeWithBroadcast(const DeviceContext &dev_ctx,
                                         BcastY,
                                         KeepIntermediateOut,
                                         SameShapeOfIntermediateOutAndOut>(
-          dev_ctx.stream(),
+          reinterpret_cast<const GPUContext &>(dev_ctx),
           x.data<T>(),
           y.data<T>(),
           compound_functor,
@@ -449,7 +467,7 @@ void FusedElemwiseAndActComputeWithBroadcast(const DeviceContext &dev_ctx,
                                         BcastY,
                                         KeepIntermediateOut,
                                         SameShapeOfIntermediateOutAndOut>(
-          dev_ctx.stream(),
+          reinterpret_cast<const GPUContext &>(dev_ctx),
           x.data<T>(),
           y.data<T>(),
           pre,
@@ -585,8 +603,8 @@ static void FusedElemwiseAndActGradBroadcast1CPU(
     const T *intermediate_out,
     const T *out,
     const T *dout,
-    int h,
-    int w,
+    int64_t h,
+    int64_t w,
     DX_OP dx_op,
     DY_OP dy_op,
     DIntermediate_OP dintermediate_op,
@@ -595,9 +613,9 @@ static void FusedElemwiseAndActGradBroadcast1CPU(
     T *d_intermediate) {
   int64_t tmp_out_idx, x_idx, y_idx;
   T zero = static_cast<T>(0);
-  for (int i = 0; i < h; ++i) {
-    for (int j = 0; j < w; ++j) {
-      int64_t offset = static_cast<int64_t>(i) * w + j;
+  for (int64_t i = 0; i < h; ++i) {
+    for (int64_t j = 0; j < w; ++j) {
+      int64_t offset = i * w + j;
 
       tmp_out_idx = BcastY ? j : offset;
       y_idx = BcastY ? j : offset;
@@ -785,8 +803,8 @@ static __global__ void FusedElemwiseAndActGradBroadcast1CUDAKernel(
     const T *intermediate_out,
     const T *out,
     const T *dout,
-    int h,
-    int w,
+    int64_t h,
+    int64_t w,
     DX_OP dx_op,
     DY_OP dy_op,
     DIntermediate_OP dintermediate_op,
@@ -919,8 +937,8 @@ static void FusedElemwiseAndActGradBroadcast1CUDA(
     const T *intermediate_out,
     const T *out,
     const T *dout,
-    int h,
-    int w,
+    int64_t h,
+    int64_t w,
     DX_OP dx_op,
     DY_OP dy_op,
     DIntermediate_OP dintermediate_op,
@@ -932,8 +950,11 @@ static void FusedElemwiseAndActGradBroadcast1CUDA(
   dim3 blocks(BLOCK_X, BLOCK_Y);
   int max_gpu_threads = dev_ctx.GetMaxPhysicalThreadCount();
   int max_blocks = std::max(max_gpu_threads / (BLOCK_X * BLOCK_Y), 1);
-  int theory_block = (w + BLOCK_X - 1) / BLOCK_X;
-  dim3 grids(std::min(theory_block, max_blocks));
+  int64_t theory_block = (w + BLOCK_X - 1) / BLOCK_X;
+  int64_t grid_size = std::min(theory_block, static_cast<int64_t>(max_blocks));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size,
+                               "fused elemwise activation grad grid.x");
+  dim3 grids(static_cast<uint32_t>(grid_size));
 
   FusedElemwiseAndActGradBroadcast1CUDAKernel<T,
                                               DX_OP,
@@ -1085,7 +1106,7 @@ template <typename T,
           bool BcastY,
           bool SameShapeOfIntermediateOutAndOut>
 static void FusedElemwiseAndActGradBroadcast2CUDA(
-    gpuStream_t stream,
+    const GPUContext &dev_ctx,
     const T *x,
     const T *y,
     const T *intermediate_out,
@@ -1102,7 +1123,16 @@ static void FusedElemwiseAndActGradBroadcast2CUDA(
     T *dintermediate) {
   int64_t block_size =
       std::min(static_cast<int64_t>(ELEMWISE_MAX_BLOCK_DIM), pre * post);
-  int64_t gird_size = n;
+  PADDLE_ENFORCE_LE(
+      n,
+      dev_ctx.GetCUDAMaxGridDimSize()[0],
+      common::errors::InvalidArgument(
+          "fused elemwise activation grad grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(n, "fused elemwise activation grad grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(block_size,
+                               "fused elemwise activation grad block.x");
+  uint32_t grid_size = static_cast<uint32_t>(n);
+  gpuStream_t stream = dev_ctx.stream();
   FusedElemwiseAndActGradBroadcast2CUDAKernel<T,
                                               DX_OP,
                                               DY_OP,
@@ -1110,20 +1140,21 @@ static void FusedElemwiseAndActGradBroadcast2CUDA(
                                               UseIntermediateOut,
                                               BcastY,
                                               SameShapeOfIntermediateOutAndOut>
-      <<<gird_size, block_size, 0, stream>>>(x,
-                                             y,
-                                             intermediate_out,
-                                             out,
-                                             dout,
-                                             pre,
-                                             n,
-                                             post,
-                                             dx_op,
-                                             dy_op,
-                                             dintermediate_op,
-                                             dx,
-                                             dy,
-                                             dintermediate);
+      <<<grid_size, static_cast<uint32_t>(block_size), 0, stream>>>(
+          x,
+          y,
+          intermediate_out,
+          out,
+          dout,
+          pre,
+          n,
+          post,
+          dx_op,
+          dy_op,
+          dintermediate_op,
+          dx,
+          dy,
+          dintermediate);
 }
 #endif
 
@@ -1164,8 +1195,8 @@ void FusedElemwiseAndActGradComputeWithBroadcast(
   if (x->IsInitialized()) x_data = x->data<T>();
   if (y->IsInitialized()) y_data = y->data<T>();
   if (post == 1) {
-    int h = pre;
-    int w = n;
+    int64_t h = static_cast<int64_t>(pre);
+    int64_t w = static_cast<int64_t>(n);
 
     if (dev_ctx.GetPlace().GetType() == AllocationType::GPU) {
 #if defined(__NVCC__) || defined(__HIPCC__)
@@ -1225,7 +1256,7 @@ void FusedElemwiseAndActGradComputeWithBroadcast(
                                             UseIntermediateOut,
                                             BcastY,
                                             SameShapeOfIntermediateOutAndOut>(
-          reinterpret_cast<const GPUContext &>(dev_ctx).stream(),
+          reinterpret_cast<const GPUContext &>(dev_ctx),
           x_data,
           y_data,
           intermediate_out == nullptr ? nullptr : intermediate_out->data<T>(),

--- a/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
+++ b/paddle/phi/kernels/funcs/elementwise/elementwise_op_function.h
@@ -218,8 +218,8 @@ static __global__ void FusedElemwiseAndActBroadcast1CUDAKernel(
     CompoundFunctor compound_functor,
     T *out,
     T *intermediate_out) {
-  int64_t i = blockIdx.x;
-  int64_t j = threadIdx.x;
+  int64_t i = static_cast<int64_t>(blockIdx.x);
+  int64_t j = static_cast<int64_t>(threadIdx.x);
 
   while (j < w) {
     int64_t offset = i * w + j;
@@ -298,8 +298,8 @@ static __global__ void FusedElemwiseAndActBroadcast2CUDAKernel(
     int64_t post,
     T *out,
     T *intermediate_out) {
-  int64_t tid = threadIdx.x;
-  int64_t j = blockIdx.x;
+  int64_t tid = static_cast<int64_t>(threadIdx.x);
+  int64_t j = static_cast<int64_t>(blockIdx.x);
 
   while (true) {
     int64_t i = tid / post;
@@ -1000,7 +1000,7 @@ static __global__ void FusedElemwiseAndActGradBroadcast2CUDAKernel(
     T *dy,
     T *d_intermediate) {
   int tid = threadIdx.x;
-  int64_t j = blockIdx.x;
+  int64_t j = static_cast<int64_t>(blockIdx.x);
 
   T val(0), inter_val(0);
   int64_t ttid = tid;

--- a/paddle/phi/kernels/funcs/elementwise_grad_base.h
+++ b/paddle/phi/kernels/funcs/elementwise_grad_base.h
@@ -1871,20 +1871,16 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
                                           std::multiplies<int64_t>());
   int x_block_size =
       std::min(static_cast<int64_t>(ELEMWISE_MAX_BLOCK_DIM), x_threads);
-  uint32_t max_grid_dim = dev_ctx.GetCUDAMaxGridDimSize()[0];
-  PADDLE_ENFORCE_LE(x_blocks,
-                    max_grid_dim,
-                    common::errors::InvalidArgument(
-                        "elementwise grad x grid.x exceeds device limit."));
-  PADDLE_ENFORCE_LE(y_blocks,
-                    max_grid_dim,
-                    common::errors::InvalidArgument(
-                        "elementwise grad y grid.x exceeds device limit."));
-  PADDLE_ENFORCE_LE_UINT32_MAX(x_blocks, "elementwise grad x grid.x");
-  PADDLE_ENFORCE_LE_UINT32_MAX(y_blocks, "elementwise grad y grid.x");
   int y_block_size =
       std::min(static_cast<int64_t>(ELEMWISE_MAX_BLOCK_DIM), y_threads);
   if (dx) {
+    uint32_t max_grid_dim = dev_ctx.GetCUDAMaxGridDimSize()[0];
+    PADDLE_ENFORCE_LE(x_blocks,
+                      max_grid_dim,
+                      common::errors::InvalidArgument(
+                          "elementwise grad x grid.x exceeds device limit."));
+    PADDLE_ENFORCE_LE_UINT32_MAX(x_blocks, "elementwise grad x grid.x");
+
     size_t dx_total_bytes = bytes * 2;
     auto dx_tmp_buffer = phi::memory_utils::Alloc(
         dev_ctx.GetPlace(),
@@ -1956,6 +1952,13 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
     }
   }
   if (dy) {
+    uint32_t max_grid_dim = dev_ctx.GetCUDAMaxGridDimSize()[0];
+    PADDLE_ENFORCE_LE(y_blocks,
+                      max_grid_dim,
+                      common::errors::InvalidArgument(
+                          "elementwise grad y grid.x exceeds device limit."));
+    PADDLE_ENFORCE_LE_UINT32_MAX(y_blocks, "elementwise grad y grid.x");
+
     // One part buffer for y_strides_order_gpu, the other for y_dims_order_gpu
     size_t dy_total_bytes = bytes * 2;
     auto dy_tmp_buffer = phi::memory_utils::Alloc(

--- a/paddle/phi/kernels/funcs/elementwise_grad_base.h
+++ b/paddle/phi/kernels/funcs/elementwise_grad_base.h
@@ -1871,6 +1871,17 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
                                           std::multiplies<int64_t>());
   int x_block_size =
       std::min(static_cast<int64_t>(ELEMWISE_MAX_BLOCK_DIM), x_threads);
+  uint32_t max_grid_dim = dev_ctx.GetCUDAMaxGridDimSize()[0];
+  PADDLE_ENFORCE_LE(x_blocks,
+                    max_grid_dim,
+                    common::errors::InvalidArgument(
+                        "elementwise grad x grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE(y_blocks,
+                    max_grid_dim,
+                    common::errors::InvalidArgument(
+                        "elementwise grad y grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(x_blocks, "elementwise grad x grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(y_blocks, "elementwise grad y grid.x");
   int y_block_size =
       std::min(static_cast<int64_t>(ELEMWISE_MAX_BLOCK_DIM), y_threads);
   if (dx) {
@@ -1906,36 +1917,42 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
                        dev_ctx.stream());
     if (out_size > std::numeric_limits<int32_t>::max()) {
       CommonGradBroadcastCUDAKernel<int64_t, T, DX_OP, Tout>
-          <<<x_blocks, x_block_size, 0, dev_ctx.stream()>>>(x_strides_array_gpu,
-                                                            y_strides_array_gpu,
-                                                            out_dims_array_gpu,
-                                                            x_strides_order_gpu,
-                                                            x_dims_order_gpu,
-                                                            x_data,
-                                                            y_data,
-                                                            out_data,
-                                                            dout_data,
-                                                            dx_data,
-                                                            out_size,
-                                                            max_dim,
-                                                            x_threads,
-                                                            dx_op);
+          <<<static_cast<uint32_t>(x_blocks),
+             x_block_size,
+             0,
+             dev_ctx.stream()>>>(x_strides_array_gpu,
+                                 y_strides_array_gpu,
+                                 out_dims_array_gpu,
+                                 x_strides_order_gpu,
+                                 x_dims_order_gpu,
+                                 x_data,
+                                 y_data,
+                                 out_data,
+                                 dout_data,
+                                 dx_data,
+                                 out_size,
+                                 max_dim,
+                                 x_threads,
+                                 dx_op);
     } else {
       CommonGradBroadcastCUDAKernel<uint32_t, T, DX_OP, Tout>
-          <<<x_blocks, x_block_size, 0, dev_ctx.stream()>>>(x_strides_array_gpu,
-                                                            y_strides_array_gpu,
-                                                            out_dims_array_gpu,
-                                                            x_strides_order_gpu,
-                                                            x_dims_order_gpu,
-                                                            x_data,
-                                                            y_data,
-                                                            out_data,
-                                                            dout_data,
-                                                            dx_data,
-                                                            out_size,
-                                                            max_dim,
-                                                            x_threads,
-                                                            dx_op);
+          <<<static_cast<uint32_t>(x_blocks),
+             x_block_size,
+             0,
+             dev_ctx.stream()>>>(x_strides_array_gpu,
+                                 y_strides_array_gpu,
+                                 out_dims_array_gpu,
+                                 x_strides_order_gpu,
+                                 x_dims_order_gpu,
+                                 x_data,
+                                 y_data,
+                                 out_data,
+                                 dout_data,
+                                 dx_data,
+                                 static_cast<uint32_t>(out_size),
+                                 max_dim,
+                                 static_cast<uint32_t>(x_threads),
+                                 dx_op);
     }
   }
   if (dy) {
@@ -1972,36 +1989,42 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
                        dev_ctx.stream());
     if (out_size > std::numeric_limits<int32_t>::max()) {
       CommonGradBroadcastCUDAKernel<int64_t, T, DY_OP, Tout>
-          <<<y_blocks, y_block_size, 0, dev_ctx.stream()>>>(x_strides_array_gpu,
-                                                            y_strides_array_gpu,
-                                                            out_dims_array_gpu,
-                                                            y_strides_order_gpu,
-                                                            y_dims_order_gpu,
-                                                            x_data,
-                                                            y_data,
-                                                            out_data,
-                                                            dout_data,
-                                                            dy_data,
-                                                            out_size,
-                                                            max_dim,
-                                                            y_threads,
-                                                            dy_op);
+          <<<static_cast<uint32_t>(y_blocks),
+             y_block_size,
+             0,
+             dev_ctx.stream()>>>(x_strides_array_gpu,
+                                 y_strides_array_gpu,
+                                 out_dims_array_gpu,
+                                 y_strides_order_gpu,
+                                 y_dims_order_gpu,
+                                 x_data,
+                                 y_data,
+                                 out_data,
+                                 dout_data,
+                                 dy_data,
+                                 out_size,
+                                 max_dim,
+                                 y_threads,
+                                 dy_op);
     } else {
-      CommonGradBroadcastCUDAKernel<int32_t, T, DY_OP, Tout>
-          <<<y_blocks, y_block_size, 0, dev_ctx.stream()>>>(x_strides_array_gpu,
-                                                            y_strides_array_gpu,
-                                                            out_dims_array_gpu,
-                                                            y_strides_order_gpu,
-                                                            y_dims_order_gpu,
-                                                            x_data,
-                                                            y_data,
-                                                            out_data,
-                                                            dout_data,
-                                                            dy_data,
-                                                            out_size,
-                                                            max_dim,
-                                                            y_threads,
-                                                            dy_op);
+      CommonGradBroadcastCUDAKernel<uint32_t, T, DY_OP, Tout>
+          <<<static_cast<uint32_t>(y_blocks),
+             y_block_size,
+             0,
+             dev_ctx.stream()>>>(x_strides_array_gpu,
+                                 y_strides_array_gpu,
+                                 out_dims_array_gpu,
+                                 y_strides_order_gpu,
+                                 y_dims_order_gpu,
+                                 x_data,
+                                 y_data,
+                                 out_data,
+                                 dout_data,
+                                 dy_data,
+                                 static_cast<uint32_t>(out_size),
+                                 max_dim,
+                                 static_cast<uint32_t>(y_threads),
+                                 dy_op);
     }
   }
 }

--- a/paddle/phi/kernels/funcs/math/unpooling.cu
+++ b/paddle/phi/kernels/funcs/math/unpooling.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/funcs/math/unpooling.h"
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 
 namespace phi {
@@ -147,9 +148,14 @@ class Unpool2dMaxFunctor<GPUContext, T> {
     const T* input_data = input.data<T>();
     const int* indices_data = indices.data<int>();
     T* output_data = context.template Alloc<T>(output);
-    int threads = 1024;
+    uint32_t threads = 1024;
     int64_t max_grid = context.GetCUDAMaxGridDimSize()[0];
-    int grid = std::min((input.numel() + threads - 1) / threads, max_grid);
+    int64_t grid_64 =
+        std::min((input.numel() + static_cast<int64_t>(threads) - 1) /
+                     static_cast<int64_t>(threads),
+                 max_grid);
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "KernelUnpool2dMax grid.x");
+    uint32_t grid = static_cast<uint32_t>(grid_64);
     KernelUnpool2dMax<T>
         <<<grid, threads, 0, context.stream()>>>(input.numel(),
                                                  input_data,
@@ -205,7 +211,12 @@ class Unpool2dMaxGradFunctor<GPUContext, T> {
     T* input_grad_data = context.template Alloc<T>(input_grad);
     int threads = 1024;
     int64_t max_grid = context.GetCUDAMaxGridDimSize()[0];
-    int grid = std::min((input.numel() + threads - 1) / threads, max_grid);
+    int64_t grid_64 =
+        std::min((input.numel() + static_cast<int64_t>(threads) - 1) /
+                     static_cast<int64_t>(threads),
+                 max_grid);
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "KernelUnpool2dMaxGrad grid.x");
+    uint32_t grid = static_cast<uint32_t>(grid_64);
     KernelUnpool2dMaxGrad<T>
         <<<grid, threads, 0, context.stream()>>>(input.numel(),
                                                  input_data,
@@ -265,7 +276,12 @@ class Unpool3dMaxFunctor<GPUContext, T> {
     T* output_data = context.template Alloc<T>(output);
     int threads = 1024;
     int64_t max_grid = context.GetCUDAMaxGridDimSize()[0];
-    int grid = std::min((input.numel() + threads - 1) / threads, max_grid);
+    int64_t grid_64 =
+        std::min((input.numel() + static_cast<int64_t>(threads) - 1) /
+                     static_cast<int64_t>(threads),
+                 max_grid);
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "KernelUnpool3dMax grid.x");
+    uint32_t grid = static_cast<uint32_t>(grid_64);
     KernelUnpool3dMax<T>
         <<<grid, threads, 0, context.stream()>>>(input.numel(),
                                                  input_data,
@@ -331,7 +347,12 @@ class Unpool3dMaxGradFunctor<GPUContext, T> {
     T* input_grad_data = context.template Alloc<T>(input_grad);
     int threads = 1024;
     int64_t max_grid = context.GetCUDAMaxGridDimSize()[0];
-    int grid = std::min((input.numel() + threads - 1) / threads, max_grid);
+    int64_t grid_64 =
+        std::min((input.numel() + static_cast<int64_t>(threads) - 1) /
+                     static_cast<int64_t>(threads),
+                 max_grid);
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "KernelUnpool3dMaxGrad grid.x");
+    uint32_t grid = static_cast<uint32_t>(grid_64);
     KernelUnpool3dMaxGrad<T>
         <<<grid, threads, 0, context.stream()>>>(input.numel(),
                                                  input_data,

--- a/paddle/phi/kernels/funcs/sparse/sparse_blas_impl.cu.h
+++ b/paddle/phi/kernels/funcs/sparse/sparse_blas_impl.cu.h
@@ -21,6 +21,7 @@
 #ifdef PADDLE_WITH_CUDA
 #include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #endif
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
@@ -591,7 +592,14 @@ void SparseBlas<GPUContext>::SPGEMM(bool transa,
         phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx_.stream())));
     void* tmp_buffer_ptr = tmp_buffer->ptr();
 
-    GetCsrBatchNnz<T><<<1, batch_size, 0, dev_ctx_.stream()>>>(
+    PADDLE_ENFORCE_LE(batch_size,
+                      dev_ctx_.GetMaxThreadsPerBlock(),
+                      common::errors::InvalidArgument(
+                          "cusparse spgemm block.x exceeds device limit."));
+    PADDLE_ENFORCE_LE_UINT32_MAX(batch_size, "cusparse spgemm block.x");
+    const uint32_t block = static_cast<uint32_t>(batch_size);
+
+    GetCsrBatchNnz<T><<<1, block, 0, dev_ctx_.stream()>>>(
         a_crows_data, a_rows, static_cast<int32_t*>(tmp_buffer_ptr));
 #ifdef PADDLE_WITH_CUDA
     PADDLE_ENFORCE_EQ(
@@ -610,7 +618,7 @@ void SparseBlas<GPUContext>::SPGEMM(bool transa,
                                        gpuMemcpyDeviceToHost,
                                        dev_ctx_.stream());
 
-    GetCsrBatchNnz<T><<<1, batch_size, 0, dev_ctx_.stream()>>>(
+    GetCsrBatchNnz<T><<<1, block, 0, dev_ctx_.stream()>>>(
         b_crows_data, b_rows, static_cast<int32_t*>(tmp_buffer_ptr));
     phi::backends::gpu::GpuMemcpyAsync(b_batch_nnz_vec.data(),
                                        tmp_buffer_ptr,

--- a/paddle/phi/kernels/fusion/gpu/attention_layer.norm.h
+++ b/paddle/phi/kernels/fusion/gpu/attention_layer.norm.h
@@ -48,8 +48,12 @@ class AttnLayerNorm {
                       const float quant_max_bound = 127.0,
                       const float quant_min_bound = -127.0) {
     auto stream = dev_ctx_.stream();
-    // TODO(large-tensor): generic kernel launch uses int32 grid dim
-    PADDLE_ENFORCE_LE_INT_MAX(batch_size_, "batch_size");
+    uint32_t max_grid_dim = dev_ctx_.GetCUDAMaxGridDimSize()[0];
+    PADDLE_ENFORCE_LE(batch_size_,
+                      max_grid_dim,
+                      common::errors::InvalidArgument(
+                          "attention layer norm grid.x exceeds device limit."));
+    PADDLE_ENFORCE_LE_UINT32_MAX(batch_size_, "attention layer norm grid.x");
 
     switch (funcs::GetDesiredBlockDim(feature_size_)) {
       FIXED_BLOCK_DIM_CASE(
@@ -59,20 +63,21 @@ class AttnLayerNorm {
                                   false,
                                   InType,
                                   OutType>
-          <<<batch_size_, kBlockDim, 0, stream>>>(x_data,
-                                                  scale_data,
-                                                  bias_data,
-                                                  y_data,
-                                                  mean_data,
-                                                  var_data,
-                                                  epsilon_,
-                                                  feature_size_,
-                                                  dequant_out_scale_data,
-                                                  quant_out_scale_offset,
-                                                  quant_in_scale,
-                                                  quant_round_type,
-                                                  quant_max_bound,
-                                                  quant_min_bound));
+          <<<static_cast<uint32_t>(batch_size_), kBlockDim, 0, stream>>>(
+              x_data,
+              scale_data,
+              bias_data,
+              y_data,
+              mean_data,
+              var_data,
+              epsilon_,
+              feature_size_,
+              dequant_out_scale_data,
+              quant_out_scale_offset,
+              quant_in_scale,
+              quant_round_type,
+              quant_max_bound,
+              quant_min_bound));
       default:
         PADDLE_THROW(common::errors::InvalidArgument(
             "Feature_size must be larger than 1"));

--- a/paddle/phi/kernels/fusion/gpu/cast_with_ptr.h
+++ b/paddle/phi/kernels/fusion/gpu/cast_with_ptr.h
@@ -34,6 +34,16 @@ static void VecCastKernel(const GPUContext &dev_ctx,
   auto config = backends::gpu::GetGpuLaunchConfig1D(dev_ctx, n, VecSize);
   auto block = config.GetGridSize();
   auto thread = config.GetBlockSize();
+  PADDLE_ENFORCE_LE(block,
+                    dev_ctx.GetCUDAMaxGridDimSize()[0],
+                    common::errors::InvalidArgument(
+                        "cast_with_ptr grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE(thread,
+                    dev_ctx.GetMaxThreadsPerBlock(),
+                    common::errors::InvalidArgument(
+                        "cast_with_ptr block.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(block, "cast_with_ptr grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(thread, "cast_with_ptr block.x");
   auto main_offset = n / (VecSize * thread) * VecSize * thread;
   auto stream = dev_ctx.stream();
   using FunctorT = CastFunctor<InT, OutT>;
@@ -42,8 +52,10 @@ static void VecCastKernel(const GPUContext &dev_ctx,
   Array<_ptr_ OutT *, 1> out_arr;
   out_arr[0] = y;
   funcs::VectorizedElementwiseKernel<OutT, FunctorT, 1, 1, VecSize>
-      <<<block, thread, 0, stream>>>(
-          in_arr, out_arr, n, main_offset, VecSize, FunctorT());
+      <<<static_cast<uint32_t>(block),
+         static_cast<uint32_t>(thread),
+         0,
+         stream>>>(in_arr, out_arr, n, main_offset, VecSize, FunctorT());
 }
 
 template <typename InT, typename OutT>

--- a/paddle/phi/kernels/fusion/gpu/fused_dropout_add_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_dropout_add_grad_kernel.cu
@@ -27,9 +27,10 @@
 static constexpr int kNumCUDAThreads = 512;
 static constexpr int kNumMaximumNumBlocks = 4096;
 
-static inline int NumBlocks(const int N) {
-  return std::min((N + kNumCUDAThreads - 1) / kNumCUDAThreads,
-                  kNumMaximumNumBlocks);
+static inline int NumBlocks(const int64_t N) {
+  const int64_t blocks = (N + kNumCUDAThreads - 1) / kNumCUDAThreads;
+  return static_cast<int>(
+      std::min(blocks, static_cast<int64_t>(kNumMaximumNumBlocks)));
 }
 
 namespace phi {
@@ -176,8 +177,8 @@ void FusedDropoutAddGradKernel(const Context& dev_ctx,
 
   const auto* out_grad_data = out_grad.data<T>();
   using MT = typename phi::dtype::MPTypeTrait<T>::Type;
-  int blocks = NumBlocks(numel);
-  int threads = kNumCUDAThreads;
+  uint32_t blocks = NumBlocks(numel);
+  uint32_t threads = kNumCUDAThreads;
 
   if (is_test) {
     MT factor = static_cast<MT>(1.0f - dropout_rate);
@@ -197,6 +198,16 @@ void FusedDropoutAddGradKernel(const Context& dev_ctx,
     auto random_prop = GetRandomCudaProp(numel, dev_ctx);
     size_t grid_size_64 = random_prop[0];
     size_t block_size_64 = random_prop[1];
+    PADDLE_ENFORCE_LE(
+        grid_size_64,
+        dev_ctx.GetCUDAMaxGridDimSize()[0],
+        common::errors::InvalidArgument(
+            "fused_dropout_add_grad grid.x exceeds device limit."));
+    PADDLE_ENFORCE_LE(
+        block_size_64,
+        dev_ctx.GetMaxThreadsPerBlock(),
+        common::errors::InvalidArgument(
+            "fused_dropout_add_grad block.x exceeds device limit."));
     PADDLE_ENFORCE_LE_UINT32_MAX(grid_size_64, "fused_dropout_add_grad grid.x");
     PADDLE_ENFORCE_LE_UINT32_MAX(block_size_64,
                                  "fused_dropout_add_grad block.x");

--- a/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h
@@ -1940,6 +1940,13 @@ void gqa_write_cachekv(
       common::errors::PreconditionNotMet(
           "dim_head=%d must be divisible by vec_size=%d", dim_head, x));
 
+  PADDLE_ENFORCE_LE_INT_MAX(gqa_group_size, "gqa_write_cache gqa_group_size");
+  PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "gqa_write_cache max_seq_len");
+  PADDLE_ENFORCE_LE_INT_MAX(dim_head, "gqa_write_cache dim_head");
+  const int gqa_group_size_int = static_cast<int>(gqa_group_size);
+  const int max_seq_len_int = static_cast<int>(max_seq_len);
+  const int dim_head_int = static_cast<int>(dim_head);
+
   const int64_t num_elems = unpadding_k.numel();
 
   T *cache_k = cache_kv_out->data<T>();
@@ -1966,10 +1973,10 @@ void gqa_write_cachekv(
           unpadding_k.data<T>(),
           seq_lens.data<int>(),
           padding_offsets.data<int>(),
-          gqa_group_size,
-          max_seq_len,
+          gqa_group_size_int,
+          max_seq_len_int,
           seq_len,
-          dim_head,
+          dim_head_int,
           num_elems);
   gqa_write_cache_v_kernel<T, x>
       <<<grid_size_u32, block_sz_u32, 0, dev_ctx.stream()>>>(
@@ -1977,10 +1984,10 @@ void gqa_write_cachekv(
           unpadding_v.data<T>(),
           seq_lens.data<int>(),
           padding_offsets.data<int>(),
-          gqa_group_size,
-          max_seq_len,
+          gqa_group_size_int,
+          max_seq_len_int,
           seq_len,
-          dim_head,
+          dim_head_int,
           num_elems);
 }
 

--- a/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h
@@ -1831,10 +1831,10 @@ __global__ void gqa_write_cache_k_kernel(T *cache_k,
                                          const T *k,
                                          const int *seq_lens,
                                          const int *padding_offsets,
-                                         const int gqa_group_size,
-                                         const int max_seq_len,
-                                         const int seq_len,
-                                         const int dim_head,
+                                         const int64_t gqa_group_size,
+                                         const int64_t max_seq_len,
+                                         const int64_t seq_len,
+                                         const int64_t dim_head,
                                          const int64_t num_elems) {
   AlignedVector<T, X_ELEMS> in_vec;
 
@@ -1843,23 +1843,24 @@ __global__ void gqa_write_cache_k_kernel(T *cache_k,
                              static_cast<int64_t>(threadIdx.x)) *
                             X_ELEMS;
        linear_idx < num_elems;
-       linear_idx += blockDim.x * gridDim.x * X_ELEMS) {
-    const int hidden_size = gqa_group_size * dim_head;
-    const int token_idx = linear_idx / hidden_size;
-    const int head_idx = (linear_idx % hidden_size) / dim_head;
-    const int head_offset = linear_idx % dim_head;
-    const int head_vec_id = head_offset / X_ELEMS;
-    const int ori_token_id = token_idx + padding_offsets[token_idx];
-    const int ori_bi = ori_token_id / seq_len;
+       linear_idx += static_cast<int64_t>(blockDim.x) *
+                     static_cast<int64_t>(gridDim.x) * X_ELEMS) {
+    const int64_t hidden_size = gqa_group_size * dim_head;
+    const int64_t token_idx = linear_idx / hidden_size;
+    const int64_t head_idx = (linear_idx % hidden_size) / dim_head;
+    const int64_t head_offset = linear_idx % dim_head;
+    const int64_t head_vec_id = head_offset / X_ELEMS;
+    const int64_t ori_token_id = token_idx + padding_offsets[token_idx];
+    const int64_t ori_bi = ori_token_id / seq_len;
 
     if (seq_lens[ori_bi] == 0) continue;
 
-    const int local_token_id = ori_token_id % seq_len;
+    const int64_t local_token_id = ori_token_id % seq_len;
 
-    const int tgt_idx = ori_bi * gqa_group_size * max_seq_len * dim_head +
-                        head_idx * max_seq_len * dim_head +
-                        head_vec_id * max_seq_len * X_ELEMS +
-                        local_token_id * X_ELEMS;
+    const int64_t tgt_idx = ori_bi * gqa_group_size * max_seq_len * dim_head +
+                            head_idx * max_seq_len * dim_head +
+                            head_vec_id * max_seq_len * X_ELEMS +
+                            local_token_id * X_ELEMS;
 
     Load(&k[linear_idx], &in_vec);
     Store(in_vec, &cache_k[tgt_idx]);
@@ -1871,10 +1872,10 @@ __global__ void gqa_write_cache_v_kernel(T *cache_v,
                                          const T *v,
                                          const int *seq_lens,
                                          const int *padding_offsets,
-                                         const int gqa_group_size,
-                                         const int max_seq_len,
-                                         const int seq_len,
-                                         const int dim_head,
+                                         const int64_t gqa_group_size,
+                                         const int64_t max_seq_len,
+                                         const int64_t seq_len,
+                                         const int64_t dim_head,
                                          const int64_t num_elems) {
   AlignedVector<T, X_ELEMS> in_vec;
 
@@ -1883,21 +1884,22 @@ __global__ void gqa_write_cache_v_kernel(T *cache_v,
                              static_cast<int64_t>(threadIdx.x)) *
                             X_ELEMS;
        linear_idx < num_elems;
-       linear_idx += blockDim.x * gridDim.x * X_ELEMS) {
-    const int hidden_size = gqa_group_size * dim_head;
-    const int token_idx = linear_idx / hidden_size;
-    const int head_idx = (linear_idx % hidden_size) / dim_head;
-    const int head_offset = linear_idx % dim_head;
-    const int ori_token_id = token_idx + padding_offsets[token_idx];
-    const int ori_bi = ori_token_id / seq_len;
+       linear_idx += static_cast<int64_t>(blockDim.x) *
+                     static_cast<int64_t>(gridDim.x) * X_ELEMS) {
+    const int64_t hidden_size = gqa_group_size * dim_head;
+    const int64_t token_idx = linear_idx / hidden_size;
+    const int64_t head_idx = (linear_idx % hidden_size) / dim_head;
+    const int64_t head_offset = linear_idx % dim_head;
+    const int64_t ori_token_id = token_idx + padding_offsets[token_idx];
+    const int64_t ori_bi = ori_token_id / seq_len;
 
     if (seq_lens[ori_bi] == 0) continue;
 
-    const int local_token_id = ori_token_id % seq_len;
+    const int64_t local_token_id = ori_token_id % seq_len;
 
-    const int tgt_idx = ori_bi * gqa_group_size * max_seq_len * dim_head +
-                        head_idx * max_seq_len * dim_head +
-                        local_token_id * dim_head + head_offset;
+    const int64_t tgt_idx = ori_bi * gqa_group_size * max_seq_len * dim_head +
+                            head_idx * max_seq_len * dim_head +
+                            local_token_id * dim_head + head_offset;
 
     Load(&v[linear_idx], &in_vec);
     Store(in_vec, &cache_v[tgt_idx]);
@@ -1940,13 +1942,6 @@ void gqa_write_cachekv(
       common::errors::PreconditionNotMet(
           "dim_head=%d must be divisible by vec_size=%d", dim_head, x));
 
-  PADDLE_ENFORCE_LE_INT_MAX(gqa_group_size, "gqa_write_cache gqa_group_size");
-  PADDLE_ENFORCE_LE_INT_MAX(max_seq_len, "gqa_write_cache max_seq_len");
-  PADDLE_ENFORCE_LE_INT_MAX(dim_head, "gqa_write_cache dim_head");
-  const int gqa_group_size_int = static_cast<int>(gqa_group_size);
-  const int max_seq_len_int = static_cast<int>(max_seq_len);
-  const int dim_head_int = static_cast<int>(dim_head);
-
   const int64_t num_elems = unpadding_k.numel();
 
   T *cache_k = cache_kv_out->data<T>();
@@ -1973,10 +1968,10 @@ void gqa_write_cachekv(
           unpadding_k.data<T>(),
           seq_lens.data<int>(),
           padding_offsets.data<int>(),
-          gqa_group_size_int,
-          max_seq_len_int,
-          seq_len,
-          dim_head_int,
+          gqa_group_size,
+          max_seq_len,
+          static_cast<int64_t>(seq_len),
+          dim_head,
           num_elems);
   gqa_write_cache_v_kernel<T, x>
       <<<grid_size_u32, block_sz_u32, 0, dev_ctx.stream()>>>(
@@ -1984,10 +1979,10 @@ void gqa_write_cachekv(
           unpadding_v.data<T>(),
           seq_lens.data<int>(),
           padding_offsets.data<int>(),
-          gqa_group_size_int,
-          max_seq_len_int,
-          seq_len,
-          dim_head_int,
+          gqa_group_size,
+          max_seq_len,
+          static_cast<int64_t>(seq_len),
+          dim_head,
           num_elems);
 }
 

--- a/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h
+++ b/paddle/phi/kernels/fusion/gpu/fused_multi_transformer_op.cu.h
@@ -22,6 +22,9 @@ limitations under the License. */
 #include <fstream>
 #include <iomanip>
 
+#include "paddle/phi/backends/gpu/gpu_info.h"
+
+#include "paddle/common/enforce.h"
 #include "paddle/common/flags.h"
 #include "paddle/phi/kernels/flash_attn_kernel.h"
 #include "paddle/phi/kernels/funcs/load_store_util.h"
@@ -596,32 +599,45 @@ inline size_t smem_size_in_bytes(
   return max(softmax_sz, red_sz);
 }
 
-#define MMHA_LAUNCH_KERNEL(T,                                             \
-                           Dh,                                            \
-                           Dh_MAX,                                        \
-                           THDS_PER_KEY,                                  \
-                           THDS_PER_VALUE,                                \
-                           THDS_PER_BLOCK,                                \
-                           stream,                                        \
-                           load_func,                                     \
-                           store_func)                                    \
-  size_t smem_sz =                                                        \
-      smem_size_in_bytes<T>(params, Dh, THDS_PER_VALUE, THDS_PER_BLOCK);  \
-  dim3 grid(params.num_head, params.batch_size);                          \
-  constexpr auto kernel_fn =                                              \
-      masked_multihead_attention_kernel<T,                                \
-                                        Dh,                               \
-                                        Dh_MAX,                           \
-                                        THDS_PER_KEY,                     \
-                                        THDS_PER_VALUE,                   \
-                                        THDS_PER_BLOCK,                   \
-                                        decltype(load_func),              \
-                                        decltype(store_func)>;            \
-  if (smem_sz > 0xc000) {                                                 \
-    cudaFuncSetAttribute(                                                 \
-        kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz); \
-  }                                                                       \
-  kernel_fn<<<grid, THDS_PER_BLOCK, smem_sz, stream>>>(                   \
+#define MMHA_LAUNCH_KERNEL(T,                                                \
+                           Dh,                                               \
+                           Dh_MAX,                                           \
+                           THDS_PER_KEY,                                     \
+                           THDS_PER_VALUE,                                   \
+                           THDS_PER_BLOCK,                                   \
+                           stream,                                           \
+                           load_func,                                        \
+                           store_func)                                       \
+  size_t smem_sz =                                                           \
+      smem_size_in_bytes<T>(params, Dh, THDS_PER_VALUE, THDS_PER_BLOCK);     \
+  const auto &prop = phi::backends::gpu::GetDeviceProperties(                \
+      phi::backends::gpu::GetCurrentDeviceId());                             \
+  PADDLE_ENFORCE_LE(                                                         \
+      params.num_head,                                                       \
+      prop.maxGridSize[0],                                                   \
+      common::errors::InvalidArgument("mmha grid.x exceeds device limit.")); \
+  PADDLE_ENFORCE_LE(                                                         \
+      params.batch_size,                                                     \
+      prop.maxGridSize[1],                                                   \
+      common::errors::InvalidArgument("mmha grid.y exceeds device limit.")); \
+  PADDLE_ENFORCE_LE_UINT32_MAX(params.num_head, "mmha grid.x");              \
+  PADDLE_ENFORCE_LE_UINT32_MAX(params.batch_size, "mmha grid.y");            \
+  dim3 grid(static_cast<uint32_t>(params.num_head),                          \
+            static_cast<uint32_t>(params.batch_size));                       \
+  constexpr auto kernel_fn =                                                 \
+      masked_multihead_attention_kernel<T,                                   \
+                                        Dh,                                  \
+                                        Dh_MAX,                              \
+                                        THDS_PER_KEY,                        \
+                                        THDS_PER_VALUE,                      \
+                                        THDS_PER_BLOCK,                      \
+                                        decltype(load_func),                 \
+                                        decltype(store_func)>;               \
+  if (smem_sz > 0xc000) {                                                    \
+    cudaFuncSetAttribute(                                                    \
+        kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);    \
+  }                                                                          \
+  kernel_fn<<<grid, THDS_PER_BLOCK, smem_sz, stream>>>(                      \
       params, load_func, store_func);
 
 template <typename T,
@@ -1371,49 +1387,69 @@ inline size_t get_reduce_smem_size_in_bytes(
   return reduce_shared_mem_size;
 }
 
-#define MBMMHA_LAUNCH_KERNEL(T,                                             \
-                             Dh,                                            \
-                             Dh_MAX,                                        \
-                             THDS_PER_KEY,                                  \
-                             THDS_PER_VALUE,                                \
-                             THDS_PER_BLOCK,                                \
-                             stream,                                        \
-                             load_func,                                     \
-                             reduce_store_func)                             \
-  VLOG(1) << "THREADS_PER_VALUE is: " << THREADS_PER_VALUE                  \
-          << ", partition_size: " << params.partition_size;                 \
-  size_t smem_sz = multi_block_attn_smem_size_in_bytes<T>(                  \
-      params, Dh, THDS_PER_VALUE, THDS_PER_BLOCK);                          \
-  dim3 grid(params.num_head,                                                \
-            params.batch_size,                                              \
-            div_up(params.timestep, params.partition_size));                \
-  constexpr auto kernel_fn = multi_block_masked_multihead_attention_kernel< \
-      T,                                                                    \
-      Dh,                                                                   \
-      Dh_MAX,                                                               \
-      THDS_PER_KEY,                                                         \
-      THDS_PER_VALUE,                                                       \
-      THDS_PER_BLOCK,                                                       \
-      decltype(load_func),                                                  \
-      decltype(reduce_store_func)>;                                         \
-  if (smem_sz > 0xc000) {                                                   \
-    cudaFuncSetAttribute(                                                   \
-        kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);   \
-  }                                                                         \
-  kernel_fn<<<grid, THDS_PER_BLOCK, smem_sz, stream>>>(                     \
-      params, load_func, reduce_store_func);                                \
-                                                                            \
-  dim3 reduce_kernel_grid(params.num_head, params.batch_size, 1);           \
-  size_t reduce_smem_sz = get_reduce_smem_size_in_bytes<T>(params);         \
-  constexpr int MBLHA_REDUCE_BLOCK_SIZE = 256;                              \
-  constexpr auto reduce_kernel_fn =                                         \
-      multi_block_attention_reduce_kernel<T,                                \
-                                          Dh,                               \
-                                          MBLHA_REDUCE_BLOCK_SIZE,          \
-                                          decltype(reduce_store_func)>;     \
-  reduce_kernel_fn<<<reduce_kernel_grid,                                    \
-                     MBLHA_REDUCE_BLOCK_SIZE,                               \
-                     reduce_smem_sz,                                        \
+#define MBMMHA_LAUNCH_KERNEL(T,                                                \
+                             Dh,                                               \
+                             Dh_MAX,                                           \
+                             THDS_PER_KEY,                                     \
+                             THDS_PER_VALUE,                                   \
+                             THDS_PER_BLOCK,                                   \
+                             stream,                                           \
+                             load_func,                                        \
+                             reduce_store_func)                                \
+  VLOG(1) << "THREADS_PER_VALUE is: " << THREADS_PER_VALUE                     \
+          << ", partition_size: " << params.partition_size;                    \
+  size_t smem_sz = multi_block_attn_smem_size_in_bytes<T>(                     \
+      params, Dh, THDS_PER_VALUE, THDS_PER_BLOCK);                             \
+  const auto &prop = phi::backends::gpu::GetDeviceProperties(                  \
+      phi::backends::gpu::GetCurrentDeviceId());                               \
+  int64_t grid_z = div_up(params.timestep, params.partition_size);             \
+  PADDLE_ENFORCE_LE(                                                           \
+      params.num_head,                                                         \
+      prop.maxGridSize[0],                                                     \
+      common::errors::InvalidArgument("mbmmha grid.x exceeds device limit.")); \
+  PADDLE_ENFORCE_LE(                                                           \
+      params.batch_size,                                                       \
+      prop.maxGridSize[1],                                                     \
+      common::errors::InvalidArgument("mbmmha grid.y exceeds device limit.")); \
+  PADDLE_ENFORCE_LE(                                                           \
+      grid_z,                                                                  \
+      prop.maxGridSize[2],                                                     \
+      common::errors::InvalidArgument("mbmmha grid.z exceeds device limit.")); \
+  PADDLE_ENFORCE_LE_UINT32_MAX(params.num_head, "mbmmha grid.x");              \
+  PADDLE_ENFORCE_LE_UINT32_MAX(params.batch_size, "mbmmha grid.y");            \
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_z, "mbmmha grid.z");                       \
+  dim3 grid(static_cast<uint32_t>(params.num_head),                            \
+            static_cast<uint32_t>(params.batch_size),                          \
+            static_cast<uint32_t>(grid_z));                                    \
+  constexpr auto kernel_fn = multi_block_masked_multihead_attention_kernel<    \
+      T,                                                                       \
+      Dh,                                                                      \
+      Dh_MAX,                                                                  \
+      THDS_PER_KEY,                                                            \
+      THDS_PER_VALUE,                                                          \
+      THDS_PER_BLOCK,                                                          \
+      decltype(load_func),                                                     \
+      decltype(reduce_store_func)>;                                            \
+  if (smem_sz > 0xc000) {                                                      \
+    cudaFuncSetAttribute(                                                      \
+        kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_sz);      \
+  }                                                                            \
+  kernel_fn<<<grid, THDS_PER_BLOCK, smem_sz, stream>>>(                        \
+      params, load_func, reduce_store_func);                                   \
+                                                                               \
+  dim3 reduce_kernel_grid(static_cast<uint32_t>(params.num_head),              \
+                          static_cast<uint32_t>(params.batch_size),            \
+                          1);                                                  \
+  size_t reduce_smem_sz = get_reduce_smem_size_in_bytes<T>(params);            \
+  constexpr int MBLHA_REDUCE_BLOCK_SIZE = 256;                                 \
+  constexpr auto reduce_kernel_fn =                                            \
+      multi_block_attention_reduce_kernel<T,                                   \
+                                          Dh,                                  \
+                                          MBLHA_REDUCE_BLOCK_SIZE,             \
+                                          decltype(reduce_store_func)>;        \
+  reduce_kernel_fn<<<reduce_kernel_grid,                                       \
+                     MBLHA_REDUCE_BLOCK_SIZE,                                  \
+                     reduce_smem_sz,                                           \
                      stream>>>(params, reduce_store_func);
 
 template <typename T,
@@ -1912,26 +1948,40 @@ void gqa_write_cachekv(
   int grid_size;
   GetNumBlocks(num_elems, &grid_size);
 
-  gqa_write_cache_k_kernel<T, x><<<grid_size, block_sz, 0, dev_ctx.stream()>>>(
-      cache_k,
-      unpadding_k.data<T>(),
-      seq_lens.data<int>(),
-      padding_offsets.data<int>(),
-      gqa_group_size,
-      max_seq_len,
-      seq_len,
-      dim_head,
-      num_elems);
-  gqa_write_cache_v_kernel<T, x><<<grid_size, block_sz, 0, dev_ctx.stream()>>>(
-      cache_v,
-      unpadding_v.data<T>(),
-      seq_lens.data<int>(),
-      padding_offsets.data<int>(),
-      gqa_group_size,
-      max_seq_len,
-      seq_len,
-      dim_head,
-      num_elems);
+  PADDLE_ENFORCE_LE(grid_size,
+                    dev_ctx.GetCUDAMaxGridDimSize()[0],
+                    common::errors::InvalidArgument(
+                        "gqa_write_cache grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE(block_sz,
+                    dev_ctx.GetMaxThreadsPerBlock(),
+                    common::errors::InvalidArgument(
+                        "gqa_write_cache block.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size, "gqa_write_cache grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(block_sz, "gqa_write_cache block.x");
+  const uint32_t grid_size_u32 = static_cast<uint32_t>(grid_size);
+  const uint32_t block_sz_u32 = static_cast<uint32_t>(block_sz);
+  gqa_write_cache_k_kernel<T, x>
+      <<<grid_size_u32, block_sz_u32, 0, dev_ctx.stream()>>>(
+          cache_k,
+          unpadding_k.data<T>(),
+          seq_lens.data<int>(),
+          padding_offsets.data<int>(),
+          gqa_group_size,
+          max_seq_len,
+          seq_len,
+          dim_head,
+          num_elems);
+  gqa_write_cache_v_kernel<T, x>
+      <<<grid_size_u32, block_sz_u32, 0, dev_ctx.stream()>>>(
+          cache_v,
+          unpadding_v.data<T>(),
+          seq_lens.data<int>(),
+          padding_offsets.data<int>(),
+          gqa_group_size,
+          max_seq_len,
+          seq_len,
+          dim_head,
+          num_elems);
 }
 
 template <typename T, int VecSize>

--- a/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_grad_kernel.cu
@@ -151,7 +151,7 @@ void FusedSoftmaxMaskGradKernel(const Context& dev_ctx,
 
   int warps_per_block = (threads_per_block / warp_size);
   int batches_per_block = warps_per_block * batches_per_warp;
-  int64_t blocks_64 = batch_count / batches_per_block;
+  int64_t blocks_64 = (batch_count + batches_per_block - 1) / batches_per_block;
   PADDLE_ENFORCE_LE(
       blocks_64,
       dev_ctx.GetCUDAMaxGridDimSize()[0],

--- a/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_grad_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/fused_softmax_mask_grad_kernel.cu
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 
+#include "paddle/common/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/fused_softmax_mask_grad_kernel.h"
@@ -150,7 +151,14 @@ void FusedSoftmaxMaskGradKernel(const Context& dev_ctx,
 
   int warps_per_block = (threads_per_block / warp_size);
   int batches_per_block = warps_per_block * batches_per_warp;
-  int64_t blocks = batch_count / batches_per_block;
+  int64_t blocks_64 = batch_count / batches_per_block;
+  PADDLE_ENFORCE_LE(
+      blocks_64,
+      dev_ctx.GetCUDAMaxGridDimSize()[0],
+      common::errors::InvalidArgument(
+          "fused softmax mask grad grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(blocks_64, "fused softmax mask grad grid.x");
+  uint32_t blocks = static_cast<uint32_t>(blocks_64);
   dim3 threads(warp_size, warps_per_block, 1);
 
   // launch the kernel based on the pow2_index

--- a/paddle/phi/kernels/gpu/elementwise_grad.h
+++ b/paddle/phi/kernels/gpu/elementwise_grad.h
@@ -354,10 +354,16 @@ void ElementwiseAddGrad(const GPUContext &dev_ctx,
     auto size = x.numel();
     int vec_size = max(static_cast<int>(sizeof(float4) / sizeof(T)), 1);
     dim3 block_size = dim3(PREDEFINED_BLOCK_SIZE, 1);
-    dim3 grid_size =
-        dim3(((size + vec_size - 1) / vec_size + PREDEFINED_BLOCK_SIZE - 1) /
-                 PREDEFINED_BLOCK_SIZE,
-             1);
+    int64_t grid_size_x =
+        ((size + vec_size - 1) / vec_size + PREDEFINED_BLOCK_SIZE - 1) /
+        PREDEFINED_BLOCK_SIZE;
+    uint32_t max_grid_dim = dev_ctx.GetCUDAMaxGridDimSize()[0];
+    PADDLE_ENFORCE_LE(grid_size_x,
+                      max_grid_dim,
+                      common::errors::InvalidArgument(
+                          "elementwise add grad grid.x exceeds device limit."));
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_size_x, "elementwise add grad grid.x");
+    dim3 grid_size(static_cast<uint32_t>(grid_size_x), 1);
     if (size < std::numeric_limits<int>::max()) {
       SimpleElemwiseAddGradCUDAKernel<T>
           <<<grid_size, block_size, 0, dev_ctx.stream()>>>(
@@ -443,8 +449,16 @@ void default_elementwise_sub_grad(const GPUContext &dev_ctx,
       if (dy_data != dout_data) {
         dim3 block_size = dim3(PREDEFINED_BLOCK_SIZE, 1);
         auto size = dy->numel();
-        dim3 grid_size =
-            dim3((size + PREDEFINED_BLOCK_SIZE - 1) / PREDEFINED_BLOCK_SIZE, 1);
+        int64_t grid_size_x =
+            (size + PREDEFINED_BLOCK_SIZE - 1) / PREDEFINED_BLOCK_SIZE;
+        PADDLE_ENFORCE_LE(
+            grid_size_x,
+            dev_ctx.GetCUDAMaxGridDimSize()[0],
+            common::errors::InvalidArgument(
+                "elementwise sub grad grid.x exceeds device limit."));
+        PADDLE_ENFORCE_LE_UINT32_MAX(grid_size_x,
+                                     "elementwise sub grad grid.x");
+        dim3 grid_size(static_cast<uint32_t>(grid_size_x), 1);
         SimpleElemwiseSubGradCUDAKernel<T>
             <<<grid_size, block_size, 0, dev_ctx.stream()>>>(
                 dout.data<T>(), size, nullptr, dev_ctx.template Alloc<T>(dy));
@@ -468,8 +482,14 @@ void elementwise_sub_grad(const GPUContext &dev_ctx,
                           DenseTensor *dy) {
   dim3 block_size = dim3(PREDEFINED_BLOCK_SIZE, 1);
   auto size = x.numel();
-  dim3 grid_size =
-      dim3((size + PREDEFINED_BLOCK_SIZE - 1) / PREDEFINED_BLOCK_SIZE, 1);
+  int64_t grid_size_x =
+      (size + PREDEFINED_BLOCK_SIZE - 1) / PREDEFINED_BLOCK_SIZE;
+  PADDLE_ENFORCE_LE(grid_size_x,
+                    dev_ctx.GetCUDAMaxGridDimSize()[0],
+                    common::errors::InvalidArgument(
+                        "elementwise sub grad grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size_x, "elementwise sub grad grid.x");
+  dim3 grid_size(static_cast<uint32_t>(grid_size_x), 1);
   SimpleElemwiseSubGradCUDAKernel<T>
       <<<grid_size, block_size, 0, dev_ctx.stream()>>>(
           dout.data<T>(),

--- a/paddle/phi/kernels/gpudnn/mha_cudnn_frontend.cu
+++ b/paddle/phi/kernels/gpudnn/mha_cudnn_frontend.cu
@@ -19,6 +19,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "paddle/common/enforce.h"
 #include "paddle/phi/core/enforce.h"
 
 #define CUDNN_FRONTEND_UNUSED(X) ((void)X)
@@ -593,8 +594,19 @@ void fused_attn_arbitrary_seqlen_fwd_impl(int64_t b,
     }
 
     if (is_padding) {
-      constexpr size_t nthreads_per_block = 128;
-      const size_t grid = (b + nthreads_per_block - 1) / nthreads_per_block;
+      constexpr size_t nthreads_per_block_64 = 128;
+      const size_t grid_64 =
+          (b + nthreads_per_block_64 - 1) / nthreads_per_block_64;
+      PADDLE_ENFORCE_LE(grid_64,
+                        dev_ctx.GetCUDAMaxGridDimSize()[0],
+                        common::errors::InvalidArgument(
+                            "mha cudnn frontend grid.x exceeds device limit."));
+      PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "mha cudnn frontend grid.x");
+      PADDLE_ENFORCE_LE_UINT32_MAX(nthreads_per_block_64,
+                                   "mha cudnn frontend block.x");
+      const uint32_t grid = static_cast<uint32_t>(grid_64);
+      const uint32_t nthreads_per_block =
+          static_cast<uint32_t>(nthreads_per_block_64);
       void *devActualSeqlenQ =
           static_cast<int8_t *>(workspace) + plan_workspace_size;
       void *devActualSeqlenKV =

--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -960,6 +960,15 @@ static void GetGridDim(int64_t high_dim,
   grid_x = std::min(grid_x, max_num_blocks);
   int64_t grid_y = (max_num_blocks + grid_x - 1) / grid_x;
   grid_y = std::min(grid_y, high_dim);
+  const auto& prop = phi::backends::gpu::GetDeviceProperties(device_id);
+  PADDLE_ENFORCE_LE(
+      grid_x,
+      prop.maxGridSize[0],
+      common::errors::InvalidArgument("softmax grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE(
+      grid_y,
+      prop.maxGridSize[1],
+      common::errors::InvalidArgument("softmax grid.y exceeds device limit."));
   PADDLE_ENFORCE_LE_UINT32_MAX(grid_x, "softmax grid.x");
   PADDLE_ENFORCE_LE_UINT32_MAX(grid_y, "softmax grid.y");
   grid->x = static_cast<uint32_t>(grid_x);
@@ -1336,8 +1345,14 @@ void LaunchKeMatrixSoftmaxForwardKernel(const GPUContext& dev_ctx,
   constexpr int kVecSize =
       MaxWithOne<MATRIX_SOFTMAX_ALIGN_BYTES / sizeof(T)>::kValue;
   int block_dim = CalcBlockSize(kVecSize, dim_size);
+  PADDLE_ENFORCE_LE(
+      N,
+      dev_ctx.GetCUDAMaxGridDimSize()[0],
+      common::errors::InvalidArgument("softmax grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(N, "softmax grid.x");
   KeMatrixSoftmaxForward<T, AccT, IndexType, LogMode>
-      <<<N, block_dim, 0, dev_ctx.stream()>>>(out, input, dim_size);
+      <<<static_cast<uint32_t>(N), block_dim, 0, dev_ctx.stream()>>>(
+          out, input, dim_size);
 }
 
 #if CUDNN_VERSION < 8100
@@ -2689,6 +2704,10 @@ void SoftmaxForwardCUDAKernelCompatible(const GPUContext& dev_ctx,
         remaining -= chunk_size;
       }
     } else {
+      PADDLE_ENFORCE_LE(N,
+                        dev_ctx.GetCUDAMaxGridDimSize()[0],
+                        common::errors::InvalidArgument(
+                            "softmax grid.x exceeds device limit."));
       PADDLE_ENFORCE_LE_UINT32_MAX(N, "softmax grid.x");
       dim3 grid(static_cast<uint32_t>(N));
       dispatch_host_softmax_forward<T, AccT, IndexType, Function>(
@@ -2752,6 +2771,10 @@ void SoftmaxBackwardCUDAKernelCompatible(const GPUContext& dev_ctx,
         remaining -= chunk_size;
       }
     } else {
+      PADDLE_ENFORCE_LE(N,
+                        dev_ctx.GetCUDAMaxGridDimSize()[0],
+                        common::errors::InvalidArgument(
+                            "softmax grid.x exceeds device limit."));
       PADDLE_ENFORCE_LE_UINT32_MAX(N, "softmax grid.x");
       dim3 grid(static_cast<uint32_t>(N));
       dispatch_host_softmax_backward<T, AccT, IndexType, LogMode, Function>(

--- a/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
@@ -428,9 +428,15 @@ void ComputeDDoutWithoutBroadcast(const GPUContext& dev_ctx UNUSED,
   auto* ddout_data = ddout->data<T>();
   int block = 512;
   int64_t grid = (out_numel + block - 1) / block;
+  uint32_t max_grid_dim = dev_ctx.GetCUDAMaxGridDimSize()[0];
+  PADDLE_ENFORCE_LE(grid,
+                    max_grid_dim,
+                    common::errors::InvalidArgument(
+                        "elementwise ddout grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid, "elementwise ddout grid.x");
   auto stream = reinterpret_cast<const GPUContext&>(dev_ctx).stream();
   ComputeDDoutWithoutBroadcastGPUKernel<T, DDout_OP, T>
-      <<<grid, block, 0, stream>>>(
+      <<<static_cast<uint32_t>(grid), block, 0, stream>>>(
           ddx_data, ddy_data, y_data, out_data, ddout_data, out_numel, dout_op);
 }
 
@@ -496,19 +502,26 @@ void ComputeDDoutWithBroadcast(const GPUContext& dev_ctx UNUSED,
 
   int block = 512;
   int64_t grid = (out_numel + block - 1) / block;
+  uint32_t max_grid_dim = dev_ctx.GetCUDAMaxGridDimSize()[0];
+  PADDLE_ENFORCE_LE(grid,
+                    max_grid_dim,
+                    common::errors::InvalidArgument(
+                        "elementwise ddout grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid, "elementwise ddout grid.x");
   auto stream = reinterpret_cast<const GPUContext&>(dev_ctx).stream();
   ComputeDDoutWithBroadcastGPUKernel<T, DDout_OP, T>
-      <<<grid, block, 0, stream>>>(ddx_data,
-                                   ddy_data,
-                                   y_data,
-                                   out_data,
-                                   ddout_data,
-                                   out_numel,
-                                   x_dims_array_gpu_data,
-                                   y_dims_array_gpu_data,
-                                   out_dims_array_gpu_data,
-                                   max_dim,
-                                   dout_op);
+      <<<static_cast<uint32_t>(grid), block, 0, stream>>>(
+          ddx_data,
+          ddy_data,
+          y_data,
+          out_data,
+          ddout_data,
+          out_numel,
+          x_dims_array_gpu_data,
+          y_dims_array_gpu_data,
+          out_dims_array_gpu_data,
+          max_dim,
+          dout_op);
 }
 
 #endif

--- a/paddle/phi/kernels/impl/isfinite_kernel_impl.h
+++ b/paddle/phi/kernels/impl/isfinite_kernel_impl.h
@@ -22,6 +22,7 @@
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/dense_tensor.h"
 
+#include "paddle/common/enforce.h"
 #include "paddle/phi/kernels/funcs/isfinite_functor.h"
 #include "paddle/phi/kernels/isfinite_kernel.h"
 
@@ -493,12 +494,18 @@ struct IsfiniteFunctor<GPUContext, T> {
     int64_t block = 1024;
     int64_t grid = (block - 1 + num) / block;
     grid = (grid > block) ? block : grid;
+    PADDLE_ENFORCE_LE_UINT32_MAX(block, "isfinite launch block.x");
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid, "isfinite launch grid.x");
+    uint32_t block_value = static_cast<uint32_t>(block);
+    uint32_t grid_value = static_cast<uint32_t>(grid);
     if (num + block * grid + 1 > std::numeric_limits<unsigned int>::max()) {
       IsfiniteCUDAKernel<T, int64_t>
-          <<<grid, block, 0, dev_ctx.stream()>>>(in_data, num, out_data);
+          <<<grid_value, block_value, 0, dev_ctx.stream()>>>(
+              in_data, num, out_data);
     } else {
       IsfiniteCUDAKernel<T, unsigned int>
-          <<<grid, block, 0, dev_ctx.stream()>>>(in_data, num, out_data);
+          <<<grid_value, block_value, 0, dev_ctx.stream()>>>(
+              in_data, num, out_data);
     }
   }
 };
@@ -514,12 +521,18 @@ struct IsnanFunctor<GPUContext, T> {
     int64_t block = 1024;
     int64_t grid = (block - 1 + num) / block;
     grid = (grid > block) ? block : grid;
+    PADDLE_ENFORCE_LE_UINT32_MAX(block, "isfinite launch block.x");
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid, "isfinite launch grid.x");
+    uint32_t block_value = static_cast<uint32_t>(block);
+    uint32_t grid_value = static_cast<uint32_t>(grid);
     if (num + block * grid + 1 > std::numeric_limits<unsigned int>::max()) {
       IsnanCUDAKernel<T, int64_t>
-          <<<grid, block, 0, dev_ctx.stream()>>>(in_data, num, out_data);
+          <<<grid_value, block_value, 0, dev_ctx.stream()>>>(
+              in_data, num, out_data);
     } else {
       IsnanCUDAKernel<T, unsigned int>
-          <<<grid, block, 0, dev_ctx.stream()>>>(in_data, num, out_data);
+          <<<grid_value, block_value, 0, dev_ctx.stream()>>>(
+              in_data, num, out_data);
     }
   }
 };
@@ -535,12 +548,18 @@ struct IsinfFunctor<GPUContext, T> {
     int64_t block = 1024;
     int64_t grid = (block - 1 + num) / block;
     grid = (grid > block) ? block : grid;
+    PADDLE_ENFORCE_LE_UINT32_MAX(block, "isfinite launch block.x");
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid, "isfinite launch grid.x");
+    uint32_t block_value = static_cast<uint32_t>(block);
+    uint32_t grid_value = static_cast<uint32_t>(grid);
     if (num + block * grid + 1 > std::numeric_limits<unsigned int>::max()) {
       IsinfCUDAKernel<T, int64_t>
-          <<<grid, block, 0, dev_ctx.stream()>>>(in_data, num, out_data);
+          <<<grid_value, block_value, 0, dev_ctx.stream()>>>(
+              in_data, num, out_data);
     } else {
       IsinfCUDAKernel<T, unsigned int>
-          <<<grid, block, 0, dev_ctx.stream()>>>(in_data, num, out_data);
+          <<<grid_value, block_value, 0, dev_ctx.stream()>>>(
+              in_data, num, out_data);
     }
   }
 };

--- a/paddle/phi/kernels/impl/weight_quantize_kernel_gpu_impl.h
+++ b/paddle/phi/kernels/impl/weight_quantize_kernel_gpu_impl.h
@@ -11,9 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #pragma once
-
 #include <cstdint>
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/core/dense_tensor.h"

--- a/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
@@ -11,20 +11,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #include "paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.h"
 #include <cuda_fp8.h>
 #include <cstdint>
 #include <vector>
 #include "paddle/common/flags.h"
-#include "paddle/phi/core/dense_tensor.h"
-#include "paddle/phi/core/utils/data_type.h"
-
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
+#include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/utils/data_type.h"
 #include "paddle/phi/kernels/fusion/gpu/quant_utils.h"
 
+#include "paddle/common/enforce.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
 
 namespace phi {
@@ -835,13 +834,17 @@ void FP8QuantBlockWiseKernelImpl(const Context &dev_ctx,
     const size_t min_block_x = 1024;
     const size_t gridx = std::min(min_grid_x, src_rows);
     const size_t blockx = std::min(min_block_x, src_cols / 128 * 32);
+    PADDLE_ENFORCE_LE_UINT32_MAX(gridx, "fp8 quant blockwise padding grid.x");
+    PADDLE_ENFORCE_LE_UINT32_MAX(blockx, "fp8 quant blockwise padding block.x");
+    const uint32_t grid_x = static_cast<uint32_t>(gridx);
+    const uint32_t block_x = static_cast<uint32_t>(blockx);
 
     quant_per_token_per_block_padding<NvType,
                                       ScaleT,
                                       output_scale_transpose,
                                       using_pow2_scale,
                                       using_ue8m0_scale>
-        <<<gridx, blockx, 0, dev_ctx.stream()>>>(
+        <<<grid_x, block_x, 0, dev_ctx.stream()>>>(
             reinterpret_cast<const NvType *>(X.data<T>()),
             reinterpret_cast<__nv_fp8_e4m3 *>(out->data<phi::float8_e4m3fn>()),
             reinterpret_cast<ScaleT *>(scale->data<ScaleT>()),
@@ -858,7 +861,14 @@ void FP8QuantBlockWiseKernelImpl(const Context &dev_ctx,
     } else {
       block.x = 256;
     }
-    grid.x = (src_cols / k_block_span) * (src_rows / k_block_span);
+    const size_t gridx = (src_cols / k_block_span) * (src_rows / k_block_span);
+    PADDLE_ENFORCE_LE(
+        gridx,
+        dev_ctx.GetCUDAMaxGridDimSize()[0],
+        common::errors::InvalidArgument(
+            "fp8 quant blockwise aligned grid.x exceeds device limit."));
+    PADDLE_ENFORCE_LE_UINT32_MAX(gridx, "fp8 quant blockwise aligned grid.x");
+    grid.x = static_cast<uint32_t>(gridx);
 
     auto kernel = using_1x128_vec_quant
                       ? quantize_1x128_kernel<NvType,

--- a/paddle/phi/kernels/legacy/gpu/moe_combine_no_weight_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/moe_combine_no_weight_kernel.cu
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/legacy/gpu/moe_combine_no_weight_kernel.h"
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
 
@@ -63,9 +65,17 @@ void moe_combine_no_weight_fwd(const T* x,
                                const int64_t hidden_size,
                                const float epsilon,
                                cudaStream_t stream) {
-  int threads_per_block = 1024;
+  constexpr uint32_t threads_per_block = 1024;
   dim3 blockDim(threads_per_block);
-  dim3 gridDim(seqlen);
+  const int64_t max_grid_x = backends::gpu::GetGpuMaxGridDimSize(
+      backends::gpu::GetCurrentDeviceId())[0];
+  PADDLE_ENFORCE_LE(
+      seqlen,
+      max_grid_x,
+      common::errors::InvalidArgument(
+          "combine_no_weight_kernel grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(seqlen, "combine_no_weight_kernel grid.x");
+  dim3 gridDim(static_cast<uint32_t>(seqlen));
   size_t sharedMemSize = k * (sizeof(int64_t) + sizeof(T));
 
 #define CALL_KERNEL(K)                                          \

--- a/paddle/phi/kernels/stride/indexing_kernel.cu
+++ b/paddle/phi/kernels/stride/indexing_kernel.cu
@@ -32,6 +32,7 @@
 #include "paddle/phi/kernels/stride/elementwise_stride_base.cu.h"
 
 #if defined(__NVCC__) || defined(__HIPCC__) || defined(__xpu__)
+#include "paddle/common/enforce.h"
 #include "paddle/phi/kernels/funcs/dims_simplifier.h"
 
 #endif
@@ -213,7 +214,14 @@ void LaunchIndexPutKernel_V2(const Context& dev_ctx,
   constexpr int nt = 128;
   constexpr int vt = 4;
   const dim3 block(nt);
-  const dim3 grid((N + block.x * vt - 1) / (block.x * vt));
+  int64_t grid_64 = (N + static_cast<int64_t>(block.x) * vt - 1) /
+                    (static_cast<int64_t>(block.x) * vt);
+  PADDLE_ENFORCE_LE(grid_64,
+                    dev_ctx.GetCUDAMaxGridDimSize()[0],
+                    common::errors::InvalidArgument(
+                        "index_put_kernel grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "index_put_kernel grid.x");
+  const dim3 grid(static_cast<uint32_t>(grid_64));
   auto stream = dev_ctx.stream();
 
   auto* val_data = value.data<T>();


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
 ### Description
 This PR updates CUDA kernel launch configuration in the elementwise kernel path, fusion/gpudnn kernels, and miscellaneous  kernel modules including legacy, stride, impl, sparse, and math helper kernels.
The changes add explicit `UINT32_MAX` and device-limit checks for CUDA grid/block dimensions before kernel launches, and cast  the validated launch parameters to `uint32_t`. This avoids implicit narrowing when `int64_t` or `size_t` values are passed as  CUDA launch dimensions.
  This PR is split from #79333 by directory/module scope to reduce review size. The changes are limited to CUDA launch configuration handling and do not intend to change operator algorithms or numerical behavior.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否