### PR TITLE
[CodeStyle] Bump ast-grep to v0.45.0 and Ruff to v0.16.0

### DIFF
--- a/.agents/skills/paddle-cross-ecosystem-custom-op/references/runtime-debugging.md
+++ b/.agents/skills/paddle-cross-ecosystem-custom-op/references/runtime-debugging.md
@@ -102,15 +102,15 @@ Paddle 的创建与拷贝路径显式支持 `gpu_pinned` / `CUDAPinnedPlace`，�
 
 ```python
 def dump_tensor(tag, tensor):
-   print(
-      tag,
-      {
-         "shape": list(tensor.shape),
-         "dtype": str(tensor.dtype),
-         "place": str(tensor.place),
-         "stop_gradient": tensor.stop_gradient,
-      },
-   )
+    print(
+        tag,
+        {
+            "shape": list(tensor.shape),
+            "dtype": str(tensor.dtype),
+            "place": str(tensor.place),
+            "stop_gradient": tensor.stop_gradient,
+        },
+    )
 
 
 print("expected_place", paddle.framework._current_expected_place_())

--- a/.agents/skills/paddle-debug/references/case-studies.md
+++ b/.agents/skills/paddle-debug/references/case-studies.md
@@ -117,6 +117,7 @@ float CudaEvent::ElapsedTime(CudaEvent *end_event) {
 ### 最小复现（不依赖 unittest）
 ```python
 import paddle
+
 paddle.device.set_device('gpu:0')
 event1 = paddle.device.Event()
 event2 = paddle.device.Event()

