### PR TITLE
[Windows] export operator kernel registry

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -72,6 +72,12 @@ std::vector<std::tuple<Place, LibraryType>> kKernelPriority = {
     std::make_tuple(CPUPlace(), LibraryType::kPlain),
 };
 
+paddle::flat_hash_map<std::string, OperatorWithKernel::OpKernelMap>&
+OperatorWithKernel::AllOpKernels() {
+  static paddle::flat_hash_map<std::string, OpKernelMap> g_all_op_kernels;
+  return g_all_op_kernels;
+}
+
 static DDim GetDimsDebug(const Scope& scope,
                          const std::string& name,
                          bool get_actual_dim = false) {

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -72,7 +72,7 @@ std::vector<std::tuple<Place, LibraryType>> kKernelPriority = {
     std::make_tuple(CPUPlace(), LibraryType::kPlain),
 };
 
-paddle::flat_hash_map<std::string, OperatorWithKernel::OpKernelMap>&
+TEST_API paddle::flat_hash_map<std::string, OperatorWithKernel::OpKernelMap>&
 OperatorWithKernel::AllOpKernels() {
   static paddle::flat_hash_map<std::string, OpKernelMap> g_all_op_kernels;
   return g_all_op_kernels;

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -756,11 +756,9 @@ class OperatorWithKernel : public OperatorBase {
 
   PADDLE_API virtual ~OperatorWithKernel();
 
-  static paddle::flat_hash_map<std::string /* op_type */, OpKernelMap>&
-  AllOpKernels() {
-    static paddle::flat_hash_map<std::string, OpKernelMap> g_all_op_kernels;
-    return g_all_op_kernels;
-  }
+  PADDLE_API static paddle::flat_hash_map<std::string /* op_type */,
+                                          OpKernelMap>&
+  AllOpKernels();
 
   PADDLE_API bool SupportGPU() const override;
 

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -756,8 +756,7 @@ class OperatorWithKernel : public OperatorBase {
 
   PADDLE_API virtual ~OperatorWithKernel();
 
-  PADDLE_API static paddle::flat_hash_map<std::string /* op_type */,
-                                          OpKernelMap>&
+  TEST_API static paddle::flat_hash_map<std::string /* op_type */, OpKernelMap>&
   AllOpKernels();
 
   PADDLE_API bool SupportGPU() const override;

--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -543,7 +543,6 @@ disable_win_inference_test="^trt_quant_int8_yolov3_r50_test$|\
 ^test_split_program_deprecated$|\
 ^test_trt_convert_multihead_matmul_roformer$|\
 ^test_cudnn_placement_pass$|\
-^operator_test$|\
 ^new_profiler_test$|\
 ^test_kernel_factory$|\
 ^save_load_version_compat_test$|\


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
从 Windows VS2022 CI 修复中拆出 `OperatorWithKernel::AllOpKernels()` 的单独修复。

Windows 下 header inline 函数里的局部静态 registry 可能在测试 exe 和 `libpaddle.dll` 中各有一份，导致 `REGISTER_OP_CPU_KERNEL` 写入的 Fluid op kernel 在 `OperatorWithKernel::ChooseKernel()` 查询时不可见，进而触发 `operator_test` 中 `kernels_iter == all_op_kernels.end()` 的错误。

本 PR 将 `AllOpKernels()` 从 header inline 实现改为 `operator.cc` 中的 `TEST_API` 导出函数，保证 Windows 测试构建跨 DLL 边界使用同一份 op kernel registry；普通非测试构建中 `TEST_API` 为空，不新增 `PADDLE_API` runtime 导出符号。

同时从 Windows-Inference skip list 中放出 `operator_test`，让该 CI 直接验证上述 registry 修复。

关联拆分来源：#79381

验证：
- `git diff --check`
- `prek --files paddle/fluid/framework/operator.h paddle/fluid/framework/operator.cc tools/windows/run_unittests.sh`
- `bash -n tools/windows/run_unittests.sh`

### 是否引起精度变化
否