### PR TITLE
Fixed ppc64le build by excluding SIMD/AVX code paths

### DIFF
--- a/paddle/phi/backends/cpu/cpu_info.cc
+++ b/paddle/phi/backends/cpu/cpu_info.cc
@@ -151,7 +151,8 @@ bool MayIUse(const cpu_isa_t cpu_isa) {
   } else {
 #if !defined(WITH_NV_JETSON) && !defined(PADDLE_WITH_ARM) &&  \
     !defined(PADDLE_WITH_SW) && !defined(PADDLE_WITH_MIPS) && \
-    !defined(PADDLE_WITH_LOONGARCH)
+    !defined(PADDLE_WITH_LOONGARCH) && \
+    !defined(__powerpc__) && !defined(__ppc__) && !defined(__PPC__)
     std::array<int, 4> reg;
     cpuid(reg.data(), 0);
     int nIds = reg[0];

--- a/paddle/phi/backends/cpu/cpu_info.h
+++ b/paddle/phi/backends/cpu/cpu_info.h
@@ -42,7 +42,8 @@
 #else
 #if !defined(WITH_NV_JETSON) && !defined(PADDLE_WITH_ARM) &&  \
     !defined(PADDLE_WITH_SW) && !defined(PADDLE_WITH_MIPS) && \
-    !defined(PADDLE_WITH_LOONGARCH)
+    !defined(PADDLE_WITH_LOONGARCH) && \
+    !defined(__powerpc__) && !defined(__ppc__) && !defined(__PPC__)
 #include <cpuid.h>
 inline void cpuid(int reg[4], int x) {
   __cpuid_count(x, 0, reg[0], reg[1], reg[2], reg[3]);

--- a/paddle/phi/core/platform/denormal.cc
+++ b/paddle/phi/core/platform/denormal.cc
@@ -30,7 +30,8 @@
 
 #if !defined(GCC_WITHOUT_INTRINSICS) && !defined(PADDLE_WITH_ARM) && \
     !defined(PADDLE_WITH_SW) && !defined(PADDLE_WITH_MIPS) &&        \
-    !defined(_WIN32) && !defined(PADDLE_WITH_LOONGARCH)
+    !defined(_WIN32) && !defined(PADDLE_WITH_LOONGARCH) && \
+    !defined(__powerpc__) && !defined(__ppc__) && !defined(__PPC__)
 #define DENORM_USE_INTRINSICS
 #endif
 

--- a/paddle/phi/kernels/funcs/search_compute.h
+++ b/paddle/phi/kernels/funcs/search_compute.h
@@ -15,7 +15,8 @@
 #pragma once
 
 #if !defined(PADDLE_WITH_ARM) && !defined(PADDLE_WITH_SW) && \
-    !defined(PADDLE_WITH_MIPS) && !defined(PADDLE_WITH_LOONGARCH)
+    !defined(PADDLE_WITH_MIPS) && !defined(PADDLE_WITH_LOONGARCH) && \
+    !defined(__powerpc__) && !defined(__ppc__) && !defined(__PPC__)
 #include <immintrin.h>
 #endif
 #include <cfloat>
@@ -101,7 +102,8 @@ void call_gemm_batched(const Context& dev_ctx,
 }
 
 #if !defined(PADDLE_WITH_ARM) && !defined(PADDLE_WITH_SW) && \
-    !defined(PADDLE_WITH_MIPS) && !defined(PADDLE_WITH_LOONGARCH)
+    !defined(PADDLE_WITH_MIPS) && !defined(PADDLE_WITH_LOONGARCH) && \
+    !defined(__powerpc__) && !defined(__ppc__) && !defined(__PPC__)
 
 #define __m256x __m256
 
@@ -144,6 +146,8 @@ inline void axpy(const T* x, T* y, size_t len, const T alpha) {
 #elif defined(PADDLE_WITH_ARM) || defined(PADDLE_WITH_SW) || \
     defined(PADDLE_WITH_MIPS) || defined(PADDLE_WITH_LOONGARCH)
   PADDLE_THROW(common::errors::Unimplemented("axpy is not supported"));
+#elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)
+  // fall through to the scalar tail below
 #else
   lll = len & ~SSE_CUT_LEN_MASK;
   __m128x mm_alpha = _mm_load1_px(&alpha);
@@ -174,6 +178,8 @@ inline void axpy_noadd(const T* x, T* y, size_t len, const T alpha) {
 #elif defined(PADDLE_WITH_ARM) || defined(PADDLE_WITH_SW) || \
     defined(PADDLE_WITH_MIPS) || defined(PADDLE_WITH_LOONGARCH)
   PADDLE_THROW(common::errors::Unimplemented("axpy_noadd is not supported"));
+#elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)
+  // fall through to the scalar tail below
 #else
   lll = len & ~SSE_CUT_LEN_MASK;
   __m128x mm_alpha = _mm_load1_px(&alpha);

--- a/paddle/phi/kernels/funcs/softmax_impl.h
+++ b/paddle/phi/kernels/funcs/softmax_impl.h
@@ -236,6 +236,7 @@ class SoftmaxFunctor<DeviceContext, T, enable_if_CPU<DeviceContext>> {
                   const int axis_dim,
                   const DenseTensor* X,
                   DenseTensor* Y) {
+#if defined(__AVX__) && !defined(__powerpc__) && !defined(__ppc__) && !defined(__PPC__)
     const auto& in_dims = X->dims();
     constexpr int64_t kBatchDim = 0;
     constexpr int64_t kClassDim = 1;
@@ -266,7 +267,9 @@ class SoftmaxFunctor<DeviceContext, T, enable_if_CPU<DeviceContext>> {
         in_data += num_classes;
         out_data += num_classes;
       }
-    } else {
+    } else
+#endif
+    {
       SoftmaxEigen<DeviceContext, T>()(dev_ctx, axis_dim, X, Y);
     }
   }
@@ -396,6 +399,7 @@ class SoftmaxGradFunctor<DeviceContext, T, enable_if_CPU<DeviceContext>> {
                   const DenseTensor* y,
                   const DenseTensor* y_grad,
                   DenseTensor* x_grad) {
+#if defined(__AVX__) && !defined(__powerpc__) && !defined(__ppc__) && !defined(__PPC__)
     const auto& out_dims = y->dims();
     constexpr int64_t kBatchDim = 0;
     constexpr int64_t kClassDim = 1;
@@ -421,7 +425,9 @@ class SoftmaxGradFunctor<DeviceContext, T, enable_if_CPU<DeviceContext>> {
         out_grad += num_classes;
         in_grad += num_classes;
       }
-    } else {
+    } else
+#endif
+    {
       SoftmaxGradEigen<DeviceContext, T>()(
           dev_ctx, axis_dim, y, y_grad, x_grad);
     }


### PR DESCRIPTION
### PR Category
Environment Adaptation 


### PR Types
Bug fixes 


### Description
Paddle fails to build on ppc64le because some x86-specific AVX/SSE code paths are incorrectly compiled on PowerPC targets, resulting in compilation errors related to `immintrin.h`, `pmmintrin.h`, `emmintrin.h`, and AVX helper functions.
 
This PR adds PowerPC architecture guards (`__powerpc__`, `__ppc__`, `__PPC__`) to the existing architecture checks so that ppc64le builds bypass unsupported x86 SIMD implementations and use the generic CPU fallback path instead.
 
This change fixes build failures on ppc64le while preserving existing behavior and optimizations for x86 platforms.