### PR TITLE
[Build] Compile FlashAttention on arm64 platforms

### DIFF
--- a/cmake/external/flashattn.cmake
+++ b/cmake/external/flashattn.cmake
@@ -184,6 +184,9 @@ else()
   set(CACHE_TAR_DIR "${FA_BUILD_DIR}/flashattn_libs_${FLASHATTN_TAG}")
 
   set(SKIP_BUILD_FA OFF)
+  if(WITH_ARM)
+    set(WITH_FA_BUILD_WITH_CACHE OFF)
+  endif()
   if(WITH_FA_BUILD_WITH_CACHE)
 
     message(STATUS "Downloading ${TAR_FILE_URL} to ${CACHE_TAR_PATH}")

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -349,7 +349,6 @@ include(external/glog) # download, build, install glog
 
 ########################### include third_party according to flags ###############################
 if(WITH_GPU
-   AND NOT WITH_ARM
    AND NOT WIN32
    AND NOT APPLE)
   if(${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 11.0)
@@ -601,7 +600,6 @@ if(WITH_ROCM)
 endif()
 
 if(WITH_GPU
-   AND NOT WITH_ARM
    AND NOT WIN32
    AND NOT APPLE)
   if(${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 12.3


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you've done -->
1. Remove the `NOT WITH_ARM` guard from GPU third-party dependency conditions.
2. Allow FlashAttention-related GPU third-party dependency logic to be enabled on ARM64 GPU builds.

### Tests

- `git diff --check -- cmake/third_party.cmake`
- Planned: ARM64 + GPU CMake/build validation with `WITH_ARM=ON` and `WITH_GPU=ON` to verify FlashAttention-related third-party dependency logic is enabled on ARM64 GPU builds.


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否。本变更仅调整 ARM64 GPU 构建依赖开关，不修改数值计算逻辑或算子实现。

