### PR TITLE
[Operator Mechanism] Add zero-class check for hard-label cross entropy

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -1230,6 +1230,16 @@ void CrossEntropyWithSoftmaxInferMeta(const MetaTensor& logits,
                                           "the axis dimension of "
                                           "Input(Label) should be 1."));
     }
+    if (config.is_runtime || logits_dims[axis] >= 0) {
+      PADDLE_ENFORCE_GT(
+          logits_dims[axis],
+          0,
+          common::errors::InvalidArgument(
+              "If Attr(soft_label) == false, the axis dimension of "
+              "Input(Logits), which represents the number of classes, "
+              "should be greater than 0, but received %ld.",
+              logits_dims[axis]));
+    }
   }
 
   softmax->set_dims(logits_dims);

--- a/test/legacy_test/test_cross_entropy_loss.py
+++ b/test/legacy_test/test_cross_entropy_loss.py
@@ -2772,6 +2772,21 @@ class TestCrossEntropyFAPIError(unittest.TestCase):
 
             self.assertRaises(ValueError, static_test_WeightLength_NotEqual)
 
+    def test_hard_label_zero_classes(self):
+        paddle.disable_static()
+        input_data = paddle.randn([1, 8192, 0], dtype="float32")
+        label_data = paddle.zeros([1, 8192], dtype="int64")
+        with self.assertRaisesRegex(ValueError, "number of classes"):
+            paddle.nn.functional.cross_entropy(
+                input=input_data,
+                label=label_data,
+                ignore_index=-100,
+                reduction="none",
+                soft_label=False,
+                axis=-1,
+                use_softmax=True,
+            )
+
 
 class CrossEntropyLossCompatible(unittest.TestCase):
     """


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

修复 `paddle.nn.functional.cross_entropy` 在 hard label 模式下处理零类别输入时的异常行为。

当输入 logits 的类别维为 0，例如 shape 为 `[1, 8192, 0]`，且 `soft_label=False` 时，当前实现会进入 `cross_entropy_with_softmax` kernel 的 `softmax->numel() == 0` 早退分支。该分支只分配 `loss` 内存，但不会对 hard label 场景执行 `Full(loss, 0)` 或实际计算，可能导致返回未初始化数据，并在开启 `FLAGS_alloc_fill_value=255` 和 `FLAGS_check_nan_inf=true` 时暴露为 `NaN`。

本次修改在 `CrossEntropyWithSoftmaxInferMeta` 中增加 hard label 场景下的类别维校验，要求 `Input(Logits)` 在 `axis` 维度上的类别数必须大于 0。对于 `num_classes == 0` 的非法输入，将提前抛出 `InvalidArgument`，避免进入 kernel 后产生未定义输出。

同时新增单测，覆盖 `soft_label=False`、`reduction="none"`、`axis=-1` 且类别维为 0 的场景，验证该非法输入会被正确拒绝。


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否