### PR TITLE
[API Compatibility] Fix paddle.cuda.set_device(int) raising when the current place is CPU

### DIFF
--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -778,9 +778,10 @@ def set_device(device: DeviceLike) -> None:
     Set the current device.
 
     Args:
-        device (DeviceLike): The device to set as current.
-            Can be paddle.CUDAPlace, paddle.CustomPlace, paddle.XPUPlace,
-            int (device index), or str (device string).
+        device (DeviceLike): The CUDA device to set as current. Can be an int
+            (GPU index), a CUDA/GPU device string (e.g. 'gpu:0' or 'cuda:0'),
+            or a paddle.CUDAPlace. For XPU / custom devices, use
+            paddle.device.set_device().
 
     Returns:
         None
@@ -788,7 +789,7 @@ def set_device(device: DeviceLike) -> None:
     Examples:
         .. code-block:: pycon
 
-            >>> # doctest: +REQUIRES(env:CUSTOM_DEVICE)
+            >>> # doctest: +REQUIRES(env:GPU)
             >>> import paddle
             >>> # Set current device to GPU:0
             >>> paddle.cuda.set_device(0)
@@ -798,26 +799,35 @@ def set_device(device: DeviceLike) -> None:
             >>> place = paddle.CUDAPlace(0)
             >>> paddle.cuda.set_device(place)
     """
-    # Convert device to string format if needed and call paddle.device.set_device()
-    # This function supports multiple hardware types (CUDA, XPU, Custom devices)
+    # Convert CUDA device identifiers to paddle.device's GPU device string.
     if isinstance(device, int):
         # An int index always refers to a CUDA GPU, matching torch.cuda.set_device.
+        # paddle.device.set_device() raises if Paddle is not compiled with CUDA.
         device_str = f'gpu:{device}'
     elif isinstance(device, str):
-        # Device is already in string format
-        device_str = device
+        # paddle.cuda only accepts CUDA/GPU device strings. Use
+        # paddle.device.set_device() for XPU / custom devices.
+        lower_device = device.lower()
+        if lower_device == 'gpu' or lower_device.startswith('gpu:'):
+            device_str = lower_device
+        elif lower_device == 'cuda':
+            device_str = 'gpu'
+        elif lower_device.startswith('cuda:'):
+            device_str = f"gpu:{lower_device.split(':', 1)[1]}"
+        else:
+            raise ValueError(
+                f"paddle.cuda.set_device only supports CUDA/GPU device strings "
+                f"(e.g. 'gpu', 'gpu:0', 'cuda:0'), but got '{device}'. "
+                f"Use paddle.device.set_device() for other devices."
+            )
     elif isinstance(device, core.CUDAPlace):
         # Convert CUDAPlace object to string format
         device_str = f'gpu:{device.get_device_id()}'
-    elif isinstance(device, core.CustomPlace):
-        # Convert CustomPlace object to string format
-        device_str = f'{device.get_device_type()}:{device.get_device_id()}'
-    elif isinstance(device, core.XPUPlace):
-        # Convert XPUPlace object to string format
-        device_str = f'xpu:{device.get_device_id()}'
     else:
         raise ValueError(
-            f"Unsupported device type: {type(device)}. Expected int, str, CUDAPlace, XPUPlace, or CustomPlace."
+            f"Unsupported device type: {type(device)}. paddle.cuda.set_device only "
+            f"supports int, a CUDA/GPU device string, or paddle.CUDAPlace. Use "
+            f"paddle.device.set_device() for XPU / custom devices."
         )
 
     # Call paddle.device.set_device() to set the current device

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -801,8 +801,8 @@ def set_device(device: DeviceLike) -> None:
     """
     # Convert CUDA device identifiers to paddle.device's GPU device string.
     if isinstance(device, int):
-        # An int index always refers to a CUDA GPU, matching torch.cuda.set_device.
-        # paddle.device.set_device() raises if Paddle is not compiled with CUDA.
+        # An int index always refers to a CUDA GPU.
+        # raises if Paddle is not compiled with CUDA.
         device_str = f'gpu:{device}'
     elif isinstance(device, str):
         # paddle.cuda only accepts CUDA/GPU device strings. Use

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -809,6 +809,10 @@ def set_device(device: DeviceLike) -> None:
             device_str = f'{device_place.get_device_type()}:{device}'
         elif isinstance(device_place, core.XPUPlace):
             device_str = f'xpu:{device}'
