### PR TITLE
[Cherry-Pick][Operator Mechanism] Support mm out_dtype for FP16 CUDA

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -3194,14 +3194,16 @@ void MmOutDtypeInferMeta(const MetaTensor& x,
       x.dtype() == DataType::FLOAT16 || x.dtype() == DataType::BFLOAT16,
       true,
       common::errors::InvalidArgument(
-          "The out_dtype of paddle.mm currently only supports float16 or "
-          "bfloat16 Input(X)."));
+          "The dtype of Input(X) must be FLOAT16 or BFLOAT16, but received "
+          "%s.",
+          x.dtype()));
   PADDLE_ENFORCE_EQ(
       y.dtype() == DataType::FLOAT16 || y.dtype() == DataType::BFLOAT16,
       true,
       common::errors::InvalidArgument(
-          "The out_dtype of paddle.mm currently only supports float16 or "
-          "bfloat16 Input(Y)."));
+          "The dtype of Input(Y) must be FLOAT16 or BFLOAT16, but received "
+          "%s.",
+          y.dtype()));
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       y.dtype(),

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -3191,17 +3191,23 @@ void MmOutDtypeInferMeta(const MetaTensor& x,
       common::errors::InvalidArgument(
           "The out_dtype of paddle.mm currently only supports float32."));
   PADDLE_ENFORCE_EQ(
-      x.dtype(),
-      DataType::BFLOAT16,
+      x.dtype() == DataType::FLOAT16 || x.dtype() == DataType::BFLOAT16,
+      true,
       common::errors::InvalidArgument(
-          "The out_dtype of paddle.mm currently only supports bfloat16 "
-          "Input(X)."));
+          "The out_dtype of paddle.mm currently only supports float16 or "
+          "bfloat16 Input(X)."));
   PADDLE_ENFORCE_EQ(
-      y.dtype(),
-      DataType::BFLOAT16,
+      y.dtype() == DataType::FLOAT16 || y.dtype() == DataType::BFLOAT16,
+      true,
       common::errors::InvalidArgument(
-          "The out_dtype of paddle.mm currently only supports bfloat16 "
-          "Input(Y)."));
+          "The out_dtype of paddle.mm currently only supports float16 or "
+          "bfloat16 Input(Y)."));
+  PADDLE_ENFORCE_EQ(
+      x.dtype(),
+      y.dtype(),
+      common::errors::InvalidArgument(
+          "Input(X) and Input(Y) must have the same dtype when out_dtype is "
+          "specified for paddle.mm."));
 
   auto dims_x = vectorize(x.dims());
   auto dims_y = vectorize(y.dims());

--- a/paddle/phi/kernels/funcs/blas/blas.h
+++ b/paddle/phi/kernels/funcs/blas/blas.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/dense_tensor.h"
 
 #ifdef PADDLE_WITH_MKLML
@@ -120,6 +121,17 @@ class Blas {
             float alpha,
             const phi::bfloat16* A,
             const phi::bfloat16* B,
+            float beta,
+            float* C) const;
+
+  void GEMM(CBLAS_TRANSPOSE transA,
+            CBLAS_TRANSPOSE transB,
+            int64_t M,
+            int64_t N,
+            int64_t K,
+            float alpha,
+            const phi::float16* A,
+            const phi::float16* B,
             float beta,
             float* C) const;
 

--- a/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
@@ -1724,6 +1724,87 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
 }
 
 template <>
+inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
+                                        CBLAS_TRANSPOSE transB,
+                                        int64_t M,
+                                        int64_t N,
+                                        int64_t K,
+                                        float alpha,
+                                        const phi::float16 *A,
+                                        const phi::float16 *B,
+                                        float beta,
+                                        float *C) const {
+#if CUDA_VERSION >= 8000
+  // cuBLAS uses column-major order, so swap A/B and M/N for row-major input.
+  // The int casts below are safe in the non-64-bit branch.
+  int64_t lda = (transA == CblasNoTrans) ? K : M;
+  int64_t ldb = (transB == CblasNoTrans) ? N : K;
+  cublasOperation_t cuTransA =
+      (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
+  cublasOperation_t cuTransB =
+      (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
+
+  PADDLE_ENFORCE_GE(
+      dev_ctx_.GetComputeCapability(),
+      53,
+      common::errors::InvalidArgument(
+          "cublas fp16 gemm with fp32 output requires GPU compute capability "
+          ">= 53, but received %d",
+          dev_ctx_.GetComputeCapability()));
+
+  auto &cuda_ctx = const_cast<phi::GPUContext &>(dev_ctx_);
+  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    CUBlas<phi::float16>::GEMM_EX_64(&cuda_ctx,
+                                     cuTransB,
+                                     cuTransA,
+                                     N,
+                                     M,
+                                     K,
+                                     &alpha,
+                                     B,
+                                     CUDA_R_16F,
+                                     ldb,
+                                     A,
+                                     CUDA_R_16F,
+                                     lda,
+                                     &beta,
+                                     C,
+                                     CUDA_R_32F,
+                                     N,
+                                     CUDA_R_32F);
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "GEMM_EX_64 is not supported on cuda < 12.3"));
+#endif  // CUDA_VERSION >= 12030
+  } else {
+    CheckGEMMNSize(N);
+    CUBlas<phi::float16>::GEMM_EX(&cuda_ctx,
+                                  cuTransB,
+                                  cuTransA,
+                                  static_cast<int>(N),
+                                  static_cast<int>(M),
+                                  static_cast<int>(K),
+                                  &alpha,
+                                  B,
+                                  CUDA_R_16F,
+                                  static_cast<int>(ldb),
+                                  A,
+                                  CUDA_R_16F,
+                                  static_cast<int>(lda),
+                                  &beta,
+                                  C,
+                                  CUDA_R_32F,
+                                  static_cast<int>(N),
+                                  CUDA_R_32F);
+  }
+#else
+  PADDLE_THROW(common::errors::Unimplemented(
+      "cublasGemmEx with float16 is not supported on cuda <= 7.5"));
+#endif  // CUDA_VERSION >= 8000
+}
+
+template <>
 template <>
 inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                         CBLAS_TRANSPOSE transB,

--- a/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
@@ -1748,8 +1748,8 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
       dev_ctx_.GetComputeCapability(),
       53,
       common::errors::InvalidArgument(
-          "cublas fp16 gemm with fp32 output requires GPU compute capability "
-          ">= 53, but received %d",
+          "The GPU compute capability for FP16 GEMM with FP32 output must be "
+          ">= 53, but received %d.",
           dev_ctx_.GetComputeCapability()));
 
   auto &cuda_ctx = const_cast<phi::GPUContext &>(dev_ctx_);
@@ -1775,7 +1775,7 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                      CUDA_R_32F);
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "GEMM_EX_64 is not supported on cuda < 12.3"));
+        "64-bit FP16 GEMM_EX requires CUDA 12.3 or later on Linux."));
 #endif  // CUDA_VERSION >= 12030
   } else {
     CheckGEMMNSize(N);
@@ -1800,7 +1800,7 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   }
 #else
   PADDLE_THROW(common::errors::Unimplemented(
-      "cublasGemmEx with float16 is not supported on cuda <= 7.5"));
+      "FP16 GEMM_EX requires CUDA 8.0 or later."));
 #endif  // CUDA_VERSION >= 8000
 }
 

--- a/paddle/phi/kernels/gpu/matmul_kernel.cu
+++ b/paddle/phi/kernels/gpu/matmul_kernel.cu
@@ -117,7 +117,11 @@ PD_REGISTER_KERNEL(legacy_matmul,
   }
 }
 
