### PR TITLE
[Operator Mechanism] Clean up BLAS APIs and improve int64 safety

### DIFF
--- a/paddle/phi/kernels/cpu/attention_lstm_kernel.cc
+++ b/paddle/phi/kernels/cpu/attention_lstm_kernel.cc
@@ -201,7 +201,9 @@ void AttentionLSTMKernel(const Context& dev_ctx,
                   D4);
       }
       // since input is 1xM, so can use add bias
-      blas.VADD(D4, lstm_b_data, lstm_out_data, lstm_out_data);
+      for (int j = 0; j < D4; ++j) {
+        lstm_out_data[j] += lstm_b_data[j];
+      }
 
       // gate act: sigmoid
       act_gate(D3, lstm_out_data, lstm_out_data);
@@ -227,7 +229,9 @@ void AttentionLSTMKernel(const Context& dev_ctx,
       input_tilde = input_gate.array() * tilde.array();
 
       // cell_out = a + b
-      blas.VADD(D, lstm_out_data, lstm_out_data + D, cur_cell_out_data);
+      for (int j = 0; j < D; ++j) {
+        cur_cell_out_data[j] = lstm_out_data[j] + lstm_out_data[D + j];
+      }
 
       // state act tanh(cell_out) * output_gate
       act_cell(D, cur_cell_out_data, lstm_out_data);

--- a/paddle/phi/kernels/cpu/dot_kernel.cc
+++ b/paddle/phi/kernels/cpu/dot_kernel.cc
@@ -18,6 +18,7 @@
 #include "paddle/phi/core/kernel_registry.h"
 
 #include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/funcs/blas/blas.h"
 
 namespace phi {
 
@@ -34,8 +35,8 @@ void DotKernel(const Context& dev_ctx,
   if (out->numel() <= 0) {
     return;
   }
-  auto const *x_ptr = x.data<T>(), *x_ptr_ = &x_ptr[0];
-  auto const *y_ptr = y.data<T>(), *y_ptr_ = &y_ptr[0];
+  const T* x_ptr = x.data<T>();
+  const T* y_ptr = y.data<T>();
   T* z = dev_ctx.template Alloc<T>(out);
 
   // Loop over the total N elements of both operands while sum-reducing every
@@ -50,10 +51,10 @@ void DotKernel(const Context& dev_ctx,
   // initialize for N / B <= 0
   z[0] = 0;
 
-  for (int j = 0; j < N / B; j++) {
-    T ss = 0;
-    for (int i = 0; i < B; i++) ss += (*x_ptr_++) * (*y_ptr_++);
-    z[j] = ss;
+  auto blas = funcs::GetBlas<CPUContext, T>(dev_ctx);
+  for (int64_t j = 0; j < N / B; ++j) {
+    const int64_t offset = j * B;
+    z[j] = blas.DOT(B, x_ptr + offset, y_ptr + offset);
   }
 }
 

--- a/paddle/phi/kernels/cpu/gelu_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/gelu_grad_kernel.cc
@@ -92,7 +92,9 @@ struct GeluGradFunctor {
       second_map *= static_cast<T>(0.5 * M_2_SQRTPI * M_SQRT1_2);
 
       // dx = dout * (first + second);
-      funcs::CBlas<T>::VADD(n, first, second, first);
+      for (int i = 0; i < n; ++i) {
+        first[i] += second[i];
+      }
       Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>> dx_map(dx_data, n);
       Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>> dout_map(dout_data,
                                                                      n);

--- a/paddle/phi/kernels/cpu/index_select_impl.h
+++ b/paddle/phi/kernels/cpu/index_select_impl.h
@@ -18,7 +18,6 @@
 
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/tensor_utils.h"
-#include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 
@@ -42,13 +41,14 @@ struct IndexSelectAdd<
     Context,
     T,
     typename std::enable_if<std::is_floating_point<T>::value>::type> {
-  void operator()(const Context& dev_ctx,
+  void operator()(const Context& dev_ctx UNUSED,
                   int slice_size,
                   const T* src_pointer,
                   const T* p_pointer,
                   T* dist_pointer) {
-    auto blas = funcs::GetBlas<Context, T>(dev_ctx);
-    blas.VADD(slice_size, src_pointer, p_pointer, dist_pointer);
+    for (int i = 0; i < slice_size; ++i) {
+      dist_pointer[i] = src_pointer[i] + p_pointer[i];
+    }
   }
 };
 

--- a/paddle/phi/kernels/cpu/triangular_solve_kernel.cc
+++ b/paddle/phi/kernels/cpu/triangular_solve_kernel.cc
@@ -56,15 +56,15 @@ void TriangularSolveKernel(const Context& dev_ctx,
   ExpandKernel<T, Context>(dev_ctx, y, y_bst_dims, out);
 
   // Calculate use blas library
-  int M = static_cast<int>(y_bst_dims_vec[y_bst_ndim - 2]);
-  int N = static_cast<int>(y_bst_dims_vec[y_bst_ndim - 1]);
-  int batch_size = 1;
+  const int64_t M = y_bst_dims_vec[y_bst_ndim - 2];
+  const int64_t N = y_bst_dims_vec[y_bst_ndim - 1];
+  int64_t batch_size = 1;
   for (int i = 0; i < x_bst_ndim - 2; i++) {
-    batch_size *= static_cast<int>(x_bst_dims_vec[i]);
+    batch_size *= x_bst_dims_vec[i];
   }
 
   auto blas = funcs::GetBlas<CPUContext, T>(dev_ctx);
-  for (int i = 0; i < batch_size; i++) {
+  for (int64_t i = 0; i < batch_size; i++) {
     blas.TRSM(CblasLeft,
               upper ? CblasUpper : CblasLower,
               transpose ? CblasTrans : CblasNoTrans,
@@ -73,9 +73,9 @@ void TriangularSolveKernel(const Context& dev_ctx,
               N,
               T(1),
               x_bst_data + i * M * M,
-              std::max(1, M),
+              std::max<int64_t>(1, M),
               out_data + i * N * M,
-              std::max(1, N));
+              std::max<int64_t>(1, N));
   }
 }
 

--- a/paddle/phi/kernels/funcs/blas/blas.h
+++ b/paddle/phi/kernels/funcs/blas/blas.h
@@ -256,10 +256,7 @@ class Blas {
   }
 
   template <typename T>
-  void AXPY(int n, T alpha, const T* x, T* y) const;
-
-  template <typename T>
-  void VADD(int n, const T* x, const T* y, T* z) const;
+  void AXPY(int64_t n, T alpha, const T* x, T* y) const;
 
   template <typename T>
   void GEMV(bool trans_a,
@@ -272,11 +269,20 @@ class Blas {
             T* C) const;
 
   template <typename T>
-  T DOT(int n, const T* x, const T* y) const;
+  T DOT(int64_t n, const T* x, int64_t incx, const T* y, int64_t incy) const;
 
   template <typename T>
-  void CUDOT(
-      int n, const T* x, int incx, const T* y, int incy, T* result) const;
+  T DOT(int64_t n, const T* x, const T* y) const {
+    return this->template DOT<T>(n, x, 1, y, 1);
+  }
+
+  template <typename T>
+  void CUDOT(int64_t n,
+             const T* x,
+             int64_t incx,
+             const T* y,
+             int64_t incy,
+             T* result) const;
 
   template <typename T>
   void BatchedGEMM(CBLAS_TRANSPOSE transA,
@@ -386,42 +392,43 @@ class Blas {
             CBLAS_UPLO uplo,
             CBLAS_TRANSPOSE transA,
             CBLAS_DIAG diag,
-            int M,
-            int N,
+            int64_t M,
+            int64_t N,
             T alpha,
             const T* A,
-            int lda,
+            int64_t lda,
             T* B,
-            int ldb) const;
+            int64_t ldb) const;
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   template <typename T>
-  void BatchedGETRF(int n, T** a, int* ipiv, int* info, int batch_size) const;
+  void BatchedGETRF(
+      int64_t n, T** a, int* ipiv, int* info, int64_t batch_size) const;
 
   template <typename T>
-  void BatchedGETRI(int n,
+  void BatchedGETRI(int64_t n,
                     const T** a,
                     const int* ipiv,
                     T** a_inv,
                     int* info,
-                    int batch_size) const;
+                    int64_t batch_size) const;
 
   template <typename T>
   void BatchedMatInv(
-      int n, const T** a, T** a_inv, int* info, int batch_size) const;
+      int64_t n, const T** a, T** a_inv, int* info, int64_t batch_size) const;
 
   // cuBlas solve
   template <typename T>
   void BatchedGETRS(CBLAS_TRANSPOSE trans,
-                    int n,
-                    int nrhs,
+                    int64_t n,
+                    int64_t nrhs,
                     const T** a,
-                    int lda,
+                    int64_t lda,
                     int* ipiv,
                     T** b,
-                    int ldb,
+                    int64_t ldb,
                     int* info,
-                    int batch_size) const;
+                    int64_t batch_size) const;
 
   // cuBlas triangular_solve
   template <typename T>
@@ -429,14 +436,14 @@ class Blas {
                    CBLAS_UPLO uplo,
                    CBLAS_TRANSPOSE transA,
                    CBLAS_DIAG diag,
-                   int M,
-                   int N,
+                   int64_t M,
+                   int64_t N,
                    T alpha,
                    const T** a,
-                   int lda,
+                   int64_t lda,
                    T** b,
-                   int ldb,
-                   int batch_size) const;
+                   int64_t ldb,
+                   int64_t batch_size) const;
 #endif
 
  private:
@@ -498,11 +505,6 @@ class BlasT : private Blas<DeviceContext> {
   template <typename... ARGS>
   void AXPY(ARGS... args) const {
     Base()->template AXPY<T>(args...);
-  }
-
-  template <typename... ARGS>
-  void VADD(ARGS... args) const {
-    Base()->template VADD<T>(args...);
   }
 
   template <typename... ARGS>

--- a/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
@@ -2422,38 +2422,65 @@ inline void Blas<phi::GPUContext>::GEMM(bool transA,
 
 template <>
 template <typename T>
-void Blas<phi::GPUContext>::AXPY(int n, T alpha, const T *x, T *y) const {
+void Blas<phi::GPUContext>::AXPY(int64_t n, T alpha, const T *x, T *y) const {
+  if (n <= 0) {
+    return;
+  }
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
-    CUBlas<T>::AXPY(handle, n, &alpha, x, 1, y, 1);
+    int64_t offset = 0;
+    while (offset < n) {
+      const int chunk_size = static_cast<int>(
+          n - offset > INT_MAX_VALUE ? INT_MAX_VALUE : n - offset);
+      CUBlas<T>::AXPY(handle, chunk_size, &alpha, x + offset, 1, y + offset, 1);
+      offset += chunk_size;
+    }
   });
 }
 
 template <>
 template <typename T>
-void Blas<phi::GPUContext>::CUDOT(
-    int n, const T *x, int incx, const T *y, int incy, T *result) const {
+void Blas<phi::GPUContext>::CUDOT(int64_t n,
+                                  const T *x,
+                                  int64_t incx,
+                                  const T *y,
+                                  int64_t incy,
+                                  T *result) const {
+  if (n == 1) {
+    incx = 1;
+    incy = 1;
+  }
+  const int n_int = detail::to_blas_int(n, "CUDOT n");
+  const int incx_int = detail::to_blas_int(incx, "CUDOT incx");
+  const int incy_int = detail::to_blas_int(incy, "CUDOT incy");
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
-    CUBlas<T>::DOT(handle, n, x, incx, y, incy, result);
+    CUBlas<T>::DOT(handle, n_int, x, incx_int, y, incy_int, result);
   });
 }
 
 template <>
 template <>
-inline void Blas<phi::GPUContext>::CUDOT(int n,
+inline void Blas<phi::GPUContext>::CUDOT(int64_t n,
                                          const phi::bfloat16 *x,
-                                         int incx,
+                                         int64_t incx,
                                          const phi::bfloat16 *y,
-                                         int incy,
+                                         int64_t incy,
                                          phi::bfloat16 *result) const {
+  if (n == 1) {
+    incx = 1;
+    incy = 1;
+  }
+  const int n_int = detail::to_blas_int(n, "CUDOT n");
+  const int incx_int = detail::to_blas_int(incx, "CUDOT incx");
+  const int incy_int = detail::to_blas_int(incy, "CUDOT incy");
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasDotEx(handle,
-                                                         n,
+                                                         n_int,
                                                          x,
                                                          CUDA_R_16BF,
-                                                         incx,
+                                                         incx_int,
                                                          y,
                                                          CUDA_R_16BF,
-                                                         incy,
+                                                         incy_int,
                                                          result,
                                                          CUDA_R_16BF,
                                                          CUDA_R_32F));
@@ -3305,13 +3332,17 @@ void Blas<phi::GPUContext>::TRSM(CBLAS_SIDE side,
                                  CBLAS_UPLO uplo,
                                  CBLAS_TRANSPOSE transA,
                                  CBLAS_DIAG diag,
-                                 int M,
-                                 int N,
+                                 int64_t M,
+                                 int64_t N,
                                  T alpha,
                                  const T *A,
-                                 int lda,
+                                 int64_t lda,
                                  T *B,
-                                 int ldb) const {
+                                 int64_t ldb) const {
+  const int m = detail::to_blas_int(M, "TRSM M");
+  const int n = detail::to_blas_int(N, "TRSM N");
+  const int lda_int = detail::to_blas_int(lda, "TRSM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "TRSM ldb");
   // solve row major `op ( A ) X = α B` by taking it as `X' op ( A' )  =  α B'`
   // where ' stands for transpose
   cublasSideMode_t cuSide =
@@ -3325,28 +3356,44 @@ void Blas<phi::GPUContext>::TRSM(CBLAS_SIDE side,
       (diag == CblasUnit) ? CUBLAS_DIAG_UNIT : CUBLAS_DIAG_NON_UNIT;
 
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
-    CUBlas<T>::TRSM(
-        handle, cuSide, cuUplo, cuTransA, cuDiag, N, M, &alpha, A, lda, B, ldb);
+    CUBlas<T>::TRSM(handle,
+                    cuSide,
+                    cuUplo,
+                    cuTransA,
+                    cuDiag,
+                    n,
+                    m,
+                    &alpha,
+                    A,
+                    lda_int,
+                    B,
+                    ldb_int);
   });
 }
 
 template <>
 template <typename T>
 void Blas<phi::GPUContext>::BatchedGETRF(
-    int n, T **a, int *ipiv, int *info, int batch_size) const {
+    int64_t n, T **a, int *ipiv, int *info, int64_t batch_size) const {
+  const int n_int = detail::to_blas_int(n, "BatchedGETRF n");
+  const int batch_size_int =
+      detail::to_blas_int(batch_size, "BatchedGETRF batch_size");
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
-    CUBlas<T>::GETRF_BATCH(handle, n, a, n, ipiv, info, batch_size);
+    CUBlas<T>::GETRF_BATCH(handle, n_int, a, n_int, ipiv, info, batch_size_int);
   });
 }
 
 template <>
 template <typename T>
-void Blas<phi::GPUContext>::BatchedGETRI(int n,
+void Blas<phi::GPUContext>::BatchedGETRI(int64_t n,
                                          const T **a,
                                          const int *ipiv,
                                          T **a_inv,
                                          int *info,
-                                         int batch_size) const {
+                                         int64_t batch_size) const {
+  const int n_int = detail::to_blas_int(n, "BatchedGETRI n");
+  const int batch_size_int =
+      detail::to_blas_int(batch_size, "BatchedGETRI batch_size");
   PADDLE_ENFORCE_NE(
       a_inv,
       a,
@@ -3357,37 +3404,57 @@ void Blas<phi::GPUContext>::BatchedGETRI(int n,
           a_inv,
           a));
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
-    CUBlas<T>::GETRI_BATCH(handle, n, a, n, ipiv, a_inv, n, info, batch_size);
+    CUBlas<T>::GETRI_BATCH(
+        handle, n_int, a, n_int, ipiv, a_inv, n_int, info, batch_size_int);
   });
 }
 
 template <>
 template <typename T>
 void Blas<phi::GPUContext>::BatchedMatInv(
-    int n, const T **a, T **a_inv, int *info, int batch_size) const {
+    int64_t n, const T **a, T **a_inv, int *info, int64_t batch_size) const {
+  const int n_int = detail::to_blas_int(n, "BatchedMatInv n");
+  const int batch_size_int =
+      detail::to_blas_int(batch_size, "BatchedMatInv batch_size");
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
-    CUBlas<T>::MATINV_BATCH(handle, n, a, n, a_inv, n, info, batch_size);
+    CUBlas<T>::MATINV_BATCH(
+        handle, n_int, a, n_int, a_inv, n_int, info, batch_size_int);
   });
 }
 
 template <>
 template <typename T>
 void Blas<phi::GPUContext>::BatchedGETRS(CBLAS_TRANSPOSE trans,
-                                         int n,
-                                         int nrhs,
+                                         int64_t n,
+                                         int64_t nrhs,
                                          const T **a,
-                                         int lda,
+                                         int64_t lda,
                                          int *ipiv,
                                          T **b,
-                                         int ldb,
+                                         int64_t ldb,
                                          int *info,
-                                         int batch_size) const {
+                                         int64_t batch_size) const {
+  const int n_int = detail::to_blas_int(n, "BatchedGETRS n");
+  const int nrhs_int = detail::to_blas_int(nrhs, "BatchedGETRS nrhs");
+  const int lda_int = detail::to_blas_int(lda, "BatchedGETRS lda");
+  const int ldb_int = detail::to_blas_int(ldb, "BatchedGETRS ldb");
+  const int batch_size_int =
+      detail::to_blas_int(batch_size, "BatchedGETRS batch_size");
   // use CUBLAS_OP_C (conjugate transpose) for complex
   cublasOperation_t cuTrans =
       (trans == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
-    CUBlas<T>::GETRS_BATCH(
-        handle, cuTrans, n, nrhs, a, lda, ipiv, b, ldb, info, batch_size);
+    CUBlas<T>::GETRS_BATCH(handle,
+                           cuTrans,
+                           n_int,
+                           nrhs_int,
+                           a,
+                           lda_int,
+                           ipiv,
+                           b,
+                           ldb_int,
+                           info,
+                           batch_size_int);
   });
 }
 
