### PR TITLE
ci(H-Coverage): pass github.head_ref via env var instead of inline run interpolation

### DIFF
--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  HEAD_REF: ${{ github.head_ref }}
   PR_ID: ${{ github.event.pull_request.number }}
   COMMIT_ID: ${{ github.event.pull_request.head.sha }}
   TASK: paddle-CI-${{ github.event.pull_request.number }}-coverage
@@ -543,7 +544,7 @@ jobs:
             -e PY_VERSION \
             -e work_dir \
             -e GITHUB_SHA="${{ github.event.pull_request.head.sha }}" \
-            -e GITHUB_HEAD_REF="${{ github.head_ref }}" \
+            -e GITHUB_HEAD_REF="${HEAD_REF}" \
             -e GITHUB_BASE_SHA="${{ github.event.pull_request.base.sha }}" \
             -e GITHUB_REPO_NAME="${{ github.repository }}" \
             -e GITHUB_EVENT_PULL_REQUEST_NUMBER="${{ github.event.pull_request.number }}" \
@@ -657,7 +658,7 @@ jobs:
             -e PY_VERSION \
             -e work_dir \
             -e GITHUB_SHA="${{ github.event.pull_request.head.sha }}" \
-            -e GITHUB_HEAD_REF="${{ github.head_ref }}" \
+            -e GITHUB_HEAD_REF="${HEAD_REF}" \
             -e GITHUB_BASE_SHA="${{ github.event.pull_request.base.sha }}" \
             -e GITHUB_REPO_NAME="${{ github.repository }}" \
             -e GITHUB_EVENT_NAME="${{ github.event_name }}" \


### PR DESCRIPTION
## What this does

In `.github/workflows/H-Coverage.yml`, `${{ github.head_ref }}` is currently interpolated directly into the `run:` shell in two steps (`-e GITHUB_HEAD_REF="${{ github.head_ref }}"`). This moves it to a top-level `env:` variable and references it as `${HEAD_REF}` in the shell instead.

## Why

This follows GitHub's [documented guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) to avoid interpolating context values into `run:` scripts directly — passing them through an environment variable keeps the value literal. It's a small, behavior-preserving hardening (the container still receives the same `GITHUB_HEAD_REF`).

```diff
 env:
+  HEAD_REF: ${{ github.head_ref }}
 ...
-            -e GITHUB_HEAD_REF="${{ github.head_ref }}" \
+            -e GITHUB_HEAD_REF="${HEAD_REF}" \
```

Two lines changed plus one env entry; no functional change.

---

*Disclosure: I used an AI tool to help prepare this; I verified the change against the workflow myself and take responsibility for it. Happy to adjust to your preferred style.*