-PD_REGISTER_KERNEL(
-    mm_out_dtype, GPU, ALL_LAYOUT, phi::MmOutDtypeKernel, phi::bfloat16) {
+PD_REGISTER_KERNEL(mm_out_dtype,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::MmOutDtypeKernel,
+                   phi::float16,
+                   phi::bfloat16) {
   kernel->OutputAt(0).SetDataType(phi::DataType::FLOAT32);
 }

--- a/paddle/phi/kernels/impl/matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_kernel_impl.h
@@ -2067,17 +2067,23 @@ void MmOutDtypeKernel(const Context& dev_ctx,
       common::errors::InvalidArgument(
           "The out_dtype of paddle.mm currently only supports float32."));
   PADDLE_ENFORCE_EQ(
-      x.dtype(),
-      DataType::BFLOAT16,
+      x.dtype() == DataType::FLOAT16 || x.dtype() == DataType::BFLOAT16,
+      true,
       common::errors::InvalidArgument(
-          "The out_dtype of paddle.mm currently only supports bfloat16 "
-          "Input(X)."));
+          "The out_dtype of paddle.mm currently only supports float16 or "
+          "bfloat16 Input(X)."));
   PADDLE_ENFORCE_EQ(
-      y.dtype(),
-      DataType::BFLOAT16,
+      y.dtype() == DataType::FLOAT16 || y.dtype() == DataType::BFLOAT16,
+      true,
       common::errors::InvalidArgument(
-          "The out_dtype of paddle.mm currently only supports bfloat16 "
-          "Input(Y)."));
+          "The out_dtype of paddle.mm currently only supports float16 or "
+          "bfloat16 Input(Y)."));
+  PADDLE_ENFORCE_EQ(
+      x.dtype(),
+      y.dtype(),
+      common::errors::InvalidArgument(
+          "Input(X) and Input(Y) must have the same dtype when out_dtype is "
+          "specified for paddle.mm."));
   const std::vector<std::int64_t> x_dims = vectorize(x.dims());
   const std::vector<std::int64_t> y_dims = vectorize(y.dims());
   PADDLE_ENFORCE_EQ(
@@ -2092,7 +2098,8 @@ void MmOutDtypeKernel(const Context& dev_ctx,
           "The out_dtype of paddle.mm currently only supports 2-D Input(Y)."));
 #if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP)
   if constexpr (std::is_same<Context, phi::GPUContext>::value &&
-                std::is_same<T, phi::bfloat16>::value) {
+                (std::is_same<T, phi::float16>::value ||
+                 std::is_same<T, phi::bfloat16>::value)) {
     const int64_t M = x_dims[0];
     const int64_t K = x_dims[1];
     const int64_t N = y_dims[1];
@@ -2128,14 +2135,14 @@ void MmOutDtypeKernel(const Context& dev_ctx,
               N,
               K,
               1.0f,
-              x_ptr->data<phi::bfloat16>(),
-              y_ptr->data<phi::bfloat16>(),
+              x_ptr->data<T>(),
+              y_ptr->data<T>(),
               0.0f,
               out->data<float>());
   } else {
     PADDLE_THROW(common::errors::Unimplemented(
-        "The out_dtype of paddle.mm currently only supports CUDA bfloat16 "
-        "inputs."));
+        "The out_dtype of paddle.mm currently only supports CUDA float16 or "
+        "bfloat16 inputs."));
   }
 #else
   PADDLE_THROW(common::errors::Unimplemented(

--- a/paddle/phi/kernels/impl/matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_kernel_impl.h
@@ -2070,14 +2070,16 @@ void MmOutDtypeKernel(const Context& dev_ctx,
       x.dtype() == DataType::FLOAT16 || x.dtype() == DataType::BFLOAT16,
       true,
       common::errors::InvalidArgument(
-          "The out_dtype of paddle.mm currently only supports float16 or "
-          "bfloat16 Input(X)."));
+          "The dtype of Input(X) must be FLOAT16 or BFLOAT16, but received "
+          "%s.",
+          x.dtype()));
   PADDLE_ENFORCE_EQ(
       y.dtype() == DataType::FLOAT16 || y.dtype() == DataType::BFLOAT16,
       true,
       common::errors::InvalidArgument(
-          "The out_dtype of paddle.mm currently only supports float16 or "
-          "bfloat16 Input(Y)."));
+          "The dtype of Input(Y) must be FLOAT16 or BFLOAT16, but received "
+          "%s.",
+          y.dtype()));
   PADDLE_ENFORCE_EQ(
       x.dtype(),
       y.dtype(),

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2111,7 +2111,7 @@ def mm(
         name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Keywords Argument:
-        out_dtype (paddle.dtype|None, optional): The desired output data type. Currently only supports ``paddle.float32`` for CUDA bfloat16 2-D inputs in dynamic graph. Default: None.
+        out_dtype (paddle.dtype|None, optional): The desired output data type. Currently only supports ``paddle.float32`` for CUDA float16 or bfloat16 2-D inputs in dynamic graph. Both inputs must have the same data type. Default: None.
         out (Tensor, optional): The output Tensor. It must have the same data type and shape as the expected output. Default is None, and a new Tensor will be created to store the result.
 
     Returns:
@@ -2167,18 +2167,27 @@ def mm(
     if out_dtype is not None:
         out_dtype = convert_np_dtype_to_dtype_(out_dtype)
         float32_dtypes = (core.DataType.FLOAT32, core.VarDesc.VarType.FP32)
-        bf16_dtypes = (core.DataType.BFLOAT16, core.VarDesc.VarType.BF16)
+        supported_input_dtypes = (
+            core.DataType.FLOAT16,
+            core.VarDesc.VarType.FP16,
+            core.DataType.BFLOAT16,
+            core.VarDesc.VarType.BF16,
+        )
         if out_dtype not in float32_dtypes:
             raise TypeError(
                 "The out_dtype of paddle.mm currently only supports paddle.float32."
             )
-        if input.dtype not in bf16_dtypes:
+        if input.dtype not in supported_input_dtypes:
             raise TypeError(
-                "The out_dtype of paddle.mm currently only supports bfloat16 input."
+                "The out_dtype of paddle.mm currently only supports float16 or bfloat16 input."
             )
-        if mat2.dtype not in bf16_dtypes:
+        if mat2.dtype not in supported_input_dtypes:
             raise TypeError(
-                "The out_dtype of paddle.mm currently only supports bfloat16 mat2."
+                "The out_dtype of paddle.mm currently only supports float16 or bfloat16 mat2."
+            )
+        if input.dtype != mat2.dtype:
+            raise TypeError(
+                "The input and mat2 of paddle.mm must have the same dtype when out_dtype is specified."
             )
         if len(input.shape) != 2 or len(mat2.shape) != 2:
             raise ValueError(

--- a/test/legacy_test/test_mm_out.py
+++ b/test/legacy_test/test_mm_out.py
@@ -194,6 +194,15 @@ class TestMmOutDtypeDynamicOnly(unittest.TestCase):
                 "BF16 mm out_dtype requires CUDA compute capability >= 8"
             )
 
+    def test_out_dtype_rejects_unsupported_input_dtype(self):
+        x = paddle.empty([3, 4], dtype='float32')
+        y = paddle.empty([4, 5], dtype='float16')
+        with self.assertRaisesRegex(
+            TypeError,
+            "only supports float16 or bfloat16 input",
+        ):
+            paddle.mm(x, y, out_dtype=paddle.float32)
+
     def test_fp16_to_fp32(self):
         self._skip_if_no_fp16_cuda()
         x = paddle.randn([3, 4], dtype='float16')

--- a/test/legacy_test/test_mm_out.py
+++ b/test/legacy_test/test_mm_out.py
@@ -178,6 +178,14 @@ class TestMmOutDtypeDynamicOnly(unittest.TestCase):
     def setUp(self):
         paddle.disable_static()
 
+    def _skip_if_no_fp16_cuda(self):
+        if not paddle.is_compiled_with_cuda() or paddle.is_compiled_with_rocm():
+            self.skipTest("CUDA is required for mm out_dtype")
+        if paddle.device.cuda.get_device_capability() < (5, 3):
+            self.skipTest(
+                "FP16 mm out_dtype requires CUDA compute capability >= 5.3"
+            )
+
     def _skip_if_no_bf16_cuda(self):
         if not paddle.is_compiled_with_cuda() or paddle.is_compiled_with_rocm():
             self.skipTest("CUDA is required for mm out_dtype")
@@ -185,6 +193,50 @@ class TestMmOutDtypeDynamicOnly(unittest.TestCase):
             self.skipTest(
                 "BF16 mm out_dtype requires CUDA compute capability >= 8"
             )
+
+    def test_fp16_to_fp32(self):
+        self._skip_if_no_fp16_cuda()
+        x = paddle.randn([3, 4], dtype='float16')
+        y = paddle.randn([4, 5], dtype='float16')
+        out = paddle.mm(x, y, out_dtype=paddle.float32)
+        ref = paddle.mm(x.astype('float32'), y.astype('float32'))
+        self.assertEqual(out.dtype, paddle.float32)
+        np.testing.assert_allclose(
+            out.numpy(), ref.numpy(), rtol=1e-3, atol=1e-3
+        )
+
+    def test_fp16_to_fp32_transposed_rhs(self):
+        self._skip_if_no_fp16_cuda()
+        x = paddle.randn([3, 4], dtype='float16')
+        weight = paddle.randn([5, 4], dtype='float16')
+        out = paddle.mm(x, weight.t(), out_dtype=paddle.float32)
+        ref = paddle.mm(x.astype('float32'), weight.t().astype('float32'))
+        self.assertEqual(out.dtype, paddle.float32)
+        np.testing.assert_allclose(
+            out.numpy(), ref.numpy(), rtol=1e-3, atol=1e-3
+        )
+
+    def test_fp16_to_fp32_out(self):
+        self._skip_if_no_fp16_cuda()
+        x = paddle.randn([3, 4], dtype='float16')
+        y = paddle.randn([4, 5], dtype='float16')
+        out = paddle.empty([3, 5], dtype='float32')
+        ret = paddle.mm(x, y, out_dtype=paddle.float32, out=out)
+        ref = paddle.mm(x.astype('float32'), y.astype('float32'))
+        self.assertEqual(ret.dtype, paddle.float32)
+        np.testing.assert_allclose(
+            ret.numpy(), ref.numpy(), rtol=1e-3, atol=1e-3
+        )
+        np.testing.assert_allclose(
+            out.numpy(), ref.numpy(), rtol=1e-3, atol=1e-3
+        )
+
+    def test_out_dtype_rejects_mixed_input_dtypes(self):
+        self._skip_if_no_fp16_cuda()
+        x = paddle.randn([3, 4], dtype='float16')
+        y = paddle.randn([4, 5], dtype='bfloat16')
+        with self.assertRaises(TypeError):
+            paddle.mm(x, y, out_dtype=paddle.float32)
 
     def test_bf16_to_fp32(self):
         self._skip_if_no_bf16_cuda()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

本 PR 为 `paddle.mm` 的 `out_dtype` 参数新增 CUDA FP16 支持。

当输入矩阵均为 FP16 且显式指定 `out_dtype=paddle.float32` 时，使用 cuBLAS 执行 FP16 × FP16 → FP32 GEMM，其中 `alpha`、`beta`、计算累加类型及输出类型均为 FP32。

#### 主要改动

- 扩展 `mm_out_dtype`，支持同类型的 FP16 或 BF16 输入。
- 新增 FP16 输入、FP32 输出的 cuBLAS GEMM 实现。
- 为 `mm_out_dtype` GPU Kernel 注册 `phi::float16`。
- 在 Python、InferMeta 和 Kernel 层增加输入类型检查，禁止 FP16 与 BF16 混合输入。
- 更新 `paddle.mm` API 文档。
- 增加 FP16 基本计算、转置输入、`out` 参数及非法类型组合测试。

devPR:https://github.com/PaddlePaddle/Paddle/pull/79549
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否