@@ -3397,14 +3464,20 @@ void Blas<phi::GPUContext>::BatchedTRSM(CBLAS_SIDE side,
                                         CBLAS_UPLO uplo,
                                         CBLAS_TRANSPOSE transA,
                                         CBLAS_DIAG diag,
-                                        int M,
-                                        int N,
+                                        int64_t M,
+                                        int64_t N,
                                         T alpha,
                                         const T **A,
-                                        int lda,
+                                        int64_t lda,
                                         T **B,
-                                        int ldb,
-                                        int batch_size) const {
+                                        int64_t ldb,
+                                        int64_t batch_size) const {
+  const int m = detail::to_blas_int(M, "BatchedTRSM M");
+  const int n = detail::to_blas_int(N, "BatchedTRSM N");
+  const int lda_int = detail::to_blas_int(lda, "BatchedTRSM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "BatchedTRSM ldb");
+  const int batch_size_int =
+      detail::to_blas_int(batch_size, "BatchedTRSM batch_size");
   // solve row major `op ( A ) X = α B` by taking it as `X' op ( A' )  =  α B'`
   // where ' stands for transpose
   cublasSideMode_t cuSide =
@@ -3423,14 +3496,14 @@ void Blas<phi::GPUContext>::BatchedTRSM(CBLAS_SIDE side,
                           cuUplo,
                           cuTransA,
                           cuDiag,
-                          N,
-                          M,
+                          n,
+                          m,
                           &alpha,
                           A,
-                          lda,
+                          lda_int,
                           B,
-                          ldb,
-                          batch_size);
+                          ldb_int,
+                          batch_size_int);
   });
 }
 

