### PR TITLE
[cherry-pick][release/3.4]fix write overflow in unstack kernel

### DIFF
--- a/paddle/phi/kernels/funcs/stack_and_unstack.h
+++ b/paddle/phi/kernels/funcs/stack_and_unstack.h
@@ -95,7 +95,7 @@ void StackRawKernel(const Context& dev_ctx,
   int64_t x_col = x[0]->numel() / x_row_bak;
   int64_t out_col = x_col * num;
 
-  if (out->numel() < std::numeric_limits<int32_t>::max()) {
+  if (out->numel() < std::numeric_limits<int32_t>::max() / 2) {
     switch (CalcArraySize(num)) {
       SEGMENTED_ARRAY_KERNEL_HELPER(
           LaunchStackKernel<Context, T, int32_t, kArraySize>(
@@ -127,9 +127,10 @@ __global__ void UnStackCudaKernel(const T* __restrict__ input,
   IndexT each_dim_size = split_dim / num_splits;
   IndexT split_dim_with_out_col = split_dim * out_col;
 
-  IndexT offset = blockIdx.x * blockDim.x + threadIdx.x;
+  IndexT offset = static_cast<IndexT>(blockIdx.x) * blockDim.x + threadIdx.x;
+  IndexT stride = static_cast<IndexT>(blockDim.x) * gridDim.x;
   if (each_dim_size == 1) {
-    for (; offset < numel; offset += blockDim.x * gridDim.x) {
+    for (; offset < numel; offset += stride) {
       auto col_divmod_rslt = col_divmoder.Divmod(offset);
 
       IndexT i = offset / split_dim_with_out_col;
@@ -143,7 +144,7 @@ __global__ void UnStackCudaKernel(const T* __restrict__ input,
       }
     }
   } else {
-    for (; offset < numel; offset += blockDim.x * gridDim.x) {
+    for (; offset < numel; offset += stride) {
       auto col_divmod_rslt = col_divmoder.Divmod(offset);
 
       IndexT i = offset / split_dim_with_out_col;
@@ -281,7 +282,7 @@ void UnStackRawKernel(const Context& dev_ctx,
 
   int64_t out_col = x.numel() / (split_dim * out_row);
 
-  if (x.numel() < std::numeric_limits<int32_t>::max()) {
+  if (x.numel() < std::numeric_limits<int32_t>::max() / 2) {
     switch (CalcArraySize(split_dim)) {
       SEGMENTED_ARRAY_KERNEL_HELPER(
           LaunchUnStackKernel<Context, T, int32_t, kArraySize>(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
devPR:https://github.com/PaddlePaddle/Paddle/pull/79533
修复unstack的反向大tensor越界的问题

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否 