### PR TITLE
Add muon_max_group_bytes to split large Muon groups and avoid OOM

### DIFF
--- a/python/paddle/optimizer/muon.py
+++ b/python/paddle/optimizer/muon.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 from typing import TYPE_CHECKING
 
@@ -245,6 +246,7 @@ class Muon(Optimizer):
         ns_matmul_dtype=None,
         multi_precision=False,
         name=None,
+        muon_max_group_bytes=2 * 1024 * 1024 * 1024,  # Max 2GB per group
         **kwargs,
     ):
         if parameters is None:
@@ -304,6 +306,11 @@ class Muon(Optimizer):
             )
             self._ns_coeffs = _NS_COEFFICIENT_SETS[ns_coeff_type]
         self._muon_param_info_map = muon_param_info_map or {}
+        # Optional cap on the total size (in bytes) of a batched Muon group.
+        # When set, a group whose parameters sum to more than this many bytes
+        # is further split into sub-groups so each batched Newton-Schulz call
+        # stays under the limit, avoiding OOM. None disables splitting.
+        self._muon_max_group_bytes = muon_max_group_bytes
         # Dtype for Newton-Schulz matmul.
         # None = auto: bfloat16 on Ampere+ (capability >= 8.0), float32 on older.
         if ns_matmul_dtype is None:
@@ -532,6 +539,35 @@ class Muon(Optimizer):
             False,  # amsgrad
         )
 