--- a/paddle/phi/kernels/funcs/blas/blas_impl.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.h
@@ -19,25 +19,257 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstring>
 #include <limits>
 #include <vector>
 
+#include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 
 namespace phi {
 namespace funcs {
 
 namespace detail {
+inline int to_blas_int(int64_t value, const char *name) {
+  PADDLE_ENFORCE_GE(
+      value,
+      0,
+      common::errors::InvalidArgument("BLAS parameter %s must be non-negative, "
+                                      "but received %ld.",
+                                      name,
+                                      value));
+  PADDLE_ENFORCE_LE_INT_MAX(value, name);
+  return static_cast<int>(value);
+}
+
+template <typename T>
+static void axpy_fallback(
+    int64_t n, const T alpha, const T *x, int64_t incx, T *y, int64_t incy) {
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+  const MT mp_alpha = static_cast<MT>(alpha);
+  for (int64_t i = 0; i < n; ++i) {
+    const int64_t x_index = i * incx;
+    const int64_t y_index = i * incy;
+    y[y_index] = static_cast<T>(static_cast<MT>(y[y_index]) +
+                                mp_alpha * static_cast<MT>(x[x_index]));
+  }
+}
+
+inline bool level1_blas_compatible(int64_t n, int64_t incx, int64_t incy) {
+  constexpr auto kIntMin = std::numeric_limits<int>::lowest();
+  constexpr auto kIntMax = std::numeric_limits<int>::max();
+  return n >= 0 && n <= kIntMax && incx >= kIntMin && incx <= kIntMax &&
+         incy >= kIntMin && incy <= kIntMax;
+}
+
+template <typename T, typename BlasAxpy>
+static void axpy_with_blas(int64_t n,
+                           const T alpha,
+                           const T *x,
+                           int64_t incx,
+                           T *y,
+                           int64_t incy,
+                           BlasAxpy blas_axpy) {
+  if (n <= 0) {
+    return;
+  }
+  if (n == 1) {
+    incx = 1;
+    incy = 1;
+  }
+  if (level1_blas_compatible(n, incx, incy)) {
+    blas_axpy(static_cast<int>(n),
+              alpha,
+              x,
+              static_cast<int>(incx),
+              y,
+              static_cast<int>(incy));
+    return;
+  }
+  axpy_fallback(n, alpha, x, incx, y, incy);
+}
+
 template <typename T>
 static void axpy(
-    int n, const T alpha, const T *x, const int incx, T *y, const int incy) {
-  // Y = Y + alpha * X
-  while (n-- > 0) {
-    *y += alpha * *x;
-    y = y + incy;
-    x = x + incx;
+    int64_t n, const T alpha, const T *x, int64_t incx, T *y, int64_t incy) {
+  if (n == 1) {
+    incx = 1;
+    incy = 1;
   }
+  axpy_fallback(n, alpha, x, incx, y, incy);
+}
+
+static void axpy(int64_t n,
+                 const float alpha,
+                 const float *x,
+                 int64_t incx,
+                 float *y,
+                 int64_t incy) {
+  axpy_with_blas(
+      n,
+      alpha,
+      x,
+      incx,
+      y,
+      incy,
+      [](int n, float alpha, const float *x, int incx, float *y, int incy) {
+#if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
+        phi::dynload::cblas_saxpy(n, alpha, x, incx, y, incy);
+#else
+        cblas_saxpy(n, alpha, x, incx, y, incy);
+#endif
+      });
+}
+
+static void axpy(int64_t n,
+                 const double alpha,
+                 const double *x,
+                 int64_t incx,
+                 double *y,
+                 int64_t incy) {
+  axpy_with_blas(
+      n,
+      alpha,
+      x,
+      incx,
+      y,
+      incy,
+      [](int n, double alpha, const double *x, int incx, double *y, int incy) {
+#if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
+        phi::dynload::cblas_daxpy(n, alpha, x, incx, y, incy);
+#else
+        cblas_daxpy(n, alpha, x, incx, y, incy);
+#endif
+      });
+}
+
+static void axpy(int64_t n,
+                 const phi::complex64 alpha,
+                 const phi::complex64 *x,
+                 int64_t incx,
+                 phi::complex64 *y,
+                 int64_t incy) {
+  axpy_with_blas(n,
+                 alpha,
+                 x,
+                 incx,
+                 y,
+                 incy,
+                 [](int n,
+                    phi::complex64 alpha,
+                    const phi::complex64 *x,
+                    int incx,
+                    phi::complex64 *y,
+                    int incy) {
+#if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
+                   phi::dynload::cblas_caxpy(n, &alpha, x, incx, y, incy);
+#else
+        cblas_caxpy(n, &alpha, x, incx, y, incy);
+#endif
+                 });
+}
+
+static void axpy(int64_t n,
+                 const phi::complex128 alpha,
+                 const phi::complex128 *x,
+                 int64_t incx,
+                 phi::complex128 *y,
+                 int64_t incy) {
+  axpy_with_blas(n,
+                 alpha,
+                 x,
+                 incx,
+                 y,
+                 incy,
+                 [](int n,
+                    phi::complex128 alpha,
+                    const phi::complex128 *x,
+                    int incx,
+                    phi::complex128 *y,
+                    int incy) {
+#if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
+                   phi::dynload::cblas_zaxpy(n, &alpha, x, incx, y, incy);
+#else
+        cblas_zaxpy(n, &alpha, x, incx, y, incy);
+#endif
+                 });
+}
+
+template <typename T>
+static T dot_fallback(
+    int64_t n, const T *x, int64_t incx, const T *y, int64_t incy) {
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+  MT sum = static_cast<MT>(0);
+  for (int64_t i = 0; i < n; ++i) {
+    sum += static_cast<MT>(x[i * incx]) * static_cast<MT>(y[i * incy]);
+  }
+  return static_cast<T>(sum);
+}
+
+template <typename T, typename BlasDot>
+static T dot_with_blas(int64_t n,
+                       const T *x,
+                       int64_t incx,
+                       const T *y,
+                       int64_t incy,
+                       BlasDot blas_dot) {
+  if (n <= 0) {
+    return static_cast<T>(0);
+  }
+  if (n == 1) {
+    incx = 1;
+    incy = 1;
+  }
+  if (level1_blas_compatible(n, incx, incy)) {
+    return blas_dot(static_cast<int>(n),
+                    x,
+                    static_cast<int>(incx),
+                    y,
+                    static_cast<int>(incy));
+  }
+  return dot_fallback(n, x, incx, y, incy);
+}
+
+template <typename T>
+static T dot(int64_t n, const T *x, int64_t incx, const T *y, int64_t incy) {
+  if (n == 1) {
+    incx = 1;
+    incy = 1;
+  }
+  return dot_fallback(n, x, incx, y, incy);
+}
+
+static float dot(
+    int64_t n, const float *x, int64_t incx, const float *y, int64_t incy) {
+  return dot_with_blas(
+      n,
+      x,
+      incx,
+      y,
+      incy,
+      [](int n, const float *x, int incx, const float *y, int incy) {
+#if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
+        return phi::dynload::cblas_sdot(n, x, incx, y, incy);
+#else
+        return cblas_sdot(n, x, incx, y, incy);
+#endif
+      });
+}
+
+static double dot(
+    int64_t n, const double *x, int64_t incx, const double *y, int64_t incy) {
+  return dot_with_blas(
+      n,
+      x,
+      incx,
+      y,
+      incy,
+      [](int n, const double *x, int incx, const double *y, int incy) {
+#if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
+        return phi::dynload::cblas_ddot(n, x, incx, y, incy);
+#else
+        return cblas_ddot(n, x, incx, y, incy);
+#endif
+      });
 }
 }  // namespace detail
 
@@ -58,33 +290,8 @@ struct CBlas<phi::bfloat16> {
   }
 
   template <typename... ARGS>
-  static void VADD(int n,
-                   const phi::bfloat16 *x,
-                   const phi::bfloat16 *y,
-                   phi::bfloat16 *z) {
-    for (int i = 0; i < n; ++i) {
-      z[i] = x[i] + y[i];
-    }
-  }
-
-  template <typename... ARGS>
-  static void VMUL(int n,
-                   const phi::bfloat16 *x,
-                   const phi::bfloat16 *y,
-                   phi::bfloat16 *z) {
-    for (int i = 0; i < n; ++i) {
-      z[i] = x[i] * y[i];
-    }
-  }
-
-  template <typename... ARGS>
-  static void VSUB(int n,
-                   const phi::bfloat16 *x,
-                   const phi::bfloat16 *y,
-                   phi::bfloat16 *z) {
-    for (int i = 0; i < n; ++i) {
-      z[i] = x[i] - y[i];
-    }
+  static phi::bfloat16 DOT(ARGS... args) {
+    return detail::dot(args...);
   }
 };
 
@@ -125,7 +332,7 @@ struct CBlas<float> {
 
   template <typename... ARGS>
   static void AXPY(ARGS... args) {
-    phi::dynload::cblas_saxpy(args...);
+    detail::axpy(args...);
   }
 
   template <typename... ARGS>
@@ -135,69 +342,13 @@ struct CBlas<float> {
 
   template <typename... ARGS>
   static float DOT(ARGS... args) {
-    return phi::dynload::cblas_sdot(args...);
-  }
-
-  template <typename... ARGS>
-  static float ASUM(ARGS... args) {
-    return phi::dynload::cblas_sasum(args...);
+    return detail::dot(args...);
   }
 
   template <typename... ARGS>
   static void GEMM_BATCH(ARGS... args) {
     phi::dynload::cblas_sgemm_batch(args...);
   }
-
-  template <typename... ARGS>
-  static void VADD(ARGS... args) {
-    phi::dynload::vsAdd(args...);
-  }
-
-  template <typename... ARGS>
-  static void VSUB(ARGS... args) {
-    phi::dynload::vsSub(args...);
-  }
-
-  template <typename... ARGS>
-  static void VMUL(ARGS... args) {
-    phi::dynload::vsMul(args...);
-  }
-
-  template <typename... ARGS>
-  static void VDIV(ARGS... args) {
-    phi::dynload::vsDiv(args...);
-  }
-
-  template <typename... ARGS>
-  static void VEXP(ARGS... args) {
-    phi::dynload::vsExp(args...);
-  }
-
-  template <typename... ARGS>
-  static void VSQUARE(ARGS... args) {
-    phi::dynload::vsSqr(args...);
-  }
-
-  template <typename... ARGS>
-  static void VPOW(ARGS... args) {
-    phi::dynload::vsPowx(args...);
-  }
-
-  template <typename... ARGS>
-  static void VINV(ARGS... args) {
-    phi::dynload::vsInv(args...);
-  }
-
-  template <typename... ARGS>
-  static void VMERF(ARGS... args) {
-    phi::dynload::vmsErf(args...);
-  }
-#if !defined(_WIN32)
-  template <typename... ARGS>
-  static void CSRMM(ARGS... args) {
-    phi::dynload::mkl_scsrmm(args...);
-  }
-#endif
 
   template <typename... ARGS>
   static void TRSM(ARGS... args) {
@@ -241,7 +392,7 @@ struct CBlas<double> {
 
   template <typename... ARGS>
   static void AXPY(ARGS... args) {
-    phi::dynload::cblas_daxpy(args...);
+    detail::axpy(args...);
   }
 
   template <typename... ARGS>
@@ -251,69 +402,13 @@ struct CBlas<double> {
 
   template <typename... ARGS>
   static double DOT(ARGS... args) {
-    return phi::dynload::cblas_ddot(args...);
-  }
-
-  template <typename... ARGS>
-  static double ASUM(ARGS... args) {
-    return phi::dynload::cblas_dasum(args...);
+    return detail::dot(args...);
   }
 
   template <typename... ARGS>
   static void GEMM_BATCH(ARGS... args) {
     phi::dynload::cblas_dgemm_batch(args...);
   }
-
-  template <typename... ARGS>
-  static void VADD(ARGS... args) {
-    phi::dynload::vdAdd(args...);
-  }
-
-  template <typename... ARGS>
-  static void VSUB(ARGS... args) {
-    phi::dynload::vdSub(args...);
-  }
-
-  template <typename... ARGS>
-  static void VMUL(ARGS... args) {
-    phi::dynload::vdMul(args...);
-  }
-
-  template <typename... ARGS>
-  static void VDIV(ARGS... args) {
-    phi::dynload::vdDiv(args...);
-  }
-
-  template <typename... ARGS>
-  static void VEXP(ARGS... args) {
-    phi::dynload::vdExp(args...);
-  }
-
-  template <typename... ARGS>
-  static void VSQUARE(ARGS... args) {
-    phi::dynload::vdSqr(args...);
-  }
-
-  template <typename... ARGS>
-  static void VPOW(ARGS... args) {
-    phi::dynload::vdPowx(args...);
-  }
-
-  template <typename... ARGS>
-  static void VINV(ARGS... args) {
-    phi::dynload::vdInv(args...);
-  }
-
-  template <typename... ARGS>
-  static void VMERF(ARGS... args) {
-    phi::dynload::vmdErf(args...);
-  }
-#if !defined(_WIN32)
-  template <typename... ARGS>
-  static void CSRMM(ARGS... args) {
-    phi::dynload::mkl_dcsrmm(args...);
-  }
-#endif
 
   template <typename... ARGS>
   static void TRSM(ARGS... args) {
@@ -324,77 +419,13 @@ struct CBlas<double> {
 template <>
 struct CBlas<phi::complex64> {
   template <typename... ARGS>
-  static void AXPY(int n,
+  static void AXPY(int64_t n,
                    const phi::complex64 alpha,
                    const phi::complex64 *X,
-                   const int incX,
+                   int64_t incX,
                    phi::complex64 *Y,
-                   const int incY) {
-    phi::dynload::cblas_caxpy(n, &alpha, X, incX, Y, incY);
-  }
-
-  // the libmklml_intel.so paddle used has no vcAdd, vcSub,
-  // vcMul, vcDiv apis before rebuild from source
-  // so replace with the raw operator methods
-  /*
-  template <typename... ARGS>
-  static void VADD(ARGS... args) {
-    phi::dynload::vcAdd(args...);
-  }
-
-  template <typename... ARGS>
-  static void VSUB(ARGS... args) {
-    phi::dynload::vcSub(args...);
-  }
-
-  template <typename... ARGS>
-  static void VMUL(ARGS... args) {
-    phi::dynload::vcMul(args...);
-  }
-
-  template <typename... ARGS>
-  static void VDIV(ARGS... args) {
-    phi::dynload::vcDiv(args...);
-  }
-  */
-
-  template <typename... ARGS>
-  static void VADD(int n,
-                   const phi::complex64 *a,
-                   const phi::complex64 *b,
-                   phi::complex64 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] + b[i];
-    }
-  }
-
-  template <typename... ARGS>
-  static void VSUB(int n,
-                   const phi::complex64 *a,
-                   const phi::complex64 *b,
-                   phi::complex64 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] - b[i];
-    }
-  }
-
-  template <typename... ARGS>
-  static void VMUL(int n,
-                   const phi::complex64 *a,
-                   const phi::complex64 *b,
-                   phi::complex64 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] * b[i];
-    }
-  }
-  template <typename... ARGS>
-  static void VDIV(int n,
-                   const phi::complex64 *a,
-                   const phi::complex64 *b,
-                   phi::complex64 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] / b[i];
-    }
+                   int64_t incY) {
+    detail::axpy(n, alpha, X, incX, Y, incY);
   }
 
   template <typename... ARGS>
@@ -517,77 +548,13 @@ struct CBlas<phi::complex64> {
 template <>
 struct CBlas<phi::complex128> {
   template <typename... ARGS>
-  static void AXPY(int n,
+  static void AXPY(int64_t n,
                    const phi::complex128 alpha,
                    const phi::complex128 *X,
-                   const int incX,
+                   int64_t incX,
                    phi::complex128 *Y,
-                   const int incY) {
-    phi::dynload::cblas_zaxpy(n, &alpha, X, incX, Y, incY);
-  }
-
-  // the libmklml_intel.so paddle used has no vzAdd, vzSub,
-  // vzMul, vzDiv apis before rebuild from source
-  // so replace with the raw operator methods
-  /*
-  template <typename... ARGS>
-  static void VADD(ARGS... args) {
-    phi::dynload::vzAdd(args...);
-  }
-
-  template <typename... ARGS>
-  static void VSUB(ARGS... args) {
-    phi::dynload::vzSub(args...);
-  }
-
-  template <typename... ARGS>
-  static void VMUL(ARGS... args) {
-    phi::dynload::vzMul(args...);
-  }
-
-  template <typename... ARGS>
-  static void VDIV(ARGS... args) {
-    phi::dynload::vzDiv(args...);
-  }
-  */
-
-  template <typename... ARGS>
-  static void VADD(int n,
-                   const phi::complex128 *a,
-                   const phi::complex128 *b,
-                   phi::complex128 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] + b[i];
-    }
-  }
-
-  template <typename... ARGS>
-  static void VSUB(int n,
-                   const phi::complex128 *a,
-                   const phi::complex128 *b,
-                   phi::complex128 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] - b[i];
-    }
-  }
-
-  template <typename... ARGS>
-  static void VMUL(int n,
-                   const phi::complex128 *a,
-                   const phi::complex128 *b,
-                   phi::complex128 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] * b[i];
-    }
-  }
-  template <typename... ARGS>
-  static void VDIV(int n,
-                   const phi::complex128 *a,
-                   const phi::complex128 *b,
-                   phi::complex128 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] / b[i];
-    }
+                   int64_t incY) {
+    detail::axpy(n, alpha, X, incX, Y, incY);
   }
 
   template <typename... ARGS>