--- a/.agents/skills/paddle-debug/references/cuda-debug.md
+++ b/.agents/skills/paddle-debug/references/cuda-debug.md
@@ -109,6 +109,7 @@ if (err != cudaSuccess) {
 3. **Python 层快速验证**：
    ```python
    import ctypes
+
    libcudart = ctypes.CDLL("libcudart.so")
    err = libcudart.cudaGetLastError()
    print(f"CUDA last error: {err}")  # 0 表示无错误

--- a/.agents/skills/paddle-design-compiler/references/sot-design.md
+++ b/.agents/skills/paddle-design-compiler/references/sot-design.md
@@ -100,7 +100,11 @@ Guard 是一个 `Callable[[FrameType], bool]`，判断当前帧的输入是否�
 # 概念示例
 def guard(frame: FrameType) -> bool:
     x = frame.f_locals["x"]
-    return isinstance(x, paddle.Tensor) and x.shape == [2, 3] and x.dtype == paddle.float32
+    return (
+        isinstance(x, paddle.Tensor)
+        and x.shape == [2, 3]
+        and x.dtype == paddle.float32
+    )
 ```
 
 ### Guard 生成
@@ -139,12 +143,14 @@ Python 代码可能修改全局变量、修改可变对象（list.append 等）�
 ```python
 import paddle
 
+
 @paddle.jit.to_static  # 默认 full_graph=False，启用 SOT 模式
 def train_step(net, x, label):
     pred = net(x)
     loss = paddle.nn.functional.cross_entropy(pred, label)
     loss.backward()
     return loss
+
 
 # full_graph=False（默认）：SOT 模式（字节码级别转换 + 自动 fallback）
 # full_graph=True：传统 AST Transformer（要求整图可转）

--- a/.agents/skills/paddle-design-distributed/SKILL.md
+++ b/.agents/skills/paddle-design-distributed/SKILL.md
@@ -27,6 +27,7 @@ description: "Use when working with Paddle's distributed training system: unders
 
 ```python
 import paddle.distributed as dist
+
 mesh = dist.ProcessMesh([0, 1, 2, 3], dim_names=["x"])
 x = dist.shard_tensor(x, mesh, [dist.Shard(0)])  # 沿 dim 0 切分
 ```

--- a/.agents/skills/paddle-design-distributed/references/distributed-primer.md
+++ b/.agents/skills/paddle-design-distributed/references/distributed-primer.md
@@ -26,6 +26,7 @@
 
 ```python
 import paddle.distributed.fleet as fleet
+
 fleet.init(is_collective=True)
 strategy = fleet.DistributedStrategy()
 strategy.tensor_parallel = True
@@ -38,6 +39,7 @@ strategy.tensor_parallel_configs = {"tensor_parallel_degree": 2}
 
 ```python
 import paddle.distributed as dist
+
 mesh = dist.ProcessMesh([0, 1, 2, 3], dim_names=["x"])
 x = dist.shard_tensor(x, mesh, [dist.Shard(0)])  # 沿 dim 0 切分
 ```
@@ -48,6 +50,7 @@ x = dist.shard_tensor(x, mesh, [dist.Shard(0)])  # 沿 dim 0 切分
 
 ```python
 from paddle.distributed.auto_parallel import Engine
+
 engine = Engine(model, loss, optimizer, strategy=strategy)
 engine.fit(train_dataset)
 ```

--- a/.agents/skills/paddle-design-eager-graph/references/inplace.md
+++ b/.agents/skills/paddle-design-eager-graph/references/inplace.md
@@ -46,8 +46,8 @@ x.add_(1.0)  # RuntimeError! 不允许
 ```python
 x = paddle.randn([3, 4])
 x.stop_gradient = False
-y = x * 2        # y 是非叶 Tensor
-y.add_(1.0)      # 允许，但会触发版本检查
+y = x * 2  # y 是非叶 Tensor
+y.add_(1.0)  # 允许，但会触发版本检查
 ```
 
 ## 版本追踪机制
@@ -97,8 +97,8 @@ TensorWrapper（保存前向 Tensor 用于反向）
 ```python
 x = paddle.randn([3, 4])
 x.stop_gradient = False
-y = x * 2            # y 的 TensorWrapper 保存了 x，版本快照 = 0
-x.add_(1.0)          # x.inplace_version = 1（但 x 是叶 Tensor，实际会报错）
+y = x * 2  # y 的 TensorWrapper 保存了 x，版本快照 = 0
+x.add_(1.0)  # x.inplace_version = 1（但 x 是叶 Tensor，实际会报错）
 
 # 若绕过叶 Tensor 检查：
 # y.backward() 时 TensorWrapper.recover() 发现版本 1 != 快照 0，报错

--- a/.agents/skills/paddle-design-eager-graph/references/pylayer.md
+++ b/.agents/skills/paddle-design-eager-graph/references/pylayer.md
@@ -8,6 +8,7 @@
 import paddle
 from paddle.autograd import PyLayer
 
+
 class SquaredReLU(PyLayer):
     @staticmethod
     def forward(ctx, x):
@@ -17,8 +18,9 @@ class SquaredReLU(PyLayer):
 
     @staticmethod
     def backward(ctx, dy):
-        y, = ctx.saved_tensor()
+        (y,) = ctx.saved_tensor()
         return dy * 2 * y
+
 
 x = paddle.randn([3, 4], dtype='float32')
 x.stop_gradient = False

--- a/.agents/skills/paddle-design-phi-kernel/references/kernel-selection.md
+++ b/.agents/skills/paddle-design-phi-kernel/references/kernel-selection.md
@@ -140,6 +140,7 @@ GLOG_vmodule=phi_kernel_adaptor=4 python test.py
 
 ```python
 import paddle
+
 paddle.framework._phi_kernel_factory().get_all_kernel_names()
 ```
 

--- a/.agents/skills/paddle-op-dev/references/python-api.md
+++ b/.agents/skills/paddle-op-dev/references/python-api.md
@@ -52,7 +52,7 @@ helper.append_op(
     type='op_name',
     inputs={'X': input},
     outputs={'Out': out},
-    attrs={'attr1': value1}
+    attrs={'attr1': value1},
 )
 return out
 ```

--- a/.agents/skills/paddle-op-dev/references/unit-test.md
+++ b/.agents/skills/paddle-op-dev/references/unit-test.md
@@ -88,7 +88,12 @@ def test_check_grad(self):
 
 ```python
 def test_check_grad_no_x(self):
-    self.check_grad(['Y'], 'Out', no_grad_set=set("X"), check_pir=True)
+    self.check_grad(
+        ['Y'],
+        'Out',
+        no_grad_set=set("X"),
+        check_pir=True,
+    )
 ```
 
 ## 完整测试示例

--- a/.agents/skills/paddle-op-dev/references/unit-test.md
+++ b/.agents/skills/paddle-op-dev/references/unit-test.md
@@ -36,8 +36,8 @@ import numpy as np
 ```python
 class TestXxxOp(OpTest):
     def setUp(self):
-        self.op_type = "xxx"           # 算子名
-        self.python_api = paddle.xxx   # 对应的 Python API
+        self.op_type = "xxx"  # 算子名
+        self.python_api = paddle.xxx  # 对应的 Python API
         self.init_config()
         # 设置输入
         self.inputs = {
@@ -77,9 +77,9 @@ def test_check_output(self):
 ```python
 def test_check_grad(self):
     self.check_grad(
-        ['X'],           # 需要检查梯度的输入列表
-        'Out',           # 对应的输出名
-        check_pir=True
+        ['X'],  # 需要检查梯度的输入列表
+        'Out',  # 对应的输出名
+        check_pir=True,
     )
 ```
 
@@ -88,11 +88,7 @@ def test_check_grad(self):
 
 ```python
 def test_check_grad_no_x(self):
-    self.check_grad(
-        ['Y'], 'Out',
-        no_grad_set=set("X"),
-        check_pir=True
-    )
+    self.check_grad(['Y'], 'Out', no_grad_set=set("X"), check_pir=True)
 ```
 
 ## 完整测试示例
@@ -118,10 +114,12 @@ class TestTraceOp(OpTest):
         self.inputs = {'Input': self.case}
         self.attrs = {'offset': 0, 'axis1': 0, 'axis2': 1}
         self.outputs = {
-            'Out': np.trace(self.inputs['Input'],
-                           offset=self.attrs['offset'],
-                           axis1=self.attrs['axis1'],
-                           axis2=self.attrs['axis2'])
+            'Out': np.trace(
+                self.inputs['Input'],
+                offset=self.attrs['offset'],
+                axis1=self.attrs['axis1'],
+                axis2=self.attrs['axis2'],
+            )
         }
 
     def test_check_output(self):
@@ -133,34 +131,41 @@ class TestTraceOp(OpTest):
 
 class TestTraceOpCase1(TestTraceOp):
     """测试不同参数配置"""
+
     def init_config(self):
         self.case = np.random.randn(20, 6).astype('float64')
         self.inputs = {'Input': self.case}
         self.attrs = {'offset': 1, 'axis1': 0, 'axis2': 1}
         self.outputs = {
-            'Out': np.trace(self.inputs['Input'],
-                           offset=self.attrs['offset'],
-                           axis1=self.attrs['axis1'],
-                           axis2=self.attrs['axis2'])
+            'Out': np.trace(
+                self.inputs['Input'],
+                offset=self.attrs['offset'],
+                axis1=self.attrs['axis1'],
+                axis2=self.attrs['axis2'],
+            )
         }
 
 
 class TestTraceOpCase2(TestTraceOp):
     """测试高维输入"""
+
     def init_config(self):
         self.case = np.random.randn(2, 20, 2, 3).astype('float64')
         self.inputs = {'Input': self.case}
         self.attrs = {'offset': 1, 'axis1': 1, 'axis2': 2}
         self.outputs = {
-            'Out': np.trace(self.inputs['Input'],
-                           offset=self.attrs['offset'],
-                           axis1=self.attrs['axis1'],
-                           axis2=self.attrs['axis2'])
+            'Out': np.trace(
+                self.inputs['Input'],
+                offset=self.attrs['offset'],
+                axis1=self.attrs['axis1'],
+                axis2=self.attrs['axis2'],
+            )
         }
 
 
 class TestTraceAPICase(unittest.TestCase):
     """测试 Python API 调用"""
+
     def test_case1(self):
         x = paddle.to_tensor(np.random.randn(20, 6).astype('float64'))
         result = paddle.trace(x)

--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install pre-commit==2.17.0
-          pip install ast-grep-cli==0.44.0 # This version should be consistent with the one in .pre-commit-config.yaml
+          pip install ast-grep-cli==0.45.0 # This version should be consistent with the one in .pre-commit-config.yaml
 
       - name: Run ast-grep unit tests
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,7 @@ repos:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix, --no-cache]
       - id: ruff-format
+        types_or: [python, pyi, jupyter, markdown]
   # For C++ files
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         files: \.sh$
         args: [--whitespaces-count, '4']
   - repo: https://github.com/PFCCLab/ast-grep-pre-commit-mirror
-    rev: v0.44.0
+    rev: v0.45.0
     hooks:
       - id: ast-grep
   - repo: local
@@ -65,7 +65,7 @@ repos:
         args: [--force-exclude]
   # For Python files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix, --no-cache]

--- a/paddle/fluid/imperative/README.md
+++ b/paddle/fluid/imperative/README.md
@@ -47,28 +47,37 @@ Current: Python Variable -> C++ VarBase -> C++ Variable -> C++ Tensor
 
 Longer term.
 ```python
-
 # Parent class.
 class PyVarBase:
-  pass
+    pass
+
 
 # Current python variable.
 class Variable(PyVarBase):
-  pass
+    pass
+
 
 class IVariable(PyVarBase):
-  def __init__(self):
-    self._ivar = core.VarBase()
+    def __init__(self):
+        self._ivar = core.VarBase()
 
-  # Move var to a device.
-  def to(device): pass
-  # Get var value.
-  def value(): pass
-  # Trigger backward.
-  def backward(): pass
-  # Get var's gradient value.
-  def gradient_value(): pass
-  # operators to override.
+    # Move var to a device.
+    def to(device):
+        pass
+
+    # Get var value.
+    def value():
+        pass
+
+    # Trigger backward.
+    def backward():
+        pass
+
+    # Get var's gradient value.
+    def gradient_value():
+        pass
+
+    # operators to override.
 ```
 
 

--- a/python/paddle/static/nn/control_flow.py
+++ b/python/paddle/static/nn/control_flow.py
@@ -1350,8 +1350,9 @@ def switch_case(branch_index, branch_fns, default=None, name=None):
                 )
 
         if default is None:
-            default = sorted(branch_fns)[-1][1]
-            branch_fns = sorted(branch_fns)[:-1]
+            branch_fns = sorted(branch_fns)
+            default = branch_fns[-1][1]
+            branch_fns = branch_fns[:-1]
         elif not callable(default):
             raise TypeError("The default in Op(case) must be callable.")
 

--- a/security/advisory/pdsa-2022-001.md
+++ b/security/advisory/pdsa-2022-001.md
@@ -11,12 +11,12 @@ The PoC is as follows:
 ```python
 import paddle
 import paddle.base as fluid
-import numpy as  np
+import numpy as np
 
-ids = paddle.to_tensor([[2,2],[6,1]])
-parents = paddle.to_tensor([[2,2],[6,1]])
+ids = paddle.to_tensor([[2, 2], [6, 1]])
+parents = paddle.to_tensor([[2, 2], [6, 1]])
 
-out = paddle.nn.functional.gather_tree(ids,parents)
+out = paddle.nn.functional.gather_tree(ids, parents)
 ```
 
 The [implementation](https://github.com/PaddlePaddle/Paddle/blob/release/2.3/paddle/phi/kernels/cpu/gather_tree_kernel.cc#L31-L33) of GatherTreeKernel does not validate the ids_dims size which would result in a memory out-of-bounds read if the ids shape is invalid.

--- a/security/advisory/pdsa-2022-001_cn.md
+++ b/security/advisory/pdsa-2022-001_cn.md
@@ -11,12 +11,12 @@ PoC如下：
 ```python
 import paddle
 import paddle.base as fluid
-import numpy as  np
+import numpy as np
 
-ids = paddle.to_tensor([[2,2],[6,1]])
-parents = paddle.to_tensor([[2,2],[6,1]])
+ids = paddle.to_tensor([[2, 2], [6, 1]])
+parents = paddle.to_tensor([[2, 2], [6, 1]])
 
-out = paddle.nn.functional.gather_tree(ids,parents)
+out = paddle.nn.functional.gather_tree(ids, parents)
 ```
 
 在GatherTreeKernel的[实现代码中](https://github.com/PaddlePaddle/Paddle/blob/release/2.3/paddle/phi/kernels/cpu/gather_tree_kernel.cc#L31-L33)，并没有检查ids_dims的大小，当输入非预期的ids，其shape不正确时会造成可能造成越界读ids_dims。

--- a/security/advisory/pdsa-2023-002.md
+++ b/security/advisory/pdsa-2023-002.md
@@ -13,8 +13,10 @@ import paddle
 import numpy as np
 from paddle import flip
 
-x = paddle.to_tensor(np.random.uniform(-10, 10, [1, 2, 3]).astype(np.int64)),
-axis = paddle.to_tensor(np.random.uniform(-2147483648, 2147483647, [3, 3]).astype(np.int32))
+x = (paddle.to_tensor(np.random.uniform(-10, 10, [1, 2, 3]).astype(np.int64)),)
+axis = paddle.to_tensor(
+    np.random.uniform(-2147483648, 2147483647, [3, 3]).astype(np.int32)
+)
 
 flip(x, axis)
 ```

--- a/security/advisory/pdsa-2023-002_cn.md
+++ b/security/advisory/pdsa-2023-002_cn.md
@@ -13,8 +13,10 @@ import paddle
 import numpy as np
 from paddle import flip
 
-x = paddle.to_tensor(np.random.uniform(-10, 10, [1, 2, 3]).astype(np.int64)),
-axis = paddle.to_tensor(np.random.uniform(-2147483648, 2147483647, [3, 3]).astype(np.int32))
+x = (paddle.to_tensor(np.random.uniform(-10, 10, [1, 2, 3]).astype(np.int64)),)
+axis = paddle.to_tensor(
+    np.random.uniform(-2147483648, 2147483647, [3, 3]).astype(np.int32)
+)
 
 flip(x, axis)
 ```

--- a/security/advisory/pdsa-2023-004.md
+++ b/security/advisory/pdsa-2023-004.md
@@ -13,7 +13,9 @@ import paddle
 import numpy as np
 from paddle.linalg import matrix_power
 
-x = paddle.to_tensor(np.random.uniform(-10, 10, [1, 1, 0, 0]).astype(np.float32))
+x = paddle.to_tensor(
+    np.random.uniform(-10, 10, [1, 1, 0, 0]).astype(np.float32)
+)
 
 matrix_power(x, -1)
 ```

--- a/security/advisory/pdsa-2023-004_cn.md
+++ b/security/advisory/pdsa-2023-004_cn.md
@@ -13,7 +13,9 @@ import paddle
 import numpy as np
 from paddle.linalg import matrix_power
 
-x = paddle.to_tensor(np.random.uniform(-10, 10, [1, 1, 0, 0]).astype(np.float32))
+x = paddle.to_tensor(
+    np.random.uniform(-10, 10, [1, 1, 0, 0]).astype(np.float32)
+)
 
 matrix_power(x, -1)
 ```

--- a/security/advisory/pdsa-2023-006.md
+++ b/security/advisory/pdsa-2023-006.md
@@ -12,7 +12,7 @@ When `x` dim calculates `stride` to 0, `paddle.nanmedian` triggers FPE by `numel
 import paddle
 import numpy as np
 
-x = np.random.uniform(0,0,[0,0,0,0,0]).astype(np.float32)
+x = np.random.uniform(0, 0, [0, 0, 0, 0, 0]).astype(np.float32)
 x = paddle.to_tensor(x)
 paddle.nanmedian(x)
 ```

--- a/security/advisory/pdsa-2023-006_cn.md
+++ b/security/advisory/pdsa-2023-006_cn.md
@@ -12,7 +12,7 @@ CVE-2023-38674
 import paddle
 import numpy as np
 
-x = np.random.uniform(0,0,[0,0,0,0,0]).astype(np.float32)
+x = np.random.uniform(0, 0, [0, 0, 0, 0, 0]).astype(np.float32)
 x = paddle.to_tensor(x)
 paddle.nanmedian(x)
 ```

--- a/security/advisory/pdsa-2023-007.md
+++ b/security/advisory/pdsa-2023-007.md
@@ -12,7 +12,7 @@ When `x` dim calculates `rows` or `cols` to 0, `paddle.linalg.matrix_rank` trigg
 import paddle
 import numpy as np
 
-x = np.random.uniform(0,0,[0,0,0,0,0]).astype(np.float32)
+x = np.random.uniform(0, 0, [0, 0, 0, 0, 0]).astype(np.float32)
 x = paddle.to_tensor(x)
 paddle.linalg.matrix_rank(x)
 ```

--- a/security/advisory/pdsa-2023-007_cn.md
+++ b/security/advisory/pdsa-2023-007_cn.md
@@ -12,7 +12,7 @@ CVE-2023-38675
 import paddle
 import numpy as np
 
-x = np.random.uniform(0,0,[0,0,0,0,0]).astype(np.float32)
+x = np.random.uniform(0, 0, [0, 0, 0, 0, 0]).astype(np.float32)
 x = paddle.to_tensor(x)
 paddle.linalg.matrix_rank(x)
 ```

--- a/security/advisory/pdsa-2023-008.md
+++ b/security/advisory/pdsa-2023-008.md
@@ -12,8 +12,12 @@ Segfault occurs when `x` and `y` shape is 0 in `paddle.dot`. The PoC is as follo
 import paddle
 import numpy as np
 
-x = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [0, 0]).astype(np.float32))
-y = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [0, 0]).astype(np.float32))
+x = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [0, 0]).astype(np.float32)
+)
+y = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [0, 0]).astype(np.float32)
+)
 paddle.dot(x, y)
 ```
 

--- a/security/advisory/pdsa-2023-008_cn.md
+++ b/security/advisory/pdsa-2023-008_cn.md
@@ -12,8 +12,12 @@ CVE-2023-38676
 import paddle
 import numpy as np
 
-x = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [0, 0]).astype(np.float32))
-y = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [0, 0]).astype(np.float32))
+x = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [0, 0]).astype(np.float32)
+)
+y = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [0, 0]).astype(np.float32)
+)
 paddle.dot(x, y)
 ```
 

