### PR TITLE
fix: validate LoD byte size in DenseTensor deserialization to prevent heap overflow (CWE-787)

### DIFF
--- a/paddle/phi/core/framework/dense_tensor_serialize.cc
+++ b/paddle/phi/core/framework/dense_tensor_serialize.cc
@@ -117,9 +117,35 @@ void DeserializeFromStream(std::istream &is,
     for (uint64_t i = 0; i < lod_level; ++i) {
       uint64_t size = 0;
       is.read(reinterpret_cast<char *>(&size), sizeof(size));
+      // `size` is an attacker-controlled byte count read from the stream. The
+      // destination buffer holds `size / sizeof(size_t)` elements, i.e.
+      // `(size / sizeof(size_t)) * sizeof(size_t)` bytes, but the read below
+      // consumes the full `size` bytes. If `size` is not a multiple of
+      // `sizeof(size_t)`, the read writes past the allocation (CWE-787 / heap
+      // buffer overflow). Reject such sizes before allocating/reading.
+      PADDLE_ENFORCE_EQ(
+          size % sizeof(size_t),
+          0,
+          common::errors::InvalidArgument(
+              "Deserialize LoD information failed, the byte size of LoD level "
+              "%llu is %llu, which is not a multiple of sizeof(size_t) (%zu). "
+              "The input stream may be corrupted or malicious.",
+              i,
+              size,
+              sizeof(size_t)));
       std::vector<size_t> tmp(size / sizeof(size_t));
       is.read(reinterpret_cast<char *>(tmp.data()),
               static_cast<std::streamsize>(size));
+      PADDLE_ENFORCE_EQ(
+          static_cast<uint64_t>(is.gcount()),
+          size,
+          common::errors::InvalidArgument(
+              "Deserialize LoD information failed, expected to read %llu bytes "
+              "for LoD level %llu but only %lld bytes were available. The "
+              "input stream may be truncated or corrupted.",
+              size,
+              i,
+              static_cast<int64_t>(is.gcount())));
       lod[i] = tmp;
     }
   }

--- a/paddle/phi/core/framework/dense_tensor_serialize.cc
+++ b/paddle/phi/core/framework/dense_tensor_serialize.cc
@@ -14,9 +14,30 @@
 
 #include "paddle/phi/core/framework/dense_tensor_serialize.h"
 #include <cstdint>
