### PR TITLE
[cherry-pick][release/3.4] Fix p_norm_grad kernel precision compatibility for GPU

### DIFF
--- a/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/p_norm_grad_kernel.cu
@@ -16,6 +16,7 @@
 
 #include <vector>
 
+#include "paddle/common/flags.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -34,6 +35,8 @@
 #include "paddle/phi/kernels/sign_kernel.h"
 #include "paddle/phi/kernels/unsqueeze_kernel.h"
 #include "paddle/phi/kernels/where_kernel.h"
+
+COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
 
 namespace phi {
 
@@ -61,9 +64,49 @@ __device__ __forceinline__ MT compute_pow_like_kernel(MT val, double exponent) {
   }
 }
 
+// Round an intermediate value (kept in compute type MT) back to the storage
+// dtype T and return it as MT again. This reproduces the rounding point of a
+// single torch elementwise kernel, whose output tensor is dtype T. For
+// fp32/fp64 (MT == T) this is the identity; only fp16/bf16 are affected.
+template <typename T, typename MT>
+__device__ __forceinline__ MT RoundToStorage(MT v) {
+  return static_cast<MT>(static_cast<T>(v));
+}
+
+// Torch-compatible pow: operates in storage type T (like a standalone torch
+// elementwise kernel whose output tensor is dtype T). The exponent is first
+// narrowed to T then promoted back to MT before calling pow(), matching the
+// truncation behavior of torch's type promotion for scalar exponents.
+template <typename T, typename MT>
+__device__ __forceinline__ T
+compute_pow_like_kernel_torch_compat(T val, double exponent) {
+  MT val_MT = static_cast<MT>(val);
+  if (exponent == 0.5) {
+    return static_cast<T>(sqrt(val_MT));
+  } else if (exponent == -0.5) {
+    return static_cast<T>(rsqrt(val_MT));
+  } else if (exponent == -1.0) {
+    return static_cast<T>(static_cast<MT>(1) / val_MT);
+  } else if (exponent == -2.0) {
+    return static_cast<T>(static_cast<MT>(1) /
+                          RoundToStorage<T, MT>(val_MT * val_MT));
+  } else if (exponent == 0.0) {
+    return static_cast<T>(1);
+  } else if (exponent == 1.0) {
+    return val;
+  } else if (exponent == 2.0) {
+    return static_cast<T>(val_MT * val_MT);
+  } else if (exponent == 3.0) {
+    return static_cast<T>(RoundToStorage<T, MT>(val_MT * val_MT) * val_MT);
+  } else {
+    MT exponent_MT = static_cast<MT>(static_cast<T>(exponent));
+    return static_cast<T>(pow(val_MT, exponent_MT));
+  }
+}
+
 // Fused CUDA kernel for p=2 norm gradient
 // dx = grad * (x / norm).masked_fill_(norm == 0, 0)
-template <typename T>
+template <typename T, bool Compat = false>
 __global__ void PNormGradP2Kernel(const T* x,
                                   const T* norm,
                                   const T* grad,
@@ -90,15 +133,24 @@ __global__ void PNormGradP2Kernel(const T* x,
     } else {
       MT x_val = static_cast<MT>(x[idx]);
       MT grad_val = static_cast<MT>(grad[norm_idx]);
-      MT x_div_norm = x_val / norm_val;
-      dx[idx] = static_cast<T>(x_div_norm * grad_val);
+      if constexpr (Compat) {
+        // Match torch's two separate elementwise kernels (norm_backward p==2:
+        // `grad * (self / norm)`): each op stores back to dtype T, so for
+        // fp16/bf16 there are two rounding points. Round `self / norm` to T
+        // before the multiply to stay bitwise-aligned with torch.
+        MT x_div_norm = RoundToStorage<T>(x_val / norm_val);
+        dx[idx] = static_cast<T>(grad_val * x_div_norm);
+      } else {
+        MT x_div_norm = x_val / norm_val;
+        dx[idx] = static_cast<T>(x_div_norm * grad_val);
+      }
     }
   }
 }
 
 // Fused CUDA kernel for p < 1 norm gradient
 // dx = sign(x) * |x|^(p-1) * grad * norm^(1-p), masked_fill(x == 0, 0)
