### PR TITLE
[Build] Ensure load nvidia libraries from `site-packages` on arm64 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,7 @@ if(WITH_GPU AND NOT APPLE)
     add_definitions(-DPADDLE_WITH_PIP_CUDA_LIBRARIES)
   endif()
   #(Note risemeup1): The cudart dynamic library libcudart.so is used by set CUDA_USE_STATIC_CUDA_RUNTIME and CMAKE_CUDA_FLAGS
-  if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL
-                                            "x86_64")
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CUDA_USE_STATIC_CUDA_RUNTIME
         OFF
         CACHE BOOL "" FORCE)

--- a/paddle/phi/backends/dynload/dynamic_loader.cc
+++ b/paddle/phi/backends/dynload/dynamic_loader.cc
@@ -826,6 +826,12 @@ void* GetNVRTCDsoHandle() {
   return GetDsoHandleFromSearchPath(FLAGS_cuda_dir, RTC_LIB_NAME);
 #elif defined(PADDLE_WITH_HIP)
   return GetDsoHandleFromSearchPath(FLAGS_rocm_dir, "libamdhip64.so", false);
+#elif defined(__linux__) && defined(PADDLE_WITH_CUDA) && \
+    defined(PADDLE_WITH_PIP_CUDA_LIBRARIES)
+  if (CUDA_VERSION >= 13000 && CUDA_VERSION < 14000) {
+    return GetDsoHandleFromSearchPath(FLAGS_cuda_dir, "libnvrtc.so.13", false);
+  }
+  return GetDsoHandleFromSearchPath(FLAGS_cuda_dir, "libnvrtc.so", false);
 #else
   return GetDsoHandleFromSearchPath(FLAGS_cuda_dir, "libnvrtc.so", false);
 #endif

--- a/paddle/phi/backends/dynload/dynamic_loader.cc
+++ b/paddle/phi/backends/dynload/dynamic_loader.cc
@@ -1125,6 +1125,12 @@ void* GetCusparseLtDsoHandle() {
 #if defined(PADDLE_WITH_CUSTOM_DEVICE)
   return GetDsoHandleFromSearchPath(FLAGS_cusparselt_dir, SPARSELT_LIB_NAME);
 #elif defined(PADDLE_WITH_CUDA)
+#ifdef PADDLE_WITH_PIP_CUDA_LIBRARIES
+  if (CUDA_VERSION >= 13000 && CUDA_VERSION < 14000) {
+    return GetDsoHandleFromSearchPath(FLAGS_cusparselt_dir,
+                                      "libcusparseLt.so.0;libcusparseLt.so");
+  }
+#endif
   return GetDsoHandleFromSearchPath(FLAGS_cusparselt_dir, "libcusparseLt.so");
 #else
   std::string warning_msg(

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -200,9 +200,7 @@ if(APPLE)
     message(FATAL_ERROR "install_name_tool not found, please check.\n")
   endif()
 endif()
-if(LINUX
-   AND NOT WITH_SW
-   AND NOT WITH_ARM)
+if(LINUX AND NOT WITH_SW)
   find_program(PATCHELF_EXECUTABLE patchelf)
   if(NOT PATCHELF_EXECUTABLE)
     message(

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -929,9 +929,7 @@ if __is_metainfo_generated and is_compiled_with_cuda():
             cusparse_lib_path = package_dir + "/.." + "/nvidia/cusparse/lib"
             set_flags({"FLAGS_cusparse_dir": cusparse_lib_path})
 
-            cupti_dir_lib_path = (
-                package_dir + "/.." + "/nvidia/cuda_cupti/lib"
-            )
+            cupti_dir_lib_path = package_dir + "/.." + "/nvidia/cuda_cupti/lib"
             set_flags({"FLAGS_cupti_dir": cupti_dir_lib_path})
 
         cudnn_lib_path = package_dir + "/.." + "/nvidia/cudnn/lib"

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -18,6 +18,7 @@
 # parameter semantics. It is important to clarify that these APIs are
 # implemented as independent modules with no runtime dependency on PyTorch.
 
+import builtins as _builtins
 import math
 import sys as _sys
 import typing
@@ -88,7 +89,7 @@ if __is_metainfo_generated:
                     platform.machine() in ('x86_64', 'AMD64')
                     or (
                         platform.machine() == 'aarch64'
-                        and builtins.int(_cuda_version.split('.')[0]) >= 13
+                        and _builtins.int(_cuda_version.split('.')[0]) >= 13
                     )
                 )
             ):
@@ -167,8 +168,6 @@ from .framework.dtype import (
 if typing.TYPE_CHECKING:
     from .tensor.tensor import Tensor
 else:
-    import builtins
-
     Tensor = framework.core.eager.Tensor
     Tensor.__qualname__ = 'Tensor'
     original_init = Tensor.__init__
@@ -214,7 +213,7 @@ else:
                 place=device,
             )
         elif (
-            builtins.all(isinstance(arg, builtins.int) for arg in args)
+            _builtins.all(isinstance(arg, _builtins.int) for arg in args)
             and len(kwargs) == 0
         ):
             # case 3, 4
@@ -892,7 +891,7 @@ if (
 
     from .version import cuda_version as _cuda_version, with_pip_cuda_libraries
 
-    cuda_major = builtins.int(_cuda_version.split('.')[0])
+    cuda_major = _builtins.int(_cuda_version.split('.')[0])
 
     if (
         platform.system() == 'Linux'

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -72,7 +72,6 @@ def _preload_nvidia_lib(lib_glob, sub_dirs=None):
 
 
 if __is_metainfo_generated:
-    import builtins
     import platform
 
     if platform.system() == 'Linux':
@@ -82,11 +81,15 @@ if __is_metainfo_generated:
                 with_pip_cuda_libraries,
             )
 
-            if with_pip_cuda_libraries == 'ON' and (
-                platform.machine() in ('x86_64', 'AMD64')
-                or (
-                    platform.machine() == 'aarch64'
-                    and builtins.float(_cuda_version) >= 13.0
+            if (
+                _cuda_version != 'False'
+                and with_pip_cuda_libraries == 'ON'
+                and (
+                    platform.machine() in ('x86_64', 'AMD64')
+                    or (
+                        platform.machine() == 'aarch64'
+                        and int(_cuda_version.split('.')[0]) >= 13
+                    )
                 )
             ):
                 _preload_nvidia_lib('libcublasLt.so.*[0-9]', ['cublas'])
@@ -879,21 +882,23 @@ if is_compiled_with_cinn():
     data_file_path = resources.files('paddle.cinn_config')
     os.environ['CINN_CONFIG_PATH'] = str(data_file_path)
 
-if __is_metainfo_generated and is_compiled_with_cuda():
-    import builtins
+if (
+    __is_metainfo_generated
+    and is_compiled_with_cuda()
+    and not is_compiled_with_rocm()
+):
     import os
     import platform
 
     from .version import cuda_version as _cuda_version, with_pip_cuda_libraries
 
+    cuda_major = int(_cuda_version.split('.')[0])
+
     if (
         platform.system() == 'Linux'
         and (
             platform.machine() in ('x86_64', 'AMD64')
-            or (
-                platform.machine() == 'aarch64'
-                and builtins.float(_cuda_version) >= 13.0
-            )
+            or (platform.machine() == 'aarch64' and cuda_major >= 13)
         )
         and with_pip_cuda_libraries == 'ON'
     ):
@@ -901,8 +906,7 @@ if __is_metainfo_generated and is_compiled_with_cuda():
         nvidia_package_path = package_dir + "/.." + "/nvidia"
         set_flags({"FLAGS_nvidia_package_dir": nvidia_package_path})
 
-        if builtins.float(_cuda_version) >= 13.0:
-            cuda_major = _cuda_version.split('.')[0]
+        if cuda_major >= 13:
             cuda_lib_path = os.path.join(
                 nvidia_package_path, f'cu{cuda_major}', 'lib'
             )
@@ -943,7 +947,7 @@ if __is_metainfo_generated and is_compiled_with_cuda():
         set_flags({"FLAGS_nccl_dir": nccl_lib_path})
 
         if is_compiled_with_cinn():
-            if builtins.float(_cuda_version) >= 13.0:
+            if cuda_major >= 13:
                 cuda_cccl_path = os.path.join(
                     nvidia_package_path, f'cu{cuda_major}', 'include'
                 )

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -88,7 +88,7 @@ if __is_metainfo_generated:
                     platform.machine() in ('x86_64', 'AMD64')
                     or (
                         platform.machine() == 'aarch64'
-                        and int(_cuda_version.split('.')[0]) >= 13
+                        and builtins.int(_cuda_version.split('.')[0]) >= 13
                     )
                 )
             ):
@@ -892,7 +892,7 @@ if (
 
     from .version import cuda_version as _cuda_version, with_pip_cuda_libraries
 
-    cuda_major = int(_cuda_version.split('.')[0])
+    cuda_major = builtins.int(_cuda_version.split('.')[0])
 
     if (
         platform.system() == 'Linux'

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -901,29 +901,54 @@ if __is_metainfo_generated and is_compiled_with_cuda():
         nvidia_package_path = package_dir + "/.." + "/nvidia"
         set_flags({"FLAGS_nvidia_package_dir": nvidia_package_path})
 
-        cublas_lib_path = package_dir + "/.." + "/nvidia/cublas/lib"
-        set_flags({"FLAGS_cublas_dir": cublas_lib_path})
+        if builtins.float(_cuda_version) >= 13.0:
+            cuda_major = _cuda_version.split('.')[0]
+            cuda_lib_path = os.path.join(
+                nvidia_package_path, f'cu{cuda_major}', 'lib'
+            )
+            set_flags(
+                {
+                    "FLAGS_cuda_dir": cuda_lib_path,
+                    "FLAGS_cublas_dir": cuda_lib_path,
+                    "FLAGS_curand_dir": cuda_lib_path,
+                    "FLAGS_cusolver_dir": cuda_lib_path,
+                    "FLAGS_cusparse_dir": cuda_lib_path,
+                    "FLAGS_cupti_dir": cuda_lib_path,
+                }
+            )
+        else:
+            cublas_lib_path = package_dir + "/.." + "/nvidia/cublas/lib"
+            set_flags({"FLAGS_cublas_dir": cublas_lib_path})
+
+            curand_lib_path = package_dir + "/.." + "/nvidia/curand/lib"
+            set_flags({"FLAGS_curand_dir": curand_lib_path})
+
+            cusolver_lib_path = package_dir + "/.." + "/nvidia/cusolver/lib"
+            set_flags({"FLAGS_cusolver_dir": cusolver_lib_path})
+
+            cusparse_lib_path = package_dir + "/.." + "/nvidia/cusparse/lib"
+            set_flags({"FLAGS_cusparse_dir": cusparse_lib_path})
+
+            cupti_dir_lib_path = (
+                package_dir + "/.." + "/nvidia/cuda_cupti/lib"
+            )
+            set_flags({"FLAGS_cupti_dir": cupti_dir_lib_path})
 
         cudnn_lib_path = package_dir + "/.." + "/nvidia/cudnn/lib"
         set_flags({"FLAGS_cudnn_dir": cudnn_lib_path})
 
-        curand_lib_path = package_dir + "/.." + "/nvidia/curand/lib"
-        set_flags({"FLAGS_curand_dir": curand_lib_path})
-
-        cusolver_lib_path = package_dir + "/.." + "/nvidia/cusolver/lib"
-        set_flags({"FLAGS_cusolver_dir": cusolver_lib_path})
-
-        cusparse_lib_path = package_dir + "/.." + "/nvidia/cusparse/lib"
-        set_flags({"FLAGS_cusparse_dir": cusparse_lib_path})
-
         nccl_lib_path = package_dir + "/.." + "/nvidia/nccl/lib"
         set_flags({"FLAGS_nccl_dir": nccl_lib_path})
 
-        cupti_dir_lib_path = package_dir + "/.." + "/nvidia/cuda_cupti/lib"
-        set_flags({"FLAGS_cupti_dir": cupti_dir_lib_path})
-
         if is_compiled_with_cinn():
-            cuda_cccl_path = package_dir + "/.." + "/nvidia/cuda_cccl/include/"
+            if builtins.float(_cuda_version) >= 13.0:
+                cuda_cccl_path = os.path.join(
+                    nvidia_package_path, f'cu{cuda_major}', 'include'
+                )
+            else:
+                cuda_cccl_path = (
+                    package_dir + "/.." + "/nvidia/cuda_cccl/include/"
+                )
             set_flags({"FLAGS_cuda_cccl_dir": cuda_cccl_path})
             _preload_nvidia_lib("libnvrtc-builtins.so.*", ['cuda_nvrtc'])
 

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -906,6 +906,9 @@ if __is_metainfo_generated and is_compiled_with_cuda():
             cuda_lib_path = os.path.join(
                 nvidia_package_path, f'cu{cuda_major}', 'lib'
             )
+            cusparselt_lib_path = os.path.join(
+                nvidia_package_path, 'cusparselt', 'lib'
+            )
             set_flags(
                 {
                     "FLAGS_cuda_dir": cuda_lib_path,
@@ -913,6 +916,7 @@ if __is_metainfo_generated and is_compiled_with_cuda():
                     "FLAGS_curand_dir": cuda_lib_path,
                     "FLAGS_cusolver_dir": cuda_lib_path,
                     "FLAGS_cusparse_dir": cuda_lib_path,
+                    "FLAGS_cusparselt_dir": cusparselt_lib_path,
                     "FLAGS_cupti_dir": cuda_lib_path,
                 }
             )

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1530,13 +1530,13 @@ if '${CMAKE_BUILD_TYPE}' == 'Release':
                 commands.append("install_name_tool -add_rpath '@loader_path' ${PADDLE_BINARY_DIR}/python/paddle/libs/${IR_NAME}")
         else:
             if ('@WITH_GPU@' == 'ON' and tuple(map(int, '@CUDA_VERSION@'.split('.'))) >= (13, 0) and tuple(map(int, '@CUDA_VERSION@'.split('.'))) < (14, 0)):
-                commands = ["patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../cusparselt/lib:$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/python/paddle/base/${FLUID_CORE_NAME}" + '.so']
+                commands = ["patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../nvidia/cusparselt/lib:$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/python/paddle/base/${FLUID_CORE_NAME}" + '.so']
                 if('${WITH_SHARED_PHI}' == 'ON'):
                     # change rpath of phi.ext for loading 3rd party lib
-                    commands.append("patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_NAME}")
-                    commands.append("patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_CORE_NAME}")
+                    commands.append("patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_NAME}")
+                    commands.append("patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_CORE_NAME}")
                     if('${WITH_GPU}' == 'ON' or '${WITH_ROCM}' == 'ON'):
-                        commands.append("patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib/:$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_GPU_NAME}")
+                        commands.append("patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN:$ORIGIN/../libs' ${PADDLE_BINARY_DIR}/python/paddle/libs/${PHI_GPU_NAME}")
             else:
                 commands = ["patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN/../../nvidia/cuda_nvrtc/lib:$ORIGIN/../../nvidia/cublas/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/curand/lib:$ORIGIN/../../nvidia/cusparse/lib:$ORIGIN/../../nvidia/nvjitlink/lib:$ORIGIN/../../nvidia/cuda_cupti/lib:$ORIGIN/../../nvidia/cuda_runtime/lib:$ORIGIN/../../nvidia/cufft/lib:$ORIGIN/../../nvidia/cufft/lib:$ORIGIN/../../nvidia/cusolver/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../nvidia/nvtx/lib:$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/python/paddle/base/${FLUID_CORE_NAME}" + '.so']
                 if('${WITH_SHARED_PHI}' == 'ON'):

--- a/setup.py
+++ b/setup.py
@@ -2043,7 +2043,7 @@ def get_package_data_and_package_dir():
                     < (14, 0)
                 ):
                     commands = [
-                        "patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../cusparselt/lib:$ORIGIN/../libs/' "
+                        "patchelf --force-rpath --set-rpath '$ORIGIN/../../nvidia/cu13/lib:$ORIGIN/../../nvidia/cudnn/lib:$ORIGIN/../../nvidia/nccl/lib:$ORIGIN/../../nvidia/cusparselt/lib:$ORIGIN/../libs/' "
                         + env_dict.get("PADDLE_BINARY_DIR")
                         + '/python/paddle/base/'
                         + env_dict.get("FLUID_CORE_NAME")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

确保 ARM build 下能够正确加载 site-packages 中 `nvidia-*` 包中的 `.so` 而非系统里的，避免 cublas 等库加载错版本而导致报错、精度有差异等问题（包括部分算子报 cublas 未初始化的问题）

- 确保 `PADDLE_WITH_PIP_CUDA_LIBRARIES` 宏可以在 ARM build 上会被设置
- 确保 `python/paddle/__init__.py` 里在 cuda13 下  `FLAGS_cuda_dir`、`FLAGS_cublas_dir` 等路径是合理的
- 一些额外修复
   - nvrtc 在 cu13 下应该搜索 `libnvrtc.so.13` 而非 `libnvrtc.so`
   - cuda13 下没有 `nvidia/cuda_runtime/lib`，故清理，这个 `setup.py` 本来也没有
   - `cusparselt` 路径应该有 `nvidia` 前缀，及 `FLAGS_cusparselt_dir` 设置

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.6 sol max)</sup>
</div>