@@ -717,7 +684,7 @@ struct CBlas<float> {
 
   template <typename... ARGS>
   static void AXPY(ARGS... args) {
-    phi::dynload::cblas_saxpy(args...);
+    detail::axpy(args...);
   }
 
   template <typename... ARGS>
@@ -727,12 +694,7 @@ struct CBlas<float> {
 
   template <typename... ARGS>
   static float DOT(ARGS... args) {
-    return phi::dynload::cblas_sdot(args...);
-  }
-
-  template <typename... ARGS>
-  static float ASUM(ARGS... args) {
-    return phi::dynload::cblas_sasum(args...);
+    return detail::dot(args...);
   }
 
   template <typename... ARGS>
@@ -743,46 +705,6 @@ struct CBlas<float> {
   template <typename... ARGS>
   static void GEMM_BATCH(ARGS... args) {
     phi::dynload::cblas_sgemm_batch(args...);
-  }
-
-  template <typename... ARGS>
-  static void VADD(ARGS... args) {
-    phi::dynload::vsAdd(args...);
-  }
-
-  template <typename... ARGS>
-  static void VSUB(ARGS... args) {
-    phi::dynload::vsSub(args...);
-  }
-
-  template <typename... ARGS>
-  static void VMUL(ARGS... args) {
-    phi::dynload::vsMul(args...);
-  }
-
-  template <typename... ARGS>
-  static void VDIV(ARGS... args) {
-    phi::dynload::vsDiv(args...);
-  }
-
-  template <typename... ARGS>
-  static void VEXP(ARGS... args) {
-    phi::dynload::vsExp(args...);
-  }
-
-  template <typename... ARGS>
-  static void VSQUARE(ARGS... args) {
-    phi::dynload::vsSqr(args...);
-  }
-
-  template <typename... ARGS>
-  static void VPOW(ARGS... args) {
-    phi::dynload::vsPowx(args...);
-  }
-
-  template <typename... ARGS>
-  static void VINV(ARGS... args) {
-    phi::dynload::vsInv(args...);
   }
 };
 
@@ -795,7 +717,7 @@ struct CBlas<double> {
 
   template <typename... ARGS>
   static void AXPY(ARGS... args) {
-    phi::dynload::cblas_daxpy(args...);
+    detail::axpy(args...);
   }
 
   template <typename... ARGS>
@@ -805,57 +727,12 @@ struct CBlas<double> {
 
   template <typename... ARGS>
   static double DOT(ARGS... args) {
-    return phi::dynload::cblas_ddot(args...);
-  }
-
-  template <typename... ARGS>
-  static double ASUM(ARGS... args) {
-    return phi::dynload::cblas_dasum(args...);
+    return detail::dot(args...);
   }
 
   template <typename... ARGS>
   static void GEMM_BATCH(ARGS... args) {
     phi::dynload::cblas_dgemm_batch(args...);
-  }
-
-  template <typename... ARGS>
-  static void VADD(ARGS... args) {
-    phi::dynload::vdAdd(args...);
-  }
-
-  template <typename... ARGS>
-  static void VSUB(ARGS... args) {
-    phi::dynload::vdSub(args...);
-  }
-
-  template <typename... ARGS>
-  static void VMUL(ARGS... args) {
-    phi::dynload::vdMul(args...);
-  }
-
-  template <typename... ARGS>
-  static void VDIV(ARGS... args) {
-    phi::dynload::vdDiv(args...);
-  }
-
-  template <typename... ARGS>
-  static void VEXP(ARGS... args) {
-    phi::dynload::vdExp(args...);
-  }
-
-  template <typename... ARGS>
-  static void VSQUARE(ARGS... args) {
-    phi::dynload::vdSqr(args...);
-  }
-
-  template <typename... ARGS>
-  static void VPOW(ARGS... args) {
-    phi::dynload::vdPowx(args...);
-  }
-
-  template <typename... ARGS>
-  static void VINV(ARGS... args) {
-    phi::dynload::vdInv(args...);
   }
 
   template <typename... ARGS>
@@ -867,52 +744,13 @@ struct CBlas<double> {
 template <>
 struct CBlas<phi::complex64> {
   template <typename... ARGS>
-  static void AXPY(int n,
+  static void AXPY(int64_t n,
                    const phi::complex64 alpha,
                    const phi::complex64 *X,
-                   const int incX,
+                   int64_t incX,
                    phi::complex64 *Y,
-                   const int incY) {
-    phi::dynload::cblas_caxpy(n, &alpha, X, incX, Y, incY);
-  }
-
-  template <typename... ARGS>
-  static void VADD(int n,
-                   const phi::complex64 *a,
-                   const phi::complex64 *b,
-                   phi::complex64 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] + b[i];
-    }
-  }
-
-  template <typename... ARGS>
-  static void VSUB(int n,
-                   const phi::complex64 *a,
-                   const phi::complex64 *b,
-                   phi::complex64 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] - b[i];
-    }
-  }
-
-  template <typename... ARGS>
-  static void VMUL(int n,
-                   const phi::complex64 *a,
-                   const phi::complex64 *b,
-                   phi::complex64 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] * b[i];
-    }
-  }
-  template <typename... ARGS>
-  static void VDIV(int n,
-                   const phi::complex64 *a,
-                   const phi::complex64 *b,
-                   phi::complex64 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] / b[i];
-    }
+                   int64_t incY) {
+    detail::axpy(n, alpha, X, incX, Y, incY);
   }
 
   template <typename... ARGS>
