### PR TITLE
[User Experience] Muon optimizer 支持 lr_ratio

### DIFF
--- a/python/paddle/optimizer/muon.py
+++ b/python/paddle/optimizer/muon.py
@@ -606,6 +606,9 @@ class Muon(Optimizer):
                 self._master_weights[param.name] if find_master else None
             )
 
+            lr_ratio = 1.0 if self._lr_ratio is None else self._lr_ratio(param)
+            effective_lr = lr * lr_ratio
+
             with_decay = True
             if (
                 self._apply_decay_param_fun is not None
@@ -614,11 +617,11 @@ class Muon(Optimizer):
                 with_decay = False
             if with_decay and weight_decay > 0:
                 if find_master:
-                    master_weight.scale_(1.0 - lr * weight_decay)
+                    master_weight.scale_(1.0 - effective_lr * weight_decay)
                 else:
-                    param.scale_(1.0 - lr * weight_decay)
+                    param.scale_(1.0 - effective_lr * weight_decay)
 
-            final_step = orthogonal_update * lr
+            final_step = orthogonal_update * effective_lr
 
             if find_master:
                 master_weight.subtract_(final_step)

--- a/test/ai_edited_test/test_ai_optimizer_muon.py
+++ b/test/ai_edited_test/test_ai_optimizer_muon.py
@@ -274,5 +274,38 @@ class TestZeropowerNewtonschulz5(unittest.TestCase):
         self.assertEqual(result.shape, [4, 4])
 
 
+class TestMuonLrRatio(unittest.TestCase):
+    """测试 Muon 优化器的 lr_ratio
+    Test lr_ratio in Muon optimizer"""
+
+    def test_freeze_parameter(self):
+        """测试 lr_ratio=0 时冻结指定的 Muon 参数
+        Test that lr_ratio=0 freezes the selected Muon parameter"""
+        paddle.seed(2026)
+        frozen = paddle.create_parameter(shape=[4, 4], dtype='float32')
+        trainable = paddle.create_parameter(shape=[4, 4], dtype='float32')
+
+        optimizer = Muon(
+            learning_rate=0.02,
+            parameters=[frozen, trainable],
+            lr_ratio=lambda param: 0.0 if param.name == frozen.name else 1.0,
+            weight_decay=0.01,
+            muon_param_info_map={
+                frozen.name: MuonParamInfo(use_muon=True),
+                trainable.name: MuonParamInfo(use_muon=True),
+            },
+            ns_matmul_dtype=paddle.float32,
+        )
+
+        frozen_before = frozen.numpy().copy()
+        trainable_before = trainable.numpy().copy()
+        loss = frozen.sum() + trainable.sum()
+        loss.backward()
+        optimizer.step()
+
+        np.testing.assert_array_equal(frozen.numpy(), frozen_before)
+        self.assertFalse(np.array_equal(trainable.numpy(), trainable_before))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/ai_edited_test/test_ai_optimizer_muon.py
+++ b/test/ai_edited_test/test_ai_optimizer_muon.py
@@ -275,12 +275,10 @@ class TestZeropowerNewtonschulz5(unittest.TestCase):
 
 
 class TestMuonLrRatio(unittest.TestCase):
-    """测试 Muon 优化器的 lr_ratio
-    Test lr_ratio in Muon optimizer"""
+    """Test lr_ratio in Muon optimizer."""
 
     def test_freeze_parameter(self):
-        """测试 lr_ratio=0 时冻结指定的 Muon 参数
-        Test that lr_ratio=0 freezes the selected Muon parameter"""
+        """Test that lr_ratio=0 freezes the selected Muon parameter."""
         paddle.seed(2026)
         frozen = paddle.create_parameter(shape=[4, 4], dtype='float32')
         trainable = paddle.create_parameter(shape=[4, 4], dtype='float32')
@@ -305,6 +303,40 @@ class TestMuonLrRatio(unittest.TestCase):
 
         np.testing.assert_array_equal(frozen.numpy(), frozen_before)
         self.assertFalse(np.array_equal(trainable.numpy(), trainable_before))
+
+    def test_muon_lr_ratio_scales_muon_update(self):
+        """lr_ratio=0.0 freezes the param; lr_ratio=0.5 update is half of lr_ratio=1.0."""
+        paddle.disable_static()
+        weight_np = np.array([[0.2, -0.4], [0.6, 0.8]], dtype="float32")
+        grad_np = np.array([[0.1, 0.3], [-0.2, 0.4]], dtype="float32")
+
+        def run(ratio):
+            p = paddle.create_parameter(shape=[2, 2], dtype="float32")
+            p.set_value(weight_np)
+            p.grad = paddle.to_tensor(grad_np)
+            opt = Muon(
+                parameters=[p],
+                learning_rate=0.01,
+                weight_decay=0.01,
+                ns_steps=1,
+                ns_matmul_dtype=paddle.float32,
+                muon_param_info_map={p.name: MuonParamInfo(use_muon=True)},
+                lr_ratio=lambda _: ratio,
+            )
+            opt.step()
+            return p.numpy()
+
+        full = run(1.0)
+        half = run(0.5)
+        zero = run(0.0)
+
+        np.testing.assert_allclose(zero, weight_np, rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(
+            weight_np - half,
+            0.5 * (weight_np - full),
+            rtol=1e-5,
+            atol=1e-6,
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
Add `lr_ratio` support for Muon optimizer. This change uses `effective_lr = learning_rate * lr_ratio(param)` in the Muon orthogonal update path, and applies it to both decoupled weight decay and the final parameter update. When `lr_ratio` is `None`, the behavior remains unchanged.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否