--- a/security/advisory/pdsa-2023-009.md
+++ b/security/advisory/pdsa-2023-009.md
@@ -12,7 +12,9 @@ When tensor dims contain 0, `paddle.linalg.eig` will trigger a float point excep
 import paddle
 import numpy as np
 
-x = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [3, 6, 0, 2, 2]).astype(np.float32))
+x = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [3, 6, 0, 2, 2]).astype(np.float32)
+)
 
 paddle.linalg.eig(x)
 ```

--- a/security/advisory/pdsa-2023-009_cn.md
+++ b/security/advisory/pdsa-2023-009_cn.md
@@ -12,7 +12,9 @@ CVE-2023-38677
 import paddle
 import numpy as np
 
-x = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [3, 6, 0, 2, 2]).astype(np.float32))
+x = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [3, 6, 0, 2, 2]).astype(np.float32)
+)
 
 paddle.linalg.eig(x)
 ```

--- a/security/advisory/pdsa-2023-010.md
+++ b/security/advisory/pdsa-2023-010.md
@@ -13,9 +13,13 @@ import paddle
 import numpy as np
 
 paddle.mode(
-    x=paddle.to_tensor(np.random.uniform(-6666666, 100000000, []).astype(np.float64)),
-    axis=paddle.to_tensor(np.random.uniform(-2147483648, 2147483647, []).astype(np.int32)),
-    keepdim=True
+    x=paddle.to_tensor(
+        np.random.uniform(-6666666, 100000000, []).astype(np.float64)
+    ),
+    axis=paddle.to_tensor(
+        np.random.uniform(-2147483648, 2147483647, []).astype(np.int32)
+    ),
+    keepdim=True,
 )
 ```
 

--- a/security/advisory/pdsa-2023-010_cn.md
+++ b/security/advisory/pdsa-2023-010_cn.md
@@ -13,9 +13,13 @@ import paddle
 import numpy as np
 
 paddle.mode(
-    x=paddle.to_tensor(np.random.uniform(-6666666, 100000000, []).astype(np.float64)),
-    axis=paddle.to_tensor(np.random.uniform(-2147483648, 2147483647, []).astype(np.int32)),
-    keepdim=True
+    x=paddle.to_tensor(
+        np.random.uniform(-6666666, 100000000, []).astype(np.float64)
+    ),
+    axis=paddle.to_tensor(
+        np.random.uniform(-2147483648, 2147483647, []).astype(np.int32)
+    ),
+    keepdim=True,
 )
 ```
 