@@ -1035,52 +873,13 @@ struct CBlas<phi::complex64> {
 template <>
 struct CBlas<phi::complex128> {
   template <typename... ARGS>
-  static void AXPY(int n,
+  static void AXPY(int64_t n,
                    const phi::complex128 alpha,
                    const phi::complex128 *X,
-                   const int incX,
+                   int64_t incX,
                    phi::complex128 *Y,
-                   const int incY) {
-    phi::dynload::cblas_zaxpy(n, &alpha, X, incX, Y, incY);
-  }
-
-  template <typename... ARGS>
-  static void VADD(int n,
-                   const phi::complex128 *a,
-                   const phi::complex128 *b,
-                   phi::complex128 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] + b[i];
-    }
-  }
-
-  template <typename... ARGS>
-  static void VSUB(int n,
-                   const phi::complex128 *a,
-                   const phi::complex128 *b,
-                   phi::complex128 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] - b[i];
-    }
-  }
-
-  template <typename... ARGS>
-  static void VMUL(int n,
-                   const phi::complex128 *a,
-                   const phi::complex128 *b,
-                   phi::complex128 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] * b[i];
-    }
-  }
-  template <typename... ARGS>
-  static void VDIV(int n,
-                   const phi::complex128 *a,
-                   const phi::complex128 *b,
-                   phi::complex128 *y) {
-    for (int i = 0; i < n; ++i) {
-      y[i] = a[i] / b[i];
-    }
+                   int64_t incY) {
+    detail::axpy(n, alpha, X, incX, Y, incY);
   }
 
   template <typename... ARGS>
