### PR TITLE
[VMM] add large/small pool separate query APIs 

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -260,6 +260,12 @@ PYBIND11_MAKE_OPAQUE(paddle::framework::FetchUnmergedList);
 PYBIND11_MAKE_OPAQUE(paddle::framework::FetchList);
 PYBIND11_MAKE_OPAQUE(paddle::framework::FetchType);
 
+// Opaque type for AllBlockInfoOfAllocator — avoid full O(n) conversion
+// at pybind boundary; only convert on per-group access (__getitem__).
+using AllBlocksInfoType =
+    std::vector<std::vector<std::tuple<size_t, uintptr_t, bool>>>;
+PYBIND11_MAKE_OPAQUE(AllBlocksInfoType);
+
 DECLARE_FILE_SYMBOLS(init_phi);
 DECLARE_FILE_SYMBOLS(kernel_dialect);
 #ifdef PADDLE_WITH_DISTRIBUTE
@@ -3779,6 +3785,24 @@ All parameter, weight, gradient are variables in Paddle.
 #endif
 #endif
 #if defined(PADDLE_WITH_CUDA)
+  // Register opaque AllBlocksInfo type — lazy per-group conversion
+  py::class_<AllBlocksInfoType>(m, "AllBlocksInfo")
+      .def("__len__", &AllBlocksInfoType::size)
+      .def("__getitem__",
+           [](const AllBlocksInfoType &self,
+              int64_t i) -> std::vector<std::tuple<size_t, uintptr_t, bool>> {
+             if (i < 0) i += static_cast<int64_t>(self.size());
+             if (i < 0 || static_cast<size_t>(i) >= self.size())
+               throw py::index_error();
+             return self[i];
+           })
+      .def(
+          "__iter__",
+          [](const AllBlocksInfoType &self) {
+            return py::make_iterator(self.begin(), self.end());
+          },
+          py::keep_alive<0, 1>());
+
   m.def("vmm_max_free_size", [](int device_id) {
     return memory::VmmMaxFreeSize(GPUPlace(device_id), 1);
   });
@@ -3788,12 +3812,30 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("vmm_free_block_info", [](int device_id) {
     return paddle::memory::FreeBlockInfoOfVmmAllocator(GPUPlace(device_id));
   });
-  m.def("all_block_info", [](int device_id) {
-    return paddle::memory::AllBlockInfoOfAllocator(GPUPlace(device_id));
-  });
-  m.def("vmm_all_block_info", [](int device_id) {
-    return paddle::memory::AllBlockInfoOfAllocator(GPUPlace(device_id));
-  });
+  m.def(
+      "all_block_info",
+      [](int device_id) -> AllBlocksInfoType {
+        return paddle::memory::AllBlockInfoOfAllocator(GPUPlace(device_id));
+      },
+      py::return_value_policy::move);
+  m.def(
+      "vmm_all_block_info",
+      [](int device_id) -> AllBlocksInfoType {
+        return paddle::memory::AllBlockInfoOfAllocator(GPUPlace(device_id));
+      },
+      py::return_value_policy::move);
+  m.def(
+      "large_pool_block_info",
+      [](int device_id) -> AllBlocksInfoType {
+        return paddle::memory::LargePoolBlockInfo(GPUPlace(device_id));
+      },
+      py::return_value_policy::move);
+  m.def(
+      "small_pool_block_info",
+      [](int device_id) -> AllBlocksInfoType {
+        return paddle::memory::SmallPoolBlockInfo(GPUPlace(device_id));
+      },
+      py::return_value_policy::move);
   m.def("get_allocate_record", [](int device_id) {
     return paddle::memory::GetAllocateEvent(GPUPlace(device_id));
   });

