### PR TITLE
[release/3.4][Operator Mechanism]  Fix baddbmm_grad input_grad overflow for large tensors

### DIFF
--- a/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
@@ -186,9 +186,14 @@ void BaddbmmGradKernel(const Context& dev_ctx,
     } else {
       funcs::ForRange<Context> for_range(dev_ctx, total_elems);
       BCopyOrScaleFunctor<T> functor(
-          beta, out_grad.data<T>(), input_grad->data<T>(), total_elems);
+          1, out_grad.data<T>(), input_grad->data<T>(), total_elems);
       for_range(functor);
     }
+
+    funcs::ForRange<Context> for_range(dev_ctx, total_elems);
+    BCopyOrScaleFunctor<T> functor(
+        beta, input_grad->data<T>(), input_grad->data<T>(), total_elems);
+    for_range(functor);
   }
   if (x_grad) {
     dev_ctx.template Alloc<T>(x_grad);

--- a/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
@@ -184,25 +184,9 @@ void BaddbmmGradKernel(const Context& dev_ctx,
                                          .template cast<T>();
       }
     } else {
-      // The VCOPY does not support the float16, bfloat16
-      if (!is_float16_or_bfloat16) {
-        mt_blas.VCOPY(
-            total_elems, out_grad.data<MPType>(), input_grad->data<MPType>());
-      } else {
-        funcs::ForRange<Context> for_range(dev_ctx, total_elems);
-        BCopyOrScaleFunctor<T> functor(
-            1, out_grad.data<T>(), input_grad->data<T>(), total_elems);
-        for_range(functor);
-      }
-    }
-
-    // The SCAL does not support the float16, bfloat16
-    if (!is_float16_or_bfloat16) {
-      mt_blas.SCAL(total_elems, beta, input_grad->data<MPType>());
-    } else {
       funcs::ForRange<Context> for_range(dev_ctx, total_elems);
       BCopyOrScaleFunctor<T> functor(
-          beta, input_grad->data<T>(), input_grad->data<T>(), total_elems);
+          beta, out_grad.data<T>(), input_grad->data<T>(), total_elems);
       for_range(functor);
     }
   }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->

input_grad = beta * out_grad

但这两个 BLAS 接口的长度参数是 int n。当 input_grad.numel() 超过 INT_MAX 时，长度参数会发生溢出，导致 input_grad 没有被正确写入，最终出现梯度为 0 或保留旧内存内容的问题。

本次修改改为使用 ForRange elementwise kernel 直接计算：

input_grad[i] = beta * out_grad[i]

从而避开 BLAS int n 的限制，使 baddbmm backward 在超大 tensor 场景下能够正确计算 input_grad。

devPR:https://github.com/PaddlePaddle/Paddle/pull/79455
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否