+#include <limits>
 #include "paddle/phi/core/framework/convert_utils.h"
 
 namespace phi {
+
+namespace {
+// Returns the number of bytes remaining to be read from a seekable stream, or
+// -1 if the stream does not support seeking (e.g. a pure input pipe). Used to
+// bound attacker-controlled length fields before allocating, so a malformed
+// serialized tensor cannot force a huge allocation (OOM).
+int64_t GetRemainingStreamBytes(std::istream &is) {
+  const std::istream::pos_type cur = is.tellg();
+  if (cur == std::istream::pos_type(-1)) {
+    return -1;
+  }
+  is.seekg(0, std::ios::end);
+  const std::istream::pos_type end = is.tellg();
+  is.seekg(cur);
+  if (end == std::istream::pos_type(-1)) {
+    return -1;
+  }
+  return static_cast<int64_t>(end - cur);
+}
+}  // namespace
 
 void SerializeToStream(std::ostream &os,
                        const DenseTensor &tensor,
@@ -84,6 +105,32 @@ void DeserializeFromStream(std::istream &is,
     // the 2nd field, LoD information
     uint64_t lod_level = 0;
     is.read(reinterpret_cast<char *>(&lod_level), sizeof(lod_level));
+    // `lod_level` is attacker-controlled. Ensure the header was fully read and
+    // bound it by the number of LoD levels the remaining stream could hold
+    // (each level needs at least one uint64_t) before `resize` allocates, so a
+    // crafted file cannot force a huge allocation (OOM).
+    PADDLE_ENFORCE_EQ(
+        static_cast<uint64_t>(is.gcount()),
+        sizeof(lod_level),
+        common::errors::InvalidArgument(
+            "Deserialize LoD information failed, expected to read %zu bytes "
+            "for the LoD level count but only %lld bytes were available. The "
+            "input stream may be truncated or corrupted.",
+            sizeof(lod_level),
+            static_cast<int64_t>(is.gcount())));
+    const int64_t remaining_bytes = GetRemainingStreamBytes(is);
+    if (remaining_bytes >= 0) {
+      PADDLE_ENFORCE_LE(
+          lod_level,
+          static_cast<uint64_t>(remaining_bytes) / sizeof(uint64_t),
+          common::errors::InvalidArgument(
+              "Deserialize LoD information failed, the declared LoD level "
+              "count (%llu) exceeds what the remaining %lld bytes of the input "
+              "stream can hold. The input stream may be corrupted or "
+              "malicious.",
+              lod_level,
+              static_cast<int64_t>(remaining_bytes)));
+    }
     auto &lod = *tensor->mutable_lod();
     lod.resize(lod_level);
   }
@@ -112,17 +159,51 @@ void DeserializeFromStream(std::istream &is,
     // the 2nd field, LoD information
     uint64_t lod_level = 0;
     is.read(reinterpret_cast<char *>(&lod_level), sizeof(lod_level));
+    // `lod_level` is attacker-controlled. Ensure the header was fully read and
+    // bound it by the number of LoD levels the remaining stream could hold
+    // (each level needs at least one uint64_t size field) before `resize`
+    // allocates, so a crafted file cannot force a huge allocation (OOM).
+    PADDLE_ENFORCE_EQ(
+        static_cast<uint64_t>(is.gcount()),
+        sizeof(lod_level),
+        common::errors::InvalidArgument(
+            "Deserialize LoD information failed, expected to read %zu bytes "
+            "for the LoD level count but only %lld bytes were available. The "
+            "input stream may be truncated or corrupted.",
+            sizeof(lod_level),
+            static_cast<int64_t>(is.gcount())));
+    const int64_t remaining_bytes = GetRemainingStreamBytes(is);
+    if (remaining_bytes >= 0) {
+      PADDLE_ENFORCE_LE(
+          lod_level,
+          static_cast<uint64_t>(remaining_bytes) / sizeof(uint64_t),
+          common::errors::InvalidArgument(
+              "Deserialize LoD information failed, the declared LoD level "
+              "count (%llu) exceeds what the remaining %lld bytes of the input "
+              "stream can hold. The input stream may be corrupted or "
+              "malicious.",
+              lod_level,
+              static_cast<int64_t>(remaining_bytes)));
+    }
     auto &lod = *tensor->mutable_lod();
     lod.resize(lod_level);
     for (uint64_t i = 0; i < lod_level; ++i) {
       uint64_t size = 0;
       is.read(reinterpret_cast<char *>(&size), sizeof(size));
-      // `size` is an attacker-controlled byte count read from the stream. The
-      // destination buffer holds `size / sizeof(size_t)` elements, i.e.
-      // `(size / sizeof(size_t)) * sizeof(size_t)` bytes, but the read below
-      // consumes the full `size` bytes. If `size` is not a multiple of
-      // `sizeof(size_t)`, the read writes past the allocation (CWE-787 / heap
-      // buffer overflow). Reject such sizes before allocating/reading.
+      PADDLE_ENFORCE_EQ(
+          static_cast<uint64_t>(is.gcount()),
+          sizeof(size),
+          common::errors::InvalidArgument(
+              "Deserialize LoD information failed, expected to read %zu bytes "
+              "for the byte size of LoD level %llu but only %lld bytes were "
+              "available. The input stream may be truncated or corrupted.",
+              sizeof(size),
+              i,
+              static_cast<int64_t>(is.gcount())));
+      // The destination buffer holds `size / sizeof(size_t)` elements, i.e.
+      // exactly `size` bytes only when `size` is a multiple of `sizeof(size_t)`.
+      // Otherwise the read below would write past the allocation (CWE-787 /
+      // heap buffer overflow), so reject such sizes.
       PADDLE_ENFORCE_EQ(
           size % sizeof(size_t),
           0,
@@ -133,6 +214,30 @@ void DeserializeFromStream(std::istream &is,
               i,
               size,
               sizeof(size_t)));
+      // Bound `size` before allocating so a crafted file cannot force a huge
+      // allocation (OOM), and guard the `std::streamsize` cast used by `read`.
+      PADDLE_ENFORCE_LE(
+          size,
+          static_cast<uint64_t>(std::numeric_limits<std::streamsize>::max()),
+          common::errors::InvalidArgument(
+              "Deserialize LoD information failed, the byte size of LoD level "
+              "%llu (%llu) exceeds the maximum readable stream size. The input "
+              "stream may be corrupted or malicious.",
+              i,
+              size));
+      const int64_t level_remaining_bytes = GetRemainingStreamBytes(is);
+      if (level_remaining_bytes >= 0) {
+        PADDLE_ENFORCE_LE(
+            size,
+            static_cast<uint64_t>(level_remaining_bytes),
+            common::errors::InvalidArgument(
+                "Deserialize LoD information failed, the byte size of LoD "
+                "level %llu (%llu) exceeds the remaining %lld bytes of the "
+                "input stream. The input stream may be corrupted or malicious.",
+                i,
+                size,
+                static_cast<int64_t>(level_remaining_bytes)));
+      }
       std::vector<size_t> tmp(size / sizeof(size_t));
       is.read(reinterpret_cast<char *>(tmp.data()),
               static_cast<std::streamsize>(size));

--- a/paddle/phi/core/framework/dense_tensor_serialize.cc
+++ b/paddle/phi/core/framework/dense_tensor_serialize.cc
@@ -201,9 +201,9 @@ void DeserializeFromStream(std::istream &is,
               i,
               static_cast<int64_t>(is.gcount())));
       // The destination buffer holds `size / sizeof(size_t)` elements, i.e.
-      // exactly `size` bytes only when `size` is a multiple of `sizeof(size_t)`.
-      // Otherwise the read below would write past the allocation (CWE-787 /
-      // heap buffer overflow), so reject such sizes.
+      // exactly `size` bytes only when `size` is a multiple of
+      // `sizeof(size_t)`. Otherwise the read below would write past the
+      // allocation (CWE-787 / heap buffer overflow), so reject such sizes.
       PADDLE_ENFORCE_EQ(
           size % sizeof(size_t),
           0,

--- a/test/legacy_test/test_paddle_save_load_binary.py
+++ b/test/legacy_test/test_paddle_save_load_binary.py
@@ -232,6 +232,39 @@ class TestSaveLoadBinaryFormat(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             paddle.framework.io._load_dense_tensor(1)
 
+    def test_load_dense_tensor_malformed_lod_raises(self):
+        # Regression test: DeserializeFromStream parses attacker-controlled LoD
+        # headers. A malformed serialized tensor must raise cleanly instead of
+        # overflowing the destination buffer (CWE-787) or attempting a huge
+        # allocation (OOM). See DeserializeFromStream in
+        # paddle/phi/core/framework/dense_tensor_serialize.cc.
+        import struct
+
+        def make_blob(lod_level, levels):
+            # version(uint32)=0, lod_level(uint64), then per level:
+            # size(uint64) + `size` bytes of data.
+            blob = struct.pack('<I', 0)
+            blob += struct.pack('<Q', lod_level)
+            for size, payload in levels:
+                blob += struct.pack('<Q', size)
+                blob += payload
+            return blob
+
+        # (a) LoD level byte size not a multiple of sizeof(size_t): the read
+        #     would write past the (size // 8) * 8 byte allocation.
+        blob_unaligned = make_blob(1, [(9, b'\x41' * 9)])
+        # (b) Absurd lod_level with no payload: must not attempt a huge
+        #     allocation via lod.resize(lod_level).
+        blob_huge_level = make_blob(10**18, [])
+        # (c) Absurd (8-aligned) LoD byte size with no payload: must not attempt
+        #     a huge std::vector<size_t> allocation before reading.
+        blob_huge_size = make_blob(1, [(8 * 10**9, b'')])
+
+        for blob in (blob_unaligned, blob_huge_level, blob_huge_size):
+            tensor = base.core.DenseTensor()
+            with self.assertRaises((ValueError, RuntimeError)):
+                base.core.load_dense_tensor_from_memory(tensor, blob)
+
     def test_save_load_selected_rows(self):
         paddle.enable_static()
         place = get_device_place()


### PR DESCRIPTION
### PR Category

Execute Infrastructure

### PR Types

Security

### Description

Fixes #79492 — heap buffer overflow in `DeserializeFromStream` (LoD length integer-division truncation).

**Problem**

In `paddle/phi/core/framework/dense_tensor_serialize.cc`, the LoD header is parsed by reading an attacker-controlled 64-bit byte count `size`, allocating a `std::vector<size_t>` sized by integer division `size / sizeof(size_t)`, and then reading the **full** `size` bytes into that buffer:

```cpp
uint64_t size = 0;
is.read(reinterpret_cast<char *>(&size), sizeof(size));
std::vector<size_t> tmp(size / sizeof(size_t));   // (size / 8) * 8 bytes
is.read(reinterpret_cast<char *>(tmp.data()),
        static_cast<std::streamsize>(size));       // reads full `size` bytes
```

When `size` is not a multiple of `sizeof(size_t)` (8), the destination buffer is smaller than the read length, so the read writes up to 7 bytes past the heap allocation with attacker-supplied bytes — a heap buffer overflow (`WRITE`). The routine is reachable from Python via `paddle.base.core.load_dense_tensor` and the tensor/weight loading paths.

A crafted serialized tensor and an AddressSanitizer trace (`heap-buffer-overflow WRITE`) are in issue #79492.

**Solution**

- Reject any `size` that is **not** a multiple of `sizeof(size_t)` before allocating/reading.
- Verify that the full `size` bytes were actually read (`gcount()`), rejecting truncated or corrupted streams.

`SerializeToStream` always writes `level.size() * sizeof(size_t)` bytes per LoD level, so legitimately serialized tensors are always a multiple of `sizeof(size_t)` and are never rejected by this check. Tensors with no LoD (the common case, `lod_level == 0`) do not enter this loop at all.

This vulnerability has also been responsibly disclosed to the Baidu security team (international_bsrc@baidu.com).

cc  @luotao1 

### 是否引起精度变化

否
