### PR TITLE
[CodeStyle][Ast-grep] Bump ast-grep to v0.44.0

### DIFF
--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install pre-commit==2.17.0
-          pip install ast-grep-cli==0.42.1 # This version should be consistent with the one in .pre-commit-config.yaml
+          pip install ast-grep-cli==0.44.0 # This version should be consistent with the one in .pre-commit-config.yaml
 
       - name: Run ast-grep unit tests
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         files: \.sh$
         args: [--whitespaces-count, '4']
   - repo: https://github.com/PFCCLab/ast-grep-pre-commit-mirror
-    rev: v0.42.1
+    rev: v0.44.0
     hooks:
       - id: ast-grep
   - repo: local


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
Devs

### Description
升级代码风格检查使用的 `ast-grep` 到 `v0.44.0`：

- 将 `.pre-commit-config.yaml` 中 `PFCCLab/ast-grep-pre-commit-mirror` 更新到 `v0.44.0`
- 将 Codestyle-Check workflow 中用于 `ast-grep test` 的 `ast-grep-cli` 更新到 `0.44.0`

同步说明：PaddlePaddle/docs#7908 已追加普通增量 commit，将代码风格指南中的 `ast-grep` 版本同步到 `0.44.0`。

本地验证：

- `ast-grep test`
- `pre-commit run ast-grep --all-files`
- `git diff --check -- .pre-commit-config.yaml .github/workflows/Codestyle-Check.yml`

### 是否引起精度变化
否