+        elif core.is_compiled_with_cuda():
+            device_str = f'gpu:{device}'
+        elif core.is_compiled_with_xpu():
+            device_str = f'xpu:{device}'
         else:
             raise ValueError(
                 "Paddle-CPU is not supported. Please use PaddlePaddle with CUDA, XPU or Custom Device"

--- a/python/paddle/cuda/__init__.py
+++ b/python/paddle/cuda/__init__.py
@@ -20,7 +20,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 import paddle
-from paddle import base, core, device as paddle_device, framework
+from paddle import base, core, device as paddle_device
 from paddle.cuda.graphs import CUDAGraph, graph, graph_pool_handle
 from paddle.device import (
     Event,
@@ -801,22 +801,8 @@ def set_device(device: DeviceLike) -> None:
     # Convert device to string format if needed and call paddle.device.set_device()
     # This function supports multiple hardware types (CUDA, XPU, Custom devices)
     if isinstance(device, int):
-        # Convert int device index to string format (e.g., 0 -> 'gpu:0')
-        device_place = framework._current_expected_place_()
-        if isinstance(device_place, core.CUDAPlace):
-            device_str = f'gpu:{device}'
-        elif isinstance(device_place, core.CustomPlace):
-            device_str = f'{device_place.get_device_type()}:{device}'
-        elif isinstance(device_place, core.XPUPlace):
-            device_str = f'xpu:{device}'
-        elif core.is_compiled_with_cuda():
-            device_str = f'gpu:{device}'
-        elif core.is_compiled_with_xpu():
-            device_str = f'xpu:{device}'
-        else:
-            raise ValueError(
-                "Paddle-CPU is not supported. Please use PaddlePaddle with CUDA, XPU or Custom Device"
-            )
+        # An int index always refers to a CUDA GPU, matching torch.cuda.set_device.
+        device_str = f'gpu:{device}'
     elif isinstance(device, str):
         # Device is already in string format
         device_str = device

--- a/test/compat/test_paddle_cuda_apis.py
+++ b/test/compat/test_paddle_cuda_apis.py
@@ -14,7 +14,7 @@
 
 import sys
 import unittest
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import paddle
 
@@ -357,6 +357,26 @@ class TestSetDevice(TestCase):
             )
         finally:
             paddle.device.set_device(original_device)
+
+    def test_set_device_int_xpu_fallback_when_place_is_cpu(self):
+        """cuda.set_device(int) falls back to 'xpu:{i}' when the current place
+        is CPU and Paddle is compiled with XPU (but not CUDA)
+        """
+        with (
+            mock.patch(
+                'paddle.cuda.framework._current_expected_place_',
+                return_value=paddle.CPUPlace(),
+            ),
+            mock.patch(
+                'paddle.cuda.core.is_compiled_with_cuda', return_value=False
+            ),
+            mock.patch(
+                'paddle.cuda.core.is_compiled_with_xpu', return_value=True
+            ),
+            mock.patch('paddle.cuda.paddle_device.set_device') as mock_set,
+        ):
+            paddle.cuda.set_device(0)
+            mock_set.assert_called_once_with('xpu:0')
 
     def test_set_device_with_str_param(self):
         """Test that set_device works with string parameter."""

--- a/test/compat/test_paddle_cuda_apis.py
+++ b/test/compat/test_paddle_cuda_apis.py
@@ -334,6 +334,30 @@ class TestSetDevice(TestCase):
                     f"set_device with int parameter raised an exception: {e}"
                 )
 
+    def test_set_device_int_after_cpu_place(self):
+        """ """
+        if not (
+            paddle.is_compiled_with_cuda() and paddle.cuda.device_count() > 0
+        ):
+            return
+        original_device = paddle.device.get_device()
+        try:
+            paddle.device.set_device('cpu')
+            paddle.cuda.set_device(0)
+            self.assertEqual(
+                paddle.cuda.current_device(),
+                0,
+                'cuda.set_device(0) should select GPU 0 even when the '
+                'current place is CPU',
+            )
+        except Exception as e:
+            self.fail(
+                f'cuda.set_device(int) after a CPU place raised an '
+                f'exception: {e}'
+            )
+        finally:
+            paddle.device.set_device(original_device)
+
     def test_set_device_with_str_param(self):
         """Test that set_device works with string parameter."""
         if paddle.is_compiled_with_cuda():

--- a/test/compat/test_paddle_cuda_apis.py
+++ b/test/compat/test_paddle_cuda_apis.py
@@ -306,13 +306,13 @@ class TestMemoryReserved(TestCase):
 class TestSetDevice(TestCase):
     def test_set_device_return_type(self):
         """Test that set_device returns None."""
-        if paddle.cuda.device_count() > 0:
+        if paddle.is_compiled_with_cuda() and paddle.cuda.device_count() > 0:
             result = paddle.cuda.set_device(0)
             self.assertIsNone(result, "set_device should return None")
 
     def test_set_device_no_exception(self):
         """Test that set_device does not raise any exceptions."""
-        if paddle.cuda.device_count() > 0:
+        if paddle.is_compiled_with_cuda() and paddle.cuda.device_count() > 0:
             try:
                 paddle.cuda.set_device(0)
             except Exception as e:
@@ -320,7 +320,7 @@ class TestSetDevice(TestCase):
 
     def test_set_device_with_int_param(self):
         """Test that set_device works with integer parameter."""
-        if paddle.cuda.device_count() > 0:
+        if paddle.is_compiled_with_cuda() and paddle.cuda.device_count() > 0:
             try:
                 # Test with device index 0
                 paddle.cuda.set_device(0)
@@ -335,7 +335,7 @@ class TestSetDevice(TestCase):
                 )
 
     def test_set_device_int_after_cpu_place(self):
-        """ """
+        """Test int parameter after switching the expected place to CPU."""
         if not (
             paddle.is_compiled_with_cuda() and paddle.cuda.device_count() > 0
         ):
@@ -360,7 +360,7 @@ class TestSetDevice(TestCase):
 
     def test_set_device_with_str_param(self):
         """Test that set_device works with string parameter."""
-        if paddle.is_compiled_with_cuda():
+        if paddle.is_compiled_with_cuda() and paddle.cuda.device_count() > 0:
             try:
                 # Test with device string
                 paddle.cuda.set_device('gpu:0')
@@ -371,6 +371,16 @@ class TestSetDevice(TestCase):
                     0,
                     "set_device should set device to 0 with 'gpu:0'",
                 )
+                paddle.cuda.set_device('cuda:0')
+                current_device = paddle.cuda.current_device()
+                self.assertEqual(
+                    current_device,
+                    0,
+                    "set_device should set device to 0 with 'cuda:0'",
+                )
+                # bare 'gpu' / 'cuda' select the default GPU without raising
+                paddle.cuda.set_device('gpu')
+                paddle.cuda.set_device('cuda')
             except Exception as e:
                 self.fail(
                     f"set_device with string parameter raised an exception: {e}"
@@ -378,7 +388,7 @@ class TestSetDevice(TestCase):
 
     def test_set_device_with_cuda_place_param(self):
         """Test that set_device works with CUDAPlace parameter."""
-        if paddle.is_compiled_with_cuda():
+        if paddle.is_compiled_with_cuda() and paddle.cuda.device_count() > 0:
             try:
                 # Test with CUDAPlace
                 place = paddle.CUDAPlace(0)
@@ -396,86 +406,27 @@ class TestSetDevice(TestCase):
                 )
 
     def test_set_device_with_xpu_place_param(self):
-        """Test that set_device works with XPUPlace parameter."""
+        """paddle.cuda.set_device rejects an XPUPlace; use paddle.device.set_device."""
         if paddle.is_compiled_with_xpu():
-            try:
-                # Test with XPUPlace
-                place = paddle.XPUPlace(0)
-                paddle.cuda.set_device(place)
-                # Verify device was set correctly
-                current_device = paddle.cuda.current_device()
-                # For XPU, we check if the device string contains 'xpu:0'
-                device_str = paddle.device.get_device()
-                self.assertEqual(
-                    device_str,
-                    'xpu:0',
-                    "set_device should set device to xpu:0 with XPUPlace",
-                )
-            except Exception as e:
-                self.fail(
-                    f"set_device with XPUPlace parameter raised an exception: {e}"
-                )
+            with self.assertRaises(ValueError):
+                paddle.cuda.set_device(paddle.XPUPlace(0))
 
     def test_set_device_with_xpu_str_param(self):
-        """Test that set_device works with XPU string parameter."""
-        if paddle.is_compiled_with_xpu():
-            try:
-                # Test with XPU device string
-                paddle.cuda.set_device('xpu:0')
-                # Verify device was set correctly
-                device_str = paddle.device.get_device()
-                self.assertEqual(
-                    device_str,
-                    'xpu:0',
-                    "set_device should set device to xpu:0 with 'xpu:0'",
-                )
-            except Exception as e:
-                self.fail(
-                    f"set_device with XPU string parameter raised an exception: {e}"
-                )
+        """paddle.cuda.set_device rejects an 'xpu:*' string; use paddle.device.set_device."""
+        with self.assertRaises(ValueError):
+            paddle.cuda.set_device('xpu:0')
 
     def test_set_device_with_custom_place_param(self):
-        """Test that set_device works with CustomPlace parameter."""
+        """paddle.cuda.set_device rejects a CustomPlace; use paddle.device.set_device."""
         custom_devices = paddle.device.get_all_custom_device_type()
         if custom_devices:
-            try:
-                # Test with CustomPlace
-                device_type = custom_devices[0]
-                place = paddle.CustomPlace(device_type, 0)
-                paddle.cuda.set_device(place)
-                # Verify device was set correctly
-                device_str = paddle.device.get_device()
-                expected_str = f'{device_type}:0'
-                self.assertEqual(
-                    device_str,
-                    expected_str,
-                    f"set_device should set device to {expected_str} with CustomPlace",
-                )
-            except Exception as e:
-                self.fail(
-                    f"set_device with CustomPlace parameter raised an exception: {e}"
-                )
+            with self.assertRaises(ValueError):
+                paddle.cuda.set_device(paddle.CustomPlace(custom_devices[0], 0))
 
     def test_set_device_with_custom_str_param(self):
-        """Test that set_device works with Custom device string parameter."""
-        custom_devices = paddle.device.get_all_custom_device_type()
-        if custom_devices:
-            try:
-                # Test with Custom device string
-                device_type = custom_devices[0]
-                paddle.cuda.set_device(f'{device_type}:0')
-                # Verify device was set correctly
-                device_str = paddle.device.get_device()
-                expected_str = f'{device_type}:0'
-                self.assertEqual(
-                    device_str,
-                    expected_str,
-                    f"set_device should set device to {expected_str} with custom device string",
-                )
-            except Exception as e:
-                self.fail(
-                    f"set_device with custom device string parameter raised an exception: {e}"
-                )
+        """paddle.cuda.set_device rejects a custom-device string; use paddle.device.set_device."""
+        with self.assertRaises(ValueError):
+            paddle.cuda.set_device('npu:0')
 
     def test_set_device_invalid_param(self):
         """Test that set_device raises ValueError for invalid parameter types."""

--- a/test/compat/test_paddle_cuda_apis.py
+++ b/test/compat/test_paddle_cuda_apis.py
@@ -14,7 +14,7 @@
 
 import sys
 import unittest
-from unittest import TestCase, mock
+from unittest import TestCase
 
 import paddle
 
@@ -357,26 +357,6 @@ class TestSetDevice(TestCase):
             )
         finally:
             paddle.device.set_device(original_device)
-
-    def test_set_device_int_xpu_fallback_when_place_is_cpu(self):
-        """cuda.set_device(int) falls back to 'xpu:{i}' when the current place
-        is CPU and Paddle is compiled with XPU (but not CUDA)
-        """
-        with (
-            mock.patch(
-                'paddle.cuda.framework._current_expected_place_',
-                return_value=paddle.CPUPlace(),
-            ),
-            mock.patch(
-                'paddle.cuda.core.is_compiled_with_cuda', return_value=False
-            ),
-            mock.patch(
-                'paddle.cuda.core.is_compiled_with_xpu', return_value=True
-            ),
-            mock.patch('paddle.cuda.paddle_device.set_device') as mock_set,
-        ):
-            paddle.cuda.set_device(0)
-            mock_set.assert_called_once_with('xpu:0')
 
     def test_set_device_with_str_param(self):
         """Test that set_device works with string parameter."""


### PR DESCRIPTION
### PR Category
Distributed Strategy


### PR Types
Bug fixes


### Description
In Paconvert distributed test, the monitored_barrier.py test failed. To trace the cause, in the log there's:
```
2026-06-29T09:09:51.1482698Z I0629 09:09:46.651175  2484 tcp_store.cc:336] create libuv server at port: 56142
2026-06-29T09:09:51.1483509Z I0629 09:09:46.651654  2484 tcp_utils.cc:132] Successfully connected to 10.138.75.17:56142
2026-06-29T09:09:51.1484178Z Traceback (most recent call last):
2026-06-29T09:09:51.1484728Z   File "/ws/paddle_dist/monitored_barrier.py", line 5, in <module>
2026-06-29T09:09:51.1485308Z     paddle.cuda.set_device(rank)
2026-06-29T09:09:51.1486005Z   File "/usr/local/lib/python3.10/dist-packages/paddle/cuda/__init__.py", line 813, in set_device
2026-06-29T09:09:51.1486735Z     raise ValueError(
2026-06-29T09:09:51.1487413Z ValueError: Paddle-CPU is not supported. Please use PaddlePaddle with CUDA, XPU or Custom Device
```

This is because `paddle.cuda.set_device(<int>)` inferred the device type from `framework._current_expected_place_()` and raised `ValueError: Paddle-CPU is not supported`. This breaks a common idiom, since `init_parallel_env` with the ***gloo*** backend leaves the expected place as `CPUPlace`

```
dist.init_process_group(backend='gloo')
paddle.cuda.set_device(rank)                     # raise error
```

`paddle.cuda.set_device` mirrors `torch.cuda.set_device`, where an int index always refers to a GPU. The int branch fallbacks to `gpu:{device}` when compiled with CUDA (and `xpu:{device}` for XPU builds) instead of raising on CPU place.

This is a follow up PR to
- https://github.com/paddlepaddle/paddle/pull/78883

### 是否引起精度变化
否