@@ -1211,12 +1010,17 @@ struct CBlas<float> {
 
   template <typename... ARGS>
   static void AXPY(ARGS... args) {
-    cblas_saxpy(args...);
+    detail::axpy(args...);
   }
 
   template <typename... ARGS>
   static void GEMV(ARGS... args) {
     cblas_sgemv(args...);
+  }
+
+  template <typename... ARGS>
+  static float DOT(ARGS... args) {
+    return detail::dot(args...);
   }
 
   template <typename... ARGS>
@@ -1234,12 +1038,17 @@ struct CBlas<double> {
 
   template <typename... ARGS>
   static void AXPY(ARGS... args) {
-    cblas_daxpy(args...);
+    detail::axpy(args...);
   }
 
   template <typename... ARGS>
   static void GEMV(ARGS... args) {
     cblas_dgemv(args...);
+  }
+
+  template <typename... ARGS>
+  static double DOT(ARGS... args) {
+    return detail::dot(args...);
   }
 
   template <typename... ARGS>
@@ -1251,13 +1060,13 @@ struct CBlas<double> {
 template <>
 struct CBlas<phi::complex64> {
   template <typename... ARGS>
-  static void AXPY(int n,
+  static void AXPY(int64_t n,
                    const phi::complex64 alpha,
                    const phi::complex64 *X,
-                   const int incX,
+                   int64_t incX,
                    phi::complex64 *Y,
-                   const int incY) {
-    cblas_caxpy(n, &alpha, X, incX, Y, incY);
+                   int64_t incY) {
+    detail::axpy(n, alpha, X, incX, Y, incY);
   }
 
   template <typename... ARGS>
@@ -1314,13 +1123,13 @@ struct CBlas<phi::complex64> {
 template <>
 struct CBlas<phi::complex128> {
   template <typename... ARGS>
-  static void AXPY(int n,
+  static void AXPY(int64_t n,
                    const phi::complex128 alpha,
                    const phi::complex128 *X,
-                   const int incX,
+                   int64_t incX,
                    phi::complex128 *Y,
-                   const int incY) {
-    cblas_zaxpy(n, &alpha, X, incX, Y, incY);
+                   int64_t incY) {
+    detail::axpy(n, alpha, X, incX, Y, incY);
   }
 
   template <typename... ARGS>
@@ -1378,6 +1187,16 @@ struct CBlas<phi::complex128> {
 
 template <>
 struct CBlas<phi::float16> {
+  template <typename... ARGS>
+  static void AXPY(ARGS... args) {
+    detail::axpy(args...);
+  }
+
+  template <typename... ARGS>
+  static phi::float16 DOT(ARGS... args) {
+    return detail::dot(args...);
+  }
+
   static void GEMM(...) {
     PADDLE_THROW(common::errors::Unimplemented(
         "float16 GEMM not supported on CPU, please check your code"));
@@ -1387,30 +1206,6 @@ struct CBlas<phi::float16> {
     PADDLE_THROW(common::errors::Unimplemented(
         "float16 SMM_GEMM not supported on CPU, please check your code"));
   }
-  static void VMUL(...) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "float16 VMUL not supported on CPU, please check your code"));
-  }
-  static void VEXP(...) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "float16 VEXP not supported on CPU, please check your code"));
-  }
-  static void VSQUARE(...) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "float16 VSQUARE not supported on CPU, please check your code"));
-  }
-  static void VPOW(...) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "float16 VPOW not supported on CPU, please check your code"));
-  }
-  static void DOT(...) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "float16 DOT not supported on CPU, please check your code"));
-  };
-  static void ASUM(...) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "float16 ASUM not supported on CPU, please check your code"));
-  };
 #ifdef PADDLE_WITH_MKLML
   static void GEMM_BATCH(...) {
     PADDLE_THROW(common::errors::Unimplemented(
@@ -1680,40 +1475,15 @@ void Blas<DeviceContext>::MatMul(const DenseTensor &mat_a,
 
 template <>
 template <typename T>
-void Blas<CPUContext>::AXPY(int n, T alpha, const T *x, T *y) const {
+void Blas<CPUContext>::AXPY(int64_t n, T alpha, const T *x, T *y) const {
   CBlas<T>::AXPY(n, alpha, x, 1, y, 1);
 }
 
 template <>
 template <typename T>
-void Blas<CPUContext>::VADD(int n, const T *x, const T *y, T *z) const {
-#if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
-  CBlas<T>::VADD(n, x, y, z);
-#else
-  if (x == z) {
-    this->template AXPY<T>(n, (T)(1.), y, z);
-  } else {
-    if (y != z) {
-      std::memcpy(z, y, n * sizeof(T));
-    }
-    this->template AXPY<T>(n, (T)(1.), x, z);
-  }
-#endif
-}
-
-template <>
-template <typename T>
-T Blas<CPUContext>::DOT(int n, const T *x, const T *y) const {
-#if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
-  return CBlas<T>::DOT(n, x, 1, y, 1);
-#else
-  // try to find if openblas support cblas_dot
-  T sum = 0;
-  for (int i = 0; i < n; ++i) {
-    sum += x[i] * y[i];
-  }
-  return sum;
-#endif
+T Blas<CPUContext>::DOT(
+    int64_t n, const T *x, int64_t incx, const T *y, int64_t incy) const {
+  return detail::dot(n, x, incx, y, incy);
 }
 
 template <>
@@ -2633,15 +2403,29 @@ void Blas<CPUContext>::TRSM(CBLAS_SIDE side,
                             CBLAS_UPLO uplo,
                             CBLAS_TRANSPOSE transA,
                             CBLAS_DIAG diag,
-                            int M,
-                            int N,
+                            int64_t M,
+                            int64_t N,
                             T alpha,
                             const T *A,
-                            int lda,
+                            int64_t lda,
                             T *B,
-                            int ldb) const {
-  CBlas<T>::TRSM(
-      CblasRowMajor, side, uplo, transA, diag, M, N, alpha, A, lda, B, ldb);
+                            int64_t ldb) const {
+  const int m = detail::to_blas_int(M, "TRSM M");
+  const int n = detail::to_blas_int(N, "TRSM N");
+  const int lda_int = detail::to_blas_int(lda, "TRSM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "TRSM ldb");
+  CBlas<T>::TRSM(CblasRowMajor,
+                 side,
+                 uplo,
+                 transA,
+                 diag,
+                 m,
+                 n,
+                 alpha,
+                 A,
+                 lda_int,
+                 B,
+                 ldb_int);
 }
 
 }  // namespace funcs

--- a/paddle/phi/kernels/funcs/blas/blas_impl.hip.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.hip.h
@@ -1247,9 +1247,18 @@ inline void Blas<GPUContext>::GEMM(bool transA,
 
 template <>
 template <typename T>
-void Blas<GPUContext>::AXPY(int n, T alpha, const T *x, T *y) const {
+void Blas<GPUContext>::AXPY(int64_t n, T alpha, const T *x, T *y) const {
+  if (n <= 0) {
+    return;
+  }
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
-    CUBlas<T>::AXPY(handle, n, &alpha, x, 1, y, 1);
+    int64_t offset = 0;
+    while (offset < n) {
+      const int chunk_size = static_cast<int>(
+          n - offset > INT_MAX_VALUE ? INT_MAX_VALUE : n - offset);
+      CUBlas<T>::AXPY(handle, chunk_size, &alpha, x + offset, 1, y + offset, 1);
+      offset += chunk_size;
+    }
   });
 }
 
@@ -1848,13 +1857,17 @@ void Blas<GPUContext>::TRSM(CBLAS_SIDE side,
                             CBLAS_UPLO uplo,
                             CBLAS_TRANSPOSE transA,
                             CBLAS_DIAG diag,
-                            int M,
-                            int N,
+                            int64_t M,
+                            int64_t N,
                             T alpha,
                             const T *A,
-                            int lda,
+                            int64_t lda,
                             T *B,
-                            int ldb) const {
+                            int64_t ldb) const {
+  const int m = detail::to_blas_int(M, "TRSM M");
+  const int n = detail::to_blas_int(N, "TRSM N");
+  const int lda_int = detail::to_blas_int(lda, "TRSM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "TRSM ldb");
   // solve row major `op ( A ) X = α B` by taking it as `X' op ( A' )  =  α B'`
   // where ' stands for transpose
   rocblas_side cuSide =
@@ -1869,28 +1882,44 @@ void Blas<GPUContext>::TRSM(CBLAS_SIDE side,
       (diag == CblasUnit) ? rocblas_diagonal_unit : rocblas_diagonal_non_unit;
 
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
-    CUBlas<T>::TRSM(
-        handle, cuSide, cuUplo, cuTransA, cuDiag, N, M, &alpha, A, lda, B, ldb);
+    CUBlas<T>::TRSM(handle,
+                    cuSide,
+                    cuUplo,
+                    cuTransA,
+                    cuDiag,
+                    n,
+                    m,
+                    &alpha,
+                    A,
+                    lda_int,
+                    B,
+                    ldb_int);
   });
 }
 
 template <>
 template <typename T>
 void Blas<GPUContext>::BatchedGETRF(
-    int n, T **a, int *ipiv, int *info, int batch_size) const {
+    int64_t n, T **a, int *ipiv, int *info, int64_t batch_size) const {
+  const int n_int = detail::to_blas_int(n, "BatchedGETRF n");
+  const int batch_size_int =
+      detail::to_blas_int(batch_size, "BatchedGETRF batch_size");
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
-    CUBlas<T>::GETRF_BATCH(handle, n, a, n, ipiv, info, batch_size);
+    CUBlas<T>::GETRF_BATCH(handle, n_int, a, n_int, ipiv, info, batch_size_int);
   });
 }
 
 template <>
 template <typename T>
-void Blas<GPUContext>::BatchedGETRI(int n,
+void Blas<GPUContext>::BatchedGETRI(int64_t n,
                                     const T **a,
                                     const int *ipiv,
                                     T **a_inv,
                                     int *info,
-                                    int batch_size) const {
+                                    int64_t batch_size) const {
+  const int n_int = detail::to_blas_int(n, "BatchedGETRI n");
+  const int batch_size_int =
+      detail::to_blas_int(batch_size, "BatchedGETRI batch_size");
   PADDLE_ENFORCE_NE(
       a_inv,
       a,
@@ -1901,37 +1930,57 @@ void Blas<GPUContext>::BatchedGETRI(int n,
           a_inv,
           a));
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
-    CUBlas<T>::GETRI_BATCH(handle, n, a, n, ipiv, a_inv, n, info, batch_size);
+    CUBlas<T>::GETRI_BATCH(
+        handle, n_int, a, n_int, ipiv, a_inv, n_int, info, batch_size_int);
   });
 }
 
 template <>
 template <typename T>
 void Blas<GPUContext>::BatchedMatInv(
-    int n, const T **a, T **a_inv, int *info, int batch_size) const {
+    int64_t n, const T **a, T **a_inv, int *info, int64_t batch_size) const {
+  const int n_int = detail::to_blas_int(n, "BatchedMatInv n");
+  const int batch_size_int =
+      detail::to_blas_int(batch_size, "BatchedMatInv batch_size");
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
-    CUBlas<T>::MATINV_BATCH(handle, n, a, n, a_inv, n, info, batch_size);
+    CUBlas<T>::MATINV_BATCH(
+        handle, n_int, a, n_int, a_inv, n_int, info, batch_size_int);
   });
 }
 
 template <>
 template <typename T>
 void Blas<GPUContext>::BatchedGETRS(CBLAS_TRANSPOSE trans,
-                                    int n,
-                                    int nrhs,
+                                    int64_t n,
+                                    int64_t nrhs,
                                     const T **a,
-                                    int lda,
+                                    int64_t lda,
                                     int *ipiv,
                                     T **b,
-                                    int ldb,
+                                    int64_t ldb,
                                     int *info,
-                                    int batch_size) const {
+                                    int64_t batch_size) const {
+  const int n_int = detail::to_blas_int(n, "BatchedGETRS n");
+  const int nrhs_int = detail::to_blas_int(nrhs, "BatchedGETRS nrhs");
+  const int lda_int = detail::to_blas_int(lda, "BatchedGETRS lda");
+  const int ldb_int = detail::to_blas_int(ldb, "BatchedGETRS ldb");
+  const int batch_size_int =
+      detail::to_blas_int(batch_size, "BatchedGETRS batch_size");
   rocblas_operation cuTrans = (trans == CblasNoTrans)
                                   ? rocblas_operation_none
                                   : rocblas_operation_transpose;
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
-    CUBlas<T>::GETRS_BATCH(
-        handle, cuTrans, n, nrhs, a, lda, ipiv, b, ldb, info, batch_size);
+    CUBlas<T>::GETRS_BATCH(handle,
+                           cuTrans,
+                           n_int,
+                           nrhs_int,
+                           a,
+                           lda_int,
+                           ipiv,
+                           b,
+                           ldb_int,
+                           info,
+                           batch_size_int);
   });
 }
 
