### PR TITLE
[release/3.4][SOT][CI] Revert Python 3.14 numpy cleanup

### DIFF
--- a/ci/run_sot_test.sh
+++ b/ci/run_sot_test.sh
@@ -42,6 +42,15 @@ function run_sot_test() {
     run_and_check "Installing paddle wheel..." \
         $PYTHON_WITH_SPECIFY_VERSION -m pip install ${PADDLE_ROOT}/dist/paddlepaddle-0.0.0-cp${PY_VERSION_NO_DOT}-cp${PY_VERSION_NO_DOT}-linux_x86_64.whl
 
+    # Only python3.14 needs to install numpy>=2.3.5, because opencv-python will downgrade numpy to 2.2.6
+    # see: https://github.com/opencv/opencv-python/issues/1155
+    if [ "$PY_VERSION" == "3.14" ]; then
+        run_and_check "Uninstalling numpy for Python 3.14..." \
+            $PYTHON_WITH_SPECIFY_VERSION -m pip uninstall -y "numpy"
+        run_and_check "Installing numpy>=2.3.5 for Python 3.14..." \
+            $PYTHON_WITH_SPECIFY_VERSION -m pip install --force-reinstall --no-cache-dir "numpy>=2.3.5"
+    fi
+
     # cd to sot test dir
     cd $PADDLE_ROOT/test/sot/
 

--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -3,7 +3,7 @@ coverage==7.10.7
 mock
 gymnasium>=1.1.1
 hypothesis<6.145.0
-opencv-python>= 4.13.0.90
+opencv-python>= 4.10.0.84
 visualdl==2.5.3
 paddle2onnx>=0.9.6; python_version < "3.12"
 triton ; platform_system == 'Linux' and platform_machine == 'x86_64'


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
Reverts PaddlePaddle/Paddle#79380 for release/3.4.

The release/3.4 Python 3.14 SOT environment still needs the explicit numpy reinstall step; otherwise opencv-python can leave numpy at an older/downgraded version and trigger SOT failures like https://github.com/PaddlePaddle/Paddle/actions/runs/28562909244/job/84685959550?pr=79406.

This PR restores:

- the Python 3.14 `numpy>=2.3.5` reinstall step in `ci/run_sot_test.sh`
- the previous `opencv-python>= 4.10.0.84` lower bound in `python/unittest_py/requirements.txt`

devPR:https://github.com/PaddlePaddle/Paddle/pull/79379

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
