### PR TITLE
[Custom Device] Fix expected place lookup for custom device RNG seed under PIR

### DIFF
--- a/python/paddle/device/custom_device.py
+++ b/python/paddle/device/custom_device.py
@@ -596,7 +596,7 @@ def manual_seed(seed: int) -> None:
 
     """
     seed = int(seed)
-    place = paddle.framework._current_expected_place()
+    place = paddle.framework._current_expected_place_()
     if isinstance(place, core.CPUPlace):
         core.default_cpu_generator().manual_seed(seed)
     else:

--- a/python/paddle/framework/random.py
+++ b/python/paddle/framework/random.py
@@ -55,7 +55,7 @@ def seed(seed: int) -> paddle.base.core.Generator:
     elif paddle.is_compiled_with_xpu():
         for i in range(core.get_xpu_device_count()):
             core.default_xpu_generator(i).manual_seed(seed)
-    place = paddle.framework._current_expected_place()
+    place = paddle.framework._current_expected_place_()
     if isinstance(place, paddle.CustomPlace):
         dev_cnt = sum(
             [

--- a/test/custom_runtime/test_custom_cpu_plugin.py
+++ b/test/custom_runtime/test_custom_cpu_plugin.py
@@ -58,6 +58,7 @@ class TestCustomCPUPlugin(unittest.TestCase):
         self._test_fallback_kernel()
         self._test_scalar()
         self._test_custom_device_py_api()
+        self._test_custom_device_seed_under_pir()
         self._test_custom_device_mix_precision()
 
     def _test_custom_device_dataloader(self):
@@ -205,6 +206,27 @@ class TestCustomCPUPlugin(unittest.TestCase):
         )
         k_t = paddle.to_tensor([3], dtype="int32")
         value_1, indices_1 = paddle.topk(data_1, k=k_t)
+
+    def _test_custom_device_seed_under_pir(self):
+        import paddle
+
+        paddle.set_device('custom_cpu')
+
+        with paddle.pir_utils.IrGuard():
+            paddle.seed(2021)
+            paddle.device.manual_seed(2022)
+
+        paddle.seed(2021)
+        first = paddle.rand([4], dtype='float32').numpy()
+        paddle.seed(2021)
+        second = paddle.rand([4], dtype='float32').numpy()
+        np.testing.assert_array_equal(first, second)
+
+        paddle.device.manual_seed(2022)
+        first = paddle.rand([4], dtype='float32').numpy()
+        paddle.device.manual_seed(2022)
+        second = paddle.rand([4], dtype='float32').numpy()
+        np.testing.assert_array_equal(first, second)
 
     def _test_custom_device_gradient_accumulation(self):
         import paddle


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Custom Device

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
在PIR下_current_expected_place返回的place为undefined，导致针对custom_device_generator设置seed时异常。
由于cuda分支走paddle.is_compiled_with_cuda():逻辑，并未使用place，所以不会出现此问题。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否