-template <typename T>
+template <typename T, bool Compat = false>
 __global__ void PNormGradPLessThan1Kernel(const T* x,
                                           const T* norm,
                                           const T* grad,
@@ -136,18 +188,29 @@ __global__ void PNormGradPLessThan1Kernel(const T* x,
       // abs(x)
       MT abs_x = (x_val > static_cast<MT>(0)) ? x_val : -x_val;
 
-      // |x|^(p-1)
-      MT abs_pow = compute_pow_like_kernel(abs_x, p_minus_1);
-
       // sign(x): 1 if x > 0, -1 if x < 0 (x != 0 already checked)
       MT sign_x = (x_val > static_cast<MT>(0)) ? static_cast<MT>(1)
                                                : static_cast<MT>(-1);
 
-      MT self_scaled = sign_x * abs_pow;
-      MT temp1 = self_scaled * grad_val;
-
+      // |x|^(p-1)
+      MT abs_pow;
+      MT self_scaled;
+      MT temp1;
       // norm^(1-p)
-      MT norm_pow = compute_pow_like_kernel(norm_val, one_minus_p);
+      MT norm_pow;
+      if constexpr (Compat) {
+        abs_pow = static_cast<MT>(compute_pow_like_kernel_torch_compat<T, MT>(
+            static_cast<T>(abs_x), p_minus_1));
+        self_scaled = RoundToStorage<T>(sign_x * abs_pow);
+        temp1 = RoundToStorage<T>(self_scaled * grad_val);
+        norm_pow = static_cast<MT>(compute_pow_like_kernel_torch_compat<T, MT>(
+            static_cast<T>(norm_val), one_minus_p));
+      } else {
+        abs_pow = compute_pow_like_kernel(abs_x, p_minus_1);
+        self_scaled = sign_x * abs_pow;
+        temp1 = self_scaled * grad_val;
+        norm_pow = compute_pow_like_kernel(norm_val, one_minus_p);
+      }
 
       dx[idx] = static_cast<T>(temp1 * norm_pow);
     }
@@ -197,7 +260,7 @@ __global__ void PNormGradP1Kernel(const T* x,
 
 // Fused CUDA kernel for 1 < p < 2 norm gradient
 // dx = sign(x) * |x|^(p-1) * grad / norm^(p-1), masked_fill(norm==0, 0)
-template <typename T>
+template <typename T, bool Compat = false>
 __global__ void PNormGradPBetween1And2Kernel(const T* x,
                                              const T* norm,
                                              const T* grad,
@@ -234,9 +297,6 @@ __global__ void PNormGradPBetween1And2Kernel(const T* x,
       // abs(x)
       MT abs_x = (x_val > static_cast<MT>(0)) ? x_val : -x_val;
 
-      // |x|^(p-1)
-      MT abs_pow = compute_pow_like_kernel(abs_x, p_minus_1);
-
       // sign(x)
       MT sign_x;
       if (x_val > static_cast<MT>(0)) {
@@ -247,13 +307,27 @@ __global__ void PNormGradPBetween1And2Kernel(const T* x,
         sign_x = static_cast<MT>(0);
       }
 
-      MT self_scaled = sign_x * abs_pow;
-
+      // |x|^(p-1)
+      MT abs_pow;
+      MT self_scaled;
       // norm^(p-1)
-      MT norm_pow = compute_pow_like_kernel(norm_val, p_minus_1);
-
+      MT norm_pow;
       // scale_v = grad / norm_pow
-      MT scale_v = grad_val / norm_pow;
+      MT scale_v;
+
+      if constexpr (Compat) {
+        abs_pow = static_cast<MT>(compute_pow_like_kernel_torch_compat<T, MT>(
+            static_cast<T>(abs_x), p_minus_1));
+        self_scaled = RoundToStorage<T>(sign_x * abs_pow);
+        norm_pow = static_cast<MT>(compute_pow_like_kernel_torch_compat<T, MT>(
+            static_cast<T>(norm_val), p_minus_1));
+        scale_v = RoundToStorage<T>(grad_val / norm_pow);
+      } else {
+        abs_pow = compute_pow_like_kernel(abs_x, p_minus_1);
+        self_scaled = sign_x * abs_pow;
+        norm_pow = compute_pow_like_kernel(norm_val, p_minus_1);
+        scale_v = grad_val / norm_pow;
+      }
 
       dx[idx] = static_cast<T>(self_scaled * scale_v);
     }
@@ -262,7 +336,7 @@ __global__ void PNormGradPBetween1And2Kernel(const T* x,
 
 // Fused CUDA kernel for p > 2 norm gradient
 // dx = x * |x|^(p-2) * grad / norm^(p-1), masked_fill(norm==0, 0)
-template <typename T>
+template <typename T, bool Compat = false>
 __global__ void PNormGradPGreaterThan2Kernel(const T* x,
                                              const T* norm,
                                              const T* grad,
@@ -301,16 +375,26 @@ __global__ void PNormGradPGreaterThan2Kernel(const T* x,
       MT abs_x = (x_val > static_cast<MT>(0)) ? x_val : -x_val;
 
       // |x|^(p-2)
-      MT abs_pow = compute_pow_like_kernel(abs_x, p_minus_2);
-
+      MT abs_pow;
       // self_scaled = x * |x|^(p-2)
-      MT self_scaled = x_val * abs_pow;
-
+      MT self_scaled;
       // norm^(p-1)
-      MT norm_pow = compute_pow_like_kernel(norm_val, p_minus_1);
-
+      MT norm_pow;
       // scale_v = grad / norm_pow
-      MT scale_v = grad_val / norm_pow;
+      MT scale_v;
+      if constexpr (Compat) {
+        abs_pow = static_cast<MT>(compute_pow_like_kernel_torch_compat<T, MT>(
+            static_cast<T>(abs_x), p_minus_2));
+        self_scaled = RoundToStorage<T>(x_val * abs_pow);
+        norm_pow = static_cast<MT>(compute_pow_like_kernel_torch_compat<T, MT>(
+            static_cast<T>(norm_val), p_minus_1));
+        scale_v = RoundToStorage<T>(grad_val / norm_pow);
+      } else {
+        abs_pow = compute_pow_like_kernel(abs_x, p_minus_2);
+        self_scaled = x_val * abs_pow;
+        norm_pow = compute_pow_like_kernel(norm_val, p_minus_1);
+        scale_v = grad_val / norm_pow;
+      }
 
       dx[idx] = static_cast<T>(self_scaled * scale_v);
     }
@@ -465,28 +549,8 @@ void PNormGradKernel(const Context& dev_ctx,
     int64_t total = in_x->numel();
     auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, total);
 
-    PNormGradP2Kernel<T><<<config.block_per_grid,
-                           config.thread_per_block,
-                           0,
-                           dev_ctx.stream()>>>(in_x->data<T>(),
-                                               in_norm->data<T>(),
-                                               in_norm_dy->data<T>(),
-                                               out_dx->data<T>(),
-                                               pre,
-                                               axis_size,
-                                               post,
-                                               total,
-                                               reduce_all);
-  } else if (porder < 1.0) {
-    // Fused kernel: dx = sign(x) * |x|^(p-1) * grad * norm^(1-p)
-    // masked_fill(x == 0, 0)
-    int64_t pre, axis_size, post;
-    GetPreAxisPost(xdim, axis, reduce_all, &pre, &axis_size, &post);
-
-    int64_t total = in_x->numel();
-    auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, total);
-
-    PNormGradPLessThan1Kernel<T><<<config.block_per_grid,
+    if (FLAGS_use_accuracy_compatible_kernel) {
+      PNormGradP2Kernel<T, true><<<config.block_per_grid,
                                    config.thread_per_block,
                                    0,
                                    dev_ctx.stream()>>>(in_x->data<T>(),
@@ -497,8 +561,61 @@ void PNormGradKernel(const Context& dev_ctx,
                                                        axis_size,
                                                        post,
                                                        total,
-                                                       reduce_all,
-                                                       porder);
+                                                       reduce_all);
+    } else {
+      PNormGradP2Kernel<T, false><<<config.block_per_grid,
+                                    config.thread_per_block,
+                                    0,
+                                    dev_ctx.stream()>>>(in_x->data<T>(),
+                                                        in_norm->data<T>(),
+                                                        in_norm_dy->data<T>(),
+                                                        out_dx->data<T>(),
+                                                        pre,
+                                                        axis_size,
+                                                        post,
+                                                        total,
+                                                        reduce_all);
+    }
+  } else if (porder < 1.0) {
+    // Fused kernel: dx = sign(x) * |x|^(p-1) * grad * norm^(1-p)
+    // masked_fill(x == 0, 0)
+    int64_t pre, axis_size, post;
+    GetPreAxisPost(xdim, axis, reduce_all, &pre, &axis_size, &post);
+
+    int64_t total = in_x->numel();
+    auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, total);
+
+    if (FLAGS_use_accuracy_compatible_kernel) {
+      PNormGradPLessThan1Kernel<T, true>
+          <<<config.block_per_grid,
+             config.thread_per_block,
+             0,
+             dev_ctx.stream()>>>(in_x->data<T>(),
+                                 in_norm->data<T>(),
+                                 in_norm_dy->data<T>(),
+                                 out_dx->data<T>(),
+                                 pre,
+                                 axis_size,
+                                 post,
+                                 total,
+                                 reduce_all,
+                                 porder);
+    } else {
+      PNormGradPLessThan1Kernel<T, false>
+          <<<config.block_per_grid,
+             config.thread_per_block,
+             0,
+             dev_ctx.stream()>>>(in_x->data<T>(),
+                                 in_norm->data<T>(),
+                                 in_norm_dy->data<T>(),
+                                 out_dx->data<T>(),
+                                 pre,
+                                 axis_size,
+                                 post,
+                                 total,
+                                 reduce_all,
+                                 porder);
+    }
   } else if (porder < 2.0) {
     // Fused kernel: dx = sign(x) * |x|^(p-1) * grad / norm^(p-1),
     // masked_fill(norm==0, 0)
@@ -508,19 +625,37 @@ void PNormGradKernel(const Context& dev_ctx,
     int64_t total = in_x->numel();
     auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, total);
 
-    PNormGradPBetween1And2Kernel<T><<<config.block_per_grid,
-                                      config.thread_per_block,
-                                      0,
-                                      dev_ctx.stream()>>>(in_x->data<T>(),
-                                                          in_norm->data<T>(),
-                                                          in_norm_dy->data<T>(),
-                                                          out_dx->data<T>(),
-                                                          pre,
-                                                          axis_size,
-                                                          post,
-                                                          total,
-                                                          reduce_all,
-                                                          porder);
+    if (FLAGS_use_accuracy_compatible_kernel) {
+      PNormGradPBetween1And2Kernel<T, true>
+          <<<config.block_per_grid,
+             config.thread_per_block,
+             0,
+             dev_ctx.stream()>>>(in_x->data<T>(),
+                                 in_norm->data<T>(),
+                                 in_norm_dy->data<T>(),
+                                 out_dx->data<T>(),
+                                 pre,
+                                 axis_size,
+                                 post,
+                                 total,
+                                 reduce_all,
+                                 porder);
+    } else {
+      PNormGradPBetween1And2Kernel<T, false>
+          <<<config.block_per_grid,
+             config.thread_per_block,
+             0,
+             dev_ctx.stream()>>>(in_x->data<T>(),
+                                 in_norm->data<T>(),
+                                 in_norm_dy->data<T>(),
+                                 out_dx->data<T>(),
+                                 pre,
+                                 axis_size,
+                                 post,
+                                 total,
+                                 reduce_all,
+                                 porder);
+    }
   } else {
     // Fused kernel: dx = x * |x|^(p-2) * grad / norm^(p-1),
     // masked_fill(norm==0, 0)
@@ -530,19 +665,37 @@ void PNormGradKernel(const Context& dev_ctx,
     int64_t total = in_x->numel();
     auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, total);
 
-    PNormGradPGreaterThan2Kernel<T><<<config.block_per_grid,
-                                      config.thread_per_block,
-                                      0,
-                                      dev_ctx.stream()>>>(in_x->data<T>(),
-                                                          in_norm->data<T>(),
-                                                          in_norm_dy->data<T>(),
-                                                          out_dx->data<T>(),
-                                                          pre,
-                                                          axis_size,
-                                                          post,
-                                                          total,
-                                                          reduce_all,
-                                                          porder);
+    if (FLAGS_use_accuracy_compatible_kernel) {
+      PNormGradPGreaterThan2Kernel<T, true>
+          <<<config.block_per_grid,
+             config.thread_per_block,
+             0,
+             dev_ctx.stream()>>>(in_x->data<T>(),
+                                 in_norm->data<T>(),
+                                 in_norm_dy->data<T>(),
+                                 out_dx->data<T>(),
+                                 pre,
+                                 axis_size,
+                                 post,
+                                 total,
+                                 reduce_all,
+                                 porder);
+    } else {
+      PNormGradPGreaterThan2Kernel<T, false>
+          <<<config.block_per_grid,
+             config.thread_per_block,
+             0,
+             dev_ctx.stream()>>>(in_x->data<T>(),
+                                 in_norm->data<T>(),
+                                 in_norm_dy->data<T>(),
+                                 out_dx->data<T>(),
+                                 pre,
+                                 axis_size,
+                                 post,
+                                 total,
+                                 reduce_all,
+                                 porder);
+    }
   }
 }
 }  // namespace phi

--- a/test/legacy_test/test_norm_all.py
+++ b/test/legacy_test/test_norm_all.py
@@ -1838,6 +1838,286 @@ class API_PnormGradTest_ZeroSize(unittest.TestCase):
                 self._run_pnorm_backward(shape, axis, p)
 
 
+class TestPnormGradCompatKernel(unittest.TestCase):
+    """Test the Compat=true path (FLAGS_use_accuracy_compatible_kernel=1).
+
+    Verifies that the fused GPU kernel reproduces torch-compatible intermediate
+    rounding behavior for fp16/bf16. The reference is computed by simulating
+    torch's multi-kernel decomposition: each intermediate result is rounded
+    back to storage dtype before the next operation.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+        paddle.set_flags({'FLAGS_use_accuracy_compatible_kernel': True})
+
+    def tearDown(self):
+        paddle.set_flags({'FLAGS_use_accuracy_compatible_kernel': False})
+
+    @staticmethod
+    def _round_to_storage(val, dtype):
+        """Simulate RoundToStorage: round float32 intermediate to dtype and back."""
+        if dtype == "bfloat16":
+            # Use round-to-nearest-even (RNE) matching CUDA __float2bfloat16.
+            # NOTE: convert_float_to_uint16 uses truncation which does NOT
+            # match the kernel's rounding behavior.
+            arr = np.asarray(val, dtype=np.float32)
+            bits = arr.view(np.uint32)
+            rounding_bias = np.uint32(0x7FFF) + (
+                (bits >> np.uint32(16)) & np.uint32(1)
+            )
+            rounded_bits = bits + rounding_bias
+            bf16_uint16 = (rounded_bits >> np.uint32(16)).astype(np.uint16)
+            result_bits = bf16_uint16.astype(np.uint32) << np.uint32(16)
+            result = result_bits.view(np.float32).copy()
+            result[np.isnan(arr)] = np.float32(np.nan)
+            result[np.isinf(arr)] = arr[np.isinf(arr)]
+            result[arr == 0] = arr[arr == 0]
+            return result
+        return val.astype(dtype).astype("float32")
+
+    def _pow_like_torch(self, val_f32, exponent, dtype):
+        """Simulate torch's pow kernel for half/bf16: compute in float32,
+        truncate result to storage dtype."""
+        if exponent == 2.0:
+            result = val_f32 * val_f32
+        elif exponent == 3.0:
+            tmp = self._round_to_storage(val_f32 * val_f32, dtype)
+            result = tmp * val_f32
+        elif exponent == -1.0:
+            result = np.float32(1.0) / val_f32
+        elif exponent == -2.0:
+            sq = self._round_to_storage(val_f32 * val_f32, dtype)
+            result = np.float32(1.0) / sq
+        else:
+            result = np.power(val_f32, np.float32(exponent))
+        return self._round_to_storage(result, dtype)
+
+    def _reference_p2_grad(self, x_np, norm_np, grad_np, dtype):
+        """Reference for p=2: grad * (x / norm), masked where norm==0."""
+        x_f = x_np.astype("float32")
+        norm_f = norm_np.astype("float32")
+        grad_f = grad_np.astype("float32")
+        x_div_norm = self._round_to_storage(x_f / norm_f, dtype)
+        dx = self._round_to_storage(grad_f * x_div_norm, dtype)
+        # Broadcast norm_f == 0 mask to match dx shape
+        mask = np.broadcast_to(norm_f == 0, dx.shape)
+        dx[mask] = 0
+        return dx
+
+    def _reference_pgt2_grad(self, x_np, norm_np, grad_np, porder, dtype):
+        """Reference for p>2: x * |x|^(p-2) * grad / norm^(p-1), masked."""
+        x_f = x_np.astype("float32")
+        norm_f = norm_np.astype("float32")
+        grad_f = grad_np.astype("float32")
+        abs_x = np.abs(x_f)
+
+        abs_pow = self._pow_like_torch(abs_x, porder - 2, dtype)
+        self_scaled = self._round_to_storage(x_f * abs_pow, dtype)
+        norm_pow = self._pow_like_torch(norm_f, porder - 1, dtype)
+        scale_v = self._round_to_storage(grad_f / norm_pow, dtype)
+        dx = self._round_to_storage(self_scaled * scale_v, dtype)
+        mask = np.broadcast_to(norm_f == 0, dx.shape)
+        dx[mask] = 0
+        return dx
+
+    def _reference_p_between_1_and_2_grad(
+        self, x_np, norm_np, grad_np, porder, dtype
+    ):
+        """Reference for 1<p<2: sign(x)*|x|^(p-1) * grad / norm^(p-1)."""
+        x_f = x_np.astype("float32")
+        norm_f = norm_np.astype("float32")
+        grad_f = grad_np.astype("float32")
+        abs_x = np.abs(x_f)
+        sign_x = np.sign(x_f)
+
+        abs_pow = self._pow_like_torch(abs_x, porder - 1, dtype)
+        self_scaled = self._round_to_storage(sign_x * abs_pow, dtype)
+        norm_pow = self._pow_like_torch(norm_f, porder - 1, dtype)
+        scale_v = self._round_to_storage(grad_f / norm_pow, dtype)
+        dx = self._round_to_storage(self_scaled * scale_v, dtype)
+        mask = np.broadcast_to(norm_f == 0, dx.shape)
+        dx[mask] = 0
+        return dx
+
+    def _reference_p_less_than_1_grad(
+        self, x_np, norm_np, grad_np, porder, dtype
+    ):
+        """Reference for p<1: sign(x)*|x|^(p-1) * grad * norm^(1-p), masked x==0."""
+        x_f = x_np.astype("float32")
+        norm_f = norm_np.astype("float32")
+        grad_f = grad_np.astype("float32")
+        abs_x = np.abs(x_f)
+        sign_x = np.sign(x_f)
+
+        abs_pow = self._pow_like_torch(abs_x, porder - 1, dtype)
+        self_scaled = self._round_to_storage(sign_x * abs_pow, dtype)
+        temp1 = self._round_to_storage(self_scaled * grad_f, dtype)
+        norm_pow = self._pow_like_torch(norm_f, 1.0 - porder, dtype)
+        dx = self._round_to_storage(temp1 * norm_pow, dtype)
+        # mask: x == 0 → dx = 0
+        mask = np.broadcast_to(x_f == 0, dx.shape)
+        dx[mask] = 0
+        return dx
+
+    def _run_compat_test(self, shape, porder, axis, dtype_str):
+        """Run paddle backward and compare against reference with rounding."""
+        np.random.seed(2024)
+        x_f32 = ((np.random.random(shape) - 0.5) * 1.2).astype("float32")
+        # Round to storage dtype for numpy reference
+        x_np = self._round_to_storage(x_f32, dtype_str)
+
+        # Create paddle tensor
+        if dtype_str == "bfloat16":
+            x = paddle.to_tensor(x_np, place=paddle.CUDAPlace(0)).cast(
+                "bfloat16"
+            )
+        else:
+            x_np_stored = x_np.astype(dtype_str)
+            x = paddle.to_tensor(x_np_stored, place=paddle.CUDAPlace(0))
+        x.stop_gradient = False
+        out = paddle.linalg.vector_norm(x=x, p=porder, axis=axis, keepdim=True)
+
+        np.random.seed(100)
+        grad_f32 = ((np.random.random(out.shape) - 0.5) * 0.8).astype("float32")
+        grad_np = self._round_to_storage(grad_f32, dtype_str)
+        if dtype_str == "bfloat16":
+            grad_tensor = paddle.to_tensor(
+                grad_np, place=paddle.CUDAPlace(0)
+            ).cast("bfloat16")
+        else:
+            grad_np_stored = grad_np.astype(dtype_str)
+            grad_tensor = paddle.to_tensor(
+                grad_np_stored, place=paddle.CUDAPlace(0)
+            )
+
+        paddle_grad = paddle.grad(
+            outputs=[out], inputs=[x], grad_outputs=[grad_tensor]
+        )
+        if dtype_str == "bfloat16":
+            paddle_dx = paddle_grad[0].cast("float32").numpy()
+            norm_np = out.cast("float32").numpy()
+        else:
+            paddle_dx = paddle_grad[0].numpy().astype("float32")
+            norm_np = out.numpy().astype("float32")
+
+        # Round paddle results to storage precision for comparison
+        paddle_dx = self._round_to_storage(paddle_dx, dtype_str)
+        norm_np = self._round_to_storage(norm_np, dtype_str)
+
+        # Build reference
+        if porder == 2.0:
+            ref_dx = self._reference_p2_grad(x_np, norm_np, grad_np, dtype_str)
+        elif porder > 2.0:
+            ref_dx = self._reference_pgt2_grad(
+                x_np, norm_np, grad_np, porder, dtype_str
+            )
+        elif 1.0 < porder < 2.0:
+            ref_dx = self._reference_p_between_1_and_2_grad(
+                x_np, norm_np, grad_np, porder, dtype_str
+            )
+        elif 0 < porder < 1.0:
+            ref_dx = self._reference_p_less_than_1_grad(
+                x_np, norm_np, grad_np, porder, dtype_str
+            )
+        else:
+            return  # skip unsupported ranges in this helper
+
+        np.testing.assert_array_equal(
+            paddle_dx,
+            ref_dx,
+            err_msg=f"Compat mismatch: p={porder}, dtype={dtype_str}, "
+            f"shape={shape}, axis={axis}",
+        )
+
+    @unittest.skipIf(not core.is_compiled_with_cuda(), "CUDA not available")
+    def test_p2_fp16_compat(self):
+        self._run_compat_test((4, 8, 16), 2.0, -1, "float16")
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda()
+        or not core.is_bfloat16_supported(core.CUDAPlace(0))
+        or core.is_compiled_with_rocm(),
+        "CUDA bf16 not available or running on ROCm/DCU",
+    )
+    def test_p2_bf16_compat(self):
+        self._run_compat_test((4, 8, 16), 2.0, -1, "bfloat16")
+
+    @unittest.skipIf(not core.is_compiled_with_cuda(), "CUDA not available")
+    def test_p4_fp16_compat(self):
+        self._run_compat_test((4, 5, 32), 4.0, -1, "float16")
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda()
+        or not core.is_bfloat16_supported(core.CUDAPlace(0))
+        or core.is_compiled_with_rocm(),
+        "CUDA bf16 not available or running on ROCm/DCU",
+    )
+    def test_p4_bf16_compat(self):
+        self._run_compat_test((4, 5, 32), 4.0, -1, "bfloat16")
+
+    @unittest.skipIf(not core.is_compiled_with_cuda(), "CUDA not available")
+    def test_p3_fp16_compat(self):
+        self._run_compat_test((3, 6, 16), 3.0, -1, "float16")
+
+    @unittest.skipIf(not core.is_compiled_with_cuda(), "CUDA not available")
+    def test_p1_5_fp16_compat(self):
+        self._run_compat_test((4, 8, 16), 1.5, -1, "float16")
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda()
+        or not core.is_bfloat16_supported(core.CUDAPlace(0))
+        or core.is_compiled_with_rocm(),
+        "CUDA bf16 not available or running on ROCm/DCU",
+    )
+    def test_p1_5_bf16_compat(self):
+        self._run_compat_test((4, 8, 16), 1.5, -1, "bfloat16")
+
+    @unittest.skipIf(not core.is_compiled_with_cuda(), "CUDA not available")
+    def test_p0_5_fp16_compat(self):
+        self._run_compat_test((4, 8, 16), 0.5, -1, "float16")
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda()
+        or not core.is_bfloat16_supported(core.CUDAPlace(0))
+        or core.is_compiled_with_rocm(),
+        "CUDA bf16 not available or running on ROCm/DCU",
+    )
+    def test_p0_5_bf16_compat(self):
+        self._run_compat_test((4, 8, 16), 0.5, -1, "bfloat16")
+
+    @unittest.skipIf(not core.is_compiled_with_cuda(), "CUDA not available")
+    def test_p2_fp16_axis0_compat(self):
+        self._run_compat_test((8, 4, 16), 2.0, 0, "float16")
+
+    @unittest.skipIf(not core.is_compiled_with_cuda(), "CUDA not available")
+    def test_p4_fp16_reduce_all_compat(self):
+        """reduce_all path with Compat."""
+        np.random.seed(2024)
+        dtype_str = "float16"
+        shape = (4, 5, 6)
+        x_np = ((np.random.random(shape) - 0.5) * 1.2).astype(dtype_str)
+
+        x = paddle.to_tensor(x_np, place=paddle.CUDAPlace(0))
+        x.stop_gradient = False
+        out = paddle.linalg.vector_norm(x=x, p=4.0, keepdim=True)
+
+        np.random.seed(100)
+        grad_np = ((np.random.random(out.shape) - 0.5) * 0.8).astype(dtype_str)
+        grad_tensor = paddle.to_tensor(grad_np, place=paddle.CUDAPlace(0))
+
+        paddle_grad = paddle.grad(
+            outputs=[out], inputs=[x], grad_outputs=[grad_tensor]
+        )
+        paddle_dx = paddle_grad[0].numpy()
+
+        norm_np = out.numpy()
+        ref_dx = self._reference_pgt2_grad(
+            x_np, norm_np, grad_np, 4.0, dtype_str
+        )
+        np.testing.assert_array_equal(paddle_dx, ref_dx)
+
+
 class API_NormTest_Alias(unittest.TestCase):
     def setUp(self):
         paddle.disable_static()


### PR DESCRIPTION

### PR Category
Operator Mechanism

### PR Types
Others


### Description
devPR:https://github.com/PaddlePaddle/Paddle/pull/79481

### 是否引起精度变化
是
（仅 `FLAGS_use_accuracy_compatible_kernel=1` 的 fp16/bf16 反向兼容路径；默认路径不变）