### PR TITLE
Improve VMM OOM diagnostics

### DIFF
--- a/paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.cc
+++ b/paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.cc
@@ -23,6 +23,7 @@
 
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.h"
+#include "paddle/phi/core/memory/stats.h"
 
 #ifdef PADDLE_WITH_CUDA
 #include "paddle/phi/backends/dynload/cuda_driver.h"
@@ -30,6 +31,8 @@
 #include "paddle/phi/core/platform/device/gpu/gpu_info.h"
 
 namespace paddle::memory::allocation {
+
+constexpr size_t kVirtualAddressSpaceSizeMultiplier = 2;
 
 std::mutex CUDAVirtualMemAllocator::base_ptr_handle_mu_;
 std::unordered_map<void*, CUmemGenericAllocationHandle>
@@ -85,12 +88,13 @@ void CUDAVirtualMemAllocator::InitOnce() {
             << "actual_total: " << static_cast<double>(actual_total) / (1 << 20)
             << " MB";
 
-    virtual_mem_size_ = AlignedSize(actual_total, granularity_);
+    virtual_mem_size_ = AlignedSize(
+        actual_total * kVirtualAddressSpaceSizeMultiplier, granularity_);
 
     // Reserve the required contiguous virtual address space for the allocations
-    // The maximum video memory size we can apply for is the video memory size
-    // of GPU, so the virtual address space size we reserve is equal to the GPU
-    // video memory size
+    // Reserving a larger VA range does not allocate physical memory up front.
+    // It leaves room for VMM pool fragmentation before physical memory is
+    // exhausted.
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cuMemAddressReserve(
         &virtual_mem_base_, virtual_mem_size_, 0, 0, 0));
 
@@ -175,11 +179,14 @@ phi::Allocation* CUDAVirtualMemAllocator::AllocateImpl(size_t size) {
       size_t actual_avail, actual_total;
       PADDLE_ENFORCE_GPU_SUCCESS(cudaMemGetInfo(&actual_avail, &actual_total));
       size_t actual_allocated = actual_total - actual_avail;
+      size_t actual_allocated_memory =
+          paddle::memory::DeviceMemoryStatCurrentValue("Allocated",
+                                                       place_.device);
 
       PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
           "\n\nOut of memory error on GPU %d. "
-          "Cannot allocate %s memory on GPU %d, %s memory has been allocated "
-          "and "
+          "Cannot allocate %s memory on GPU %d, %s memory has been "
+          "allocated(actual using allocated memory %s) and "
           "available memory is only %s.\n\n"
           "Please check whether there is any other process using GPU %d.\n"
           "1. If yes, please stop them, or start PaddlePaddle on another GPU.\n"
@@ -188,6 +195,7 @@ phi::Allocation* CUDAVirtualMemAllocator::AllocateImpl(size_t size) {
           string::HumanReadableSize(size),
           place_.device,
           string::HumanReadableSize(actual_allocated),
+          string::HumanReadableSize(actual_allocated_memory),
           string::HumanReadableSize(actual_avail),
           place_.device));
     } else {

--- a/paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.cc
+++ b/paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.cc
@@ -17,6 +17,7 @@
 #include <mutex>
 #include "glog/logging.h"
 #include "paddle/common/flags.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/memory/allocation/aligned_allocator.h"
 #include "paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.h"
 
@@ -302,7 +303,23 @@ void VirtualMemoryAutoGrowthBestFitAllocator::ExtendOrCompact(size_t size) {
              std::to_string(size));
   }
 
