### PR TITLE
[Build] Avoid FlashAttention v3 for sm100 builds

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -605,7 +605,7 @@ if(WITH_GPU
   if(${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 12.3
      AND ${CMAKE_CUDA_COMPILER_VERSION} LESS_EQUAL 13.0)
     foreach(arch ${NVCC_ARCH_BIN})
-      if(${arch} EQUAL 90 AND NOT 100 IN_LIST NVCC_ARCH_BIN)
+      if(${arch} EQUAL 90)
         set(WITH_FLASHATTN_V3 ON)
         break()
       endif()

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -605,7 +605,7 @@ if(WITH_GPU
   if(${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 12.3
      AND ${CMAKE_CUDA_COMPILER_VERSION} LESS_EQUAL 13.0)
     foreach(arch ${NVCC_ARCH_BIN})
-      if(${arch} EQUAL 90)
+      if(${arch} EQUAL 90 AND NOT 100 IN_LIST NVCC_ARCH_BIN)
         set(WITH_FLASHATTN_V3 ON)
         break()
       endif()

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -605,7 +605,7 @@ if(WITH_GPU
   if(${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 12.3
      AND ${CMAKE_CUDA_COMPILER_VERSION} LESS_EQUAL 13.0)
     foreach(arch ${NVCC_ARCH_BIN})
-      if(${arch} GREATER_EQUAL 90)
+      if(${arch} EQUAL 90)
         set(WITH_FLASHATTN_V3 ON)
         break()
       endif()


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
在 CUDA 12.3 到 13.0 的构建配置中，FlashAttention v3 原先对所有 `CUDA_ARCH_BIN >= 90` 的架构启用。对于 `CUDA_ARCH_BIN=100`，这会额外触发 v3 的 `sm90` 实例化编译，而该路径在 ARM64 + CUDA 13 环境中可能出现 nvcc 编译段错误。

本次修改将 v3 的启用条件收窄到 `CUDA_ARCH_BIN == 90`。这样编译 100 架构时不会启用 FlashAttention v3，但仍会通过后续 `CUDA_ARCH_BIN >= 80` 分支编译 v2 FlashAttention。

已执行检查：
- `pre-commit run --files cmake/third_party.cmake`
- `pre-commit run --from-ref origin/develop --to-ref HEAD`
- `git diff --check -- cmake/third_party.cmake`

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否。该修改仅调整 FlashAttention v3 的构建开关条件，不修改算子实现或数值计算逻辑。