--- a/security/advisory/pdsa-2023-011.md
+++ b/security/advisory/pdsa-2023-011.md
@@ -13,8 +13,14 @@ import paddle
 import numpy as np
 
 paddle.nextafter(
-    x=paddle.to_tensor(np.random.uniform(-6666666, 100000000, [1, 2]).astype(np.float32)),
-    y=paddle.to_tensor(np.random.uniform(-6666666, 100000000, [0, 0, 0, 0, 0]).astype(np.float32))
+    x=paddle.to_tensor(
+        np.random.uniform(-6666666, 100000000, [1, 2]).astype(np.float32)
+    ),
+    y=paddle.to_tensor(
+        np.random.uniform(-6666666, 100000000, [0, 0, 0, 0, 0]).astype(
+            np.float32
+        )
+    ),
 )
 ```
 

--- a/security/advisory/pdsa-2023-011_cn.md
+++ b/security/advisory/pdsa-2023-011_cn.md
@@ -13,8 +13,14 @@ import paddle
 import numpy as np
 
 paddle.nextafter(
-    x=paddle.to_tensor(np.random.uniform(-6666666, 100000000, [1, 2]).astype(np.float32)),
-    y=paddle.to_tensor(np.random.uniform(-6666666, 100000000, [0, 0, 0, 0, 0]).astype(np.float32))
+    x=paddle.to_tensor(
+        np.random.uniform(-6666666, 100000000, [1, 2]).astype(np.float32)
+    ),
+    y=paddle.to_tensor(
+        np.random.uniform(-6666666, 100000000, [0, 0, 0, 0, 0]).astype(
+            np.float32
+        )
+    ),
 )
 ```
 

