### PR TITLE
[CI][H-Coverage] Increase Fleet test timeouts

### DIFF
--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -505,7 +505,7 @@ jobs:
     if: needs.build.outputs.can-skip != 'true'
     runs-on:
       group: Fleet-H-single-card
-    timeout-minutes: 90
+    timeout-minutes: 150
     env:
       PIP_CACHE_DIR: /root/.cache/pip
       CACHE_DIR: /root/.cache
@@ -587,7 +587,7 @@ jobs:
           '
 
       - name: Single card test
-        timeout-minutes: 60
+        timeout-minutes: 120
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -xce '
           pwd
@@ -626,7 +626,7 @@ jobs:
     if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' && needs.check-skill.outputs.can-skip != 'true' }}
     runs-on:
       group: Fleet-H-multi-card
-    timeout-minutes: 60
+    timeout-minutes: 120
     env:
       PIP_CACHE_DIR: /root/.cache/pip
       TASK: paddle-fleet-CI-${{ github.event.pull_request.number }}-multi-card_test
@@ -702,7 +702,7 @@ jobs:
           '
 
       - name: Multi-card test
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           docker exec -t ${{ env.container_name }} /bin/bash -ce '
           export PYTHONPATH=$(pwd)


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description
本 PR 仅调整 `.github/workflows/H-Coverage.yml` 中 Fleet 单卡/多卡测试的 step 与 enclosing job 超时：

- Fleet single-card：job `90` → `150` 分钟，`Single card test` step `60` → `120` 分钟。
- Fleet multi-card：job `60` → `120` 分钟，`Multi-card test` step `60` → `90` 分钟。

精确 head / rerun 证据：

- [PaddlePaddle/Paddle#79426](https://github.com/PaddlePaddle/Paddle/pull/79426) 的 head 为 `c4b2fca3e9758533e44e23227c89519825031a7b`。
- 同一 head 的 [CI-H run 29186065723](https://github.com/PaddlePaddle/Paddle/actions/runs/29186065723) 已到 `run_attempt=3`；[attempt 1 单卡 job](https://github.com/PaddlePaddle/Paddle/actions/runs/29186065723/job/86635661755) 与 [attempt 3 单卡 rerun job](https://github.com/PaddlePaddle/Paddle/actions/runs/29186065723/job/86672906005) 的 `Single card test` 分别运行约 60m12s、60m13s 后失败，与当前 60 分钟 step timeout 一致。
- 同一精确 head run 的 [multi-card job](https://github.com/PaddlePaddle/Paddle/actions/runs/29186065723/job/86672906235) 中 `Multi-card test` 约 39m15s 通过；本次同时按维护者要求为其 step 和 job 留出更充足余量。

基线与验证：

- 基于精确 `develop` SHA `881759903c1fb4330ceda894d3ace433142bc00a`。
- Ruby YAML parse 通过。
- 语义断言通过：single-card `150 > 120`，multi-card `120 > 90`。
- `git diff --check upstream/develop...HEAD`。
- scope：仅一个 workflow 文件、四处 timeout 修改。

### 是否引起精度变化
否
