### PR TITLE
[Execute Infrastructure] 跳过 FP8 Tensor 的 NaN 和 Inf 检查

### DIFF
--- a/paddle/fluid/eager/nan_inf_utils.cc
+++ b/paddle/fluid/eager/nan_inf_utils.cc
@@ -93,6 +93,11 @@ void CheckTensorHasNanOrInf(const std::string& api_name, const Tensor& tensor) {
     return;
   }
 
+  if (tensor.initialized() && (tensor.dtype() == phi::DataType::FLOAT8_E4M3FN ||
+                               tensor.dtype() == phi::DataType::FLOAT8_E5M2)) {
+    return;
+  }
+
   if (!FLAGS_check_nan_inf_blacklist.empty()) {
     std::stringstream blacklist_ss(FLAGS_check_nan_inf_blacklist);
     std::string blacklisted_op;

--- a/test/cpp/eager/task_tests/nan_inf_utils_test.cc
+++ b/test/cpp/eager/task_tests/nan_inf_utils_test.cc
@@ -119,6 +119,22 @@ TEST(NanInfUtils, BlacklistSkipCheck) {
   FLAGS_check_nan_inf_blacklist = "";
 }
 
+TEST(NanInfUtils, SkipFloat8Tensor) {
+  FLAGS_check_nan_inf_blacklist = "";
+
+  auto fp8_e4m3 =
+      paddle::experimental::full({3, 4},
+                                 std::numeric_limits<double>::quiet_NaN(),
+                                 phi::DataType::FLOAT8_E4M3FN);
+  CHECK_NO_NAN_INF(fp8_e4m3);
+
+  auto fp8_e5m2 =
+      paddle::experimental::full({3, 4},
+                                 std::numeric_limits<double>::infinity(),
+                                 phi::DataType::FLOAT8_E5M2);
+  CHECK_NO_NAN_INF(fp8_e5m2);
+}
+
 TEST(NanInfUtils, Functions) {
   // test all methods
   auto tensor = paddle::experimental::full(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
本 PR 在动态图 NaN/Inf 检查流程中跳过 FP8 Tensor，避免 FP8 数据进入 `CheckTensorHasNanOrInf` 的数值检查实现。

修改文件 `paddle/fluid/eager/nan_inf_utils.cc`:
- 当 Tensor 的 dtype 为 `FLOAT8_E4M3FN` 或 `FLOAT8_E5M2` 时直接返回。
- 保持其他数据类型原有的 NaN/Inf 检查行为不变。
- 未初始化的 Tensor 不会访问 dtype。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否