### PR TITLE
[Execute Infrastructure] ci: add bot approval required check gated on risemeup1111 approval

### DIFF
--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -15,7 +15,6 @@
 name: Bot Approval Required
 
 # 合入门禁：满足以下任一条件本检查即通过（仅统计【当前 head commit】上的评审）——
-#   0) PR 作者在豁免名单 BYPASS_AUTHORS 中，直接放行；或
 #   1) AI review 机器人 risemeup1111 对当前 head commit 提交了 APPROVED 评审；或
 #   2) sneaxiy 或 From00 任意一个账号对当前 head commit 提交了 APPROVED 评审。
 # 评审提交/修改/撤销或推送新 commit 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
@@ -35,8 +34,6 @@ env:
   # 机器人未 approve 时，任意一个账号 approve 即可放行的审批账号。
   HUMAN_APPROVER_1: sneaxiy
   HUMAN_APPROVER_2: From00
-  # 豁免作者名单（空格分隔）：这些作者提交的 PR 自动通过本门禁。
-  BYPASS_AUTHORS: liuhao2638
 
 jobs:
   check-bot-approval:
@@ -49,18 +46,9 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
           echo "AI review 机器人账号: ${REQUIRED_BOT_LOGIN}"
-
-          # 豁免名单：PR 作者在 BYPASS_AUTHORS 中则直接放行。
-          for a in ${BYPASS_AUTHORS}; do
-            if [ "${PR_AUTHOR}" = "$a" ]; then
-              echo "::notice::PR 作者 ${PR_AUTHOR} 在豁免名单中，跳过机器人审批门禁。"
-              exit 0
-            fi
-          done
 
           # 分页读取全部 reviews，避免超过 100 条时漏掉后续页面上的评审。
           reviews=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" | jq -s 'add')

--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -17,12 +17,10 @@ name: Bot Approval Required
 # 合入门禁：满足以下任一条件本检查即通过（仅统计【当前 head commit】上的评审）——
 #   1) AI review 机器人 risemeup1111 对当前 head commit 提交了 APPROVED 评审；或
 #   2) sneaxiy 或 From00 任意一个账号对当前 head commit 提交了 APPROVED 评审。
-# 评审提交/修改/撤销或推送新 commit 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
+# 评审后推送新 commit（synchronize）或重开 PR 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  pull_request_review:
-    types: [submitted, edited, dismissed]
 
 permissions:
   contents: read

--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -4,6 +4,7 @@ name: Bot Approval Required
 #   1) AI review 机器人 risemeup1111 对当前 head commit 提交了 APPROVED 评审；或
 #   2) APPROVERS 名单中任意一个账号对当前 head commit 提交了 APPROVED 评审。
 # 推送新 commit（synchronize）或重开 PR 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
+# CI 团队成员可通过 check-bypass（skip-ci label / 评论）豁免本检查。
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -19,8 +20,19 @@ env:
   APPROVERS: "sneaxiy From00"
 
 jobs:
+  check-bypass:
+    name: Check bypass
+    if: ${{ github.repository_owner == 'PaddlePaddle' }}
+    uses: ./.github/workflows/check-bypass.yml
+    with:
+      workflow-name: 'bot-approval-required'
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
   check-bot-approval:
     name: Require review-bot approval
