### PR TITLE
[release/3.4][Environment] align CUDA 13 wheel dependencies with torch

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -706,37 +706,18 @@ def get_paddle_extra_install_requirements():
                 "cuda-python==12.9.4; platform_system == 'Linux' and platform_machine == 'x86_64'"
             ),
             "13.0": (
-                "nvidia-cuda-nvrtc==13.0.88; platform_system == 'Linux' | "
-                "nvidia-cuda-runtime==13.0.88; platform_system == 'Linux' | "
-                "nvidia-cuda-cupti==13.0.85; platform_system == 'Linux' | "
-                "nvidia-cudnn-cu13==9.15.1.9; platform_system == 'Linux' | "
-                "nvidia-cublas==13.1.0.3; platform_system == 'Linux' | "
-                "nvidia-cufft==12.0.0.61; platform_system == 'Linux' | "
-                "nvidia-curand==10.4.0.35; platform_system == 'Linux' | "
-                "nvidia-cusolver==12.0.4.66; platform_system == 'Linux' | "
-                "nvidia-cusparse==12.6.3.3; platform_system == 'Linux' | "
+                "cuda-toolkit[cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == 'Linux' | "
+                "nvidia-cublas<=13.1.1.3,>=13.1.0.3; platform_system == 'Linux' | "
+                "nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | "
                 "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "
-                "nvidia-nccl-cu13==2.28.3; platform_system == 'Linux' | "
-                "nvidia-nvtx==13.0.85; platform_system == 'Linux' | "
-                "nvidia-nvjitlink==13.0.88; platform_system == 'Linux' | "
-                "nvidia-cufile==1.15.1.6; platform_system == 'Linux' | "
+                "nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | "
                 "cuda-python==13.0.3; platform_system == 'Linux'"
             ),
             "13.2": (
-                "nvidia-cuda-nvrtc==13.2.78; platform_system == 'Linux' | "
-                "nvidia-cuda-runtime==13.2.75; platform_system == 'Linux' | "
-                "nvidia-cuda-cupti==13.2.75; platform_system == 'Linux' | "
-                "nvidia-cudnn-cu13==9.21.0.82; platform_system == 'Linux' | "
-                "nvidia-cublas==13.4.0.1; platform_system == 'Linux' | "
-                "nvidia-cufft==12.2.0.46; platform_system == 'Linux' | "
-                "nvidia-curand==10.4.2.55; platform_system == 'Linux' | "
-                "nvidia-cusolver==12.2.0.1; platform_system == 'Linux' | "
-                "nvidia-cusparse==12.7.10.1; platform_system == 'Linux' | "
-                "nvidia-cusparselt-cu13==0.9.0; platform_system == 'Linux' | "
+                "cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.2.1; platform_system == 'Linux' | "
+                "nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | "
+                "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "
                 "nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | "
-                "nvidia-nvtx==13.2.75; platform_system == 'Linux' | "
-                "nvidia-nvjitlink==13.2.78; platform_system == 'Linux' | "
-                "nvidia-cufile==1.17.1.22; platform_system == 'Linux' | "
                 "cuda-python==13.2.0; platform_system == 'Linux'"
             ),
         }
