### PR TITLE
[release/3.4][SOT][CI] del Python 3.14 numpy special treatment

### DIFF
--- a/ci/run_sot_test.sh
+++ b/ci/run_sot_test.sh
@@ -42,15 +42,6 @@ function run_sot_test() {
     run_and_check "Installing paddle wheel..." \
         $PYTHON_WITH_SPECIFY_VERSION -m pip install ${PADDLE_ROOT}/dist/paddlepaddle-0.0.0-cp${PY_VERSION_NO_DOT}-cp${PY_VERSION_NO_DOT}-linux_x86_64.whl
 
-    # Only python3.14 needs to install numpy>=2.3.5, because opencv-python will downgrade numpy to 2.2.6
-    # see: https://github.com/opencv/opencv-python/issues/1155
-    if [ "$PY_VERSION" == "3.14" ]; then
-        run_and_check "Uninstalling numpy for Python 3.14..." \
-            $PYTHON_WITH_SPECIFY_VERSION -m pip uninstall -y "numpy"
-        run_and_check "Installing numpy>=2.3.5 for Python 3.14..." \
-            $PYTHON_WITH_SPECIFY_VERSION -m pip install --force-reinstall --no-cache-dir "numpy>=2.3.5"
-    fi
-
     # cd to sot test dir
     cd $PADDLE_ROOT/test/sot/
 

--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -3,7 +3,7 @@ coverage==7.10.7
 mock
 gymnasium>=1.1.1
 hypothesis<6.145.0
-opencv-python>= 4.10.0.84
+opencv-python>= 4.13.0.90
 visualdl==2.5.3
 paddle2onnx>=0.9.6; python_version < "3.12"
 triton ; platform_system == 'Linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you’ve done -->
在 [opencv 4.13.0.90](https://github.com/opencv/opencv-python/releases/tag/90) 已经支持了 Python3.14, 并且也不会跟numpy 冲突了，所以就去掉这个特殊步骤

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

---

Cherry-pick of #79379 (authored by @gouzil) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79379 <!-- For pass CI -->