### PR TITLE
fix rmsnorm grad when input size is zero

### DIFF
--- a/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
+++ b/paddle/phi/kernels/gpu/rms_norm_cuda_kernel.h
@@ -22,6 +22,7 @@
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/kernels/full_kernel.h"
 #include "paddle/phi/kernels/reduce_sum_kernel.h"
 
 COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
@@ -1400,7 +1401,11 @@ void RMSNormBwdKernel(const Context& dev_ctx,
       dev_ctx.template Alloc<T>(dX);
     }
     if (dscale) {
-      dev_ctx.template Alloc<T_ACC>(dscale);
+      // When X is empty, no element contributes to dscale, so the gradient is
+      // exactly zero. We must fill it with 0 instead of leaving the allocated
+      // buffer uninitialized (which would otherwise inject random values into
+      // the gradient computation).
+      Full<T, Context>(dev_ctx, dscale->dims(), 0, dscale);
     }
     return;
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->Operator Mechanism


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->Bug fixes


### Description
<!-- Describe what you’ve done -->fix rmsnorm grad when input size is zero

devPR:https://github.com/PaddlePaddle/Paddle/pull/79397


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->是

cherry-pick of #79397 