### PR TITLE
[API Compatibility] Bug Fix

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1619,8 +1619,9 @@ PYBIND11_MODULE(libpaddle, m) {
       .def(py::init<const DataType &>())
       .def_property_readonly("min",
                              [](const iinfo &a) { return py::int_(a.min); })
-      .def_property_readonly("max",
-                             [](const iinfo &a) { return py::int_(a.max); })
+      .def_property_readonly(
+          "max",
+          [](const iinfo &a) { return py::cast(static_cast<uint64_t>(a.max)); })
       .def_readonly("bits", &iinfo::bits)
       .def_readonly("dtype", &iinfo::dtype)
       .def("__repr__", [](const iinfo &a) {


### PR DESCRIPTION
### PR Category
  User Experience

### PR Types
  New features

### Description

iinfo.max 在 C++ 里应该是 uint64_t，但 Python 绑定时用了 py::int_(a.max) 。在 paconvert 测试 uint64 最大值 18446744073709551615 这个边界情况，它被按有符号方式解释，Python 侧变成了 -1。

### 是否引起精度变化
否

😺 