-  auto allocateptr = AllocateOrCompact(size).value_or(nullptr);
+  std::optional<AllocationPtr> allocate_result;
+  try {
+    allocate_result = AllocateOrCompact(size);
+  } catch (const paddle::memory::allocation::BadAlloc &e) {
+    auto stats = SumLargestFreeBlockSizes(free_blocks_.size());
+    PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
+        "%s\n"
+        "VMM allocator stats (pool): total_free=%s, max_free=%s.\n",
+        e.what(),
+        string::HumanReadableSize(stats.second),
+        string::HumanReadableSize(stats.first)));
+  }
+
+  AllocationPtr allocateptr = nullptr;
+  if (allocate_result.has_value()) {
+    allocateptr = std::move(allocate_result.value());
+  }
   if (!allocateptr) {
     // Allocate failed and Compact success branch.
     free_blocks_.clear();
@@ -450,12 +467,12 @@ bool VirtualMemoryAutoGrowthBestFitAllocator::TryAllocateBatch(
 
 std::pair<size_t, size_t>
 VirtualMemoryAutoGrowthBestFitAllocator::SumLargestFreeBlockSizes(
-    int32_t n) const {
-  if (n <= 0 || free_blocks_.empty()) return std::make_pair(0, 0);
+    size_t n) const {
+  if (n == 0 || free_blocks_.empty()) return std::make_pair(0, 0);
 
   size_t large_size = free_blocks_.rbegin()->first.first;
   size_t total_size = 0;
-  int32_t count = 0;
+  size_t count = 0;
 
   for (auto it = free_blocks_.rbegin(); it != free_blocks_.rend() && count < n;
        ++it, ++count) {

--- a/paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.h
+++ b/paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.h
@@ -58,7 +58,7 @@ class VirtualMemoryAutoGrowthBestFitAllocator : public Allocator {
 
   const std::list<Block> &GetAllBlocks() const { return all_blocks_; }
 
-  std::pair<size_t, size_t> SumLargestFreeBlockSizes(int32_t n) const;
+  std::pair<size_t, size_t> SumLargestFreeBlockSizes(size_t n) const;
   void Accept(AllocatorVisitor *visitor) override { visitor->Visit(this); }
 
   bool IsAllocThreadSafe() const override { return true; }

--- a/paddle/phi/core/memory/mem_visitor.cc
+++ b/paddle/phi/core/memory/mem_visitor.cc
@@ -82,8 +82,8 @@ void AllocatorComputeStreamVisitor::Visit(StreamSafeCUDAAllocator* allocator) {
 
 void FreeMemoryMetricsVisitor::Visit(
     VirtualMemoryAutoGrowthBestFitAllocator* allocator) {
-  auto [large_size, sum_size] =
-      allocator->SumLargestFreeBlockSizes(nums_blocks_);
+  auto [large_size, sum_size] = allocator->SumLargestFreeBlockSizes(
+      static_cast<size_t>(std::max(nums_blocks_, 0)));
   large_size_ = std::max(large_size_, large_size);
   sum_size_ = std::max(sum_size_, sum_size);
 }

--- a/test/cpp/fluid/memory/vmm_auto_growth_best_fit_allocator_test.cu
+++ b/test/cpp/fluid/memory/vmm_auto_growth_best_fit_allocator_test.cu
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <iostream>
 #include <memory>
+#include <string>
 
 #include "paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.h"
 
@@ -57,6 +59,18 @@ class DummyAllocator : public Allocator {
   void FreeImpl(phi::Allocation*) override {}
 };
 
+class AlwaysOOMAllocator : public Allocator {
+ public:
+  bool IsAllocThreadSafe() const override { return true; }
+
+ protected:
+  phi::Allocation* AllocateImpl(size_t size) override {
+    PADDLE_THROW_BAD_ALLOC(common::errors::ResourceExhausted(
+        "AlwaysOOMAllocator failed to allocate %zu bytes.", size));
+  }
+  void FreeImpl(phi::Allocation*) override {}
+};
+
 // Expose FreeImpl for testing.
 class ExposedVmmAllocator : public VirtualMemoryAutoGrowthBestFitAllocator {
  public:
@@ -93,6 +107,48 @@ TEST(test_vmm_allocator, free_impl_uses_allocation_block_iterator) {
             reinterpret_cast<void*>(0x1000));
   EXPECT_EQ(allocator.all_blocks_.front().size_, 7168UL);
   EXPECT_TRUE(allocator.all_blocks_.front().is_free_);
+}
+
+TEST(test_vmm_allocator, oom_error_prints_pool_stats) {
+  auto underlying = std::make_shared<AlwaysOOMAllocator>();
+  phi::GPUPlace place(0);
+  ExposedVmmAllocator allocator(underlying, 256, place);
+
+  auto used1 = allocator.all_blocks_.emplace(allocator.all_blocks_.end(),
+                                             reinterpret_cast<void*>(0x1000),
+                                             1UL << 20,
+                                             false);
+  auto free1 = allocator.all_blocks_.emplace(allocator.all_blocks_.end(),
+                                             reinterpret_cast<void*>(0x101000),
+                                             2UL << 20,
+                                             true);
+  auto used2 = allocator.all_blocks_.emplace(allocator.all_blocks_.end(),
+                                             reinterpret_cast<void*>(0x301000),
+                                             1UL << 20,
+                                             false);
+  auto free2 = allocator.all_blocks_.emplace(allocator.all_blocks_.end(),
+                                             reinterpret_cast<void*>(0x401000),
+                                             4UL << 20,
+                                             true);
+
+  allocator.free_blocks_.emplace(std::make_pair(free1->size_, free1->ptr_),
+                                 free1);
+  allocator.free_blocks_.emplace(std::make_pair(free2->size_, free2->ptr_),
+                                 free2);
+
+  try {
+    allocator.Allocate(5UL << 20);
+    FAIL() << "Expected VMM allocator OOM.";
+  } catch (const BadAlloc& ex) {
+    std::string message = ex.what();
+    std::cout << "\n[VMM OOM MESSAGE]\n" << message << std::endl;
+    EXPECT_NE(message.find("VMM allocator stats (pool): "
+                           "total_free=6.000000MB, max_free=4.000000MB."),
+              std::string::npos);
+  }
+
+  static_cast<void>(used1);
+  static_cast<void>(used2);
 }
 
 }  // namespace allocation


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] --> User Experience


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] --> Not User Facing


### Description
<!-- Describe what you’ve done --> Improve VMM OOM diagnostics


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]--> 否 

OOM Message：
```
----------------------
Error Message Summary:
----------------------
ResourceExhaustedError: 

Out of memory error on GPU 0. Cannot allocate 10.000000GB memory on GPU 0, 77.415039GB memory has been allocated(actual using allocated memory 73.000000GB) and available memory is only 1.735962GB.

Please check whether there is any other process using GPU 0.
1. If yes, please stop them, or start PaddlePaddle on another GPU.
2. If no, please decrease the batch size of your model.

 (at paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.cc:183)

VMM allocator stats (pool): total_free=4.001953GB, max_free=2.000000GB.
 (at paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.cc:311)
```
