### PR TITLE
[CI] Fix setup.py approval path check

### DIFF
--- a/ci/check_approval.sh
+++ b/ci/check_approval.sh
@@ -253,13 +253,13 @@ if [ "${HAS_MODIFIED_OPERATOR_GENE}" != "" ] && [ "${PR_ID}" != "" ]; then
     check_approval 1 zhangbo9674 wanghuancoder
 fi
 
-HAS_MODIFIED_SETUP_IN=`git diff --name-only upstream/$BRANCH | grep "python/setup.py.in" || true`
+HAS_MODIFIED_SETUP_IN=`git diff --name-only upstream/$BRANCH | grep -E "^python/setup\.py\.in$" || true`
 if [ "${HAS_MODIFIED_SETUP_IN}" != "" ] && [ "${PR_ID}" != "" ]; then
     echo_line="You must have one RD (risemeup1, zhangbo9674) approval for file changes in python/setup.py.in, which manages the header files that can be used from outside of framework.\n"
     check_approval 1 risemeup1 zhangbo9674
 fi
 
-HAS_MODIFIED_SETUP=`git diff --name-only upstream/$BRANCH | grep "${PADDLE_ROOT}/setup.py" || true`
+HAS_MODIFIED_SETUP=`git diff --name-only upstream/$BRANCH | grep -E "^setup\.py$" || true`
 if [ "${HAS_MODIFIED_SETUP}" != "" ] || ([ "${HAS_MODIFIED_SETUP_IN}" != "" ] && [ "${HAS_MODIFIED_SETUP}" == "" ]); then
     echo_line="You must have one RD (risemeup1, zhangbo9674) approval for file changes in setup.py or setup.py and python/setup.py.in are not changed synchronously.\n"
     check_approval 1 risemeup1 zhangbo9674


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
修复 `ci/check_approval.sh` 中对 `setup.py` 修改的路径匹配。

当前 `git diff --name-only upstream/$BRANCH` 输出的是相对仓库根目录的路径，例如 `setup.py`。原逻辑使用 `${PADDLE_ROOT}/setup.py` 去匹配，导致修改根目录 `setup.py` 时 `HAS_MODIFIED_SETUP` 为空，从而没有触发 setup 相关 approval 检查。

本 PR 将 `setup.py` 与 `python/setup.py.in` 的匹配改为仓库相对路径的精确匹配，避免类似 [PaddlePaddle/Paddle#79398](https://github.com/PaddlePaddle/Paddle/pull/79398) 只改 `setup.py` 时未触发 check approval 的问题。

验证：

- `git diff --check`
- `bash -n ci/check_approval.sh`
- 用 [PaddlePaddle/Paddle#79398](https://github.com/PaddlePaddle/Paddle/pull/79398) 的 head `1e98bb550b4f5a7838df27c4351c29cc0fe7e9fa` 做路径匹配验证：旧表达式匹配为空，新表达式能匹配到 `setup.py`。

### 是否引起精度变化
否
