### PR TITLE
[FlexCheckpoint] Support grouped-GEMM reshape between legacy 2-D and canonical N-D layouts

### DIFF
--- a/python/paddle/distributed/flex_checkpoint/aoa/aoa_engine.py
+++ b/python/paddle/distributed/flex_checkpoint/aoa/aoa_engine.py
@@ -912,8 +912,9 @@ class AOAEngine:
                             1,
                         )
                     else:
-                        row_start = pre_pp_intersection[0].start
-                        row_stop = pre_pp_intersection[0].stop
+                        row_base = pre_pp_sl_dst[0].start or 0
+                        row_start = pre_pp_intersection[0].start - row_base
+                        row_stop = pre_pp_intersection[0].stop - row_base
                         if (
                             row_start % block_width != 0
                             or row_stop % block_width != 0
@@ -922,10 +923,13 @@ class AOAEngine:
                                 "reshape (flatten) requires block-aligned "
                                 f"destination shards, but got slice={intersection}."
                             )
-                        block_start = row_start // block_width
-                        block_stop = row_stop // block_width
+                        source_block_start = sl_src[0].start or 0
                         src_slice = (
-                            slice(block_start, block_stop, 1),
+                            slice(
+                                source_block_start + row_start // block_width,
+                                source_block_start + row_stop // block_width,
+                                1,
+                            ),
                             *tuple(
                                 slice(0, dim, 1) for dim in canonical_shape[1:]
                             ),

--- a/python/paddle/distributed/flex_checkpoint/aoa/aoa_engine.py
+++ b/python/paddle/distributed/flex_checkpoint/aoa/aoa_engine.py
@@ -516,6 +516,11 @@ class AOAEngine:
             for destination_key, shards in self.destination_state_shard_info.items()
             if split_optimizer_state_key(destination_key)[0] == key
         }
+        if len(shapes) == 0:
+            # An intermediate variable (e.g. the ``tmp`` produced by a reshape
+            # that is later permuted) has no destination metadata; let the
+            # caller fall back to the canonical shape.
+            return None
         if len(shapes) != 1:
             raise ValueError(
                 f"Cannot determine a unique destination shape for {key}: "
@@ -882,10 +887,23 @@ class AOAEngine:
                         ast.literal_eval(reshape_marker.split(":", 1)[1])
                     )
                     block_width = canonical_shape[1]
+                    # Transposes that follow the reshape/flatten marker express
+                    # the destination in a permuted layout, so ``intersection``
+                    # (and ``sl_dst``) are no longer in the reshape-output axis
+                    # order. Undo those transposes first, then map the leading
+                    # block axis back onto the flattened source rows.
+                    marker_index = pp_list.index(reshape_marker)
+                    remaining_pp = pp_list[marker_index + 1 :]
+                    pre_pp_intersection = postprocess_transpose(
+                        list(intersection), remaining_pp, reverse=True
+                    )
+                    pre_pp_sl_dst = postprocess_transpose(
+                        list(sl_dst), remaining_pp, reverse=True
+                    )
                     if reshape_marker.startswith("reshape:"):
-                        block_base = sl_dst[0].start or 0
-                        block_start = intersection[0].start - block_base
-                        block_stop = intersection[0].stop - block_base
+                        block_base = pre_pp_sl_dst[0].start or 0
+                        block_start = pre_pp_intersection[0].start - block_base
+                        block_stop = pre_pp_intersection[0].stop - block_base
                         source_row_start = sl_src[0].start or 0
                         src_slice = list(sl_src)
                         src_slice[0] = slice(
@@ -894,8 +912,8 @@ class AOAEngine:
                             1,
                         )
                     else:
-                        row_start = intersection[0].start
-                        row_stop = intersection[0].stop
+                        row_start = pre_pp_intersection[0].start
+                        row_stop = pre_pp_intersection[0].stop
                         if (
                             row_start % block_width != 0
                             or row_stop % block_width != 0

--- a/python/paddle/distributed/flex_checkpoint/aoa/aoa_engine.py
+++ b/python/paddle/distributed/flex_checkpoint/aoa/aoa_engine.py
@@ -505,6 +505,124 @@ class AOAEngine:
             slices, tensor.shape, in_degree=1, out_degree=0, dtype=tensor.dtype
         )
 
