### PR TITLE
Fix Mac CPU C++20 warnings

### DIFF
--- a/paddle/fluid/framework/blocking_queue.h
+++ b/paddle/fluid/framework/blocking_queue.h
@@ -93,7 +93,7 @@ class BlockingQueue {
 
   T Pop() {
     std::unique_lock<std::mutex> lock(mutex_);
-    cv_.wait(lock, [=] { return !q_.empty(); });
+    cv_.wait(lock, [this] { return !q_.empty(); });
     T rc(std::move(q_.front()));
     q_.pop_front();
     return rc;
@@ -101,7 +101,7 @@ class BlockingQueue {
 
   void Pop(T *t) {
     std::unique_lock<std::mutex> lock(mutex_);
-    cv_.wait(lock, [=] { return !q_.empty(); });
+    cv_.wait(lock, [this] { return !q_.empty(); });
     *t = std::move(q_.front());
     q_.pop_front();
   }

--- a/paddle/fluid/framework/device_worker.cc
+++ b/paddle/fluid/framework/device_worker.cc
@@ -107,7 +107,7 @@ void PrintDenseTensorType<float>(DenseTensor* tensor,
       out_val += "0";
     } else {
       std::string format = "%." + std::to_string(num_decimals) + "f";
-      sprintf(buf, &format[0], tensor->data<float>()[i]);  // NOLINT
+      snprintf(buf, sizeof(buf), format.c_str(), tensor->data<float>()[i]);
       out_val += buf;
     }
   }

--- a/paddle/fluid/framework/ir/graph_traits.h
+++ b/paddle/fluid/framework/ir/graph_traits.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <iterator>
 #include <stack>
 #include <unordered_set>
 #include <utility>
@@ -48,8 +50,13 @@ class iterator_range {
 };
 
 // DFS iterator on nodes.
-struct NodesDFSIterator
-    : public std::iterator<std::forward_iterator_tag, Node *> {
+struct NodesDFSIterator {
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = Node;
+  using difference_type = std::ptrdiff_t;
+  using pointer = Node *;
+  using reference = Node &;
+
   NodesDFSIterator() = default;
   explicit NodesDFSIterator(const std::vector<Node *> &source);
   NodesDFSIterator(NodesDFSIterator &&other) noexcept;
@@ -71,8 +78,13 @@ struct NodesDFSIterator
 };
 
 // Topological sorting iterator on nodes.
-struct NodesTSIterator
-    : public std::iterator<std::forward_iterator_tag, Node *> {
+struct NodesTSIterator {
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = Node;
+  using difference_type = std::ptrdiff_t;
+  using pointer = Node *;
+  using reference = Node &;
+
   NodesTSIterator() = default;
   explicit NodesTSIterator(const std::vector<Node *> &source);
   NodesTSIterator(NodesTSIterator &&other)

--- a/paddle/fluid/framework/ir/memory_optimize_pass/reference_count_pass_helper.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/reference_count_pass_helper.cc
@@ -17,13 +17,13 @@
 namespace paddle::framework::ir {
 
 VarDesc *TryGetLatestVarDesc(const std::vector<details::VarHandle *> &vars) {
-  VarDesc *var_desc = nullptr;
-  std::find_if(
-      vars.rbegin(), vars.rend(), [&](details::VarHandle *var_handle) -> bool {
-        var_desc = var_handle->Node()->Var();
-        return var_desc != nullptr;
-      });
-  return var_desc;
+  for (auto iter = vars.rbegin(); iter != vars.rend(); ++iter) {
+    auto *var_desc = (*iter)->Node()->Var();
+    if (var_desc != nullptr) {
+      return var_desc;
+    }
+  }
+  return nullptr;
 }
 
 }  // namespace paddle::framework::ir

--- a/paddle/fluid/framework/ir/memory_optimize_pass/reference_count_pass_helper.h
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/reference_count_pass_helper.h
@@ -25,6 +25,7 @@
 #include "paddle/fluid/framework/details/computation_op_handle.h"
 #include "paddle/fluid/framework/details/var_handle.h"
 #include "paddle/fluid/framework/garbage_collector.h"
+#include "paddle/utils/test_macros.h"
 
 namespace paddle {
 namespace framework {
@@ -46,27 +47,28 @@ const char kUseCuda[] = "use_cuda";
 
 class LastLiveOpOfVarInfo {
  public:
-  details::VarHandle *var() { return var_; }
+  details::VarHandle* var() { return var_; }
 
-  void set_var(details::VarHandle *var) { var_ = var; }
+  void set_var(details::VarHandle* var) { var_ = var; }
 
-  const std::unordered_set<details::ComputationOpHandle *> &ops() const {
+  const std::unordered_set<details::ComputationOpHandle*>& ops() const {
     return ops_;
   }
 
-  std::unordered_set<details::ComputationOpHandle *> *mutable_ops() {
+  std::unordered_set<details::ComputationOpHandle*>* mutable_ops() {
     return &ops_;
   }
 
  private:
-  details::VarHandle *var_{nullptr};
-  std::unordered_set<details::ComputationOpHandle *> ops_;
+  details::VarHandle* var_{nullptr};
+  std::unordered_set<details::ComputationOpHandle*> ops_;
 };
 
 using LastLiveOpsOfVars = std::unordered_map<std::string, LastLiveOpOfVarInfo>;
 const char kLastLiveOpsOfVars[] = "last_live_ops_of_var";
 
-VarDesc *TryGetLatestVarDesc(const std::vector<details::VarHandle *> &vars);
+TEST_API VarDesc* TryGetLatestVarDesc(
+    const std::vector<details::VarHandle*>& vars);
 
 }  // namespace ir
 }  // namespace framework

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1605,12 +1605,12 @@ bool OperatorWithKernel::CanONEDNNBeUsed(const framework::ExecutionContext& ctx,
 
 bool OperatorWithKernel::CanCUDNNBeUsed(const framework::ExecutionContext& ctx,
                                         DataType data_type) const {
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
+    defined(PADDLE_WITH_CUSTOM_DEVICE)
   bool use_cudnn = ctx.HasAttr("use_cudnn") && ctx.Attr<bool>("use_cudnn") &&
                    (phi::is_gpu_place(ctx.GetPlace()) ||
                     phi::is_custom_place(ctx.GetPlace()));
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
-    defined(PADDLE_WITH_CUSTOM_DEVICE)
   if (use_cudnn) {
     const auto& dev_ctx = ctx.device_context<phi::DeviceContext>();
     use_cudnn &= (dev_ctx.cudnn_handle() != nullptr);
@@ -1627,6 +1627,7 @@ bool OperatorWithKernel::CanCUDNNBeUsed(const framework::ExecutionContext& ctx,
 #endif  // PADDLE_WITH_CUDA
   return use_cudnn && this->SupportsCUDNN(data_type);
 #endif
+  return false;
 }
 
 bool OperatorWithKernel::CanCUDNNBeUsed(const framework::ExecutionContext& ctx,

--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -468,7 +468,7 @@ void TensorToStream(std::ostream& os,
     auto* pb_dims = desc.mutable_dims();
     pb_dims->Resize(static_cast<int>(dims.size()), 0);
     std::copy(dims.begin(), dims.end(), pb_dims->begin());
-    int32_t size = desc.ByteSize();
+    int32_t size = static_cast<int32_t>(desc.ByteSizeLong());
     os.write(reinterpret_cast<const char*>(&size), sizeof(size));
     auto out = desc.SerializeAsString();
     os.write(out.data(), size);

--- a/paddle/phi/common/bfloat16.h
+++ b/paddle/phi/common/bfloat16.h
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <iostream>
 #include <limits>
+#include <type_traits>
 #include "paddle/common/backend_header.h"
 #include "paddle/common/hostdevice.h"
 
@@ -30,8 +31,10 @@ namespace dtype {
 template <typename T, typename U>
 inline T bit_cast(U x) {
   static_assert(sizeof(T) == sizeof(U), "invalid sizeof");
-  static_assert(std::is_pod<T>::value, "invalid pod type T");
-  static_assert(std::is_pod<U>::value, "invalid pod type U");
+  static_assert(std::is_trivially_copyable<T>::value,
+                "invalid trivially copyable type T");
+  static_assert(std::is_trivially_copyable<U>::value,
+                "invalid trivially copyable type U");
   T y;
   std::memcpy(&y, &x, sizeof(T));
   return y;

--- a/paddle/phi/core/framework/dense_tensor_tostream.cc
+++ b/paddle/phi/core/framework/dense_tensor_tostream.cc
@@ -118,7 +118,7 @@ void TensorToStream(std::ostream& os,
     auto* pb_dims = desc.mutable_dims();
     pb_dims->Resize(static_cast<int>(dims.size()), 0);
     std::copy(dims.begin(), dims.end(), pb_dims->begin());
-    int32_t size = desc.ByteSize();
+    int32_t size = static_cast<int32_t>(desc.ByteSizeLong());
     os.write(reinterpret_cast<const char*>(&size), sizeof(size));
     auto out = desc.SerializeAsString();
     os.write(out.data(), size);

--- a/paddle/phi/core/memory/allocation/allocator.h
+++ b/paddle/phi/core/memory/allocation/allocator.h
@@ -310,7 +310,7 @@ class PADDLE_API MultiScalePoolAllocator : public Allocator {
   virtual bool IsSmallRequest(size_t size) = 0;
 
  private:
-  phi::Allocation* AllocateImpl(size_t UNUSED) { return nullptr; }
+  phi::Allocation* AllocateImpl(size_t UNUSED) override { return nullptr; }
   std::shared_ptr<Allocator> small_allocator_;
   std::shared_ptr<Allocator> large_allocator_;
   size_t alignment_;

--- a/paddle/phi/core/memory/mem_utils.h
+++ b/paddle/phi/core/memory/mem_utils.h
@@ -63,6 +63,8 @@ using allocation::BlockAllocation;
  */
 class MemoryCompactionStrategy {
  public:
+  virtual ~MemoryCompactionStrategy() = default;
+
   /*!
    * \brief TryFuse will create new IterMark and returns an aggregated IterSum
    * that only has one IterSplit with the new IterMark.

--- a/test/cpp/fluid/framework/ir/CMakeLists.txt
+++ b/test/cpp/fluid/framework/ir/CMakeLists.txt
@@ -20,6 +20,11 @@ cc_test(
   DEPS graph graph_helper op_registry)
 
 cc_test(
+  reference_count_pass_helper_test
+  SRCS reference_count_pass_helper_test.cc
+  DEPS reference_count_pass_helper node)
+
+cc_test(
   graph_to_program_pass_test
   SRCS graph_to_program_pass_test.cc
   DEPS graph_to_program_pass)

--- a/test/cpp/fluid/framework/ir/reference_count_pass_helper_test.cc
+++ b/test/cpp/fluid/framework/ir/reference_count_pass_helper_test.cc
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/framework/ir/memory_optimize_pass/reference_count_pass_helper.h"
+
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paddle/fluid/framework/ir/node.h"
+#include "paddle/fluid/framework/var_desc.h"
+#include "paddle/phi/common/place.h"
+
+namespace paddle::framework::ir {
+
+TEST(ReferenceCountPassHelperTest, TryGetLatestVarDescSkipsTrailingNullDesc) {
+  VarDesc old_var_desc("x_old");
+  VarDesc latest_var_desc("x_latest");
+
+  std::unique_ptr<Node> old_node(CreateNodeForTest(&old_var_desc));
+  std::unique_ptr<Node> latest_node(CreateNodeForTest(&latest_var_desc));
+  std::unique_ptr<Node> trailing_empty_node(
+      CreateNodeForTest("x_empty", Node::Type::kVariable));
+
+  // VarHandleBase registers itself as the Node wrapper; Node owns the wrapper.
+  auto* old_var_handle =
+      new details::VarHandle(old_node.get(), 0, 0, "x", phi::CPUPlace());
+  auto* latest_var_handle =
+      new details::VarHandle(latest_node.get(), 1, 0, "x", phi::CPUPlace());
+  auto* trailing_empty_var_handle = new details::VarHandle(
+      trailing_empty_node.get(), 2, 0, "x", phi::CPUPlace());
+
+  std::vector<details::VarHandle*> vars{
+      old_var_handle, latest_var_handle, trailing_empty_var_handle};
+
+  EXPECT_EQ(TryGetLatestVarDesc(vars)->Name(), "x_latest");
+}
+
+TEST(ReferenceCountPassHelperTest,
+     TryGetLatestVarDescReturnsNullptrWhenAbsent) {
+  std::unique_ptr<Node> empty_node(
+      CreateNodeForTest("x_empty", Node::Type::kVariable));
+  // VarHandleBase registers itself as the Node wrapper; Node owns the wrapper.
+  auto* empty_var_handle =
+      new details::VarHandle(empty_node.get(), 0, 0, "x", phi::CPUPlace());
+
+  std::vector<details::VarHandle*> vars{empty_var_handle};
+
+  EXPECT_EQ(TryGetLatestVarDesc(vars), nullptr);
+}
+
+}  // namespace paddle::framework::ir

--- a/test/cpp/fluid/framework/tensor_util_test.cc
+++ b/test/cpp/fluid/framework/tensor_util_test.cc
@@ -487,6 +487,21 @@ TEST(Tensor, FromAndToStream) {
     EXPECT_EQ(dst_tensor.dims(), src_tensor.dims());
     delete place;
   }
+  {
+    phi::DenseTensor dst_tensor;
+    phi::CPUPlace place;
+    phi::CPUContext cpu_ctx(place);
+    std::ostringstream oss;
+    paddle::framework::TensorToStream(oss, src_tensor, cpu_ctx);
+
+    std::istringstream iss(oss.str());
+    paddle::framework::TensorFromStream(iss, &dst_tensor, cpu_ctx);
+    int* dst_ptr = dst_tensor.mutable_data<int>(phi::CPUPlace());
+    for (int i = 0; i < 6; ++i) {
+      EXPECT_EQ(dst_ptr[i], array[i]);
+    }
+    EXPECT_EQ(dst_tensor.dims(), src_tensor.dims());
+  }
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   {
     phi::DenseTensor gpu_tensor;


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Improvements

### Description
本 PR 修复 Mac CPU / C++20 构建中一批由 Clang、libc++、Protobuf 和 macOS SDK 暴露出来的 C++ warning。改动只调整编译兼容性和警告触发点，不改变序列化格式、运行逻辑或数值计算。

#### 背景

Mac CPU 构建日志中出现多类 warning，主要来自：

- C++20 / libc++ 对隐式 `this` 捕获、`std::iterator`、`std::is_pod` 等旧写法的 deprecation 或更严格诊断。
- Protobuf 新版本推荐使用 `ByteSizeLong()` 替代 `ByteSize()`。
- macOS SDK 将 `sprintf` 标记为 deprecated，并建议使用 `snprintf`。
- CPU-only 构建下部分后端宏未开启，导致非 void 函数存在无返回路径。
- 抽象类通过 `unique_ptr` 删除时缺少 virtual destructor，以及虚函数 override 未显式标注。

#### 相关 warning 与修复

| 文件 | 日志中的 warning | 修复方式 | 说明 / 文档 |
| --- | --- | --- | --- |
| `paddle/fluid/framework/operator.cc` | `warning: non-void function does not return a value [-Wreturn-type]` | CPU-only 编译路径返回 `false` | `CanCUDNNBeUsed` 在无 CUDA/HIP/custom-device 编译时语义上恒为 false。Clang 将缺失返回路径归类为 `-Wreturn-type`。 |
| `paddle/phi/core/framework/dense_tensor_tostream.cc`, `paddle/fluid/framework/tensor_util.cc` | `warning: 'ByteSize' is deprecated: Please use ByteSizeLong() instead [-Wdeprecated-declarations]` | `desc.ByteSize()` 改为 `desc.ByteSizeLong()`，再显式 cast 回 `int32_t` | Protobuf 官方 C++ API 文档中 `Message::ByteSizeLong()` 用于计算序列化大小。这里保留 `int32_t` 写入，避免改变既有 stream 格式。参考：https://protobuf.dev/reference/cpp/api-docs/google.protobuf.message/#Message.ByteSizeLong.details |
| `paddle/fluid/framework/device_worker.cc` | `warning: 'sprintf' is deprecated ... it is highly recommended that you use snprintf(3) instead` | `sprintf` 改为 `snprintf` | macOS SDK 的诊断已经说明 `sprintf` 存在边界安全风险，并推荐 `snprintf`。改动保持原格式化逻辑，仅增加缓冲区边界。 |
| `paddle/fluid/framework/ir/graph_traits.h` | `warning: 'iterator<...>' is deprecated [-Wdeprecated-declarations]` | 移除 `std::iterator` 继承，显式声明 `iterator_category`、`value_type`、`difference_type`、`pointer`、`reference` | `std::iterator` 自 C++17 起 deprecated。显式声明 iterator traits 是等价且更现代的写法。参考：https://en.cppreference.com/w/cpp/iterator/iterator |
| `paddle/fluid/framework/ir/memory_optimize_pass/reference_count_pass_helper.cc` | `warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]` | 保存并使用 `std::find_if` 返回的 iterator | 旧代码依赖 lambda 副作用设置 `var_desc`，但丢弃算法返回值。新写法保留从后向前查找最近有效 `VarDesc` 的语义，并使用返回 iterator。 |
| `paddle/phi/core/memory/allocation/allocator.h` | `warning: 'AllocateImpl' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]` | 为 override 函数补充 `override` | 显式 `override` 与基类虚函数签名保持一致，消除 Clang 诊断。 |
| `paddle/phi/core/memory/mem_utils.h` | `warning: delete called on ... abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]` | 为 `MemoryCompactionStrategy` 增加 virtual default destructor | 该类型作为抽象基类经 `std::unique_ptr` 删除，需要虚析构以保证通过基类指针删除安全。 |
| `paddle/phi/common/bfloat16.h` | C++20 下 `std::is_pod` 已 deprecated | 将 `std::is_pod` 改为 `std::is_trivially_copyable` | `bit_cast` 实现基于 `std::memcpy`，真正需要的是源/目标类型可平凡拷贝。`std::is_pod` 自 C++20 deprecated；trivially-copyable 类型可安全按字节拷贝。参考：https://en.cppreference.com/w/cpp/types/is_pod 和 https://en.cppreference.com/w/cpp/types/is_trivially_copyable |
| `paddle/fluid/framework/blocking_queue.h` | 同类 C++20 warning: `implicit capture of 'this' with a capture default of '=' is deprecated` | `[=]` 改为 `[this]` | C++20 起，以 `[=]` 隐式捕获 `this` deprecated；Clang 诊断 `-Wdeprecated-this-capture` 也说明该行为。参考：https://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-this-capture 和 https://en.cppreference.com/w/cpp/language/lambda |

#### 官方 / 一手文档说明

- Protobuf 官方 C++ API：`Message::ByteSizeLong()` 用于计算消息序列化大小。链接：https://protobuf.dev/reference/cpp/api-docs/google.protobuf.message/#Message.ByteSizeLong.details
- Clang diagnostics：`-Wdeprecated-this-capture` 的诊断文本为 `implicit capture of 'this' with a capture default of '=' is deprecated`。链接：https://clang.llvm.org/docs/DiagnosticsReference.html#wdeprecated-this-capture
- C++ reference：`std::iterator` 自 C++17 deprecated。链接：https://en.cppreference.com/w/cpp/iterator/iterator
- C++ reference：`std::is_pod` 自 C++20 deprecated。链接：https://en.cppreference.com/w/cpp/types/is_pod
- C++ reference：trivially-copyable 类型可用于 `std::memcpy` / binary serialization 场景。链接：https://en.cppreference.com/w/cpp/types/is_trivially_copyable
- C++ reference：lambda 中 `[=]` 隐式捕获 `*this` 自 C++20 deprecated。链接：https://en.cppreference.com/w/cpp/language/lambda

#### 验证

- `git diff --cached --check`
- `ninja -C build paddle/phi/CMakeFiles/phi_core.dir/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.cc.o paddle/phi/CMakeFiles/phi_core.dir/core/framework/dense_tensor_tostream.cc.o paddle/fluid/framework/CMakeFiles/tensor.dir/tensor_util.cc.o paddle/fluid/framework/CMakeFiles/device_worker.dir/device_worker.cc.o paddle/fluid/framework/CMakeFiles/operator.dir/operator.cc.o paddle/fluid/framework/CMakeFiles/executor.dir/device_worker.cc.o paddle/fluid/framework/ir/CMakeFiles/graph_traits.dir/graph_traits.cc.o paddle/fluid/framework/ir/memory_optimize_pass/CMakeFiles/reference_count_pass_helper.dir/reference_count_pass_helper.cc.o`
- `prek --files $(git diff --cached --name-only)`

本 PR 不包含新增测试文件；本地保留了 `reference_count_pass_helper` helper 单测草稿，后续如需要可单独提交。

### 是否引起精度变化
否
