### PR TITLE
[release/3.4][Build][CI] Switch pocketfft submodule URL to GitHub mirror

### DIFF
--- a/.github/workflows/_Clone-linux.yml
+++ b/.github/workflows/_Clone-linux.yml
@@ -89,7 +89,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
-          submodules: "recursive"
           fetch-depth: 1000
 
       - name: Merge PR to test branch
@@ -107,7 +106,8 @@ jobs:
           git config user.email "paddle_ci@example.com"
           git fetch origin pull/${{ github.event.pull_request.number }}/head:pr
           git merge --no-ff pr
-          git submodule update --init
+          git submodule sync --recursive
+          git submodule update --init --recursive
           git branch -d pr
           source ${ci_scripts}/check_execution.sh
           bash ${ci_scripts}/third_party_tag.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 	ignore = dirty
 [submodule "third_party/pocketfft"]
 	path = third_party/pocketfft
-	url = https://gitlab.mpcdf.mpg.de/mtr/pocketfft.git
+	url = https://github.com/mreineck/pocketfft.git
 	ignore = dirty
 [submodule "third_party/gflags"]
 	path = third_party/gflags


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
pocketfft 的原 submodule URL `https://gitlab.mpcdf.mpg.de/mtr/pocketfft.git` 当前访问 403，本 PR 将 `.gitmodules` 中的 `third_party/pocketfft` URL 切换为可访问的 GitHub 上游仓库：`https://github.com/mreineck/pocketfft.git`。

本 PR 同时调整 Linux clone workflow：`_Clone-linux.yml` 不再在 checkout base branch 时递归拉取 submodule，而是在 merge PR 后执行 `git submodule sync --recursive` 和 `git submodule update --init --recursive`。这样 clone job 会使用 PR merge 后的 `.gitmodules`，避免不可豁免的 clone 阶段继续读取 develop 上的旧 403 URL。Windows clone workflow 已经是类似顺序。

`third_party/pocketfft` 的 gitlink/submodule commit 保持为 `ea778e37710c07723435b1be58235996d1d43a5a`，未发生变更。

验证：

- `git config -f .gitmodules --get submodule.third_party/pocketfft.url` -> `https://github.com/mreineck/pocketfft.git`
- `git ls-remote https://github.com/mreineck/pocketfft.git refs/heads/cpp refs/tags/release_for_eigen refs/tags/release_for_eigen^{}` -> `refs/tags/release_for_eigen^{}` 指向 `ea778e37710c07723435b1be58235996d1d43a5a`
- 强制清理并重新初始化 `third_party/pocketfft` submodule 后运行：
  - `git submodule sync -- third_party/pocketfft`
  - `git submodule deinit -f -- third_party/pocketfft`
  - `rm -rf .git/modules/third_party/pocketfft third_party/pocketfft`
  - `git submodule update --init -- third_party/pocketfft`
- `git submodule status -- third_party/pocketfft` -> `ea778e37710c07723435b1be58235996d1d43a5a third_party/pocketfft (release_for_eigen)`
- `git -C third_party/pocketfft remote get-url origin` -> `https://github.com/mreineck/pocketfft.git`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/_Clone-linux.yml"); puts "ok"'` -> pass
- `git diff --check` -> pass
- 本地模拟 Linux clone 顺序：从 `upstream/develop` 创建临时 worktree，不做 checkout 阶段 submodule init，merge PR head 后对 `third_party/pocketfft` 执行 `git submodule sync` + `git submodule update --init`，成功从新 URL checkout 到 `ea778e37710c07723435b1be58235996d1d43a5a`
- 对 `.gitmodules`、`cmake/external/pocketfft.cmake`、`patches/pocketfft`、`ci/third_party_tag.sh`、`ci/windows/third_party_tag.bat`、`cmake/third_party.cmake` 做了旧 URL / `PFCCLab/pocketfft` / `mreineck/pocketfft` 相关 grep；除 `.gitmodules` 中已更新的 URL 外未发现其它相关 URL 引用。

未运行完整 Paddle 构建/测试；本次为 submodule URL 与 clone workflow 顺序调整，完整构建成本较高。

### 是否引起精度变化
否


---

Cherry-pick of #79420 (authored by @ShigureNyako) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79420 <!-- For pass CI -->