+    def get_destination_global_shape(self, key: str) -> tuple[int] | None:
+        """Return the destination shape, or None when metadata is unavailable."""
+        if self.destination_state_shard_info is None:
+            return None
+        if key in self.destination_state_shard_info:
+            return tuple(self.destination_state_shard_info[key][0].global_shape)
+        shapes = {
+            tuple(shards[0].global_shape)
+            for destination_key, shards in self.destination_state_shard_info.items()
+            if split_optimizer_state_key(destination_key)[0] == key
+        }
+        if len(shapes) != 1:
+            raise ValueError(
+                f"Cannot determine a unique destination shape for {key}: "
+                f"candidate_shapes={shapes}."
+            )
+        return shapes.pop()
+
+    def reshape(
+        self,
+        tensor: TensorDesc,
+        canonical_shape: str,
+        destination_shape: tuple[int] | None,
+    ) -> TensorDesc:
+        """Reshape shards between a canonical N-D layout and its flattened 2-D form.
+
+        The supported transformation merges/splits the leading two dimensions:
+        canonical ``[d0, d1, *rest]`` <-> flattened ``[d0 * d1, prod(rest)]``.
+        Element order is preserved (a pure ``reshape``); shards must therefore be
+        aligned on the ``d1`` block boundary and keep the trailing dimensions
+        whole. ``reshape:`` markers map flattened -> canonical, ``flatten:`` the
+        reverse.
+        """
+        canonical = tuple(ast.literal_eval(canonical_shape))
+        source = tuple(tensor.shape)
+        destination = (
+            canonical if destination_shape is None else tuple(destination_shape)
+        )
+        if len(canonical) < 3:
+            raise ValueError(
+                "reshape expects a canonical shape with at least 3 dimensions "
+                f"(leading block + trailing dims), but got {canonical}."
+            )
+        block_width = canonical[1]
+        flattened = (
+            canonical[0] * block_width,
+            int(np.prod(canonical[2:])),
+        )
+        if source == destination:
+            return self.identity(tensor)
+        if {source, destination} != {flattened, canonical}:
+            raise ValueError(
+                "reshape only supports conversion between "
+                f"flattened={flattened} and canonical={canonical}, but got "
+                f"source={source}, destination={destination}."
+            )
+
+        forward = source == flattened
+        marker_name = "reshape" if forward else "flatten"
+        marker = f"{marker_name}:{list(canonical)}"
+        slices = []
+        for src_key, src_sl, dst_sl, pp_list in tensor.slices:
+            new_pp_list = [] if pp_list is None else pp_list.copy()
+            new_pp_list.append(marker)
+            if forward:
+                row_start = dst_sl[0].start or 0
+                row_stop = dst_sl[0].stop or source[0]
+                col_start = dst_sl[1].start or 0
+                col_stop = dst_sl[1].stop or source[1]
+                if (
+                    row_start % block_width != 0
+                    or row_stop % block_width != 0
+                    or col_start != 0
+                    or col_stop != source[1]
+                ):
+                    raise ValueError(
+                        "reshape requires block-aligned full-row source "
+                        f"slices, but got destination slice={dst_sl}."
+                    )
+                converted_dst = (
+                    slice(
+                        row_start // block_width,
+                        row_stop // block_width,
+                        1,
+                    ),
+                    *tuple(slice(0, dim, 1) for dim in canonical[1:]),
+                )
+            else:
+                block_start = dst_sl[0].start or 0
+                block_stop = dst_sl[0].stop or canonical[0]
+                if any(
+                    (sl.start or 0) != 0
+                    or (sl.stop or canonical[i]) != canonical[i]
+                    for i, sl in enumerate(dst_sl[1:], start=1)
+                ):
+                    raise ValueError(
+                        "reshape (flatten) requires complete trailing-dim "
+                        f"slices, but got source slice={dst_sl}."
+                    )
+                converted_dst = (
+                    slice(
+                        block_start * block_width,
+                        block_stop * block_width,
+                        1,
+                    ),
+                    slice(0, flattened[1], 1),
+                )
+            slices.append((src_key, src_sl, converted_dst, new_pp_list))
+
+        tensor.out_degree += 1
+        return TensorDesc(
+            slices,
+            destination,
+            in_degree=1,
+            out_degree=0,
+            dtype=tensor.dtype,
+        )
+
     def identity(self, tensor: TensorDesc) -> TensorDesc:
         tensor.out_degree += 1
         return TensorDesc(
@@ -635,6 +753,14 @@ class AOAEngine:
                                 if self.aoa_config_reverse:
                                     src_dtype, dst_dtype = dst_dtype, src_dtype
                                 result = self.cast(in_ref, dst_dtype)
+                            elif attr.key == "reshape":
+                                result = self.reshape(
+                                    in_ref,
+                                    attr.value,
+                                    self.get_destination_global_shape(
+                                        rvar.name
+                                    ),
+                                )
                             elif attr.key == "axis":
                                 result = in_ref
                             else:
@@ -732,6 +858,70 @@ class AOAEngine:
             return slice(start, stop, 1)
 
         for src_key, sl_src, sl_dst, pp_list in tensor.slices:
+            reshape_marker = next(
+                (
+                    item
+                    for item in (pp_list or [])
+                    if isinstance(item, str)
+                    and (
+                        item.startswith("reshape:")
+                        or item.startswith("flatten:")
+                    )
+                ),
+                None,
+            )
+            if reshape_marker is not None:
+                intersection = []
+                for i in range(ndim):
+                    inter = slice_intersect(local_slice[i], sl_dst[i])
+                    if inter is None:
+                        break
+                    intersection.append(inter)
+                else:
+                    canonical_shape = tuple(
+                        ast.literal_eval(reshape_marker.split(":", 1)[1])
+                    )
+                    block_width = canonical_shape[1]
+                    if reshape_marker.startswith("reshape:"):
+                        block_base = sl_dst[0].start or 0
+                        block_start = intersection[0].start - block_base
+                        block_stop = intersection[0].stop - block_base
+                        source_row_start = sl_src[0].start or 0
+                        src_slice = list(sl_src)
+                        src_slice[0] = slice(
+                            source_row_start + block_start * block_width,
+                            source_row_start + block_stop * block_width,
+                            1,
+                        )
+                    else:
+                        row_start = intersection[0].start
+                        row_stop = intersection[0].stop
+                        if (
+                            row_start % block_width != 0
+                            or row_stop % block_width != 0
+                        ):
+                            raise ValueError(
+                                "reshape (flatten) requires block-aligned "
+                                f"destination shards, but got slice={intersection}."
+                            )
+                        block_start = row_start // block_width
+                        block_stop = row_stop // block_width
+                        src_slice = (
+                            slice(block_start, block_stop, 1),
+                            *tuple(
+                                slice(0, dim, 1) for dim in canonical_shape[1:]
+                            ),
+                        )
+                    results.append(
+                        (
+                            src_key,
+                            tuple(src_slice),
+                            tuple(intersection),
+                            pp_list.copy(),
+                        )
+                    )
+                continue
+
             intersection = []
             for i in range(ndim):
                 inter = slice_intersect(local_slice[i], sl_dst[i])

--- a/python/paddle/distributed/flex_checkpoint/aoa/macros.py
+++ b/python/paddle/distributed/flex_checkpoint/aoa/macros.py
@@ -60,6 +60,7 @@ GLOBAL_ATTRIBUTE_KEYWORDS = [
     'fused_qkv',
     'src_dtype',
     'dst_dtype',
+    'reshape',
 ]
 
 EXTRA_SUFFIX = [

--- a/python/paddle/distributed/flex_checkpoint/dcp/utils.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/utils.py
@@ -286,6 +286,19 @@ def assign_sharded_slice(
             ast.literal_eval(reshape_marker.split(":", 1)[1])
         )
         block_width = canonical_shape[1]
+        # Transposes that follow the reshape/flatten marker permute the
+        # destination layout. The reshape/flatten itself must be applied in the
+        # reshape-output axis order, so express the destination region in that
+        # pre-transpose coordinate system, slice there, and only then replay the
+        # trailing transpose/cast operations to reach the final layout.
+        marker_index = postprocess_list.index(reshape_marker)
+        remaining_pp = postprocess_list[marker_index + 1 :]
+        pre_pp_offset = postprocess_transpose(
+            list(dst_desc.global_offset), remaining_pp, reverse=True
+        )
+        pre_pp_shape = postprocess_transpose(
+            list(dst_desc.local_shape), remaining_pp, reverse=True
+        )
         src_starts = [
             offset - shard_offset
             for offset, shard_offset in zip(
@@ -320,8 +333,8 @@ def assign_sharded_slice(
             )
             source_block_offset = src_desc.global_offset[0] // block_width
             target_starts = [
-                dst_desc.global_offset[0] - source_block_offset,
-                *dst_desc.global_offset[1:],
+                pre_pp_offset[0] - source_block_offset,
+                *pre_pp_offset[1:],
             ]
         else:
             if (
@@ -344,16 +357,15 @@ def assign_sharded_slice(
                 )
             )
             target_starts = [
-                dst_desc.global_offset[0] - source_block_offset * block_width,
-                dst_desc.global_offset[1],
+                pre_pp_offset[0] - source_block_offset * block_width,
+                pre_pp_offset[1],
             ]
         src_tensor_slice = paddle.slice(
             src_tensor_slice,
-            axes=list(range(len(dst_desc.local_shape))),
+            axes=list(range(len(pre_pp_shape))),
             starts=target_starts,
             ends=[
-                start + size
-                for start, size in zip(target_starts, dst_desc.local_shape)
+                start + size for start, size in zip(target_starts, pre_pp_shape)
             ],
         )
 

--- a/python/paddle/distributed/flex_checkpoint/dcp/utils.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/utils.py
@@ -331,11 +331,7 @@ def assign_sharded_slice(
             src_tensor_slice = src_tensor_slice.reshape(
                 (local_blocks, *canonical_shape[1:])
             )
-            source_block_offset = src_desc.global_offset[0] // block_width
-            target_starts = [
-                pre_pp_offset[0] - source_block_offset,
-                *pre_pp_offset[1:],
-            ]
+            target_starts = [0, *pre_pp_offset[1:]]
         else:
             if (
                 len(src_desc.local_shape) != len(canonical_shape)
@@ -349,17 +345,13 @@ def assign_sharded_slice(
                     f"global_offset={src_desc.global_offset}, "
                     f"canonical_shape={canonical_shape}."
                 )
-            source_block_offset = src_desc.global_offset[0]
             src_tensor_slice = src_tensor_slice.reshape(
                 (
                     src_desc.local_shape[0] * block_width,
                     int(np.prod(canonical_shape[2:])),
                 )
             )
-            target_starts = [
-                pre_pp_offset[0] - source_block_offset * block_width,
-                pre_pp_offset[1],
-            ]
+            target_starts = [0, pre_pp_offset[1]]
         src_tensor_slice = paddle.slice(
             src_tensor_slice,
             axes=list(range(len(pre_pp_shape))),

--- a/python/paddle/distributed/flex_checkpoint/dcp/utils.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/utils.py
@@ -345,6 +345,7 @@ def assign_sharded_slice(
                     f"global_offset={src_desc.global_offset}, "
                     f"canonical_shape={canonical_shape}."
                 )
+            # See the forward branch above.
             src_tensor_slice = src_tensor_slice.reshape(
                 (
                     src_desc.local_shape[0] * block_width,
@@ -352,6 +353,11 @@ def assign_sharded_slice(
                 )
             )
             target_starts = [0, pre_pp_offset[1]]
+        # ``paddle.slice`` and ``reshape`` both return views that share storage
+        # with the source. On some backends (e.g. XPU) slicing such a
+        # reshape-view reads wrong (all-zero) data, so materialize a contiguous,
+        # owning copy of the reshaped layout before the slice below.
+        src_tensor_slice = src_tensor_slice.clone()
         src_tensor_slice = paddle.slice(
             src_tensor_slice,
             axes=list(range(len(pre_pp_shape))),
@@ -376,16 +382,11 @@ def assign_sharded_slice(
                 dst_desc.global_offset, dst_shard.global_offset
             )
         ]
-        dst_tensor_slice = paddle.slice(
-            dst_shard.local_tensor,
-            axes=list(range(len(dst_desc.local_shape))),
-            starts=dst_starts,
-            ends=[
-                start + size
-                for start, size in zip(dst_starts, dst_desc.local_shape)
-            ],
+        dst_index = tuple(
+            slice(start, start + size)
+            for start, size in zip(dst_starts, dst_desc.local_shape)
         )
-        paddle.assign(src_tensor_slice, dst_tensor_slice)
+        dst_shard.local_tensor[dst_index] = src_tensor_slice
         return
 
     src_has, _, overlap_shape, src_desc_starts, src_shard_starts = (

--- a/python/paddle/distributed/flex_checkpoint/dcp/utils.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/utils.py
@@ -268,6 +268,122 @@ def get_overlap_region(desc_offset, desc_shape, shard_offset, shard_shape):
 def assign_sharded_slice(
     src_desc, src_shard, dst_desc, dst_shard, postprocess_list=None
 ):
+    # Leading-block reshape between an N-D canonical layout and its 2-D
+    # flattened form: canonical [d0, d1, *rest] <-> flattened [d0*d1, prod(rest)].
+    # "reshape:" maps flattened(2-D) -> canonical(N-D); "flatten:" the reverse.
+    reshape_marker = next(
+        (
+            item
+            for item in (postprocess_list or [])
+            if isinstance(item, str)
+            and (item.startswith("reshape:") or item.startswith("flatten:"))
+        ),
+        None,
+    )
+    if reshape_marker is not None:
+        _is_forward = reshape_marker.startswith("reshape:")
+        canonical_shape = tuple(
+            ast.literal_eval(reshape_marker.split(":", 1)[1])
+        )
+        block_width = canonical_shape[1]
+        src_starts = [
+            offset - shard_offset
+            for offset, shard_offset in zip(
+                src_desc.global_offset, src_shard.global_offset
+            )
+        ]
+        src_tensor_slice = paddle.slice(
+            src_shard.local_tensor,
+            axes=list(range(len(src_desc.local_shape))),
+            starts=src_starts,
+            ends=[
+                start + size
+                for start, size in zip(src_starts, src_desc.local_shape)
+            ],
+        )
+        if _is_forward:
+            if (
+                src_desc.local_shape[0] % block_width != 0
+                or src_desc.global_offset[0] % block_width != 0
+                or src_desc.local_shape[1] != int(np.prod(canonical_shape[2:]))
+                or src_desc.global_offset[1] != 0
+            ):
+                raise ValueError(
+                    "reshape requires block-aligned full-row source shards, "
+                    f"but got local_shape={src_desc.local_shape}, "
+                    f"global_offset={src_desc.global_offset}, "
+                    f"canonical_shape={canonical_shape}."
+                )
+            local_blocks = src_desc.local_shape[0] // block_width
+            src_tensor_slice = src_tensor_slice.reshape(
+                (local_blocks, *canonical_shape[1:])
+            )
+            source_block_offset = src_desc.global_offset[0] // block_width
+            target_starts = [
+                dst_desc.global_offset[0] - source_block_offset,
+                *dst_desc.global_offset[1:],
+            ]
+        else:
+            if (
+                len(src_desc.local_shape) != len(canonical_shape)
+                or src_desc.local_shape[1:] != canonical_shape[1:]
+                or src_desc.global_offset[1:]
+                != (0,) * (len(canonical_shape) - 1)
+            ):
+                raise ValueError(
+                    "flatten requires complete trailing-dim source shards, "
+                    f"but got local_shape={src_desc.local_shape}, "
+                    f"global_offset={src_desc.global_offset}, "
+                    f"canonical_shape={canonical_shape}."
+                )
+            source_block_offset = src_desc.global_offset[0]
+            src_tensor_slice = src_tensor_slice.reshape(
+                (
+                    src_desc.local_shape[0] * block_width,
+                    int(np.prod(canonical_shape[2:])),
+                )
+            )
+            target_starts = [
+                dst_desc.global_offset[0] - source_block_offset * block_width,
+                dst_desc.global_offset[1],
+            ]
+        src_tensor_slice = paddle.slice(
+            src_tensor_slice,
+            axes=list(range(len(dst_desc.local_shape))),
+            starts=target_starts,
+            ends=[
+                start + size
+                for start, size in zip(target_starts, dst_desc.local_shape)
+            ],
+        )
+
+        for operation in postprocess_list:
+            if operation == reshape_marker:
+                continue
+            is_list, result = is_list_string(operation)
+            if is_list:
+                src_tensor_slice = paddle.transpose(src_tensor_slice, result)
+            elif isinstance(operation, str):
+                src_tensor_slice = paddle.cast(src_tensor_slice, operation)
+
+        dst_starts = [
+            offset - shard_offset
+            for offset, shard_offset in zip(
+                dst_desc.global_offset, dst_shard.global_offset
+            )
+        ]
+        dst_tensor_slice = paddle.slice(
+            dst_shard.local_tensor,
+            axes=list(range(len(dst_desc.local_shape))),
+            starts=dst_starts,
+            ends=[
+                start + size
+                for start, size in zip(dst_starts, dst_desc.local_shape)
+            ],
+        )
+        paddle.assign(src_tensor_slice, dst_tensor_slice)
+        return
+
     src_has, _, overlap_shape, src_desc_starts, src_shard_starts = (
         get_overlap_region(
             src_desc.global_offset,

--- a/test/flex_checkpoint/test_aoa_engine_reshape.py
+++ b/test/flex_checkpoint/test_aoa_engine_reshape.py
@@ -78,139 +78,76 @@ def _fill_target(engine, source_tensors, tgt_desc, dtype="float32"):
 
 
 class TestAOAEngineReshape(unittest.TestCase):
-    def test_forward_full(self):
-        # flattened [6, 4] -> canonical [2, 3, 2, 2]
-        source = paddle.arange(np.prod(FLATTENED), dtype="float32").reshape(
-            list(FLATTENED)
+    def test_full_and_sharded_reshape(self):
+        cases = (
+            (
+                "forward_full",
+                FLATTENED,
+                CANONICAL,
+                ((CANONICAL, (0, 0, 0, 0)),),
+            ),
+            (
+                "forward_sharded",
+                FLATTENED,
+                CANONICAL,
+                (
+                    ((1, H, TWO, I), (0, 0, 0, 0)),
+                    ((1, H, TWO, I), (1, 0, 0, 0)),
+                ),
+            ),
+            ("reverse_full", CANONICAL, FLATTENED, ((FLATTENED, (0, 0)),)),
+            (
+                "reverse_sharded",
+                CANONICAL,
+                FLATTENED,
+                (((H, TWO * I), (0, 0)), ((H, TWO * I), (H, 0))),
+            ),
         )
-        expected = source.reshape(list(CANONICAL))
-
-        source_desc = {
-            "s0": [
-                ShardedWeightDesc("s0", FLATTENED, FLATTENED, (0, 0), "float32")
-            ]
-        }
-        dest_desc = {
-            "d": [
-                ShardedWeightDesc(
-                    "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+        for name, source_shape, destination_shape, shards in cases:
+            with self.subTest(name=name):
+                source = paddle.arange(
+                    np.prod(source_shape), dtype="float32"
+                ).reshape(list(source_shape))
+                source_offset = (0,) * len(source_shape)
+                source_desc = {
+                    "s0": [
+                        ShardedWeightDesc(
+                            "s0",
+                            source_shape,
+                            source_shape,
+                            source_offset,
+                            "float32",
+                        )
+                    ]
+                }
+                dest_desc = {
+                    "d": [
+                        ShardedWeightDesc(
+                            "d", shape, destination_shape, offset, "float32"
+                        )
+                        for shape, offset in shards
+                    ]
+                }
+                engine = _build_engine(
+                    source_desc,
+                    dest_desc,
+                    [f"s0 -> d, reshape = '{CANONICAL_STR}'"],
                 )
-            ]
-        }
-        engine = _build_engine(
-            source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
-        )
-
-        tgt = ShardedWeightDesc(
-            "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
-        )
-        out = _fill_target(engine, {"s0": source}, tgt)
-        np.testing.assert_allclose(out.numpy(), expected.numpy())
-
-    def test_forward_sharded_along_experts(self):
-        # destination canonical split along the leading (expert) dim
-        source = paddle.arange(np.prod(FLATTENED), dtype="float32").reshape(
-            list(FLATTENED)
-        )
-        expected = source.reshape(list(CANONICAL))
-
-        source_desc = {
-            "s0": [
-                ShardedWeightDesc("s0", FLATTENED, FLATTENED, (0, 0), "float32")
-            ]
-        }
-        shard_shape = (1, H, TWO, I)
-        dest_desc = {
-            "d": [
-                ShardedWeightDesc(
-                    "d", shard_shape, CANONICAL, (0, 0, 0, 0), "float32"
-                ),
-                ShardedWeightDesc(
-                    "d", shard_shape, CANONICAL, (1, 0, 0, 0), "float32"
-                ),
-            ]
-        }
-        engine = _build_engine(
-            source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
-        )
-
-        for expert in range(E):
-            tgt = ShardedWeightDesc(
-                "d", shard_shape, CANONICAL, (expert, 0, 0, 0), "float32"
-            )
-            out = _fill_target(engine, {"s0": source}, tgt)
-            np.testing.assert_allclose(
-                out.numpy(), expected.numpy()[expert : expert + 1]
-            )
-
-    def test_reverse_full(self):
-        # canonical [2, 3, 2, 2] -> flattened [6, 4]
-        source = paddle.arange(np.prod(CANONICAL), dtype="float32").reshape(
-            list(CANONICAL)
-        )
-        expected = source.reshape(list(FLATTENED))
-
-        source_desc = {
-            "s0": [
-                ShardedWeightDesc(
-                    "s0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
-                )
-            ]
-        }
-        dest_desc = {
-            "d": [
-                ShardedWeightDesc("d", FLATTENED, FLATTENED, (0, 0), "float32")
-            ]
-        }
-        engine = _build_engine(
-            source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
-        )
-
-        tgt = ShardedWeightDesc("d", FLATTENED, FLATTENED, (0, 0), "float32")
-        out = _fill_target(engine, {"s0": source}, tgt)
-        np.testing.assert_allclose(out.numpy(), expected.numpy())
-
-    def test_reverse_sharded_block_aligned(self):
-        # destination flattened split into block-aligned row chunks
-        source = paddle.arange(np.prod(CANONICAL), dtype="float32").reshape(
-            list(CANONICAL)
-        )
-        expected = source.reshape(list(FLATTENED))
-
-        source_desc = {
-            "s0": [
-                ShardedWeightDesc(
-                    "s0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
-                )
-            ]
-        }
-        shard_shape = (H, TWO * I)
-        dest_desc = {
-            "d": [
-                ShardedWeightDesc(
-                    "d", shard_shape, FLATTENED, (0, 0), "float32"
-                ),
-                ShardedWeightDesc(
-                    "d", shard_shape, FLATTENED, (H, 0), "float32"
-                ),
-            ]
-        }
-        engine = _build_engine(
-            source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
-        )
-
-        for block in range(E):
-            offset = block * H
-            tgt = ShardedWeightDesc(
-                "d", shard_shape, FLATTENED, (offset, 0), "float32"
-            )
-            out = _fill_target(engine, {"s0": source}, tgt)
-            np.testing.assert_allclose(
-                out.numpy(), expected.numpy()[offset : offset + H]
-            )
+                expected = source.reshape(list(destination_shape))
+                for shape, offset in shards:
+                    target = ShardedWeightDesc(
+                        "d", shape, destination_shape, offset, "float32"
+                    )
+                    out = _fill_target(engine, {"s0": source}, target)
+                    index = tuple(
+                        slice(start, start + size)
+                        for start, size in zip(offset, shape)
+                    )
+                    np.testing.assert_allclose(
+                        out.numpy(), expected[index].numpy()
+                    )
 
     def test_identity_when_source_equals_destination(self):
-        # source already canonical and destination canonical -> no reshape marker
         source_desc = {
             "s0": [
                 ShardedWeightDesc(
@@ -279,8 +216,6 @@ class TestGetDestinationGlobalShape(unittest.TestCase):
         self.assertEqual(engine.get_destination_global_shape("d"), CANONICAL)
 
     def test_resolves_unique_shape_via_optimizer_state_keys(self):
-        # "d" is not a direct key, but both optimizer-state keys strip to "d"
-        # and share a single global shape.
         dest_desc = {
             "d.w_0": [
                 ShardedWeightDesc(
@@ -327,11 +262,7 @@ class TestGetDestinationGlobalShape(unittest.TestCase):
 
 class TestAOAEngineReshapeMultiSource(unittest.TestCase):
     def test_forward_query_skips_non_intersecting_slice(self):
-        # Two block-aligned flattened sources concat along rows, then reshape to
-        # canonical. The reshaped tensor carries two slices (one per expert), so
-        # a per-expert query intersects exactly one of them; the other slice is
-        # skipped, exercising the non-intersecting branch in find_shard_sources.
-        block = (H, TWO * I)  # (3, 4) == one expert block in flattened form
+        block = (H, TWO * I)
         source_desc = {
             "s0": [ShardedWeightDesc("s0", block, block, (0, 0), "float32")],
             "s1": [ShardedWeightDesc("s1", block, block, (0, 0), "float32")],
@@ -359,8 +290,6 @@ class TestAOAEngineReshapeMultiSource(unittest.TestCase):
                 "d", shard_shape, CANONICAL, (expert, 0, 0, 0), "float32"
             )
             mappings = engine.find_shard_sources(tgt)
-            # Only the intersecting slice for this expert is returned; the other
-            # reshaped slice is skipped via the non-intersecting branch.
             self.assertEqual(len(mappings), 1)
             self.assertEqual(
                 mappings[0].source_slice.key, expected_source_key[expert]
@@ -370,35 +299,44 @@ class TestAOAEngineReshapeMultiSource(unittest.TestCase):
                 (expert, 0, 0, 0),
             )
 
-
-class TestAssignShardedSliceReshapeMultiPostprocess(unittest.TestCase):
-    def test_reshape_then_transpose_then_cast(self):
-        # A reshape marker followed by two more operations exercises the
-        # postprocess loop across multiple iterations (transpose then cast).
-        source = paddle.arange(
-            int(np.prod(FLATTENED)), dtype="float32"
-        ).reshape(list(FLATTENED))
-        src_desc = ShardedWeightDesc(
-            "s", FLATTENED, FLATTENED, (0, 0), "float32"
+    def test_reverse_concat_reads_each_source(self):
+        block_shape = (1, H, TWO, I)
+        sources = {
+            f"s{expert}": paddle.arange(
+                expert * H * TWO * I,
+                (expert + 1) * H * TWO * I,
+                dtype="float32",
+            ).reshape(block_shape)
+            for expert in range(E)
+        }
+        source_desc = {
+            key: [
+                ShardedWeightDesc(
+                    key, block_shape, block_shape, (0, 0, 0, 0), "float32"
+                )
+            ]
+            for key in sources
+        }
+        shard_shape = (H, TWO * I)
+        dest_desc = {
+            "d": [
+                ShardedWeightDesc(
+                    "d", shard_shape, FLATTENED, (expert * H, 0), "float32"
+                )
+                for expert in range(E)
+            ]
+        }
+        engine = _build_engine(
+            source_desc,
+            dest_desc,
+            ["s0, s1 -> s, axis = 0", f"s -> d, reshape = '{CANONICAL_STR}'"],
         )
-        src_shard = ShardedWeight("s", source, FLATTENED, FLATTENED, (0, 0))
-        out = paddle.zeros(list(CANONICAL), dtype="float16")
-        dst_desc = ShardedWeightDesc(
-            "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float16"
-        )
-        dst_shard = ShardedWeight("d", out, CANONICAL, CANONICAL, (0, 0, 0, 0))
-
-        assign_sharded_slice(
-            src_desc,
-            src_shard,
-            dst_desc,
-            dst_shard,
-            [f"reshape:{CANONICAL_STR}", "[2, 1, 0, 3]", "float16"],
-        )
-        expected = paddle.transpose(
-            source.reshape(list(CANONICAL)), [2, 1, 0, 3]
-        ).astype("float16")
-        np.testing.assert_allclose(out.numpy(), expected.numpy())
+        for expert in range(E):
+            target = dest_desc["d"][expert]
+            out = _fill_target(engine, sources, target)
+            np.testing.assert_allclose(
+                out.numpy(), sources[f"s{expert}"].reshape(shard_shape).numpy()
+            )
 
 
 class TestAOAEngineReshapeErrors(unittest.TestCase):
@@ -597,18 +535,21 @@ class TestAssignShardedSliceReshapePostprocess(unittest.TestCase):
         dst_shard = ShardedWeight("d", out, CANONICAL, CANONICAL, (0, 0, 0, 0))
         return source, src_desc, src_shard, dst_desc, dst_shard, out
 
-    def test_reshape_then_cast(self):
+    def test_reshape_then_transpose_then_cast(self):
         source, src_desc, src_shard, dst_desc, dst_shard, out = (
             self._forward_src_dst("float16")
         )
+        permutation = [2, 1, 0, 3]
         assign_sharded_slice(
             src_desc,
             src_shard,
             dst_desc,
             dst_shard,
-            [f"reshape:{CANONICAL_STR}", "float16"],
+            [f"reshape:{CANONICAL_STR}", str(permutation), "float16"],
         )
-        expected = source.reshape(list(CANONICAL)).astype("float16")
+        expected = paddle.transpose(
+            source.reshape(list(CANONICAL)), permutation
+        ).astype("float16")
         np.testing.assert_allclose(out.numpy(), expected.numpy())
 
     def test_reshape_then_transpose(self):

--- a/test/flex_checkpoint/test_aoa_engine_reshape.py
+++ b/test/flex_checkpoint/test_aoa_engine_reshape.py
@@ -1,0 +1,586 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.distributed.flex_checkpoint.aoa.aoa_engine import (
+    AOAEngine,
+    ShardedWeightDesc,
+)
+from paddle.distributed.flex_checkpoint.dcp.sharded_weight import ShardedWeight
+from paddle.distributed.flex_checkpoint.dcp.utils import assign_sharded_slice
+
+# canonical [E, H, 2, I] <-> flattened [E * H, 2 * I]
+E, H, TWO, I = 2, 3, 2, 2
+CANONICAL = (E, H, TWO, I)
+FLATTENED = (E * H, TWO * I)
+CANONICAL_STR = "[2, 3, 2, 2]"
+
+
+def _build_engine(source_desc, dest_desc, statements):
+    return AOAEngine(
+        aoa_config={"aoa_statements": statements},
+        source_state_shard_info=source_desc,
+        destination_state_shard_info=dest_desc,
+    )
+
+
+def _fill_target(engine, source_tensors, tgt_desc, dtype="float32"):
+    """Reproduce the local reshard loop of load_state_dict for one target shard."""
+    out = paddle.zeros(list(tgt_desc.local_shape), dtype=dtype)
+    dst_shard = ShardedWeight(
+        key=tgt_desc.key,
+        local_tensor=out,
+        local_shape=tgt_desc.local_shape,
+        global_shape=tgt_desc.global_shape,
+        global_offset=tgt_desc.global_offset,
+    )
+    for mapping in engine.find_shard_sources(tgt_desc):
+        src_desc = mapping.source_slice
+        dst_desc = mapping.target_slice
+        full = source_tensors[src_desc.key]
+        region_index = tuple(
+            slice(offset, offset + size)
+            for offset, size in zip(
+                src_desc.global_offset, src_desc.local_shape
+            )
+        )
+        region = full[region_index].clone()
+        src_shard = ShardedWeight(
+            key=src_desc.key,
+            local_tensor=region,
+            local_shape=src_desc.local_shape,
+            global_shape=src_desc.global_shape,
+            global_offset=src_desc.global_offset,
+        )
+        assign_sharded_slice(
+            src_desc,
+            src_shard,
+            dst_desc,
+            dst_shard,
+            mapping.postprocess_list,
+        )
+    return out
+
+
+class TestAOAEngineReshape(unittest.TestCase):
+    def test_forward_full(self):
+        # flattened [6, 4] -> canonical [2, 3, 2, 2]
+        source = paddle.arange(np.prod(FLATTENED), dtype="float32").reshape(
+            list(FLATTENED)
+        )
+        expected = source.reshape(list(CANONICAL))
+
+        source_desc = {
+            "s0": [
+                ShardedWeightDesc("s0", FLATTENED, FLATTENED, (0, 0), "float32")
+            ]
+        }
+        dest_desc = {
+            "d": [
+                ShardedWeightDesc(
+                    "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                )
+            ]
+        }
+        engine = _build_engine(
+            source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
+        )
+
+        tgt = ShardedWeightDesc(
+            "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+        )
+        out = _fill_target(engine, {"s0": source}, tgt)
+        np.testing.assert_allclose(out.numpy(), expected.numpy())
+
+    def test_forward_sharded_along_experts(self):
+        # destination canonical split along the leading (expert) dim
+        source = paddle.arange(np.prod(FLATTENED), dtype="float32").reshape(
+            list(FLATTENED)
+        )
+        expected = source.reshape(list(CANONICAL))
+
+        source_desc = {
+            "s0": [
+                ShardedWeightDesc("s0", FLATTENED, FLATTENED, (0, 0), "float32")
+            ]
+        }
+        shard_shape = (1, H, TWO, I)
+        dest_desc = {
+            "d": [
+                ShardedWeightDesc(
+                    "d", shard_shape, CANONICAL, (0, 0, 0, 0), "float32"
+                ),
+                ShardedWeightDesc(
+                    "d", shard_shape, CANONICAL, (1, 0, 0, 0), "float32"
+                ),
+            ]
+        }
+        engine = _build_engine(
+            source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
+        )
+
+        for expert in range(E):
+            tgt = ShardedWeightDesc(
+                "d", shard_shape, CANONICAL, (expert, 0, 0, 0), "float32"
+            )
+            out = _fill_target(engine, {"s0": source}, tgt)
+            np.testing.assert_allclose(
+                out.numpy(), expected.numpy()[expert : expert + 1]
+            )
+
+    def test_reverse_full(self):
+        # canonical [2, 3, 2, 2] -> flattened [6, 4]
+        source = paddle.arange(np.prod(CANONICAL), dtype="float32").reshape(
+            list(CANONICAL)
+        )
+        expected = source.reshape(list(FLATTENED))
+
+        source_desc = {
+            "s0": [
+                ShardedWeightDesc(
+                    "s0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                )
+            ]
+        }
+        dest_desc = {
+            "d": [ShardedWeightDesc("d", FLATTENED, FLATTENED, (0, 0), "float32")]
+        }
+        engine = _build_engine(
+            source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
+        )
+
+        tgt = ShardedWeightDesc("d", FLATTENED, FLATTENED, (0, 0), "float32")
+        out = _fill_target(engine, {"s0": source}, tgt)
+        np.testing.assert_allclose(out.numpy(), expected.numpy())
+
+    def test_reverse_sharded_block_aligned(self):
+        # destination flattened split into block-aligned row chunks
+        source = paddle.arange(np.prod(CANONICAL), dtype="float32").reshape(
+            list(CANONICAL)
+        )
+        expected = source.reshape(list(FLATTENED))
+
+        source_desc = {
+            "s0": [
+                ShardedWeightDesc(
+                    "s0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                )
+            ]
+        }
+        shard_shape = (H, TWO * I)
+        dest_desc = {
+            "d": [
+                ShardedWeightDesc(
+                    "d", shard_shape, FLATTENED, (0, 0), "float32"
+                ),
+                ShardedWeightDesc(
+                    "d", shard_shape, FLATTENED, (H, 0), "float32"
+                ),
+            ]
+        }
+        engine = _build_engine(
+            source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
+        )
+
+        for block in range(E):
+            offset = block * H
+            tgt = ShardedWeightDesc(
+                "d", shard_shape, FLATTENED, (offset, 0), "float32"
+            )
+            out = _fill_target(engine, {"s0": source}, tgt)
+            np.testing.assert_allclose(
+                out.numpy(), expected.numpy()[offset : offset + H]
+            )
+
+    def test_identity_when_source_equals_destination(self):
+        # source already canonical and destination canonical -> no reshape marker
+        source_desc = {
+            "s0": [
+                ShardedWeightDesc(
+                    "s0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                )
+            ]
+        }
+        dest_desc = {
+            "d": [
+                ShardedWeightDesc(
+                    "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                )
+            ]
+        }
+        engine = _build_engine(
+            source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
+        )
+        tgt = ShardedWeightDesc(
+            "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+        )
+        mappings = engine.find_shard_sources(tgt)
+        for mapping in mappings:
+            markers = [
+                item
+                for item in (mapping.postprocess_list or [])
+                if isinstance(item, str)
+                and (item.startswith("reshape:") or item.startswith("flatten:"))
+            ]
+            self.assertEqual(markers, [])
+
+
+class TestGetDestinationGlobalShape(unittest.TestCase):
+    def _engine(self, dest_desc):
+        source_desc = {
+            "s0": [ShardedWeightDesc("s0", FLATTENED, FLATTENED, (0, 0), "float32")]
+        }
+        return _build_engine(
+            source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
+        )
+
+    def test_returns_none_without_destination_info(self):
+        engine = self._engine(
+            {"d": [ShardedWeightDesc("d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32")]}
+        )
+        engine.destination_state_shard_info = None
+        self.assertIsNone(engine.get_destination_global_shape("d"))
+
+    def test_direct_key_hit(self):
+        engine = self._engine(
+            {"d": [ShardedWeightDesc("d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32")]}
+        )
+        self.assertEqual(
+            engine.get_destination_global_shape("d"), CANONICAL
+        )
+
+    def test_resolves_unique_shape_via_optimizer_state_keys(self):
+        # "d" is not a direct key, but both optimizer-state keys strip to "d"
+        # and share a single global shape.
+        dest_desc = {
+            "d.w_0": [
+                ShardedWeightDesc("d.w_0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32")
+            ],
+            "d.moment1_0": [
+                ShardedWeightDesc(
+                    "d.moment1_0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                )
+            ],
+        }
+        engine = self._engine(dest_desc)
+        self.assertEqual(engine.get_destination_global_shape("d"), CANONICAL)
+
+    def test_ambiguous_shape_raises(self):
+        # two keys strip to "d" but carry conflicting global shapes. Inject the
+        # ambiguous metadata after a valid build so the failure is isolated to
+        # get_destination_global_shape rather than shape propagation at build.
+        engine = self._engine(
+            {"d": [ShardedWeightDesc("d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32")]}
+        )
+        engine.destination_state_shard_info = {
+            "d.w_0": [
+                ShardedWeightDesc("d.w_0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32")
+            ],
+            "d.moment1_0": [
+                ShardedWeightDesc(
+                    "d.moment1_0", FLATTENED, FLATTENED, (0, 0), "float32"
+                )
+            ],
+        }
+        with self.assertRaises(ValueError):
+            engine.get_destination_global_shape("d")
+
+
+class TestAOAEngineReshapeMultiSource(unittest.TestCase):
+    def test_forward_query_skips_non_intersecting_slice(self):
+        # Two block-aligned flattened sources concat along rows, then reshape to
+        # canonical. The reshaped tensor carries two slices (one per expert), so
+        # a per-expert query intersects exactly one of them; the other slice is
+        # skipped, exercising the non-intersecting branch in find_shard_sources.
+        block = (H, TWO * I)  # (3, 4) == one expert block in flattened form
+        source_desc = {
+            "s0": [ShardedWeightDesc("s0", block, block, (0, 0), "float32")],
+            "s1": [ShardedWeightDesc("s1", block, block, (0, 0), "float32")],
+        }
+        shard_shape = (1, H, TWO, I)
+        dest_desc = {
+            "d": [
+                ShardedWeightDesc("d", shard_shape, CANONICAL, (0, 0, 0, 0), "float32"),
+                ShardedWeightDesc("d", shard_shape, CANONICAL, (1, 0, 0, 0), "float32"),
+            ]
+        }
+        engine = _build_engine(
+            source_desc,
+            dest_desc,
+            ["s0, s1 -> s, axis = 0", f"s -> d, reshape = '{CANONICAL_STR}'"],
+        )
+
+        expected_source_key = {0: "s0", 1: "s1"}
+        for expert in range(E):
+            tgt = ShardedWeightDesc(
+                "d", shard_shape, CANONICAL, (expert, 0, 0, 0), "float32"
+            )
+            mappings = engine.find_shard_sources(tgt)
+            # Only the intersecting slice for this expert is returned; the other
+            # reshaped slice is skipped via the non-intersecting branch.
+            self.assertEqual(len(mappings), 1)
+            self.assertEqual(
+                mappings[0].source_slice.key, expected_source_key[expert]
+            )
+            self.assertEqual(
+                tuple(mappings[0].target_slice.global_offset),
+                (expert, 0, 0, 0),
+            )
+
+class TestAssignShardedSliceReshapeMultiPostprocess(unittest.TestCase):
+    def test_reshape_then_transpose_then_cast(self):
+        # A reshape marker followed by two more operations exercises the
+        # postprocess loop across multiple iterations (transpose then cast).
+        source = paddle.arange(
+            int(np.prod(FLATTENED)), dtype="float32"
+        ).reshape(list(FLATTENED))
+        src_desc = ShardedWeightDesc("s", FLATTENED, FLATTENED, (0, 0), "float32")
+        src_shard = ShardedWeight("s", source, FLATTENED, FLATTENED, (0, 0))
+        out = paddle.zeros(list(CANONICAL), dtype="float16")
+        dst_desc = ShardedWeightDesc(
+            "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float16"
+        )
+        dst_shard = ShardedWeight("d", out, CANONICAL, CANONICAL, (0, 0, 0, 0))
+
+        assign_sharded_slice(
+            src_desc,
+            src_shard,
+            dst_desc,
+            dst_shard,
+            [f"reshape:{CANONICAL_STR}", "[2, 1, 0, 3]", "float16"],
+        )
+        expected = paddle.transpose(
+            source.reshape(list(CANONICAL)), [2, 1, 0, 3]
+        ).astype("float16")
+        np.testing.assert_allclose(out.numpy(), expected.numpy())
+
+
+class TestAOAEngineReshapeErrors(unittest.TestCase):
+    def _build(self, source_desc, dest_desc, statements):
+        return _build_engine(source_desc, dest_desc, statements)
+
+    def test_canonical_shape_too_few_dims(self):
+        source_desc = {
+            "s0": [ShardedWeightDesc("s0", (6, 4), (6, 4), (0, 0), "float32")]
+        }
+        dest_desc = {
+            "d": [ShardedWeightDesc("d", (6, 4), (6, 4), (0, 0), "float32")]
+        }
+        with self.assertRaises(ValueError):
+            self._build(source_desc, dest_desc, ["s0 -> d, reshape = '[6, 4]'"])
+
+    def test_unsupported_conversion(self):
+        # source (5, 4) is neither the flattened (6, 4) nor canonical form
+        source_desc = {
+            "s0": [ShardedWeightDesc("s0", (5, 4), (5, 4), (0, 0), "float32")]
+        }
+        dest_desc = {
+            "d": [
+                ShardedWeightDesc(
+                    "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                )
+            ]
+        }
+        with self.assertRaises(ValueError):
+            self._build(
+                source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
+            )
+
+    def test_flatten_query_not_block_aligned(self):
+        source = paddle.arange(np.prod(CANONICAL), dtype="float32").reshape(
+            list(CANONICAL)
+        )
+        source_desc = {
+            "s0": [
+                ShardedWeightDesc(
+                    "s0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                )
+            ]
+        }
+        dest_desc = {
+            "d": [ShardedWeightDesc("d", FLATTENED, FLATTENED, (0, 0), "float32")]
+        }
+        engine = _build_engine(
+            source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
+        )
+        # rows [0:2] are not aligned to block_width H=3
+        tgt = ShardedWeightDesc("d", (2, TWO * I), FLATTENED, (0, 0), "float32")
+        with self.assertRaises(ValueError):
+            _fill_target(engine, {"s0": source}, tgt)
+
+
+class TestAssignShardedSliceReshapeErrors(unittest.TestCase):
+    def test_forward_source_not_block_aligned(self):
+        src_desc = ShardedWeightDesc("s", (2, 4), FLATTENED, (0, 0), "float32")
+        src_shard = ShardedWeight(
+            "s", paddle.zeros([2, 4], dtype="float32"), (2, 4), FLATTENED, (0, 0)
+        )
+        dst_desc = ShardedWeightDesc(
+            "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+        )
+        dst_shard = ShardedWeight(
+            "d",
+            paddle.zeros(list(CANONICAL), dtype="float32"),
+            CANONICAL,
+            CANONICAL,
+            (0, 0, 0, 0),
+        )
+        with self.assertRaises(ValueError):
+            assign_sharded_slice(
+                src_desc,
+                src_shard,
+                dst_desc,
+                dst_shard,
+                [f"reshape:{CANONICAL_STR}"],
+            )
+
+    def test_flatten_source_trailing_dims_incomplete(self):
+        # trailing dims (2, 2, 2) do not match canonical trailing dims (3, 2, 2)
+        bad_canonical = (1, 2, 2, 2)
+        src_desc = ShardedWeightDesc(
+            "s", bad_canonical, CANONICAL, (0, 0, 0, 0), "float32"
+        )
+        src_shard = ShardedWeight(
+            "s",
+            paddle.zeros(list(bad_canonical), dtype="float32"),
+            bad_canonical,
+            CANONICAL,
+            (0, 0, 0, 0),
+        )
+        dst_desc = ShardedWeightDesc(
+            "d", (H, TWO * I), FLATTENED, (0, 0), "float32"
+        )
+        dst_shard = ShardedWeight(
+            "d",
+            paddle.zeros([H, TWO * I], dtype="float32"),
+            (H, TWO * I),
+            FLATTENED,
+            (0, 0),
+        )
+        with self.assertRaises(ValueError):
+            assign_sharded_slice(
+                src_desc,
+                src_shard,
+                dst_desc,
+                dst_shard,
+                [f"flatten:{CANONICAL_STR}"],
+            )
+
+
+class TestAOAEngineReshapeMisalignedSlices(unittest.TestCase):
+    """Cover the reshape() alignment checks reached via a preceding concat."""
+
+    def test_forward_concat_source_not_block_aligned(self):
+        # concat produces flattened row slices [0:2] and [2:6]; the [0:2] slice
+        # is not aligned to block_width H=3.
+        source_desc = {
+            "s0": [ShardedWeightDesc("s0", (2, 4), (2, 4), (0, 0), "float32")],
+            "s1": [ShardedWeightDesc("s1", (4, 4), (4, 4), (0, 0), "float32")],
+        }
+        dest_desc = {
+            "d": [
+                ShardedWeightDesc(
+                    "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                )
+            ]
+        }
+        with self.assertRaises(ValueError):
+            _build_engine(
+                source_desc,
+                dest_desc,
+                [
+                    "s0, s1 -> s, axis = 0",
+                    f"s -> d, reshape = '{CANONICAL_STR}'",
+                ],
+            )
+
+    def test_reverse_concat_trailing_dims_incomplete(self):
+        # concat along a trailing dim leaves canonical slices that are not
+        # complete on that dim, so the flatten direction must reject them.
+        source_desc = {
+            "a": [ShardedWeightDesc("a", (2, 3, 1, 2), (2, 3, 1, 2), (0, 0, 0, 0), "float32")],
+            "b": [ShardedWeightDesc("b", (2, 3, 1, 2), (2, 3, 1, 2), (0, 0, 0, 0), "float32")],
+        }
+        dest_desc = {
+            "d": [ShardedWeightDesc("d", FLATTENED, FLATTENED, (0, 0), "float32")]
+        }
+        with self.assertRaises(ValueError):
+            _build_engine(
+                source_desc,
+                dest_desc,
+                [
+                    "a, b -> s, axis = 2",
+                    f"s -> d, reshape = '{CANONICAL_STR}'",
+                ],
+            )
+
+
+class TestAssignShardedSliceReshapePostprocess(unittest.TestCase):
+    """Cover the transpose/cast postprocess loop that follows a reshape."""
+
+    def _forward_src_dst(self, dtype):
+        source = paddle.arange(
+            int(np.prod(FLATTENED)), dtype="float32"
+        ).reshape(list(FLATTENED))
+        src_desc = ShardedWeightDesc("s", FLATTENED, FLATTENED, (0, 0), "float32")
+        src_shard = ShardedWeight(
+            "s", source, FLATTENED, FLATTENED, (0, 0)
+        )
+        out = paddle.zeros(list(CANONICAL), dtype=dtype)
+        dst_desc = ShardedWeightDesc(
+            "d", CANONICAL, CANONICAL, (0, 0, 0, 0), dtype
+        )
+        dst_shard = ShardedWeight(
+            "d", out, CANONICAL, CANONICAL, (0, 0, 0, 0)
+        )
+        return source, src_desc, src_shard, dst_desc, dst_shard, out
+
+    def test_reshape_then_cast(self):
+        source, src_desc, src_shard, dst_desc, dst_shard, out = (
+            self._forward_src_dst("float16")
+        )
+        assign_sharded_slice(
+            src_desc,
+            src_shard,
+            dst_desc,
+            dst_shard,
+            [f"reshape:{CANONICAL_STR}", "float16"],
+        )
+        expected = source.reshape(list(CANONICAL)).astype("float16")
+        np.testing.assert_allclose(out.numpy(), expected.numpy())
+
+    def test_reshape_then_transpose(self):
+        # perm [2, 1, 0, 3] keeps the shape (2, 3, 2, 2) unchanged.
+        source, src_desc, src_shard, dst_desc, dst_shard, out = (
+            self._forward_src_dst("float32")
+        )
+        assign_sharded_slice(
+            src_desc,
+            src_shard,
+            dst_desc,
+            dst_shard,
+            [f"reshape:{CANONICAL_STR}", "[2, 1, 0, 3]"],
+        )
+        expected = paddle.transpose(
+            source.reshape(list(CANONICAL)), [2, 1, 0, 3]
+        )
+        np.testing.assert_allclose(out.numpy(), expected.numpy())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/flex_checkpoint/test_aoa_engine_reshape.py
+++ b/test/flex_checkpoint/test_aoa_engine_reshape.py
@@ -158,7 +158,9 @@ class TestAOAEngineReshape(unittest.TestCase):
             ]
         }
         dest_desc = {
-            "d": [ShardedWeightDesc("d", FLATTENED, FLATTENED, (0, 0), "float32")]
+            "d": [
+                ShardedWeightDesc("d", FLATTENED, FLATTENED, (0, 0), "float32")
+            ]
         }
         engine = _build_engine(
             source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
@@ -243,7 +245,9 @@ class TestAOAEngineReshape(unittest.TestCase):
 class TestGetDestinationGlobalShape(unittest.TestCase):
     def _engine(self, dest_desc):
         source_desc = {
-            "s0": [ShardedWeightDesc("s0", FLATTENED, FLATTENED, (0, 0), "float32")]
+            "s0": [
+                ShardedWeightDesc("s0", FLATTENED, FLATTENED, (0, 0), "float32")
+            ]
         }
         return _build_engine(
             source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
@@ -251,25 +255,37 @@ class TestGetDestinationGlobalShape(unittest.TestCase):
 
     def test_returns_none_without_destination_info(self):
         engine = self._engine(
-            {"d": [ShardedWeightDesc("d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32")]}
+            {
+                "d": [
+                    ShardedWeightDesc(
+                        "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                    )
+                ]
+            }
         )
         engine.destination_state_shard_info = None
         self.assertIsNone(engine.get_destination_global_shape("d"))
 
     def test_direct_key_hit(self):
         engine = self._engine(
-            {"d": [ShardedWeightDesc("d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32")]}
+            {
+                "d": [
+                    ShardedWeightDesc(
+                        "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                    )
+                ]
+            }
         )
-        self.assertEqual(
-            engine.get_destination_global_shape("d"), CANONICAL
-        )
+        self.assertEqual(engine.get_destination_global_shape("d"), CANONICAL)
 
     def test_resolves_unique_shape_via_optimizer_state_keys(self):
         # "d" is not a direct key, but both optimizer-state keys strip to "d"
         # and share a single global shape.
         dest_desc = {
             "d.w_0": [
-                ShardedWeightDesc("d.w_0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32")
+                ShardedWeightDesc(
+                    "d.w_0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                )
             ],
             "d.moment1_0": [
                 ShardedWeightDesc(
@@ -285,11 +301,19 @@ class TestGetDestinationGlobalShape(unittest.TestCase):
         # ambiguous metadata after a valid build so the failure is isolated to
         # get_destination_global_shape rather than shape propagation at build.
         engine = self._engine(
-            {"d": [ShardedWeightDesc("d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32")]}
+            {
+                "d": [
+                    ShardedWeightDesc(
+                        "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                    )
+                ]
+            }
         )
         engine.destination_state_shard_info = {
             "d.w_0": [
-                ShardedWeightDesc("d.w_0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32")
+                ShardedWeightDesc(
+                    "d.w_0", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
+                )
             ],
             "d.moment1_0": [
                 ShardedWeightDesc(
@@ -315,8 +339,12 @@ class TestAOAEngineReshapeMultiSource(unittest.TestCase):
         shard_shape = (1, H, TWO, I)
         dest_desc = {
             "d": [
-                ShardedWeightDesc("d", shard_shape, CANONICAL, (0, 0, 0, 0), "float32"),
-                ShardedWeightDesc("d", shard_shape, CANONICAL, (1, 0, 0, 0), "float32"),
+                ShardedWeightDesc(
+                    "d", shard_shape, CANONICAL, (0, 0, 0, 0), "float32"
+                ),
+                ShardedWeightDesc(
+                    "d", shard_shape, CANONICAL, (1, 0, 0, 0), "float32"
+                ),
             ]
         }
         engine = _build_engine(
@@ -342,6 +370,7 @@ class TestAOAEngineReshapeMultiSource(unittest.TestCase):
                 (expert, 0, 0, 0),
             )
 
+
 class TestAssignShardedSliceReshapeMultiPostprocess(unittest.TestCase):
     def test_reshape_then_transpose_then_cast(self):
         # A reshape marker followed by two more operations exercises the
@@ -349,7 +378,9 @@ class TestAssignShardedSliceReshapeMultiPostprocess(unittest.TestCase):
         source = paddle.arange(
             int(np.prod(FLATTENED)), dtype="float32"
         ).reshape(list(FLATTENED))
-        src_desc = ShardedWeightDesc("s", FLATTENED, FLATTENED, (0, 0), "float32")
+        src_desc = ShardedWeightDesc(
+            "s", FLATTENED, FLATTENED, (0, 0), "float32"
+        )
         src_shard = ShardedWeight("s", source, FLATTENED, FLATTENED, (0, 0))
         out = paddle.zeros(list(CANONICAL), dtype="float16")
         dst_desc = ShardedWeightDesc(
@@ -398,7 +429,9 @@ class TestAOAEngineReshapeErrors(unittest.TestCase):
         }
         with self.assertRaises(ValueError):
             self._build(
-                source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
+                source_desc,
+                dest_desc,
+                [f"s0 -> d, reshape = '{CANONICAL_STR}'"],
             )
 
     def test_flatten_query_not_block_aligned(self):
@@ -413,7 +446,9 @@ class TestAOAEngineReshapeErrors(unittest.TestCase):
             ]
         }
         dest_desc = {
-            "d": [ShardedWeightDesc("d", FLATTENED, FLATTENED, (0, 0), "float32")]
+            "d": [
+                ShardedWeightDesc("d", FLATTENED, FLATTENED, (0, 0), "float32")
+            ]
         }
         engine = _build_engine(
             source_desc, dest_desc, [f"s0 -> d, reshape = '{CANONICAL_STR}'"]
@@ -428,7 +463,11 @@ class TestAssignShardedSliceReshapeErrors(unittest.TestCase):
     def test_forward_source_not_block_aligned(self):
         src_desc = ShardedWeightDesc("s", (2, 4), FLATTENED, (0, 0), "float32")
         src_shard = ShardedWeight(
-            "s", paddle.zeros([2, 4], dtype="float32"), (2, 4), FLATTENED, (0, 0)
+            "s",
+            paddle.zeros([2, 4], dtype="float32"),
+            (2, 4),
+            FLATTENED,
+            (0, 0),
         )
         dst_desc = ShardedWeightDesc(
             "d", CANONICAL, CANONICAL, (0, 0, 0, 0), "float32"
@@ -513,11 +552,21 @@ class TestAOAEngineReshapeMisalignedSlices(unittest.TestCase):
         # concat along a trailing dim leaves canonical slices that are not
         # complete on that dim, so the flatten direction must reject them.
         source_desc = {
-            "a": [ShardedWeightDesc("a", (2, 3, 1, 2), (2, 3, 1, 2), (0, 0, 0, 0), "float32")],
-            "b": [ShardedWeightDesc("b", (2, 3, 1, 2), (2, 3, 1, 2), (0, 0, 0, 0), "float32")],
+            "a": [
+                ShardedWeightDesc(
+                    "a", (2, 3, 1, 2), (2, 3, 1, 2), (0, 0, 0, 0), "float32"
+                )
+            ],
+            "b": [
+                ShardedWeightDesc(
+                    "b", (2, 3, 1, 2), (2, 3, 1, 2), (0, 0, 0, 0), "float32"
+                )
+            ],
         }
         dest_desc = {
-            "d": [ShardedWeightDesc("d", FLATTENED, FLATTENED, (0, 0), "float32")]
+            "d": [
+                ShardedWeightDesc("d", FLATTENED, FLATTENED, (0, 0), "float32")
+            ]
         }
         with self.assertRaises(ValueError):
             _build_engine(
@@ -537,17 +586,15 @@ class TestAssignShardedSliceReshapePostprocess(unittest.TestCase):
         source = paddle.arange(
             int(np.prod(FLATTENED)), dtype="float32"
         ).reshape(list(FLATTENED))
-        src_desc = ShardedWeightDesc("s", FLATTENED, FLATTENED, (0, 0), "float32")
-        src_shard = ShardedWeight(
-            "s", source, FLATTENED, FLATTENED, (0, 0)
+        src_desc = ShardedWeightDesc(
+            "s", FLATTENED, FLATTENED, (0, 0), "float32"
         )
+        src_shard = ShardedWeight("s", source, FLATTENED, FLATTENED, (0, 0))
         out = paddle.zeros(list(CANONICAL), dtype=dtype)
         dst_desc = ShardedWeightDesc(
             "d", CANONICAL, CANONICAL, (0, 0, 0, 0), dtype
         )
-        dst_shard = ShardedWeight(
-            "d", out, CANONICAL, CANONICAL, (0, 0, 0, 0)
-        )
+        dst_shard = ShardedWeight("d", out, CANONICAL, CANONICAL, (0, 0, 0, 0))
         return source, src_desc, src_shard, dst_desc, dst_shard, out
 
     def test_reshape_then_cast(self):
@@ -580,6 +627,89 @@ class TestAssignShardedSliceReshapePostprocess(unittest.TestCase):
             source.reshape(list(CANONICAL)), [2, 1, 0, 3]
         )
         np.testing.assert_allclose(out.numpy(), expected.numpy())
+
+
+class TestAOAEngineReshapeThenPermute(unittest.TestCase):
+    """reshape marker followed by a permute: the destination lives in a permuted
+    layout, so the leading block axis is no longer axis 0. Both find_shard_sources
+    and assign_sharded_slice must undo the trailing permute before mapping shards
+    back onto the flattened source rows."""
+
+    # flattened [6, 4] -> canonical [2, 3, 4] --permute[1,0,2]--> [3, 2, 4]
+    RESHAPE_STR = "[2, 3, 4]"
+    PERMUTE = "[1, 0, 2]"
+
+    def _engine(self, dest_desc):
+        source_desc = {
+            "s0": [ShardedWeightDesc("s0", (6, 4), (6, 4), (0, 0), "float32")]
+        }
+        return _build_engine(
+            source_desc,
+            dest_desc,
+            [
+                f"s0 -> tmp, reshape = '{self.RESHAPE_STR}'",
+                f"tmp -> d, permute = '{self.PERMUTE}'",
+            ],
+        )
+
+    def test_find_sources_maps_permuted_block_axis(self):
+        # d has shape [3, 2, 4]; axis 1 is the block/expert axis after permute.
+        # Sharding along axis 1 must route each destination block to the matching
+        # source block (rows [0:3] vs [3:6]), not always block 0.
+        dest_desc = {
+            "d": [
+                ShardedWeightDesc(
+                    "d", (3, 1, 4), (3, 2, 4), (0, 0, 0), "float32"
+                ),
+                ShardedWeightDesc(
+                    "d", (3, 1, 4), (3, 2, 4), (0, 1, 0), "float32"
+                ),
+            ]
+        }
+        engine = self._engine(dest_desc)
+        expected_rows = {0: (0, 3), 1: (3, 6)}
+        for block in range(2):
+            tgt = ShardedWeightDesc(
+                "d", (3, 1, 4), (3, 2, 4), (0, block, 0), "float32"
+            )
+            mappings = engine.find_shard_sources(tgt)
+            self.assertEqual(len(mappings), 1)
+            src = mappings[0].source_slice
+            self.assertEqual(src.key, "s0")
+            self.assertEqual(
+                (
+                    src.global_offset[0],
+                    src.global_offset[0] + src.local_shape[0],
+                ),
+                expected_rows[block],
+            )
+
+    def test_assign_sharded_slice_writes_correct_block(self):
+        # End-to-end check through assign_sharded_slice: each permuted block must
+        # contain the data of the corresponding flattened source block.
+        s0 = paddle.arange(24, dtype="float32").reshape([6, 4])
+        expected = paddle.transpose(
+            s0.reshape([2, 3, 4]), [1, 0, 2]
+        )  # [3, 2, 4]
+        dest_desc = {
+            "d": [
+                ShardedWeightDesc(
+                    "d", (3, 1, 4), (3, 2, 4), (0, 0, 0), "float32"
+                ),
+                ShardedWeightDesc(
+                    "d", (3, 1, 4), (3, 2, 4), (0, 1, 0), "float32"
+                ),
+            ]
+        }
+        engine = self._engine(dest_desc)
+        for block in range(2):
+            tgt = ShardedWeightDesc(
+                "d", (3, 1, 4), (3, 2, 4), (0, block, 0), "float32"
+            )
+            out = _fill_target(engine, {"s0": s0}, tgt)
+            np.testing.assert_allclose(
+                out.numpy(), expected.numpy()[:, block : block + 1, :]
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### PR Category
Auto Parallel

### PR Types
New features

### Description
FlexCheckpoint 在做 checkpoint 重切分（resharding）时，grouped-GEMM 权重存在两种等价布局：早期的 legacy 2-D 布局 `[B*W, prod(rest)]`，以及规范的 N-D 布局 `[B, W, *rest]`。当源、目的两侧布局不一致时，原有的 AOA 流程无法在保持切片语义的前提下完成两种布局之间的转换。

本 PR 新增在这两种布局之间做无损转换的能力：

- `aoa/macros.py`：在 `GLOBAL_ATTRIBUTE_KEYWORDS` 中新增 `reshape` 关键字，使其可作为 AOA 规则属性被识别。
- `aoa/aoa_engine.py`：
  - 新增 `get_destination_global_shape`，从目的端 shard 元数据推导唯一的目标 global shape。
  - 新增 `reshape_grouped_gemm`，在 legacy 2-D 与 canonical N-D 之间做切片映射，并写入 `reshape:` / `flatten:` 标记（`reshape:` 表示 legacy→canonical，`flatten:` 为反向），同时在 slice 求交逻辑中按 expert 宽度对齐处理带标记的分片。
- `dcp/utils.py`：`assign_sharded_slice` 识别 `reshape:` / `flatten:` 标记，按 block 宽度对源 shard 做 reshape 后再按目的 shard 做切片赋值，并保持后续 transpose/cast 等 postprocess 操作链。

所有转换均要求 block/expert 对齐的完整行分片，不满足时抛出明确的 `ValueError`，避免静默产生错误结果。

### 是否引起精度变化
否