### PR TITLE
[Operator Mechanism] fix zero-size contiguous strides

### DIFF
--- a/paddle/common/ddim.cc
+++ b/paddle/common/ddim.cc
@@ -219,7 +219,7 @@ DDim stride(const DDim& ddim) {
   strides.rank_ = ddim.size();
   if (ddim.size() > 0) strides[ddim.size() - 1] = 1;
   for (int i = ddim.size() - 2; i >= 0; --i) {
-    strides[i] = strides[i + 1] * ddim[i + 1];
+    strides[i] = strides[i + 1] * (ddim[i + 1] == 0 ? 1 : ddim[i + 1]);
   }
   return strides;
 }

--- a/paddle/phi/core/tensor_meta.cc
+++ b/paddle/phi/core/tensor_meta.cc
@@ -13,12 +13,19 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/phi/core/tensor_meta.h"
+
 #include "paddle/common/flags.h"
 #include "paddle/phi/core/enforce.h"
 
 COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
+
+namespace {
+
+inline int64_t SizeForStride(int64_t dim) { return dim == 0 ? 1 : dim; }
+
+}  // namespace
 
 DDim DenseTensorMeta::calc_strides(const DDim& dims) {
   if (dims.size() == -1 || contain_unknown_dim(dims)) {
@@ -43,7 +50,7 @@ DDim DenseTensorMeta::calc_strides(const DDim& dims) {
   // } else {
   //   strides[dims.size() - 1] = 1;
   //   for (int i = dims.size() - 2; i >= 0; --i) {
-  //     strides[i] = strides[i + 1] * dims[i + 1];
+  //     strides[i] = strides[i + 1] * (dims[i + 1] == 0 ? 1 : dims[i + 1]);
   //   }
   // }
   auto p_dims = dims.Get();
@@ -56,63 +63,63 @@ DDim DenseTensorMeta::calc_strides(const DDim& dims) {
       return strides;
     case 2:
       p_strides[1] = 1;
-      p_strides[0] = p_dims[1];
+      p_strides[0] = SizeForStride(p_dims[1]);
       return strides;
     case 3:
       p_strides[2] = 1;
-      p_strides[1] = p_dims[2];
-      p_strides[0] = p_strides[1] * p_dims[1];
+      p_strides[1] = SizeForStride(p_dims[2]);
+      p_strides[0] = p_strides[1] * SizeForStride(p_dims[1]);
       return strides;
     case 4:
       p_strides[3] = 1;
-      p_strides[2] = p_dims[3];
-      p_strides[1] = p_strides[2] * p_dims[2];
-      p_strides[0] = p_strides[1] * p_dims[1];
+      p_strides[2] = SizeForStride(p_dims[3]);
+      p_strides[1] = p_strides[2] * SizeForStride(p_dims[2]);
+      p_strides[0] = p_strides[1] * SizeForStride(p_dims[1]);
       return strides;
     case 5:
       p_strides[4] = 1;
-      p_strides[3] = p_dims[4];
-      p_strides[2] = p_strides[3] * p_dims[3];
-      p_strides[1] = p_strides[2] * p_dims[2];
-      p_strides[0] = p_strides[1] * p_dims[1];
+      p_strides[3] = SizeForStride(p_dims[4]);
+      p_strides[2] = p_strides[3] * SizeForStride(p_dims[3]);
+      p_strides[1] = p_strides[2] * SizeForStride(p_dims[2]);
+      p_strides[0] = p_strides[1] * SizeForStride(p_dims[1]);
       return strides;
     case 6:
       p_strides[5] = 1;
-      p_strides[4] = p_dims[5];
-      p_strides[3] = p_strides[4] * p_dims[4];
-      p_strides[2] = p_strides[3] * p_dims[3];
-      p_strides[1] = p_strides[2] * p_dims[2];
-      p_strides[0] = p_strides[1] * p_dims[1];
+      p_strides[4] = SizeForStride(p_dims[5]);
+      p_strides[3] = p_strides[4] * SizeForStride(p_dims[4]);
+      p_strides[2] = p_strides[3] * SizeForStride(p_dims[3]);
+      p_strides[1] = p_strides[2] * SizeForStride(p_dims[2]);
+      p_strides[0] = p_strides[1] * SizeForStride(p_dims[1]);
       return strides;
     case 7:
       p_strides[6] = 1;
-      p_strides[5] = p_dims[6];
-      p_strides[4] = p_strides[5] * p_dims[5];
-      p_strides[3] = p_strides[4] * p_dims[4];
-      p_strides[2] = p_strides[3] * p_dims[3];
-      p_strides[1] = p_strides[2] * p_dims[2];
-      p_strides[0] = p_strides[1] * p_dims[1];
+      p_strides[5] = SizeForStride(p_dims[6]);
+      p_strides[4] = p_strides[5] * SizeForStride(p_dims[5]);
+      p_strides[3] = p_strides[4] * SizeForStride(p_dims[4]);
+      p_strides[2] = p_strides[3] * SizeForStride(p_dims[3]);
+      p_strides[1] = p_strides[2] * SizeForStride(p_dims[2]);
+      p_strides[0] = p_strides[1] * SizeForStride(p_dims[1]);
       return strides;
     case 8:
       p_strides[7] = 1;
-      p_strides[6] = p_dims[7];
-      p_strides[5] = p_strides[6] * p_dims[6];
-      p_strides[4] = p_strides[5] * p_dims[5];
-      p_strides[3] = p_strides[4] * p_dims[4];
-      p_strides[2] = p_strides[3] * p_dims[3];
-      p_strides[1] = p_strides[2] * p_dims[2];
-      p_strides[0] = p_strides[1] * p_dims[1];
+      p_strides[6] = SizeForStride(p_dims[7]);
+      p_strides[5] = p_strides[6] * SizeForStride(p_dims[6]);
+      p_strides[4] = p_strides[5] * SizeForStride(p_dims[5]);
+      p_strides[3] = p_strides[4] * SizeForStride(p_dims[4]);
+      p_strides[2] = p_strides[3] * SizeForStride(p_dims[3]);
+      p_strides[1] = p_strides[2] * SizeForStride(p_dims[2]);
+      p_strides[0] = p_strides[1] * SizeForStride(p_dims[1]);
       return strides;
     case 9:
       p_strides[8] = 1;
-      p_strides[7] = p_dims[8];
-      p_strides[6] = p_strides[7] * p_dims[7];
-      p_strides[5] = p_strides[6] * p_dims[6];
-      p_strides[4] = p_strides[5] * p_dims[5];
-      p_strides[3] = p_strides[4] * p_dims[4];
-      p_strides[2] = p_strides[3] * p_dims[3];
-      p_strides[1] = p_strides[2] * p_dims[2];
-      p_strides[0] = p_strides[1] * p_dims[1];
+      p_strides[7] = SizeForStride(p_dims[8]);
+      p_strides[6] = p_strides[7] * SizeForStride(p_dims[7]);
+      p_strides[5] = p_strides[6] * SizeForStride(p_dims[6]);
+      p_strides[4] = p_strides[5] * SizeForStride(p_dims[5]);
+      p_strides[3] = p_strides[4] * SizeForStride(p_dims[4]);
+      p_strides[2] = p_strides[3] * SizeForStride(p_dims[3]);
+      p_strides[1] = p_strides[2] * SizeForStride(p_dims[2]);
+      p_strides[0] = p_strides[1] * SizeForStride(p_dims[1]);
       return strides;
     default:
       PADDLE_THROW(common::errors::InvalidArgument(

--- a/test/cpp/phi/core/test_dense_tensor.cc
+++ b/test/cpp/phi/core/test_dense_tensor.cc
@@ -200,6 +200,7 @@ TEST(dense_tensor, zero_size_strides) {
   const auto zero_size_strides = DenseTensorMeta::calc_strides(zero_size_dims);
   const auto expected_zero_size_strides = common::make_ddim({2048, 1});
   EXPECT_EQ(zero_size_strides, expected_zero_size_strides);
+  EXPECT_EQ(common::stride(zero_size_dims), expected_zero_size_strides);
 
   DenseTensorMeta zero_size_meta(DataType::FLOAT32, zero_size_dims);
   EXPECT_EQ(zero_size_meta.strides, expected_zero_size_strides);
@@ -208,6 +209,29 @@ TEST(dense_tensor, zero_size_strides) {
   const auto reshaped_zero_size_dims = common::make_ddim({0, 512, 4});
   EXPECT_EQ(DenseTensorMeta::calc_strides(reshaped_zero_size_dims),
             common::make_ddim({2048, 4, 1}));
+  EXPECT_EQ(common::stride(reshaped_zero_size_dims),
+            common::make_ddim({2048, 4, 1}));
+
+  const auto zero_size_last_dim = common::make_ddim({1024, 0});
+  const auto expected_zero_size_last_dim_strides = common::make_ddim({1, 1});
+  EXPECT_EQ(DenseTensorMeta::calc_strides(zero_size_last_dim),
+            expected_zero_size_last_dim_strides);
+  EXPECT_EQ(common::stride(zero_size_last_dim),
+            expected_zero_size_last_dim_strides);
+
+  DenseTensorMeta zero_size_last_dim_meta(DataType::FLOAT32,
+                                          zero_size_last_dim);
+  EXPECT_EQ(zero_size_last_dim_meta.strides,
+            expected_zero_size_last_dim_strides);
+  EXPECT_TRUE(zero_size_last_dim_meta.is_contiguous());
+
+  const auto zero_size_middle_dim = common::make_ddim({2, 0, 4});
+  const auto expected_zero_size_middle_dim_strides =
+      common::make_ddim({4, 4, 1});
+  EXPECT_EQ(DenseTensorMeta::calc_strides(zero_size_middle_dim),
+            expected_zero_size_middle_dim_strides);
+  EXPECT_EQ(common::stride(zero_size_middle_dim),
+            expected_zero_size_middle_dim_strides);
 
   const auto unknown_dims = common::make_ddim({-1, 2048});
   EXPECT_EQ(DenseTensorMeta::calc_strides(unknown_dims), unknown_dims);

--- a/test/legacy_test/test_eager_tensor.py
+++ b/test/legacy_test/test_eager_tensor.py
@@ -2339,6 +2339,16 @@ class TestEagerTensorStride(unittest.TestCase):
         self.assertEqual(contiguous.stride(), [1024, 1])
         self.assertTrue(contiguous.is_contiguous())
 
+        zero_size_last_dim = paddle.empty([1024, 0], dtype='float32')
+        self.assertEqual(zero_size_last_dim.stride(), [1, 1])
+        self.assertEqual(zero_size_last_dim.get_strides(), [1, 1])
+        self.assertTrue(zero_size_last_dim.is_contiguous())
+
+        zero_size_middle_dim = paddle.empty([2, 0, 4], dtype='float32')
+        self.assertEqual(zero_size_middle_dim.stride(), [4, 4, 1])
+        self.assertEqual(zero_size_middle_dim.get_strides(), [4, 4, 1])
+        self.assertTrue(zero_size_middle_dim.is_contiguous())
+
     def test_stride_different_dtypes(self):
         paddle.disable_static()
 

--- a/test/legacy_test/test_zero_size.py
+++ b/test/legacy_test/test_zero_size.py
@@ -24,7 +24,7 @@ def contiguous_strides(shape):
     running = 1
     for i in range(len(shape) - 1, -1, -1):
         strides[i] = running
-        running *= shape[i]
+        running *= shape[i] if shape[i] != 0 else 1
     return strides
 
 


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
#### 问题背景

当前 Paddle 在计算 zero-size Tensor 的默认 contiguous strides 时，会直接使用后一维大小参与连乘。因此当 0 维不在首维时，部分 stride 会被计算为 0，例如：

- `[1024, 0]` 原为 `[0, 1]`
- `[2, 0, 4]` 原为 `[0, 4, 1]`

对于 zero-size Tensor，这类 0 stride 不会参与实际元素访问，但会让 contiguous dense layout 的元数据表现异常。

#### 问题定位与解决方案

本 PR 调整 Paddle 默认 contiguous stride 计算逻辑：当后一维 size 为 0 时，按 1 参与 stride 计算，避免 zero-size contiguous Tensor 的默认 stride 中出现非预期的 0 stride。

stride 变化如下：

| shape | 修改前 stride | 修改后 stride |
| --- | --- | --- |
| `[0, 2048]` | `[2048, 1]` | `[2048, 1]` |
| `[1024, 0]` | `[0, 1]` | `[1, 1]` |
| `[2, 0, 4]` | `[0, 4, 1]` | `[4, 4, 1]` |

同时保留 `DenseTensorMeta::calc_strides` 原有按 rank 展开的 switch 结构。

#### 修改文件
- `paddle/common/ddim.cc`
  - 调整 `common::stride`，zero-size 维度按 1 参与 stride 连乘。
- `paddle/phi/core/tensor_meta.cc`
  - 调整 `DenseTensorMeta::calc_strides`，保持原有 switch 展开结构，仅修改 0 维参与 stride 计算的规则。
  - 更新注释中的 stride 公式。
- `test/cpp/phi/core/test_dense_tensor.cc`
  - 增加 C++ 层 zero-size stride 测试，覆盖 0 维在首维、中间维、末维情况。
- `test/legacy_test/test_eager_tensor.py`
  - 增加 Python/eager 行为测试，检查 `stride()`、`get_strides()` 和 `is_contiguous()`。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否