### PR TITLE
Use double precision for the norm_p value in norm reduce GPU kernel

### DIFF
--- a/paddle/phi/kernels/funcs/reduce_gpu_kernel.h
+++ b/paddle/phi/kernels/funcs/reduce_gpu_kernel.h
@@ -1375,7 +1375,7 @@ void ReduceGpuKernel(const KPDevice& dev_ctx,
                      const phi::DenseTensor& x,
                      phi::DenseTensor* y,
                      const std::vector<int>& origin_reduce_dims,
-                     const float norm_p = 1.0f) {
+                     const double norm_p = 1.0) {
   if (x.numel() == 0) {
     dev_ctx.Alloc<Ty>(y);
     return;
@@ -1424,7 +1424,7 @@ void ReduceGpuKernel(const KPDevice& dev_ctx,
                       static_cast<MPType>(iter.numel());
       return ReduceOp<Tx, MPType, Ty>{factor};
     } else if constexpr (kIsPNormOp) {
-      return ReduceOp<Tx, MPType, Ty>{norm_p};
+      return ReduceOp<Tx, MPType, Ty>{static_cast<MPType>(norm_p)};
     } else {
       return ReduceOp<Tx, MPType, Ty>{};
     }

--- a/paddle/phi/kernels/gpu/p_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_kernel.cu
@@ -43,13 +43,13 @@ struct AbsFunctor {
 
 template <typename T>
 struct UnsignedPowFunctor {
-  HOSTDEVICE explicit inline UnsignedPowFunctor(float porder) {
+  HOSTDEVICE explicit inline UnsignedPowFunctor(double porder) {
     this->porder = porder;
   }
   HOSTDEVICE inline T operator()(const T x) const {
     return static_cast<T>(inline_pow(inline_abs(x), static_cast<T>(porder)));
   }
-  float porder;
+  double porder;
 };
 
 #ifndef _WIN32

--- a/test/legacy_test/test_norm_all.py
+++ b/test/legacy_test/test_norm_all.py
@@ -422,6 +422,30 @@ class TestPnormOp6(TestPnormOp):
         )
 
 
+# Regression test: porder=2.3 (not exactly representable in float32) with float64
+# input to verify that the GPU kernel uses double precision for porder without
+# truncating it to float, which would cause forward output mismatch.
+class TestPnormOp7(TestPnormOp):
+    def init_test_case(self):
+        self.shape = [3, 20, 3]
+        self.axis = 2
+        self.epsilon = 1e-12
+        self.porder = 2.3
+        self.keepdim = True
+        self.asvector = False
+
+    def init_dtype(self):
+        self.dtype = "float64"
+
+    def test_check_output(self):
+        self.check_output(atol=1e-12, rtol=1e-12, check_prim_pir=True)
+
+    def test_check_grad(self):
+        self.check_grad(
+            ['X'], 'Out', user_defined_grads=self.gradient, check_prim_pir=True
+        )
+
+
 class TestPnormOpZeroSize(TestPnormOp):
     def init_test_case(self):
         self.shape = [0, 20, 3]


### PR DESCRIPTION
### PR Category
Operator Mechanism 

### PR Types
Bug fixes

### Description
`paddle/phi/kernels/funcs/reduce_gpu_kernel.h`
- norm_p 参数类型从 float 改为 double，避免fp64下p值在传递过程中丢失精度
- fp64的前向与torch对齐 不会带来额外性能开销

`paddle/phi/kernels/gpu/p_norm_kernel.cu`
- porder参数由float改为double，避免fp64在`_WIN32`路径下计算时精度丢失porder精度

### 是否引起精度变化
是