--- a/security/advisory/pdsa-2023-012.md
+++ b/security/advisory/pdsa-2023-012.md
@@ -13,11 +13,19 @@ import paddle
 import numpy as np
 
 paddle.put_along_axis(
-    arr=paddle.to_tensor(np.random.uniform(-2147483648, 2147483647, [1]).astype(np.int32)),
-    indices=paddle.to_tensor(np.random.uniform(-9223372036854775808, 9223372036854775807, [1]).astype(np.int64)),
-    values=paddle.to_tensor(np.random.uniform(-2147483648, 2147483647, []).astype(np.int32)),
+    arr=paddle.to_tensor(
+        np.random.uniform(-2147483648, 2147483647, [1]).astype(np.int32)
+    ),
+    indices=paddle.to_tensor(
+        np.random.uniform(
+            -9223372036854775808, 9223372036854775807, [1]
+        ).astype(np.int64)
+    ),
+    values=paddle.to_tensor(
+        np.random.uniform(-2147483648, 2147483647, []).astype(np.int32)
+    ),
     axis=0,
-    reduce="assign"
+    reduce="assign",
 )
 ```
 

--- a/security/advisory/pdsa-2023-012_cn.md
+++ b/security/advisory/pdsa-2023-012_cn.md
@@ -13,11 +13,19 @@ import paddle
 import numpy as np
 
 paddle.put_along_axis(
-    arr=paddle.to_tensor(np.random.uniform(-2147483648, 2147483647, [1]).astype(np.int32)),
-    indices=paddle.to_tensor(np.random.uniform(-9223372036854775808, 9223372036854775807, [1]).astype(np.int64)),
-    values=paddle.to_tensor(np.random.uniform(-2147483648, 2147483647, []).astype(np.int32)),
+    arr=paddle.to_tensor(
+        np.random.uniform(-2147483648, 2147483647, [1]).astype(np.int32)
+    ),
+    indices=paddle.to_tensor(
+        np.random.uniform(
+            -9223372036854775808, 9223372036854775807, [1]
+        ).astype(np.int64)
+    ),
+    values=paddle.to_tensor(
+        np.random.uniform(-2147483648, 2147483647, []).astype(np.int32)
+    ),
     axis=0,
-    reduce="assign"
+    reduce="assign",
 )
 ```
 