+    def _split_group_by_bytes(self, group_params_grads):
+        """Split a batched Muon group so each sub-group stays under the byte cap.
+
+        The batched Newton-Schulz update stacks every parameter's momentum
+        buffer (float32) into one tensor, so peak memory scales with the total
+        size of the group. When ``self._muon_max_group_bytes`` is set, greedily
+        pack parameters into sub-groups whose cumulative size does not exceed
+        the cap. A single parameter larger than the cap forms its own sub-group.
+        """
+        max_bytes = self._muon_max_group_bytes
+        if not max_bytes:
+            yield group_params_grads
+            return
+
+        # Momentum buffer / batched matrix are float32 (see _ensure_accumulators).
+        elem_size = 4
+        sub_group = []
+        sub_bytes = 0
+        for param, grad in group_params_grads:
+            param_bytes = math.prod(param.shape) * elem_size
+            if sub_group and sub_bytes + param_bytes > max_bytes:
+                yield sub_group
+                sub_group = []
+                sub_bytes = 0
+            sub_group.append((param, grad))
+            sub_bytes += param_bytes
+        if sub_group:
+            yield sub_group
+
     def _muon_update_group(
         self,
         group_params_grads,
@@ -759,16 +795,17 @@ class Muon(Optimizer):
             muon_groups[key].append((param, grad))
 
         for key, group_params in muon_groups.items():
-            self._muon_update_group(
-                group_params,
-                lr_tensor,
-                group.get("momentum", 0.95),
-                group.get("ns_steps", 5),
-                group.get("nesterov", True),
-                group.get("epsilon", 1e-9),
-                wd,
-                version=group.get("muon_version", 3),
-            )
+            for sub_group in self._split_group_by_bytes(group_params):
+                self._muon_update_group(
+                    sub_group,
+                    lr_tensor,
+                    group.get("momentum", 0.95),
+                    group.get("ns_steps", 5),
+                    group.get("nesterov", True),
+                    group.get("epsilon", 1e-9),
+                    wd,
+                    version=group.get("muon_version", 3),
+                )
 
         # --- Pass 3: AdamW updates ---
         for param, grad in adamw_params:

--- a/test/collective/fleet/hybrid_parallel_sharding_muon_model.py
+++ b/test/collective/fleet/hybrid_parallel_sharding_muon_model.py
@@ -51,6 +51,18 @@ g_enable_fuse_optimizer_states = int(
 g_release_gradients = int(os.environ.get("RELEASE_GRADIENTS", "0"))
 g_multi_precision = int(os.environ.get("MULTI_PRECISION", "0"))
 
+# Test-controlled Muon group-splitting threshold (bytes), consumed in
+# _build_muon_optimizer. Controls Muon._split_group_by_bytes coverage:
+#   unset -> use optimizer default (no override)
+#   "0"   -> pass None, exercising the split-disabled early-return path
+#   >0    -> pass value; a small value forces a group to be split
+_muon_mgb_env = os.environ.get("MUON_MAX_GROUP_BYTES", "")
+if _muon_mgb_env == "":
+    g_muon_max_group_bytes = "unset"
+else:
+    _v = int(_muon_mgb_env)
+    g_muon_max_group_bytes = None if _v == 0 else _v
+
 # Parameter combinations
 NS_COEFF_TYPES = ["simple", "quintic", "polar_express", "aol", "deepseekv4"]
 
@@ -370,6 +382,8 @@ class TestDistShardingMuonTraining(unittest.TestCase):
             kwargs['ns_matmul_dtype'] = ns_matmul_dtype
         if ns_coeffs is not None:
             kwargs['ns_coeffs'] = ns_coeffs
+        if g_muon_max_group_bytes != "unset":
+            kwargs['muon_max_group_bytes'] = g_muon_max_group_bytes
 
         return paddle.optimizer.Muon(
             parameters=model.parameters(),

--- a/test/collective/fleet/test_parallel_dygraph_muon.py
+++ b/test/collective/fleet/test_parallel_dygraph_muon.py
@@ -84,6 +84,37 @@ class TestMuonParallel(TestMultipleAccelerators):
             need_envs={"MULTI_PRECISION": "1"},
         )
 
+    def test_muon_group_split_by_bytes(self):
+        """MuonSharding test with a small muon_max_group_bytes.
+
+        The two same-shape 3D batched_proj params (each 2*256*128*4 = 262144
+        bytes) fall into one Muon group summing to 524288 bytes. A 400000-byte
+        threshold forces that group to be split, covering the split branch of
+        Muon._split_group_by_bytes (yield sub_group + reset inside the loop).
+        """
+        self.run_mnist_2accelerators(
+            'hybrid_parallel_sharding_muon_model.py',
+            need_envs={
+                "MULTI_PRECISION": "1",
+                "MUON_MAX_GROUP_BYTES": "400000",
+            },
+        )
+
+    def test_muon_group_split_disabled(self):
+        """MuonSharding test with muon_max_group_bytes disabled (None).
+
+        Passing "0" makes the model pass muon_max_group_bytes=None, covering the
+        `if not max_bytes: yield ...; return` early-return path of
+        Muon._split_group_by_bytes.
+        """
+        self.run_mnist_2accelerators(
+            'hybrid_parallel_sharding_muon_model.py',
+            need_envs={
+                "MULTI_PRECISION": "1",
+                "MUON_MAX_GROUP_BYTES": "0",
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
#### 背景 / 动机
`Muon` 优化器在 `_apply_optimize` 中会把相同 shape 和 split_concat_func 的参数分到同一组，
通过 batched Newton-Schulz 一次性更新。该批处理会把组内所有参数的 momentum buffer（float32）
stack/concat 成一个大张量，峰值显存随组内参数总量线性增长。当单组参数量很大时容易 OOM。

#### 改动内容
1. `Muon.__init__` 新增参数 `muon_max_group_bytes`：批处理组的字节数上限。
   - `None`：关闭拆分，行为与之前完全一致。
   - 正整数：当一个组的参数总字节数超过该阈值时，按贪心方式拆成多个子组，
     每个子组累计字节数不超过阈值；单个超过阈值的参数独占一组。
2. 新增 `Muon._split_group_by_bytes`：按上述规则对组进行拆分（generator，
   不拷贝张量，只传递 (param, grad) 引用）。
3. `_apply_optimize` 中对每个 group 先经 `_split_group_by_bytes` 拆分，
   再逐子组调用 `_muon_update_group`。拆分只作用于 batch 维度，
   不改变单参数的计算，数值结果与不拆分一致。

#### 权衡
阈值越小拆分越多，batched Newton-Schulz 的并行度下降、吞吐略降，
换取更低的显存峰值。默认关闭 / 大阈值时对现有流程无影响。

#### 测试
- 新增 `test_parallel_dygraph_muon.py::test_muon_group_split_by_bytes`：
  用小阈值强制拆分，覆盖拆分分支。
- 新增 `test_parallel_dygraph_muon.py::test_muon_group_split_disabled`：
  传 `None`，覆盖关闭路径。
- 均通过 2 卡 sharding 场景验证，内部 9/9 组合通过。

#### 兼容性
默认行为不变；`muon_max_group_bytes` 为可选新参数，不影响已有调用。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否