@@ -757,10 +738,10 @@ def get_paddle_extra_install_requirements():
                     " | nvidia-cuda-cccl-cu12==12.9.27;platform_system == 'Linux' and platform_machine == 'x86_64' "
             )
             PADDLE_CUDA_INSTALL_REQUIREMENTS["13.0"] += (
-                    " | nvidia-cuda-cccl==13.0.85;platform_system == 'Linux' "
+                    " | cuda-toolkit[cccl]==13.0.2;platform_system == 'Linux' "
             )
             PADDLE_CUDA_INSTALL_REQUIREMENTS["13.2"] += (
-                    " | nvidia-cuda-cccl==13.2.75;platform_system == 'Linux' "
+                    " | cuda-toolkit[cccl]==13.2.1;platform_system == 'Linux' "
             )
         elif platform.system() == 'Windows':
             PADDLE_CUDA_INSTALL_REQUIREMENTS = {

--- a/setup.py
+++ b/setup.py
@@ -1205,37 +1205,18 @@ def get_paddle_extra_install_requirements():
                     "cuda-python==12.9.4; platform_system == 'Linux' and platform_machine == 'x86_64'"
                 ),
                 "13.0": (
-                    "nvidia-cuda-nvrtc==13.0.88; platform_system == 'Linux' | "
-                    "nvidia-cuda-runtime==13.0.88; platform_system == 'Linux' | "
-                    "nvidia-cuda-cupti==13.0.85; platform_system == 'Linux' | "
-                    "nvidia-cudnn-cu13==9.15.1.9; platform_system == 'Linux' | "
-                    "nvidia-cublas==13.1.0.3; platform_system == 'Linux' | "
-                    "nvidia-cufft==12.0.0.61; platform_system == 'Linux' | "
-                    "nvidia-curand==10.4.0.35; platform_system == 'Linux' | "
-                    "nvidia-cusolver==12.0.4.66; platform_system == 'Linux' | "
-                    "nvidia-cusparse==12.6.3.3; platform_system == 'Linux' | "
+                    "cuda-toolkit[cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2; platform_system == 'Linux' | "
+                    "nvidia-cublas<=13.1.1.3,>=13.1.0.3; platform_system == 'Linux' | "
+                    "nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | "
                     "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "
-                    "nvidia-nccl-cu13==2.28.3; platform_system == 'Linux' | "
-                    "nvidia-nvtx==13.0.85; platform_system == 'Linux' | "
-                    "nvidia-nvjitlink==13.0.88; platform_system == 'Linux' | "
-                    "nvidia-cufile==1.15.1.6; platform_system == 'Linux' | "
+                    "nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | "
                     "cuda-python==13.0.3; platform_system == 'Linux'"
                 ),
                 "13.2": (
-                    "nvidia-cuda-nvrtc==13.2.78; platform_system == 'Linux' | "
-                    "nvidia-cuda-runtime==13.2.75; platform_system == 'Linux' | "
-                    "nvidia-cuda-cupti==13.2.75; platform_system == 'Linux' | "
-                    "nvidia-cudnn-cu13==9.21.0.82; platform_system == 'Linux' | "
-                    "nvidia-cublas==13.4.0.1; platform_system == 'Linux' | "
-                    "nvidia-cufft==12.2.0.46; platform_system == 'Linux' | "
-                    "nvidia-curand==10.4.2.55; platform_system == 'Linux' | "
-                    "nvidia-cusolver==12.2.0.1; platform_system == 'Linux' | "
-                    "nvidia-cusparse==12.7.10.1; platform_system == 'Linux' | "
-                    "nvidia-cusparselt-cu13==0.9.0; platform_system == 'Linux' | "
+                    "cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.2.1; platform_system == 'Linux' | "
+                    "nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | "
+                    "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "
                     "nvidia-nccl-cu13==2.29.7; platform_system == 'Linux' | "
-                    "nvidia-nvtx==13.2.75; platform_system == 'Linux' | "
-                    "nvidia-nvjitlink==13.2.78; platform_system == 'Linux' | "
-                    "nvidia-cufile==1.17.1.22; platform_system == 'Linux' | "
                     "cuda-python==13.2.0; platform_system == 'Linux'"
                 ),
             }
@@ -1256,10 +1237,10 @@ def get_paddle_extra_install_requirements():
                     " | nvidia-cuda-cccl-cu12==12.9.27;platform_system == 'Linux' and platform_machine == 'x86_64' "
                 )
                 PADDLE_CUDA_INSTALL_REQUIREMENTS["13.0"] += (
-                    " | nvidia-cuda-cccl==13.0.85;platform_system == 'Linux' "
+                    " | cuda-toolkit[cccl]==13.0.2;platform_system == 'Linux' "
                 )
                 PADDLE_CUDA_INSTALL_REQUIREMENTS["13.2"] += (
-                    " | nvidia-cuda-cccl==13.2.75;platform_system == 'Linux' "
+                    " | cuda-toolkit[cccl]==13.2.1;platform_system == 'Linux' "
                 )
 
         elif platform.system() == 'Windows':


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Improvements

### Description
本 PR 将 Paddle wheel 中 Linux CUDA 13.0 和 CUDA 13.2 对应的 Python 依赖声明与 PyTorch 2.12.0 的 CUDA wheel 元数据对齐，使用 cuda-toolkit[...] 聚合依赖替代原来逐项声明的 CUDA toolkit 组件，避免手工维护这些组件版本。

主要改动：
- CUDA 13.0：用 cuda-toolkit[cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.0.2 替代原有 CUDA toolkit 组件包，并按 torch metadata 对齐 cublas、cuDNN、cuSPARSELt、NCCL 版本；保留 Paddle 原有 cuda-python 依赖。
- CUDA 13.2：用 cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.2.1 替代原有 CUDA toolkit 组件包，并按 torch metadata 对齐 cuDNN、cuSPARSELt、NCCL 版本；保留 Paddle 原有 cuda-python 依赖。
- WITH_CINN 场景下的 CUDA 13 CCCL 依赖改为 cuda-toolkit[cccl] 写法，保持与 cuda-toolkit 聚合依赖风格一致。
- 未新增 cuda-bindings、nvidia-nvshmem-cu13 等 Paddle 原先未声明的额外依赖。
- 同步更新生成后的 setup.py 和模板 python/setup.py.in 中的依赖声明。

参考来源：
- torch-2.12.0+cu130 Linux wheel metadata
- torch-2.12.0+cu132 Linux wheel metadata

已验证：
- prek --files python/setup.py.in setup.py
- git diff --check -- python/setup.py.in setup.py
- python -m py_compile setup.py
- 使用 pip vendored packaging 解析新增 requirement 字符串

### 是否引起精度变化
否。该改动仅调整 wheel 安装依赖声明，不涉及算子实现、训练逻辑或数值计算路径。

---

Cherry-pick of #79329 (authored by @gouzil) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79329 <!-- For pass CI -->