### PR TITLE
[Operator Mechanism]fix cuda launch dimension checks for gpu kernels

### DIFF
--- a/paddle/phi/kernels/cpu/gumbel_softmax_kernel.cc
+++ b/paddle/phi/kernels/cpu/gumbel_softmax_kernel.cc
@@ -26,8 +26,8 @@ struct GumbleNoiseGenerator<CPUContext, T> {
   static void Transform(const CPUContext& dev_ctx,
                         const T* input_data,
                         T* output_data,
-                        int size_to_axis,
-                        int size_from_axis,
+                        int64_t size_to_axis,
+                        int64_t size_from_axis,
                         const float temperature) {
     // generate uniform random number
     const int64_t size = static_cast<int64_t>(size_to_axis) * size_from_axis;

--- a/paddle/phi/kernels/gpu/arg_min_max_kernel.cu
+++ b/paddle/phi/kernels/gpu/arg_min_max_kernel.cu
@@ -21,6 +21,7 @@
 
 #include <limits>
 #include "paddle/common/ddim.h"
+#include "paddle/common/enforce.h"
 #include "paddle/phi/core/utils/data_type.h"
 #include "paddle/phi/kernels/funcs/cub.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
@@ -109,7 +110,13 @@ void ComputeFullArg(const GPUContext& dev_ctx,
   int64_t max_grid_dimx = dev_ctx.GetCUDAMaxGridDimSize()[0];
   int64_t height = pre * post;
   int64_t width = n;
-  int64_t grid_size = height < max_grid_dimx ? height : max_grid_dimx;
+  int64_t grid_size_64 = height < max_grid_dimx ? height : max_grid_dimx;
+  PADDLE_ENFORCE_LE(grid_size_64,
+                    max_grid_dimx,
+                    common::errors::InvalidArgument(
+                        "ArgCUDAKernel grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size_64, "ArgCUDAKernel grid.x");
+  uint32_t grid_size = static_cast<uint32_t>(grid_size_64);
 
   const T* in_data = input.data<T>();
   IndType* out_data = dev_ctx.template Alloc<IndType>(indices);

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -31,6 +31,7 @@
 
 #ifdef __HIPCC__
 #include <rocprim/config.hpp>
+#include "paddle/common/enforce.h"
 #if defined(ROCPRIM_VERSION) && ROCPRIM_VERSION >= 400000
 // rocPRIM 4.x (ROCm 7.0+) replaces detail::radix_key_codec_base
 // with traits::define for non-builtin / wrapper types.
@@ -227,6 +228,10 @@ void ArgFullSort(const GPUContext& dev_ctx,
       return 128;
   };
   const int block_size = ComputeBlockSize(num_cols);
+  PADDLE_ENFORCE_LE(block_size,
+                    dev_ctx.GetMaxThreadsPerBlock(),
+                    common::errors::InvalidArgument(
+                        "FillIndex block.x exceeds device limit."));
   const int64_t maxGridDimX = dev_ctx.GetCUDAMaxGridDimSize()[0];
 
   const T* inp = input->data<T>();
@@ -273,7 +278,13 @@ void ArgFullSort(const GPUContext& dev_ctx,
       input_indices.Resize({n_segments, segment_size});
       ind_ptr = dev_ctx.template Alloc<IndType>(&input_indices);
     }
-    const int64_t grid_size = std::min(n_segments, maxGridDimX);
+    const int64_t grid_size_64 = std::min(n_segments, maxGridDimX);
+    PADDLE_ENFORCE_LE(grid_size_64,
+                      maxGridDimX,
+                      common::errors::InvalidArgument(
+                          "FillIndex grid.x exceeds device limit."));
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_size_64, "FillIndex grid.x");
+    uint32_t grid_size = static_cast<uint32_t>(grid_size_64);
     // Init a index array
     FillIndex<<<grid_size, block_size, 0, cu_stream>>>(
         ind_ptr, n_segments, segment_size);

--- a/paddle/phi/kernels/gpu/correlation_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/correlation_grad_kernel.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/gpu/correlation_grad_kernel.h"
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -223,51 +224,68 @@ void CorrelationCUDAGradKernel(const Context &dev_ctx,
   rinput2.Resize({N, padded_input_height, padded_input_width, C});
   dev_ctx.template Alloc<T>(&rinput2);
 
-  auto max_grid_dim = static_cast<int64_t>(dev_ctx.GetCUDAMaxGridDimSize()[0]);
+  int64_t max_grid_dim =
+      static_cast<int64_t>(dev_ctx.GetCUDAMaxGridDimSize()[0]);
 
   int64_t grid_size = (rinput1.numel() + 512 - 1) / 512;
   grid_size = std::min(static_cast<int64_t>(grid_size), max_grid_dim);
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size, "correlation grad set zero grid.x");
+  uint32_t grid_size_value = static_cast<uint32_t>(grid_size);
 
-  set_zero<<<static_cast<int64_t>(grid_size), 512, 0, dev_ctx.stream()>>>(
-      rinput1.data<T>(), rinput1.numel());
+  set_zero<<<grid_size_value, 512, 0, dev_ctx.stream()>>>(rinput1.data<T>(),
+                                                          rinput1.numel());
   grid_size = std::min(static_cast<int64_t>((rinput2.numel() + 512 - 1) / 512),
                        max_grid_dim);
-  set_zero<<<grid_size, 512, 0, dev_ctx.stream()>>>(rinput2.data<T>(),
-                                                    rinput2.numel());
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size, "correlation grad set zero grid.x");
+  grid_size_value = static_cast<uint32_t>(grid_size);
+  set_zero<<<grid_size_value, 512, 0, dev_ctx.stream()>>>(rinput2.data<T>(),
+                                                          rinput2.numel());
   grid_size =
       std::min(static_cast<int64_t>((grad_input1->numel() + 512 - 1) / 512),
                max_grid_dim);
-  set_zero<<<grid_size, 512, 0, dev_ctx.stream()>>>(grad_input1->data<T>(),
-                                                    grad_input1->numel());
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size, "correlation grad set zero grid.x");
+  grid_size_value = static_cast<uint32_t>(grid_size);
+  set_zero<<<grid_size_value, 512, 0, dev_ctx.stream()>>>(
+      grad_input1->data<T>(), grad_input1->numel());
   grid_size =
       std::min(static_cast<int64_t>((grad_input2->numel() + 512 - 1) / 512),
                max_grid_dim);
-  set_zero<<<grid_size, 512, 0, dev_ctx.stream()>>>(grad_input2->data<T>(),
-                                                    grad_input2->numel());
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size, "correlation grad set zero grid.x");
+  grid_size_value = static_cast<uint32_t>(grid_size);
+  set_zero<<<grid_size_value, 512, 0, dev_ctx.stream()>>>(
+      grad_input2->data<T>(), grad_input2->numel());
 
   auto grad_out_dims = grad_output->dims();
   int GOC = grad_out_dims[1];
   int GOH = grad_out_dims[2];
   int GOW = grad_out_dims[3];
 
-  int blocks_grid = std::min(static_cast<int64_t>(N) * H * W, max_grid_dim);
+  int64_t blocks_grid = std::min(static_cast<int64_t>(N) * H * W, max_grid_dim);
+  PADDLE_ENFORCE_LE_UINT32_MAX(blocks_grid,
+                               "correlation grad channel first grid.x");
+  uint32_t blocks_grid_value = static_cast<uint32_t>(blocks_grid);
   dim3 threads_block(THREADS_PER_BLOCK);
 
-  channel_first<T><<<blocks_grid, threads_block, 0, dev_ctx.stream()>>>(
+  channel_first<T><<<blocks_grid_value, threads_block, 0, dev_ctx.stream()>>>(
       input1.data<T>(), rinput1.data<T>(), N, C, H, W, pad_size);
-  channel_first<T><<<blocks_grid, threads_block, 0, dev_ctx.stream()>>>(
+  channel_first<T><<<blocks_grid_value, threads_block, 0, dev_ctx.stream()>>>(
       input2.data<T>(), rinput2.data<T>(), N, C, H, W, pad_size);
 
   dim3 threadsPerBlock(THREADS_PER_BLOCK);
   dim3 totalBlocksCorr(H, W, C);
-  grid_size =
-      std::min((static_cast<int64_t>(C) * H * W + THREADS_PER_BLOCK - 1) /
-                   THREADS_PER_BLOCK,
-               max_grid_dim);
+  grid_size = (static_cast<int64_t>(C) * H * W + THREADS_PER_BLOCK - 1) /
+              THREADS_PER_BLOCK;
+  PADDLE_ENFORCE_LE(
+      grid_size,
+      max_grid_dim,
+      common::errors::InvalidArgument(
+          "correlation backward input grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size, "correlation backward input grid.x");
+  grid_size_value = static_cast<uint32_t>(grid_size);
 
   for (int n = 0; n < N; n++) {
     correlation_backward_input1<T>
-        <<<grid_size, threadsPerBlock, 0, dev_ctx.stream()>>>(
+        <<<grid_size_value, threadsPerBlock, 0, dev_ctx.stream()>>>(
             n,
             grad_input1->data<T>(),
             C,
@@ -287,7 +305,7 @@ void CorrelationCUDAGradKernel(const Context &dev_ctx,
 
   for (int n = 0; n < N; n++) {
     correlation_backward_input2<T>
-        <<<grid_size, threadsPerBlock, 0, dev_ctx.stream()>>>(
+        <<<grid_size_value, threadsPerBlock, 0, dev_ctx.stream()>>>(
             n,
             grad_input2->data<T>(),
             C,

--- a/paddle/phi/kernels/gpu/correlation_kernel.cu
+++ b/paddle/phi/kernels/gpu/correlation_kernel.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/gpu/correlation_kernel.h"
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -140,57 +141,73 @@ void CorrelationCUDAKernel(const Context &dev_ctx,
   rinput2.Resize({N, padded_input_height, padded_input_width, C});
   dev_ctx.template Alloc<T>(&rinput2);
 
-  auto max_grid_dim = static_cast<int64_t>(dev_ctx.GetCUDAMaxGridDimSize()[0]);
+  int64_t max_grid_dim =
+      static_cast<int64_t>(dev_ctx.GetCUDAMaxGridDimSize()[0]);
 
   int64_t grid_size = (rinput1.numel() + 512 - 1) / 512;
   grid_size = std::min(static_cast<int64_t>(grid_size), max_grid_dim);
-  set_zero<<<grid_size, 512, 0, dev_ctx.stream()>>>(rinput1.data<T>(),
-                                                    rinput1.numel());
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size, "correlation set zero grid.x");
+  uint32_t grid_size_value = static_cast<uint32_t>(grid_size);
+  set_zero<<<grid_size_value, 512, 0, dev_ctx.stream()>>>(rinput1.data<T>(),
+                                                          rinput1.numel());
 
   grid_size = std::min(static_cast<int64_t>((rinput2.numel() + 512 - 1) / 512),
                        max_grid_dim);
-  set_zero<<<grid_size, 512, 0, dev_ctx.stream()>>>(rinput2.data<T>(),
-                                                    rinput2.numel());
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size, "correlation set zero grid.x");
+  grid_size_value = static_cast<uint32_t>(grid_size);
+  set_zero<<<grid_size_value, 512, 0, dev_ctx.stream()>>>(rinput2.data<T>(),
+                                                          rinput2.numel());
 
   grid_size = std::min(static_cast<int64_t>((out->numel() + 512 - 1) / 512),
                        max_grid_dim);
-  set_zero<<<grid_size, 512, 0, dev_ctx.stream()>>>(out->data<T>(),
-                                                    out->numel());
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size, "correlation set zero grid.x");
+  grid_size_value = static_cast<uint32_t>(grid_size);
+  set_zero<<<grid_size_value, 512, 0, dev_ctx.stream()>>>(out->data<T>(),
+                                                          out->numel());
 
   auto out_dims = out->dims();
   int OC = out_dims[1];
   int OH = out_dims[2];
   int OW = out_dims[3];
 
-  int blocks_grid = std::min(static_cast<int64_t>(N) * H * W, max_grid_dim);
+  int64_t blocks_grid = std::min(static_cast<int64_t>(N) * H * W, max_grid_dim);
+  PADDLE_ENFORCE_LE_UINT32_MAX(blocks_grid, "correlation channel first grid.x");
+  uint32_t blocks_grid_value = static_cast<uint32_t>(blocks_grid);
   dim3 threads_block(THREADS_PER_BLOCK);
 
-  channel_first<T><<<blocks_grid, threads_block, 0, dev_ctx.stream()>>>(
+  channel_first<T><<<blocks_grid_value, threads_block, 0, dev_ctx.stream()>>>(
       input1.data<T>(), rinput1.data<T>(), N, C, H, W, pad_size);
-  channel_first<T><<<blocks_grid, threads_block, 0, dev_ctx.stream()>>>(
+  channel_first<T><<<blocks_grid_value, threads_block, 0, dev_ctx.stream()>>>(
       input2.data<T>(), rinput2.data<T>(), N, C, H, W, pad_size);
 
   dim3 threadsPerBlock(THREADS_PER_BLOCK);
   // dim3 totalBlocksCorr(N, OH, OW);
-  grid_size = std::min(static_cast<int64_t>(N) * OH * OW, max_grid_dim);
+  grid_size = static_cast<int64_t>(N) * OH * OW;
+  PADDLE_ENFORCE_LE(grid_size,
+                    max_grid_dim,
+                    common::errors::InvalidArgument(
+                        "correlation forward grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size, "correlation forward grid.x");
+  grid_size_value = static_cast<uint32_t>(grid_size);
 
   correlation_forward<T>
-      <<<grid_size, threadsPerBlock, 0, dev_ctx.stream()>>>(out->data<T>(),
-                                                            OC,
-                                                            OH,
-                                                            OW,
-                                                            rinput1.data<T>(),
-                                                            C,
-                                                            H,
-                                                            W,
-                                                            rinput2.data<T>(),
-                                                            pad_size,
-                                                            kernel_size,
-                                                            max_displacement,
-                                                            stride1,
-                                                            stride2,
-                                                            OH,
-                                                            OW);
+      <<<grid_size_value, threadsPerBlock, 0, dev_ctx.stream()>>>(
+          out->data<T>(),
+          OC,
+          OH,
+          OW,
+          rinput1.data<T>(),
+          C,
+          H,
+          W,
+          rinput2.data<T>(),
+          pad_size,
+          kernel_size,
+          max_displacement,
+          stride1,
+          stride2,
+          OH,
+          OW);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
@@ -213,27 +213,20 @@ void CrossEntropyWithSoftmaxGradGPUKernel(const GPUContext& dev_ctx,
       DenseTensor logits_grad_2d(*logit_grad);
       logits_grad_2d.Resize({n, d});
       int64_t grid = (n * remain + block - 1) / block;
-      PADDLE_ENFORCE_LE(
-          grid,
-          max_grid_dim,
-          common::errors::InvalidArgument(
-              "cross entropy grad hard label grid.x exceeds device limit."));
-      PADDLE_ENFORCE_LE_UINT32_MAX(grid,
+      int64_t launch_grid = std::min(grid, static_cast<int64_t>(max_grid_dim));
+      PADDLE_ENFORCE_LE_UINT32_MAX(launch_grid,
                                    "cross entropy grad hard label grid.x");
-      uint32_t grid_value = static_cast<uint32_t>(grid);
+      uint32_t grid_value = static_cast<uint32_t>(launch_grid);
       const auto* label_data = label.data<LabelT>();
       HardLabelCrossEntropyGradientKernel<T, LabelT>
           <<<grid_value, block, 0, stream>>>(
               logit_grad_data, label_data, n, d, remain, ignore_index);
       int64_t num = n * d;
       grid = (num + block - 1) / block;
-      PADDLE_ENFORCE_LE(
-          grid,
-          max_grid_dim,
-          common::errors::InvalidArgument(
-              "cross entropy grad scale grid.x exceeds device limit."));
-      PADDLE_ENFORCE_LE_UINT32_MAX(grid, "cross entropy grad scale grid.x");
-      grid_value = static_cast<uint32_t>(grid);
+      launch_grid = std::min(grid, static_cast<int64_t>(max_grid_dim));
+      PADDLE_ENFORCE_LE_UINT32_MAX(launch_grid,
+                                   "cross entropy grad scale grid.x");
+      grid_value = static_cast<uint32_t>(launch_grid);
       ScaleCrossEntropyGradient<T, LabelT>
           <<<grid_value, block, 0, stream>>>(logit_grad_data,
                                              loss_grad_data,

--- a/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
@@ -33,14 +33,14 @@ template <typename T>
 __global__ void SoftLabelCrossEntropyGradientKernel(T* logit_grad,
                                                     const T* loss_grad,
                                                     const T* labels,
-                                                    const int n,
-                                                    const int d,
-                                                    const int remain) {
+                                                    const int64_t n,
+                                                    const int64_t d,
+                                                    const int64_t remain) {
   int64_t ids = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (ids < static_cast<int64_t>(n) * d) {
-    int idx_n = ids / d;
-    int idx_remain = ids % remain;
-    int idx_loss = idx_n * remain + idx_remain;
+  if (ids < n * d) {
+    int64_t idx_n = ids / d;
+    int64_t idx_remain = ids % remain;
+    int64_t idx_loss = idx_n * remain + idx_remain;
     using AccT = typename MPTypeTrait<T>::Type;
     AccT loss_g = static_cast<AccT>(loss_grad[idx_loss]);
     AccT label_v = static_cast<AccT>(labels[ids]);

--- a/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
@@ -53,16 +53,15 @@ __global__ void SoftLabelCrossEntropyGradientKernel(T* logit_grad,
 template <typename T, typename LabelT>
 __global__ void HardLabelCrossEntropyGradientKernel(T* logit_grad,
                                                     const LabelT* labels,
-                                                    const int n,
-                                                    const int d,
-                                                    const int remain,
+                                                    const int64_t n,
+                                                    const int64_t d,
+                                                    const int64_t remain,
                                                     const int ignore_index) {
-  CUDA_KERNEL_LOOP(index, static_cast<int64_t>(n) * remain) {
-    int idx_n = index / remain;
-    int idx_remain = index % remain;
-    int tmp = static_cast<int>(labels[index]);
-    int64_t idx = static_cast<int64_t>(idx_n) * d +
-                  static_cast<int64_t>(tmp) * remain + idx_remain;
+  CUDA_KERNEL_LOOP_TYPE(index, n * remain, int64_t) {
+    int64_t idx_n = index / remain;
+    int64_t idx_remain = index % remain;
+    int64_t tmp = static_cast<int64_t>(labels[index]);
+    int64_t idx = idx_n * d + tmp * remain + idx_remain;
     if (ignore_index != tmp) {
       using AccT = typename MPTypeTrait<T>::Type;
       AccT softmax_v = static_cast<AccT>(logit_grad[idx]);
@@ -75,16 +74,16 @@ __global__ void HardLabelCrossEntropyGradientKernel(T* logit_grad,
 template <typename T, typename LabelT>
 __global__ void ScaleCrossEntropyGradient(T* logit_grad,
                                           const T* loss_grad,
-                                          const int num,
-                                          const int d,
-                                          const int remain,
+                                          const int64_t num,
+                                          const int64_t d,
+                                          const int64_t remain,
                                           const LabelT* labels,
                                           const int ignore_index) {
-  CUDA_KERNEL_LOOP(index, num) {
-    int idx_n = index / d;
-    int idx_remain = index % remain;
-    int idx_lbl = idx_n * remain + idx_remain;
-    int k = (index % d) / remain;
+  CUDA_KERNEL_LOOP_TYPE(index, num, int64_t) {
+    int64_t idx_n = index / d;
+    int64_t idx_remain = index % remain;
+    int64_t idx_lbl = idx_n * remain + idx_remain;
+    int64_t k = (index % d) / remain;
     auto lbl = static_cast<int64_t>(labels[idx_lbl]);
     if (lbl == ignore_index || lbl != k) {
       logit_grad[index] = static_cast<T>(0.);

--- a/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_entropy_grad_kernel.cu
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/kernels/cross_entropy_grad_kernel.h"
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
 #include "paddle/phi/backends/gpu/gpu_dnn.h"
 #include "paddle/phi/common/amp_type_traits.h"
@@ -192,32 +193,56 @@ void CrossEntropyWithSoftmaxGradGPUKernel(const GPUContext& dev_ctx,
 
   int block = 512;
   auto stream = dev_ctx.stream();
+  uint32_t max_grid_dim = dev_ctx.GetCUDAMaxGridDimSize()[0];
 
   // do not with softmax op, and input is softmax
   if (!use_softmax) {
     if (soft_label) {
       int64_t grid = (n * d + block - 1) / block;
+      PADDLE_ENFORCE_LE(
+          grid,
+          max_grid_dim,
+          common::errors::InvalidArgument(
+              "cross entropy grad soft label grid.x exceeds device limit."));
+      PADDLE_ENFORCE_LE_UINT32_MAX(grid,
+                                   "cross entropy grad soft label grid.x");
+      uint32_t grid_value = static_cast<uint32_t>(grid);
       const T* label_data = label.data<T>();
-      SoftLabelCrossEntropyGradientKernel<T><<<grid, block, 0, stream>>>(
+      SoftLabelCrossEntropyGradientKernel<T><<<grid_value, block, 0, stream>>>(
           logit_grad_data, loss_grad_data, label_data, n, d, remain);
     } else {
       DenseTensor logits_grad_2d(*logit_grad);
       logits_grad_2d.Resize({n, d});
       int64_t grid = (n * remain + block - 1) / block;
+      PADDLE_ENFORCE_LE(
+          grid,
+          max_grid_dim,
+          common::errors::InvalidArgument(
+              "cross entropy grad hard label grid.x exceeds device limit."));
+      PADDLE_ENFORCE_LE_UINT32_MAX(grid,
+                                   "cross entropy grad hard label grid.x");
+      uint32_t grid_value = static_cast<uint32_t>(grid);
       const auto* label_data = label.data<LabelT>();
       HardLabelCrossEntropyGradientKernel<T, LabelT>
-          <<<grid, block, 0, stream>>>(
+          <<<grid_value, block, 0, stream>>>(
               logit_grad_data, label_data, n, d, remain, ignore_index);
       int64_t num = n * d;
       grid = (num + block - 1) / block;
+      PADDLE_ENFORCE_LE(
+          grid,
+          max_grid_dim,
+          common::errors::InvalidArgument(
+              "cross entropy grad scale grid.x exceeds device limit."));
+      PADDLE_ENFORCE_LE_UINT32_MAX(grid, "cross entropy grad scale grid.x");
+      grid_value = static_cast<uint32_t>(grid);
       ScaleCrossEntropyGradient<T, LabelT>
-          <<<grid, block, 0, stream>>>(logit_grad_data,
-                                       loss_grad_data,
-                                       num,
-                                       d,
-                                       remain,
-                                       label_data,
-                                       ignore_index);
+          <<<grid_value, block, 0, stream>>>(logit_grad_data,
+                                             loss_grad_data,
+                                             num,
+                                             d,
+                                             remain,
+                                             label_data,
+                                             ignore_index);
     }
 
     return;
@@ -227,22 +252,37 @@ void CrossEntropyWithSoftmaxGradGPUKernel(const GPUContext& dev_ctx,
 
   if (soft_label) {
     int64_t grid = (n * d + block - 1) / block;
+    PADDLE_ENFORCE_LE(
+        grid,
+        max_grid_dim,
+        common::errors::InvalidArgument(
+            "cross entropy grad soft grid.x exceeds device limit."));
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid, "cross entropy grad soft grid.x");
+    uint32_t grid_value = static_cast<uint32_t>(grid);
     const T* label_data = label.data<T>();
-    SoftCrossEntropyGradientKernel<T><<<grid, block, 0, stream>>>(
+    SoftCrossEntropyGradientKernel<T><<<grid_value, block, 0, stream>>>(
         logit_grad_data, loss_grad_data, label_data, n, d, remain);
   } else {
     const T* softmax_data = softmax.data<T>();
     const auto* label_data = label.data<LabelT>();
     int64_t grid = (n * d + block - 1) / block;
+    PADDLE_ENFORCE_LE(
+        grid,
+        max_grid_dim,
+        common::errors::InvalidArgument(
+            "cross entropy grad softmax hard grid.x exceeds device limit."));
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid,
+                                 "cross entropy grad softmax hard grid.x");
+    uint32_t grid_value = static_cast<uint32_t>(grid);
     SoftmaxWithCrossEntropyGradHardLabel<T>
-        <<<grid, block, 0, stream>>>(logit_grad_data,
-                                     loss_grad_data,
-                                     softmax_data,
-                                     label_data,
-                                     n,
-                                     d / remain,
-                                     remain,
-                                     ignore_index);
+        <<<grid_value, block, 0, stream>>>(logit_grad_data,
+                                           loss_grad_data,
+                                           softmax_data,
+                                           label_data,
+                                           n,
+                                           d / remain,
+                                           remain,
+                                           ignore_index);
   }
 }
 

--- a/paddle/phi/kernels/gpu/cuda_gemm_kernel.cu
+++ b/paddle/phi/kernels/gpu/cuda_gemm_kernel.cu
@@ -14,7 +14,9 @@
 
 #include "paddle/phi/kernels/gpu/cuda_gemm_kernel.h"
 #include <glog/logging.h>
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -109,7 +111,21 @@ template <typename InputType,
           int32_t BLOCK_SIZE>
 void cudaCoreGemmKernel(GemmParams const& params) {
   dim3 block(BLOCK_SIZE);
-  dim3 grid(params.m / TILE_M, params.n / TILE_N);
+  int64_t grid_x_64 = params.m / TILE_M;
+  int64_t grid_y_64 = params.n / TILE_N;
+  const auto& prop =
+      backends::gpu::GetDeviceProperties(backends::gpu::GetCurrentDeviceId());
+  PADDLE_ENFORCE_LE(grid_x_64,
+                    prop.maxGridSize[0],
+                    common::errors::InvalidArgument(
+                        "cuda gemm grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE(grid_y_64,
+                    prop.maxGridSize[1],
+                    common::errors::InvalidArgument(
+                        "cuda gemm grid.y exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_x_64, "cuda gemm grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_y_64, "cuda gemm grid.y");
+  dim3 grid(static_cast<uint32_t>(grid_x_64), static_cast<uint32_t>(grid_y_64));
   int8_gemm<OutputType, TILE_M, TILE_N, BLOCK_SIZE>
       <<<grid, block, 0, params.stream>>>(
           reinterpret_cast<InputType const*>(params.act),

--- a/paddle/phi/kernels/gpu/cuda_gemm_kernel.cu
+++ b/paddle/phi/kernels/gpu/cuda_gemm_kernel.cu
@@ -184,8 +184,10 @@ void CudaGemm(const Context& dev_ctx,
 
   auto out_dims = output->dims();
 
-  const int m = input_dims[0];
-  const int n = weight_dims[0];
+  const int64_t m64 = input_dims[0];
+  const int64_t n64 = weight_dims[0];
+  PADDLE_ENFORCE_LE_INT_MAX(m64, "cuda gemm m");
+  PADDLE_ENFORCE_LE_INT_MAX(n64, "cuda gemm n");
 
   PADDLE_ENFORCE_EQ(
       input_dims[1],
@@ -194,7 +196,12 @@ void CudaGemm(const Context& dev_ctx,
           "The input dims[1] %d should be equal to weight dims[1] %d.",
           input_dims[1],
           weight_dims[1]));
-  const int k = weight_dims[1];
+  const int64_t k64 = weight_dims[1];
+  PADDLE_ENFORCE_LE_INT_MAX(k64, "cuda gemm k");
+
+  const int m = static_cast<int>(m64);
+  const int n = static_cast<int>(n64);
+  const int k = static_cast<int>(k64);
 
   GemmParams params = {
       reinterpret_cast<const void*>(input.data<T>()),

--- a/paddle/phi/kernels/gpu/deformable_conv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/deformable_conv_grad_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/deformable_conv_grad_kernel.h"
 
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -24,9 +25,9 @@ namespace phi {
 static constexpr int kNumCUDAThreads = 512;
 static constexpr int kNumMaximumNumBlocks = 4096;
 
-static inline int NumBlocks(const int N) {
+static inline int64_t NumBlocks(const int64_t N) {
   return std::min((N + kNumCUDAThreads - 1) / kNumCUDAThreads,
-                  kNumMaximumNumBlocks);
+                  static_cast<int64_t>(kNumMaximumNumBlocks));
 }
 
 template <typename T, typename IndexT>
@@ -132,28 +133,33 @@ void ModulatedDeformableCol2im(const Context& dev_ctx,
       col_shape[0] * col_shape[1] * col_shape[2] * col_shape[3];
   int64_t blocks = NumBlocks(num_kernels);
   int64_t threads = kNumCUDAThreads;
+  PADDLE_ENFORCE_LE_UINT32_MAX(blocks, "deformable_conv_grad col2im grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(threads, "deformable_conv_grad col2im block.x");
   ModulatedDeformableCol2imGpuKernel<T, IndexT>
-      <<<blocks, threads, 0, dev_ctx.stream()>>>(num_kernels,
-                                                 data_col,
-                                                 data_offset,
-                                                 data_mask,
-                                                 im_shape[0],
-                                                 im_shape[1],
-                                                 im_shape[2],
-                                                 kernel_shape[2],
-                                                 kernel_shape[3],
-                                                 pad[0],
-                                                 pad[1],
-                                                 stride[0],
-                                                 stride[1],
-                                                 dilation[0],
-                                                 dilation[1],
-                                                 channel_per_deformable_group,
-                                                 col_shape[1],
-                                                 deformable_group,
-                                                 col_shape[2],
-                                                 col_shape[3],
-                                                 grad_im);
+      <<<static_cast<uint32_t>(blocks),
+         static_cast<uint32_t>(threads),
+         0,
+         dev_ctx.stream()>>>(num_kernels,
+                             data_col,
+                             data_offset,
+                             data_mask,
+                             im_shape[0],
+                             im_shape[1],
+                             im_shape[2],
+                             kernel_shape[2],
+                             kernel_shape[3],
+                             pad[0],
+                             pad[1],
+                             stride[0],
+                             stride[1],
+                             dilation[0],
+                             dilation[1],
+                             channel_per_deformable_group,
+                             col_shape[1],
+                             deformable_group,
+                             col_shape[2],
+                             col_shape[3],
+                             grad_im);
 }
 
 template <typename T, typename IndexT>
@@ -296,9 +302,14 @@ void ModulatedDeformableCol2imCoord(const Context& dev_ctx,
   int64_t channel_per_deformable_group = col_shape[0] / deformable_groups;
   int64_t blocks = NumBlocks(num_kernels);
   int64_t threads = kNumCUDAThreads;
+  PADDLE_ENFORCE_LE_UINT32_MAX(blocks, "deformable_conv_grad coord grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(threads, "deformable_conv_grad coord block.x");
 
   ModulatedDeformableCol2imCoordGpuKernel<T, IndexT>
-      <<<blocks, threads, 0, dev_ctx.stream()>>>(
+      <<<static_cast<uint32_t>(blocks),
+         static_cast<uint32_t>(threads),
+         0,
+         dev_ctx.stream()>>>(
           num_kernels,
           data_col,
           data_im,
@@ -351,9 +362,14 @@ void FilterGradAddup(const Context& dev_ctx,
   const int64_t grid_size = std::min<int64_t>(
       (nthreads + kNumCUDAThreads - 1) / kNumCUDAThreads, max_grid_x);
 
-  FilterGradAddupGpuKernel<T, IndexT>
-      <<<grid_size, kNumCUDAThreads, 0, dev_ctx.stream()>>>(
-          nthreads, n, height, width, dweight_3d, filter_grad);
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size, "deformable_conv_grad filter grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(kNumCUDAThreads,
+                               "deformable_conv_grad filter block.x");
+  FilterGradAddupGpuKernel<T, IndexT><<<static_cast<uint32_t>(grid_size),
+                                        static_cast<uint32_t>(kNumCUDAThreads),
+                                        0,
+                                        dev_ctx.stream()>>>(
+      nthreads, n, height, width, dweight_3d, filter_grad);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/edit_distance_kernel.cu
+++ b/paddle/phi/kernels/gpu/edit_distance_kernel.cu
@@ -11,12 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #include "paddle/phi/kernels/edit_distance_kernel.h"
 
 #include <algorithm>
 #include <vector>
 
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/cuda/cuda_graph_with_memory_pool.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
@@ -155,20 +155,33 @@ void EditDistanceKernel(const Context& dev_ctx,
       dist_t.Resize({m + 1, n + 1});
       dev_ctx.template Alloc<T>(&dist_t);
       auto dist = dist_t.data<T>();
+      PADDLE_ENFORCE_LE_INT_MAX(m, "edit_distance m");
+      PADDLE_ENFORCE_LE_INT_MAX(n, "edit_distance n");
+      PADDLE_ENFORCE_LE(
+          m,
+          std::numeric_limits<int>::max() - n - 1,
+          common::errors::InvalidArgument(
+              "edit_distance anti-diagonal slice exceeds int limit."));
+      const int m_int = static_cast<int>(m);
+      const int n_int = static_cast<int>(n);
       auto hyp_offset = use_length ? num * hyps.dims()[1] : hyp_lod[num];
       auto ref_offset = use_length ? num * refs.dims()[1] : ref_lod[num];
       auto x1 = hyps.data<int64_t>() + hyp_offset;
       auto x2 = refs.data<int64_t>() + ref_offset;
 
-      FillFirstColumn<T><<<1 + m / PADDLE_CUDA_NUM_THREADS,
-                           PADDLE_CUDA_NUM_THREADS,
-                           0,
-                           stream>>>(dist, m, n);
+      int64_t fill_column_grid_64 = 1 + m / PADDLE_CUDA_NUM_THREADS;
+      PADDLE_ENFORCE_LE_UINT32_MAX(fill_column_grid_64,
+                                   "FillFirstColumn grid.x");
+      uint32_t fill_column_grid = static_cast<uint32_t>(fill_column_grid_64);
+      FillFirstColumn<T>
+          <<<fill_column_grid, PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
+              dist, m_int, n_int);
 
-      FillFirstRow<T><<<1 + n / PADDLE_CUDA_NUM_THREADS,
-                        PADDLE_CUDA_NUM_THREADS,
-                        0,
-                        stream>>>(dist, n);
+      int64_t fill_row_grid_64 = 1 + n / PADDLE_CUDA_NUM_THREADS;
+      PADDLE_ENFORCE_LE_UINT32_MAX(fill_row_grid_64, "FillFirstRow grid.x");
+      uint32_t fill_row_grid = static_cast<uint32_t>(fill_row_grid_64);
+      FillFirstRow<T>
+          <<<fill_row_grid, PADDLE_CUDA_NUM_THREADS, 0, stream>>>(dist, n_int);
 
       // Compute the elements of distance matrix in the anti-diagonal direction
       for (int64_t slice = 2; slice < m + n + 1; ++slice) {
@@ -181,9 +194,10 @@ void EditDistanceKernel(const Context& dev_ctx,
         Levenshtein<T><<<1 + (size - 1) / PADDLE_CUDA_NUM_THREADS,
                          PADDLE_CUDA_NUM_THREADS,
                          0,
-                         stream>>>(dist, x1, x2, m, n, start);
+                         stream>>>(dist, x1, x2, m_int, n_int, start);
       }
-      SetOutput<T><<<1, 1, 0, stream>>>(out_data + num, dist, m, n, normalized);
+      SetOutput<T>
+          <<<1, 1, 0, stream>>>(out_data + num, dist, m_int, n_int, normalized);
     }
   }
 }

--- a/paddle/phi/kernels/gpu/edit_distance_kernel.cu
+++ b/paddle/phi/kernels/gpu/edit_distance_kernel.cu
@@ -51,33 +51,34 @@ template <typename T>
 __global__ void Levenshtein(T* dist,
                             const int64_t* x1,
                             const int64_t* x2,
-                            const int M,
-                            const int N,
-                            const int start) {
+                            const int64_t M,
+                            const int64_t N,
+                            const int64_t start) {
   int64_t idx =
       static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
       static_cast<int64_t>(threadIdx.x);
-  int offset = N;
-  int index = start + idx * offset;
-  int row = index / (N + 1);
-  int col = index % (N + 1);
+  int64_t offset = N;
+  int64_t index = start + idx * offset;
+  int64_t row = index / (N + 1);
+  int64_t col = index % (N + 1);
   if (row > 0 && col > 0 && row < M + 1 && col < N + 1) {
     int cost = x1[row - 1] == x2[col - 1] ? 0 : 1;
-    int dels = dist[static_cast<int64_t>(row - 1) * (N + 1) + col] + 1;
-    int ins = dist[static_cast<int64_t>(row) * (N + 1) + col - 1] + 1;
-    int subs = dist[static_cast<int64_t>(row - 1) * (N + 1) + (col - 1)] + cost;
+    int dels = dist[(row - 1) * (N + 1) + col] + 1;
+    int ins = dist[row * (N + 1) + col - 1] + 1;
+    int subs = dist[(row - 1) * (N + 1) + (col - 1)] + cost;
     dist[index] = min(dels, min(ins, subs));
   }
 }
 
 template <typename T>
 __global__ void SetOutput(
-    T* out, const T* dist, const int M, const int N, bool normalized) {
+    T* out, const T* dist, const int64_t M, const int64_t N, bool normalized) {
   int64_t idx =
       static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(blockIdx.x) +
       static_cast<int64_t>(threadIdx.x);
   if (idx == 0) {
-    out[0] = normalized ? dist[M * (N + 1) + N] / N : dist[M * (N + 1) + N];
+    int64_t dist_idx = M * (N + 1) + N;
+    out[0] = normalized ? dist[dist_idx] / N : dist[dist_idx];
   }
 }
 
@@ -185,19 +186,27 @@ void EditDistanceKernel(const Context& dev_ctx,
 
       // Compute the elements of distance matrix in the anti-diagonal direction
       for (int64_t slice = 2; slice < m + n + 1; ++slice) {
-        int z_m = slice < m + 1 ? 0 : slice - m;
-        int z_n = slice < n + 1 ? 0 : slice - n;
-        int size = slice - (z_m + z_n) + 1;  // number of elements in the same
-                                             // anti-diagonal line to update
+        int64_t z_m = slice < m + 1 ? 0 : slice - m;
+        int64_t z_n = slice < n + 1 ? 0 : slice - n;
+        int64_t size =
+            slice - (z_m + z_n) + 1;  // number of elements in the same
+                                      // anti-diagonal line to update
         // the start index at which computes from
-        int start = slice < n + 1 ? slice : (z_n + 1) * (n + 1) - 1;
-        Levenshtein<T><<<1 + (size - 1) / PADDLE_CUDA_NUM_THREADS,
-                         PADDLE_CUDA_NUM_THREADS,
-                         0,
-                         stream>>>(dist, x1, x2, m_int, n_int, start);
+        int64_t start = slice < n + 1 ? slice : (z_n + 1) * (n + 1) - 1;
+        int64_t levenshtein_grid_64 = 1 + (size - 1) / PADDLE_CUDA_NUM_THREADS;
+        PADDLE_ENFORCE_LE(
+            levenshtein_grid_64,
+            dev_ctx.GetCUDAMaxGridDimSize()[0],
+            common::errors::InvalidArgument(
+                "edit_distance levenshtein grid.x exceeds device limit."));
+        PADDLE_ENFORCE_LE_UINT32_MAX(levenshtein_grid_64,
+                                     "edit_distance levenshtein grid.x");
+        uint32_t levenshtein_grid = static_cast<uint32_t>(levenshtein_grid_64);
+        Levenshtein<T>
+            <<<levenshtein_grid, PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
+                dist, x1, x2, m, n, start);
       }
-      SetOutput<T>
-          <<<1, 1, 0, stream>>>(out_data + num, dist, m_int, n_int, normalized);
+      SetOutput<T><<<1, 1, 0, stream>>>(out_data + num, dist, m, n, normalized);
     }
   }
 }

--- a/paddle/phi/kernels/gpu/flash_attn_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/flash_attn_grad_kernel.cu
@@ -151,9 +151,11 @@ static void kvReduceForGQA(const Context& dev_ctx,
       1,
       common::errors::InvalidArgument("headdim dimension must be contiguous"));
   const int64_t reduceDimSize = dk_tmp.dims()[2];
-  const size_t blockNum =
+  const size_t blockNum_64 =
       std::min((static_cast<int64_t>(dk_tmp.dims()[0] + 31) / 32),
                static_cast<int64_t>(1024l));
+  PADDLE_ENFORCE_LE_UINT32_MAX(blockNum_64, "flash_attn gqa reduce grid.x");
+  const uint32_t blockNum = static_cast<uint32_t>(blockNum_64);
   const dim3 threadNum{32, 4, 1};
   auto sumkernel = selectSumkernel<T>(dk_tmp.dims()[3]);
   sumkernel<<<blockNum, threadNum, 0, dev_ctx.stream()>>>(
@@ -193,9 +195,11 @@ static void kvReduceBatchedForGQA(const Context& dev_ctx,
                     common::errors::InvalidArgument(
                         "batchsize dimension must be contiguous"));
   const int64_t reduceDimSize = dk_tmp.dims()[3];
-  const size_t blockNum = std::min(
+  const size_t blockNum_64 = std::min(
       (static_cast<int64_t>(dk_tmp.dims()[0] * dk_tmp.dims()[1] + 31) / 32),
       static_cast<int64_t>(1024l));
+  PADDLE_ENFORCE_LE_UINT32_MAX(blockNum_64, "flash_attn gqa reduce grid.x");
+  const uint32_t blockNum = static_cast<uint32_t>(blockNum_64);
   const dim3 threadNum{32, 4, 1};
   auto sumkernel = selectSumkernel<T>(dk_tmp.dims()[4]);
   // here implicitly flat [batch,seqlen], and require batch dim to be contiguous

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -327,7 +327,8 @@ void ReindexDst(const Context& dev_ctx,
                 int node_len) {
   constexpr int BLOCK_WARPS = 128 / WARP_SIZE;
   constexpr int TILE_SIZE = BLOCK_WARPS * 16;
-  const int grid_x = (node_len + TILE_SIZE - 1) / TILE_SIZE;
+  const int64_t grid_x =
+      (static_cast<int64_t>(node_len) + TILE_SIZE - 1) / TILE_SIZE;
   PADDLE_ENFORCE_LE(grid_x,
                     dev_ctx.GetCUDAMaxGridDimSize()[0],
                     common::errors::InvalidArgument(

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -190,12 +190,15 @@ void Reindex(const Context& dev_ctx,
   int64_t num = out_nodes->size();
   int64_t log_num = 1 << static_cast<size_t>(1 + std::log2(num >> 1));
   int64_t table_size = log_num << 1;
+  PADDLE_ENFORCE_LE_INT_MAX(table_size, "graph_reindex table_size");
+  const size_t table_size_bytes = static_cast<size_t>(table_size);
 
-  auto keys = memory_utils::Alloc(dev_ctx.GetPlace(), table_size * sizeof(T));
+  auto keys =
+      memory_utils::Alloc(dev_ctx.GetPlace(), table_size_bytes * sizeof(T));
   auto values =
-      memory_utils::Alloc(dev_ctx.GetPlace(), table_size * sizeof(int));
+      memory_utils::Alloc(dev_ctx.GetPlace(), table_size_bytes * sizeof(int));
   auto key_index =
-      memory_utils::Alloc(dev_ctx.GetPlace(), table_size * sizeof(int));
+      memory_utils::Alloc(dev_ctx.GetPlace(), table_size_bytes * sizeof(int));
   T* keys_ptr = reinterpret_cast<T*>(keys->ptr());
   int* values_ptr = reinterpret_cast<int*>(values->ptr());
   int* key_index_ptr = reinterpret_cast<int*>(key_index->ptr());
@@ -209,7 +212,6 @@ void Reindex(const Context& dev_ctx,
   PADDLE_ENFORCE_LE_UINT32_MAX(table_blocks, "graph_reindex init table grid.x");
   PADDLE_ENFORCE_LE_UINT32_MAX(CUDA_NUM_THREADS,
                                "graph_reindex init table block.x");
-  PADDLE_ENFORCE_LE_INT_MAX(table_size, "graph_reindex table_size");
   const uint32_t table_grid = static_cast<uint32_t>(table_blocks);
   const uint32_t table_block = static_cast<uint32_t>(CUDA_NUM_THREADS);
   const int table_size_int = static_cast<int>(table_size);

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -386,6 +386,11 @@ void GraphReindexKernel(const Context& dev_ctx,
       bs,
       errors::InvalidArgument("The first of dims should not be equal to 0."));
   int64_t num_edges = neighbors.dims()[0];
+  PADDLE_ENFORCE_LE_INT_MAX(bs, "graph_reindex num_inputs");
+  PADDLE_ENFORCE_LE_INT_MAX(num_edges, "graph_reindex num_edges");
+
+  const int bs_int = static_cast<int>(bs);
+  const int num_edges_int = static_cast<int>(num_edges);
 
   reindex_src->Resize({num_edges});
 
@@ -411,13 +416,13 @@ void GraphReindexKernel(const Context& dev_ctx,
                               x_data,
                               src_outputs,
                               &unique_nodes,
-                              bs,
+                              bs_int,
                               hashtable_value_data,
                               hashtable_index_data,
-                              num_edges);
+                              num_edges_int);
   } else {
     Reindex<T, Context>(
-        dev_ctx, x_data, src_outputs, &unique_nodes, bs, num_edges);
+        dev_ctx, x_data, src_outputs, &unique_nodes, bs_int, num_edges_int);
   }
 
   // Get reindex dst edge.

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -429,6 +429,8 @@ void GraphReindexKernel(const Context& dev_ctx,
   // Add support for multi-type edges reindex.
   int64_t num_ac_count = count.dims()[0];
   int64_t num_edge_types = num_ac_count / bs;
+  PADDLE_ENFORCE_LE_INT_MAX(num_edge_types, "graph_reindex num_edge_types");
+  const int num_edge_types_int = static_cast<int>(num_edge_types);
   // TODO(large-tensor): downstream functors may still use int
   thrust::device_vector<int> unique_dst_reindex(bs);
   thrust::sequence(unique_dst_reindex.begin(), unique_dst_reindex.end());
@@ -439,8 +441,8 @@ void GraphReindexKernel(const Context& dev_ctx,
                          reindex_dst_data,
                          thrust::raw_pointer_cast(unique_dst_reindex.data()),
                          count_data,
-                         num_edge_types,
-                         bs);
+                         num_edge_types_int,
+                         bs_int);
   // TODO(large-tensor): Resize not support int64
   PADDLE_ENFORCE_LE_INT_MAX(unique_nodes.size(), "unique_nodes.size()");
   out_nodes->Resize({static_cast<int>(unique_nodes.size())});

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -340,32 +340,36 @@ void ReindexDst(const Context& dev_ctx,
                    static_cast<uint32_t>(BLOCK_WARPS));
   const dim3 grid(static_cast<uint32_t>(grid_x));
 
-  int begin = 0, count_i = 0;
-  thrust::device_vector<int> dst_ptr(node_len + 1, 0);
+  int64_t begin = 0;
+  int count_i = 0;
+  const int64_t node_len_64 = static_cast<int64_t>(node_len);
+  thrust::device_vector<int> dst_ptr(static_cast<size_t>(node_len_64) + 1, 0);
   for (int i = 0; i < num_edge_types; i++) {
+    const int64_t count_offset = static_cast<int64_t>(i) * node_len_64;
     thrust::inclusive_scan(
-        thrust::device_pointer_cast(count_data) + i * node_len,
-        thrust::device_pointer_cast(count_data) + (i + 1) * node_len,
+        thrust::device_pointer_cast(count_data) + count_offset,
+        thrust::device_pointer_cast(count_data) + count_offset + node_len_64,
         dst_ptr.begin() + 1);
     GetDstEdgeCUDAKernel<T, BLOCK_WARPS, TILE_SIZE>
         <<<grid, block, 0, dev_ctx.stream()>>>(
             node_len,
             scan_dst_data,
-            count_data + i * node_len,
+            count_data + count_offset,
             thrust::raw_pointer_cast(dst_ptr.data()),
             reindex_dst_data + begin);
 #ifdef PADDLE_WITH_HIP
     hipMemcpy(&count_i,
-              thrust::raw_pointer_cast(dst_ptr.data()) + node_len,
+              thrust::raw_pointer_cast(dst_ptr.data()) + node_len_64,
               sizeof(int),
               hipMemcpyDeviceToHost);
 #else
     cudaMemcpy(&count_i,
-               thrust::raw_pointer_cast(dst_ptr.data()) + node_len,
+               thrust::raw_pointer_cast(dst_ptr.data()) + node_len_64,
                sizeof(int),
                cudaMemcpyDeviceToHost);
 #endif
     begin += count_i;
+    PADDLE_ENFORCE_LE_INT_MAX(begin, "graph_reindex dst offset");
   }
 }
 

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -19,6 +19,7 @@
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
 #include <thrust/sequence.h>
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/common/memory_utils.h"
@@ -30,7 +31,7 @@ namespace phi {
 
 constexpr int WARP_SIZE = 32;
 const int CUDA_NUM_THREADS = 512;
-inline int GET_BLOCKS(const int N) {
+inline int64_t GET_BLOCKS(const int64_t N) {
   return (N + CUDA_NUM_THREADS - 1) / CUDA_NUM_THREADS;
 }
 
@@ -134,13 +135,22 @@ void ResetBufferHashTable(const Context& dev_ctx,
                           int* key_index) {
   int block = 1024;
   int max_grid_dimx = dev_ctx.GetCUDAMaxGridDimSize()[0];
-  int grid_tmp = (unique_items->size() + block - 1) / block;
-  int grid = grid_tmp < max_grid_dimx ? grid_tmp : max_grid_dimx;
-  ResetHashTable<T><<<grid, block, 0, dev_ctx.stream()>>>(
-      thrust::raw_pointer_cast(unique_items->data()),
-      unique_items->size(),
-      key_index,
-      values);
+  size_t unique_items_size = unique_items->size();
+  size_t grid_tmp = (unique_items_size + static_cast<size_t>(block) - 1) /
+                    static_cast<size_t>(block);
+  size_t grid = grid_tmp < static_cast<size_t>(max_grid_dimx)
+                    ? grid_tmp
+                    : static_cast<size_t>(max_grid_dimx);
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid, "graph_reindex reset grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(block, "graph_reindex reset block.x");
+  ResetHashTable<T>
+      <<<static_cast<uint32_t>(grid),
+         static_cast<uint32_t>(block),
+         0,
+         dev_ctx.stream()>>>(thrust::raw_pointer_cast(unique_items->data()),
+                             unique_items_size,
+                             key_index,
+                             values);
 }
 
 template <typename T, typename Context>
@@ -155,8 +165,13 @@ void ReindexSrc(const Context& dev_ctx,
   int max_grid_dimx = dev_ctx.GetCUDAMaxGridDimSize()[0];
   int grid_tmp = (num_edges + block - 1) / block;
   int grid = grid_tmp < max_grid_dimx ? grid_tmp : max_grid_dimx;
-  ReindexSrcOutput<T><<<grid, block, 0, dev_ctx.stream()>>>(
-      edges_src, num_edges, table_size, keys, values);
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid, "graph_reindex src grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(block, "graph_reindex src block.x");
+  ReindexSrcOutput<T>
+      <<<static_cast<uint32_t>(grid),
+         static_cast<uint32_t>(block),
+         0,
+         dev_ctx.stream()>>>(edges_src, num_edges, table_size, keys, values);
 }
 
 template <typename T, typename Context>
@@ -185,15 +200,23 @@ void Reindex(const Context& dev_ctx,
   int* values_ptr = reinterpret_cast<int*>(values->ptr());
   int* key_index_ptr = reinterpret_cast<int*>(key_index->ptr());
 
+  int64_t table_blocks = GET_BLOCKS(table_size);
+  PADDLE_ENFORCE_LE(
+      table_blocks,
+      dev_ctx.GetCUDAMaxGridDimSize()[0],
+      common::errors::InvalidArgument(
+          "graph_reindex init table grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(table_blocks, "graph_reindex init table grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(CUDA_NUM_THREADS,
+                               "graph_reindex init table block.x");
+  const uint32_t table_grid = static_cast<uint32_t>(table_blocks);
+  const uint32_t table_block = static_cast<uint32_t>(CUDA_NUM_THREADS);
   InitializeHashTable<T>
-      <<<GET_BLOCKS(table_size), CUDA_NUM_THREADS, 0, dev_ctx.stream()>>>(
-          keys_ptr, table_size);
-  InitializeHashTable<int>
-      <<<GET_BLOCKS(table_size), CUDA_NUM_THREADS, 0, dev_ctx.stream()>>>(
-          values_ptr, table_size);
-  InitializeHashTable<int>
-      <<<GET_BLOCKS(table_size), CUDA_NUM_THREADS, 0, dev_ctx.stream()>>>(
-          key_index_ptr, table_size);
+      <<<table_grid, table_block, 0, dev_ctx.stream()>>>(keys_ptr, table_size);
+  InitializeHashTable<int><<<table_grid, table_block, 0, dev_ctx.stream()>>>(
+      values_ptr, table_size);
+  InitializeHashTable<int><<<table_grid, table_block, 0, dev_ctx.stream()>>>(
+      key_index_ptr, table_size);
 
   int unique_len = 0;
   std::shared_ptr<Allocation> unique_items =
@@ -250,7 +273,12 @@ void BufferReindex(const Context& dev_ctx,
   int max_grid_dimx = dev_ctx.GetCUDAMaxGridDimSize()[0];
   int grid_tmp = (num_edges + block - 1) / block;
   int grid = grid_tmp < max_grid_dimx ? grid_tmp : max_grid_dimx;
-  ReindexSrcOutput<T><<<grid, block, 0, dev_ctx.stream()>>>(
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid, "graph_reindex buffer src grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(block, "graph_reindex buffer src block.x");
+  ReindexSrcOutput<T><<<static_cast<uint32_t>(grid),
+                        static_cast<uint32_t>(block),
+                        0,
+                        dev_ctx.stream()>>>(
       thrust::raw_pointer_cast(src_outputs), num_edges, hashtable_value);
 
   ResetBufferHashTable<T, Context>(dev_ctx,
@@ -295,8 +323,17 @@ void ReindexDst(const Context& dev_ctx,
                 int node_len) {
   constexpr int BLOCK_WARPS = 128 / WARP_SIZE;
   constexpr int TILE_SIZE = BLOCK_WARPS * 16;
-  const dim3 block(WARP_SIZE, BLOCK_WARPS);
-  const dim3 grid((node_len + TILE_SIZE - 1) / TILE_SIZE);
+  const int grid_x = (node_len + TILE_SIZE - 1) / TILE_SIZE;
+  PADDLE_ENFORCE_LE(grid_x,
+                    dev_ctx.GetCUDAMaxGridDimSize()[0],
+                    common::errors::InvalidArgument(
+                        "graph_reindex dst grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(WARP_SIZE, "graph_reindex dst block.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(BLOCK_WARPS, "graph_reindex dst block.y");
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_x, "graph_reindex dst grid.x");
+  const dim3 block(static_cast<uint32_t>(WARP_SIZE),
+                   static_cast<uint32_t>(BLOCK_WARPS));
+  const dim3 grid(static_cast<uint32_t>(grid_x));
 
   int begin = 0, count_i = 0;
   thrust::device_vector<int> dst_ptr(node_len + 1, 0);

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -209,14 +209,16 @@ void Reindex(const Context& dev_ctx,
   PADDLE_ENFORCE_LE_UINT32_MAX(table_blocks, "graph_reindex init table grid.x");
   PADDLE_ENFORCE_LE_UINT32_MAX(CUDA_NUM_THREADS,
                                "graph_reindex init table block.x");
+  PADDLE_ENFORCE_LE_INT_MAX(table_size, "graph_reindex table_size");
   const uint32_t table_grid = static_cast<uint32_t>(table_blocks);
   const uint32_t table_block = static_cast<uint32_t>(CUDA_NUM_THREADS);
-  InitializeHashTable<T>
-      <<<table_grid, table_block, 0, dev_ctx.stream()>>>(keys_ptr, table_size);
+  const int table_size_int = static_cast<int>(table_size);
+  InitializeHashTable<T><<<table_grid, table_block, 0, dev_ctx.stream()>>>(
+      keys_ptr, table_size_int);
   InitializeHashTable<int><<<table_grid, table_block, 0, dev_ctx.stream()>>>(
-      values_ptr, table_size);
+      values_ptr, table_size_int);
   InitializeHashTable<int><<<table_grid, table_block, 0, dev_ctx.stream()>>>(
-      key_index_ptr, table_size);
+      key_index_ptr, table_size_int);
 
   int unique_len = 0;
   std::shared_ptr<Allocation> unique_items =

--- a/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
+++ b/paddle/phi/kernels/gpu/graph_reindex_kernel.cu
@@ -390,6 +390,7 @@ void GraphReindexKernel(const Context& dev_ctx,
   int64_t num_edges = neighbors.dims()[0];
   PADDLE_ENFORCE_LE_INT_MAX(bs, "graph_reindex num_inputs");
   PADDLE_ENFORCE_LE_INT_MAX(num_edges, "graph_reindex num_edges");
+  PADDLE_ENFORCE_LE_INT_MAX(bs + num_edges, "graph_reindex total nodes");
 
   const int bs_int = static_cast<int>(bs);
   const int num_edges_int = static_cast<int>(num_edges);

--- a/paddle/phi/kernels/gpu/group_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/group_norm_grad_kernel.cu
@@ -14,6 +14,9 @@
 
 #include "paddle/phi/kernels/group_norm_grad_kernel.h"
 
+#include <array>
+
+#include "paddle/common/enforce.h"
 #include "paddle/common/layout.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
@@ -812,6 +815,7 @@ void GroupNormGradKernel(const Context& dev_ctx,
     // PyTorch-aligned NCHW backward path (optimized)
     // =========================================================
     const int64_t HxW = imsize;
+    const int64_t max_grid_x = dev_ctx.GetCUDAMaxGridDimSize()[0];
 
     // Stage 1: Compute internal gradients ds[n,c] = sum_hw(dY*X),
     //          db[n,c] = sum_hw(dY)
@@ -827,9 +831,21 @@ void GroupNormGradKernel(const Context& dev_ctx,
       {
         int64_t num_threads =
             HxW < kGradBlockReduceNumThreads ? 32 : kGradBlockReduceNumThreads;
+        const int64_t internal_grad_blocks = N * C;
+        PADDLE_ENFORCE_LE(
+            internal_grad_blocks,
+            dev_ctx.GetCUDAMaxGridDimSize()[0],
+            common::errors::InvalidArgument(
+                "group_norm grad internal grid.x exceeds device limit."));
+        PADDLE_ENFORCE_LE_UINT32_MAX(internal_grad_blocks,
+                                     "group_norm grad internal grid.x");
+        PADDLE_ENFORCE_LE_UINT32_MAX(num_threads,
+                                     "group_norm grad internal block.x");
         ComputeInternalGradientsCUDAKernel<T, AccT>
-            <<<N * C, num_threads, 0, dev_ctx.stream()>>>(
-                HxW, dy_data, x_data, ds_data, db_data);
+            <<<static_cast<uint32_t>(internal_grad_blocks),
+               static_cast<uint32_t>(num_threads),
+               0,
+               dev_ctx.stream()>>>(HxW, dy_data, x_data, ds_data, db_data);
       }
     }
 
@@ -845,23 +861,40 @@ void GroupNormGradKernel(const Context& dev_ctx,
       {
         int64_t num_threads =
             D < kGradBlockReduceNumThreads ? 32 : kGradBlockReduceNumThreads;
+        std::array<unsigned int, 3> max_grid_dim =
+            dev_ctx.GetCUDAMaxGridDimSize();
+        PADDLE_ENFORCE_LE(N,
+                          max_grid_dim[0],
+                          common::errors::InvalidArgument(
+                              "group_norm grad fused params grid.x exceeds "
+                              "device limit."));
+        PADDLE_ENFORCE_LE(G,
+                          max_grid_dim[1],
+                          common::errors::InvalidArgument(
+                              "group_norm grad fused params grid.y exceeds "
+                              "device limit."));
+        PADDLE_ENFORCE_LE_UINT32_MAX(N, "group_norm grad fused params grid.x");
+        PADDLE_ENFORCE_LE_UINT32_MAX(G, "group_norm grad fused params grid.y");
+        PADDLE_ENFORCE_LE_UINT32_MAX(num_threads,
+                                     "group_norm grad fused params block.x");
         ComputeBackwardFusedParamsCUDAKernel<T, AccT>
-            <<<dim3(N, G), num_threads, 0, dev_ctx.stream()>>>(
-                C,
-                HxW,
-                G,
-                mean_data,
-                var_data,
-                scale_data,
-                ds_data,
-                db_data,
-                static_cast<AccT>(epsilon),
-                c2_data,
-                c3_data);
+            <<<dim3(static_cast<uint32_t>(N), static_cast<uint32_t>(G)),
+               static_cast<uint32_t>(num_threads),
+               0,
+               dev_ctx.stream()>>>(C,
+                                   HxW,
+                                   G,
+                                   mean_data,
+                                   var_data,
+                                   scale_data,
+                                   ds_data,
+                                   db_data,
+                                   static_cast<AccT>(epsilon),
+                                   c2_data,
+                                   c3_data);
       }
 
       // Stage 4: dX = c1 * dY + c2 * X + c3 (optimized)
-      int64_t max_grid_x = dev_ctx.GetCUDAMaxGridDimSize()[0];
       constexpr int64_t kElemThreads = 256;
 
       if (scale_data != nullptr) {
@@ -875,15 +908,20 @@ void GroupNormGradKernel(const Context& dev_ctx,
           const int64_t N_C = N * C;
           const int64_t c1_blocks =
               std::min((N_C + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(c1_blocks, "group_norm grad c1 grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(kElemThreads,
+                                       "group_norm grad c1 block.x");
           ComputeC1CUDAKernel<T, AccT>
-              <<<c1_blocks, kElemThreads, 0, dev_ctx.stream()>>>(
-                  N_C,
-                  C,
-                  G,
-                  static_cast<AccT>(epsilon),
-                  var_data,
-                  scale_data,
-                  c1_data);
+              <<<static_cast<uint32_t>(c1_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(N_C,
+                                     C,
+                                     G,
+                                     static_cast<AccT>(epsilon),
+                                     var_data,
+                                     scale_data,
+                                     c1_data);
         }
 
         // Dispatch vectorized or scalar dX kernel
@@ -892,46 +930,67 @@ void GroupNormGradKernel(const Context& dev_ctx,
           const int64_t total_vec = N * C * HxW_vec;
           const int64_t elem_blocks = std::min(
               (total_vec + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(elem_blocks,
+                                       "group_norm grad dx vec4 grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(kElemThreads,
+                                       "group_norm grad dx vec4 block.x");
           GroupNormBackwardDxVec4CUDAKernel<T, AccT>
-              <<<elem_blocks, kElemThreads, 0, dev_ctx.stream()>>>(N * C,
-                                                                   HxW_vec,
-                                                                   D,
-                                                                   dy_data,
-                                                                   x_data,
-                                                                   c1_data,
-                                                                   c2_data,
-                                                                   c3_data,
-                                                                   d_x_data);
+              <<<static_cast<uint32_t>(elem_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(N * C,
+                                     HxW_vec,
+                                     D,
+                                     dy_data,
+                                     x_data,
+                                     c1_data,
+                                     c2_data,
+                                     c3_data,
+                                     d_x_data);
         } else if (std::is_same<T, double>::value && (HxW % 2 == 0)) {
           const int64_t HxW_vec = HxW / 2;
           const int64_t total_vec = N * C * HxW_vec;
           const int64_t elem_blocks = std::min(
               (total_vec + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(elem_blocks,
+                                       "group_norm grad dx vec2 grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(kElemThreads,
+                                       "group_norm grad dx vec2 block.x");
           GroupNormBackwardDxVec2DoubleCUDAKernel<T, AccT>
-              <<<elem_blocks, kElemThreads, 0, dev_ctx.stream()>>>(N * C,
-                                                                   HxW_vec,
-                                                                   D,
-                                                                   dy_data,
-                                                                   x_data,
-                                                                   c1_data,
-                                                                   c2_data,
-                                                                   c3_data,
-                                                                   d_x_data);
+              <<<static_cast<uint32_t>(elem_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(N * C,
+                                     HxW_vec,
+                                     D,
+                                     dy_data,
+                                     x_data,
+                                     c1_data,
+                                     c2_data,
+                                     c3_data,
+                                     d_x_data);
         } else {
           // Scalar fallback with pre-computed c1
           const int64_t total = N * C * HxW;
           const int64_t elem_blocks =
               std::min((total + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(elem_blocks,
+                                       "group_norm grad dx grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(kElemThreads,
+                                       "group_norm grad dx block.x");
           GroupNormBackwardDxOptCUDAKernel<T, AccT>
-              <<<elem_blocks, kElemThreads, 0, dev_ctx.stream()>>>(N * C,
-                                                                   HxW,
-                                                                   D,
-                                                                   dy_data,
-                                                                   x_data,
-                                                                   c1_data,
-                                                                   c2_data,
-                                                                   c3_data,
-                                                                   d_x_data);
+              <<<static_cast<uint32_t>(elem_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(N * C,
+                                     HxW,
+                                     D,
+                                     dy_data,
+                                     x_data,
+                                     c1_data,
+                                     c2_data,
+                                     c3_data,
+                                     d_x_data);
         }
       } else {
         // No gamma path: c1 = rstd[ng], pre-compute rstd rounded through T
@@ -943,9 +1002,15 @@ void GroupNormGradKernel(const Context& dev_ctx,
           const int64_t N_G = N * G;
           const int64_t rstd_blocks =
               std::min((N_G + kElemThreads - 1) / kElemThreads, max_grid_x);
-          ComputeRstdCUDAKernel<T, AccT>
-              <<<rstd_blocks, kElemThreads, 0, dev_ctx.stream()>>>(
-                  N_G, static_cast<AccT>(epsilon), var_data, c1_ng_data);
+          PADDLE_ENFORCE_LE_UINT32_MAX(rstd_blocks,
+                                       "group_norm grad rstd grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(kElemThreads,
+                                       "group_norm grad rstd block.x");
+          ComputeRstdCUDAKernel<T, AccT><<<static_cast<uint32_t>(rstd_blocks),
+                                           static_cast<uint32_t>(kElemThreads),
+                                           0,
+                                           dev_ctx.stream()>>>(
+              N_G, static_cast<AccT>(epsilon), var_data, c1_ng_data);
         }
 
         const int64_t D_HxW = D * HxW;
@@ -955,43 +1020,64 @@ void GroupNormGradKernel(const Context& dev_ctx,
           const int64_t total_vec = N * G * D_HxW_vec;
           const int64_t elem_blocks = std::min(
               (total_vec + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(
+              elem_blocks, "group_norm grad dx no gamma vec4 grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(
+              kElemThreads, "group_norm grad dx no gamma vec4 block.x");
           GroupNormBackwardDxNoGammaVec4CUDAKernel<T, AccT>
-              <<<elem_blocks, kElemThreads, 0, dev_ctx.stream()>>>(N * G,
-                                                                   D_HxW_vec,
-                                                                   dy_data,
-                                                                   x_data,
-                                                                   c1_ng_data,
-                                                                   c2_data,
-                                                                   c3_data,
-                                                                   d_x_data);
+              <<<static_cast<uint32_t>(elem_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(N * G,
+                                     D_HxW_vec,
+                                     dy_data,
+                                     x_data,
+                                     c1_ng_data,
+                                     c2_data,
+                                     c3_data,
+                                     d_x_data);
         } else if (std::is_same<T, double>::value && (D_HxW % 2 == 0)) {
           const int64_t D_HxW_vec = D_HxW / 2;
           const int64_t total_vec = N * G * D_HxW_vec;
           const int64_t elem_blocks = std::min(
               (total_vec + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(
+              elem_blocks, "group_norm grad dx no gamma vec2 grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(
+              kElemThreads, "group_norm grad dx no gamma vec2 block.x");
           GroupNormBackwardDxNoGammaVec2DoubleCUDAKernel<T, AccT>
-              <<<elem_blocks, kElemThreads, 0, dev_ctx.stream()>>>(N * G,
-                                                                   D_HxW_vec,
-                                                                   dy_data,
-                                                                   x_data,
-                                                                   c1_ng_data,
-                                                                   c2_data,
-                                                                   c3_data,
-                                                                   d_x_data);
+              <<<static_cast<uint32_t>(elem_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(N * G,
+                                     D_HxW_vec,
+                                     dy_data,
+                                     x_data,
+                                     c1_ng_data,
+                                     c2_data,
+                                     c3_data,
+                                     d_x_data);
         } else {
           // Scalar fallback with pre-computed rstd
           const int64_t total = N * G * D_HxW;
           const int64_t elem_blocks =
               std::min((total + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(elem_blocks,
+                                       "group_norm grad dx no gamma grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(kElemThreads,
+                                       "group_norm grad dx no gamma block.x");
           GroupNormBackwardDxNoGammaOptCUDAKernel<T, AccT>
-              <<<elem_blocks, kElemThreads, 0, dev_ctx.stream()>>>(N * G,
-                                                                   D_HxW,
-                                                                   dy_data,
-                                                                   x_data,
-                                                                   c1_ng_data,
-                                                                   c2_data,
-                                                                   c3_data,
-                                                                   d_x_data);
+              <<<static_cast<uint32_t>(elem_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(N * G,
+                                     D_HxW,
+                                     dy_data,
+                                     x_data,
+                                     c1_ng_data,
+                                     c2_data,
+                                     c3_data,
+                                     d_x_data);
         }
       }
     }
@@ -1001,45 +1087,81 @@ void GroupNormGradKernel(const Context& dev_ctx,
       if (N <= 128) {
         constexpr int kNumThreads = 256;
         const int64_t B = (C + kNumThreads - 1) / kNumThreads;
+        PADDLE_ENFORCE_LE(
+            B,
+            max_grid_x,
+            common::errors::InvalidArgument(
+                "group_norm grad gamma beta grid.x exceeds device limit."));
+        PADDLE_ENFORCE_LE_UINT32_MAX(B, "group_norm grad gamma beta grid.x");
+        PADDLE_ENFORCE_LE_UINT32_MAX(kNumThreads,
+                                     "group_norm grad gamma beta block.x");
         GammaBetaBackwardCUDAKernel1<T, AccT>
-            <<<B, kNumThreads, 0, dev_ctx.stream()>>>(
-                N,
-                C,
-                G,
-                mean_data,
-                var_data,
-                ds_data,
-                db_data,
-                static_cast<AccT>(epsilon),
-                d_scale_data,
-                d_bias_data);
+            <<<static_cast<uint32_t>(B),
+               static_cast<uint32_t>(kNumThreads),
+               0,
+               dev_ctx.stream()>>>(N,
+                                   C,
+                                   G,
+                                   mean_data,
+                                   var_data,
+                                   ds_data,
+                                   db_data,
+                                   static_cast<AccT>(epsilon),
+                                   d_scale_data,
+                                   d_bias_data);
       } else {
         const int64_t B = (C + kGradReduceTileSize - 1) / kGradReduceTileSize;
         constexpr int kThreadX = kGradReduceTileSize;
         constexpr int kThreadY = kGradReduceTileSize / 2;
+        PADDLE_ENFORCE_LE(
+            B,
+            max_grid_x,
+            common::errors::InvalidArgument(
+                "group_norm grad gamma beta 2 grid.x exceeds device limit."));
+        PADDLE_ENFORCE_LE_UINT32_MAX(B, "group_norm grad gamma beta 2 grid.x");
+        PADDLE_ENFORCE_LE_UINT32_MAX(kThreadX,
+                                     "group_norm grad gamma beta 2 block.x");
+        PADDLE_ENFORCE_LE_UINT32_MAX(kThreadY,
+                                     "group_norm grad gamma beta 2 block.y");
         GammaBetaBackwardCUDAKernel2<T, AccT>
-            <<<B, dim3(kThreadX, kThreadY), 0, dev_ctx.stream()>>>(
-                N,
-                C,
-                G,
-                mean_data,
-                var_data,
-                ds_data,
-                db_data,
-                static_cast<AccT>(epsilon),
-                d_scale_data,
-                d_bias_data);
+            <<<static_cast<uint32_t>(B),
+               dim3(static_cast<uint32_t>(kThreadX),
+                    static_cast<uint32_t>(kThreadY)),
+               0,
+               dev_ctx.stream()>>>(N,
+                                   C,
+                                   G,
+                                   mean_data,
+                                   var_data,
+                                   ds_data,
+                                   db_data,
+                                   static_cast<AccT>(epsilon),
+                                   d_scale_data,
+                                   d_bias_data);
       }
     }
   } else {
     // =========================================================
     // NHWC backward path (kept unchanged)
     // =========================================================
-    int block_size = std::min(static_cast<int64_t>(1024), imsize);
+    int64_t block_size_64 = std::min(static_cast<int64_t>(1024), imsize);
     int64_t max_grid_x = dev_ctx.GetCUDAMaxGridDimSize()[0];
+    int64_t max_grid_y = dev_ctx.GetCUDAMaxGridDimSize()[1];
     int64_t max_grid_z = dev_ctx.GetCUDAMaxGridDimSize()[2];
-    dim3 grid(
-        std::min(max_grid_x, group_size), groups, std::min(max_grid_z, N));
+    const int64_t grid_x = std::min(max_grid_x, group_size);
+    const int64_t grid_z = std::min(max_grid_z, N);
+    PADDLE_ENFORCE_LE(groups,
+                      max_grid_y,
+                      common::errors::InvalidArgument(
+                          "group_norm grad grid.y exceeds device limit."));
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_x, "group_norm grad grid.x");
+    PADDLE_ENFORCE_LE_UINT32_MAX(groups, "group_norm grad grid.y");
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_z, "group_norm grad grid.z");
+    PADDLE_ENFORCE_LE_UINT32_MAX(block_size_64, "group_norm grad block.x");
+    uint32_t block_size = static_cast<uint32_t>(block_size_64);
+    dim3 grid(static_cast<uint32_t>(grid_x),
+              static_cast<uint32_t>(groups),
+              static_cast<uint32_t>(grid_z));
     dim3 threads(block_size, 1, 1);
 
     auto* y_data = y.data<T>();

--- a/paddle/phi/kernels/gpu/group_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/group_norm_kernel.cu
@@ -14,9 +14,11 @@
 
 #include "paddle/phi/kernels/group_norm_kernel.h"
 
+#include "paddle/common/enforce.h"
 #include "paddle/common/layout.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/gpu/group_norm_utils.h"
@@ -1391,11 +1393,25 @@ void GroupNormDirectCUDAFunctor<T, AccT>::operator()(
     }
   }
   int block_size = std::min(static_cast<int64_t>(1024), image_size);
-  int64_t max_grid_x = 65535;
-  dim3 grid(std::min(group_size, max_grid_x),
-            groups,
-            std::min(input_ddim[0], max_grid_x));
-  dim3 threads(block_size, 1, 1);
+  const auto max_grid_dim =
+      backends::gpu::GetGpuMaxGridDimSize(backends::gpu::GetCurrentDeviceId());
+  int64_t max_grid_x = max_grid_dim[0];
+  int64_t max_grid_y = max_grid_dim[1];
+  int64_t max_grid_z = max_grid_dim[2];
+  const int64_t grid_x = std::min(group_size, max_grid_x);
+  const int64_t grid_z = std::min(input_ddim[0], max_grid_z);
+  PADDLE_ENFORCE_LE(groups,
+                    max_grid_y,
+                    common::errors::InvalidArgument(
+                        "group_norm forward grid.y exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_x, "group_norm forward grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(groups, "group_norm forward grid.y");
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_z, "group_norm forward grid.z");
+  PADDLE_ENFORCE_LE_UINT32_MAX(block_size, "group_norm forward block.x");
+  dim3 grid(static_cast<uint32_t>(grid_x),
+            static_cast<uint32_t>(groups),
+            static_cast<uint32_t>(grid_z));
+  dim3 threads(static_cast<uint32_t>(block_size), 1, 1);
   if (data_layout == DataLayout::NCHW) {
     if (FLAGS_use_accuracy_compatible_kernel) {
       // =========================================================
@@ -1409,7 +1425,17 @@ void GroupNormDirectCUDAFunctor<T, AccT>::operator()(
           D_times_HxW < kBlockReduceNumThreads ? 32 : kBlockReduceNumThreads;
 
       // Phase 1: Welford moments -> mean and centered variance in temp_variance
-      WelfordMomentsCUDAKernel<T, AccT><<<N * G, num_threads, 0, stream>>>(
+      const int64_t welford_blocks = N * G;
+      PADDLE_ENFORCE_LE(welford_blocks,
+                        max_grid_x,
+                        common::errors::InvalidArgument(
+                            "group_norm welford grid.x exceeds device limit."));
+      PADDLE_ENFORCE_LE_UINT32_MAX(welford_blocks, "group_norm welford grid.x");
+      PADDLE_ENFORCE_LE_UINT32_MAX(num_threads, "group_norm welford block.x");
+      WelfordMomentsCUDAKernel<T, AccT><<<static_cast<uint32_t>(welford_blocks),
+                                          static_cast<uint32_t>(num_threads),
+                                          0,
+                                          stream>>>(
           D_times_HxW, static_cast<AccT>(eps), input, mean, temp_variance);
 
       // Phase 2: Fused normalization using mean/var on the fly
@@ -1418,31 +1444,45 @@ void GroupNormDirectCUDAFunctor<T, AccT>::operator()(
         const int64_t elem_threads = 256;
         const int64_t elem_blocks =
             std::min((total + elem_threads - 1) / elem_threads, max_grid_x);
+        PADDLE_ENFORCE_LE_UINT32_MAX(elem_blocks,
+                                     "group_norm forward fused grid.x");
+        PADDLE_ENFORCE_LE_UINT32_MAX(elem_threads,
+                                     "group_norm forward fused block.x");
         GroupNormForwardFusedNCHWKernel<T, AccT>
-            <<<elem_blocks, elem_threads, 0, stream>>>(N * C,
-                                                       image_size,
-                                                       C,
-                                                       G,
-                                                       input,
-                                                       mean,
-                                                       temp_variance,
-                                                       scale,
-                                                       bias,
-                                                       static_cast<AccT>(eps),
-                                                       output);
+            <<<static_cast<uint32_t>(elem_blocks),
+               static_cast<uint32_t>(elem_threads),
+               0,
+               stream>>>(N * C,
+                         image_size,
+                         C,
+                         G,
+                         input,
+                         mean,
+                         temp_variance,
+                         scale,
+                         bias,
+                         static_cast<AccT>(eps),
+                         output);
       } else {
         const int64_t total = N * G * D_times_HxW;
         const int64_t elem_threads = 256;
         const int64_t elem_blocks =
             std::min((total + elem_threads - 1) / elem_threads, max_grid_x);
+        PADDLE_ENFORCE_LE_UINT32_MAX(elem_blocks,
+                                     "group_norm forward no scale bias grid.x");
+        PADDLE_ENFORCE_LE_UINT32_MAX(
+            elem_threads, "group_norm forward no scale bias block.x");
         GroupNormForwardNoScaleBiasCUDAKernel<T, AccT>
-            <<<elem_blocks, elem_threads, 0, stream>>>(N * G,
-                                                       D_times_HxW,
-                                                       input,
-                                                       mean,
-                                                       temp_variance,
-                                                       static_cast<AccT>(eps),
-                                                       output);
+            <<<static_cast<uint32_t>(elem_blocks),
+               static_cast<uint32_t>(elem_threads),
+               0,
+               stream>>>(N * G,
+                         D_times_HxW,
+                         input,
+                         mean,
+                         temp_variance,
+                         static_cast<AccT>(eps),
+                         output);
       }
 
       // Copy centered variance to variance output
@@ -1474,8 +1514,12 @@ void GroupNormDirectCUDAFunctor<T, AccT>::operator()(
       }
       block_size_nchw = std::max(block_size_nchw, kps::details::kWarpSize);
       int64_t n_groups = input_ddim[0] * static_cast<int64_t>(groups);
-      dim3 grids(std::min(max_grid_x, n_groups));
-      dim3 blocks(block_size_nchw);
+      const int64_t grids_x = std::min(max_grid_x, n_groups);
+      PADDLE_ENFORCE_LE_UINT32_MAX(grids_x, "group_norm mean var grid.x");
+      PADDLE_ENFORCE_LE_UINT32_MAX(block_size_nchw,
+                                   "group_norm mean var block.x");
+      dim3 grids(static_cast<uint32_t>(grids_x));
+      dim3 blocks(static_cast<uint32_t>(block_size_nchw));
       if (size < vec_size * block_size_nchw) {
         ScalarGetMeanAndVarNCHW<T, AccT><<<grids, blocks, 0, stream>>>(
             input, mean, temp_variance, size, n_groups);
@@ -1594,6 +1638,8 @@ void GroupNormGeneralCaseKernel(const Context& dev_ctx,
     }
   }
 
+  const int64_t max_grid_x = dev_ctx.GetCUDAMaxGridDimSize()[0];
+
   if (data_layout == DataLayout::NCHW) {
     if (FLAGS_use_accuracy_compatible_kernel) {
       // =========================================================
@@ -1605,13 +1651,21 @@ void GroupNormGeneralCaseKernel(const Context& dev_ctx,
       const int64_t num_threads =
           D_times_HxW < kBlockReduceNumThreads ? 32 : kBlockReduceNumThreads;
 
-      WelfordMomentsCUDAKernel<T, AccT>
-          <<<N * G, num_threads, 0, dev_ctx.stream()>>>(
-              D_times_HxW,
-              static_cast<AccT>(epsilon),
-              x_data,
-              mean_data,
-              var_data);
+      const int64_t welford_blocks = N * G;
+      PADDLE_ENFORCE_LE(
+          welford_blocks,
+          max_grid_x,
+          common::errors::InvalidArgument(
+              "group_norm general welford grid.x exceeds device limit."));
+      PADDLE_ENFORCE_LE_UINT32_MAX(welford_blocks,
+                                   "group_norm general welford grid.x");
+      PADDLE_ENFORCE_LE_UINT32_MAX(num_threads,
+                                   "group_norm general welford block.x");
+      WelfordMomentsCUDAKernel<T, AccT><<<static_cast<uint32_t>(welford_blocks),
+                                          static_cast<uint32_t>(num_threads),
+                                          0,
+                                          dev_ctx.stream()>>>(
+          D_times_HxW, static_cast<AccT>(epsilon), x_data, mean_data, var_data);
 
       // Phase 2: Normalization
       if (scale_data != nullptr || bias_data != nullptr) {
@@ -1624,18 +1678,28 @@ void GroupNormGeneralCaseKernel(const Context& dev_ctx,
 
         constexpr int64_t kNumThreads = 256;
         const int64_t B = (N * C + kNumThreads - 1) / kNumThreads;
+        PADDLE_ENFORCE_LE(
+            B,
+            max_grid_x,
+            common::errors::InvalidArgument(
+                "group_norm fused params grid.x exceeds device limit."));
+        PADDLE_ENFORCE_LE_UINT32_MAX(B, "group_norm fused params grid.x");
+        PADDLE_ENFORCE_LE_UINT32_MAX(kNumThreads,
+                                     "group_norm fused params block.x");
         ComputeFusedParamsCUDAKernel<T, AccT>
-            <<<B, kNumThreads, 0, dev_ctx.stream()>>>(
-                N,
-                C,
-                G,
-                static_cast<AccT>(epsilon),
-                mean_data,
-                var_data,
-                scale_data,
-                bias_data,
-                a_data,
-                b_data);
+            <<<static_cast<uint32_t>(B),
+               static_cast<uint32_t>(kNumThreads),
+               0,
+               dev_ctx.stream()>>>(N,
+                                   C,
+                                   G,
+                                   static_cast<AccT>(epsilon),
+                                   mean_data,
+                                   var_data,
+                                   scale_data,
+                                   bias_data,
+                                   a_data,
+                                   b_data);
 
         // Phase 2b: Element-wise Y = a * X + b
         constexpr int64_t kElemThreads = 256;
@@ -1646,23 +1710,44 @@ void GroupNormGeneralCaseKernel(const Context& dev_ctx,
           const int64_t total_vec = N * C * HxW_vec;
           const int64_t elem_blocks = std::min(
               (total_vec + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(elem_blocks,
+                                       "group_norm elementwise vec4 grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(kElemThreads,
+                                       "group_norm elementwise vec4 block.x");
           GroupNormForwardElementwiseVec4CUDAKernel<T, AccT>
-              <<<elem_blocks, kElemThreads, 0, dev_ctx.stream()>>>(
+              <<<static_cast<uint32_t>(elem_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(
                   N * C, HxW_vec, x_data, a_data, b_data, y_data);
         } else if (std::is_same<T, double>::value && (imsize % 2 == 0)) {
           const int64_t HxW_vec = imsize / 2;
           const int64_t total_vec = N * C * HxW_vec;
           const int64_t elem_blocks = std::min(
               (total_vec + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(elem_blocks,
+                                       "group_norm elementwise vec2 grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(kElemThreads,
+                                       "group_norm elementwise vec2 block.x");
           GroupNormForwardElementwiseVec2DoubleCUDAKernel<T, AccT>
-              <<<elem_blocks, kElemThreads, 0, dev_ctx.stream()>>>(
+              <<<static_cast<uint32_t>(elem_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(
                   N * C, HxW_vec, x_data, a_data, b_data, y_data);
         } else {
           const int64_t total = N * C * imsize;
           const int64_t elem_blocks =
               std::min((total + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(elem_blocks,
+                                       "group_norm elementwise grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(kElemThreads,
+                                       "group_norm elementwise block.x");
           GroupNormForwardElementwiseCUDAKernel<T, AccT>
-              <<<elem_blocks, kElemThreads, 0, dev_ctx.stream()>>>(
+              <<<static_cast<uint32_t>(elem_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(
                   N * C, imsize, x_data, a_data, b_data, y_data);
         }
       } else {
@@ -1675,42 +1760,60 @@ void GroupNormGeneralCaseKernel(const Context& dev_ctx,
           const int64_t total_vec = N * G * D_HxW_vec;
           const int64_t elem_blocks = std::min(
               (total_vec + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(elem_blocks,
+                                       "group_norm no scale bias vec4 grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(kElemThreads,
+                                       "group_norm no scale bias vec4 block.x");
           GroupNormForwardNoScaleBiasVec4CUDAKernel<T, AccT>
-              <<<elem_blocks, kElemThreads, 0, dev_ctx.stream()>>>(
-                  N * G,
-                  D_HxW_vec,
-                  x_data,
-                  mean_data,
-                  var_data,
-                  static_cast<AccT>(epsilon),
-                  y_data);
+              <<<static_cast<uint32_t>(elem_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(N * G,
+                                     D_HxW_vec,
+                                     x_data,
+                                     mean_data,
+                                     var_data,
+                                     static_cast<AccT>(epsilon),
+                                     y_data);
         } else if (std::is_same<T, double>::value && (D_times_HxW % 2 == 0)) {
           const int64_t D_HxW_vec = D_times_HxW / 2;
           const int64_t total_vec = N * G * D_HxW_vec;
           const int64_t elem_blocks = std::min(
               (total_vec + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(elem_blocks,
+                                       "group_norm no scale bias vec2 grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(kElemThreads,
+                                       "group_norm no scale bias vec2 block.x");
           GroupNormForwardNoScaleBiasVec2DoubleCUDAKernel<T, AccT>
-              <<<elem_blocks, kElemThreads, 0, dev_ctx.stream()>>>(
-                  N * G,
-                  D_HxW_vec,
-                  x_data,
-                  mean_data,
-                  var_data,
-                  static_cast<AccT>(epsilon),
-                  y_data);
+              <<<static_cast<uint32_t>(elem_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(N * G,
+                                     D_HxW_vec,
+                                     x_data,
+                                     mean_data,
+                                     var_data,
+                                     static_cast<AccT>(epsilon),
+                                     y_data);
         } else {
           const int64_t D_total = N * G * D_times_HxW;
           const int64_t elem_blocks =
               std::min((D_total + kElemThreads - 1) / kElemThreads, max_grid_x);
+          PADDLE_ENFORCE_LE_UINT32_MAX(elem_blocks,
+                                       "group_norm no scale bias grid.x");
+          PADDLE_ENFORCE_LE_UINT32_MAX(kElemThreads,
+                                       "group_norm no scale bias block.x");
           GroupNormForwardNoScaleBiasCUDAKernel<T, AccT>
-              <<<elem_blocks, kElemThreads, 0, dev_ctx.stream()>>>(
-                  N * G,
-                  D_times_HxW,
-                  x_data,
-                  mean_data,
-                  var_data,
-                  static_cast<AccT>(epsilon),
-                  y_data);
+              <<<static_cast<uint32_t>(elem_blocks),
+                 static_cast<uint32_t>(kElemThreads),
+                 0,
+                 dev_ctx.stream()>>>(N * G,
+                                     D_times_HxW,
+                                     x_data,
+                                     mean_data,
+                                     var_data,
+                                     static_cast<AccT>(epsilon),
+                                     y_data);
         }
       }
     } else {
@@ -1734,8 +1837,13 @@ void GroupNormGeneralCaseKernel(const Context& dev_ctx,
       block_size_nchw = std::max(block_size_nchw, kps::details::kWarpSize);
       int64_t n_groups = N * static_cast<int64_t>(groups);
       int64_t max_grid_x = dev_ctx.GetCUDAMaxGridDimSize()[0];
-      dim3 grids(std::min(max_grid_x, n_groups));
-      dim3 blocks(block_size_nchw);
+      const int64_t grids_x = std::min(max_grid_x, n_groups);
+      PADDLE_ENFORCE_LE_UINT32_MAX(grids_x,
+                                   "group_norm general mean var grid.x");
+      PADDLE_ENFORCE_LE_UINT32_MAX(block_size_nchw,
+                                   "group_norm general mean var block.x");
+      dim3 grids(static_cast<uint32_t>(grids_x));
+      dim3 blocks(static_cast<uint32_t>(block_size_nchw));
       if (size < vec_size * block_size_nchw) {
         ScalarGetMeanAndVarNCHW<T, AccT>
             <<<grids, blocks, 0, dev_ctx.stream()>>>(
@@ -1746,11 +1854,25 @@ void GroupNormGeneralCaseKernel(const Context& dev_ctx,
                 x_data, mean_data, temp_var_data, size, n_groups);
       }
 
+      int64_t max_grid_y = dev_ctx.GetCUDAMaxGridDimSize()[1];
       int64_t max_grid_z = dev_ctx.GetCUDAMaxGridDimSize()[2];
       int block_size_orig = std::min(static_cast<int64_t>(1024), imsize);
-      dim3 grid(
-          std::min(max_grid_x, group_size), groups, std::min(max_grid_z, N));
-      dim3 threads(block_size_orig, 1, 1);
+      const int64_t grid_x = std::min(max_grid_x, group_size);
+      const int64_t grid_z = std::min(max_grid_z, N);
+      PADDLE_ENFORCE_LE(groups,
+                        max_grid_y,
+                        common::errors::InvalidArgument(
+                            "group_norm general forward grid.y exceeds "
+                            "device limit."));
+      PADDLE_ENFORCE_LE_UINT32_MAX(grid_x, "group_norm general forward grid.x");
+      PADDLE_ENFORCE_LE_UINT32_MAX(groups, "group_norm general forward grid.y");
+      PADDLE_ENFORCE_LE_UINT32_MAX(grid_z, "group_norm general forward grid.z");
+      PADDLE_ENFORCE_LE_UINT32_MAX(block_size_orig,
+                                   "group_norm general forward block.x");
+      dim3 grid(static_cast<uint32_t>(grid_x),
+                static_cast<uint32_t>(groups),
+                static_cast<uint32_t>(grid_z));
+      dim3 threads(static_cast<uint32_t>(block_size_orig), 1, 1);
       int flags = (scale_data != nullptr) * kHasScale +
                   (bias_data != nullptr) * kHasBias;
       UNROLL_ALL_CASES(flags,
@@ -1784,12 +1906,26 @@ void GroupNormGeneralCaseKernel(const Context& dev_ctx,
     set_zero_AccT(dev_ctx, mean, static_cast<AccT>(0));
     set_zero_AccT(dev_ctx, &temp_var, static_cast<AccT>(0));
 
-    int block_size = std::min(static_cast<int64_t>(1024), imsize);
+    int64_t block_size_64 = std::min(static_cast<int64_t>(1024), imsize);
     int64_t max_grid_x = dev_ctx.GetCUDAMaxGridDimSize()[0];
+    int64_t max_grid_y = dev_ctx.GetCUDAMaxGridDimSize()[1];
     int64_t max_grid_z = dev_ctx.GetCUDAMaxGridDimSize()[2];
-    dim3 grid(
-        std::min(max_grid_x, group_size), groups, std::min(max_grid_z, N));
-    dim3 threads(block_size, 1, 1);
+    const int64_t grid_x = std::min(max_grid_x, group_size);
+    const int64_t grid_z = std::min(max_grid_z, N);
+    PADDLE_ENFORCE_LE(groups,
+                      max_grid_y,
+                      common::errors::InvalidArgument(
+                          "group_norm legacy forward grid.y exceeds device "
+                          "limit."));
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_x, "group_norm legacy forward grid.x");
+    PADDLE_ENFORCE_LE_UINT32_MAX(groups, "group_norm legacy forward grid.y");
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_z, "group_norm legacy forward grid.z");
+    PADDLE_ENFORCE_LE_UINT32_MAX(block_size_64,
+                                 "group_norm legacy forward block.x");
+    dim3 grid(static_cast<uint32_t>(grid_x),
+              static_cast<uint32_t>(groups),
+              static_cast<uint32_t>(grid_z));
+    dim3 threads(static_cast<uint32_t>(block_size_64), 1, 1);
 
     GroupNormForwardGetMeanAndVar<T,
                                   AccT><<<grid, threads, 0, dev_ctx.stream()>>>(

--- a/paddle/phi/kernels/gpu/gumbel_softmax_kernel.cu
+++ b/paddle/phi/kernels/gpu/gumbel_softmax_kernel.cu
@@ -61,8 +61,8 @@ __global__ void OneHotCUDAKernel(const int64_t height,
 
   for (int64_t idx = blockIdx.x; idx < height; idx += gridDim.x) {
     KeyValuePair<int64_t, T> kv_pair = {-1, init};
-    int h = idx / size_out_axis;
-    int w = idx % size_out_axis;
+    int64_t h = idx / size_out_axis;
+    int64_t w = idx % size_out_axis;
     cub::ArgMax reducer;
     for (int64_t k = threadIdx.x; k < width; k += blockDim.x) {
       kv_pair = reducer(
@@ -70,7 +70,7 @@ __global__ void OneHotCUDAKernel(const int64_t height,
     }
     kv_pair = BlockReduce(temp_storage).Reduce(kv_pair, reducer);
     if (threadIdx.x == 0) {
-      int index = static_cast<int>(kv_pair.key);
+      int64_t index = kv_pair.key;
       out[h * width * size_out_axis + index * size_out_axis + w] = 1;
     }
     __syncthreads();

--- a/paddle/phi/kernels/gpu/gumbel_softmax_kernel.cu
+++ b/paddle/phi/kernels/gpu/gumbel_softmax_kernel.cu
@@ -83,9 +83,9 @@ struct OneHotGenerator<GPUContext, T> {
                         const DenseTensor& X,
                         DenseTensor* out,
                         int axis) {
-    const int size_to_axis = funcs::SizeToAxis(axis, X.dims());
-    const int size_from_axis = funcs::SizeFromAxis(axis, X.dims());
-    const int size_out_axis = funcs::SizeOutAxis(axis, X.dims());
+    const int64_t size_to_axis = funcs::SizeToAxis(axis, X.dims());
+    const int64_t size_from_axis = funcs::SizeFromAxis(axis, X.dims());
+    const int64_t size_out_axis = funcs::SizeOutAxis(axis, X.dims());
     constexpr int thread_size = 512;
     int64_t max_grid_dimx = dev_ctx.GetCUDAMaxGridDimSize()[0];
     int64_t height = static_cast<int64_t>(size_to_axis) * size_out_axis;
@@ -135,8 +135,8 @@ struct GumbleNoiseGenerator<GPUContext, T> {
   static void Transform(const GPUContext& dev_ctx,
                         const T* input_data,
                         T* output_data,
-                        int size_to_axis,
-                        int size_from_axis,
+                        int64_t size_to_axis,
+                        int64_t size_from_axis,
                         const float temperature) {
     DenseTensor random_tensor;
     int64_t size = static_cast<int64_t>(size_to_axis) * size_from_axis;

--- a/paddle/phi/kernels/gpu/gumbel_softmax_kernel.cu
+++ b/paddle/phi/kernels/gpu/gumbel_softmax_kernel.cu
@@ -19,6 +19,7 @@
 #include "paddle/phi/kernels/impl/gumbel_softmax_kernel_impl.h"
 
 #if defined(__NVCC__) || defined(__HIPCC__)
+#include "paddle/common/enforce.h"
 #include "paddle/phi/core/generator.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/cub.h"
@@ -32,21 +33,18 @@ using KeyValuePair = cub::KeyValuePair<K, V>;
 template <typename T>
 struct UniformCUDAGenerator {
   T min_, max_;
-  unsigned int seed_;
-  unsigned int offset_ = 0;
-  HOSTDEVICE UniformCUDAGenerator(T min, T max, unsigned int seed)
+  uint32_t seed_;
+  uint64_t offset_ = 0;
+  HOSTDEVICE UniformCUDAGenerator(T min, T max, uint32_t seed)
       : min_(min), max_(max), seed_(seed) {}
-  HOSTDEVICE UniformCUDAGenerator(T min,
-                                  T max,
-                                  unsigned int seed,
-                                  unsigned int offset)
+  HOSTDEVICE UniformCUDAGenerator(T min, T max, uint32_t seed, uint64_t offset)
       : min_(min), max_(max), seed_(seed), offset_(offset) {}
 
-  HOSTDEVICE T operator()(const unsigned int n) const {
+  HOSTDEVICE T operator()(const int64_t n) const {
     thrust::minstd_rand rng;
     rng.seed(seed_);
     thrust::uniform_real_distribution<T> dist(min_, max_);
-    rng.discard(n + offset_);
+    rng.discard(static_cast<uint64_t>(n) + offset_);
     return dist(rng);
   }
 };
@@ -90,8 +88,11 @@ struct OneHotGenerator<GPUContext, T> {
     const int size_out_axis = funcs::SizeOutAxis(axis, X.dims());
     constexpr int thread_size = 512;
     int64_t max_grid_dimx = dev_ctx.GetCUDAMaxGridDimSize()[0];
-    int64_t height = size_to_axis * size_out_axis;
-    int block_size = height < max_grid_dimx ? height : max_grid_dimx;
+    int64_t height = static_cast<int64_t>(size_to_axis) * size_out_axis;
+    int64_t block_size_64 = height < max_grid_dimx ? height : max_grid_dimx;
+    PADDLE_ENFORCE_LE_UINT32_MAX(block_size_64,
+                                 "gumbel_softmax one hot grid.x");
+    const uint32_t block_size = static_cast<uint32_t>(block_size_64);
 
     DenseTensor input_tensor;
     input_tensor.Resize(out->dims());
@@ -99,13 +100,15 @@ struct OneHotGenerator<GPUContext, T> {
     Copy(dev_ctx, *out, dev_ctx.GetPlace(), false, &input_tensor);
     funcs::set_constant(dev_ctx, out, static_cast<T>(0.0));
     OneHotCUDAKernel<T, thread_size>
-        <<<block_size, thread_size, 0, dev_ctx.stream()>>>(
-            height,
-            size_from_axis / size_out_axis,
-            size_out_axis,
-            std::numeric_limits<T>::lowest(),
-            input_tensor.data<T>(),
-            out->data<T>());
+        <<<block_size,
+           static_cast<uint32_t>(thread_size),
+           0,
+           dev_ctx.stream()>>>(height,
+                               size_from_axis / size_out_axis,
+                               size_out_axis,
+                               std::numeric_limits<T>::lowest(),
+                               input_tensor.data<T>(),
+                               out->data<T>());
   }
 };
 
@@ -118,7 +121,8 @@ __global__ void AddGumbelNoiseCUDAKernel(const T* input_data,
   int64_t index =
       static_cast<int64_t>(threadIdx.x) +
       static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x);
-  int step = blockDim.x * gridDim.x;
+  int64_t step =
+      static_cast<int64_t>(blockDim.x) * static_cast<int64_t>(gridDim.x);
   for (int64_t i = index; i < n; i += step) {
     MT gumbel_noise = -log(-log(noise[i]));
     output_data[i] = static_cast<T>(
@@ -135,7 +139,7 @@ struct GumbleNoiseGenerator<GPUContext, T> {
                         int size_from_axis,
                         const float temperature) {
     DenseTensor random_tensor;
-    int64_t size = size_to_axis * size_from_axis;
+    int64_t size = static_cast<int64_t>(size_to_axis) * size_from_axis;
     random_tensor.Resize({size});
     using MT = typename MPTypeTrait<T>::Type;
     MT* random_data = dev_ctx.template Alloc<MT>(&random_tensor);
@@ -147,19 +151,26 @@ struct GumbleNoiseGenerator<GPUContext, T> {
     auto seed_offset = gen_cuda->IncrementOffset(1);
     uint64_t seed = seed_offset.first;
     uint64_t offset = seed_offset.second;
+    const uint64_t offset_64 = size * offset;
+    const uint32_t seed_u32 = static_cast<uint32_t>(seed);
 
     thrust::counting_iterator<int64_t> index_sequence_begin(0);
     thrust::transform(
         index_sequence_begin,
         index_sequence_begin + size,
         thrust::device_ptr<MT>(random_data),
-        UniformCUDAGenerator<MT>(0.00001, 1, seed, size * offset));
+        UniformCUDAGenerator<MT>(0.00001, 1, seed_u32, offset_64));
 
     // add gumbel noise to X
     const int thread_size = 512;
-    int64_t block_size = (size + thread_size) / thread_size;
+    int64_t block_size_64 = size / thread_size + (size % thread_size != 0);
+    int64_t max_grid_dim = dev_ctx.GetCUDAMaxGridDimSize()[0];
+    block_size_64 = block_size_64 < max_grid_dim ? block_size_64 : max_grid_dim;
+    PADDLE_ENFORCE_LE_UINT32_MAX(block_size_64, "gumbel_softmax noise grid.x");
+    const uint32_t block_size = static_cast<uint32_t>(block_size_64);
+    constexpr uint32_t thread_size_u32 = static_cast<uint32_t>(thread_size);
     AddGumbelNoiseCUDAKernel<T>
-        <<<block_size, thread_size, 0, dev_ctx.stream()>>>(
+        <<<block_size, thread_size_u32, 0, dev_ctx.stream()>>>(
             input_data, output_data, random_data, temperature, size);
   }
 };

--- a/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
@@ -126,8 +126,9 @@ void GPUIndexElementwiseGetGrad(const GPUContext& dev_ctx,
       common::errors::InvalidArgument("grid_x (%d) is too large to be "
                                       "launched in a CUDA grid.",
                                       grid_x));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_x, "index elementwise get grad grid.x");
   const dim3 block(nt);
-  const dim3 grid(grid_x);
+  const dim3 grid(static_cast<uint32_t>(grid_x));
   auto stream = dev_ctx.stream();
 
   using dtype = funcs::OpaqueType<sizeof(T)>;
@@ -349,14 +350,24 @@ void IndexPutWithSortKernel(const GPUContext& dev_ctx,
     auto max_grid_size =
         backends::gpu::GetGpuMaxGridDimSize(dev_ctx.GetPlace().GetDeviceId());
 
-    dim3 grid(
+    const int64_t grid_x =
         std::min(static_cast<int64_t>(max_grid_size[0]),
-                 (num_indices + INDICES_PER_BLOCK - 1) / INDICES_PER_BLOCK),
+                 (num_indices + INDICES_PER_BLOCK - 1) / INDICES_PER_BLOCK);
+    const int64_t grid_y =
         std::min(static_cast<int64_t>(max_grid_size[1]),
-                 (sliceSize + WARP_SIZE * UNROLL - 1) / (WARP_SIZE * UNROLL)),
-        std::min(std::max(static_cast<int64_t>(1),
-                          static_cast<int64_t>(nElemBefore)),
-                 static_cast<int64_t>(max_grid_size[2])));
+                 (sliceSize + WARP_SIZE * UNROLL - 1) / (WARP_SIZE * UNROLL));
+    const int64_t grid_z = std::min(
+        std::max(static_cast<int64_t>(1), static_cast<int64_t>(nElemBefore)),
+        static_cast<int64_t>(max_grid_size[2]));
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_x,
+                                 "index elementwise get grad sort grid.x");
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_y,
+                                 "index elementwise get grad sort grid.y");
+    PADDLE_ENFORCE_LE_UINT32_MAX(grid_z,
+                                 "index elementwise get grad sort grid.z");
+    dim3 grid(static_cast<uint32_t>(grid_x),
+              static_cast<uint32_t>(grid_y),
+              static_cast<uint32_t>(grid_z));
     dim3 block(WARP_SIZE, INDICES_PER_BLOCK);
 
     IndexingBackwardKernel<T, UNROLL>

--- a/paddle/phi/kernels/gpu/index_elementwise_get_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_kernel.cu
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/index_elementwise_get_kernel.h"
 #include <cstdio>
 
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
@@ -73,7 +74,9 @@ void GPUIndexElementwiseGetKernel(const GPUContext& dev_ctx,
   const dim3 block(nt);
   const int64_t grid_x = (N + block.x * vt - 1) / (block.x * vt);
   const int64_t max_grid_dim = dev_ctx.GetCUDAMaxGridDimSize()[0];
-  const dim3 grid(std::min(max_grid_dim, grid_x));
+  const int64_t grid_x_limit = std::min(max_grid_dim, grid_x);
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_x_limit, "index elementwise get grid.x");
+  const dim3 grid(static_cast<uint32_t>(grid_x_limit));
   auto stream = dev_ctx.stream();
 
   using dtype = funcs::OpaqueType<sizeof(T)>;
@@ -112,7 +115,10 @@ void GPUIndexElementwiseGetKernel(const GPUContext& dev_ctx,
       const int64_t end_idx = std::min((chunk + 1) * max_grid_dim * nt * vt, N);
       const int64_t chunk_size = end_idx - start_idx;
       const int64_t chunk_grid_x = (chunk_size + nt * vt - 1) / (nt * vt);
-      const dim3 chunk_grid(std::min(chunk_grid_x, max_grid_dim));
+      const int64_t chunk_grid_x_limit = std::min(chunk_grid_x, max_grid_dim);
+      PADDLE_ENFORCE_LE_UINT32_MAX(chunk_grid_x_limit,
+                                   "index elementwise get chunk grid.x");
+      const dim3 chunk_grid(static_cast<uint32_t>(chunk_grid_x_limit));
 
       funcs::index_elementwise_with_tensor_kernel<nt, vt>
           <<<chunk_grid, block, 0, stream>>>(

--- a/paddle/phi/kernels/gpu/index_elementwise_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_put_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/index_elementwise_put_kernel.h"
 
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/index_elementwise.cu.h"
@@ -91,7 +92,13 @@ void GPUIndexElementwisePutKernel(const GPUContext& dev_ctx,
   constexpr int nt = 128;
   constexpr int vt = 4;
   const dim3 block(nt);
-  const dim3 grid((N + block.x * vt - 1) / (block.x * vt));
+  const int64_t grid_x = (N + block.x * vt - 1) / (block.x * vt);
+  PADDLE_ENFORCE_LE(grid_x,
+                    dev_ctx.GetCUDAMaxGridDimSize()[0],
+                    common::errors::InvalidArgument(
+                        "index elementwise put grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_x, "index elementwise put grid.x");
+  const dim3 grid(static_cast<uint32_t>(grid_x));
   auto stream = dev_ctx.stream();
 
   char* out_ptr = reinterpret_cast<char*>(output_);

--- a/paddle/phi/kernels/gpu/index_elementwise_put_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_put_kernel.cu
@@ -204,7 +204,13 @@ void GPUIndexElementwisePutWithTensorKernel(
   constexpr int nt = 128;
   constexpr int vt = 4;
   const dim3 block(nt);
-  const dim3 grid((N + block.x * vt - 1) / (block.x * vt));
+  const int64_t grid_x = (N + block.x * vt - 1) / (block.x * vt);
+  PADDLE_ENFORCE_LE(grid_x,
+                    dev_ctx.GetCUDAMaxGridDimSize()[0],
+                    common::errors::InvalidArgument(
+                        "index elementwise put grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_x, "index elementwise put grid.x");
+  const dim3 grid(static_cast<uint32_t>(grid_x));
   auto stream = dev_ctx.stream();
 
   using dtype = funcs::OpaqueType<sizeof(T)>;

--- a/paddle/phi/kernels/gpu/index_sample_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_sample_kernel.cu
@@ -89,7 +89,10 @@ void IndexSampleKernel(const Context& dev_ctx,
   int64_t block_height =
       backends::gpu::RoundToPowerOfTwo(index_length * batch_size) / block_width;
   block_height = MIN(block_height, PREDEFINED_BLOCK_SIZE / block_width);
-  dim3 block_dim(block_width, block_height);
+  PADDLE_ENFORCE_LE_UINT32_MAX(block_width, "index sample block.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(block_height, "index sample block.y");
+  dim3 block_dim(static_cast<uint32_t>(block_width),
+                 static_cast<uint32_t>(block_height));
   const uint64_t grid_x = (index_length + block_dim.x - 1) / block_dim.x;
   const uint64_t grid_y = (batch_size + block_dim.y - 1) / block_dim.y;
   PADDLE_ENFORCE_LE_UINT32_MAX(grid_x, "grid.x");

--- a/paddle/phi/kernels/gpu/min_max_with_index_kernel.cu
+++ b/paddle/phi/kernels/gpu/min_max_with_index_kernel.cu
@@ -21,6 +21,7 @@
 #include <limits>
 
 #include "paddle/common/ddim.h"
+#include "paddle/common/enforce.h"
 #include "paddle/phi/core/utils/data_type.h"
 #include "paddle/phi/kernels/funcs/cub.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
@@ -112,7 +113,9 @@ void ComputeMinMaxWithIndex(const GPUContext& dev_ctx,
   int64_t max_grid_dimx = dev_ctx.GetCUDAMaxGridDimSize()[0];
   int64_t height = pre * post;
   int64_t width = n;
-  int64_t grid_size = height < max_grid_dimx ? height : max_grid_dimx;
+  int64_t grid_size_64 = height < max_grid_dimx ? height : max_grid_dimx;
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_size_64, "MinMaxWithIndexKernel grid.x");
+  uint32_t grid_size = static_cast<uint32_t>(grid_size_64);
 
   const T* in_data = input.data<T>();
 

--- a/paddle/phi/kernels/gpu/multinomial_kernel.cu
+++ b/paddle/phi/kernels/gpu/multinomial_kernel.cu
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/phi/kernels/multinomial_kernel.h"
 #include "paddle/common/ddim.h"
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/scalar.h"
@@ -174,6 +175,9 @@ void MultinomialKernel(const Context& dev_ctx,
     return;
   }
 
+  PADDLE_ENFORCE_LE_INT_MAX(num_categories, "num_categories");
+  const int num_categories_int = static_cast<int>(num_categories);
+
   // Sum of input may not be 1. To get probability in range [0, 1], calculate
   // sum of each row of input, and then use the sum to normalize the input.
   // sum_row_data: sum of each row
@@ -205,9 +209,20 @@ void MultinomialKernel(const Context& dev_ctx,
   norm_probs_tensor.Resize({num_distributions, num_categories});
   auto* norm_probs_data = dev_ctx.template Alloc<MT>(&norm_probs_tensor);
   // number of threads in a block is min(num_categories, 512)
-  int block_size = num_categories < 512 ? num_categories : 512;
-  dim3 block_norm(block_size);
-  dim3 grid_norm((num_distributions * num_categories - 1) / block_norm.x + 1);
+  int block_size = num_categories_int < 512 ? num_categories_int : 512;
+  PADDLE_ENFORCE_LE_UINT32_MAX(block_size, "multinomial normalize block.x");
+  dim3 block_norm(static_cast<uint32_t>(block_size));
+  int64_t norm_numel = x.numel();
+  int64_t grid_norm_x_64 =
+      norm_numel / block_norm.x + (norm_numel % block_norm.x != 0);
+  int64_t device_id = dev_ctx.GetPlace().GetDeviceId();
+  const auto& prop = backends::gpu::GetDeviceProperties(device_id);
+  PADDLE_ENFORCE_LE(grid_norm_x_64,
+                    prop.maxGridSize[0],
+                    common::errors::InvalidArgument(
+                        "multinomial normalize grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_norm_x_64, "multinomial normalize grid.x");
+  dim3 grid_norm(static_cast<uint32_t>(grid_norm_x_64));
 
   NormalizeProbability<T, MT>
       <<<grid_norm, block_norm, 0, dev_ctx.stream()>>>(norm_probs_data,
@@ -235,14 +250,19 @@ void MultinomialKernel(const Context& dev_ctx,
       dev_ctx);
   // Sample the multinomial distributions.
   dim3 block(128);
-  int64_t device_id = dev_ctx.GetPlace().GetDeviceId();
-  const auto& prop = backends::gpu::GetDeviceProperties(device_id);
-  int grid_y = std::min<int64_t>(num_distributions, prop.maxGridSize[1]);
-  dim3 grid((int_num_samples - 1) / block.x + 1, grid_y);
+  int64_t grid_y_64 = std::min<int64_t>(num_distributions, prop.maxGridSize[1]);
+  int64_t grid_x_64 = (int_num_samples - 1) / block.x + 1;
+  PADDLE_ENFORCE_LE(grid_x_64,
+                    prop.maxGridSize[0],
+                    common::errors::InvalidArgument(
+                        "multinomial sample grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_x_64, "multinomial sample grid.x");
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_y_64, "multinomial sample grid.y");
+  dim3 grid(static_cast<uint32_t>(grid_x_64), static_cast<uint32_t>(grid_y_64));
 
   auto gen_cuda = dev_ctx.GetGenerator();
   size_t curand4_loop_times =
-      (num_distributions + 4 * grid_y - 1) / (4 * grid_y);
+      (num_distributions + 4 * grid_y_64 - 1) / (4 * grid_y_64);
   // 'increment' should be multiple of 4
   uint64_t increment = curand4_loop_times * 4;
   auto seed_offset = gen_cuda->IncrementOffset(increment);
@@ -251,7 +271,7 @@ void MultinomialKernel(const Context& dev_ctx,
       <<<grid, block, 0, dev_ctx.stream()>>>(int_num_samples,
                                              out_data,
                                              num_distributions,
-                                             num_categories,
+                                             num_categories_int,
                                              cumulative_probs_data,
                                              norm_probs_data,
                                              seed_offset.first,

--- a/paddle/phi/kernels/gpu/pad3d_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/pad3d_grad_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/pad3d_grad_kernel.h"
 
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -359,10 +360,17 @@ void Pad3dGradKernel(const Context& dev_ctx,
   const int64_t num = d_in_dims[0];
 
   auto stream = dev_ctx.stream();
-  int block = PADDLE_CUDA_NUM_THREADS;
+  uint32_t block = PADDLE_CUDA_NUM_THREADS;
   const size_t out_size = d_out->numel();
   const size_t in_size = d_in->numel();
-  uint32_t grid = (out_size + block - 1) / block;
+  size_t grid_64 = (out_size + block - 1) / block;
+  uint32_t max_grid_dim = dev_ctx.GetCUDAMaxGridDimSize()[0];
+  PADDLE_ENFORCE_LE(grid_64,
+                    max_grid_dim,
+                    common::errors::InvalidArgument(
+                        "pad3d grad grid.x exceeds device limit."));
+  PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "pad3d grad grid.x");
+  uint32_t grid = static_cast<uint32_t>(grid_64);
 
   bool use_int32_index = true;
   if (out_size > std::numeric_limits<int32_t>::max()) {
@@ -434,7 +442,13 @@ void Pad3dGradKernel(const Context& dev_ctx,
                                          pad_left,
                                          d_out_data);
       } else {
-        grid = (in_size + block - 1) / block;
+        grid_64 = (in_size + block - 1) / block;
+        PADDLE_ENFORCE_LE(grid_64,
+                          max_grid_dim,
+                          common::errors::InvalidArgument(
+                              "pad3d grad const grid.x exceeds device limit."));
+        PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "pad3d grad const grid.x");
+        grid = static_cast<uint32_t>(grid_64);
         Pad3DGradConstNCDHW<T, int32_t><<<grid, block, 0, stream>>>(in_size,
                                                                     d_in_data,
                                                                     num,
@@ -507,7 +521,13 @@ void Pad3dGradKernel(const Context& dev_ctx,
                                          pad_left,
                                          d_out_data);
       } else {
-        grid = (in_size + block - 1) / block;
+        grid_64 = (in_size + block - 1) / block;
+        PADDLE_ENFORCE_LE(grid_64,
+                          max_grid_dim,
+                          common::errors::InvalidArgument(
+                              "pad3d grad const grid.x exceeds device limit."));
+        PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "pad3d grad const grid.x");
+        grid = static_cast<uint32_t>(grid_64);
         Pad3DGradConstNDHWC<T, int32_t><<<grid, block, 0, stream>>>(in_size,
                                                                     d_in_data,
                                                                     num,
@@ -584,7 +604,13 @@ void Pad3dGradKernel(const Context& dev_ctx,
                                          pad_left,
                                          d_out_data);
       } else {
-        grid = (in_size + block - 1) / block;
+        grid_64 = (in_size + block - 1) / block;
+        PADDLE_ENFORCE_LE(grid_64,
+                          max_grid_dim,
+                          common::errors::InvalidArgument(
+                              "pad3d grad const grid.x exceeds device limit."));
+        PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "pad3d grad const grid.x");
+        grid = static_cast<uint32_t>(grid_64);
         Pad3DGradConstNCDHW<T, int64_t><<<grid, block, 0, stream>>>(in_size,
                                                                     d_in_data,
                                                                     num,
@@ -657,7 +683,13 @@ void Pad3dGradKernel(const Context& dev_ctx,
                                          pad_left,
                                          d_out_data);
       } else {
-        grid = (in_size + block - 1) / block;
+        grid_64 = (in_size + block - 1) / block;
+        PADDLE_ENFORCE_LE(grid_64,
+                          max_grid_dim,
+                          common::errors::InvalidArgument(
+                              "pad3d grad const grid.x exceeds device limit."));
+        PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "pad3d grad const grid.x");
+        grid = static_cast<uint32_t>(grid_64);
         Pad3DGradConstNDHWC<T, int64_t><<<grid, block, 0, stream>>>(in_size,
                                                                     d_in_data,
                                                                     num,

--- a/paddle/phi/kernels/gpu/pad3d_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/pad3d_grad_kernel.cu
@@ -365,10 +365,7 @@ void Pad3dGradKernel(const Context& dev_ctx,
   const size_t in_size = d_in->numel();
   size_t grid_64 = (out_size + block - 1) / block;
   uint32_t max_grid_dim = dev_ctx.GetCUDAMaxGridDimSize()[0];
-  PADDLE_ENFORCE_LE(grid_64,
-                    max_grid_dim,
-                    common::errors::InvalidArgument(
-                        "pad3d grad grid.x exceeds device limit."));
+  grid_64 = std::min(grid_64, static_cast<size_t>(max_grid_dim));
   PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "pad3d grad grid.x");
   uint32_t grid = static_cast<uint32_t>(grid_64);
 
@@ -443,10 +440,7 @@ void Pad3dGradKernel(const Context& dev_ctx,
                                          d_out_data);
       } else {
         grid_64 = (in_size + block - 1) / block;
-        PADDLE_ENFORCE_LE(grid_64,
-                          max_grid_dim,
-                          common::errors::InvalidArgument(
-                              "pad3d grad const grid.x exceeds device limit."));
+        grid_64 = std::min(grid_64, static_cast<size_t>(max_grid_dim));
         PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "pad3d grad const grid.x");
         grid = static_cast<uint32_t>(grid_64);
         Pad3DGradConstNCDHW<T, int32_t><<<grid, block, 0, stream>>>(in_size,
@@ -522,10 +516,7 @@ void Pad3dGradKernel(const Context& dev_ctx,
                                          d_out_data);
       } else {
         grid_64 = (in_size + block - 1) / block;
-        PADDLE_ENFORCE_LE(grid_64,
-                          max_grid_dim,
-                          common::errors::InvalidArgument(
-                              "pad3d grad const grid.x exceeds device limit."));
+        grid_64 = std::min(grid_64, static_cast<size_t>(max_grid_dim));
         PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "pad3d grad const grid.x");
         grid = static_cast<uint32_t>(grid_64);
         Pad3DGradConstNDHWC<T, int32_t><<<grid, block, 0, stream>>>(in_size,
@@ -605,10 +596,7 @@ void Pad3dGradKernel(const Context& dev_ctx,
                                          d_out_data);
       } else {
         grid_64 = (in_size + block - 1) / block;
-        PADDLE_ENFORCE_LE(grid_64,
-                          max_grid_dim,
-                          common::errors::InvalidArgument(
-                              "pad3d grad const grid.x exceeds device limit."));
+        grid_64 = std::min(grid_64, static_cast<size_t>(max_grid_dim));
         PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "pad3d grad const grid.x");
         grid = static_cast<uint32_t>(grid_64);
         Pad3DGradConstNCDHW<T, int64_t><<<grid, block, 0, stream>>>(in_size,
@@ -684,10 +672,7 @@ void Pad3dGradKernel(const Context& dev_ctx,
                                          d_out_data);
       } else {
         grid_64 = (in_size + block - 1) / block;
-        PADDLE_ENFORCE_LE(grid_64,
-                          max_grid_dim,
-                          common::errors::InvalidArgument(
-                              "pad3d grad const grid.x exceeds device limit."));
+        grid_64 = std::min(grid_64, static_cast<size_t>(max_grid_dim));
         PADDLE_ENFORCE_LE_UINT32_MAX(grid_64, "pad3d grad const grid.x");
         grid = static_cast<uint32_t>(grid_64);
         Pad3DGradConstNDHWC<T, int64_t><<<grid, block, 0, stream>>>(in_size,

--- a/paddle/phi/kernels/gpu/top_k_kernel.cu
+++ b/paddle/phi/kernels/gpu/top_k_kernel.cu
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #include "paddle/phi/kernels/top_k_kernel.h"
 
 #include "glog/logging.h"

--- a/paddle/phi/kernels/impl/gumbel_softmax_kernel_impl.h
+++ b/paddle/phi/kernels/impl/gumbel_softmax_kernel_impl.h
@@ -77,8 +77,8 @@ void GumbelSoftmaxKernelHelper(const Context& dev_ctx,
   // TODO(large-tensor): SoftmaxFunctor not support int64
   PADDLE_ENFORCE_LE_INT_MAX(axis_dim, "axis_dim");
 
-  const int size_to_axis = funcs::SizeToAxis(axis, x.dims());
-  const int size_from_axis = funcs::SizeFromAxis(axis, x.dims());
+  const int64_t size_to_axis = funcs::SizeToAxis(axis, x.dims());
+  const int64_t size_from_axis = funcs::SizeFromAxis(axis, x.dims());
   DenseTensor x_noise_2d, out_2d(*out);
   x_noise_2d.Resize({size_to_axis, size_from_axis});
   out_2d.Resize({size_to_axis, size_from_axis});


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
 Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
This PR updates CUDA kernel launch configuration in the `paddle/phi/kernels/funcs` module.                                     
The changes add explicit `UINT32_MAX` and device-limit checks for CUDA grid/block dimensions before kernel launches, and cast the validated launch parameters to `uint32_t`. This avoids implicit narrowing when `int64_t` or `size_t` values are passed as  CUDA launch dimensions.                                                                 
This PR is split from #79333 by directory/module scope to reduce review size. The changes are limited to CUDA launch 
 configuration handling and do not intend to change operator algorithms or numerical behavior.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否