### PR TITLE
[Profiler] Export common host event gather

### DIFF
--- a/paddle/fluid/platform/profiler/host_tracer.cc
+++ b/paddle/fluid/platform/profiler/host_tracer.cc
@@ -24,6 +24,7 @@ namespace paddle::platform {
 
 PADDLE_API HostEventSection<CommonEvent> GatherCommonHostEvents();
 PADDLE_API HostEventSection<CommonMemEvent> GatherCommonHostMemEvents();
+PADDLE_API void SetHostTraceLevel(int64_t trace_level);
 
 namespace {
 
@@ -136,7 +137,7 @@ void ProcessOperatorSupplementEvents(
 
 void HostTracer::PrepareTracing() {
   // warm up
-  HostTraceLevel::GetInstance().SetLevel(options_.trace_level);
+  SetHostTraceLevel(options_.trace_level);
   state_ = TracerState::READY;
 }
 
@@ -149,7 +150,7 @@ void HostTracer::StartTracing() {
   GatherCommonHostMemEvents();
   HostEventRecorder<OperatorSupplementOriginEvent>::GetInstance()
       .GatherEvents();
-  HostTraceLevel::GetInstance().SetLevel(options_.trace_level);
+  SetHostTraceLevel(options_.trace_level);
   state_ = TracerState::STARTED;
 }
 
@@ -158,7 +159,7 @@ void HostTracer::StopTracing() {
       state_,
       TracerState::STARTED,
       common::errors::PreconditionNotMet("TracerState must be STARTED"));
-  HostTraceLevel::GetInstance().SetLevel(HostTraceLevel::kDisabled);
+  SetHostTraceLevel(HostTraceLevel::kDisabled);
   state_ = TracerState::STOPPED;
 }
 

--- a/paddle/fluid/platform/profiler/host_tracer.cc
+++ b/paddle/fluid/platform/profiler/host_tracer.cc
@@ -22,6 +22,9 @@
 
 namespace paddle::platform {
 
+PADDLE_API HostEventSection<CommonEvent> GatherCommonHostEvents();
+PADDLE_API HostEventSection<CommonMemEvent> GatherCommonHostMemEvents();
+
 namespace {
 
 void ProcessHostEvents(const HostEventSection<CommonEvent>& host_events,
@@ -142,8 +145,8 @@ void HostTracer::StartTracing() {
       state_ == TracerState::READY || state_ == TracerState::STOPPED,
       true,
       common::errors::PreconditionNotMet("TracerState must be READY"));
-  HostEventRecorder<CommonEvent>::GetInstance().GatherEvents();
-  HostEventRecorder<CommonMemEvent>::GetInstance().GatherEvents();
+  GatherCommonHostEvents();
+  GatherCommonHostMemEvents();
   HostEventRecorder<OperatorSupplementOriginEvent>::GetInstance()
       .GatherEvents();
   HostTraceLevel::GetInstance().SetLevel(options_.trace_level);
@@ -164,11 +167,10 @@ void HostTracer::CollectTraceData(TraceEventCollector* collector) {
       state_,
       TracerState::STOPPED,
       common::errors::PreconditionNotMet("TracerState must be STOPPED"));
-  HostEventSection<CommonEvent> host_events =
-      HostEventRecorder<CommonEvent>::GetInstance().GatherEvents();
+  HostEventSection<CommonEvent> host_events = GatherCommonHostEvents();
   ProcessHostEvents(host_events, collector);
   HostEventSection<CommonMemEvent> host_mem_events =
-      HostEventRecorder<CommonMemEvent>::GetInstance().GatherEvents();
+      GatherCommonHostMemEvents();
   ProcessHostMemEvents(host_mem_events, collector);
   HostEventSection<OperatorSupplementOriginEvent> op_supplement_events =
       HostEventRecorder<OperatorSupplementOriginEvent>::GetInstance()

--- a/paddle/fluid/platform/profiler/host_tracer.cc
+++ b/paddle/fluid/platform/profiler/host_tracer.cc
@@ -22,10 +22,6 @@
 
 namespace paddle::platform {
 
-PADDLE_API HostEventSection<CommonEvent> GatherCommonHostEvents();
-PADDLE_API HostEventSection<CommonMemEvent> GatherCommonHostMemEvents();
-PADDLE_API void SetHostTraceLevel(int64_t trace_level);
-
 namespace {
 
 void ProcessHostEvents(const HostEventSection<CommonEvent>& host_events,

--- a/paddle/phi/api/profiler/host_tracer.h
+++ b/paddle/phi/api/profiler/host_tracer.h
@@ -14,7 +14,16 @@
 
 #pragma once
 
+#include <cstdint>
+
+#include "paddle/common/macros.h"
+
 namespace phi {
+
+struct CommonEvent;
+struct CommonMemEvent;
+template <typename EventType>
+struct HostEventSection;
 
 class HostTraceLevel {
  public:
@@ -41,3 +50,12 @@ struct HostTracerOptions {
 };
 
 }  // namespace phi
+
+namespace paddle::platform {
+
+PADDLE_API phi::HostEventSection<phi::CommonEvent> GatherCommonHostEvents();
+PADDLE_API phi::HostEventSection<phi::CommonMemEvent>
+GatherCommonHostMemEvents();
+PADDLE_API void SetHostTraceLevel(int64_t trace_level);
+
+}  // namespace paddle::platform

--- a/paddle/phi/core/platform/profiler.cc
+++ b/paddle/phi/core/platform/profiler.cc
@@ -819,7 +819,8 @@ void DisableMemoryRecorder() { FLAGS_enable_record_memory = false; }
 
 std::string PrintHostEvents() {
   std::ostringstream oss;
-  auto host_evt_sec = GatherCommonHostEvents();
+  auto host_evt_sec =
+      HostEventRecorder<phi::CommonEvent>::GetInstance().GatherEvents();
   for (const auto &thr_evt_sec : host_evt_sec.thr_sections) {
     oss << thr_evt_sec.thread_id << std::endl;
     for (const auto &evt : thr_evt_sec.events) {
@@ -910,7 +911,8 @@ static std::map<uint64_t, phi::ThreadEvents> DockHostEventRecorderHostPart() {
   if (FLAGS_enable_host_event_recorder_hook == false) {
     return thr_events;
   }
-  auto host_evt_sec = GatherCommonHostEvents();
+  auto host_evt_sec =
+      HostEventRecorder<phi::CommonEvent>::GetInstance().GatherEvents();
   EmulateEventPushAndPop(host_evt_sec, &thr_events);
   EmulateCPURecordsAdd(host_evt_sec);
   return thr_events;

--- a/paddle/phi/core/platform/profiler.cc
+++ b/paddle/phi/core/platform/profiler.cc
@@ -62,6 +62,14 @@ namespace paddle::platform {
 
 MemEventRecorder MemEventRecorder::recorder;
 
+PADDLE_API HostEventSection<phi::CommonEvent> GatherCommonHostEvents() {
+  return HostEventRecorder<phi::CommonEvent>::GetInstance().GatherEvents();
+}
+
+PADDLE_API HostEventSection<phi::CommonMemEvent> GatherCommonHostMemEvents() {
+  return HostEventRecorder<phi::CommonMemEvent>::GetInstance().GatherEvents();
+}
+
 RecordInstantEvent::RecordInstantEvent(const char *name,
                                        phi::TracerEventType type,
                                        uint32_t level) {
@@ -807,8 +815,7 @@ void DisableMemoryRecorder() { FLAGS_enable_record_memory = false; }
 
 std::string PrintHostEvents() {
   std::ostringstream oss;
-  auto host_evt_sec =
-      HostEventRecorder<phi::CommonEvent>::GetInstance().GatherEvents();
+  auto host_evt_sec = GatherCommonHostEvents();
   for (const auto &thr_evt_sec : host_evt_sec.thr_sections) {
     oss << thr_evt_sec.thread_id << std::endl;
     for (const auto &evt : thr_evt_sec.events) {
@@ -899,8 +906,7 @@ static std::map<uint64_t, phi::ThreadEvents> DockHostEventRecorderHostPart() {
   if (FLAGS_enable_host_event_recorder_hook == false) {
     return thr_events;
   }
-  auto host_evt_sec =
-      HostEventRecorder<phi::CommonEvent>::GetInstance().GatherEvents();
+  auto host_evt_sec = GatherCommonHostEvents();
   EmulateEventPushAndPop(host_evt_sec, &thr_events);
   EmulateCPURecordsAdd(host_evt_sec);
   return thr_events;

--- a/paddle/phi/core/platform/profiler.cc
+++ b/paddle/phi/core/platform/profiler.cc
@@ -70,6 +70,10 @@ PADDLE_API HostEventSection<phi::CommonMemEvent> GatherCommonHostMemEvents() {
   return HostEventRecorder<phi::CommonMemEvent>::GetInstance().GatherEvents();
 }
 
+PADDLE_API void SetHostTraceLevel(int64_t trace_level) {
+  phi::HostTraceLevel::GetInstance().SetLevel(trace_level);
+}
+
 RecordInstantEvent::RecordInstantEvent(const char *name,
                                        phi::TracerEventType type,
                                        uint32_t level) {

--- a/test/cpp/fluid/platform/profiler/profiler_test.cc
+++ b/test/cpp/fluid/platform/profiler/profiler_test.cc
@@ -14,6 +14,7 @@
 
 #include <set>
 #include <string>
+#include <utility>
 
 #include "glog/logging.h"
 #include "gtest/gtest.h"
@@ -100,6 +101,7 @@ TEST(ProfilerTest, TestCudaTracer) {
 
 TEST(ProfilerTest, TestHostTracerForMem) {
   using paddle::platform::EnableHostEventRecorder;
+  using paddle::platform::EnableMemoryRecorder;
   using paddle::platform::MemTraceEventNode;
   using paddle::platform::Profiler;
   using paddle::platform::ProfilerOptions;
@@ -116,6 +118,7 @@ TEST(ProfilerTest, TestHostTracerForMem) {
   auto profiler = Profiler::Create(options);
   EXPECT_TRUE(profiler);
   EnableHostEventRecorder();
+  EnableMemoryRecorder();
   profiler->Prepare();
   profiler->Start();
   {
@@ -141,5 +144,21 @@ TEST(ProfilerTest, TestHostTracerForMem) {
                    TracerMemEventType::Free);
   }
   auto profiler_result = profiler->Stop();
+  paddle::platform::DisableMemoryRecorder();
   auto nodetree = profiler_result->GetNodeTrees();
+  std::set<std::pair<uint64_t, TracerMemEventType>> mem_events;
+  for (const auto& pair : nodetree->Traverse(true)) {
+    for (const auto host_node : pair.second) {
+      for (const auto mem_node : host_node->GetMemTraceEventNodes()) {
+        if (mem_node->Addr() == 0 || mem_node->Addr() == 1024) {
+          mem_events.emplace(mem_node->Addr(), mem_node->Type());
+        }
+      }
+    }
+  }
+  EXPECT_EQ(mem_events.size(), 4u);
+  EXPECT_EQ(mem_events.count({0, TracerMemEventType::Allocate}), 1u);
+  EXPECT_EQ(mem_events.count({0, TracerMemEventType::Free}), 1u);
+  EXPECT_EQ(mem_events.count({1024, TracerMemEventType::Allocate}), 1u);
+  EXPECT_EQ(mem_events.count({1024, TracerMemEventType::Free}), 1u);
 }

--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -286,7 +286,6 @@ disable_wingpu_cuda12_test="^test_cholesky_op$|\
 ^test_trt_convert_clip$|\
 ^test_trt_convert_grid_sampler$|\
 ^test_trt_convert_p_norm$|\
-^new_profiler_test$|\
 ^save_load_version_compat_test$|\
 ^test_weight_decay$|\
 ^disable_wingpu_cuda12_test$"
@@ -544,7 +543,6 @@ disable_win_inference_test="^trt_quant_int8_yolov3_r50_test$|\
 ^test_trt_convert_multihead_matmul_roformer$|\
 ^test_cudnn_placement_pass$|\
 ^operator_test$|\
-^new_profiler_test$|\
 ^test_kernel_factory$|\
 ^save_load_version_compat_test$|\
 ^trt_mobilenet_test$|\
@@ -572,7 +570,6 @@ disable_wincpu_test="^jit_kernel_test$|\
 ^test_build_strategy$|\
 ^test_se_resnet$|\
 ^operator_test|\
-^new_profiler_test$|\
 ^save_load_version_compat_test|\
 ^disable_wincpu_test$"
 

--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -542,7 +542,6 @@ disable_win_inference_test="^trt_quant_int8_yolov3_r50_test$|\
 ^test_split_program_deprecated$|\
 ^test_trt_convert_multihead_matmul_roformer$|\
 ^test_cudnn_placement_pass$|\
-^operator_test$|\
 ^test_kernel_factory$|\
 ^save_load_version_compat_test$|\
 ^trt_mobilenet_test$|\


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
从 Windows Inference VS2022/CUDA 13.3 调试主 PR PaddlePaddle/Paddle#79381 中拆出 profiler shared-DLL 的最小修复。

Windows shared-DLL 构建下，`HostTraceLevel`、`HostEventRecorder<CommonEvent>` 和 `HostEventRecorder<CommonMemEvent>` 都是 header 单例/模板单例。`host_tracer.cc` 直接设置 trace level 或直接调用 `GetInstance().GatherEvents()` 时，可能在调用方模块生成另一份 function-local static，导致 profiler 设置侧、记录侧和收集侧不在同一份实例上。

本 PR 在 `paddle/phi/core/platform/profiler.cc` 中导出 `SetHostTraceLevel()`、`GatherCommonHostEvents()` 和 `GatherCommonHostMemEvents()`，并让 `host_tracer.cc` 通过这些非模板导出函数设置 trace level、收集/清空 common host event，修复 Windows shared-DLL 下 `new_profiler_test` 暴露的 host event 未记录或收集不一致问题。

同时从 Windows CUDA12、Windows-Inference、Windows-OPENBLAS 的 skip 列表中移除 `new_profiler_test`，让该 profiler 单测在 Windows CI 中重新执行，覆盖本 PR 修复。

关联 PR：
- PaddlePaddle/Paddle#79381：Windows-Inference VS2022 + CUDA 13.3 适配主 PR，本 PR 是其中 profiler shared-DLL 问题的独立拆分修复。
- PaddlePaddle/Paddle#79419：同类 Windows DLL / EXE 共享状态修复，将 Fluid op kernel registry 的访问入口改为导出函数，避免测试注册的 kernel 在查询侧不可见。

验证：
- `git diff --check`
- `prek`

### 是否引起精度变化
否