--- a/paddle/phi/core/memory/mem_utils.cc
+++ b/paddle/phi/core/memory/mem_utils.cc
@@ -183,7 +183,21 @@ AllBlockInfoOfAllocator(const GPUPlace& place) {
   AllBlocksInfoVisitor all_blocks_info_visitor;
   allocation::AllocatorFacade::Instance().Accept(place,
                                                  &all_blocks_info_visitor);
-  return all_blocks_info_visitor.GetAllBlocksInfo();
+  return std::move(all_blocks_info_visitor).GetAllBlocksInfo();
+}
+
+std::vector<std::vector<std::tuple<size_t, uintptr_t, bool>>>
+LargePoolBlockInfo(const GPUPlace& place) {
+  AllBlocksInfoVisitor visitor(AllBlocksInfoVisitor::PoolFilter::kLargeOnly);
+  allocation::AllocatorFacade::Instance().Accept(place, &visitor);
+  return std::move(visitor).GetAllBlocksInfo();
+}
+
+std::vector<std::vector<std::tuple<size_t, uintptr_t, bool>>>
+SmallPoolBlockInfo(const GPUPlace& place) {
+  AllBlocksInfoVisitor visitor(AllBlocksInfoVisitor::PoolFilter::kSmallOnly);
+  allocation::AllocatorFacade::Instance().Accept(place, &visitor);
+  return std::move(visitor).GetAllBlocksInfo();
 }
 
 std::vector<std::tuple<uintptr_t, bool, uint64_t, size_t, int64_t, int64_t>>

--- a/paddle/phi/core/memory/mem_utils.h
+++ b/paddle/phi/core/memory/mem_utils.h
@@ -108,6 +108,14 @@ FreeBlockInfoOfVmmAllocator(const GPUPlace& place);
 PADDLE_API extern std::vector<std::vector<std::tuple<size_t, uintptr_t, bool>>>
 AllBlockInfoOfAllocator(const GPUPlace& place);
 
+// Get large pool block info only (skip small pool traversal).
+PADDLE_API extern std::vector<std::vector<std::tuple<size_t, uintptr_t, bool>>>
+LargePoolBlockInfo(const GPUPlace& place);
+
+// Get small pool block info only (skip large pool traversal).
+PADDLE_API extern std::vector<std::vector<std::tuple<size_t, uintptr_t, bool>>>
+SmallPoolBlockInfo(const GPUPlace& place);
+
 // Get allocate event when start FLAGS_record_alloc_event.
 PADDLE_API extern std::vector<
     std::tuple<uintptr_t, bool, uint64_t, size_t, int64_t, int64_t>>

--- a/paddle/phi/core/memory/mem_visitor.cc
+++ b/paddle/phi/core/memory/mem_visitor.cc
@@ -82,8 +82,8 @@ void AllocatorComputeStreamVisitor::Visit(StreamSafeCUDAAllocator* allocator) {
 
 void FreeMemoryMetricsVisitor::Visit(
     VirtualMemoryAutoGrowthBestFitAllocator* allocator) {
-  auto [large_size, sum_size] = allocator->SumLargestFreeBlockSizes(
-      static_cast<size_t>(std::max(nums_blocks_, 0)));
+  const size_t num_blocks = static_cast<size_t>(std::max(nums_blocks_, 0));
+  auto [large_size, sum_size] = allocator->SumLargestFreeBlockSizes(num_blocks);
   large_size_ = std::max(large_size_, large_size);
   sum_size_ = std::max(sum_size_, sum_size);
 }
@@ -105,6 +105,18 @@ void VMMFreeBlocksInfoVisitor::Visit(
   }
   if (!keys.empty()) {
     free_blocks_info_.push_back(keys);
+  }
+}
+
+void AllBlocksInfoVisitor::Visit(
+    VirtualMemoryAutoGrowthBestFitMultiScalePoolAllocator* allocator) {
+  if (pool_filter_ != PoolFilter::kLargeOnly) {
+    if (allocator->GetSmallAllocator())
+      allocator->GetSmallAllocator()->Accept(this);
+  }
+  if (pool_filter_ != PoolFilter::kSmallOnly) {
+    if (allocator->GetLargeAllocator())
+      allocator->GetLargeAllocator()->Accept(this);
   }
 }
 

