### PR TITLE
[Operator Mechanism] fix Broadcast do not support big_tensor

### DIFF
--- a/paddle/phi/kernels/primitive/datamover_primitives.h
+++ b/paddle/phi/kernels/primitive/datamover_primitives.h
@@ -41,7 +41,7 @@ struct alignas(sizeof(T) * VecSize) VectorType {
  * must be [dim1, dim0].
  */
 struct BroadcastConfig {
-  funcs::FastDivMod<int> divmoders[DDim::kMaxRank];
+  funcs::FastDivMod<int64_t> divmoders[DDim::kMaxRank];
   uint64_t strides[DDim::kMaxRank];
   int rank{0};
 
@@ -52,8 +52,7 @@ struct BroadcastConfig {
                   const std::vector<int64_t>& in_dims,
                   int dim_size) {
     for (int i = 0; i < dim_size; ++i) {
-      PADDLE_ENFORCE_LE_INT_MAX(out_dims[i], "out_dim");
-      divmoders[i] = funcs::FastDivMod<int>(static_cast<int>(out_dims[i]));
+      divmoders[i] = funcs::FastDivMod<int64_t>(out_dims[i]);
     }
 
     for (int i = 0; i < dim_size; ++i) {
@@ -420,13 +419,15 @@ __device__ __forceinline__ void ReadDataBc(
     int stride_nx,
     int stride_ny) {
   uint32_t thread_offset = block_offset + threadIdx.x;
-  uint32_t index_src = 0;
+  int64_t index_src = 0;
 
 #pragma unroll
   for (int ny = 0; ny < NY; ++ny) {
 #pragma unroll
     for (uint32_t nx = 0; nx < NX; ++nx) {
-      uint32_t index_output = thread_offset + ny * stride_ny + nx * stride_nx;
+      int64_t index_output = thread_offset +
+                             static_cast<int64_t>(ny) * stride_ny +
+                             static_cast<int64_t>(nx) * stride_nx;
       index_src = 0;
       if (IsBoundary) {
         if (index_output >= total_num_output) {
@@ -755,11 +756,11 @@ __device__ __forceinline__ void ReadDataBc(
     int total_num_output,
     int read_lens = NX) {
   uint32_t thread_offset = block_offset + threadIdx.x * NX;
-  uint32_t index_src = 0;
+  int64_t index_src = 0;
 
 #pragma unroll
   for (uint32_t nx = 0; nx < NX; ++nx) {
-    uint32_t index_output = thread_offset + nx;
+    int64_t index_output = thread_offset + nx;
     index_src = 0;
     if (IsBoundary) {
       if (index_output >= total_num_output) {
@@ -816,11 +817,11 @@ __device__ __forceinline__ void ReadDataBc(
     int total_num_output,
     int read_lens = NX) {
   uint32_t thread_offset = block_offset + threadIdx.x * NX;
-  uint32_t index_src = 0;
+  int64_t index_src = 0;
 
 #pragma unroll
   for (uint32_t nx = 0; nx < NX; ++nx) {
-    uint32_t index_output = thread_offset + nx;
+    int64_t index_output = thread_offset + nx;
     index_src = 0;
     if (IsBoundary) {
       if (index_output >= total_num_output) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

BroadcastConfig 中使用 FastDivMod<int> 对输出线性索引进行维度坐标拆解。当 tensor 某一维度大小超过 INT_MAX（2^31 - 1）时，int 类型发生溢出，导致索引计算错误，广播结果产生静默错误。

#### 修复
将 BroadcastConfig 中的 FastDivMod<int> 替换为 FastDivMod<int64_t>，移除 PADDLE_ENFORCE_LE_INT_MAX 的限制，使广播操作支持单维度超过 2^31 的大 tensor。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否