### PR TITLE
[Cherry-Pick][Operator Mechanism] Fix `embedding` invalid index handling (#79510)

### DIFF
--- a/paddle/phi/kernels/cpu/embedding_kernel.cc
+++ b/paddle/phi/kernels/cpu/embedding_kernel.cc
@@ -43,6 +43,11 @@ struct EmbeddingCPUFunctor {
 
     int64_t row_number = weight_.dims()[0];
     int64_t row_width = weight_.dims()[1];
+    if (ids_numel > 0 && row_number == 0) {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "The first dimension of Input(Weight) in OP(embedding) must be "
+          "greater than 0 when Input(Ids) is not empty."));
+    }
 
     auto* table = weight_.data<T>();
 
@@ -50,7 +55,7 @@ struct EmbeddingCPUFunctor {
     auto* output = out_->data<T>();
 
     for (int64_t i = 0; i < ids_numel; ++i) {
-      if (padding_idx_ == kNoPadding && ids[i] != padding_idx_) {
+      if (padding_idx_ == kNoPadding || ids[i] != padding_idx_) {
         PADDLE_ENFORCE_LT(
             ids[i],
             row_number,

--- a/paddle/phi/kernels/gpu/embedding_kernel.cu
+++ b/paddle/phi/kernels/gpu/embedding_kernel.cu
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/embedding_kernel.h"
+#include "paddle/common/enforce.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
 #include "paddle/phi/kernels/funcs/embedding_util.h"
+
 namespace phi {
 
 template <typename T, typename IdT, bool PaddingFlag>
@@ -80,6 +82,12 @@ struct EmbeddingCUDAFunctor {
     size_t N = weight_.dims()[0];
     size_t D = weight_.dims()[1];
     size_t K = input_.numel();
+
+    if (K > 0 && N == 0) {
+      PADDLE_THROW(common::errors::InvalidArgument(
+          "The first dimension of Input(Weight) in OP(embedding) must be "
+          "greater than 0 when Input(Ids) is not empty."));
+    }
 
     const int gridx = 2 * dev_ctx_.GetSMCount();
     dim3 threads(256, 4);

--- a/paddle/phi/kernels/xpu/embedding_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/embedding_grad_kernel.cc
@@ -42,6 +42,23 @@ void EmbeddingGradKernel(const Context& dev_ctx,
 
   int64_t ids_numel = ids_t->numel();
 
+  T* d_table_data = dev_ctx.template Alloc<T>(d_table_t);
+  int64_t xm = d_table_t->dims()[0];
+  int64_t ym = ids_numel;
+  int64_t n = d_table_t->dims()[1];
+
+  if (xm == 0 || n == 0) {
+    return;
+  }
+  if (ids_numel == 0) {
+    int r = xpu::constant(dev_ctx.x_context(),
+                          reinterpret_cast<XPUType*>(d_table_data),
+                          d_table_t->numel(),
+                          (XPUType)0);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
+    return;
+  }
+
   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
   const int64_t* ids_data;
   if (ids_t->dtype() == DataType::INT64) {
@@ -55,14 +72,6 @@ void EmbeddingGradKernel(const Context& dev_ctx,
   }
 
   const T* d_output_data = d_output_t->data<T>();
-  T* d_table_data = dev_ctx.template Alloc<T>(d_table_t);
-  int64_t xm = d_table_t->dims()[0];
-  int64_t ym = ids_numel;
-  int64_t n = d_table_t->dims()[1];
-
-  if (xm == 0 || ym == 0 || n == 0) {
-    return;
-  }
   int r = xpu::embedding_grad<XPUType, int64_t>(
       dev_ctx.x_context(),
       reinterpret_cast<const XPUType*>(d_output_data),

--- a/paddle/phi/kernels/xpu/embedding_kernel.cc
+++ b/paddle/phi/kernels/xpu/embedding_kernel.cc
@@ -38,6 +38,12 @@ void EmbeddingKernel(const Context &dev_ctx,
 
   int64_t ids_numel = ids_t->numel();
 
+  if (ids_numel > 0 && weight.dims()[0] == 0) {
+    PADDLE_THROW(common::errors::InvalidArgument(
+        "The first dimension of Input(Weight) in OP(embedding) must be "
+        "greater than 0 when Input(Ids) is not empty."));
+  }
+
   auto *table_t = &weight;
 
   auto *table = table_t->data<T>();

--- a/test/legacy_test/test_lookup_table_v2_op.py
+++ b/test/legacy_test/test_lookup_table_v2_op.py
@@ -310,6 +310,53 @@ class TestLookupTableOp_ZeroSize2(TestLookupTableOp_ZeroSize):
         self.outputs = {'Out': table[ids.flatten()].reshape((0, 1, 10))}
 
 
+class TestEmbeddingCPUOutOfRangeError(unittest.TestCase):
+    def test_embedding_out_of_range(self):
+        paddle.disable_static()
+        paddle.set_device('cpu')
+        try:
+            weight = paddle.randn([4, 3], dtype='float32')
+            cases = [(-1, None), (-1, 0), (4, 0)]
+            for invalid_id, padding_idx in cases:
+                with self.subTest(
+                    invalid_id=invalid_id, padding_idx=padding_idx
+                ):
+                    ids = paddle.to_tensor([invalid_id], dtype='int64')
+                    with self.assertRaisesRegex(
+                        Exception, r'expected >= 0 and < 4'
+                    ):
+                        paddle.nn.functional.embedding(
+                            ids, weight, padding_idx=padding_idx
+                        )
+
+            weight = paddle.empty([0, 3], dtype='float32')
+            ids = paddle.to_tensor([0], dtype='int64')
+            with self.assertRaisesRegex(
+                Exception,
+                r'Input\(Weight\) in OP\(embedding\).*Input\(Ids\) is not empty',
+            ):
+                paddle.nn.functional.embedding(ids, weight, padding_idx=0)
+        finally:
+            paddle.enable_static()
+
+
+class TestEmbeddingOutOfRangeError(unittest.TestCase):
+    def test_embedding_out_of_range(self):
+        paddle.disable_static()
+        device = 'gpu' if paddle.is_compiled_with_cuda() else 'cpu'
+        paddle.set_device(device)
+        try:
+            weight = paddle.randn([0, 7168], dtype='float32')
+            ids = paddle.to_tensor([0], dtype='int64')
+            error_pattern = (
+                r'Input\(Weight\) in OP\(embedding\).*Input\(Ids\) is not empty'
+            )
+            with self.assertRaisesRegex(Exception, error_pattern):
+                paddle.nn.functional.embedding(ids, weight)
+        finally:
+            paddle.enable_static()
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()

--- a/test/xpu/test_lookup_table_v2_op_xpu.py
+++ b/test/xpu/test_lookup_table_v2_op_xpu.py
@@ -23,6 +23,7 @@ from get_test_cover_info import (
 from op_test_xpu import XPUOpTest
 
 import paddle
+from paddle import base
 
 paddle.enable_static()
 
@@ -99,6 +100,27 @@ class XPUTestLookupTableOP(XPUOpTestWrapper):
             self.outputs['Out'][np.squeeze(ids == padding_idx)] = np.zeros(31)
             self.attrs = {'padding_idx': padding_idx}
             self.check_output_with_place(self.place)
+
+
+class TestEmbeddingInvalidInput(unittest.TestCase):
+    def test_empty_weight_with_nonempty_ids(self):
+        with base.dygraph.guard(paddle.XPUPlace(0)):
+            weight = paddle.empty([0, 8], dtype='float32')
+            for dtype in ['int32', 'int64']:
+                with self.subTest(dtype=dtype):
+                    ids = paddle.zeros([1], dtype=dtype)
+                    with self.assertRaisesRegex(
+                        Exception,
+                        r'Input\(Weight\) in OP\(embedding\).*Input\(Ids\) is not empty',
+                    ):
+                        paddle.nn.functional.embedding(ids, weight)
+
+    def test_empty_weight_with_empty_ids(self):
+        with base.dygraph.guard(paddle.XPUPlace(0)):
+            weight = paddle.empty([0, 8], dtype='float32')
+            ids = paddle.empty([0], dtype='int64')
+            out = paddle.nn.functional.embedding(ids, weight)
+            self.assertEqual(out.shape, [0, 8])
 
 
 support_types = get_xpu_op_support_types('lookup_table_v2')

--- a/test/xpu/test_zero_dim_tensor_xpu.py
+++ b/test/xpu/test_zero_dim_tensor_xpu.py
@@ -2741,23 +2741,25 @@ class TestNoBackwardAPI(unittest.TestCase):
             self.assertEqual(emb.numpy()[i], res[i])
 
     def test_embedding_grad_ids_3_weight_20_32(self):
-        ids = paddle.to_tensor([], dtype='int64').reshape([0, 1, 1])
-        w = paddle.randn([20, 32], dtype='float32')
-        ids.stop_gradient = False
-        w.stop_gradient = False
-        out = paddle.nn.functional.embedding(
-            input=ids,
-            weight=w,
-            padding_idx=None,
-            max_norm=None,
-            norm_type=2.0,
-            sparse=False,
-            scale_grad_by_freq=False,
-            name=None,
-        )
-        loss = out.sum()
-        loss.backward()
-        self.assertEqual(out.shape, [0, 1, 1, 32])
+        for dtype in ['int32', 'int64']:
+            with self.subTest(dtype=dtype):
+                ids = paddle.to_tensor([], dtype=dtype).reshape([0, 1, 1])
+                w = paddle.randn([20, 32], dtype='float32')
+                w.stop_gradient = False
+                out = paddle.nn.functional.embedding(
+                    input=ids,
+                    weight=w,
+                    padding_idx=None,
+                    max_norm=None,
+                    norm_type=2.0,
+                    sparse=False,
+                    scale_grad_by_freq=False,
+                    name=None,
+                )
+                loss = out.sum()
+                loss.backward()
+                self.assertEqual(out.shape, [0, 1, 1, 32])
+                self.assertEqual(np.count_nonzero(w.grad.numpy()), 0)
 
     def test_one_hot_label(self):
         label = paddle.full(shape=[], fill_value=2, dtype='int64')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
devPR:https://github.com/PaddlePaddle/Paddle/pull/79510

#### 问题背景

`paddle.nn.functional.embedding(x, weight, padding_idx=None, max_norm=None, norm_type=2.0, sparse=False, scale_grad_by_freq=False, name=None)`

其中 `x`（下文称 `ids`）是 int32/int64 索引 Tensor，`weight` 是形状为 `[N, D]` 的二维词表。embedding 会按 `ids` 到 `weight` 第 0 维取行，并输出 `ids.shape + [D]`。

`padding_idx` 对应的 ID 会输出全零向量，其他 ID 都需要查询 `weight`，因此必须落在 `[0, N)` 范围内。当 `padding_idx=None` 时，所有输入 ID 都必须接受范围检查。

#### 问题定位与解决方案

**1. CPU forward：padding 判断条件导致范围检查不完整**

```python
import paddle

paddle.set_device("cpu")
weight = paddle.arange(12, dtype="float32").reshape([4, 3])
ids = paddle.to_tensor([-1], dtype="int64")
print(paddle.nn.functional.embedding(ids, weight))

# 输出
Tensor(shape=[1, 3], dtype=float32, place=Place(cpu), stop_gradient=True,
       [[0.        , 0.00000000, 0.        ]])
```

`weight` 共有 4 行，非 padding ID 的合法范围应为 `[0, 4)`，`ids` 的 `-1` 为非法输入但未抛出异常。问题出在 `paddle/phi/kernels/cpu/embedding_kernel.cc` 的 padding 判断条件：
```cpp
if (padding_idx_ == kNoPadding && ids[i] != padding_idx_) {
```

原条件使用了 `&&`，实际上无 padding 时，`padding_idx_` 使用 sentinel 值 `-1`，如果输入里出现 `id=-1`，它会被误认为等于 padding 值，从而跳过范围检查；有 padding 时，`padding_idx_ == kNoPadding` 恒为 false，整个条件不成立，所有 ID 都会跳过范围检查。

本 PR 将 `&&` 修正为 `||`，修改后，无 padding 时检查所有 ID；有 padding 时仅跳过等于 `padding_idx` 的 ID。

**2. GPU/XPU forward：空词表查询没有在 host 端拦截**

```python
import paddle

paddle.set_device("gpu")
weight = paddle.empty([0, 7168], dtype="float32")
ids = paddle.to_tensor([0], dtype="int64")
paddle.nn.functional.embedding(ids, weight)
paddle.device.cuda.synchronize()

# 输出
OSError: (External) CUDA error(719), unspecified launch failure. 
  [Hint: 'cudaErrorLaunchFailure'. An exception occurred on the device while executing a kernel. Common causes include dereferencing an invalid device pointerand accessing out of bounds shared memory. Less common cases can be system specific - more information about these cases canbe found in the system specific user guide. This leaves the process in an inconsistent state and any further CUDA work willreturn the same error. To continue using CUDA, the process must be terminated and relaunched.] (at /paddle/paddle/fluid/pybind/cuda_streams_py.cc:164)
```

此时词表行数为 0 但 `ids` 非空。按照 embedding 的取行语义，不存在任何合法 ID 可以被查询。原有实现 GPU 取得 `N/D/K` 后会直接启动 CUDA kernel；XPU 只对空 IDs 早退，非空 IDs 会继续进入 dtype 转换和 vendor API。GPU 与 XPU 均未覆盖 `ids.numel() > 0 && weight.dims()[0] == 0` 的检查。

本 PR 将增加同一条 host 端检查：

```cpp
if (ids.numel() > 0 && weight.dims()[0] == 0) {
  PADDLE_THROW(common::errors::InvalidArgument(...));
}
```

修改后，该输入会在 host 端明确抛出错误：

```text
ValueError: (InvalidArgument) The first dimension of Input(Weight) in OP(embedding)
must be greater than 0 when Input(Ids) is not empty.
```

**3. XPU dense backward：空 IDs 路径返回前没有写零梯度**

问题位于 `paddle/phi/kernels/xpu/embedding_grad_kernel.cc`：
```cpp
  T* d_table_data = dev_ctx.template Alloc<T>(d_table_t);
  int64_t xm = d_table_t->dims()[0];
  int64_t ym = ids_numel;
  int64_t n = d_table_t->dims()[1];

  if (xm == 0 || ym == 0 || n == 0) {
    return;
  }
```

原有实现虽然已经分配了 `weight_grad`，但将空 IDs 与空 gradient 合并早退，没有写入已分配的非空 gradient。

本 PR 修改如下：
- `weight_grad` 自身为空时保持快速返回；
- `ids` 为空且 `weight_grad` 非空时，使用 `xpu::constant` 填零后返回。
- 迁移代码块位置，将 ID dtype 转换和 `out_grad.data()` 获取仅保留在非空 IDs 路径执行。

#### 修改文件与含义

本 PR 共修改 7 个文件。

**Kernel 实现**

- `paddle/phi/kernels/cpu/embedding_kernel.cc`
  - 修正 padding-aware 范围检查条件，避免非 padding 越界 ID 被用于地址计算。
- `paddle/phi/kernels/gpu/embedding_kernel.cu`
  - 在 CUDA kernel 启动前检查空词表配合非空 IDs 的非法输入。
- `paddle/phi/kernels/xpu/embedding_kernel.cc`
  - 在 XPU vendor API 调用前增加同样的空词表检查，并保留空 IDs 的合法空输出路径。
- `paddle/phi/kernels/xpu/embedding_grad_kernel.cc`
  - 空 IDs 且 `weight_grad` 非空时写零梯度；非空 IDs 路径保持原有转换与 grad kernel 调用。

**回归测试**

- `test/legacy_test/test_lookup_table_v2_op.py`
  - 覆盖 CPU 越界 ID，以及 GPU 空词表配合非空 IDs 的异常路径。
- `test/xpu/test_lookup_table_v2_op_xpu.py`
  - 覆盖 XPU 空词表异常，并增加空词表配合空 IDs 的合法对照。
- `test/xpu/test_zero_dim_tensor_xpu.py`
  - 覆盖 XPU 空 IDs dense backward 的全零 `weight.grad`。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否