@@ -1941,14 +1990,20 @@ void Blas<GPUContext>::BatchedTRSM(CBLAS_SIDE side,
                                    CBLAS_UPLO uplo,
                                    CBLAS_TRANSPOSE transA,
                                    CBLAS_DIAG diag,
-                                   int M,
-                                   int N,
+                                   int64_t M,
+                                   int64_t N,
                                    T alpha,
                                    const T **A,
-                                   int lda,
+                                   int64_t lda,
                                    T **B,
-                                   int ldb,
-                                   int batch_size) const {
+                                   int64_t ldb,
+                                   int64_t batch_size) const {
+  const int m = detail::to_blas_int(M, "BatchedTRSM M");
+  const int n = detail::to_blas_int(N, "BatchedTRSM N");
+  const int lda_int = detail::to_blas_int(lda, "BatchedTRSM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "BatchedTRSM ldb");
+  const int batch_size_int =
+      detail::to_blas_int(batch_size, "BatchedTRSM batch_size");
   // solve row major `op ( A ) X = α B` by taking it as `X' op ( A' )  =  α B'`
   // where ' stands for transpose
   rocblas_side cuSide =
@@ -1968,14 +2023,14 @@ void Blas<GPUContext>::BatchedTRSM(CBLAS_SIDE side,
                           cuUplo,
                           cuTransA,
                           cuDiag,
-                          N,
-                          M,
+                          n,
+                          m,
                           &alpha,
                           A,
-                          lda,
+                          lda_int,
                           B,
-                          ldb,
-                          batch_size);
+                          ldb_int,
+                          batch_size_int);
   });
 }
 

