### PR TITLE
[release/3.4] update empty_strided for compat

### DIFF
--- a/paddle/phi/api/include/compat/ATen/ops/empty_strided.h
+++ b/paddle/phi/api/include/compat/ATen/ops/empty_strided.h
@@ -17,23 +17,125 @@
 #include <ATen/core/Tensor.h>
 #include <c10/core/TensorOptions.h>
 #include <c10/util/ArrayRef.h>
+#include <utils/pinned_place.h>
+
+#include <limits>
 #include <optional>
 #include <string_view>
 
 #include "paddle/phi/api/include/api.h"
+#include "paddle/phi/common/data_type.h"
+#include "paddle/phi/common/place.h"
 
 namespace at {
+
+namespace detail {
+
+// PyTorch's `empty_strided_cpu` forwards `options.pinned_memory_opt()` into
+// `GetCPUAllocatorMaybePinned`, so `pin_memory=true` yields page-locked
+// memory. Paddle's `empty` API has no allocator hook, so follow the
+// `empty_like.h` convention instead: allocate on CPU first and move the
+// storage to the pinned place.
+inline paddle::Tensor _PD_EmptyStridedFlatTensor(
+    int64_t storage_elems,
+    phi::DataType dtype,
+    const at::TensorOptions& options) {
+  const paddle::experimental::IntArray shape(
+      std::vector<int64_t>{storage_elems});
+  if (!options.pinned_memory()) {
+    return paddle::experimental::empty(shape, dtype, options._PD_GetPlace());
+  }
+  // Pinning memory is only supported for CPU tensors.
+  TORCH_CHECK(
+      !options.has_device() || options.device().is_cpu(),
+      "pin_memory=true requires device to be CPU, but got non-CPU device");
+  auto flat_cpu = paddle::experimental::empty(shape, dtype, phi::CPUPlace());
+  const phi::Place pinned_place =
+      compat::_PD_GetCreatePinnedPlace(options._PD_GetPlace());
+  return flat_cpu.copy_to(pinned_place, /*blocking=*/true);
+}
+
+}  // namespace detail
 
 inline at::Tensor empty_strided(at::IntArrayRef size,
                                 at::IntArrayRef stride,
                                 at::TensorOptions options = {}) {
-  auto empty_tensor = paddle::experimental::empty(
-      size._PD_ToPaddleIntArray(),
-      compat::_PD_AtenScalarTypeToPhiDataType(options.dtype()),
-      options._PD_GetPlace());
+  // Match PyTorch's semantics (`computeStorageNbytes` in
+  // aten/src/ATen/EmptyTensor.cpp): the storage must cover the largest
+  // offset reachable through the strides, i.e.
+  // `1 + sum((size[i] - 1) * stride[i])` elements (0 if any dim is 0).
+  // This can exceed `numel()` for padded layouts (e.g. TMA-aligned tensors),
+  // so allocating by `size` alone would under-allocate and cause OOB writes.
+  TORCH_CHECK(size.size() == stride.size(),
+              "dimensionality of sizes (",
+              size.size(),
+              ") must match dimensionality of strides (",
+              stride.size(),
+              ")");
+
+  // PyTorch's `empty_strided` only supports the strided layout.
+  TORCH_CHECK(options.layout() == at::kStrided,
+              "empty_strided only supports strided layout, got: ",
+              options.layout());
+
+  // Match PyTorch's `_empty_strided_generic`, which runs
+  // `check_size_nonnegative` over every dimension before the storage
+  // computation. The 0-size fast path below breaks out early, so folding
+  // this check into that loop would let inputs like size={0, -1} slip
+  // through unvalidated.
+  for (size_t i = 0; i < size.size(); ++i) {
+    TORCH_CHECK(size[i] >= 0,
+                "Trying to create tensor with negative dimension ",
+                size[i],
+                ": ",
+                size);
+  }
+
+  int64_t storage_elems = 1;
+  for (size_t i = 0; i < size.size(); ++i) {
+    if (size[i] == 0) {
+      storage_elems = 0;
+      break;
+    }
+    TORCH_CHECK(stride[i] >= 0,
+                "empty_strided: Negative strides are not supported, got ",
+                stride[i],
+                " at dimension ",
+                i);
+    const int64_t extent = size[i] - 1;
+    TORCH_CHECK(extent == 0 ||
+                    stride[i] <= std::numeric_limits<int64_t>::max() / extent,
+                "Storage size calculation overflowed with sizes=",
+                size,
+                " and strides=",
+                stride);
+    const int64_t strided_elems = extent * stride[i];
+    TORCH_CHECK(
+        storage_elems <= std::numeric_limits<int64_t>::max() - strided_elems,
+        "Storage size calculation overflowed with sizes=",
+        size,
+        " and strides=",
+        stride);
+    storage_elems += strided_elems;
+  }
+
+  // The allocator sizes the buffer as `storage_elems * itemsize` bytes; make
+  // sure that product cannot wrap around `size_t` either.
+  const auto dtype = compat::_PD_AtenScalarTypeToPhiDataType(options.dtype());
+  const size_t itemsize = phi::SizeOf(dtype);
+  TORCH_CHECK(
+      itemsize == 0 || static_cast<size_t>(storage_elems) <=
+                           std::numeric_limits<size_t>::max() / itemsize,
+      "Storage size calculation overflowed with sizes=",
+      size,
+      " and strides=",
+      stride);
+
+  auto flat_tensor =
+      detail::_PD_EmptyStridedFlatTensor(storage_elems, dtype, options);
 
   return paddle::experimental::as_strided(
-      empty_tensor,
+      flat_tensor,
       std::vector<int64_t>(size.begin(), size.end()),
       std::vector<int64_t>(stride.begin(), stride.end()));
 }


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
本 PR 修复 ATen compat empty_strided 的 padded stride storage 分配和边界校验，同torch逻辑采用stride计算，旧的numel计算方式会在新deepgemm下产生越界


```python

import paddle
paddle.enable_compat()

import torch
import hashlib

import deep_gemm
from deep_gemm.testing import calc_diff, get_arch_major

from generators import (
    QuantConfig, KernelType, MajorTypeAB,
    generate_normal, get_ue8m0_usage,
    cast_fp8_fp4_with_major
)
from deep_gemm.utils import per_token_cast_to_fp4, per_token_cast_to_fp8, cast_back_from_fp4


def test_fp8_gemm_gran_k_a_32():
    """Test fp8*fp8 GEMM with gran_k_a=32, gran_k_b=32."""
    assert get_arch_major() == 10, "This test requires SM100 (Blackwell) architecture"

    print("Testing fp8_fp4_gemm_nt with gran_k_a=32 (fp8*fp8):")
    quant_config = QuantConfig((32, 32, False, False))  # gran_k_a=32, gran_k_b=32, both fp8
    recipe, recipe_a, recipe_b = quant_config.get_recipes()
    kernel_type = KernelType.Kernel1D1D
    use_ue8m0 = get_ue8m0_usage(kernel_type)
    disable_ue8m0_cast = not use_ue8m0

    test_shapes = [
        # (m, n, k)
        (1, 2112, 7168),
        (64, 4096, 7168),
        (128, 7168, 2048),
        (256, 7168, 4096),
        (4096, 2112, 7168),
    ]

    for m, n, k in test_shapes:
        torch.manual_seed(42)
        a, b, c, d, ref_d = generate_normal(
            m, n, k, MajorTypeAB.KMajor, MajorTypeAB.KMajor,
            accumulate=False, out_dtype=torch.bfloat16,
            kernel_type=kernel_type, use_ue8m0=use_ue8m0, quant_config=quant_config)
        # print(f"before gemm {ref_d=}, {ref_d._md5sum()}",flush=True)
        deep_gemm.fp8_fp4_gemm_nt(a, b, d, recipe_a=recipe_a, recipe_b=recipe_b,
                                   disable_ue8m0_cast=disable_ue8m0_cast)
        # print(f"after gemm {ref_d=}, {ref_d._md5sum()}",flush=True)
        diff = calc_diff(d, ref_d)
        print(f'  > m={m:5}, n={n:5}, k={k:5} | diff={diff:.6f} | {"PASS" if diff < quant_config.max_diff() else "FAIL"}')
        assert diff < quant_config.max_diff(), f'FAILED: {m=}, {n=}, {k=}, {diff=:.6f}'

    print("  All fp8*fp8 gran_k_a=32 tests passed!\n")

if __name__ == '__main__':
    test_fp8_gemm_gran_k_a_32()

```

单测测试精度验证通过，依赖最新deepgemm

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

---

Cherry-pick of #79540 (authored by @liuruyan) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79540 <!-- For pass CI -->