--- a/security/advisory/pdsa-2023-014.md
+++ b/security/advisory/pdsa-2023-014.md
@@ -12,10 +12,14 @@ FPE in `paddle.topk` when `x` and `k` dims not correct. The PoC is as follows:
 import paddle
 import numpy as np
 
-x = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [6, 2, 1, 4, 2, 0]).astype(np.float64))
+x = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [6, 2, 1, 4, 2, 0]).astype(
+        np.float64
+    )
+)
 k = paddle.to_tensor(np.array(1).astype(np.int32))
 
-paddle.topk(x, k, axis=2,largest=False, sorted=True)
+paddle.topk(x, k, axis=2, largest=False, sorted=True)
 ```
 
 ### Patches

--- a/security/advisory/pdsa-2023-014_cn.md
+++ b/security/advisory/pdsa-2023-014_cn.md
@@ -12,10 +12,14 @@ CVE-2023-52305
 import paddle
 import numpy as np
 
-x = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [6, 2, 1, 4, 2, 0]).astype(np.float64))
+x = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [6, 2, 1, 4, 2, 0]).astype(
+        np.float64
+    )
+)
 k = paddle.to_tensor(np.array(1).astype(np.int32))
 
-paddle.topk(x, k, axis=2,largest=False, sorted=True)
+paddle.topk(x, k, axis=2, largest=False, sorted=True)
 ```
 
 ### 补丁

--- a/security/advisory/pdsa-2023-015.md
+++ b/security/advisory/pdsa-2023-015.md
@@ -12,9 +12,15 @@ FPE in `paddle.lerp` when tensor shape is invalid. The PoC is as follows:
 import paddle
 import numpy as np
 
-x = paddle.to_tensor(np.random.uniform(-6666666, 100000000, []).astype(np.float64))
-y = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [4, 0, 0, 2, 6]).astype(np.float64))
-weight = paddle.to_tensor(np.random.uniform(-6666666, 100000000, []).astype(np.float64))
+x = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, []).astype(np.float64)
+)
+y = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [4, 0, 0, 2, 6]).astype(np.float64)
+)
+weight = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, []).astype(np.float64)
+)
 
 paddle.lerp(x, y, weight)
 ```

--- a/security/advisory/pdsa-2023-015_cn.md
+++ b/security/advisory/pdsa-2023-015_cn.md
@@ -12,9 +12,15 @@ CVE-2023-52306
 import paddle
 import numpy as np
 
-x = paddle.to_tensor(np.random.uniform(-6666666, 100000000, []).astype(np.float64))
-y = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [4, 0, 0, 2, 6]).astype(np.float64))
-weight = paddle.to_tensor(np.random.uniform(-6666666, 100000000, []).astype(np.float64))
+x = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, []).astype(np.float64)
+)
+y = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [4, 0, 0, 2, 6]).astype(np.float64)
+)
+weight = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, []).astype(np.float64)
+)
 
 paddle.lerp(x, y, weight)
 ```

--- a/security/advisory/pdsa-2023-016.md
+++ b/security/advisory/pdsa-2023-016.md
@@ -12,8 +12,12 @@ Invalid shapes cause stack buffer overflow in `paddle.linalg.lu_unpack`.  The Po
 import paddle
 import numpy as np
 
-x = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [1, 6, 4, 8, 2]).astype(np.float32))
-y = paddle.to_tensor(np.random.uniform(-2147483648, 2147483647, []).astype(np.int32))
+x = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [1, 6, 4, 8, 2]).astype(np.float32)
+)
+y = paddle.to_tensor(
+    np.random.uniform(-2147483648, 2147483647, []).astype(np.int32)
+)
 
 paddle.linalg.lu_unpack(x, y, True, True)
 ```

--- a/security/advisory/pdsa-2023-016_cn.md
+++ b/security/advisory/pdsa-2023-016_cn.md
@@ -12,8 +12,12 @@ CVE-2023-52307
 import paddle
 import numpy as np
 
-x = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [1, 6, 4, 8, 2]).astype(np.float32))
-y = paddle.to_tensor(np.random.uniform(-2147483648, 2147483647, []).astype(np.int32))
+x = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [1, 6, 4, 8, 2]).astype(np.float32)
+)
+y = paddle.to_tensor(
+    np.random.uniform(-2147483648, 2147483647, []).astype(np.int32)
+)
 
 paddle.linalg.lu_unpack(x, y, True, True)
 ```