--- a/paddle/phi/kernels/funcs/gru_compute.cc
+++ b/paddle/phi/kernels/funcs/gru_compute.cc
@@ -207,8 +207,9 @@ struct GRUUnitFunctorV2<CPUContext, T> {
     T *cell_state_value = value.gate_value + 2 * frame_size;
     T *reset_output_value = value.reset_output_value;
     for (int b = 0; b < batch_size; ++b) {
-      blas.VADD(
-          frame_size, cell_state_value, reset_output_value, cell_state_value);
+      for (int i = 0; i < frame_size; ++i) {
+        cell_state_value[i] += reset_output_value[i];
+      }
       cell_state_value += frame_size * 3;
       reset_output_value += frame_size;
     }
@@ -339,9 +340,12 @@ struct GRUUnitGradFunctorV2<CPUContext, T> {
     T *state_bias_grad = grad.bias_hh_grad + 2 * frame_size;
     T *reset_output_grad = grad.reset_output_grad;
     for (int b = 0; b < batch_size; ++b) {
-      blas.VADD(2 * frame_size, bias_hh_grad, gate_grad, bias_hh_grad);
-      blas.VADD(
-          frame_size, state_bias_grad, reset_output_grad, state_bias_grad);
+      for (int i = 0; i < 2 * frame_size; ++i) {
+        bias_hh_grad[i] += gate_grad[i];
+      }
+      for (int i = 0; i < frame_size; ++i) {
+        state_bias_grad[i] += reset_output_grad[i];
+      }
       gate_grad += 3 * frame_size;
       reset_output_grad += frame_size;
     }

--- a/paddle/phi/kernels/funcs/math/context_project.h
+++ b/paddle/phi/kernels/funcs/math/context_project.h
@@ -295,9 +295,7 @@ class ContextProjectGradFunctor {
               DenseTensor out_t_sub = out_t.Slice(
                   k * context_length, k * context_length + padding_size);
               DenseTensor w_sub = padding_data->Slice(k, k + padding_size);
-              PADDLE_ENFORCE_LE_INT_MAX(w_sub.numel(),
-                                        "context_project AXPY size");
-              blas.AXPY(static_cast<int>(w_sub.numel()),
+              blas.AXPY(w_sub.numel(),
                         static_cast<T>(1),
                         out_t_sub.data<T>(),
                         w_sub.data<T>());
@@ -331,9 +329,7 @@ class ContextProjectGradFunctor {
                   (down_pad_begin_row + t) * context_length);
               DenseTensor w_sub = padding_data->Slice(
                   up_pad + padding_idx, up_pad + padding_idx + padding_size);
-              PADDLE_ENFORCE_LE_INT_MAX(w_sub.numel(),
-                                        "context_project AXPY size");
-              blas.AXPY(static_cast<int>(w_sub.numel()),
+              blas.AXPY(w_sub.numel(),
                         static_cast<T>(1),
                         out_t_sub.data<T>(),
                         w_sub.data<T>());

--- a/paddle/phi/kernels/funcs/scatter.h
+++ b/paddle/phi/kernels/funcs/scatter.h
@@ -19,6 +19,7 @@ limitations under the License. */
 #include <unordered_set>
 
 #include "paddle/common/ddim.h"
+#include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"

--- a/paddle/phi/kernels/funcs/scatter.h
+++ b/paddle/phi/kernels/funcs/scatter.h
@@ -21,7 +21,6 @@ limitations under the License. */
 #include "paddle/common/ddim.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/dense_tensor.h"
-#include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 namespace phi {
@@ -33,17 +32,17 @@ namespace funcs {
  */
 template <typename T, typename IndexT = int>
 typename std::enable_if<std::is_floating_point<T>::value>::type
-elementwise_inner_add(const CPUContext& dev_ctx,
+elementwise_inner_add(const CPUContext& dev_ctx UNUSED,
                       const T* src_pointer,
                       T* dst_pointer,
                       size_t src_index,
                       IndexT dst_index,
                       size_t slice_size) {
-  auto blas = funcs::GetBlas<CPUContext, T>(dev_ctx);
-  blas.VADD(slice_size,
-            src_pointer + src_index * slice_size,
-            dst_pointer + dst_index * slice_size,
-            dst_pointer + dst_index * slice_size);
+  auto* z = dst_pointer + dst_index * slice_size;
+  const auto* x = src_pointer + src_index * slice_size;
+  for (size_t i = 0; i < slice_size; ++i) {
+    z[i] += x[i];
+  }
 }
 
 template <typename T, typename IndexT = int>

--- a/paddle/phi/kernels/fusion/cpu/fused_embedding_fc_lstm_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/fused_embedding_fc_lstm_kernel.cc
@@ -32,6 +32,13 @@ inline void EigenVecMul(int n, const T* x, const T* y, T* z) {
   z_map = x_map.array() * y_map.array();
 }
 
+template <typename T>
+inline void VecAdd(int n, const T* x, const T* y, T* z) {
+  for (int i = 0; i < n; ++i) {
+    z[i] = x[i] + y[i];
+  }
+}
+
 #define OP_PARAM                                                             \
   dev_ctx, ids_in, embeddings_in, weight_h_in, bias_in, h0_in, c0_in,        \
       use_peepholes, is_reverse, use_seq, gate_activation, cell_activation,  \
@@ -127,7 +134,7 @@ class FusedEmbeddingFCLSTMKernel {
   act_cand(D, gates, gates);                       \
   EigenVecMul<T>(D, gates, gates + D, gates + D);  \
   EigenVecMul<T>(D, ct_1, gates + D2, gates + D2); \
-  blas.VADD(D, gates + D, gates + D2, ct)
+  VecAdd<T>(D, gates + D, gates + D2, ct)
 
 #define GET_Ht(ct, gates, ht)        \
   /* H_t = act_cell(C_t) * ogated */ \
@@ -149,7 +156,7 @@ class FusedEmbeddingFCLSTMKernel {
   GET_Ct_NOH0C0(gates, ct);                         \
   /* get outgated, put W_oc * C_t on igated */      \
   EigenVecMul<T>(D, wc_data + D2, ct, gates + D);   \
-  blas.VADD(D, gates + D, gates + D3, gates + D3);  \
+  VecAdd<T>(D, gates + D, gates + D3, gates + D3);  \
   act_gate(D, gates + D3, gates + D3);              \
   GET_Ht(ct, gates, ht)
 
@@ -162,12 +169,12 @@ class FusedEmbeddingFCLSTMKernel {
   /* get fgated and igated*/                                   \
   EigenVecMul<T>(D, wc_data, ct_1, checked_cell_data);         \
   EigenVecMul<T>(D, wc_data + D, ct_1, checked_cell_data + D); \
-  blas.VADD(D2, checked_cell_data, gates + D, gates + D);      \
+  VecAdd<T>(D2, checked_cell_data, gates + D, gates + D);      \
   act_gate(D2, gates + D, gates + D);                          \
   GET_Ct(ct_1, gates, ct);                                     \
   /* get ogated*/                                              \
   EigenVecMul<T>(D, wc_data + D2, ct, gates + D);              \
-  blas.VADD(D, gates + D, gates + D3, gates + D3);             \
+  VecAdd<T>(D, gates + D, gates + D3, gates + D3);             \
   act_gate(D, gates + D3, gates + D3);                         \
   GET_Ht(ct, gates, ht)
 
@@ -350,7 +357,7 @@ class FusedEmbeddingFCLSTMKernel {
         GET_Ct_NOH0C0(cur_in_data, cur_c_out_data);
         if (use_peepholes) {
           EigenVecMul<T>(D, wc_data + D2, cur_c_out_data, cur_in_data + D);
-          blas.VADD(D, cur_in_data + D, cur_in_data + D3, cur_in_data + D3);
+          VecAdd<T>(D, cur_in_data + D, cur_in_data + D3, cur_in_data + D3);
         }
         act_gate(D, cur_in_data + D3, cur_in_data + D3);
         GET_Ht(cur_c_out_data, cur_in_data, cur_h_out_data);

--- a/paddle/phi/kernels/gpu/triangular_solve_kernel.cu
+++ b/paddle/phi/kernels/gpu/triangular_solve_kernel.cu
@@ -62,10 +62,10 @@ void TriangularSolveKernel(const Context& dev_ctx,
   CBLAS_TRANSPOSE transA = transpose ? CblasTrans : CblasNoTrans;
   CBLAS_DIAG diag = unitriangular ? CblasUnit : CblasNonUnit;
 
-  int M = static_cast<int>(y_bst_dims_vec[y_bst_ndim - 2]);
-  int N = static_cast<int>(y_bst_dims_vec[y_bst_ndim - 1]);
-  int lda = std::max(1, M);
-  int ldb = std::max(1, N);
+  const int64_t M = y_bst_dims_vec[y_bst_ndim - 2];
+  const int64_t N = y_bst_dims_vec[y_bst_ndim - 1];
+  const int64_t lda = std::max<int64_t>(1, M);
+  const int64_t ldb = std::max<int64_t>(1, N);
 
   int64_t batch_size = 1;
   for (int64_t i = 0; i < x_bst_ndim - 2; i++) {

--- a/paddle/phi/kernels/impl/cholesky_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/cholesky_grad_kernel_impl.h
@@ -250,12 +250,14 @@ void CholeskyGradKernel(const Context& dev_ctx,
 
   auto* x_grad_data = dev_ctx.template Alloc<T>(x_grad);
   auto& dims = out.dims();
-  int batch_count = 1;
+  int64_t batch_count = 1;
   for (int i = 0; i < dims.size() - 2; i++) {
     batch_count *= dims[i];
   }
-  auto m = dims[dims.size() - 1];
-  int64_t tensor_size = static_cast<int64_t>(batch_count) * m * m;
+  const int64_t m_64 = dims[dims.size() - 1];
+  PADDLE_ENFORCE_LE_INT_MAX(m_64, "CholeskyGrad TRSM matrix dimension");
+  const int m = static_cast<int>(m_64);
+  int64_t tensor_size = batch_count * m * m;
 
   std::vector<int> axis(dims.size() - 2);
   std::iota(axis.begin(), axis.end(), 0);
@@ -304,7 +306,7 @@ void CholeskyGradKernel(const Context& dev_ctx,
   EyeFunctor<T> eye_functor(m, m, identity_data);
   for_range(eye_functor);
   // TODO(guosheng): use trsmBatched for GPU
-  for (int i = 0; i < batch_count; i++) {
+  for (int64_t i = 0; i < batch_count; i++) {
     int64_t offset = static_cast<int64_t>(i) * m * m;
     blas.TRSM(/*side*/ CblasLeft,
               /*uplo*/ CblasLower,

--- a/test/cpp/phi/kernels/test_math_function.cc
+++ b/test/cpp/phi/kernels/test_math_function.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <array>
+#include <limits>
 #include <set>
 
 #include "gtest/gtest.h"
@@ -76,6 +77,73 @@ TEST(math_function, gemm_notrans_cblas) {
   EXPECT_EQ(input3_ptr[6], 86);
   EXPECT_EQ(input3_ptr[7], 99);
 }
+
+TEST(math_function, dot_with_blas_zero_length) {
+  bool called = false;
+  auto result = phi::funcs::detail::dot_with_blas<float>(
+      0,
+      nullptr,
+      1,
+      nullptr,
+      1,
+      [&](int, const float*, int, const float*, int) {
+        called = true;
+        return 1.0f;
+      });
+
+  EXPECT_FALSE(called);
+  EXPECT_FLOAT_EQ(result, 0.0f);
+}
+
+TEST(math_function, dot_with_blas_single_element) {
+  const std::array<float, 1> x = {3.0f};
+  const std::array<float, 1> y = {4.0f};
+  bool called = false;
+
+  auto result = phi::funcs::detail::dot_with_blas<float>(
+      1,
+      x.data(),
+      8,
+      y.data(),
+      9,
+      [&](int n, const float* px, int incx, const float* py, int incy) {
+        called = true;
+        EXPECT_EQ(n, 1);
+        EXPECT_EQ(incx, 1);
+        EXPECT_EQ(incy, 1);
+        return px[0] * py[0];
+      });
+
+  EXPECT_TRUE(called);
+  EXPECT_FLOAT_EQ(result, 12.0f);
+}
+
+TEST(math_function, dot_fallback_strided) {
+  const std::array<float, 5> x = {1.0f, 0.0f, 2.0f, 0.0f, 3.0f};
+  const std::array<float, 7> y = {4.0f, 0.0f, 0.0f, 5.0f, 0.0f, 0.0f, 6.0f};
+
+  auto result =
+      phi::funcs::detail::dot_fallback<float>(3, x.data(), 2, y.data(), 3);
+
+  EXPECT_FLOAT_EQ(result, 32.0f);
+}
+
+TEST(math_function, level1_blas_compatible_true) {
+  EXPECT_TRUE(phi::funcs::detail::level1_blas_compatible(0, 1, 1));
+  EXPECT_TRUE(phi::funcs::detail::level1_blas_compatible(
+      std::numeric_limits<int>::max(), std::numeric_limits<int>::min(), 0));
+}
+
+TEST(math_function, level1_blas_compatible_false) {
+  EXPECT_FALSE(phi::funcs::detail::level1_blas_compatible(-1, 1, 1));
+  EXPECT_FALSE(phi::funcs::detail::level1_blas_compatible(
+      static_cast<int64_t>(std::numeric_limits<int>::max()) + 1, 1, 1));
+  EXPECT_FALSE(phi::funcs::detail::level1_blas_compatible(
+      1, static_cast<int64_t>(std::numeric_limits<int>::min()) - 1, 1));
+  EXPECT_FALSE(phi::funcs::detail::level1_blas_compatible(
+      1, 1, static_cast<int64_t>(std::numeric_limits<int>::max()) + 1));
+}
+
 #ifdef PADDLE_WITH_LIBXSMM
 template <typename T>
 void MklSmmCompare(int m, int n, int k) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description

本 PR 清理了未使用的 BLAS API，并完善了 BLAS 尺寸参数的 int64 安全处理。

#### 删除的 API

- 删除 VADD API，并将调用处替换为逐元素循环或局部向量加法实现。
- 删除 PR 79513中清理的API的CPU 后端残留实现：

#### 修改的 API

以下 API 的尺寸参数已改为 int64_t：

- AXPY：n
- DOT：n、incx、incy
- CUDOT：n、incx、incy
- TRSM：M、N、lda、ldb
- BatchedTRSM：M、N、lda、ldb、batch_size
- BatchedGETRF：n、batch_size
- BatchedGETRI：n、batch_size
- BatchedMatInv：n、batch_size
- BatchedGETRS：n、nrhs、lda、ldb、batch_size

#### 大尺寸参数处理方式

| API | 参数不超过 INT_MAX | 参数超过 INT_MAX |
| ---- | ------------------ | ---------------- |
| CPU AXPY | 对支持的类型调用 CBLAS | 使用 int64 逐元素 fallback |
| CUDA/HIP AXPY | 直接调用 cuBLAS/rocBLAS | 按最多 INT_MAX 个元素分块调用 |
| CPU DOT | float/double 调用 CBLAS | 使用 int64 累加 fallback |
| CUDA CUDOT | 检查并转换后调用 cuBLAS | 明确报错 |
| TRSM | 检查并转换后调用后端 BLAS | 明确报错 |
| BatchedTRSM | 检查并转换后调用 cuBLAS/rocBLAS | 明确报错 |
| Batched GET 系列 | 检查并转换后调用 cuBLAS/rocBLAS | 明确报错 |

对于 CPU Level-1 BLAS 操作，新增 level1_blas_compatible，用于检查 n、incx 和 incy 是否能由 32 位 CBLAS 接口表示。

当 float/double 等类型的参数满足 CBLAS 范围时，继续调用 BLAS 库；当参数超出范围，或者使用 float16、bfloat16 等类型时，使用自主实现的 fallback。

对于 TRSM、BatchedTRSM 和 Batched GET 系列等无法安全拆分的操作，本 PR 提供的是 int64 安全接口，而不是支持单个维度超过 INT_MAX 的计算。这些参数在调用供应商库前会通过 to_blas_int 检查，避免静默的整数窄化和溢出。


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否