### PR TITLE
[release/3.4][Build] Packaging vendored liblapack dylib on ARM64 platform

### DIFF
--- a/cmake/external/lapack.cmake
+++ b/cmake/external/lapack.cmake
@@ -23,14 +23,24 @@ set(LAPACK_LIB_DIR ${LAPACK_INSTALL_DIR}/lib)
 # Note(zhouwei): lapack need fortran compiler which many machines don't have, so use precompiled library.
 # use lapack tag v3.10.0 on 06/28/2021 https://github.com/Reference-LAPACK/lapack
 if(LINUX)
-  set(LAPACK_FILE
-      "lapack_lnx_v3.10.0.20210628.tar.gz"
-      CACHE STRING "" FORCE)
-  set(LAPACK_URL
-      "https://paddlepaddledeps.bj.bcebos.com/${LAPACK_FILE}"
-      CACHE STRING "" FORCE)
-  set(LAPACK_URL_MD5 71f8cc8237a8571692f3e07f9a4f25f6)
-  set(GNU_RT_LIB_1 "${LAPACK_LIB_DIR}/libquadmath.so.0")
+  if(WITH_ARM)
+    set(LAPACK_FILE
+        "lapack_lnx_arm64_v3.10.0.20260720.tar.gz"
+        CACHE STRING "" FORCE)
+    set(LAPACK_URL
+        "https://paddlepaddledeps.cdn.bcebos.com/${LAPACK_FILE}"
+        CACHE STRING "" FORCE)
+    set(LAPACK_URL_MD5 c23e6389dc5309bd29111bf6836f4d55)
+  else()
+    set(LAPACK_FILE
+        "lapack_lnx_v3.10.0.20210628.tar.gz"
+        CACHE STRING "" FORCE)
+    set(LAPACK_URL
+        "https://paddlepaddledeps.bj.bcebos.com/${LAPACK_FILE}"
+        CACHE STRING "" FORCE)
+    set(LAPACK_URL_MD5 71f8cc8237a8571692f3e07f9a4f25f6)
+    set(GNU_RT_LIB_1 "${LAPACK_LIB_DIR}/libquadmath.so.0")
+  endif()
   set(GFORTRAN_LIB "${LAPACK_LIB_DIR}/libgfortran.so.3")
   set(BLAS_LIB "${LAPACK_LIB_DIR}/libblas.so.3")
   set(LAPACK_LIB "${LAPACK_LIB_DIR}/liblapack.so.3")

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1232,12 +1232,14 @@ shutil.copy('${WARPRNNT_LIBRARIES}', libs_path)
 package_data['paddle.libs']+=[
     os.path.basename('${LAPACK_LIB}'),
     os.path.basename('${BLAS_LIB}'),
-    os.path.basename('${GFORTRAN_LIB}'),
-    os.path.basename('${GNU_RT_LIB_1}')]
+    os.path.basename('${GFORTRAN_LIB}')]
 shutil.copy('${BLAS_LIB}', libs_path)
 shutil.copy('${LAPACK_LIB}', libs_path)
 shutil.copy('${GFORTRAN_LIB}', libs_path)
-shutil.copy('${GNU_RT_LIB_1}', libs_path)
+if len('${GNU_RT_LIB_1}') > 1:
+    package_data['paddle.libs'] += [
+        os.path.basename('${GNU_RT_LIB_1}')]
+    shutil.copy('${GNU_RT_LIB_1}', libs_path)
 if('${WITH_MAGMA}' == 'ON'):
     package_data['paddle.libs']+=[
         os.path.basename('${MAGMA_LIB}')]

--- a/setup.py
+++ b/setup.py
@@ -1589,12 +1589,15 @@ def get_package_data_and_package_dir():
         os.path.basename(env_dict.get("LAPACK_LIB")),
         os.path.basename(env_dict.get("BLAS_LIB")),
         os.path.basename(env_dict.get("GFORTRAN_LIB")),
-        os.path.basename(env_dict.get("GNU_RT_LIB_1")),
     ]
     shutil.copy(env_dict.get("BLAS_LIB"), libs_path)
     shutil.copy(env_dict.get("LAPACK_LIB"), libs_path)
     shutil.copy(env_dict.get("GFORTRAN_LIB"), libs_path)
-    shutil.copy(env_dict.get("GNU_RT_LIB_1"), libs_path)
+    if env_dict.get("GNU_RT_LIB_1"):
+        package_data['paddle.libs'] += [
+            os.path.basename(env_dict.get("GNU_RT_LIB_1"))
+        ]
+        shutil.copy(env_dict.get("GNU_RT_LIB_1"), libs_path)
     if env_dict.get("WITH_MAGMA") == 'ON':
         package_data['paddle.libs'] += [
             os.path.basename('MAGMA_LIB'),


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

ARM64 上编译单独编译 liblapack 动态库，避免 paddle arm64 wheel 包里 liblapack 及其依赖项均为 x86 的

| dylibs in `paddle/libs` | arch |
| - | - |
| `libblas.so.3` | x86 |
| `libgfortran.so.3` | x86 |
| `libphi_core.so` | arm64 |
| `libphi.so` | arm64 |
| `libwarpctc.so` | arm64 |
| `libcommon.so` | arm64 |
| `liblapack.so.3` | x86 |
| `libphi_gpu.so` | arm64 |
| `libquadmath.so.0` | x86 |
| `libwarprnnt.so` | arm64 |

该问题如下代码即可复现：

```
python -c 'import paddle; x = paddle.to_tensor([[1, -2j], [2j, 5]]).cpu(); out_value = paddle.eigvalsh(x, UPLO="L"); print(out_value)'
```

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.6 sol max)</sup>
</div>

---

Cherry-pick of #79516 (authored by @SigureMo) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79516 <!-- For pass CI -->