--- a/paddle/phi/core/memory/mem_visitor.h
+++ b/paddle/phi/core/memory/mem_visitor.h
@@ -260,6 +260,11 @@ class AllBlocksInfoVisitor : public AllocatorComputeStreamVisitor {
   using AllocatorComputeStreamVisitor::Visit;
 
  public:
+  enum class PoolFilter : int { kAll = 0, kSmallOnly = 1, kLargeOnly = 2 };
+
+  explicit AllBlocksInfoVisitor(PoolFilter filter = PoolFilter::kAll)
+      : pool_filter_(filter) {}
+
   /**
    * @brief Retrieves the collected information about the free memory blocks.
    *
@@ -272,10 +277,17 @@ class AllBlocksInfoVisitor : public AllocatorComputeStreamVisitor {
    * @return A nested vector structure containing the size, integer address,
    * free info of all blocks.
    */
-  std::vector<std::vector<std::tuple<size_t, uintptr_t, bool>>>
-  GetAllBlocksInfo() const {
+  const std::vector<std::vector<std::tuple<size_t, uintptr_t, bool>>>&
+  GetAllBlocksInfo() const& {
     return all_blocks_info_;
   }
+
+  std::vector<std::vector<std::tuple<size_t, uintptr_t, bool>>>
+  GetAllBlocksInfo() && {
+    return std::move(all_blocks_info_);
+  }
+
+  PoolFilter GetPoolFilter() const { return pool_filter_; }
 
   /**
    * @brief Visits the VirtualMemoryAutoGrowthBestFitAllocator.
@@ -290,8 +302,12 @@ class AllBlocksInfoVisitor : public AllocatorComputeStreamVisitor {
    */
   void Visit(VirtualMemoryAutoGrowthBestFitAllocator* allocator) override;
   void Visit(AutoGrowthBestFitAllocator* allocator) override;
+  void Visit(VirtualMemoryAutoGrowthBestFitMultiScalePoolAllocator* allocator)
+      override;
 
  private:
+  PoolFilter pool_filter_ = PoolFilter::kAll;
+
   /**
    * @brief Stores the extracted all block information.
    *

--- a/python/paddle/device/cuda/memory_analyzer.py
+++ b/python/paddle/device/cuda/memory_analyzer.py
@@ -124,7 +124,8 @@ class MemoryAnalysisTool:
             if device_id is not None
             else core.get_cuda_current_device_id()
         )
-        return core.all_block_info(device_id)
+        info = core.all_block_info(device_id)
+        return [list(chunk) for chunk in info]
 
     @classmethod
     def vmm_all_block_info(
@@ -132,6 +133,40 @@ class MemoryAnalysisTool:
         device_id: int | None = None,
     ) -> list[list[tuple[int, int, bool]]]:
         return self.all_block_info(device_id)
+
+    @classmethod
+    def vmm_large_all_block_info(
+        self,
+        device_id: int | None = None,
+    ) -> list[list[tuple[int, int, bool]]]:
+        name = 'paddle.device.cuda.vmm_large_all_block_info'
+        if not (core.is_compiled_with_cuda()):
+            raise ValueError(
+                f"The API {name} is not supported in CPU-only PaddlePaddle. Please reinstall PaddlePaddle with GPU support to call this API."
+            )
+        device_id = (
+            device_id
+            if device_id is not None
+            else core.get_cuda_current_device_id()
+        )
+        return core.large_pool_block_info(device_id)
+
+    @classmethod
+    def vmm_small_all_block_info(
+        self,
+        device_id: int | None = None,
+    ) -> list[list[tuple[int, int, bool]]]:
+        name = 'paddle.device.cuda.vmm_small_all_block_info'
+        if not (core.is_compiled_with_cuda()):
+            raise ValueError(
+                f"The API {name} is not supported in CPU-only PaddlePaddle. Please reinstall PaddlePaddle with GPU support to call this API."
+            )
+        device_id = (
+            device_id
+            if device_id is not None
+            else core.get_cuda_current_device_id()
+        )
+        return core.small_pool_block_info(device_id)
 
     @classmethod
     def memory_summary(self, device_id: int | None = None) -> None:

--- a/test/cpp/fluid/memory/allocator_visitor_test.cc
+++ b/test/cpp/fluid/memory/allocator_visitor_test.cc
@@ -24,6 +24,8 @@
 #endif
 #include "glog/logging.h"
 #include "gtest/gtest.h"
+
+PD_DECLARE_uint64(vmm_small_pool_size_in_mb);
 namespace paddle {
 namespace memory {
 namespace allocation {
@@ -49,7 +51,7 @@ TEST(VirtualMemoryAutoGrowthBestFitAllocator, TestAllBlocksInfoVisitor) {
   auto allocation = vma_allocator->Allocate(platform::GpuMinChunkSize());
   AllBlocksInfoVisitor visitor;
   vma_allocator->Accept(&visitor);
-  auto all_blocks_info = visitor.GetAllBlocksInfo();
+  auto all_blocks_info = std::move(visitor).GetAllBlocksInfo();
 
   ASSERT_EQ(all_blocks_info.size(), 1UL);
   ASSERT_GE(all_blocks_info[0].size(), 1UL);
@@ -75,7 +77,7 @@ TEST(VirtualMemoryAutoGrowthBestFitAllocator, TestAllBlocksInfoVisitor) {
   allocation.reset();
   AllBlocksInfoVisitor after_free_visitor;
   vma_allocator->Accept(&after_free_visitor);
-  auto after_free_info = after_free_visitor.GetAllBlocksInfo();
+  auto after_free_info = std::move(after_free_visitor).GetAllBlocksInfo();
 
   ASSERT_EQ(after_free_info.size(), 1UL);
   ASSERT_EQ(after_free_info[0].size(), 1UL);
@@ -96,7 +98,7 @@ TEST(AutoGrowthBestFitAllocator, TestAllBlocksInfoVisitor) {
   auto second = ag_allocator->Allocate(2048);
   AllBlocksInfoVisitor visitor;
   ag_allocator->Accept(&visitor);
-  auto all_blocks_info = visitor.GetAllBlocksInfo();
+  auto all_blocks_info = std::move(visitor).GetAllBlocksInfo();
 
   ASSERT_EQ(all_blocks_info.size(), 1UL);
   ASSERT_EQ(all_blocks_info[0].size(), 3UL);
@@ -127,7 +129,7 @@ TEST(AutoGrowthBestFitAllocator, TestAllBlocksInfoVisitor) {
   second.reset();
   AllBlocksInfoVisitor after_free_visitor;
   ag_allocator->Accept(&after_free_visitor);
-  auto after_free_info = after_free_visitor.GetAllBlocksInfo();
+  auto after_free_info = std::move(after_free_visitor).GetAllBlocksInfo();
 
   ASSERT_EQ(after_free_info.size(), 1UL);
   ASSERT_EQ(after_free_info[0].size(), 1UL);
@@ -135,6 +137,75 @@ TEST(AutoGrowthBestFitAllocator, TestAllBlocksInfoVisitor) {
   EXPECT_EQ(std::get<1>(after_free_info[0][0]),
             std::get<1>(all_blocks_info[0][0]));
   EXPECT_TRUE(std::get<2>(after_free_info[0][0]));
+}
+
+TEST(MultiScalePoolAllocator, TestPoolFilterLargeOnly) {
+  FLAGS_vmm_small_pool_size_in_mb = 20;
+
+  auto vmm_cuda_allocator_small =
+      std::make_shared<CUDAVirtualMemAllocator>(phi::GPUPlace(0));
+  auto vmm_cuda_allocator_large =
+      std::make_shared<CUDAVirtualMemAllocator>(phi::GPUPlace(0));
+  auto small_alloc = std::make_shared<VirtualMemoryAutoGrowthBestFitAllocator>(
+      vmm_cuda_allocator_small, platform::GpuMinChunkSize(), GPUPlace(0));
+  auto large_alloc = std::make_shared<VirtualMemoryAutoGrowthBestFitAllocator>(
+      vmm_cuda_allocator_large, platform::GpuMinChunkSize(), GPUPlace(0));
+  auto multi_scale =
+      std::make_shared<VirtualMemoryAutoGrowthBestFitMultiScalePoolAllocator>(
+          small_alloc, large_alloc, platform::GpuMinChunkSize(), GPUPlace(0));
+
+  // Allocate in small pool (< 20MB)
+  auto small_allocation = multi_scale->Allocate(1 << 20);  // 1MB
+  // Allocate in large pool (>= 20MB)
+  auto large_allocation = multi_scale->Allocate(30 << 20);  // 30MB
+
+  // Query all pools
+  AllBlocksInfoVisitor all_visitor;
+  multi_scale->Accept(&all_visitor);
+  auto all_info = std::move(all_visitor).GetAllBlocksInfo();
+  ASSERT_EQ(all_info.size(), 2UL);  // small + large
+
+  // Query large pool only
+  AllBlocksInfoVisitor large_visitor(
+      AllBlocksInfoVisitor::PoolFilter::kLargeOnly);
+  multi_scale->Accept(&large_visitor);
+  auto large_info = std::move(large_visitor).GetAllBlocksInfo();
+  ASSERT_EQ(large_info.size(), 1UL);  // only large
+
+  // Verify large pool contains allocated block
+  bool found_large = false;
+  for (const auto& block : large_info[0]) {
+    if (std::get<1>(block) ==
+        reinterpret_cast<uintptr_t>(large_allocation->ptr())) {
+      found_large = true;
+      EXPECT_FALSE(std::get<2>(block));  // not free
+    }
+  }
+  EXPECT_TRUE(found_large);
+
+  // Query small pool only
+  AllBlocksInfoVisitor small_visitor(
+      AllBlocksInfoVisitor::PoolFilter::kSmallOnly);
+  multi_scale->Accept(&small_visitor);
+  auto small_info = std::move(small_visitor).GetAllBlocksInfo();
+  ASSERT_EQ(small_info.size(), 1UL);  // only small
+
+  // Verify small pool contains allocated block
+  bool found_small = false;
+  for (const auto& block : small_info[0]) {
+    if (std::get<1>(block) ==
+        reinterpret_cast<uintptr_t>(small_allocation->ptr())) {
+      found_small = true;
+      EXPECT_FALSE(std::get<2>(block));  // not free
+    }
+  }
+  EXPECT_TRUE(found_small);
+
+  // Verify large pool does NOT contain small allocation
+  for (const auto& block : large_info[0]) {
+    EXPECT_NE(std::get<1>(block),
+              reinterpret_cast<uintptr_t>(small_allocation->ptr()));
+  }
 }
 
 }  // namespace allocation

--- a/test/legacy_test/test_allocator_visitor.py
+++ b/test/legacy_test/test_allocator_visitor.py
@@ -86,6 +86,26 @@ class TestAllocatorVisitor(unittest.TestCase):
         self.assertEqual(len(y), 1)  # 1 allocators
         self.assertEqual(len(y[0]), 4)  # 4 blocks
 
+    def test_pool_filter_block_info(self):
+        """Test vmm_large_all_block_info and vmm_small_all_block_info."""
+        # Allocate in large pool (>= vmm_small_pool_size_in_mb)
+        params = self.allocate_cmds(self.cmds)
+
+        large_info = MemoryAnalysisTool.vmm_large_all_block_info()
+        small_info = MemoryAnalysisTool.vmm_small_all_block_info()
+        all_info = MemoryAnalysisTool.vmm_all_block_info()
+
+        # large_info should have blocks (our 1GB allocations go to large pool)
+        self.assertGreater(len(large_info), 0)
+        self.assertGreater(len(large_info[0]), 0)
+
+        # Total blocks from large + small should equal all
+        total_filtered = sum(len(g) for g in large_info) + sum(
+            len(g) for g in small_info
+        )
+        total_all = sum(len(g) for g in all_info)
+        self.assertEqual(total_filtered, total_all)
+
     def test_memory_summary(self):
         paddle.set_flags({'FLAGS_use_virtual_memory_auto_growth': True})
         paddle.device.cuda.memory_summary()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
解决 `vmm_all_block_info()` 查询耗时随 training step 持续增长的问题。根因是该接口同时遍历大小池，而 small pool 的 blocks 因碎片化单调递增，导致查询越来越慢。auto subbatch
  仅需 large pool 信息。

  主要改动：

  1. **pybind 惰性转换**：使用 `PYBIND11_MAKE_OPAQUE` + `py::return_value_policy::move` 将返回类型注册为不透明对象，跨边界 O(1)，仅在 `__getitem__` 访问时按需转换单组数据。

  2. **大小池分离查询**：`AllBlocksInfoVisitor` 新增 `PoolFilter` 枚举（`kAll`/`kLargeOnly`/`kSmallOnly`），override `Visit(MultiScalePoolAllocator*)` 按 filter 路由，C++
  侧新增 `LargePoolBlockInfo()` / `SmallPoolBlockInfo()` 接口。

  3. **Python API**：新增 `MemoryAnalysisTool.vmm_large_all_block_info()` / `vmm_small_all_block_info()`，`MemoryAnalysisTool.all_block_info()` 保持返回 `list`
  的兼容语义（显式 materialize）。

  4. **move 语义安全**：`GetAllBlocksInfo()` 的 move 重载限定为 `&&`（rvalue-only），防止非 const lvalue 上意外清空 visitor。

  效果：auto subbatch 热路径使用 `vmm_large_all_block_info()` 后，完全跳过 small pool 遍历，查询耗时与 small pool 碎片化解耦，不再随 step 增长。


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否