### PR TITLE
fix: validate embedding ids unconditionally in CPU kernel to prevent OOB read (CWE-125)

### DIFF
--- a/paddle/phi/kernels/cpu/embedding_kernel.cc
+++ b/paddle/phi/kernels/cpu/embedding_kernel.cc
@@ -49,27 +49,31 @@ struct EmbeddingCPUFunctor {
     dev_ctx_.template Alloc<T>(out_);
     auto* output = out_->data<T>();
 
+    // Validate every id unconditionally. The range check must not be gated on
+    // padding_idx: `kNoPadding` is -1, so when the layer is created with any
+    // padding_idx (e.g. the common padding_idx=0) the previous guard skipped
+    // validation for all ids, allowing an out-of-bounds read in the copy loop
+    // below (CWE-125). Only the padding-row zeroing should depend on
+    // padding_idx.
     for (int64_t i = 0; i < ids_numel; ++i) {
-      if (padding_idx_ == kNoPadding && ids[i] != padding_idx_) {
-        PADDLE_ENFORCE_LT(
-            ids[i],
-            row_number,
-            common::errors::InvalidArgument(
-                "Variable value (input) of OP(embedding) "
-                "expected >= 0 and < %ld, but got %ld. Please check input "
-                "value.",
-                row_number,
-                ids[i]));
-        PADDLE_ENFORCE_GE(
-            ids[i],
-            0,
-            common::errors::InvalidArgument(
-                "Variable value (input) of OP(embedding) "
-                "expected >= 0 and < %ld, but got %ld. Please check input "
-                "value.",
-                row_number,
-                ids[i]));
-      }
+      PADDLE_ENFORCE_LT(
+          ids[i],
+          row_number,
+          common::errors::InvalidArgument(
+              "Variable value (input) of OP(embedding) "
+              "expected >= 0 and < %ld, but got %ld. Please check input "
+              "value.",
+              row_number,
+              ids[i]));
+      PADDLE_ENFORCE_GE(
+          ids[i],
+          0,
+          common::errors::InvalidArgument(
+              "Variable value (input) of OP(embedding) "
+              "expected >= 0 and < %ld, but got %ld. Please check input "
+              "value.",
+              row_number,
+              ids[i]));
     }
 
 #if defined(_OPENMP) && !defined(PADDLE_WITH_CUDA)

--- a/test/ai_edited_test/test_ai_nn_functional_input.py
+++ b/test/ai_edited_test/test_ai_nn_functional_input.py
@@ -134,6 +134,27 @@ class TestEmbedding(unittest.TestCase):
         with self.assertRaises(ValueError):
             paddle.nn.functional.embedding(x, weight, padding_idx=10)
 
+    def test_embedding_out_of_range_id_with_padding_idx(self):
+        """测试设置 padding_idx 时越界输入 id 会报错（CPU 内核越界读回归）
+        When padding_idx is set, an out-of-range input id must raise instead
+        of reading out of bounds (CWE-125 regression for the CPU kernel).
+        Forces the CPU place so the test is independent of the build target."""
+        orig_device = paddle.device.get_device()
+        paddle.set_device('cpu')
+        try:
+            weight = paddle.randn([16, 8])
+            # id 40 is out of range for a 16-row table; padding_idx=0 must not
+            # cause the range check to be skipped.
+            x = paddle.to_tensor([0, 40], dtype='int64')
+            with self.assertRaises(ValueError):
+                paddle.nn.functional.embedding(x, weight, padding_idx=0)
+            # A negative out-of-range id must also raise.
+            x_neg = paddle.to_tensor([0, -3], dtype='int64')
+            with self.assertRaises(ValueError):
+                paddle.nn.functional.embedding(x_neg, weight, padding_idx=0)
+        finally:
+            paddle.set_device(orig_device)
+
     def test_embedding_sparse(self):
         """测试 sparse 模式的 embedding
         Test embedding in sparse mode"""


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Security

### Description

Fixes #79491 — out-of-bounds read in the CPU embedding kernel when `padding_idx` is set.

**Problem**

In `paddle/phi/kernels/cpu/embedding_kernel.cc`, `EmbeddingCPUFunctor::apply` validates each id only inside:

```cpp
if (padding_idx_ == kNoPadding && ids[i] != padding_idx_) {
  PADDLE_ENFORCE_LT(ids[i], row_number, ...);
  PADDLE_ENFORCE_GE(ids[i], 0, ...);
}
```

`kNoPadding` is `-1`, so as soon as an embedding layer is created with **any** `padding_idx` (e.g. the very common `padding_idx=0` used in NLP models), the entire range check is skipped for every id. The copy loop then indexes the weight table with an unvalidated, attacker-controlled `ids[i]`:

```cpp
memcpy(output + i * row_width,
       table + ids[i] * row_width,   // ids[i] unchecked
       row_width * sizeof(T));
```

- An out-of-range id (e.g. `40` on a 16-row table) returns raw heap bytes past the weight matrix — information disclosure.
- A large id (e.g. `1e9`) crashes the process with SIGSEGV in `EmbeddingCPUFunctor::apply`.

A reproducible PoC and an AddressSanitizer trace (`heap-buffer-overflow READ`) are in issue #79491.

**Solution**

- Make the range check `0 <= id < row_number` **unconditional** for every id.
- Keep only the padding-row zeroing conditional on `padding_idx`.

Valid inputs are unaffected (padding indices are always in range); only genuinely out-of-range ids are now rejected with the existing `InvalidArgument` error instead of reading out of bounds.

> Note: this PR fixes the CPU kernel reported in the issue. The GPU/XPU embedding kernels share the same padding pattern and can be hardened as a follow-up.

This vulnerability has also been responsibly disclosed to the Baidu security team (international_bsrc@baidu.com).

cc @luotao1 

### 是否引起精度变化

否