+    needs: [check-bypass]
+    if: ${{ needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Verify approval status

--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -1,0 +1,97 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Bot Approval Required
+
+# 合入门禁：满足以下任一条件本检查即通过（仅统计【当前 head commit】上的评审）——
+#   1) AI review 机器人 risemeup1111 对当前 head commit 提交了 APPROVED 评审；或
+#   2) sneaxiy 或 From00 任意一个账号对当前 head commit 提交了 APPROVED 评审。
+# 评审提交/修改/撤销或推送新 commit 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  # AI review 机器人的 GitHub login。
+  REQUIRED_BOT_LOGIN: risemeup1111
+  # 机器人未 approve 时，任意一个账号 approve 即可放行的审批账号。
+  HUMAN_APPROVER_1: sneaxiy
+  HUMAN_APPROVER_2: From00
+
+jobs:
+  check-bot-approval:
+    name: Require review-bot approval
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify approval status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          echo "AI review 机器人账号: ${REQUIRED_BOT_LOGIN}"
+
+          # 分页读取全部 reviews，避免超过 100 条时漏掉后续页面上的评审。
+          reviews=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" | jq -s 'add')
+
+          # 取指定 login 在【当前 PR head commit】上的最新一条“决定性”评审状态。
+          # 仅统计 commit_id == 当前 head 的评审，避免旧 commit 上的审批放行未复审的新代码。
+          # COMMENT / PENDING 不影响审批结论。
+          latest_state() {
+            echo "${reviews}" | jq -r --arg u "$1" --arg head "${HEAD_SHA}" '
+              [ .[]
+                | select(.user.login == $u)
+                | select(.commit_id == $head)
+                | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+              ]
+              | sort_by(.submitted_at)
+              | last
+              | .state // "NONE"
+            '
+          }
+
+          bot_state=$(latest_state "${REQUIRED_BOT_LOGIN}")
+          approver1_state=$(latest_state "${HUMAN_APPROVER_1}")
+          approver2_state=$(latest_state "${HUMAN_APPROVER_2}")
+
+          if [ "${bot_state}" = "APPROVED" ]; then
+            echo "::notice::AI review 机器人 ${REQUIRED_BOT_LOGIN} 已 approve，本 PR 通过审批门禁。"
+            exit 0
+          fi
+
+          if [ "${approver1_state}" = "APPROVED" ] || [ "${approver2_state}" = "APPROVED" ]; then
+            echo "::notice::${HUMAN_APPROVER_1} / ${HUMAN_APPROVER_2} 中已有账号 approve，本 PR 通过审批门禁。"
+            exit 0
+          fi
+
+          echo "==================================================================="
+          echo "本PR 尚未通过AI review机器人approve。"
+          echo "请研发同学按AI review机器人的review 意见修改代码并提交新的commit；或联系 ${HUMAN_APPROVER_1} 或 ${HUMAN_APPROVER_2} 进行 approve。"
+          echo ""
+          echo "评审意见处理要求（按优先级）："
+          echo "  - P0（阻塞）：必须修复问题并提交新的 commit，仅回复不算解决。"
+          echo "  - P1（高）：必须修复问题并提交新的 commit，仅回复不算解决。"
+          echo "  - P2（中）：需针对评论进行回复（同意并已修改回复 Done，不同意请给出理由）。"
+          echo "  - P3（低）：需针对评论进行回复（同意并已修改回复 Done，不同意请给出理由）。"
+          echo "==================================================================="
+          echo "::error::本PR 尚未通过AI review机器人approve。请研发同学按AI review机器人的review 意见修改代码并提交新的commit（P0/P1 必须修复并提交新 commit；P2/P3 需针对评论回复）；或联系 ${HUMAN_APPROVER_1} 或 ${HUMAN_APPROVER_2} 进行 approve。"
+          exit 1

--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -1,23 +1,9 @@
-# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: Bot Approval Required
 
 # 合入门禁：满足以下任一条件本检查即通过（仅统计【当前 head commit】上的评审）——
 #   1) AI review 机器人 risemeup1111 对当前 head commit 提交了 APPROVED 评审；或
-#   2) sneaxiy 或 From00 任意一个账号对当前 head commit 提交了 APPROVED 评审。
-# 评审后推送新 commit（synchronize）或重开 PR 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
+#   2) APPROVERS 名单中任意一个账号对当前 head commit 提交了 APPROVED 评审。
+# 推送新 commit（synchronize）或重开 PR 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -29,9 +15,8 @@ permissions:
 env:
   # AI review 机器人的 GitHub login。
   REQUIRED_BOT_LOGIN: risemeup1111
-  # 机器人未 approve 时，任意一个账号 approve 即可放行的审批账号。
-  HUMAN_APPROVER_1: sneaxiy
-  HUMAN_APPROVER_2: From00
+  # 机器人未 approve 时，名单中任意一个账号 approve 即可放行（空格分隔）。
+  APPROVERS: "sneaxiy From00"
 
 jobs:
   check-bot-approval:
@@ -67,23 +52,21 @@ jobs:
             '
           }
 
-          bot_state=$(latest_state "${REQUIRED_BOT_LOGIN}")
-          approver1_state=$(latest_state "${HUMAN_APPROVER_1}")
-          approver2_state=$(latest_state "${HUMAN_APPROVER_2}")
-
-          if [ "${bot_state}" = "APPROVED" ]; then
+          if [ "$(latest_state "${REQUIRED_BOT_LOGIN}")" = "APPROVED" ]; then
             echo "::notice::AI review 机器人 ${REQUIRED_BOT_LOGIN} 已 approve，本 PR 通过审批门禁。"
             exit 0
           fi
 
-          if [ "${approver1_state}" = "APPROVED" ] || [ "${approver2_state}" = "APPROVED" ]; then
-            echo "::notice::${HUMAN_APPROVER_1} / ${HUMAN_APPROVER_2} 中已有账号 approve，本 PR 通过审批门禁。"
-            exit 0
-          fi
+          for u in ${APPROVERS}; do
+            if [ "$(latest_state "$u")" = "APPROVED" ]; then
+              echo "::notice::审批账号 ${u} 已 approve，本 PR 通过审批门禁。"
+              exit 0
+            fi
+          done
 
           echo "==================================================================="
           echo "本PR 尚未通过AI review机器人approve。"
-          echo "请研发同学按AI review机器人的review 意见修改代码并提交新的commit；或联系 ${HUMAN_APPROVER_1} 或 ${HUMAN_APPROVER_2} 进行 approve。"
+          echo "请研发同学按AI review机器人的review 意见修改代码并提交新的commit；或联系审批账号（${APPROVERS}）中任一人进行 approve。"
           echo ""
           echo "评审意见处理要求（按优先级）："
           echo "  - P0（阻塞）：必须修复问题并提交新的 commit，仅回复不算解决。"
@@ -91,5 +74,5 @@ jobs:
           echo "  - P2（中）：需针对评论进行回复（同意并已修改回复 Done，不同意请给出理由）。"
           echo "  - P3（低）：需针对评论进行回复（同意并已修改回复 Done，不同意请给出理由）。"
           echo "==================================================================="
-          echo "::error::本PR 尚未通过AI review机器人approve。请研发同学按AI review机器人的review 意见修改代码并提交新的commit（P0/P1 必须修复并提交新 commit；P2/P3 需针对评论回复）；或联系 ${HUMAN_APPROVER_1} 或 ${HUMAN_APPROVER_2} 进行 approve。"
+          echo "::error::本PR 尚未通过AI review机器人approve。请研发同学按AI review机器人的review 意见修改代码并提交新的commit（P0/P1 必须修复并提交新 commit；P2/P3 需针对评论回复）；或联系审批账号（${APPROVERS}）中任一人进行 approve。"
           exit 1

--- a/.github/workflows/bot-approval-required.yml
+++ b/.github/workflows/bot-approval-required.yml
@@ -15,6 +15,7 @@
 name: Bot Approval Required
 
 # 合入门禁：满足以下任一条件本检查即通过（仅统计【当前 head commit】上的评审）——
+#   0) PR 作者在豁免名单 BYPASS_AUTHORS 中，直接放行；或
 #   1) AI review 机器人 risemeup1111 对当前 head commit 提交了 APPROVED 评审；或
 #   2) sneaxiy 或 From00 任意一个账号对当前 head commit 提交了 APPROVED 评审。
 # 评审提交/修改/撤销或推送新 commit 时自动复检；旧 commit 上的审批在 push 新提交后自动失效。
@@ -34,6 +35,8 @@ env:
   # 机器人未 approve 时，任意一个账号 approve 即可放行的审批账号。
   HUMAN_APPROVER_1: sneaxiy
   HUMAN_APPROVER_2: From00
+  # 豁免作者名单（空格分隔）：这些作者提交的 PR 自动通过本门禁。
+  BYPASS_AUTHORS: liuhao2638
 
 jobs:
   check-bot-approval:
@@ -46,9 +49,18 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
           echo "AI review 机器人账号: ${REQUIRED_BOT_LOGIN}"
+
+          # 豁免名单：PR 作者在 BYPASS_AUTHORS 中则直接放行。
+          for a in ${BYPASS_AUTHORS}; do
+            if [ "${PR_AUTHOR}" = "$a" ]; then
+              echo "::notice::PR 作者 ${PR_AUTHOR} 在豁免名单中，跳过机器人审批门禁。"
+              exit 0
+            fi
+          done
 
           # 分页读取全部 reviews，避免超过 100 条时漏掉后续页面上的评审。
           reviews=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" | jq -s 'add')

--- a/.github/workflows/check-bypass.yml
+++ b/.github/workflows/check-bypass.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
     env:
-      CI_TEAM_MEMBERS: '["swgu98", "risemeup1" , "XieYunshen", "luotao1", "SigureMo"]'
+      CI_TEAM_MEMBERS: '["swgu98", "risemeup1" , "XieYunshen", "luotao1", "SigureMo", "liuhao2638"]'
     outputs:
       can-skip: ${{ steps.check-bypass.outputs.can-skip }}
     timeout-minutes: 3


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Devs

### Description
<!-- Describe what you've done -->
1. 新增 `.github/workflows/bot-approval-required.yml`，作为合入门禁 required check（仅统计当前 head commit 上的评审）。通过条件：AI review 机器人 `risemeup1111` approve；**或** 名单 `APPROVERS`（`sneaxiy`、`From00`）中任一账号 approve。按 `commit_id` 过滤当前 head，`--paginate` 读取全部 reviews；未通过时给出中文提醒及 P0/P1/P2/P3 处理要求。
2. `.github/workflows/check-bypass.yml`：`CI_TEAM_MEMBERS` 白名单新增 `liuhao2638`，使其可通过 `skip-ci` label / 评论对 CI 豁免。

评审意见处理：已移除 license 头、审批人合并为单一 `APPROVERS` 名单、移除 `BYPASS_AUTHORS`（豁免统一走 check-bypass 白名单）。`pull_request_review` 触发器按需求方要求刻意不加，已在对应评论说明。

### 是否引起精度变化
<!-- Describe the impact on precision if any -->
否。本 PR 仅新增/修改 GitHub Actions CI workflow，不涉及框架代码，不引起任何精度变化。
