### PR TITLE
[cherry-pick]align the precision of log2 api with torch+2.12.0

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -5544,12 +5544,15 @@ __device__ __forceinline__
   static_assert(!std::is_same<T, double>::value,
                 "this template must be used with float or less precise type");
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_ARCH__)
-  // use __logf fast approximation for peak bandwidth
-  return __log2f(x);
-#else
-  return ::log2(x);
-#endif
+  // Use the standard implementation rather than the faster but lower-precision
+  // __log2f intrinsic, so that the floating-point results match PyTorch's
+  // bit-for-bit. For peak bandwidth at the cost of accuracy, switch to the
+  // __log2f intrinsic to obtain an approximate value.
+  if constexpr (std::is_integral<T>::value) {
+    return ::log2f(static_cast<float>(x));
+  } else {
+    return ::log2f(x);  // T == float
+  }
 }
 
 template <>
@@ -5582,12 +5585,18 @@ struct CudaLog2Functor<ComplexType<T>>
 
 template <typename T>
 struct CudaLog2GradFunctor : public BaseActivationFunctor<T> {
-  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-  T log_two = static_cast<T>(log(static_cast<MPType>(2.0f)));
+  using MT = typename MPTypeTrait<T>::Type;
+  MT ln_two = static_cast<MT>(log(static_cast<MT>(2.0f)));
 
-  // dx = dout / (x * log(2))
+  // dx = dout / (x * ln(2))
   __device__ __forceinline__ T operator()(const T dout, const T x) const {
-    return dout / (x * log_two);
+    // Both the multiplication and division are performed in the math type (MT,
+    // i.e. float for fp16/bf16) rather than in T.  This matches Torch2.12.0's
+    // type-promotion behaviour for low-precision dtypes and ensures identical
+    // rounding on all devices (CUDA, ROCm/HIP), independent of how each
+    // platform overloads operator/ for fp16/bf16.
+    T denominator = static_cast<T>(static_cast<MT>(x) * ln_two);
+    return static_cast<T>(static_cast<MT>(dout) / static_cast<MT>(denominator));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
<!-- Describe what you’ve done -->
devPR:https://github.com/PaddlePaddle/Paddle/pull/79541
log2的前向和反向与torch2.12.0的逐位对齐

### 是否引起精度变化
是
