### PR TITLE
[CodeStyle][Typos] Bump typos to v1.48.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
             paddle/cinn/utils/registry.h
           )$
   - repo: https://github.com/PFCCLab/typos-pre-commit-mirror.git
-    rev: v1.47.0
+    rev: v1.48.0
     hooks:
       - id: typos
         args: [--force-exclude]


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Devs

### Description
同步 Paddle 代码风格检查工具版本：

- 将 `.pre-commit-config.yaml` 中 `PFCCLab/typos-pre-commit-mirror` 从 `v1.47.0` 升级到 `v1.48.0`
- `typos v1.48.0` 上游发布说明：更新 2026 年 6 月词典 [crate-ci/typos@v1.48.0](https://github.com/crate-ci/typos/releases/tag/v1.48.0)

本地验证：

```bash
pre-commit validate-config .pre-commit-config.yaml
pre-commit run typos --all-files
pre-commit run yamlfmt --files .pre-commit-config.yaml
git diff --check -- .pre-commit-config.yaml
```

### 是否引起精度变化
否