--- a/security/advisory/pdsa-2023-017.md
+++ b/security/advisory/pdsa-2023-017.md
@@ -13,9 +13,11 @@ import paddle
 import numpy as np
 
 paddle.amin(
-    x=paddle.to_tensor(np.random.uniform(-6666666, 100000000, [0, 0, 6, 3]).astype(np.float32)),
+    x=paddle.to_tensor(
+        np.random.uniform(-6666666, 100000000, [0, 0, 6, 3]).astype(np.float32)
+    ),
     axis=-1,
-    keepdim=True
+    keepdim=True,
 )
 ```
 

--- a/security/advisory/pdsa-2023-017_cn.md
+++ b/security/advisory/pdsa-2023-017_cn.md
@@ -13,9 +13,11 @@ import paddle
 import numpy as np
 
 paddle.amin(
-    x=paddle.to_tensor(np.random.uniform(-6666666, 100000000, [0, 0, 6, 3]).astype(np.float32)),
+    x=paddle.to_tensor(
+        np.random.uniform(-6666666, 100000000, [0, 0, 6, 3]).astype(np.float32)
+    ),
     axis=-1,
-    keepdim=True
+    keepdim=True,
 )
 ```
 

--- a/security/advisory/pdsa-2023-018.md
+++ b/security/advisory/pdsa-2023-018.md
@@ -12,8 +12,14 @@ Heap buffer overflow in `paddle.repeat_interleave` by using invalid params. The 
 import paddle
 import numpy as np
 
-x = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [4, 4, 8, 3, 2, 4]).astype(np.float64))
-repeats = paddle.to_tensor(np.random.uniform(-2147483648, 2147483647, [2, 1]).astype(np.int32))
+x = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [4, 4, 8, 3, 2, 4]).astype(
+        np.float64
+    )
+)
+repeats = paddle.to_tensor(
+    np.random.uniform(-2147483648, 2147483647, [2, 1]).astype(np.int32)
+)
 
 paddle.repeat_interleave(x, repeats, axis=-2)
 ```

--- a/security/advisory/pdsa-2023-018_cn.md
+++ b/security/advisory/pdsa-2023-018_cn.md
@@ -12,8 +12,14 @@ CVE-2023-52309
 import paddle
 import numpy as np
 
-x = paddle.to_tensor(np.random.uniform(-6666666, 100000000, [4, 4, 8, 3, 2, 4]).astype(np.float64))
-repeats = paddle.to_tensor(np.random.uniform(-2147483648, 2147483647, [2, 1]).astype(np.int32))
+x = paddle.to_tensor(
+    np.random.uniform(-6666666, 100000000, [4, 4, 8, 3, 2, 4]).astype(
+        np.float64
+    )
+)
+repeats = paddle.to_tensor(
+    np.random.uniform(-2147483648, 2147483647, [2, 1]).astype(np.int32)
+)
 
 paddle.repeat_interleave(x, repeats, axis=-2)
 ```

--- a/security/advisory/pdsa-2023-019.md
+++ b/security/advisory/pdsa-2023-019.md
@@ -17,7 +17,7 @@ online_pass_interval = fleet_util.get_online_pass_interval(
     hours="9;touch /home/test/aaaa",
     split_interval=5,
     split_per_pass=2,
-    is_data_hourly_placed=False
+    is_data_hourly_placed=False,
 )
 ```
 

--- a/security/advisory/pdsa-2023-019_cn.md
+++ b/security/advisory/pdsa-2023-019_cn.md
@@ -17,7 +17,7 @@ online_pass_interval = fleet_util.get_online_pass_interval(
     hours="9;touch /home/test/aaaa",
     split_interval=5,
     split_per_pass=2,
-    is_data_hourly_placed=False
+    is_data_hourly_placed=False,
 )
 ```
 

--- a/security/advisory/pdsa-2023-023.md
+++ b/security/advisory/pdsa-2023-023.md
@@ -11,7 +11,9 @@ Command injection in `convert_shape_compare` which could lead to execute arbitra
 ```python
 import paddle
 
-paddle.jit.dy2static.convert_operators.convert_shape_compare('prefix','+ str(__import__("os").system("cat /etc/passwd")) +','1')
+paddle.jit.dy2static.convert_operators.convert_shape_compare(
+    'prefix', '+ str(__import__("os").system("cat /etc/passwd")) +', '1'
+)
 ```
 
 ### Patches

--- a/security/advisory/pdsa-2023-023_cn.md
+++ b/security/advisory/pdsa-2023-023_cn.md
@@ -11,7 +11,9 @@ CVE-2023-52314
 ```python
 import paddle
 
-paddle.jit.dy2static.convert_operators.convert_shape_compare('prefix','+ str(__import__("os").system("cat /etc/passwd")) +','1')
+paddle.jit.dy2static.convert_operators.convert_shape_compare(
+    'prefix', '+ str(__import__("os").system("cat /etc/passwd")) +', '1'
+)
 ```
 
 ### 补丁

--- a/test/dataset/imikolov_test.py
+++ b/test/dataset/imikolov_test.py
@@ -67,7 +67,7 @@ class TestMikolov(unittest.TestCase):
 
     def test_total(self):
         _, idx = list(zip(*list(WORD_DICT.items())))
-        self.assertEqual(sorted(idx)[-1], len(WORD_DICT) - 1)
+        self.assertEqual(max(idx), len(WORD_DICT) - 1)
 
 
 if __name__ == '__main__':

--- a/test/ipu/custom_ops/README.md
+++ b/test/ipu/custom_ops/README.md
@@ -29,7 +29,6 @@ https://docs.graphcore.ai/projects/popart-user-guide/en/latest/custom_ops.html
 分别在 Paddle 和 PopART 中实现 custom op 的定义后, 使用 `paddle.utils.cpp_extension.load` 编译源文件并把对应的动态库加载到当前进程中.
 
 ```python
-
 cur_dir = os.path.dirname(os.path.realpath(__file__))
 custom_ops = load(
     name="custom_jit_ops",
@@ -38,14 +37,13 @@ custom_ops = load(
         f"{cur_dir}/leaky_relu_ipu.cc",
     ],
     # 编译 leaky_relu_ipu.cc 时需要添加此参数
-    extra_cxx_cflags=['-DONNX_NAMESPACE=onnx'])
-
+    extra_cxx_cflags=['-DONNX_NAMESPACE=onnx'],
+)
 ```
 
 由于 Paddle 中 op 的定义和 PopART 中存在一些差异, 需要手动映射 custom op
 
 ```python
-
 # paddle_op is custom op type in Paddle
 # popart_op, domain and version is custom op identifier in PopART
 ipu_strategy = paddle.static.IpuStrategy()
@@ -53,19 +51,16 @@ ipu_strategy.add_custom_op(
     paddle_op="custom_leaky_relu",
     popart_op="LeakyRelu",
     domain='custom.ops',
-    version=1)
-
+    version=1,
+)
 ```
 
 ### 使用 custom op
 
 ```python
-
 x = paddle.static.data(
-    name=self.feed_list[0],
-    shape=self.feed_shape[0],
-    dtype=self.feed_dtype[0])
+    name=self.feed_list[0], shape=self.feed_shape[0], dtype=self.feed_dtype[0]
+)
 # custom op
 out = custom_ops.custom_leaky_relu(x, **self.attrs)
-
 ```

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -160,7 +160,7 @@ def get_all_api(root_path='paddle', attr="__all__"):
     )
 
     return [
-        (sorted(api_info['all_names'])[0], md5(api_info['docstring']))
+        (min(api_info['all_names']), md5(api_info['docstring']))
         for api_info in api_info_dict.values()
     ]
 
@@ -313,7 +313,7 @@ if __name__ == '__main__':
     for k, api_info in api_info_dict.items():
         # 1. the shortest suggested_name may be renamed;
         # 2. some api's fullname is not accessible, the module name of it is overridden by the function with the same name;
-        api_name = sorted(api_info['all_names'])[0]
+        api_name = min(api_info['all_names'])
         all_api_names_to_k[api_name] = k
     all_api_names_sorted = sorted(all_api_names_to_k.keys())
     for api_name in all_api_names_sorted:

--- a/tools/sampcd_processor_readme.md
+++ b/tools/sampcd_processor_readme.md
@@ -177,7 +177,7 @@
 
 ``` python
 def something():
-    """ Function summary ...
+    """Function summary ...
     Some description ...
 
     .. code-block:: pycon
@@ -186,7 +186,7 @@ def something():
         this is some blabla...
 
         >>> # doctest: +SKIP
-        >>> print(1+1)
+        >>> print(1 + 1)
         2
 
     Examples:
@@ -208,11 +208,11 @@ def something():
 
 ```python
 def something():
-    """ Function summary ...
+    """Function summary ...
     Some description ...
 
     >>> # doctest: +SKIP
-    >>> print(1+1)
+    >>> print(1 + 1)
     2
 
     Examples:
@@ -234,7 +234,7 @@ def something():
 
 ``` python
 def something():
-    """ Function summary ...
+    """Function summary ...
     Some description ...
 
     .. code-block:: pycon
@@ -243,7 +243,7 @@ def something():
         this is some blabla...
 
         >>> # doctest: +SKIP
-        >>> print(1+1)
+        >>> print(1 + 1)
        2
 
     Examples:
@@ -266,7 +266,7 @@ def something():
 
 ``` python
 def something():
-    """ Function summary ...
+    """Function summary ...
     Some description ...
 
     .. code-block:: pycon
@@ -275,7 +275,7 @@ def something():
         this is some blabla...
 
         >>> # xdoctest: +SKIP
-        >>> print(1+1)
+        >>> print(1 + 1)
         2
 
     Examples:


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description

本 PR 同步升级代码检查工具的新 minor 版本：

- 将 ast-grep 从 `0.44.0` 升级到 `0.45.0`，并同步更新 `Codestyle-Check` 工作流中的 `ast-grep-cli` 版本；
- 将 Ruff 从 `0.15.0` 升级到 `0.16.0`；
- 修复 Ruff 0.16 中新稳定的 `FURB192` 规则发现的 4 处问题。`switch_case` 中保留原有排序及空输入异常语义，其余位置使用 `min`/`max` 直接取得极值；
- 将 Markdown 明确纳入 `ruff-format` pre-commit 范围，并格式化 Ruff 0.16 发现的 48 个 Markdown 文件中的 Python 代码块。

上游发布说明：

- [ast-grep 0.45.0](https://github.com/ast-grep/ast-grep/releases/tag/0.45.0)
- [Ruff 0.16.0](https://github.com/astral-sh/ruff/releases/tag/0.16.0)

本地验证：

- `ast-grep 0.45.0`: `ast-grep test`（5/5 通过）及全仓 `ast-grep scan` 通过；
- `ruff 0.16.0 check --no-cache --force-exclude .` 全仓检查通过；
- `ruff 0.16.0 format --check --force-exclude .` 全仓检查通过（5525 个 Python/PYI/Jupyter/Markdown 文件）；
- 48 个 Markdown 文件的非代码块正文与 fence 保持不变；61 个可解析 Python 代码块的 AST 保持等价，另有 4 个 docstring 示例及 7 个 pycon/非完整示例由 Ruff 原样负责格式化；
- 变更文件上的 pre-commit hooks 全部通过（稀疏工作区缺少脚本导致的首次 copyright hook 启动失败，在补齐未修改的脚本后单独验证通过）；
- `git diff --check` 通过。

### 是否引起精度变化
否

