### PR TITLE
[Operator Mechanism] Support int64 Dimensions for GEMM and Related BLAS APIs

### DIFF
--- a/paddle/phi/backends/dynload/cublas.h
+++ b/paddle/phi/backends/dynload/cublas.h
@@ -145,9 +145,21 @@ CUBLAS_WORKSPACE_ROUTINE(DECLARE_DYNAMIC_LOAD_CUBLAS_WRAP)
 
 #if CUDA_VERSION >= 12030 && defined(__linux__)
 #define CUBLAS_BLAS_ROUTINE_EACH_R5(__macro) \
+  __macro(cublasSgemv_v2_64);                \
+  __macro(cublasDgemv_v2_64);                \
+  __macro(cublasCgemv_v2_64);                \
+  __macro(cublasZgemv_v2_64);                \
+  __macro(cublasSgemm_v2_64);                \
+  __macro(cublasDgemm_v2_64);                \
+  __macro(cublasCgemm_v2_64);                \
+  __macro(cublasZgemm_v2_64);                \
+  __macro(cublasHgemmStridedBatched_64);     \
+  __macro(cublasSgemmStridedBatched_64);     \
+  __macro(cublasDgemmStridedBatched_64);     \
+  __macro(cublasCgemmStridedBatched_64);     \
+  __macro(cublasZgemmStridedBatched_64);     \
   __macro(cublasGemmStridedBatchedEx_64);    \
-  __macro(cublasGemmEx_64);                  \
-  __macro(cublasSgemmEx_64);
+  __macro(cublasGemmEx_64);
 
 CUBLAS_BLAS_ROUTINE_EACH_R5(DECLARE_DYNAMIC_LOAD_CUBLAS_WRAP)
 #endif

--- a/paddle/phi/kernels/cpu/gru_kernel.cc
+++ b/paddle/phi/kernels/cpu/gru_kernel.cc
@@ -76,11 +76,9 @@ void GRUCPUKernel(const Context &dev_ctx,
     add_bias(dev_ctx, *batch_gate, bias.get(), batch_gate);
   }
 
-  int frame_size = static_cast<int>(hidden_dims[1]);
+  const int64_t frame_size = hidden_dims[1];
   funcs::GRUMetaValue<T> gru_value;
   gru_value.gate_weight = const_cast<T *>(weight_data);
-  gru_value.state_weight =
-      const_cast<T *>(weight_data + 2 * frame_size * frame_size);
   DenseTensor ordered_h0;
 
   Vector<size_t> order(batch_gate->lod()[2]);
@@ -121,6 +119,8 @@ void GRUCPUKernel(const Context &dev_ctx,
                    gru_value.gate_weight,
                    frame_size * 2,
                    packed_gate);
+    gru_value.state_weight =
+        const_cast<T *>(weight_data + 2 * frame_size * frame_size);
     T *packed_state = blas.GEMM_ALLOC(CblasBMatrix,
                                       1 /*height of C*/,
                                       frame_size /*width of weight*/,
@@ -204,6 +204,10 @@ void GRUCPUKernel(const Context &dev_ctx,
     blas.GEMM_FREE(packed_state);
   } else {
 #endif
+    PADDLE_ENFORCE_LE_INT_MAX(frame_size, "GRU elementwise frame size");
+    const int frame_size_int = static_cast<int>(frame_size);
+    gru_value.state_weight =
+        const_cast<T *>(weight_data + 2 * frame_size * frame_size);
     for (size_t n = 0; n < seq_len; n++) {
       int bstart = static_cast<int>(batch_starts[n]);
       int bend = static_cast<int>(batch_starts[n + 1]);
@@ -219,7 +223,7 @@ void GRUCPUKernel(const Context &dev_ctx,
 
       funcs::GRUUnitFunctor<Context, T>::compute(dev_ctx,  // NOLINT
                                                  gru_value,
-                                                 frame_size,
+                                                 frame_size_int,
                                                  cur_batch_size,
                                                  active_node,
                                                  active_gate,

--- a/paddle/phi/kernels/funcs/blas/blas.h
+++ b/paddle/phi/kernels/funcs/blas/blas.h
@@ -126,64 +126,64 @@ class Blas {
   template <typename T>
   void GEMM(bool transA,
             bool transB,
-            int M,
-            int N,
-            int K,
+            int64_t M,
+            int64_t N,
+            int64_t K,
             T alpha,
             const T* A,
-            int lda,
+            int64_t lda,
             const T* B,
-            int ldb,
+            int64_t ldb,
             T beta,
             T* C,
-            int ldc) const;
+            int64_t ldc) const;
 
   template <typename T>
   void GEMM(CBLAS_TRANSPOSE transA,
             CBLAS_TRANSPOSE transB,
-            int M,
-            int N,
-            int K,
+            int64_t M,
+            int64_t N,
+            int64_t K,
             T alpha,
             const T* A,
-            int lda,
+            int64_t lda,
             const T* B,
-            int ldb,
+            int64_t ldb,
             T beta,
             T* C,
-            int ldc) const;
+            int64_t ldc) const;
 
 #ifdef PADDLE_WITH_MKLML  // @{ Group MKLML: class Blas
   template <typename T>
   T* GEMM_ALLOC(const CBLAS_IDENTIFIER id,
-                const int M,
-                const int N,
-                const int K) const;
+                int64_t M,
+                int64_t N,
+                int64_t K) const;
 
   template <typename T>
   void GEMM_PACK(const CBLAS_IDENTIFIER id,
                  const CBLAS_TRANSPOSE trans,
-                 int M,
-                 int N,
-                 int K,
+                 int64_t M,
+                 int64_t N,
+                 int64_t K,
                  const T alpha,
                  const T* src,
-                 const int ld,
+                 int64_t ld,
                  T* dst) const;
 
   template <typename T>
   void GEMM_COMPUTE(int transA,
                     int transB,
-                    int M,
-                    int N,
-                    int K,
+                    int64_t M,
+                    int64_t N,
+                    int64_t K,
                     const T* A,
-                    const int lda,
+                    int64_t lda,
                     const T* B,
-                    const int ldb,
+                    int64_t ldb,
                     T beta,
                     T* C,
-                    const int ldc) const;
+                    int64_t ldc) const;
 
   template <typename T>
   void GEMM_FREE(T* data) const;
@@ -195,7 +195,7 @@ class Blas {
                       const DenseTensor& mat_b,
                       const MatDescriptor& dim_b,
                       T alpha,
-                      int head_number,
+                      int64_t head_number,
                       DenseTensor* mat_out,
                       T beta,
                       bool mat_y_split_vertical) const;
@@ -210,19 +210,15 @@ class Blas {
                       const DenseTensor& mat_b,
                       const MatDescriptor& dim_b,
                       T alpha,
-                      int head_number,
+                      int64_t head_number,
                       DenseTensor* mat_out,
                       T beta,
                       bool mat_y_split_vertical) const;
 #endif
 
   template <typename T>
-  void MatMul(const int M,
-              const int N,
-              const int K,
-              const T* A,
-              const T* B,
-              T* C) const;
+  void MatMul(
+      int64_t M, int64_t N, int64_t K, const T* A, const T* B, T* C) const;
 
   template <typename T>
   void MatMul(const DenseTensor& mat_a,
@@ -260,8 +256,8 @@ class Blas {
 
   template <typename T>
   void GEMV(bool trans_a,
-            int M,
-            int N,
+            int64_t M,
+            int64_t N,
             T alpha,
             const T* A,
             const T* B,
@@ -317,31 +313,31 @@ class Blas {
   template <typename T>
   void BatchedGEMM(CBLAS_TRANSPOSE transA,
                    CBLAS_TRANSPOSE transB,
-                   int M,
-                   int N,
-                   int K,
+                   int64_t M,
+                   int64_t N,
+                   int64_t K,
                    T alpha,
                    const T** A,
                    const T** B,
                    T beta,
                    T** C,
-                   int batchCount) const;
+                   int64_t batchCount) const;
 
 #if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA) && \
     !defined(PADDLE_WITH_HIP)
   template <typename T>
   void BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                            CBLAS_TRANSPOSE transB,
-                           int W1,
-                           int H1,
-                           int W2,
-                           int H2,
+                           int64_t W1,
+                           int64_t H1,
+                           int64_t W2,
+                           int64_t H2,
                            T alpha,
                            const T* A,
                            const T* B,
                            T beta,
                            T* C,
-                           int batchCount,
+                           int64_t batchCount,
                            int64_t strideA,
                            int64_t strideB,
                            int64_t head_number,
@@ -353,16 +349,16 @@ class Blas {
   template <typename T>
   void BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                            CBLAS_TRANSPOSE transB,
-                           int W1,
-                           int H1,
-                           int W2,
-                           int H2,
+                           int64_t W1,
+                           int64_t H1,
+                           int64_t W2,
+                           int64_t H2,
                            T alpha,
                            const T* A,
                            const T* B,
                            T beta,
                            T* C,
-                           int batchCount,
+                           int64_t batchCount,
                            int64_t strideA,
                            int64_t strideB,
                            int64_t head_number,

--- a/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
@@ -44,6 +44,16 @@ struct CUBlas<float> {
   }
 
   template <typename... ARGS>
+  static void GEMM_64(ARGS... args) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasSgemm_v2_64(args...));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif
+  }
+
+  template <typename... ARGS>
   static void AXPY(ARGS... args) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasSaxpy(args...));
   }
@@ -51,6 +61,16 @@ struct CUBlas<float> {
   template <typename... ARGS>
   static void GEMV(ARGS... args) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasSgemv(args...));
+  }
+
+  template <typename... ARGS>
+  static void GEMV_64(ARGS... args) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasSgemv_v2_64(args...));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS GEMV requires CUDA 12.3 or later on Linux."));
+#endif
   }
 
   template <typename... ARGS>
@@ -71,6 +91,18 @@ struct CUBlas<float> {
 #else
     PADDLE_THROW(common::errors::Unimplemented(
         "SgemmStridedBatched is not supported on cuda <= 7.5"));
+#endif
+  }
+
+  template <typename... ARGS>
+  static void GEMM_STRIDED_BATCH_64(ARGS... args) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cublasSgemmStridedBatched_64(args...));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
 #endif
   }
 
@@ -125,54 +157,6 @@ struct CUBlas<float> {
 #endif
   }
 
-  static void GEMM_EX_64(phi::GPUContext *dev_ctx,
-                         cublasOperation_t transa,
-                         cublasOperation_t transb,
-                         int64_t m,
-                         int64_t n,
-                         int64_t k,
-                         const float *alpha,
-                         const void *A,
-                         cudaDataType_t Atype,
-                         int64_t lda,
-                         const void *B,
-                         cudaDataType_t Btype,
-                         int64_t ldb,
-                         const float *beta,
-                         void *C,
-                         cudaDataType_t Ctype,
-                         int64_t ldc) {
-// Because the gcc 4.8 doesn't expand template parameter pack that
-// appears in a lambda-expression, I can not use template parameter pack
-// here.
-#if CUDA_VERSION >= 12030 && defined(__linux__)
-    VLOG(5) << "use_tensor_op_math: "
-            << (dev_ctx->tensor_core_available() ? "True" : "False");
-    dev_ctx->TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
-      PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasSgemmEx_64(handle,
-                                                                transa,
-                                                                transb,
-                                                                m,
-                                                                n,
-                                                                k,
-                                                                alpha,
-                                                                A,
-                                                                Atype,
-                                                                lda,
-                                                                B,
-                                                                Btype,
-                                                                ldb,
-                                                                beta,
-                                                                C,
-                                                                Ctype,
-                                                                ldc));
-    });
-#else
-    PADDLE_THROW(common::errors::Unimplemented(
-        "cublasSgemmEx_64 is not supported on cuda < 12.3"));
-#endif
-  }
-
   template <typename... ARGS>
   static void TRSM(ARGS... args) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasStrsm(args...));
@@ -217,6 +201,16 @@ struct CUBlas<double> {
   }
 
   template <typename... ARGS>
+  static void GEMM_64(ARGS... args) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasDgemm_v2_64(args...));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif
+  }
+
+  template <typename... ARGS>
   static void AXPY(ARGS... args) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasDaxpy(args...));
   }
@@ -224,6 +218,16 @@ struct CUBlas<double> {
   template <typename... ARGS>
   static void GEMV(ARGS... args) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasDgemv(args...));
+  }
+
+  template <typename... ARGS>
+  static void GEMV_64(ARGS... args) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasDgemv_v2_64(args...));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS GEMV requires CUDA 12.3 or later on Linux."));
+#endif
   }
 
   template <typename... ARGS>
@@ -248,15 +252,21 @@ struct CUBlas<double> {
   }
 
   template <typename... ARGS>
-  static void GEMM_EX(ARGS... args UNUSED) {
+  static void GEMM_STRIDED_BATCH_64(ARGS... args) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cublasDgemmStridedBatched_64(args...));
+#else
     PADDLE_THROW(common::errors::Unimplemented(
-        "Currently there are not cublasDgemmEx."));
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
+#endif
   }
 
   template <typename... ARGS>
-  static void GEMM_EX_64(ARGS... args UNUSED) {
+  static void GEMM_EX(ARGS... args UNUSED) {
     PADDLE_THROW(common::errors::Unimplemented(
-        "Currently there are not cublasDgemmEx_64."));
+        "Currently there are not cublasDgemmEx."));
   }
 
   template <typename... ARGS>
@@ -435,6 +445,51 @@ struct CUBlas<phi::float16> {
 #endif
   }
 
+  static void GEMM_STRIDED_BATCH_64(cublasHandle_t handle,
+                                    cublasOperation_t transa,
+                                    cublasOperation_t transb,
+                                    int64_t m,
+                                    int64_t n,
+                                    int64_t k,
+                                    const float16 *alpha,
+                                    const float16 *A,
+                                    int64_t lda,
+                                    long long int strideA,  // NOLINT
+                                    const float16 *B,       // NOLINT
+                                    int64_t ldb,
+                                    long long int strideB,  // NOLINT
+                                    const float16 *beta,
+                                    float16 *C,
+                                    int64_t ldc,
+                                    long long int strideC,  // NOLINT
+                                    int64_t batchCount) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasHgemmStridedBatched_64(
+        handle,
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        reinterpret_cast<const __half *>(alpha),
+        reinterpret_cast<const __half *>(A),
+        lda,
+        strideA,
+        reinterpret_cast<const __half *>(B),
+        ldb,
+        strideB,
+        reinterpret_cast<const __half *>(beta),
+        reinterpret_cast<__half *>(C),
+        ldc,
+        strideC,
+        batchCount));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
+#endif
+  }
+
   // NOTES: GEMM_EX can use Tensor Core to accelerate matrix multiply.
   // https://docs.nvidia.com/cuda/cublas/index.html#cublassetmathmode
   template <typename... ARGS>
@@ -599,6 +654,74 @@ struct CUBlas<phi::complex64> {
         ldc));
   }
 
+  static void GEMM_64(cublasHandle_t handle,
+                      cublasOperation_t transa,
+                      cublasOperation_t transb,
+                      int64_t m,
+                      int64_t n,
+                      int64_t k,
+                      const phi::complex64 *alpha,
+                      const phi::complex64 *A,
+                      int64_t lda,
+                      const phi::complex64 *B,
+                      int64_t ldb,
+                      const phi::complex64 *beta,
+                      phi::complex64 *C,
+                      int64_t ldc) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasCgemm_v2_64(
+        handle,
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        reinterpret_cast<const cuFloatComplex *>(alpha),
+        reinterpret_cast<const cuFloatComplex *>(A),
+        lda,
+        reinterpret_cast<const cuFloatComplex *>(B),
+        ldb,
+        reinterpret_cast<const cuFloatComplex *>(beta),
+        reinterpret_cast<cuFloatComplex *>(C),
+        ldc));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif
+  }
+
+  static void GEMV_64(cublasHandle_t handle,
+                      cublasOperation_t transa,
+                      int64_t m,
+                      int64_t n,
+                      const phi::complex64 *alpha,
+                      const phi::complex64 *A,
+                      int64_t lda,
+                      const phi::complex64 *B,
+                      int64_t incx,
+                      const phi::complex64 *beta,
+                      phi::complex64 *C,
+                      int64_t incy) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasCgemv_v2_64(
+        handle,
+        transa,
+        m,
+        n,
+        reinterpret_cast<const cuFloatComplex *>(alpha),
+        reinterpret_cast<const cuFloatComplex *>(A),
+        lda,
+        reinterpret_cast<const cuFloatComplex *>(B),
+        incx,
+        reinterpret_cast<const cuFloatComplex *>(beta),
+        reinterpret_cast<cuFloatComplex *>(C),
+        incy));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS GEMV requires CUDA 12.3 or later on Linux."));
+#endif
+  }
+
   static void AXPY(cublasHandle_t handle,
                    int n,
                    const phi::complex64 *alpha,
@@ -657,6 +780,51 @@ struct CUBlas<phi::complex64> {
 #else
     PADDLE_THROW(common::errors::Unimplemented(
         "CgemmStridedBatched is not supported on cuda <= 7.5"));
+#endif
+  }
+
+  static void GEMM_STRIDED_BATCH_64(cublasHandle_t handle,
+                                    cublasOperation_t transa,
+                                    cublasOperation_t transb,
+                                    int64_t m,
+                                    int64_t n,
+                                    int64_t k,
+                                    const phi::complex64 *alpha,
+                                    const phi::complex64 *A,
+                                    int64_t lda,
+                                    long long int strideA,    // NOLINT
+                                    const phi::complex64 *B,  // NOLINT
+                                    int64_t ldb,
+                                    long long int strideB,  // NOLINT
+                                    const phi::complex64 *beta,
+                                    phi::complex64 *C,
+                                    int64_t ldc,
+                                    long long int strideC,  // NOLINT
+                                    int64_t batchCount) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasCgemmStridedBatched_64(
+        handle,
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        reinterpret_cast<const cuFloatComplex *>(alpha),
+        reinterpret_cast<const cuFloatComplex *>(A),
+        lda,
+        strideA,
+        reinterpret_cast<const cuFloatComplex *>(B),
+        ldb,
+        strideB,
+        reinterpret_cast<const cuFloatComplex *>(beta),
+        reinterpret_cast<cuFloatComplex *>(C),
+        ldc,
+        strideC,
+        batchCount));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
 #endif
   }
 
@@ -774,61 +942,6 @@ struct CUBlas<phi::complex64> {
 #else
     PADDLE_THROW(common::errors::Unimplemented(
         "cublasGemmEx is not supported on cuda <= 7.5"));
-#endif
-  }
-
-  static void GEMM_EX_64(phi::GPUContext *dev_ctx,
-                         cublasOperation_t transa,
-                         cublasOperation_t transb,
-                         int64_t m,
-                         int64_t n,
-                         int64_t k,
-                         const void *alpha,
-                         const void *A,
-                         cudaDataType_t Atype,
-                         int64_t lda,
-                         const void *B,
-                         cudaDataType_t Btype,
-                         int64_t ldb,
-                         const void *beta,
-                         void *C,
-                         cudaDataType_t Ctype,
-                         int64_t ldc,
-                         cudaDataType_t computeType) {
-#if CUDA_VERSION >= 12030 && defined(__linux__)
-    cublasGemmAlgo_t algo = CUBLAS_GEMM_DFALT;
-    bool use_tensor_op_math = dev_ctx->tensor_core_available();
-    if (use_tensor_op_math) {
-      algo = CUBLAS_GEMM_DFALT_TENSOR_OP;
-    }
-    VLOG(5) << "use_tensor_op_math: "
-            << (use_tensor_op_math ? "True" : "False");
-    cublasComputeType_t migratedComputeType = CUBLAS_COMPUTE_32F;
-    dev_ctx->TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
-      PADDLE_ENFORCE_GPU_SUCCESS(
-          phi::dynload::cublasGemmEx_64(handle,
-                                        transa,
-                                        transb,
-                                        m,
-                                        n,
-                                        k,
-                                        alpha,
-                                        A,
-                                        Atype,
-                                        lda,
-                                        B,
-                                        Btype,
-                                        ldb,
-                                        beta,
-                                        C,
-                                        Ctype,
-                                        ldc,
-                                        migratedComputeType,
-                                        algo));
-    });
-#else
-    PADDLE_THROW(common::errors::Unimplemented(
-        "cublasGemmEx_64 is not supported on cuda < 12.3"));
 #endif
   }
 
@@ -965,6 +1078,74 @@ struct CUBlas<phi::complex128> {
         ldc));
   }
 
+  static void GEMM_64(cublasHandle_t handle,
+                      cublasOperation_t transa,
+                      cublasOperation_t transb,
+                      int64_t m,
+                      int64_t n,
+                      int64_t k,
+                      const phi::complex128 *alpha,
+                      const phi::complex128 *A,
+                      int64_t lda,
+                      const phi::complex128 *B,
+                      int64_t ldb,
+                      const phi::complex128 *beta,
+                      phi::complex128 *C,
+                      int64_t ldc) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasZgemm_v2_64(
+        handle,
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        reinterpret_cast<const cuDoubleComplex *>(alpha),
+        reinterpret_cast<const cuDoubleComplex *>(A),
+        lda,
+        reinterpret_cast<const cuDoubleComplex *>(B),
+        ldb,
+        reinterpret_cast<const cuDoubleComplex *>(beta),
+        reinterpret_cast<cuDoubleComplex *>(C),
+        ldc));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif
+  }
+
+  static void GEMV_64(cublasHandle_t handle,
+                      cublasOperation_t transa,
+                      int64_t m,
+                      int64_t n,
+                      const phi::complex128 *alpha,
+                      const phi::complex128 *A,
+                      int64_t lda,
+                      const phi::complex128 *B,
+                      int64_t incx,
+                      const phi::complex128 *beta,
+                      phi::complex128 *C,
+                      int64_t incy) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasZgemv_v2_64(
+        handle,
+        transa,
+        m,
+        n,
+        reinterpret_cast<const cuDoubleComplex *>(alpha),
+        reinterpret_cast<const cuDoubleComplex *>(A),
+        lda,
+        reinterpret_cast<const cuDoubleComplex *>(B),
+        incx,
+        reinterpret_cast<const cuDoubleComplex *>(beta),
+        reinterpret_cast<cuDoubleComplex *>(C),
+        incy));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS GEMV requires CUDA 12.3 or later on Linux."));
+#endif
+  }
+
   static void AXPY(cublasHandle_t handle,
                    int n,
                    const phi::complex128 *alpha,
@@ -1023,6 +1204,51 @@ struct CUBlas<phi::complex128> {
 #else
     PADDLE_THROW(common::errors::Unimplemented(
         "CgemmStridedBatched is not supported on cuda <= 7.5"));
+#endif
+  }
+
+  static void GEMM_STRIDED_BATCH_64(cublasHandle_t handle,
+                                    cublasOperation_t transa,
+                                    cublasOperation_t transb,
+                                    int64_t m,
+                                    int64_t n,
+                                    int64_t k,
+                                    const phi::complex128 *alpha,
+                                    const phi::complex128 *A,
+                                    int64_t lda,
+                                    long long int strideA,     // NOLINT
+                                    const phi::complex128 *B,  // NOLINT
+                                    int64_t ldb,
+                                    long long int strideB,  // NOLINT
+                                    const phi::complex128 *beta,
+                                    phi::complex128 *C,
+                                    int64_t ldc,
+                                    long long int strideC,  // NOLINT
+                                    int64_t batchCount) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasZgemmStridedBatched_64(
+        handle,
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        reinterpret_cast<const cuDoubleComplex *>(alpha),
+        reinterpret_cast<const cuDoubleComplex *>(A),
+        lda,
+        strideA,
+        reinterpret_cast<const cuDoubleComplex *>(B),
+        ldb,
+        strideB,
+        reinterpret_cast<const cuDoubleComplex *>(beta),
+        reinterpret_cast<cuDoubleComplex *>(C),
+        ldc,
+        strideC,
+        batchCount));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
 #endif
   }
 
@@ -1172,61 +1398,6 @@ struct CUBlas<phi::complex128> {
 #endif
   }
 
-  static void GEMM_EX_64(phi::GPUContext *dev_ctx,
-                         cublasOperation_t transa,
-                         cublasOperation_t transb,
-                         int64_t m,
-                         int64_t n,
-                         int64_t k,
-                         const void *alpha,
-                         const void *A,
-                         cudaDataType_t Atype,
-                         int64_t lda,
-                         const void *B,
-                         cudaDataType_t Btype,
-                         int64_t ldb,
-                         const void *beta,
-                         void *C,
-                         cudaDataType_t Ctype,
-                         int64_t ldc,
-                         cudaDataType_t computeType) {
-#if CUDA_VERSION >= 12030 && defined(__linux__)
-    cublasGemmAlgo_t algo = CUBLAS_GEMM_DFALT;
-    bool use_tensor_op_math = dev_ctx->tensor_core_available();
-    if (use_tensor_op_math) {
-      algo = CUBLAS_GEMM_DFALT_TENSOR_OP;
-    }
-    VLOG(5) << "use_tensor_op_math: "
-            << (use_tensor_op_math ? "True" : "False");
-    cublasComputeType_t migratedComputeType = CUBLAS_COMPUTE_32F;
-    dev_ctx->TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
-      PADDLE_ENFORCE_GPU_SUCCESS(
-          phi::dynload::cublasGemmEx_64(handle,
-                                        transa,
-                                        transb,
-                                        m,
-                                        n,
-                                        k,
-                                        alpha,
-                                        A,
-                                        Atype,
-                                        lda,
-                                        B,
-                                        Btype,
-                                        ldb,
-                                        beta,
-                                        C,
-                                        Ctype,
-                                        ldc,
-                                        migratedComputeType,
-                                        algo));
-    });
-#else
-    PADDLE_THROW(common::errors::Unimplemented(
-        "cublasGemmEx_64 is not supported on cuda < 12.3"));
-#endif
-  }
-
   static void GETRF_BATCH(cublasHandle_t handle,
                           int n,
                           phi::complex128 **A,
@@ -1330,75 +1501,74 @@ void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
+  detail::check_blas_int64(M, "GEMM M");
+  detail::check_blas_int64(N, "GEMM N");
+  detail::check_blas_int64(K, "GEMM K");
+  const bool requires_64_bit_blas =
+      M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+      CUBlas<T>::GEMM_64(handle,
+                         cuTransB,
+                         cuTransA,
+                         N,
+                         M,
+                         K,
+                         &alpha,
+                         B,
+                         ldb,
+                         A,
+                         lda,
+                         &beta,
+                         C,
+                         N);
+    });
+    return;
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif
+  }
 #if CUDA_VERSION >= 8000
   if (FLAGS_enable_cublas_tensor_op_math && std::is_same<T, float>::value) {
     auto &cuda_ctx = const_cast<phi::GPUContext &>(dev_ctx_);
-    if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
-#if CUDA_VERSION >= 12030 && defined(__linux__)
-      CUBlas<T>::GEMM_EX_64(&cuda_ctx,
-                            cuTransB,
-                            cuTransA,
-                            N,
-                            M,
-                            K,
-                            &alpha,
-                            B,
-                            CUDA_R_32F,
-                            ldb,
-                            A,
-                            CUDA_R_32F,
-                            lda,
-                            &beta,
-                            C,
-                            CUDA_R_32F,
-                            N);
-#else
-      PADDLE_THROW(common::errors::Unimplemented(
-          "GEMM_EX_64 is not supported on cuda < 12.3"));
-#endif
-    } else {
-      CheckGEMMNSize(N);
-      CUBlas<T>::GEMM_EX(&cuda_ctx,
-                         cuTransB,
-                         cuTransA,
-                         static_cast<int>(N),
-                         static_cast<int>(M),
-                         static_cast<int>(K),
-                         &alpha,
-                         B,
-                         CUDA_R_32F,
-                         static_cast<int>(ldb),
-                         A,
-                         CUDA_R_32F,
-                         static_cast<int>(lda),
-                         &beta,
-                         C,
-                         CUDA_R_32F,
-                         static_cast<int>(N));
-    }
+    CheckGEMMNSize(N);
+    CUBlas<T>::GEMM_EX(&cuda_ctx,
+                       cuTransB,
+                       cuTransA,
+                       static_cast<int>(N),
+                       static_cast<int>(M),
+                       static_cast<int>(K),
+                       &alpha,
+                       B,
+                       CUDA_R_32F,
+                       static_cast<int>(ldb),
+                       A,
+                       CUDA_R_32F,
+                       static_cast<int>(lda),
+                       &beta,
+                       C,
+                       CUDA_R_32F,
+                       static_cast<int>(N));
   } else {
 #endif  // CUDA_VERSION >= 8000
-    if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
-      PADDLE_THROW(common::errors::Unimplemented(
-          "GEMM_EX_64 is not supported on cuda < 12.3"));
-    } else {
-      dev_ctx_.CublasCall([&](cublasHandle_t handle) {
-        CUBlas<T>::GEMM(handle,
-                        cuTransB,
-                        cuTransA,
-                        static_cast<int>(N),
-                        static_cast<int>(M),
-                        static_cast<int>(K),
-                        &alpha,
-                        B,
-                        static_cast<int>(ldb),
-                        A,
-                        static_cast<int>(lda),
-                        &beta,
-                        C,
-                        static_cast<int>(N));
-      });
-    }
+    dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+      CUBlas<T>::GEMM(handle,
+                      cuTransB,
+                      cuTransA,
+                      static_cast<int>(N),
+                      static_cast<int>(M),
+                      static_cast<int>(K),
+                      &alpha,
+                      B,
+                      static_cast<int>(ldb),
+                      A,
+                      static_cast<int>(lda),
+                      &beta,
+                      C,
+                      static_cast<int>(N));
+    });
 
 #if CUDA_VERSION >= 8000
   }
@@ -1417,6 +1587,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                         const phi::float16 *B,
                                         phi::float16 beta,
                                         phi::float16 *C) const {
+  detail::check_blas_int64(M, "GEMM M");
+  detail::check_blas_int64(N, "GEMM N");
+  detail::check_blas_int64(K, "GEMM K");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   int64_t lda = (transA == CblasNoTrans) ? K : M;
@@ -1538,76 +1711,75 @@ void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
 
   T t_alpha = static_cast<T>(alpha);
   T t_beta = static_cast<T>(beta);
+  detail::check_blas_int64(M, "GEMM M");
+  detail::check_blas_int64(N, "GEMM N");
+  detail::check_blas_int64(K, "GEMM K");
+  const bool requires_64_bit_blas =
+      M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+      CUBlas<T>::GEMM_64(handle,
+                         cuTransB,
+                         cuTransA,
+                         N,
+                         M,
+                         K,
+                         &t_alpha,
+                         B,
+                         ldb,
+                         A,
+                         lda,
+                         &t_beta,
+                         C,
+                         N);
+    });
+    return;
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif
+  }
 
 #if CUDA_VERSION >= 8000
   if (FLAGS_enable_cublas_tensor_op_math && std::is_same<T, float>::value) {
     auto &cuda_ctx = const_cast<phi::GPUContext &>(dev_ctx_);
-    if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
-#if CUDA_VERSION >= 12030 && defined(__linux__)
-      CUBlas<T>::GEMM_EX_64(&cuda_ctx,
-                            cuTransB,
-                            cuTransA,
-                            N,
-                            M,
-                            K,
-                            &t_alpha,
-                            B,
-                            CUDA_R_32F,
-                            ldb,
-                            A,
-                            CUDA_R_32F,
-                            lda,
-                            &t_beta,
-                            C,
-                            CUDA_R_32F,
-                            N);
-#else
-      PADDLE_THROW(common::errors::Unimplemented(
-          "GEMM_EX_64 is not supported on cuda < 12.3"));
-#endif
-    } else {
-      CheckGEMMNSize(N);
-      CUBlas<T>::GEMM_EX(&cuda_ctx,
-                         cuTransB,
-                         cuTransA,
-                         static_cast<int>(N),
-                         static_cast<int>(M),
-                         static_cast<int>(K),
-                         &t_alpha,
-                         B,
-                         CUDA_R_32F,
-                         static_cast<int>(ldb),
-                         A,
-                         CUDA_R_32F,
-                         static_cast<int>(lda),
-                         &t_beta,
-                         C,
-                         CUDA_R_32F,
-                         static_cast<int>(N));
-    }
+    CheckGEMMNSize(N);
+    CUBlas<T>::GEMM_EX(&cuda_ctx,
+                       cuTransB,
+                       cuTransA,
+                       static_cast<int>(N),
+                       static_cast<int>(M),
+                       static_cast<int>(K),
+                       &t_alpha,
+                       B,
+                       CUDA_R_32F,
+                       static_cast<int>(ldb),
+                       A,
+                       CUDA_R_32F,
+                       static_cast<int>(lda),
+                       &t_beta,
+                       C,
+                       CUDA_R_32F,
+                       static_cast<int>(N));
   } else {
 #endif  // CUDA_VERSION >= 8000
-    if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
-      PADDLE_THROW(common::errors::Unimplemented(
-          "GEMM_EX_64 is not supported on cuda < 12.3"));
-    } else {
-      dev_ctx_.CublasCall([&](cublasHandle_t handle) {
-        CUBlas<T>::GEMM(handle,
-                        cuTransB,
-                        cuTransA,
-                        static_cast<int>(N),
-                        static_cast<int>(M),
-                        static_cast<int>(K),
-                        &t_alpha,
-                        B,
-                        static_cast<int>(ldb),
-                        A,
-                        static_cast<int>(lda),
-                        &t_beta,
-                        C,
-                        static_cast<int>(N));
-      });
-    }
+    dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+      CUBlas<T>::GEMM(handle,
+                      cuTransB,
+                      cuTransA,
+                      static_cast<int>(N),
+                      static_cast<int>(M),
+                      static_cast<int>(K),
+                      &t_alpha,
+                      B,
+                      static_cast<int>(ldb),
+                      A,
+                      static_cast<int>(lda),
+                      &t_beta,
+                      C,
+                      static_cast<int>(N));
+    });
 
 #if CUDA_VERSION >= 8000
   }
@@ -1626,6 +1798,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                         const phi::float16 *B,
                                         float beta,
                                         phi::float16 *C) const {
+  detail::check_blas_int64(M, "GEMM M");
+  detail::check_blas_int64(N, "GEMM N");
+  detail::check_blas_int64(K, "GEMM K");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   int64_t lda = (transA == CblasNoTrans) ? K : M;
@@ -1733,6 +1908,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                         const phi::bfloat16 *B,
                                         phi::bfloat16 beta,
                                         phi::bfloat16 *C) const {
+  detail::check_blas_int64(M, "GEMM M");
+  detail::check_blas_int64(N, "GEMM N");
+  detail::check_blas_int64(K, "GEMM K");
 #if CUDA_VERSION >= 11000
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
@@ -1833,6 +2011,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                         const phi::bfloat16 *B,
                                         float beta,
                                         float *C) const {
+  detail::check_blas_int64(M, "GEMM M");
+  detail::check_blas_int64(N, "GEMM N");
+  detail::check_blas_int64(K, "GEMM K");
 #if CUDA_VERSION >= 11000
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention. The int casts of lda/ldb below are safe because
@@ -1930,6 +2111,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                         const phi::bfloat16 *B,
                                         float beta,
                                         phi::bfloat16 *C) const {
+  detail::check_blas_int64(M, "GEMM M");
+  detail::check_blas_int64(N, "GEMM N");
+  detail::check_blas_int64(K, "GEMM K");
 #if CUDA_VERSION >= 11000
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
@@ -2031,6 +2215,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                         const phi::complex64 *B,
                                         phi::complex64 beta,
                                         phi::complex64 *C) const {
+  detail::check_blas_int64(M, "GEMM M");
+  detail::check_blas_int64(N, "GEMM N");
+  detail::check_blas_int64(K, "GEMM K");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   int64_t lda = (transA == CblasNoTrans) ? K : M;
@@ -2059,27 +2246,25 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
 
   if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
-    CUBlas<phi::complex64>::GEMM_EX_64(&cuda_ctx,
-                                       cuTransB,
-                                       cuTransA,
-                                       N,
-                                       M,
-                                       K,
-                                       &c_alpha,
-                                       B,
-                                       CUDA_C_32F,
-                                       ldb,
-                                       A,
-                                       CUDA_C_32F,
-                                       lda,
-                                       &c_beta,
-                                       C,
-                                       CUDA_C_32F,
-                                       N,
-                                       CUDA_C_32F);
+    dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+      CUBlas<phi::complex64>::GEMM_64(handle,
+                                      cuTransB,
+                                      cuTransA,
+                                      N,
+                                      M,
+                                      K,
+                                      &alpha,
+                                      B,
+                                      ldb,
+                                      A,
+                                      lda,
+                                      &beta,
+                                      C,
+                                      N);
+    });
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "GEMM_EX_64 is not supported on cuda < 12.3"));
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
 #endif  // CUDA_VERSION >= 12030
   } else {
 #if CUDA_VERSION >= 8000
@@ -2137,6 +2322,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                         const phi::complex128 *B,
                                         phi::complex128 beta,
                                         phi::complex128 *C) const {
+  detail::check_blas_int64(M, "GEMM M");
+  detail::check_blas_int64(N, "GEMM N");
+  detail::check_blas_int64(K, "GEMM K");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   int64_t lda = (transA == CblasNoTrans) ? K : M;
@@ -2169,27 +2357,25 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   // using tensor cores in volta GPUs.
   if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
-    CUBlas<phi::complex128>::GEMM_EX_64(&cuda_ctx,
-                                        cuTransB,
-                                        cuTransA,
-                                        N,
-                                        M,
-                                        K,
-                                        &c_alpha,
-                                        B,
-                                        CUDA_C_64F,
-                                        ldb,
-                                        A,
-                                        CUDA_C_64F,
-                                        lda,
-                                        &c_beta,
-                                        C,
-                                        CUDA_C_64F,
-                                        N,
-                                        CUDA_C_64F);
+    dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+      CUBlas<phi::complex128>::GEMM_64(handle,
+                                       cuTransB,
+                                       cuTransA,
+                                       N,
+                                       M,
+                                       K,
+                                       &alpha,
+                                       B,
+                                       ldb,
+                                       A,
+                                       lda,
+                                       &beta,
+                                       C,
+                                       N);
+    });
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "GEMM_EX_64 is not supported on cuda < 12.3"));
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
 #endif  // CUDA_VERSION >= 12030
   } else {
 #if CUDA_VERSION >= 8000
@@ -2238,43 +2424,82 @@ template <>
 template <typename T>
 void Blas<phi::GPUContext>::GEMM(bool transA,
                                  bool transB,
-                                 int M,
-                                 int N,
-                                 int K,
+                                 int64_t M,
+                                 int64_t N,
+                                 int64_t K,
                                  T alpha,
                                  const T *A,
-                                 int lda,
+                                 int64_t lda,
                                  const T *B,
-                                 int ldb,
+                                 int64_t ldb,
                                  T beta,
                                  T *C,
-                                 int ldc) const {
+                                 int64_t ldc) const {
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   cublasOperation_t cuTransA = transA ? CUBLAS_OP_T : CUBLAS_OP_N;
   cublasOperation_t cuTransB = transB ? CUBLAS_OP_T : CUBLAS_OP_N;
+  detail::check_blas_int64(M, "GEMM M");
+  detail::check_blas_int64(N, "GEMM N");
+  detail::check_blas_int64(K, "GEMM K");
+  detail::check_blas_int64(lda, "GEMM lda");
+  detail::check_blas_int64(ldb, "GEMM ldb");
+  detail::check_blas_int64(ldc, "GEMM ldc");
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE || lda > INT_MAX_VALUE ||
+                                    ldb > INT_MAX_VALUE || ldc > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+      CUBlas<T>::GEMM_64(handle,
+                         cuTransB,
+                         cuTransA,
+                         N,
+                         M,
+                         K,
+                         &alpha,
+                         B,
+                         ldb,
+                         A,
+                         lda,
+                         &beta,
+                         C,
+                         ldc);
+    });
+    return;
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif
+  }
+  const int m = static_cast<int>(M);
+  const int n = static_cast<int>(N);
+  const int k = static_cast<int>(K);
+  const int lda_int = static_cast<int>(lda);
+  const int ldb_int = static_cast<int>(ldb);
+  const int ldc_int = static_cast<int>(ldc);
 
 #if CUDA_VERSION >= 8000
-  CheckGEMMNSize(N);
+  CheckGEMMNSize(n);
   if (FLAGS_enable_cublas_tensor_op_math && std::is_same<T, float>::value) {
     auto &cuda_ctx = const_cast<phi::GPUContext &>(dev_ctx_);
     CUBlas<T>::GEMM_EX(&cuda_ctx,
                        cuTransB,
                        cuTransA,
-                       N,
-                       M,
-                       K,
+                       n,
+                       m,
+                       k,
                        &alpha,
                        B,
                        CUDA_R_32F,
-                       ldb,
+                       ldb_int,
                        A,
                        CUDA_R_32F,
-                       lda,
+                       lda_int,
                        &beta,
                        C,
                        CUDA_R_32F,
-                       ldc);
+                       ldc_int);
   } else {
 #endif  // CUDA_VERSION >= 8000
 
@@ -2282,17 +2507,17 @@ void Blas<phi::GPUContext>::GEMM(bool transA,
       CUBlas<T>::GEMM(handle,
                       cuTransB,
                       cuTransA,
-                      N,
-                      M,
-                      K,
+                      n,
+                      m,
+                      k,
                       &alpha,
                       B,
-                      ldb,
+                      ldb_int,
                       A,
-                      lda,
+                      lda_int,
                       &beta,
                       C,
-                      ldc);
+                      ldc_int);
     });
 
 #if CUDA_VERSION >= 8000
@@ -2304,17 +2529,23 @@ template <>
 template <>
 inline void Blas<phi::GPUContext>::GEMM(bool transA,
                                         bool transB,
-                                        int M,
-                                        int N,
-                                        int K,
+                                        int64_t M,
+                                        int64_t N,
+                                        int64_t K,
                                         phi::float16 alpha,
                                         const phi::float16 *A,
-                                        int lda,
+                                        int64_t lda,
                                         const phi::float16 *B,
-                                        int ldb,
+                                        int64_t ldb,
                                         phi::float16 beta,
                                         phi::float16 *C,
-                                        int ldc) const {
+                                        int64_t ldc) const {
+  const int m = detail::to_blas_int(M, "GEMM M");
+  const int n = detail::to_blas_int(N, "GEMM N");
+  const int k = detail::to_blas_int(K, "GEMM K");
+  const int lda_int = detail::to_blas_int(lda, "GEMM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "GEMM ldb");
+  const int ldc_int = detail::to_blas_int(ldc, "GEMM ldc");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   cublasOperation_t cuTransA = transA ? CUBLAS_OP_T : CUBLAS_OP_N;
@@ -2328,25 +2559,25 @@ inline void Blas<phi::GPUContext>::GEMM(bool transA,
   if (use_tensor_op_math) {
     algo = CUBLAS_GEMM_DFALT_TENSOR_OP;
   }
-  CheckGEMMNSize(N);
+  CheckGEMMNSize(n);
   dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasGemmEx(handle,
                                                           cuTransB,
                                                           cuTransA,
-                                                          N,
-                                                          M,
-                                                          K,
+                                                          n,
+                                                          m,
+                                                          k,
                                                           &h_alpha,
                                                           B,
                                                           CUDA_R_16F,
-                                                          ldb,
+                                                          ldb_int,
                                                           A,
                                                           CUDA_R_16F,
-                                                          lda,
+                                                          lda_int,
                                                           &h_beta,
                                                           C,
                                                           CUDA_R_16F,
-                                                          ldc,
+                                                          ldc_int,
                                                           CUDA_R_32F,
                                                           algo));
   });
@@ -2356,18 +2587,24 @@ template <>
 template <>
 inline void Blas<phi::GPUContext>::GEMM(bool transA,
                                         bool transB,
-                                        int M,
-                                        int N,
-                                        int K,
+                                        int64_t M,
+                                        int64_t N,
+                                        int64_t K,
                                         phi::bfloat16 alpha,
                                         const phi::bfloat16 *A,
-                                        int lda,
+                                        int64_t lda,
                                         const phi::bfloat16 *B,
-                                        int ldb,
+                                        int64_t ldb,
                                         phi::bfloat16 beta,
                                         phi::bfloat16 *C,
-                                        int ldc) const {
+                                        int64_t ldc) const {
 #if CUDA_VERSION >= 11000
+  const int m = detail::to_blas_int(M, "GEMM M");
+  const int n = detail::to_blas_int(N, "GEMM N");
+  const int k = detail::to_blas_int(K, "GEMM K");
+  const int lda_int = detail::to_blas_int(lda, "GEMM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "GEMM ldb");
+  const int ldc_int = detail::to_blas_int(ldc, "GEMM ldc");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   cublasOperation_t cuTransA = transA ? CUBLAS_OP_T : CUBLAS_OP_N;
@@ -2390,25 +2627,25 @@ inline void Blas<phi::GPUContext>::GEMM(bool transA,
     algo = CUBLAS_GEMM_DFALT_TENSOR_OP;
   }
 
-  CheckGEMMNSize(N);
+  CheckGEMMNSize(n);
   dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasGemmEx(handle,
                                                           cuTransB,
                                                           cuTransA,
-                                                          N,
-                                                          M,
-                                                          K,
+                                                          n,
+                                                          m,
+                                                          k,
                                                           &h_alpha,
                                                           B,
                                                           CUDA_R_16BF,
-                                                          ldb,
+                                                          ldb_int,
                                                           A,
                                                           CUDA_R_16BF,
-                                                          lda,
+                                                          lda_int,
                                                           &h_beta,
                                                           C,
                                                           CUDA_R_16BF,
-                                                          ldc,
+                                                          ldc_int,
                                                           CUDA_R_32F,
                                                           algo));
   });
@@ -2490,25 +2727,41 @@ inline void Blas<phi::GPUContext>::CUDOT(int64_t n,
 template <>
 template <typename T>
 void Blas<phi::GPUContext>::GEMV(bool trans_a,
-                                 int M,
-                                 int N,
+                                 int64_t M,
+                                 int64_t N,
                                  T alpha,
                                  const T *A,
                                  const T *B,
                                  T beta,
                                  T *C) const {
+  detail::check_blas_int64(M, "GEMV M");
+  detail::check_blas_int64(N, "GEMV N");
   cublasOperation_t cuTransA = !trans_a ? CUBLAS_OP_T : CUBLAS_OP_N;
 
+  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+      CUBlas<T>::GEMV_64(
+          handle, cuTransA, N, M, &alpha, A, N, B, 1, &beta, C, 1);
+    });
+    return;
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS GEMV requires CUDA 12.3 or later on Linux."));
+#endif
+  }
+  const int m = static_cast<int>(M);
+  const int n = static_cast<int>(N);
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
-    CUBlas<T>::GEMV(handle, cuTransA, N, M, &alpha, A, N, B, 1, &beta, C, 1);
+    CUBlas<T>::GEMV(handle, cuTransA, n, m, &alpha, A, n, B, 1, &beta, C, 1);
   });
 }
 
 template <>
 template <>
 inline void Blas<phi::GPUContext>::GEMV(bool trans_a,
-                                        int M,
-                                        int N,
+                                        int64_t M,
+                                        int64_t N,
                                         phi::float16 alpha,
                                         const phi::float16 *A,
                                         const phi::float16 *B,
@@ -2527,8 +2780,8 @@ inline void Blas<phi::GPUContext>::GEMV(bool trans_a,
 template <>
 template <>
 inline void Blas<phi::GPUContext>::GEMV(bool trans_a,
-                                        int M,
-                                        int N,
+                                        int64_t M,
+                                        int64_t N,
                                         phi::bfloat16 alpha,
                                         const phi::bfloat16 *A,
                                         const phi::bfloat16 *B,
@@ -2569,9 +2822,18 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
-  const int64_t strideC = M * N;
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
+  const int64_t strideC =
+      detail::checked_blas_mul(M, N, "BatchedGEMM output stride");
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE ||
+                                    batchCount > INT_MAX_VALUE;
 #if CUDA_VERSION >= 9010
-  if ((FLAGS_enable_cublas_tensor_op_math && (std::is_same<T, float>::value)) ||
+  if (((FLAGS_enable_cublas_tensor_op_math || requires_64_bit_blas) &&
+       std::is_same<T, float>::value) ||
       std::is_same<T, phi::float16>::value) {
     cublasGemmAlgo_t algo = CUBLAS_GEMM_DFALT;
     bool use_tensor_op_math = dev_ctx_.tensor_core_available();
@@ -2605,7 +2867,7 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       compute_type = CUDA_R_16F;
 #endif
     }
-    if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
+    if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
       dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
         PADDLE_ENFORCE_GPU_SUCCESS(
@@ -2667,6 +2929,42 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
     }
   } else {
 #endif  // CUDA_VERSION >= 9010
+    if (requires_64_bit_blas) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+      dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+        CUBlas<T>::GEMM_STRIDED_BATCH_64(handle,
+                                         cuTransB,
+                                         cuTransA,
+                                         N,
+                                         M,
+                                         K,
+                                         &alpha,
+                                         B,
+                                         ldb,
+                                         strideB,
+                                         A,
+                                         lda,
+                                         strideA,
+                                         &beta,
+                                         C,
+                                         ldc,
+                                         strideC,
+                                         batchCount);
+      });
+      return;
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
+#endif
+    }
+    detail::to_blas_int(M, "BatchedGEMM M");
+    detail::to_blas_int(N, "BatchedGEMM N");
+    detail::to_blas_int(K, "BatchedGEMM K");
+    detail::to_blas_int(lda, "BatchedGEMM lda");
+    detail::to_blas_int(ldb, "BatchedGEMM ldb");
+    detail::to_blas_int(ldc, "BatchedGEMM ldc");
+    detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
     dev_ctx_.CublasCall([&](cublasHandle_t handle) {
 #if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
       if (N == 1 && ldc >= std::max<int64_t>(1, M) && !FLAGS_use_legacy_gemm) {
@@ -2692,28 +2990,27 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
             static_cast<int>(ldc),
             strideC,
             static_cast<int>(batchCount));
-      } else  // NOLINT
-#endif
-      {
-        CUBlas<T>::GEMM_STRIDED_BATCH(handle,
-                                      cuTransB,
-                                      cuTransA,
-                                      static_cast<int>(N),
-                                      static_cast<int>(M),
-                                      static_cast<int>(K),
-                                      &alpha,
-                                      B,
-                                      static_cast<int>(ldb),
-                                      strideB,
-                                      A,
-                                      static_cast<int>(lda),
-                                      strideA,
-                                      &beta,
-                                      C,
-                                      static_cast<int>(ldc),
-                                      strideC,
-                                      static_cast<int>(batchCount));
+        return;
       }
+#endif
+      CUBlas<T>::GEMM_STRIDED_BATCH(handle,
+                                    cuTransB,
+                                    cuTransA,
+                                    static_cast<int>(N),
+                                    static_cast<int>(M),
+                                    static_cast<int>(K),
+                                    &alpha,
+                                    B,
+                                    static_cast<int>(ldb),
+                                    strideB,
+                                    A,
+                                    static_cast<int>(lda),
+                                    strideA,
+                                    &beta,
+                                    C,
+                                    static_cast<int>(ldc),
+                                    strideC,
+                                    static_cast<int>(batchCount));
     });
 
 #if CUDA_VERSION >= 9010
@@ -2745,9 +3042,18 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
-  const int64_t strideC = M * N;
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
+  const int64_t strideC =
+      detail::checked_blas_mul(M, N, "BatchedGEMM output stride");
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE ||
+                                    batchCount > INT_MAX_VALUE;
 #if CUDA_VERSION >= 9010
-  if ((FLAGS_enable_cublas_tensor_op_math && (std::is_same<T, float>::value)) ||
+  if (((FLAGS_enable_cublas_tensor_op_math || requires_64_bit_blas) &&
+       std::is_same<T, float>::value) ||
       std::is_same<T, phi::float16>::value) {
     cublasGemmAlgo_t algo = CUBLAS_GEMM_DFALT;
     bool use_tensor_op_math = dev_ctx_.tensor_core_available();
@@ -2782,8 +3088,7 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
 #endif
     }
 
-    if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-        batchCount > INT_MAX_VALUE) {
+    if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
       dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
         PADDLE_ENFORCE_GPU_SUCCESS(
@@ -2848,6 +3153,43 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
     T h_alpha = static_cast<T>(alpha);
     T h_beta = static_cast<T>(beta);
 
+    if (requires_64_bit_blas) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+      dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+        CUBlas<T>::GEMM_STRIDED_BATCH_64(handle,
+                                         cuTransB,
+                                         cuTransA,
+                                         N,
+                                         M,
+                                         K,
+                                         &h_alpha,
+                                         B,
+                                         ldb,
+                                         strideB,
+                                         A,
+                                         lda,
+                                         strideA,
+                                         &h_beta,
+                                         C,
+                                         ldc,
+                                         strideC,
+                                         batchCount);
+      });
+      return;
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
+#endif
+    }
+    detail::to_blas_int(M, "BatchedGEMM M");
+    detail::to_blas_int(N, "BatchedGEMM N");
+    detail::to_blas_int(K, "BatchedGEMM K");
+    detail::to_blas_int(lda, "BatchedGEMM lda");
+    detail::to_blas_int(ldb, "BatchedGEMM ldb");
+    detail::to_blas_int(ldc, "BatchedGEMM ldc");
+    detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+
     dev_ctx_.CublasCall([&](cublasHandle_t handle) {
       CUBlas<T>::GEMM_STRIDED_BATCH(handle,
                                     cuTransB,
@@ -2900,7 +3242,12 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
-  const int64_t strideC = M * N;
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
+  const int64_t strideC =
+      detail::checked_blas_mul(M, N, "BatchedGEMM output stride");
 
   float h_alpha = static_cast<float>(alpha);
   float h_beta = static_cast<float>(beta);
@@ -3005,7 +3352,12 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
-  const int64_t strideC = M * N;
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
+  const int64_t strideC =
+      detail::checked_blas_mul(M, N, "BatchedGEMM output stride");
 
   float h_alpha = alpha;
   float h_beta = beta;
@@ -3089,18 +3441,19 @@ template <>
 template <typename T>
 void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                         CBLAS_TRANSPOSE transB,
-                                        int M,
-                                        int N,
-                                        int K,
+                                        int64_t M,
+                                        int64_t N,
+                                        int64_t K,
                                         T alpha,
                                         const T **A,
                                         const T **B,
                                         T beta,
                                         T **C,
-                                        int batchCount) const {
-  for (int k = 0; k < batchCount; ++k) {
+                                        int64_t batchCount) const {
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+  for (int64_t i = 0; i < batchCount; ++i) {
     this->template GEMM<T>(
-        transA, transB, M, N, K, alpha, A[k], B[k], beta, C[k]);
+        transA, transB, M, N, K, alpha, A[i], B[i], beta, C[i]);
   }
 }
 
@@ -3109,35 +3462,40 @@ template <>
 template <>
 inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                                CBLAS_TRANSPOSE transB,
-                                               int M,
-                                               int N,
-                                               int K,
+                                               int64_t M,
+                                               int64_t N,
+                                               int64_t K,
                                                double alpha,
                                                const double **A,
                                                const double **B,
                                                double beta,
                                                double **C,
-                                               int batchCount) const {
+                                               int64_t batchCount) const {
+  const int m = detail::to_blas_int(M, "BatchedGEMM M");
+  const int n = detail::to_blas_int(N, "BatchedGEMM N");
+  const int k = detail::to_blas_int(K, "BatchedGEMM K");
+  const int batch_count =
+      detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
-  int lda = (transA == CblasNoTrans) ? K : M;
-  int ldb = (transB == CblasNoTrans) ? N : K;
-  int ldc = N;
+  int lda = (transA == CblasNoTrans) ? k : m;
+  int ldb = (transB == CblasNoTrans) ? n : k;
+  int ldc = n;
   cublasOperation_t cuTransA =
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
-  thrust::device_vector<const double *> A_ptr(A, A + batchCount);
-  thrust::device_vector<const double *> B_ptr(B, B + batchCount);
-  thrust::device_vector<double *> C_ptr(C, C + batchCount);
+  thrust::device_vector<const double *> A_ptr(A, A + batch_count);
+  thrust::device_vector<const double *> B_ptr(B, B + batch_count);
+  thrust::device_vector<double *> C_ptr(C, C + batch_count);
 
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
     CUBlas<double>::GEMM_BATCH(handle,
                                cuTransB,
                                cuTransA,
-                               N,
-                               M,
-                               K,
+                               n,
+                               m,
+                               k,
                                &alpha,
                                B_ptr.data().get(),
                                ldb,
@@ -3146,7 +3504,7 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                &beta,
                                C_ptr.data().get(),
                                ldc,
-                               batchCount);
+                               batch_count);
   });
 }
 
@@ -3154,35 +3512,40 @@ template <>
 template <>
 inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                                CBLAS_TRANSPOSE transB,
-                                               int M,
-                                               int N,
-                                               int K,
+                                               int64_t M,
+                                               int64_t N,
+                                               int64_t K,
                                                float alpha,
                                                const float **A,
                                                const float **B,
                                                float beta,
                                                float **C,
-                                               int batchCount) const {
+                                               int64_t batchCount) const {
+  const int m = detail::to_blas_int(M, "BatchedGEMM M");
+  const int n = detail::to_blas_int(N, "BatchedGEMM N");
+  const int k = detail::to_blas_int(K, "BatchedGEMM K");
+  const int batch_count =
+      detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
-  int lda = (transA == CblasNoTrans) ? K : M;
-  int ldb = (transB == CblasNoTrans) ? N : K;
-  int ldc = N;
+  int lda = (transA == CblasNoTrans) ? k : m;
+  int ldb = (transB == CblasNoTrans) ? n : k;
+  int ldc = n;
   cublasOperation_t cuTransA =
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
-  thrust::device_vector<const float *> A_ptr(A, A + batchCount);
-  thrust::device_vector<const float *> B_ptr(B, B + batchCount);
-  thrust::device_vector<float *> C_ptr(C, C + batchCount);
+  thrust::device_vector<const float *> A_ptr(A, A + batch_count);
+  thrust::device_vector<const float *> B_ptr(B, B + batch_count);
+  thrust::device_vector<float *> C_ptr(C, C + batch_count);
 
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
     CUBlas<float>::GEMM_BATCH(handle,
                               cuTransB,
                               cuTransA,
-                              N,
-                              M,
-                              K,
+                              n,
+                              m,
+                              k,
                               &alpha,
                               B_ptr.data().get(),
                               ldb,
@@ -3191,7 +3554,7 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                               &beta,
                               C_ptr.data().get(),
                               ldc,
-                              batchCount);
+                              batch_count);
   });
 }
 
@@ -3199,20 +3562,25 @@ template <>
 template <>
 inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                                CBLAS_TRANSPOSE transB,
-                                               int M,
-                                               int N,
-                                               int K,
+                                               int64_t M,
+                                               int64_t N,
+                                               int64_t K,
                                                phi::float16 alpha,
                                                const phi::float16 **A,
                                                const phi::float16 **B,
                                                phi::float16 beta,
                                                phi::float16 **C,
-                                               int batchCount) const {
+                                               int64_t batchCount) const {
+  const int m = detail::to_blas_int(M, "BatchedGEMM M");
+  const int n = detail::to_blas_int(N, "BatchedGEMM N");
+  const int k = detail::to_blas_int(K, "BatchedGEMM K");
+  const int batch_count =
+      detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
-  int lda = (transA == CblasNoTrans) ? K : M;
-  int ldb = (transB == CblasNoTrans) ? N : K;
-  int ldc = N;
+  int lda = (transA == CblasNoTrans) ? k : m;
+  int ldb = (transB == CblasNoTrans) ? n : k;
+  int ldc = n;
   cublasOperation_t cuTransA =
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
@@ -3231,9 +3599,9 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   CUBlas<phi::float16>::GEMM_BATCH(&cuda_ctx,
                                    cuTransB,
                                    cuTransA,
-                                   N,
-                                   M,
-                                   K,
+                                   n,
+                                   m,
+                                   k,
                                    &f_alpha,
                                    B,
                                    CUDA_R_16F,
@@ -3245,7 +3613,7 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                    C,
                                    CUDA_R_16F,
                                    ldc,
-                                   batchCount,
+                                   batch_count,
                                    CUDA_R_32F);
 }
 
@@ -3253,21 +3621,26 @@ template <>
 template <>
 inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                                CBLAS_TRANSPOSE transB,
-                                               int M,
-                                               int N,
-                                               int K,
+                                               int64_t M,
+                                               int64_t N,
+                                               int64_t K,
                                                phi::bfloat16 alpha,
                                                const phi::bfloat16 **A,
                                                const phi::bfloat16 **B,
                                                phi::bfloat16 beta,
                                                phi::bfloat16 **C,
-                                               int batchCount) const {
+                                               int64_t batchCount) const {
 #if CUDA_VERSION >= 11000
+  const int m = detail::to_blas_int(M, "BatchedGEMM M");
+  const int n = detail::to_blas_int(N, "BatchedGEMM N");
+  const int k = detail::to_blas_int(K, "BatchedGEMM K");
+  const int batch_count =
+      detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
-  int lda = (transA == CblasNoTrans) ? K : M;
-  int ldb = (transB == CblasNoTrans) ? N : K;
-  int ldc = N;
+  int lda = (transA == CblasNoTrans) ? k : m;
+  int ldb = (transB == CblasNoTrans) ? n : k;
+  int ldc = n;
   cublasOperation_t cuTransA =
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
@@ -3291,17 +3664,17 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   }
   VLOG(5) << "use_tensor_op_math: " << (use_tensor_op_math ? "True" : "False");
 
-  thrust::device_vector<const void *> A_ptr(A, A + batchCount);
-  thrust::device_vector<const void *> B_ptr(B, B + batchCount);
-  thrust::device_vector<void *> C_ptr(C, C + batchCount);
+  thrust::device_vector<const void *> A_ptr(A, A + batch_count);
+  thrust::device_vector<const void *> B_ptr(B, B + batch_count);
+  thrust::device_vector<void *> C_ptr(C, C + batch_count);
   dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
     PADDLE_ENFORCE_GPU_SUCCESS(
         phi::dynload::cublasGemmBatchedEx(handle,
                                           cuTransB,
                                           cuTransA,
-                                          N,
-                                          M,
-                                          K,
+                                          n,
+                                          m,
+                                          k,
                                           &f_alpha,
                                           B_ptr.data().get(),
                                           CUDA_R_16BF,
@@ -3313,7 +3686,7 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                           C_ptr.data().get(),
                                           CUDA_R_16BF,
                                           ldc,
-                                          batchCount,
+                                          batch_count,
                                           CUDA_R_32F,
                                           algo));
   });

--- a/paddle/phi/kernels/funcs/blas/blas_impl.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.h
@@ -29,7 +29,7 @@ namespace phi {
 namespace funcs {
 
 namespace detail {
-inline int to_blas_int(int64_t value, const char *name) {
+inline void check_blas_int64(int64_t value, const char *name) {
   PADDLE_ENFORCE_GE(
       value,
       0,
@@ -37,8 +37,36 @@ inline int to_blas_int(int64_t value, const char *name) {
                                       "but received %ld.",
                                       name,
                                       value));
+}
+
+inline int to_blas_int(int64_t value, const char *name) {
+  check_blas_int64(value, name);
   PADDLE_ENFORCE_LE_INT_MAX(value, name);
   return static_cast<int>(value);
+}
+
+inline int64_t checked_blas_mul(int64_t lhs, int64_t rhs, const char *name) {
+  check_blas_int64(lhs, name);
+  check_blas_int64(rhs, name);
+  if (lhs != 0) {
+    PADDLE_ENFORCE_LE(
+        rhs,
+        std::numeric_limits<int64_t>::max() / lhs,
+        common::errors::InvalidArgument(
+            "BLAS parameter %s overflows int64_t: %ld * %ld.", name, lhs, rhs));
+  }
+  return lhs * rhs;
+}
+
+inline int64_t checked_blas_int32_batched_stride(int64_t m,
+                                                 int64_t n,
+                                                 int64_t k,
+                                                 int64_t batch_count) {
+  to_blas_int(m, "BatchedGEMM M");
+  to_blas_int(n, "BatchedGEMM N");
+  to_blas_int(k, "BatchedGEMM K");
+  to_blas_int(batch_count, "BatchedGEMM batchCount");
+  return checked_blas_mul(m, n, "BatchedGEMM output stride");
 }
 
 template <typename T>
@@ -1224,42 +1252,67 @@ struct CBlas<phi::float16> {
 template <>
 template <typename T>
 T *Blas<CPUContext>::GEMM_ALLOC(const CBLAS_IDENTIFIER id,
-                                const int M,
-                                const int N,
-                                const int K) const {
-  return CBlas<T>::GEMM_ALLOC(id, M, N, K);
+                                int64_t M,
+                                int64_t N,
+                                int64_t K) const {
+  const int m = detail::to_blas_int(M, "GEMM_ALLOC M");
+  const int n = detail::to_blas_int(N, "GEMM_ALLOC N");
+  const int k = detail::to_blas_int(K, "GEMM_ALLOC K");
+  return CBlas<T>::GEMM_ALLOC(id, m, n, k);
 }
 
 template <>
 template <typename T>
 void Blas<CPUContext>::GEMM_PACK(const CBLAS_IDENTIFIER id,
                                  const CBLAS_TRANSPOSE trans,
-                                 int M,
-                                 int N,
-                                 int K,
+                                 int64_t M,
+                                 int64_t N,
+                                 int64_t K,
                                  const T alpha,
                                  const T *src,
-                                 const int ld,
+                                 int64_t ld,
                                  T *dst) const {
-  CBlas<T>::GEMM_PACK(CblasRowMajor, id, trans, M, N, K, alpha, src, ld, dst);
+  const int m = detail::to_blas_int(M, "GEMM_PACK M");
+  const int n = detail::to_blas_int(N, "GEMM_PACK N");
+  const int k = detail::to_blas_int(K, "GEMM_PACK K");
+  const int ld_int = detail::to_blas_int(ld, "GEMM_PACK ld");
+  CBlas<T>::GEMM_PACK(
+      CblasRowMajor, id, trans, m, n, k, alpha, src, ld_int, dst);
 }
 
 template <>
 template <typename T>
 void Blas<CPUContext>::GEMM_COMPUTE(int transA,
                                     int transB,
-                                    int M,
-                                    int N,
-                                    int K,
+                                    int64_t M,
+                                    int64_t N,
+                                    int64_t K,
                                     const T *A,
-                                    const int lda,
+                                    int64_t lda,
                                     const T *B,
-                                    const int ldb,
+                                    int64_t ldb,
                                     T beta,
                                     T *C,
-                                    const int ldc) const {
-  CBlas<T>::GEMM_COMPUTE(
-      CblasRowMajor, transA, transB, M, N, K, A, lda, B, ldb, beta, C, ldc);
+                                    int64_t ldc) const {
+  const int m = detail::to_blas_int(M, "GEMM_COMPUTE M");
+  const int n = detail::to_blas_int(N, "GEMM_COMPUTE N");
+  const int k = detail::to_blas_int(K, "GEMM_COMPUTE K");
+  const int lda_int = detail::to_blas_int(lda, "GEMM_COMPUTE lda");
+  const int ldb_int = detail::to_blas_int(ldb, "GEMM_COMPUTE ldb");
+  const int ldc_int = detail::to_blas_int(ldc, "GEMM_COMPUTE ldc");
+  CBlas<T>::GEMM_COMPUTE(CblasRowMajor,
+                         transA,
+                         transB,
+                         m,
+                         n,
+                         k,
+                         A,
+                         lda_int,
+                         B,
+                         ldb_int,
+                         beta,
+                         C,
+                         ldc_int);
 }
 
 template <>
@@ -1281,29 +1334,18 @@ void Blas<CPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                             const T *B,
                             T beta,
                             T *C) const {
-  if (M > std::numeric_limits<int>::max() ||
-      N > std::numeric_limits<int>::max() ||
-      K > std::numeric_limits<int>::max()) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "CPU GEMM only supports M, N and K not larger than INT_MAX. "
-        "Expected M <= %d, N <= %d and K <= %d, but received M = %ld, "
-        "N = %ld, K = %ld.",
-        std::numeric_limits<int>::max(),
-        std::numeric_limits<int>::max(),
-        std::numeric_limits<int>::max(),
-        M,
-        N,
-        K));
-  }
-  int lda = static_cast<int>((transA == CblasNoTrans) ? K : M);
-  int ldb = static_cast<int>((transB == CblasNoTrans) ? N : K);
-  int ldc = static_cast<int>(N);
+  const int m = detail::to_blas_int(M, "GEMM M");
+  const int n = detail::to_blas_int(N, "GEMM N");
+  const int k = detail::to_blas_int(K, "GEMM K");
+  const int lda = (transA == CblasNoTrans) ? k : m;
+  const int ldb = (transB == CblasNoTrans) ? n : k;
+  const int ldc = n;
   CBlas<T>::GEMM(CblasRowMajor,
                  transA,
                  transB,
-                 static_cast<int>(M),
-                 static_cast<int>(N),
-                 static_cast<int>(K),
+                 m,
+                 n,
+                 k,
                  alpha,
                  A,
                  lda,
@@ -1326,29 +1368,18 @@ void Blas<CPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                             const T *B,
                             U beta,
                             T *C) const {
-  if (M > std::numeric_limits<int>::max() ||
-      N > std::numeric_limits<int>::max() ||
-      K > std::numeric_limits<int>::max()) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "CPU GEMM only supports M, N and K not larger than INT_MAX. "
-        "Expected M <= %d, N <= %d and K <= %d, but received M = %ld, "
-        "N = %ld, K = %ld.",
-        std::numeric_limits<int>::max(),
-        std::numeric_limits<int>::max(),
-        std::numeric_limits<int>::max(),
-        M,
-        N,
-        K));
-  }
-  int lda = static_cast<int>((transA == CblasNoTrans) ? K : M);
-  int ldb = static_cast<int>((transB == CblasNoTrans) ? N : K);
-  int ldc = static_cast<int>(N);
+  const int m = detail::to_blas_int(M, "GEMM M");
+  const int n = detail::to_blas_int(N, "GEMM N");
+  const int k = detail::to_blas_int(K, "GEMM K");
+  const int lda = (transA == CblasNoTrans) ? k : m;
+  const int ldb = (transB == CblasNoTrans) ? n : k;
+  const int ldc = n;
   CBlas<T>::GEMM(CblasRowMajor,
                  transA,
                  transB,
-                 static_cast<int>(M),
-                 static_cast<int>(N),
-                 static_cast<int>(K),
+                 m,
+                 n,
+                 k,
                  alpha,
                  A,
                  lda,
@@ -1363,62 +1394,74 @@ template <>
 template <typename T>
 void Blas<CPUContext>::GEMM(bool transA,
                             bool transB,
-                            int M,
-                            int N,
-                            int K,
+                            int64_t M,
+                            int64_t N,
+                            int64_t K,
                             T alpha,
                             const T *A,
-                            int lda,
+                            int64_t lda,
                             const T *B,
-                            int ldb,
+                            int64_t ldb,
                             T beta,
                             T *C,
-                            int ldc) const {
+                            int64_t ldc) const {
+  const int m = detail::to_blas_int(M, "GEMM M");
+  const int n = detail::to_blas_int(N, "GEMM N");
+  const int k = detail::to_blas_int(K, "GEMM K");
+  const int lda_int = detail::to_blas_int(lda, "GEMM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "GEMM ldb");
+  const int ldc_int = detail::to_blas_int(ldc, "GEMM ldc");
   CBlas<T>::GEMM(CblasRowMajor,
                  transA == false ? CblasNoTrans : CblasTrans,
                  transB == false ? CblasNoTrans : CblasTrans,
-                 M,
-                 N,
-                 K,
+                 m,
+                 n,
+                 k,
                  alpha,
                  A,
-                 lda,
+                 lda_int,
                  B,
-                 ldb,
+                 ldb_int,
                  beta,
                  C,
-                 ldc);
+                 ldc_int);
 }
 
 template <>
 template <typename T>
 void Blas<CPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                             CBLAS_TRANSPOSE transB,
-                            int M,
-                            int N,
-                            int K,
+                            int64_t M,
+                            int64_t N,
+                            int64_t K,
                             T alpha,
                             const T *A,
-                            int lda,
+                            int64_t lda,
                             const T *B,
-                            int ldb,
+                            int64_t ldb,
                             T beta,
                             T *C,
-                            int ldc) const {
+                            int64_t ldc) const {
+  const int m = detail::to_blas_int(M, "GEMM M");
+  const int n = detail::to_blas_int(N, "GEMM N");
+  const int k = detail::to_blas_int(K, "GEMM K");
+  const int lda_int = detail::to_blas_int(lda, "GEMM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "GEMM ldb");
+  const int ldc_int = detail::to_blas_int(ldc, "GEMM ldc");
   CBlas<T>::GEMM(CblasRowMajor,
                  transA,
                  transB,
-                 M,
-                 N,
-                 K,
+                 m,
+                 n,
+                 k,
                  alpha,
                  A,
-                 lda,
+                 lda_int,
                  B,
-                 ldb,
+                 ldb_int,
                  beta,
                  C,
-                 ldc);
+                 ldc_int);
 }
 
 template <typename DeviceContext>
@@ -1450,13 +1493,9 @@ void Blas<DeviceContext>::MatMul(const DenseTensor &mat_a,
                                       "should be same, please check your "
                                       "code."));
 
-  const int64_t K_64 = !trans_a ? dim_a[1] : dim_a[0];
-  PADDLE_ENFORCE_LE_INT_MAX(dim_out[0], "dim_out[0]");
-  PADDLE_ENFORCE_LE_INT_MAX(dim_out[1], "dim_out[1]");
-  PADDLE_ENFORCE_LE_INT_MAX(K_64, "cblas GEMM K");
-  int M = static_cast<int>(dim_out[0]);
-  int N = static_cast<int>(dim_out[1]);
-  int K = static_cast<int>(K_64);
+  const int64_t M = dim_out[0];
+  const int64_t N = dim_out[1];
+  const int64_t K = !trans_a ? dim_a[1] : dim_a[0];
 
   CBLAS_TRANSPOSE transA = !trans_a ? CblasNoTrans : CblasTrans;
   CBLAS_TRANSPOSE transB = !trans_b ? CblasNoTrans : CblasTrans;
@@ -1489,15 +1528,17 @@ T Blas<CPUContext>::DOT(
 template <>
 template <typename T>
 void Blas<CPUContext>::GEMV(bool trans_a,
-                            int M,
-                            int N,
+                            int64_t M,
+                            int64_t N,
                             T alpha,
                             const T *A,
                             const T *B,
                             T beta,
                             T *C) const {
+  const int m = detail::to_blas_int(M, "GEMV M");
+  const int n = detail::to_blas_int(N, "GEMV N");
   CBLAS_TRANSPOSE transA = !trans_a ? CblasNoTrans : CblasTrans;
-  CBlas<T>::GEMV(CblasRowMajor, transA, M, N, alpha, A, N, B, 1, beta, C, 1);
+  CBlas<T>::GEMV(CblasRowMajor, transA, m, n, alpha, A, n, B, 1, beta, C, 1);
 }
 
 template <>
@@ -1522,24 +1563,8 @@ void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   PADDLE_ENFORCE_NOT_NULL(
       C, common::errors::InvalidArgument("Pointer C should not be null."));
 
-  if (M > std::numeric_limits<int>::max() ||
-      N > std::numeric_limits<int>::max() ||
-      K > std::numeric_limits<int>::max() ||
-      batchCount > std::numeric_limits<int>::max()) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "CPU BatchedGEMM only supports M, N, K and batchCount not larger "
-        "than INT_MAX. Expected M <= %d, N <= %d, K <= %d and "
-        "batchCount <= %d, but received M = %ld, N = %ld, K = %ld, "
-        "batchCount = %ld.",
-        std::numeric_limits<int>::max(),
-        std::numeric_limits<int>::max(),
-        std::numeric_limits<int>::max(),
-        std::numeric_limits<int>::max(),
-        M,
-        N,
-        K,
-        batchCount));
-  }
+  const int64_t strideC =
+      detail::checked_blas_int32_batched_stride(M, N, K, batchCount);
 
 #if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
   int M_int = static_cast<int>(M);
@@ -1555,7 +1580,7 @@ void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   for (int k = 0; k < batchCount; ++k) {
     a_array[k] = &A[k * strideA];
     b_array[k] = &B[k * strideB];
-    c_array[k] = &C[k * M * N];
+    c_array[k] = &C[k * strideC];
   }
   CBlas<T>::GEMM_BATCH(CblasRowMajor,
                        &transA,
@@ -1577,7 +1602,7 @@ void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   for (int64_t k = 0; k < batchCount; ++k) {
     auto *Ak = &A[k * strideA];
     auto *Bk = &B[k * strideB];
-    auto *Ck = &C[k * M * N];
+    auto *Ck = &C[k * strideC];
     this->template GEMM<T>(transA,
                            transB,
                            static_cast<int>(M),
@@ -1613,14 +1638,8 @@ void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       B, common::errors::InvalidArgument("Pointer B should not be null."));
   PADDLE_ENFORCE_NOT_NULL(
       C, common::errors::InvalidArgument("Pointer C should not be null."));
-  if (M > std::numeric_limits<int>::max() ||
-      N > std::numeric_limits<int>::max() ||
-      K > std::numeric_limits<int>::max() ||
-      batchCount > std::numeric_limits<int>::max()) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "CPU BatchedGEMM does not support M, N, K or batchCount larger than "
-        "INT_MAX."));
-  }
+  const int64_t strideC =
+      detail::checked_blas_int32_batched_stride(M, N, K, batchCount);
 
 #if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
   int M_int = static_cast<int>(M);
@@ -1636,7 +1655,7 @@ void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   for (int k = 0; k < batchCount; ++k) {
     a_array[k] = &A[k * strideA];
     b_array[k] = &B[k * strideB];
-    c_array[k] = &C[k * M * N];
+    c_array[k] = &C[k * strideC];
   }
 
   CBlas<T>::GEMM_BATCH(CblasRowMajor,
@@ -1659,7 +1678,7 @@ void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   for (int64_t k = 0; k < batchCount; ++k) {
     auto *Ak = &A[k * strideA];
     auto *Bk = &B[k * strideB];
-    auto *Ck = &C[k * M * N];
+    auto *Ck = &C[k * strideC];
     this->template GEMM<T>(transA,
                            transB,
                            static_cast<int>(M),
@@ -1678,25 +1697,29 @@ template <>
 template <typename T>
 void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                    CBLAS_TRANSPOSE transB,
-                                   int M,
-                                   int N,
-                                   int K,
+                                   int64_t M,
+                                   int64_t N,
+                                   int64_t K,
                                    T alpha,
                                    const T **A,
                                    const T **B,
                                    T beta,
                                    T **C,
-                                   int batchCount) const {
+                                   int64_t batchCount) const {
+  int m = detail::to_blas_int(M, "BatchedGEMM M");
+  int n = detail::to_blas_int(N, "BatchedGEMM N");
+  int k = detail::to_blas_int(K, "BatchedGEMM K");
+  int batch_count = detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
 #if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
-  const int lda = (std::max)((transA == CblasNoTrans) ? K : M, 1);
-  const int ldb = (std::max)((transB == CblasNoTrans) ? N : K, 1);
-  const int ldc = (std::max)(N, 1);
+  const int lda = (std::max)((transA == CblasNoTrans) ? k : m, 1);
+  const int ldb = (std::max)((transB == CblasNoTrans) ? n : k, 1);
+  const int ldc = (std::max)(n, 1);
   CBlas<T>::GEMM_BATCH(CblasRowMajor,
                        &transA,
                        &transB,
-                       &M,
-                       &N,
-                       &K,
+                       &m,
+                       &n,
+                       &k,
                        &alpha,
                        A,
                        &lda,
@@ -1706,11 +1729,11 @@ void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                        C,
                        &ldc,
                        1 /* group_count */,
-                       &batchCount);
+                       &batch_count);
 #else
-  for (int k = 0; k < batchCount; ++k) {
+  for (int i = 0; i < batch_count; ++i) {
     this->template GEMM<T>(
-        transA, transB, M, N, K, alpha, A[k], B[k], beta, C[k]);
+        transA, transB, m, n, k, alpha, A[i], B[i], beta, C[i]);
   }
 #endif
 }
@@ -1721,39 +1744,80 @@ template <>
 template <typename T>
 void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                                            CBLAS_TRANSPOSE transB,
-                                           int W1,
-                                           int H1,
-                                           int W2,
-                                           int H2,
+                                           int64_t W1,
+                                           int64_t H1,
+                                           int64_t W2,
+                                           int64_t H2,
                                            T alpha,
                                            const T *A,
                                            const T *B,
                                            T beta,
                                            T *C,
-                                           int batchCount,
+                                           int64_t batchCount,
                                            int64_t strideA,
                                            int64_t strideB,
                                            int64_t head_number,
                                            bool split_b_vertical) const {
-  int lda = (transA == CblasNoTrans) ? W1 : H1;
-  int ldb = (transB == CblasNoTrans) ? W2 : H2;
-  auto a_array = std::vector<const T *>(batchCount);
-  auto b_array = std::vector<const T *>(batchCount);
-  auto c_array = std::vector<T *>(batchCount);
+  PADDLE_ENFORCE_GE(
+      head_number,
+      1,
+      common::errors::InvalidArgument(
+          "BatchedGEMMWithHead head_number must be at least 1, but received "
+          "%ld.",
+          head_number));
+  PADDLE_ENFORCE_EQ(
+      W1 % head_number,
+      0,
+      common::errors::InvalidArgument(
+          "BatchedGEMMWithHead W1 must be divisible by head_number, but "
+          "received W1 = %ld and head_number = %ld.",
+          W1,
+          head_number));
+  PADDLE_ENFORCE_LE(
+      head_number,
+      W1,
+      common::errors::InvalidArgument(
+          "BatchedGEMMWithHead head_number must not exceed W1, but received "
+          "head_number = %ld and W1 = %ld.",
+          head_number,
+          W1));
+  if (split_b_vertical) {
+    PADDLE_ENFORCE_EQ(
+        W2 % head_number,
+        0,
+        common::errors::InvalidArgument(
+            "BatchedGEMMWithHead W2 must be divisible by head_number when "
+            "split_b_vertical is true, but received W2 = %ld and "
+            "head_number = %ld.",
+            W2,
+            head_number));
+  }
+  int w1 = detail::to_blas_int(W1, "BatchedGEMMWithHead W1");
+  int h1 = detail::to_blas_int(H1, "BatchedGEMMWithHead H1");
+  int w2 = detail::to_blas_int(W2, "BatchedGEMMWithHead W2");
+  int h2 = detail::to_blas_int(H2, "BatchedGEMMWithHead H2");
+  int batch_count =
+      detail::to_blas_int(batchCount, "BatchedGEMMWithHead batchCount");
+  const int lda = (transA == CblasNoTrans) ? w1 : h1;
+  const int ldb = (transB == CblasNoTrans) ? w2 : h2;
+  auto a_array = std::vector<const T *>(batch_count);
+  auto b_array = std::vector<const T *>(batch_count);
+  auto c_array = std::vector<T *>(batch_count);
 
   if (split_b_vertical) {
-    int ldc = W2;
-    int sub_width = W2 / head_number;
+    const int ldc = w2;
+    int sub_width =
+        detail::to_blas_int(W2 / head_number, "BatchedGEMMWithHead sub_width");
 
-    for (int i = 0; i < head_number; i++) {
-      int sub_matA_offset = (transA == CblasNoTrans)
-                                ? i * (W1 / head_number)
-                                : i * (W1 / head_number) * H1;
-      int sub_matB_offset = (transB == CblasNoTrans)
-                                ? i * (W2 / head_number)
-                                : i * (W2 / head_number) * H2;
-      int sub_matC_offset = i * W2 / head_number;
-      for (int k = 0; k < batchCount; ++k) {
+    for (int64_t i = 0; i < head_number; ++i) {
+      const int64_t sub_matA_offset = (transA == CblasNoTrans)
+                                          ? i * (W1 / head_number)
+                                          : i * (W1 / head_number) * H1;
+      const int64_t sub_matB_offset = (transB == CblasNoTrans)
+                                          ? i * (W2 / head_number)
+                                          : i * (W2 / head_number) * H2;
+      const int64_t sub_matC_offset = i * W2 / head_number;
+      for (int64_t k = 0; k < batchCount; ++k) {
         a_array[k] = &A[k * strideA] + sub_matA_offset;
         b_array[k] = &B[k * strideB] + sub_matB_offset;
         c_array[k] = &C[k * H1 * W2] + sub_matC_offset;
@@ -1762,9 +1826,9 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
       CBlas<T>::GEMM_BATCH(CblasRowMajor,
                            &transA,
                            &transB,
-                           &H1,
+                           &h1,
                            &sub_width,
-                           &H2,
+                           &h2,
                            &alpha,
                            a_array.data(),
                            &lda,
@@ -1774,7 +1838,7 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                            c_array.data(),
                            &ldc,
                            1 /* group_count */,
-                           &batchCount);
+                           &batch_count);
     }
 
   } else {
@@ -1783,22 +1847,24 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
         H2,
         common::errors::InvalidArgument(
             "The first matrix width should be same as second matrix height,"
-            "but received first matrix width %d"
-            ", second matrix height %d",
+            "but received first matrix width %ld"
+            ", second matrix height %ld",
             W1,
             H2));
-    int ldc = W2 * head_number;
-    int sub_width = W1 / head_number;
+    const int ldc =
+        detail::to_blas_int(W2 * head_number, "BatchedGEMMWithHead ldc");
+    int sub_width =
+        detail::to_blas_int(W1 / head_number, "BatchedGEMMWithHead sub_width");
 
-    for (int i = 0; i < head_number; i++) {
-      int sub_matA_offset = (transA == CblasNoTrans)
-                                ? i * (W1 / head_number)
-                                : i * (W1 / head_number) * H1;
-      int sub_matB_offset = (transB == CblasNoTrans)
-                                ? i * (W1 / head_number) * W2
-                                : i * (W1 / head_number);
-      int sub_matC_offset = i * W2;
-      for (int k = 0; k < batchCount; ++k) {
+    for (int64_t i = 0; i < head_number; ++i) {
+      const int64_t sub_matA_offset = (transA == CblasNoTrans)
+                                          ? i * (W1 / head_number)
+                                          : i * (W1 / head_number) * H1;
+      const int64_t sub_matB_offset = (transB == CblasNoTrans)
+                                          ? i * (W1 / head_number) * W2
+                                          : i * (W1 / head_number);
+      const int64_t sub_matC_offset = i * W2;
+      for (int64_t k = 0; k < batchCount; ++k) {
         a_array[k] = &A[k * strideA] + sub_matA_offset;
         b_array[k] = &B[k * strideB] + sub_matB_offset;
         c_array[k] = &C[k * H1 * head_number * W2] + sub_matC_offset;
@@ -1807,8 +1873,8 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
       CBlas<T>::GEMM_BATCH(CblasRowMajor,
                            &transA,
                            &transB,
-                           &H1,
-                           &W2,
+                           &h1,
+                           &w2,
                            &sub_width,
                            &alpha,
                            a_array.data(),
@@ -1819,7 +1885,7 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                            c_array.data(),
                            &ldc,
                            1 /* group_count */,
-                           &batchCount);
+                           &batch_count);
     }
   }
 }
@@ -1831,39 +1897,80 @@ template <>
 template <typename T>
 void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                                            CBLAS_TRANSPOSE transB,
-                                           int W1,
-                                           int H1,
-                                           int W2,
-                                           int H2,
+                                           int64_t W1,
+                                           int64_t H1,
+                                           int64_t W2,
+                                           int64_t H2,
                                            T alpha,
                                            const T *A,
                                            const T *B,
                                            T beta,
                                            T *C,
-                                           int batchCount,
+                                           int64_t batchCount,
                                            int64_t strideA,
                                            int64_t strideB,
                                            int64_t head_number,
                                            bool split_b_vertical) const {
-  int lda = (transA == CblasNoTrans) ? W1 : H1;
-  int ldb = (transB == CblasNoTrans) ? W2 : H2;
-  auto a_array = std::vector<const T *>(batchCount);
-  auto b_array = std::vector<const T *>(batchCount);
-  auto c_array = std::vector<T *>(batchCount);
+  PADDLE_ENFORCE_GE(
+      head_number,
+      1,
+      common::errors::InvalidArgument(
+          "BatchedGEMMWithHead head_number must be at least 1, but received "
+          "%ld.",
+          head_number));
+  PADDLE_ENFORCE_EQ(
+      W1 % head_number,
+      0,
+      common::errors::InvalidArgument(
+          "BatchedGEMMWithHead W1 must be divisible by head_number, but "
+          "received W1 = %ld and head_number = %ld.",
+          W1,
+          head_number));
+  PADDLE_ENFORCE_LE(
+      head_number,
+      W1,
+      common::errors::InvalidArgument(
+          "BatchedGEMMWithHead head_number must not exceed W1, but received "
+          "head_number = %ld and W1 = %ld.",
+          head_number,
+          W1));
+  if (split_b_vertical) {
+    PADDLE_ENFORCE_EQ(
+        W2 % head_number,
+        0,
+        common::errors::InvalidArgument(
+            "BatchedGEMMWithHead W2 must be divisible by head_number when "
+            "split_b_vertical is true, but received W2 = %ld and "
+            "head_number = %ld.",
+            W2,
+            head_number));
+  }
+  int w1 = detail::to_blas_int(W1, "BatchedGEMMWithHead W1");
+  int h1 = detail::to_blas_int(H1, "BatchedGEMMWithHead H1");
+  int w2 = detail::to_blas_int(W2, "BatchedGEMMWithHead W2");
+  int h2 = detail::to_blas_int(H2, "BatchedGEMMWithHead H2");
+  int batch_count =
+      detail::to_blas_int(batchCount, "BatchedGEMMWithHead batchCount");
+  const int lda = (transA == CblasNoTrans) ? w1 : h1;
+  const int ldb = (transB == CblasNoTrans) ? w2 : h2;
+  auto a_array = std::vector<const T *>(batch_count);
+  auto b_array = std::vector<const T *>(batch_count);
+  auto c_array = std::vector<T *>(batch_count);
 
   if (split_b_vertical) {
-    int ldc = W2;
-    int sub_width = W2 / head_number;
+    const int ldc = w2;
+    int sub_width =
+        detail::to_blas_int(W2 / head_number, "BatchedGEMMWithHead sub_width");
 
-    for (int i = 0; i < head_number; i++) {
-      int sub_matA_offset = (transA == CblasNoTrans)
-                                ? i * (W1 / head_number)
-                                : i * (W1 / head_number) * H1;
-      int sub_matB_offset = (transB == CblasNoTrans)
-                                ? i * (W2 / head_number)
-                                : i * (W2 / head_number) * H2;
-      int sub_matC_offset = i * W2 / head_number;
-      for (int k = 0; k < batchCount; ++k) {
+    for (int64_t i = 0; i < head_number; ++i) {
+      const int64_t sub_matA_offset = (transA == CblasNoTrans)
+                                          ? i * (W1 / head_number)
+                                          : i * (W1 / head_number) * H1;
+      const int64_t sub_matB_offset = (transB == CblasNoTrans)
+                                          ? i * (W2 / head_number)
+                                          : i * (W2 / head_number) * H2;
+      const int64_t sub_matC_offset = i * W2 / head_number;
+      for (int64_t k = 0; k < batchCount; ++k) {
         a_array[k] = &A[k * strideA] + sub_matA_offset;
         b_array[k] = &B[k * strideB] + sub_matB_offset;
         c_array[k] = &C[k * H1 * W2] + sub_matC_offset;
@@ -1872,9 +1979,9 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
       CBlas<T>::GEMM_BATCH(CblasRowMajor,
                            &transA,
                            &transB,
-                           &H1,
+                           &h1,
                            &sub_width,
-                           &H2,
+                           &h2,
                            &alpha,
                            a_array.data(),
                            &lda,
@@ -1884,7 +1991,7 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                            c_array.data(),
                            &ldc,
                            1 /* group_count */,
-                           &batchCount);
+                           &batch_count);
     }
 
   } else {
@@ -1893,22 +2000,24 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
         H2,
         common::errors::InvalidArgument(
             "The first matrix width should be same as second matrix height,"
-            "but received first matrix width %d"
-            ", second matrix height %d",
+            "but received first matrix width %ld"
+            ", second matrix height %ld",
             W1,
             H2));
-    int ldc = W2 * head_number;
-    int sub_width = W1 / head_number;
+    const int ldc =
+        detail::to_blas_int(W2 * head_number, "BatchedGEMMWithHead ldc");
+    int sub_width =
+        detail::to_blas_int(W1 / head_number, "BatchedGEMMWithHead sub_width");
 
-    for (int i = 0; i < head_number; i++) {
-      int sub_matA_offset = (transA == CblasNoTrans)
-                                ? i * (W1 / head_number)
-                                : i * (W1 / head_number) * H1;
-      int sub_matB_offset = (transB == CblasNoTrans)
-                                ? i * (W1 / head_number) * W2
-                                : i * (W1 / head_number);
-      int sub_matC_offset = i * W2;
-      for (int k = 0; k < batchCount; ++k) {
+    for (int64_t i = 0; i < head_number; ++i) {
+      const int64_t sub_matA_offset = (transA == CblasNoTrans)
+                                          ? i * (W1 / head_number)
+                                          : i * (W1 / head_number) * H1;
+      const int64_t sub_matB_offset = (transB == CblasNoTrans)
+                                          ? i * (W1 / head_number) * W2
+                                          : i * (W1 / head_number);
+      const int64_t sub_matC_offset = i * W2;
+      for (int64_t k = 0; k < batchCount; ++k) {
         a_array[k] = &A[k * strideA] + sub_matA_offset;
         b_array[k] = &B[k * strideB] + sub_matB_offset;
         c_array[k] = &C[k * H1 * head_number * W2] + sub_matC_offset;
@@ -1917,8 +2026,8 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
       CBlas<T>::GEMM_BATCH(CblasRowMajor,
                            &transA,
                            &transB,
-                           &H1,
-                           &W2,
+                           &h1,
+                           &w2,
                            &sub_width,
                            &alpha,
                            a_array.data(),
@@ -1929,7 +2038,7 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                            c_array.data(),
                            &ldc,
                            1 /* group_count */,
-                           &batchCount);
+                           &batch_count);
     }
   }
 }
@@ -1938,27 +2047,23 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
 template <typename DeviceContext>
 template <typename T>
 void Blas<DeviceContext>::MatMul(
-    const int M, const int N, const int K, const T *A, const T *B, T *C) const {
-  this->template GEMM<T>(CblasRowMajor,
-                         CblasNoTrans,
+    int64_t M, int64_t N, int64_t K, const T *A, const T *B, T *C) const {
+  this->template GEMM<T>(CblasNoTrans,
                          CblasNoTrans,
                          M,
                          N,
                          K,
                          static_cast<T>(1),
                          A,
-                         K,
                          B,
-                         N,
                          static_cast<T>(0),
-                         C,
-                         N);
+                         C);
 }
 
 template <>
 template <typename T>
 void Blas<CPUContext>::MatMul(
-    const int M, const int N, const int K, const T *A, const T *B, T *C) const {
+    int64_t M, int64_t N, int64_t K, const T *A, const T *B, T *C) const {
 #ifdef PADDLE_WITH_LIBXSMM
   // Refer to https://github.com/hfp/libxsmm/blob/master/README.md
   // But the threshold is custom constexpr int LIBXSMM_THRESHOLD = 20 * 20 * 20;
@@ -1968,29 +2073,32 @@ void Blas<CPUContext>::MatMul(
   // and the if( M*N*K < LIBXSMM_THRESHOLD) would be overhead,
   // use xsmm directly.
   // Note: SMM use ColMajor
-  const char transa = 'N';
-  const char transb = 'N';
-  const T alpha = static_cast<T>(1);
-  const T beta = static_cast<T>(0);
-  CBlas<T>::SMM_GEMM(
-      &transa, &transb, &N, &M, &K, &alpha, B, &N, A, &K, &beta, C, &N);
-  return;
+  if (M >= 0 && M <= std::numeric_limits<int>::max() && N >= 0 &&
+      N <= std::numeric_limits<int>::max() && K >= 0 &&
+      K <= std::numeric_limits<int>::max()) {
+    const char transa = 'N';
+    const char transb = 'N';
+    const int m = static_cast<int>(M);
+    const int n = static_cast<int>(N);
+    const int k = static_cast<int>(K);
+    const T alpha = static_cast<T>(1);
+    const T beta = static_cast<T>(0);
+    CBlas<T>::SMM_GEMM(
+        &transa, &transb, &n, &m, &k, &alpha, B, &n, A, &k, &beta, C, &n);
+    return;
+  }
 #endif
 
-  CBlas<T>::GEMM(CblasRowMajor,
-                 CblasNoTrans,
-                 CblasNoTrans,
-                 M,
-                 N,
-                 K,
-                 static_cast<T>(1),
-                 A,
-                 K,
-                 B,
-                 N,
-                 static_cast<T>(0),
-                 C,
-                 N);
+  this->template GEMM<T>(CblasNoTrans,
+                         CblasNoTrans,
+                         M,
+                         N,
+                         K,
+                         static_cast<T>(1),
+                         A,
+                         B,
+                         static_cast<T>(0),
+                         C);
 }
 
 template <typename DeviceContext>
@@ -2098,32 +2206,32 @@ void Blas<DeviceContext>::MatMulWithHead(const DenseTensor &mat_a,
                                          const DenseTensor &mat_b,
                                          const MatDescriptor &dim_b,
                                          T alpha,
-                                         int head_number,
+                                         int64_t head_number,
                                          DenseTensor *mat_out,
                                          T beta,
                                          bool mat_b_split_vertical) const {
+  PADDLE_ENFORCE_GE(head_number,
+                    1,
+                    common::errors::InvalidArgument(
+                        "The head number should be greater equal 1,"
+                        "but received head number %ld",
+                        head_number));
   PADDLE_ENFORCE_EQ(
       dim_a.width_ % head_number,
       0,
       common::errors::InvalidArgument(
           "The first input width must be some times the head number, "
-          "but received first input width %d"
-          ",  head_number %d",
+          "but received first input width %ld"
+          ",  head_number %ld",
           dim_a.width_,
           head_number));
-  PADDLE_ENFORCE_GE(head_number,
-                    1,
-                    common::errors::InvalidArgument(
-                        "The head number should be greater equal 1,"
-                        "but received head number %d",
-                        head_number));
   PADDLE_ENFORCE_LE(
       head_number,
       dim_a.width_,
       common::errors::InvalidArgument(
           "The head number should be less equal first input width,"
-          "but received first input width %d"
-          ",  head_number %d",
+          "but received first input width %ld"
+          ",  head_number %ld",
           dim_a.width_,
           head_number));
   CBLAS_TRANSPOSE transA = !dim_a.trans_ ? CblasNoTrans : CblasTrans;
@@ -2135,32 +2243,32 @@ void Blas<DeviceContext>::MatMulWithHead(const DenseTensor &mat_a,
         dim_a.width_ / head_number,
         common::errors::InvalidArgument(
             "The second input height should be equal than first input width,"
-            "but received second input height %d, first input width %d",
+            "but received second input height %ld, first input width %ld",
             dim_b.height_,
             dim_a.width_ / head_number));
     PADDLE_ENFORCE_EQ(
-        dim_a.width_ % head_number,
+        dim_b.width_ % head_number,
         0,
         common::errors::InvalidArgument(
             "The second input width should be some times the head number, "
-            "but received second input width %d"
-            ",  head_number %d",
+            "but received second input width %ld"
+            ",  head_number %ld",
             dim_b.width_,
             head_number));
   }
 
   if (dim_a.batch_size_ == 0 && dim_b.batch_size_ == 0) {
-    int lda = !dim_a.trans_ ? dim_a.width_ : dim_a.height_;
-    int ldb = !dim_b.trans_ ? dim_b.width_ : dim_b.height_;
-    int sub_matA_offset;
-    int sub_matB_offset;
-    int sub_matC_offset;
-    int sub_mat_M = dim_a.height_;
-    int sub_mat_N;
-    int sub_mat_K;
-    int ldc;
+    const int64_t lda = !dim_a.trans_ ? dim_a.width_ : dim_a.height_;
+    const int64_t ldb = !dim_b.trans_ ? dim_b.width_ : dim_b.height_;
+    int64_t sub_matA_offset;
+    int64_t sub_matB_offset;
+    int64_t sub_matC_offset;
+    const int64_t sub_mat_M = dim_a.height_;
+    int64_t sub_mat_N;
+    int64_t sub_mat_K;
+    int64_t ldc;
 
-    for (int i = 0; i < head_number; i++) {
+    for (int64_t i = 0; i < head_number; ++i) {
       sub_matA_offset = dim_a.trans_
                             ? i * (dim_a.width_ / head_number) * dim_a.height_
                             : i * (dim_a.width_ / head_number);
@@ -2209,7 +2317,7 @@ void Blas<DeviceContext>::MatMulWithHead(const DenseTensor &mat_a,
             "The first input batch size should be equal than second input,"
             "either two input batch size is 0, but received first input batch "
             "size"
-            " %d, second input batch size %d",
+            " %ld, second input batch size %ld",
             dim_a.batch_size_,
             dim_b.batch_size_));
 
@@ -2261,32 +2369,32 @@ void Blas<DeviceContext>::MatMulWithHead(const DenseTensor &mat_a,
                                          const DenseTensor &mat_b,
                                          const MatDescriptor &dim_b,
                                          T alpha,
-                                         int head_number,
+                                         int64_t head_number,
                                          DenseTensor *mat_out,
                                          T beta,
                                          bool mat_b_split_vertical) const {
+  PADDLE_ENFORCE_GE(head_number,
+                    1,
+                    common::errors::InvalidArgument(
+                        "The head number should be greater equal 1,"
+                        "but received head number %ld",
+                        head_number));
   PADDLE_ENFORCE_EQ(
       dim_a.width_ % head_number,
       0,
       common::errors::InvalidArgument(
           "The first input width must be some times the head number, "
-          "but received first input width %d"
-          ",  head_number %d",
+          "but received first input width %ld"
+          ",  head_number %ld",
           dim_a.width_,
           head_number));
-  PADDLE_ENFORCE_GE(head_number,
-                    1,
-                    common::errors::InvalidArgument(
-                        "The head number should be greater equal 1,"
-                        "but received head number %d",
-                        head_number));
   PADDLE_ENFORCE_LE(
       head_number,
       dim_a.width_,
       common::errors::InvalidArgument(
           "The head number should be less equal first input width,"
-          "but received first input width %d"
-          ",  head_number %d",
+          "but received first input width %ld"
+          ",  head_number %ld",
           dim_a.width_,
           head_number));
   CBLAS_TRANSPOSE transA = !dim_a.trans_ ? CblasNoTrans : CblasTrans;
@@ -2298,32 +2406,32 @@ void Blas<DeviceContext>::MatMulWithHead(const DenseTensor &mat_a,
         dim_a.width_ / head_number,
         common::errors::InvalidArgument(
             "The second input height should be equal than first input width,"
-            "but received second input height %d, first input width %d",
+            "but received second input height %ld, first input width %ld",
             dim_b.height_,
             dim_a.width_ / head_number));
     PADDLE_ENFORCE_EQ(
-        dim_a.width_ % head_number,
+        dim_b.width_ % head_number,
         0,
         common::errors::InvalidArgument(
             "The second input width should be some times the head number, "
-            "but received second input width %d"
-            ",  head_number %d",
+            "but received second input width %ld"
+            ",  head_number %ld",
             dim_b.width_,
             head_number));
   }
 
   if (dim_a.batch_size_ == 0 && dim_b.batch_size_ == 0) {
-    int lda = !dim_a.trans_ ? dim_a.width_ : dim_a.height_;
-    int ldb = !dim_b.trans_ ? dim_b.width_ : dim_b.height_;
-    int sub_matA_offset;
-    int sub_matB_offset;
-    int sub_matC_offset;
-    int sub_mat_M = dim_a.height_;
-    int sub_mat_N;
-    int sub_mat_K;
-    int ldc;
+    const int64_t lda = !dim_a.trans_ ? dim_a.width_ : dim_a.height_;
+    const int64_t ldb = !dim_b.trans_ ? dim_b.width_ : dim_b.height_;
+    int64_t sub_matA_offset;
+    int64_t sub_matB_offset;
+    int64_t sub_matC_offset;
+    const int64_t sub_mat_M = dim_a.height_;
+    int64_t sub_mat_N;
+    int64_t sub_mat_K;
+    int64_t ldc;
 
-    for (int i = 0; i < head_number; i++) {
+    for (int64_t i = 0; i < head_number; ++i) {
       sub_matA_offset = dim_a.trans_
                             ? i * (dim_a.width_ / head_number) * dim_a.height_
                             : i * (dim_a.width_ / head_number);
@@ -2372,7 +2480,7 @@ void Blas<DeviceContext>::MatMulWithHead(const DenseTensor &mat_a,
             "The first input batch size should be equal to second input,"
             "either two input batch size is 0, but received first input batch "
             "size"
-            " %d, second input batch size %d",
+            " %ld, second input batch size %ld",
             dim_a.batch_size_,
             dim_b.batch_size_));
 

--- a/paddle/phi/kernels/funcs/blas/blas_impl.hip.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.hip.h
@@ -628,10 +628,9 @@ void Blas<GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                             const T *B,
                             T beta,
                             T *C) const {
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip GEMM not supported for large tensor size"));
-  }
+  detail::to_blas_int(M, "GEMM M");
+  detail::to_blas_int(N, "GEMM N");
+  detail::to_blas_int(K, "GEMM K");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   int64_t lda = (transA == CblasNoTrans) ? K : M;
@@ -672,10 +671,9 @@ void Blas<GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                             const T *B,
                             U beta,
                             T *C) const {
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip GEMM not supported for large tensor size"));
-  }
+  detail::to_blas_int(M, "GEMM M");
+  detail::to_blas_int(N, "GEMM N");
+  detail::to_blas_int(K, "GEMM K");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   int64_t lda = (transA == CblasNoTrans) ? K : M;
@@ -720,10 +718,9 @@ inline void Blas<GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                    const phi::float16 *B,
                                    phi::float16 beta,
                                    phi::float16 *C) const {
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip GEMM not supported for large tensor size"));
-  }
+  detail::to_blas_int(M, "GEMM M");
+  detail::to_blas_int(N, "GEMM N");
+  detail::to_blas_int(K, "GEMM K");
 
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
@@ -788,10 +785,9 @@ inline void Blas<GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                    const phi::float16 *B,
                                    float beta,
                                    phi::float16 *C) const {
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip GEMM not supported for large tensor size"));
-  }
+  detail::to_blas_int(M, "GEMM M");
+  detail::to_blas_int(N, "GEMM N");
+  detail::to_blas_int(K, "GEMM K");
 
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
@@ -856,10 +852,9 @@ inline void Blas<GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                    const phi::bfloat16 *B,
                                    phi::bfloat16 beta,
                                    phi::bfloat16 *C) const {
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip GEMM not supported for large tensor size"));
-  }
+  detail::to_blas_int(M, "GEMM M");
+  detail::to_blas_int(N, "GEMM N");
+  detail::to_blas_int(K, "GEMM K");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   int64_t lda = (transA == CblasNoTrans) ? K : M;
@@ -924,10 +919,9 @@ inline void Blas<GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                    const phi::bfloat16 *B,
                                    float beta,
                                    phi::bfloat16 *C) const {
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip GEMM not supported for large tensor size"));
-  }
+  detail::to_blas_int(M, "GEMM M");
+  detail::to_blas_int(N, "GEMM N");
+  detail::to_blas_int(K, "GEMM K");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   int64_t lda = (transA == CblasNoTrans) ? K : M;
@@ -992,10 +986,9 @@ inline void Blas<GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                    const phi::complex64 *B,
                                    phi::complex64 beta,
                                    phi::complex64 *C) const {
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip GEMM not supported for large tensor size"));
-  }
+  detail::to_blas_int(M, "GEMM M");
+  detail::to_blas_int(N, "GEMM N");
+  detail::to_blas_int(K, "GEMM K");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   int64_t lda = (transA == CblasNoTrans) ? K : M;
@@ -1054,10 +1047,9 @@ inline void Blas<GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                    const phi::complex128 *B,
                                    phi::complex128 beta,
                                    phi::complex128 *C) const {
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip GEMM not supported for large tensor size"));
-  }
+  detail::to_blas_int(M, "GEMM M");
+  detail::to_blas_int(N, "GEMM N");
+  detail::to_blas_int(K, "GEMM K");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   int64_t lda = (transA == CblasNoTrans) ? K : M;
@@ -1108,17 +1100,23 @@ template <>
 template <typename T>
 void Blas<GPUContext>::GEMM(bool transA,
                             bool transB,
-                            int M,
-                            int N,
-                            int K,
+                            int64_t M,
+                            int64_t N,
+                            int64_t K,
                             T alpha,
                             const T *A,
-                            int lda,
+                            int64_t lda,
                             const T *B,
-                            int ldb,
+                            int64_t ldb,
                             T beta,
                             T *C,
-                            int ldc) const {
+                            int64_t ldc) const {
+  const int m = detail::to_blas_int(M, "GEMM M");
+  const int n = detail::to_blas_int(N, "GEMM N");
+  const int k = detail::to_blas_int(K, "GEMM K");
+  const int lda_int = detail::to_blas_int(lda, "GEMM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "GEMM ldb");
+  const int ldc_int = detail::to_blas_int(ldc, "GEMM ldc");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   rocblas_operation cuTransA =
@@ -1129,17 +1127,17 @@ void Blas<GPUContext>::GEMM(bool transA,
     CUBlas<T>::GEMM(handle,
                     cuTransB,
                     cuTransA,
-                    N,
-                    M,
-                    K,
+                    n,
+                    m,
+                    k,
                     &alpha,
                     B,
-                    ldb,
+                    ldb_int,
                     A,
-                    lda,
+                    lda_int,
                     &beta,
                     C,
-                    ldc);
+                    ldc_int);
   });
 }
 
@@ -1147,17 +1145,23 @@ template <>
 template <>
 inline void Blas<GPUContext>::GEMM(bool transA,
                                    bool transB,
-                                   int M,
-                                   int N,
-                                   int K,
+                                   int64_t M,
+                                   int64_t N,
+                                   int64_t K,
                                    phi::float16 alpha,
                                    const phi::float16 *A,
-                                   int lda,
+                                   int64_t lda,
                                    const phi::float16 *B,
-                                   int ldb,
+                                   int64_t ldb,
                                    phi::float16 beta,
                                    phi::float16 *C,
-                                   int ldc) const {
+                                   int64_t ldc) const {
+  const int m = detail::to_blas_int(M, "GEMM M");
+  const int n = detail::to_blas_int(N, "GEMM N");
+  const int k = detail::to_blas_int(K, "GEMM K");
+  const int lda_int = detail::to_blas_int(lda, "GEMM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "GEMM ldb");
+  const int ldc_int = detail::to_blas_int(ldc, "GEMM ldc");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   rocblas_operation cuTransA =
@@ -1169,17 +1173,17 @@ inline void Blas<GPUContext>::GEMM(bool transA,
     CUBlas<phi::float16>::GEMM(handle,
                                cuTransB,
                                cuTransA,
-                               N,
-                               M,
-                               K,
+                               n,
+                               m,
+                               k,
                                &alpha,
                                B,
-                               ldb,
+                               ldb_int,
                                A,
-                               lda,
+                               lda_int,
                                &beta,
                                C,
-                               ldc);
+                               ldc_int);
   });
 }
 
@@ -1187,17 +1191,23 @@ template <>
 template <>
 inline void Blas<GPUContext>::GEMM(bool transA,
                                    bool transB,
-                                   int M,
-                                   int N,
-                                   int K,
+                                   int64_t M,
+                                   int64_t N,
+                                   int64_t K,
                                    phi::bfloat16 alpha,
                                    const phi::bfloat16 *A,
-                                   int lda,
+                                   int64_t lda,
                                    const phi::bfloat16 *B,
-                                   int ldb,
+                                   int64_t ldb,
                                    phi::bfloat16 beta,
                                    phi::bfloat16 *C,
-                                   int ldc) const {
+                                   int64_t ldc) const {
+  const int m = detail::to_blas_int(M, "GEMM M");
+  const int n = detail::to_blas_int(N, "GEMM N");
+  const int k = detail::to_blas_int(K, "GEMM K");
+  const int lda_int = detail::to_blas_int(lda, "GEMM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "GEMM ldb");
+  const int ldc_int = detail::to_blas_int(ldc, "GEMM ldc");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
   rocblas_operation cuTransA =
@@ -1221,23 +1231,23 @@ inline void Blas<GPUContext>::GEMM(bool transA,
         phi::dynload::rocblas_gemm_ex(handle,
                                       cuTransB,
                                       cuTransA,
-                                      N,
-                                      M,
-                                      K,
+                                      n,
+                                      m,
+                                      k,
                                       &h_alpha,
                                       B,
                                       rocblas_datatype_bf16_r,
-                                      ldb,
+                                      ldb_int,
                                       A,
                                       rocblas_datatype_bf16_r,
-                                      lda,
+                                      lda_int,
                                       &h_beta,
                                       C,
                                       rocblas_datatype_bf16_r,
-                                      ldc,
+                                      ldc_int,
                                       C,
                                       rocblas_datatype_bf16_r,
-                                      ldc,
+                                      ldc_int,
                                       rocblas_datatype_f32_r,
                                       algo,
                                       0,
@@ -1265,26 +1275,28 @@ void Blas<GPUContext>::AXPY(int64_t n, T alpha, const T *x, T *y) const {
 template <>
 template <typename T>
 void Blas<GPUContext>::GEMV(bool trans_a,
-                            int M,
-                            int N,
+                            int64_t M,
+                            int64_t N,
                             T alpha,
                             const T *A,
                             const T *B,
                             T beta,
                             T *C) const {
+  const int m = detail::to_blas_int(M, "GEMV M");
+  const int n = detail::to_blas_int(N, "GEMV N");
   rocblas_operation cuTransA =
       !trans_a ? rocblas_operation_transpose : rocblas_operation_none;
 
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
-    CUBlas<T>::GEMV(handle, cuTransA, N, M, &alpha, A, N, B, 1, &beta, C, 1);
+    CUBlas<T>::GEMV(handle, cuTransA, n, m, &alpha, A, n, B, 1, &beta, C, 1);
   });
 }
 
 template <>
 template <>
 inline void Blas<GPUContext>::GEMV(bool trans_a,
-                                   int M,
-                                   int N,
+                                   int64_t M,
+                                   int64_t N,
                                    phi::float16 alpha,
                                    const phi::float16 *A,
                                    const phi::float16 *B,
@@ -1303,8 +1315,8 @@ inline void Blas<GPUContext>::GEMV(bool trans_a,
 template <>
 template <>
 inline void Blas<GPUContext>::GEMV(bool trans_a,
-                                   int M,
-                                   int N,
+                                   int64_t M,
+                                   int64_t N,
                                    phi::bfloat16 alpha,
                                    const phi::bfloat16 *A,
                                    const phi::bfloat16 *B,
@@ -1340,18 +1352,14 @@ void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
   rocblas_operation cuTransB = (transB == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
-  const int64_t strideC = M * N;
+  const int64_t strideC =
+      detail::checked_blas_int32_batched_stride(M, N, K, batchCount);
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
     CUBlas<T>::GEMM_STRIDED_BATCH(handle,
                                   cuTransB,
@@ -1394,18 +1402,14 @@ void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
   rocblas_operation cuTransB = (transB == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
-  const int64_t strideC = M * N;
+  const int64_t strideC =
+      detail::checked_blas_int32_batched_stride(M, N, K, batchCount);
 
   T h_alpha = static_cast<T>(alpha);
   T h_beta = static_cast<T>(beta);
@@ -1452,18 +1456,14 @@ inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
   rocblas_operation cuTransB = (transB == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
-  const int64_t strideC = M * N;
+  const int64_t strideC =
+      detail::checked_blas_int32_batched_stride(M, N, K, batchCount);
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::rocblas_hgemm_strided_batched(
         handle,
@@ -1507,18 +1507,14 @@ inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
   rocblas_operation cuTransB = (transB == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
-  const int64_t strideC = M * N;
+  const int64_t strideC =
+      detail::checked_blas_int32_batched_stride(M, N, K, batchCount);
 
   float16 h_alpha = static_cast<float16>(alpha);
   float16 h_beta = static_cast<float16>(beta);
@@ -1568,18 +1564,14 @@ inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
   rocblas_operation cuTransB = (transB == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
-  const int64_t strideC = M * N;
+  const int64_t strideC =
+      detail::checked_blas_int32_batched_stride(M, N, K, batchCount);
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::rocblas_sgemm_strided_batched(
         handle,
@@ -1623,18 +1615,14 @@ inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
   rocblas_operation cuTransB = (transB == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
-  const int64_t strideC = M * N;
+  const int64_t strideC =
+      detail::checked_blas_int32_batched_stride(M, N, K, batchCount);
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::rocblas_dgemm_strided_batched(
         handle,
@@ -1676,12 +1664,8 @@ inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
-  const int64_t strideC = M * N;
+  const int64_t strideC =
+      detail::checked_blas_int32_batched_stride(M, N, K, batchCount);
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
@@ -1744,12 +1728,8 @@ inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  const int64_t strideC = M * N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
+  const int64_t strideC =
+      detail::checked_blas_int32_batched_stride(M, N, K, batchCount);
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
@@ -1798,18 +1778,19 @@ template <>
 template <typename T>
 void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                    CBLAS_TRANSPOSE transB,
-                                   int M,
-                                   int N,
-                                   int K,
+                                   int64_t M,
+                                   int64_t N,
+                                   int64_t K,
                                    T alpha,
                                    const T **A,
                                    const T **B,
                                    T beta,
                                    T **C,
-                                   int batchCount) const {
-  for (int k = 0; k < batchCount; ++k) {
+                                   int64_t batchCount) const {
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+  for (int64_t i = 0; i < batchCount; ++i) {
     this->template GEMM<T>(
-        transA, transB, M, N, K, alpha, A[k], B[k], beta, C[k]);
+        transA, transB, M, N, K, alpha, A[i], B[i], beta, C[i]);
   }
 }
 
@@ -1817,18 +1798,19 @@ template <>
 template <>
 inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                           CBLAS_TRANSPOSE transB,
-                                          int M,
-                                          int N,
-                                          int K,
+                                          int64_t M,
+                                          int64_t N,
+                                          int64_t K,
                                           phi::float16 alpha,
                                           const phi::float16 **A,
                                           const phi::float16 **B,
                                           phi::float16 beta,
                                           phi::float16 **C,
-                                          int batchCount) const {
-  for (int k = 0; k < batchCount; ++k) {
+                                          int64_t batchCount) const {
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+  for (int64_t i = 0; i < batchCount; ++i) {
     this->template GEMM<phi::float16>(
-        transA, transB, M, N, K, alpha, A[k], B[k], beta, C[k]);
+        transA, transB, M, N, K, alpha, A[i], B[i], beta, C[i]);
   }
 }
 
@@ -1836,18 +1818,19 @@ template <>
 template <>
 inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                           CBLAS_TRANSPOSE transB,
-                                          int M,
-                                          int N,
-                                          int K,
+                                          int64_t M,
+                                          int64_t N,
+                                          int64_t K,
                                           phi::bfloat16 alpha,
                                           const phi::bfloat16 **A,
                                           const phi::bfloat16 **B,
                                           phi::bfloat16 beta,
                                           phi::bfloat16 **C,
-                                          int batchCount) const {
-  for (int k = 0; k < batchCount; ++k) {
+                                          int64_t batchCount) const {
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+  for (int64_t i = 0; i < batchCount; ++i) {
     this->template GEMM<phi::bfloat16>(
-        transA, transB, M, N, K, alpha, A[k], B[k], beta, C[k]);
+        transA, transB, M, N, K, alpha, A[i], B[i], beta, C[i]);
   }
 }
 

--- a/paddle/phi/kernels/funcs/detail/gru_cpu_kernel.h
+++ b/paddle/phi/kernels/funcs/detail/gru_cpu_kernel.h
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #pragma once
+
+#include <cstdint>
 #include <type_traits>
 
 #include "paddle/phi/kernels/funcs/activation_functor.h"
@@ -33,7 +35,7 @@ void hl_naive_gru_forward_reset_output(OpResetOutput op_reset_output,
                                        T *gate_value,
                                        T *reset_output_value,
                                        const T *prev_output_value,
-                                       int frame_size,
+                                       int64_t frame_size,
                                        ActivationType active_gate,
                                        bool old_version = true,
                                        const T *reset_bias = nullptr) {
@@ -51,7 +53,7 @@ void hl_naive_gru_forward_reset_output(OpResetOutput op_reset_output,
     reset_gate = gate_value;
     update_gate = gate_value + frame_size;
   }
-  for (int i = 0; i < frame_size; i++) {
+  for (int64_t i = 0; i < frame_size; i++) {
     r_value_update_gate = update_gate[i];
     r_value_reset_gate = reset_gate[i];
     if (!old_version) {
@@ -81,7 +83,7 @@ void hl_naive_gru_forward_final_output(OpFinalOutput op_final_output,
                                        T *gate_value,
                                        const T *prev_output_value,
                                        T *output_value,
-                                       int frame_size,
+                                       int64_t frame_size,
                                        ActivationType active_node,
                                        bool origin_mode,
                                        bool old_version = true) {
@@ -97,7 +99,7 @@ void hl_naive_gru_forward_final_output(OpFinalOutput op_final_output,
   }
   T *frame_state = gate_value + frame_size * 2;
 
-  for (int i = 0; i < frame_size; i++) {
+  for (int64_t i = 0; i < frame_size; i++) {
     r_value_update_gate = update_gate[i];
     r_value_frame_state = frame_state[i];
     if (prev_output_value) {
@@ -121,7 +123,7 @@ void hl_avx_gru_forward_reset_output(OpResetOutput op_reset_output,
                                      T *gate_value,
                                      T *reset_output_value,
                                      const T *prev_output_value,
-                                     int frame_size,
+                                     int64_t frame_size,
                                      ActivationType active_gate,
                                      bool old_version = true,
                                      const T *reset_bias = nullptr) {
@@ -141,11 +143,11 @@ void hl_avx_gru_forward_reset_output(OpResetOutput op_reset_output,
     reset_gate = gate_value;
     update_gate = gate_value + frame_size;
   }
-  int block = 8;
-  const int n = frame_size;
-  const int rest = n % block;
-  const int end = n - rest;
-  int i = 0;
+  const int64_t block = 8;
+  const int64_t n = frame_size;
+  const int64_t rest = n % block;
+  const int64_t end = n - rest;
+  int64_t i = 0;
 
   if (rest > 0) {
     i = n - block;
@@ -211,7 +213,7 @@ void hl_avx_gru_forward_final_output(OpFinalOutput op_final_output,
                                      T *gate_value,
                                      const T *prev_output_value,
                                      T *output_value,
-                                     int frame_size,
+                                     int64_t frame_size,
                                      ActivationType active_node,
                                      bool origin_mode,
                                      bool old_version = true) {
@@ -229,11 +231,11 @@ void hl_avx_gru_forward_final_output(OpFinalOutput op_final_output,
   }
 
   T *frame_state = gate_value + frame_size * 2;
-  int block = 8;
-  const int n = frame_size;
-  const int rest = n % block;
-  const int end = n - rest;
-  int i = 0;
+  const int64_t block = 8;
+  const int64_t n = frame_size;
+  const int64_t rest = n % block;
+  const int64_t end = n - rest;
+  int64_t i = 0;
 
   if (rest > 0) {
     i = n - block;
@@ -285,7 +287,7 @@ void hl_avx_gru_forward_final_output(OpFinalOutput op_final_output,
 template <typename T, typename Context>
 inline void forward_reset_outputV2(const Context &dev_ctx,
                                    phi::funcs::GRUMetaValue<T> value,
-                                   int frame_size) {
+                                   int64_t frame_size) {
   auto &place = *dev_ctx.eigen_device();
   auto value_reset_gate =
       typename EigenVector<T>::Type(value.gate_value, Array1(frame_size));
@@ -304,7 +306,7 @@ inline void forward_reset_outputV2(const Context &dev_ctx,
 template <typename Context, class OpResetOutput, typename T>
 inline void forward_reset_output(OpResetOutput op_reset_output,
                                  phi::funcs::GRUMetaValue<T> value,
-                                 int frame_size,
+                                 int64_t frame_size,
                                  int batch_size,
                                  ActivationType active_gate,
                                  bool old_version = true,
@@ -314,8 +316,7 @@ inline void forward_reset_output(OpResetOutput op_reset_output,
       // use eigen
       forward_reset_outputV2(*dev_ctx, value, frame_size);
     } else {
-      if (OpResetOutput::avx && (frame_size > static_cast<int>(8 - 1)) &&
-          (sizeof(T) == 4)) {
+      if (OpResetOutput::avx && (frame_size > 7) && (sizeof(T) == 4)) {
         hl_avx_gru_forward_reset_output(op_reset_output,
                                         value.gate_value,
                                         value.reset_output_value,
@@ -346,7 +347,7 @@ inline void forward_reset_output(OpResetOutput op_reset_output,
 template <typename T, typename Context>
 inline void forward_final_outputV2(const Context &dev_ctx,
                                    phi::funcs::GRUMetaValue<T> value,
-                                   int frame_size) {
+                                   int64_t frame_size) {
   auto &place = *dev_ctx.eigen_device();
   auto value_update_gate = typename EigenVector<T>::Type(
       value.gate_value + frame_size, Array1(frame_size));
@@ -368,7 +369,7 @@ inline void forward_final_outputV2(const Context &dev_ctx,
 template <typename Context, class OpFinalOutput, typename T>
 inline void forward_final_output(OpFinalOutput op_final_output,
                                  phi::funcs::GRUMetaValue<T> value,
-                                 int frame_size,
+                                 int64_t frame_size,
                                  int batch_size,
                                  ActivationType active_node,
                                  bool origin_mode,
@@ -379,8 +380,7 @@ inline void forward_final_output(OpFinalOutput op_final_output,
       // eigen
       forward_final_outputV2(*dev_ctx, value, frame_size);
     } else {
-      if (OpFinalOutput::avx && (frame_size > static_cast<int>(8 - 1)) &&
-          (sizeof(T) == 4)) {
+      if (OpFinalOutput::avx && (frame_size > 7) && (sizeof(T) == 4)) {
         hl_avx_gru_forward_final_output(op_final_output,
                                         value.gate_value,
                                         value.prev_out_value,

--- a/paddle/phi/kernels/funcs/fc_functor.cc
+++ b/paddle/phi/kernels/funcs/fc_functor.cc
@@ -14,6 +14,8 @@ limitations under the License. */
 
 #include "paddle/phi/kernels/funcs/fc_functor.h"
 
+#include <limits>
+
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/jit/kernels.h"
@@ -23,21 +25,66 @@ namespace funcs {
 
 template <typename DeviceContext, typename T>
 void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& dev_ctx,
-                                             const int M,
-                                             const int N,
-                                             const int K,
+                                             int M,
+                                             int N,
+                                             int K,
                                              const T* X,
                                              const T* W,
                                              T* Y,
                                              const T* B,
                                              bool relu,
                                              bool padding_weights) {
+  (*this)(dev_ctx,
+          static_cast<int64_t>(M),
+          static_cast<int64_t>(N),
+          static_cast<int64_t>(K),
+          X,
+          W,
+          Y,
+          B,
+          relu,
+          padding_weights);
+}
+
+template <typename DeviceContext, typename T>
+void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& dev_ctx,
+                                             int64_t M,
+                                             int64_t N,
+                                             int64_t K,
+                                             const T* X,
+                                             const T* W,
+                                             T* Y,
+                                             const T* B,
+                                             bool relu,
+                                             bool padding_weights) {
+  detail::to_blas_int(M, "FC CPU row count");
+  detail::to_blas_int(N, "FC CPU output width");
+  detail::to_blas_int(K, "FC CPU input width");
+  if (padding_weights) {
+    constexpr int64_t kMaxPaddedDimension =
+        std::numeric_limits<int>::max() - 4LL;
+    PADDLE_ENFORCE_LE(
+        N,
+        kMaxPaddedDimension,
+        errors::InvalidArgument(
+            "FC CPU padded output width exceeds INT_MAX, but received %ld.",
+            N));
+    PADDLE_ENFORCE_LE(
+        K,
+        kMaxPaddedDimension,
+        errors::InvalidArgument(
+            "FC CPU padded input width exceeds INT_MAX, but received %ld.", K));
+  }
+  int bias_width = 0;
+  if (B != nullptr) {
+    bias_width = static_cast<int>(N);
+  }
   auto blas = GetBlas<DeviceContext, T>(dev_ctx);
   DenseTensor Y1;
   T* Y1_data = nullptr;
   if (padding_weights) {
-    const int NN = N + 4;
-    const int KK = K + 4;
+    const int64_t NN = N + 4;
+    const int64_t KK = K + 4;
     DenseTensor X1;
     X1.Resize({M * KK});
     T* X1_data = dev_ctx.template HostAlloc<T>(&X1);
@@ -47,7 +94,7 @@ void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& dev_ctx,
 #if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
 #pragma omp parallel for
 #endif
-    for (int i = 0; i < M; i++) {
+    for (int64_t i = 0; i < M; i++) {
       memcpy(X1_data + i * KK, X + i * K, K * sizeof(T));
     }
     blas.GEMM(false,
@@ -71,7 +118,7 @@ void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& dev_ctx,
 #if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
 #pragma omp parallel for
 #endif
-      for (int i = 0; i < M; i++) {
+      for (int64_t i = 0; i < M; i++) {
         memcpy(Y + i * N, Y1_data + i * (N + 4), N * sizeof(T));
       }
     }
@@ -81,19 +128,22 @@ void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& dev_ctx,
         errors::PermissionDenied("When bias is NULL, relu can not be true."));
     return;
   }
+  if (M == 0 || N == 0) {
+    return;
+  }
   auto compute =
       relu
           ? phi::jit::KernelFuncs<phi::jit::VAddReluTuple<T>, CPUPlace>::Cache()
-                .At(N)
+                .At(bias_width)
           : phi::jit::KernelFuncs<phi::jit::VAddTuple<T>, CPUPlace>::Cache().At(
-                N);
+                bias_width);
 #if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
 #pragma omp parallel for
 #endif
-  for (int i = 0; i < M; i++) {
+  for (int64_t i = 0; i < M; i++) {
     T* dst = Y + i * N;
     T* src = (padding_weights) ? Y1_data + i * (N + 4) : dst;
-    compute(B, src, dst, N);
+    compute(B, src, dst, bias_width);
   }
 }
 

--- a/paddle/phi/kernels/funcs/fc_functor.cu
+++ b/paddle/phi/kernels/funcs/fc_functor.cu
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include <algorithm>
+#include <limits>
 
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/kernels/funcs/aligned_vector.h"
@@ -337,9 +338,32 @@ void AddReluKernel(gpuStream_t stream,
 
 template <typename DeviceContext, typename T>
 void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& dev_ctx,
-                                             const int M,
-                                             const int N,
-                                             const int K,
+                                             int M,
+                                             int N,
+                                             int K,
+                                             const T* X,
+                                             const T* W,
+                                             T* Y,
+                                             const T* B,
+                                             bool relu,
+                                             bool padding_weights) {
+  (*this)(dev_ctx,
+          static_cast<int64_t>(M),
+          static_cast<int64_t>(N),
+          static_cast<int64_t>(K),
+          X,
+          W,
+          Y,
+          B,
+          relu,
+          padding_weights);
+}
+
+template <typename DeviceContext, typename T>
+void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& dev_ctx,
+                                             int64_t M,
+                                             int64_t N,
+                                             int64_t K,
                                              const T* X,
                                              const T* W,
                                              T* Y,
@@ -350,6 +374,21 @@ void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& dev_ctx,
                     false,
                     errors::PermissionDenied(
                         "Weight padding in fc can not be used in GPU scope."));
+  detail::check_blas_int64(M, "FC GPU row count");
+  detail::check_blas_int64(N, "FC GPU output width");
+  detail::check_blas_int64(K, "FC GPU input width");
+  if (B != nullptr) {
+    PADDLE_ENFORCE_LE_INT_MAX(M, "FC GPU bias row count");
+    PADDLE_ENFORCE_LE_INT_MAX(N, "FC GPU bias row width");
+    PADDLE_ENFORCE_EQ(
+        M == 0 || N <= std::numeric_limits<int>::max() / M,
+        true,
+        errors::InvalidArgument(
+            "FC GPU bias element count must not exceed INT_MAX, but received "
+            "M = %ld and N = %ld.",
+            M,
+            N));
+  }
   auto blas = funcs::GetBlas<DeviceContext, T>(dev_ctx);
   blas.GEMM(CblasNoTrans,
             CblasNoTrans,
@@ -364,9 +403,12 @@ void FCFunctor<DeviceContext, T>::operator()(const DeviceContext& dev_ctx,
   if (B == NULL) {
     return;
   }
+  if (M == 0 || N == 0) {
+    return;
+  }
 
-  // M * N
-  AddReluKernel(dev_ctx.stream(), M, N, Y, B, relu);
+  AddReluKernel(
+      dev_ctx.stream(), static_cast<int>(M), static_cast<int>(N), Y, B, relu);
 }
 
 template class FCFunctor<GPUContext, float16>;

--- a/paddle/phi/kernels/funcs/fc_functor.h
+++ b/paddle/phi/kernels/funcs/fc_functor.h
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "paddle/phi/backends/all_context.h"
@@ -26,9 +27,20 @@ template <typename DeviceContext, typename T>
 class FCFunctor {
  public:
   void operator()(const DeviceContext& dev_ctx,
-                  const int M,
-                  const int N,
-                  const int K,
+                  int M,
+                  int N,
+                  int K,
+                  const T* X,
+                  const T* W,
+                  T* Y,
+                  const T* B = nullptr,
+                  bool relu = false,
+                  bool weight_pass = false);
+
+  void operator()(const DeviceContext& dev_ctx,
+                  int64_t M,
+                  int64_t N,
+                  int64_t K,
                   const T* X,
                   const T* W,
                   T* Y,

--- a/paddle/phi/kernels/funcs/math_function_blas_impl.h
+++ b/paddle/phi/kernels/funcs/math_function_blas_impl.h
@@ -49,11 +49,9 @@ void ColwiseSum<GPUContext, double>::operator()(const GPUContext& dev_ctx,
 
   SetConstant<GPUContext, double> set;
   set(dev_ctx, &one, static_cast<double>(1.0));
-  PADDLE_ENFORCE_LE_INT_MAX(in_dims[0], "ColwiseSum GEMV m");
-  PADDLE_ENFORCE_LE_INT_MAX(in_dims[1], "ColwiseSum GEMV n");
   funcs::GetBlas<GPUContext, double>(dev_ctx).GEMV(true,
-                                                   static_cast<int>(in_dims[0]),
-                                                   static_cast<int>(in_dims[1]),
+                                                   in_dims[0],
+                                                   in_dims[1],
                                                    1.0,
                                                    input.data<double>(),
                                                    one.data<double>(),
@@ -85,11 +83,9 @@ void RowwiseSum<GPUContext, double>::operator()(const GPUContext& dev_ctx,
 
   SetConstant<GPUContext, double> set;
   set(dev_ctx, &one, static_cast<double>(1.0));
-  PADDLE_ENFORCE_LE_INT_MAX(in_dims[1], "RowwiseSum GEMV m");
-  PADDLE_ENFORCE_LE_INT_MAX(in_dims[0], "RowwiseSum GEMV n");
   funcs::GetBlas<GPUContext, double>(dev_ctx).GEMV(true,
-                                                   static_cast<int>(in_dims[1]),
-                                                   static_cast<int>(in_dims[0]),
+                                                   in_dims[1],
+                                                   in_dims[0],
                                                    1.0,
                                                    one.data<double>(),
                                                    input.data<double>(),

--- a/paddle/phi/kernels/funcs/search_compute.h
+++ b/paddle/phi/kernels/funcs/search_compute.h
@@ -20,6 +20,7 @@
 #endif
 #include <cfloat>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 
 #include "paddle/phi/kernels/funcs/blas/blas.h"
@@ -32,16 +33,16 @@ template <typename DeviceContext, typename T>
 void call_gemm(const funcs::BlasT<DeviceContext, T>& blas,
                const CBLAS_TRANSPOSE TransA,
                const CBLAS_TRANSPOSE TransB,
-               const int M,
-               const int N,
-               const int K,
+               const int64_t M,
+               const int64_t N,
+               const int64_t K,
                const T alpha,
                const T* A,
                const T* B,
                const T beta,
                T* C) {
-  int lda = (TransA == CblasNoTrans) ? K : M;
-  int ldb = (TransB == CblasNoTrans) ? N : K;
+  int64_t lda = (TransA == CblasNoTrans) ? K : M;
+  int64_t ldb = (TransB == CblasNoTrans) ? N : K;
   blas.GEMM(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N);
 }
 
@@ -49,16 +50,16 @@ template <typename T, typename Context>
 void call_gemm(const Context& dev_ctx,
                const CBLAS_TRANSPOSE TransA,
                const CBLAS_TRANSPOSE TransB,
-               const int M,
-               const int N,
-               const int K,
+               const int64_t M,
+               const int64_t N,
+               const int64_t K,
                const T alpha,
                const T* A,
                const T* B,
                const T beta,
                T* C) {
-  int lda = (TransA == CblasNoTrans) ? K : M;
-  int ldb = (TransB == CblasNoTrans) ? N : K;
+  int64_t lda = (TransA == CblasNoTrans) ? K : M;
+  int64_t ldb = (TransB == CblasNoTrans) ? N : K;
   // auto& dev_ctx = dev_ctx.template device_context<CPUContext>();
   auto blas = funcs::GetBlas<CPUContext, T>(dev_ctx);
   blas.GEMM(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N);
@@ -68,16 +69,16 @@ template <typename DeviceContext, typename T>
 void call_gemm_with_lda(const funcs::BlasT<DeviceContext, T>& blas,
                         const CBLAS_TRANSPOSE TransA,
                         const CBLAS_TRANSPOSE TransB,
-                        const int M,
-                        const int N,
-                        const int K,
+                        const int64_t M,
+                        const int64_t N,
+                        const int64_t K,
                         const T alpha,
                         const T* A,
                         const T* B,
                         const T beta,
                         T* C,
-                        int lda) {
-  int ldb = (TransB == CblasNoTrans) ? N : K;
+                        int64_t lda) {
+  int64_t ldb = (TransB == CblasNoTrans) ? N : K;
 
   blas.GEMM(TransA, TransB, M, N, K, alpha, A, lda, B, ldb, beta, C, N);
 }
@@ -86,16 +87,16 @@ template <typename T, typename Context>
 void call_gemm_batched(const Context& dev_ctx,
                        const CBLAS_TRANSPOSE TransA,
                        const CBLAS_TRANSPOSE TransB,
-                       const int M,
-                       const int N,
-                       const int K,
+                       const int64_t M,
+                       const int64_t N,
+                       const int64_t K,
                        const T alpha,
                        const T** A,
                        const T** B,
                        const T beta,
                        T** C,
-                       const int batch) {
-  for (int i = 0; i < batch; ++i) {
+                       const int64_t batch) {
+  for (int64_t i = 0; i < batch; ++i) {
     call_gemm(dev_ctx, TransA, TransB, M, N, K, alpha, A[i], B[i], beta, C[i]);
   }
 }

--- a/paddle/phi/kernels/fusion/cpu/fusion_lstm_kernel.cc
+++ b/paddle/phi/kernels/fusion/cpu/fusion_lstm_kernel.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <cstring>
 #include <string>
 
@@ -248,15 +249,22 @@ void BatchCompute(const Context &dev_ctx,
   auto blas = funcs::GetBlas<Context, T>(dev_ctx);
   funcs::FCFunctor<Context, T> fc;
   if (M > D4) {
-    fc(dev_ctx, x_dims[0], D4, M, x_data, wx_data, xx_data, bias->data<T>());
+    fc(dev_ctx,
+       x_dims[0],
+       static_cast<int64_t>(D4),
+       static_cast<int64_t>(M),
+       x_data,
+       wx_data,
+       xx_data,
+       bias->data<T>());
     to_batch(dev_ctx, *xx, batched_input, true, is_reverse);
   } else {
     to_batch(dev_ctx, *x, xx, true, is_reverse);
     batched_input->set_lod(xx->lod());
     fc(dev_ctx,
        x_dims[0],
-       D4,
-       M,
+       static_cast<int64_t>(D4),
+       static_cast<int64_t>(M),
        xx_data,
        wx_data,
        batched_input_data,

--- a/paddle/phi/kernels/impl/fc_kernel_impl.h
+++ b/paddle/phi/kernels/impl/fc_kernel_impl.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -45,7 +46,7 @@ void FCKernel(const Context& dev_ctx,
   auto out_dims = out->dims();
   auto w_dims0 = padding_weights ? w_dims[0] - 4 : w_dims[0];
   auto w_dims1 = padding_weights ? w_dims[1] - 4 : w_dims[1];
-  int M = common::product(out_dims) / w_dims1;
+  int64_t M = common::product(out_dims) / w_dims1;
 
   const T* input_data = input.data<T>();
   const T* w_data = w.data<T>();

--- a/paddle/phi/kernels/impl/matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_kernel_impl.h
@@ -14,6 +14,8 @@ limitations under the License. */
 
 #pragma once
 
+#include <limits>
+
 #include "glog/logging.h"
 
 #include "paddle/phi/common/memory_utils.h"
@@ -110,6 +112,65 @@ static void IndexIncreaseFromDims(const int ndim,
     }
   }
 }
+
+static int64_t GetMatmulBatchSize(const std::vector<int64_t>& dims,
+                                  int batch_dim,
+                                  const char* name) {
+  int64_t batch_size = 1;
+  for (int i = 0; i < batch_dim; ++i) {
+    PADDLE_ENFORCE_GE(
+        dims[i],
+        0,
+        common::errors::InvalidArgument(
+            "%s dimensions must be non-negative, but received %ld at index "
+            "%d.",
+            name,
+            dims[i],
+            i));
+    if (dims[i] == 0) {
+      batch_size = 0;
+      continue;
+    }
+    if (batch_size != 0) {
+      PADDLE_ENFORCE_LE(
+          batch_size,
+          std::numeric_limits<int64_t>::max() / dims[i],
+          common::errors::InvalidArgument(
+              "%s batch size overflows int64_t when multiplying dimension %d "
+              "(%ld).",
+              name,
+              i,
+              dims[i]));
+      batch_size *= dims[i];
+    }
+  }
+  return batch_size;
+}
+
+#if defined(PADDLE_WITH_CUDA) && CUDA_VERSION >= 11060
+static bool MatmulBatchSizeFitsCublasLt(const std::vector<int64_t>& x_dims,
+                                        const std::vector<int64_t>& y_dims) {
+  if (x_dims.size() <= 2 && y_dims.size() <= 2) {
+    return true;
+  }
+
+  const int x_batch_dim = (std::max)(static_cast<int>(x_dims.size()) - 2, 0);
+  const int y_batch_dim = (std::max)(static_cast<int>(y_dims.size()) - 2, 0);
+  const int batch_dim = (std::max)(x_batch_dim, y_batch_dim);
+  std::vector<int64_t> x_broadcast_dims(batch_dim);
+  std::vector<int64_t> y_broadcast_dims(batch_dim);
+  std::vector<int64_t> out_broadcast_dims(batch_dim);
+  GetBroadcastFromDims(x_batch_dim,
+                       x_dims.data(),
+                       y_batch_dim,
+                       y_dims.data(),
+                       x_broadcast_dims.data(),
+                       y_broadcast_dims.data(),
+                       out_broadcast_dims.data());
+  return GetMatmulBatchSize(out_broadcast_dims, batch_dim, "MatMul output") <=
+         std::numeric_limits<int>::max();
+}
+#endif
 
 // The general implementation with blas.
 template <typename Context, typename T>
@@ -380,9 +441,6 @@ void MatMulFunctionImplWithBlas(
   out_broadcast_dims[ndim - 2] = M;
   out_broadcast_dims[ndim - 1] = N;
 
-  Out->ResizeAndAllocate(make_ddim(out_broadcast_dims));
-  dev_ctx.template Alloc<T>(Out);
-
   const int batch_dim = ndim - 2;
   // broadcast message
   const bool is_broadcast_dims =
@@ -391,20 +449,28 @@ void MatMulFunctionImplWithBlas(
                   y_broadcast_dims.cbegin());
 
   const std::int64_t x_batch_size =
-      std::accumulate(x_broadcast_dims.cbegin(),
-                      x_broadcast_dims.cbegin() + batch_dim,
-                      1LL,
-                      std::multiplies<std::int64_t>());
+      GetMatmulBatchSize(x_broadcast_dims, batch_dim, "Input(X)");
   const std::int64_t y_batch_size =
-      std::accumulate(y_broadcast_dims.cbegin(),
-                      y_broadcast_dims.cbegin() + batch_dim,
-                      1LL,
-                      std::multiplies<std::int64_t>());
+      GetMatmulBatchSize(y_broadcast_dims, batch_dim, "Input(Y)");
   const std::int64_t out_batch_size =
-      std::accumulate(out_broadcast_dims.cbegin(),
-                      out_broadcast_dims.cbegin() + batch_dim,
-                      1LL,
-                      std::multiplies<std::int64_t>());
+      GetMatmulBatchSize(out_broadcast_dims, batch_dim, "MatMul output");
+  const std::int64_t case_9_m =
+      x_batch_size == 1 && M == 1 && trans_y
+          ? funcs::detail::checked_blas_mul(
+                y_batch_size, N, "MatMul case 9 flattened dimension")
+          : 0;
+  const std::int64_t case_11_m =
+      y_batch_size == 1 && !trans_x
+          ? funcs::detail::checked_blas_mul(
+                x_batch_size, M, "MatMul case 11 flattened dimension")
+          : 0;
+
+  if (is_broadcast_dims && out_batch_size != 0) {
+    PADDLE_ENFORCE_LE_INT_MAX(out_batch_size, "broadcast MatMul batch size");
+  }
+
+  Out->ResizeAndAllocate(make_ddim(out_broadcast_dims));
+  dev_ctx.template Alloc<T>(Out);
   if (out_batch_size == 0) return;
   if (x_batch_size == 1 && y_batch_size == 1) {
     VLOG(3) << "MatMul's case 8";
@@ -421,9 +487,8 @@ void MatMulFunctionImplWithBlas(
   } else if (x_batch_size == 1) {
     if (M == 1 && trans_y) {
       VLOG(3) << "MatMul's case 9";
-      PADDLE_ENFORCE_LE_INT_MAX(y_batch_size * N, "GEMV M");
       blas.GEMV(false,
-                static_cast<int>(y_batch_size * N),
+                case_9_m,
                 K,
                 static_cast<T>(1),
                 y_data,
@@ -482,10 +547,9 @@ void MatMulFunctionImplWithBlas(
   } else if (y_batch_size == 1) {
     if (!trans_x) {
       VLOG(3) << "MatMul's case 11";
-      PADDLE_ENFORCE_LE_INT_MAX(x_batch_size * M, "GEMM M");
       blas.GEMM(CblasNoTrans,
                 trans_y ? CblasTrans : CblasNoTrans,
-                x_batch_size * M,
+                case_11_m,
                 N,
                 K,
                 static_cast<T>(1),
@@ -526,7 +590,6 @@ void MatMulFunctionImplWithBlas(
                      K * N);
   } else {
     // in the case, can't use stridedgemm
-    PADDLE_ENFORCE_LE_INT_MAX(out_batch_size, "out_batch_size");
     std::vector<const T*> x_ptr(out_batch_size);
     std::vector<const T*> y_ptr(out_batch_size);
     std::vector<T*> out_ptr(out_batch_size);
@@ -554,7 +617,7 @@ void MatMulFunctionImplWithBlas(
                      y_ptr.data(),
                      static_cast<T>(flag),
                      out_ptr.data(),
-                     static_cast<int>(out_batch_size));
+                     out_batch_size);
   }
 }
 
@@ -819,9 +882,6 @@ void MatMulFunctionImplWithCublasLt(
   out_broadcast_dims[ndim - 2] = M;
   out_broadcast_dims[ndim - 1] = N;
 
-  Out->ResizeAndAllocate(make_ddim(out_broadcast_dims));
-  dev_ctx.template Alloc<T>(Out);
-
   const int batch_dim = ndim - 2;
   // broadcast message
   const bool is_broadcast_dims =
@@ -830,22 +890,26 @@ void MatMulFunctionImplWithCublasLt(
                   y_broadcast_dims.cbegin());
 
   const std::int64_t x_batch_size =
-      std::accumulate(x_broadcast_dims.cbegin(),
-                      x_broadcast_dims.cbegin() + batch_dim,
-                      1LL,
-                      std::multiplies<std::int64_t>());
+      GetMatmulBatchSize(x_broadcast_dims, batch_dim, "Input(X)");
   const std::int64_t y_batch_size =
-      std::accumulate(y_broadcast_dims.cbegin(),
-                      y_broadcast_dims.cbegin() + batch_dim,
-                      1LL,
-                      std::multiplies<std::int64_t>());
+      GetMatmulBatchSize(y_broadcast_dims, batch_dim, "Input(Y)");
   const std::int64_t out_batch_size =
-      std::accumulate(out_broadcast_dims.cbegin(),
-                      out_broadcast_dims.cbegin() + batch_dim,
-                      1LL,
-                      std::multiplies<std::int64_t>());
+      GetMatmulBatchSize(out_broadcast_dims, batch_dim, "MatMul output");
+  const std::int64_t case_9_m =
+      x_batch_size == 1 && M == 1 && trans_y
+          ? funcs::detail::checked_blas_mul(
+                y_batch_size, N, "MatMul case 9 flattened dimension")
+          : 0;
+  const std::int64_t case_11_m =
+      y_batch_size == 1 && !trans_x
+          ? funcs::detail::checked_blas_mul(
+                x_batch_size, M, "MatMul case 11 flattened dimension")
+          : 0;
+
+  PADDLE_ENFORCE_LE_INT_MAX(out_batch_size, "cuBLASLt MatMul batch size");
+  Out->ResizeAndAllocate(make_ddim(out_broadcast_dims));
+  dev_ctx.template Alloc<T>(Out);
   if (out_batch_size == 0) return;
-  PADDLE_ENFORCE_LE_INT_MAX(out_batch_size, "out_batch_size");
   if (x_batch_size == 1 && y_batch_size == 1) {
     VLOG(3) << "MatMul with blaslt 8";
     blaslt::Run(dev_ctx,
@@ -861,12 +925,11 @@ void MatMulFunctionImplWithCublasLt(
   } else if (x_batch_size == 1) {
     if (M == 1 && trans_y) {
       VLOG(3) << "MatMul with blaslt 9";
-      PADDLE_ENFORCE_LE_INT_MAX(y_batch_size * N, "GEMV M");
       blaslt::Run(dev_ctx,
                   y_data,
                   x_data,
                   dev_ctx.template Alloc<T>(Out),
-                  y_batch_size * N,
+                  case_9_m,
                   1,
                   K,
                   false,
@@ -892,12 +955,11 @@ void MatMulFunctionImplWithCublasLt(
   } else if (y_batch_size == 1) {
     if (!trans_x) {
       VLOG(3) << "MatMul with blaslt 11";
-      PADDLE_ENFORCE_LE_INT_MAX(x_batch_size * M, "GEMM M");
       blaslt::Run(dev_ctx,
                   x_data,
                   y_data,
                   dev_ctx.template Alloc<T>(Out),
-                  x_batch_size * M,
+                  case_11_m,
                   N,
                   K,
                   false,
@@ -999,6 +1061,11 @@ struct MatMulDispatcher<GPUContext, T> {
                   bool trans_y,
                   bool flag = false) {
 #if CUDA_VERSION >= 11060
+    if (!MatmulBatchSizeFitsCublasLt(x_dims, y_dims)) {
+      MatMulFunctionImplWithBlas<GPUContext, T>(
+          dev_ctx, x, y, x_dims, y_dims, out, trans_x, trans_y, flag);
+      return;
+    }
     auto* tuner =
         autotune::MakeMatmulTuner<T>(MatMulFunctionImplWithBlas<GPUContext, T>);
     tuner->AddCallBack(MatMulFunctionImplWithCublasLt<GPUContext, T>);

--- a/test/cpp/phi/kernels/test_math_function.cc
+++ b/test/cpp/phi/kernels/test_math_function.cc
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 #include <array>
+#include <cstdint>
 #include <limits>
 #include <set>
 
 #include "gtest/gtest.h"
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
+#include "paddle/phi/kernels/funcs/fc_functor.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 
 namespace phi {
@@ -76,6 +78,254 @@ TEST(math_function, gemm_notrans_cblas) {
   EXPECT_EQ(input3_ptr[5], 73);
   EXPECT_EQ(input3_ptr[6], 86);
   EXPECT_EQ(input3_ptr[7], 99);
+}
+
+TEST(math_function, blas_int64_dimensions) {
+  auto* dev_ctx =
+      phi::DeviceContextPool::Instance().GetByPlace(phi::CPUPlace());
+  auto blas = GetBlas<float>(*dev_ctx);
+
+  const int64_t m = 2;
+  const int64_t n = 2;
+  const int64_t k = 3;
+  const std::array<float, 6> a = {1, 2, 3, 4, 5, 6};
+  const std::array<float, 6> b = {1, 2, 3, 4, 5, 6};
+  const std::array<float, 4> expected = {22, 28, 49, 64};
+
+  std::array<float, 4> matmul_out{};
+  blas.MatMul(m, n, k, a.data(), b.data(), matmul_out.data());
+  EXPECT_EQ(matmul_out, expected);
+
+  const std::array<float, 3> vector = {1, 1, 1};
+  const std::array<float, 2> expected_gemv = {6, 15};
+  std::array<float, 2> gemv_out{};
+  blas.GEMV(false, m, k, 1.0f, a.data(), vector.data(), 0.0f, gemv_out.data());
+  EXPECT_EQ(gemv_out, expected_gemv);
+
+  std::array<float, 4> bool_gemm_out{};
+  blas.GEMM(false,
+            false,
+            m,
+            n,
+            k,
+            1.0f,
+            a.data(),
+            k,
+            b.data(),
+            n,
+            0.0f,
+            bool_gemm_out.data(),
+            n);
+  EXPECT_EQ(bool_gemm_out, expected);
+
+  std::array<float, 4> enum_gemm_out{};
+  blas.GEMM(CblasNoTrans,
+            CblasNoTrans,
+            m,
+            n,
+            k,
+            1.0f,
+            a.data(),
+            k,
+            b.data(),
+            n,
+            0.0f,
+            enum_gemm_out.data(),
+            n);
+  EXPECT_EQ(enum_gemm_out, expected);
+
+  const std::array<float, 2> batch_a0 = {2, 3};
+  const std::array<float, 2> batch_a1 = {4, 5};
+  const std::array<float, 2> batch_b0 = {6, 7};
+  const std::array<float, 2> batch_b1 = {8, 9};
+  std::array<float, 1> batch_c0{};
+  std::array<float, 1> batch_c1{};
+  const float* batch_a[] = {batch_a0.data(), batch_a1.data()};
+  const float* batch_b[] = {batch_b0.data(), batch_b1.data()};
+  float* batch_c[] = {batch_c0.data(), batch_c1.data()};
+  const int64_t batch_count = 2;
+  blas.BatchedGEMM(CblasNoTrans,
+                   CblasNoTrans,
+                   1,
+                   1,
+                   2,
+                   1.0f,
+                   batch_a,
+                   batch_b,
+                   0.0f,
+                   batch_c,
+                   batch_count);
+  EXPECT_FLOAT_EQ(batch_c0[0], 33.0f);
+  EXPECT_FLOAT_EQ(batch_c1[0], 77.0f);
+}
+
+TEST(math_function, blas_rejects_unsupported_large_dimensions) {
+  auto* dev_ctx =
+      phi::DeviceContextPool::Instance().GetByPlace(phi::CPUPlace());
+  auto blas = GetBlas<float>(*dev_ctx);
+  float value = 1.0f;
+  const int64_t too_large =
+      static_cast<int64_t>(std::numeric_limits<int>::max()) + 1;
+
+  EXPECT_THROW(blas.MatMul(too_large, 1, 1, &value, &value, &value),
+               common::enforce::EnforceNotMet);
+  EXPECT_THROW(
+      blas.GEMV(false, too_large, 1, 1.0f, &value, &value, 0.0f, &value),
+      common::enforce::EnforceNotMet);
+  EXPECT_THROW(blas.GEMM(CblasNoTrans,
+                         CblasNoTrans,
+                         -1,
+                         1,
+                         1,
+                         1.0f,
+                         &value,
+                         &value,
+                         0.0f,
+                         &value),
+               common::enforce::EnforceNotMet);
+  EXPECT_THROW(blas.GEMM(false,
+                         false,
+                         1,
+                         1,
+                         1,
+                         1.0f,
+                         &value,
+                         too_large,
+                         &value,
+                         1,
+                         0.0f,
+                         &value,
+                         1),
+               common::enforce::EnforceNotMet);
+
+  const float** null_inputs = nullptr;
+  float** null_outputs = nullptr;
+  EXPECT_THROW(blas.BatchedGEMM(CblasNoTrans,
+                                CblasNoTrans,
+                                1,
+                                1,
+                                1,
+                                1.0f,
+                                null_inputs,
+                                null_inputs,
+                                0.0f,
+                                null_outputs,
+                                too_large),
+               common::enforce::EnforceNotMet);
+#ifdef PADDLE_WITH_MKLML
+  EXPECT_THROW(blas.GEMM_ALLOC(CblasBMatrix, too_large, 1, 1),
+               common::enforce::EnforceNotMet);
+  EXPECT_THROW(
+      blas.GEMM_PACK(
+          CblasBMatrix, CblasNoTrans, 1, 1, 1, 1.0f, &value, too_large, &value),
+      common::enforce::EnforceNotMet);
+  EXPECT_THROW(blas.GEMM_COMPUTE(CblasNoTrans,
+                                 CblasPacked,
+                                 1,
+                                 1,
+                                 1,
+                                 &value,
+                                 too_large,
+                                 &value,
+                                 1,
+                                 0.0f,
+                                 &value,
+                                 1),
+               common::enforce::EnforceNotMet);
+#endif
+#if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA) && \
+    !defined(PADDLE_WITH_HIP)
+  phi::funcs::Blas<phi::CPUContext> base_blas(*dev_ctx);
+  EXPECT_THROW(base_blas.BatchedGEMMWithHead<float>(CblasNoTrans,
+                                                    CblasNoTrans,
+                                                    too_large,
+                                                    1,
+                                                    1,
+                                                    1,
+                                                    1.0f,
+                                                    &value,
+                                                    &value,
+                                                    0.0f,
+                                                    &value,
+                                                    1,
+                                                    1,
+                                                    1,
+                                                    1,
+                                                    false),
+               common::enforce::EnforceNotMet);
+
+  phi::DenseTensor empty;
+  const phi::funcs::MatDescriptor unit_matrix{1, 1, 0, 0, false};
+  const int64_t invalid_head_number = 0;
+  EXPECT_THROW(base_blas.MatMulWithHead<float>(empty,
+                                               unit_matrix,
+                                               empty,
+                                               unit_matrix,
+                                               1.0f,
+                                               invalid_head_number,
+                                               &empty,
+                                               0.0f,
+                                               false),
+               common::enforce::EnforceNotMet);
+#endif
+}
+
+TEST(math_function, blas_dimension_validation_is_overflow_safe) {
+  const int64_t int64_max = std::numeric_limits<int64_t>::max();
+
+  EXPECT_EQ(phi::funcs::detail::checked_blas_mul(int64_max, 1, "test"),
+            int64_max);
+  EXPECT_THROW(phi::funcs::detail::checked_blas_mul(int64_max, 2, "test"),
+               common::enforce::EnforceNotMet);
+  EXPECT_THROW(phi::funcs::detail::to_blas_int(-1, "test"),
+               common::enforce::EnforceNotMet);
+}
+
+TEST(math_function, fc_functor_keeps_legacy_and_int64_signatures) {
+  using Functor = phi::funcs::FCFunctor<phi::CPUContext, float>;
+  using LegacyOperator = void (Functor::*)(const phi::CPUContext&,
+                                           int,
+                                           int,
+                                           int,
+                                           const float*,
+                                           const float*,
+                                           float*,
+                                           const float*,
+                                           bool,
+                                           bool);
+  using Int64Operator = void (Functor::*)(const phi::CPUContext&,
+                                          int64_t,
+                                          int64_t,
+                                          int64_t,
+                                          const float*,
+                                          const float*,
+                                          float*,
+                                          const float*,
+                                          bool,
+                                          bool);
+
+  auto legacy_operator = static_cast<LegacyOperator>(&Functor::operator());
+  auto int64_operator = static_cast<Int64Operator>(&Functor::operator());
+  EXPECT_TRUE(legacy_operator != nullptr);
+  EXPECT_TRUE(int64_operator != nullptr);
+
+  auto* dev_ctx =
+      phi::DeviceContextPool::Instance().GetByPlace(phi::CPUPlace());
+  float value = 1.0f;
+  const int64_t invalid_padded_width =
+      static_cast<int64_t>(std::numeric_limits<int>::max()) - 3;
+  Functor fc;
+  EXPECT_THROW(fc(*dev_ctx,
+                  int64_t{1},
+                  invalid_padded_width,
+                  int64_t{1},
+                  &value,
+                  &value,
+                  &value,
+                  nullptr,
+                  false,
+                  true),
+               common::enforce::EnforceNotMet);
 }
 
 TEST(math_function, dot_with_blas_zero_length) {
@@ -299,12 +549,12 @@ TEST(math_function, zero) {
 }
 
 template <typename T>
-void GemvTest(int m, int n, bool trans) {
+void GemvTest(int64_t m, int64_t n, bool trans) {
   phi::DenseTensor mat_a;
   phi::DenseTensor vec_b;
   phi::DenseTensor vec_c;
-  int b_num = trans ? m : n;
-  int c_num = trans ? n : m;
+  int64_t b_num = trans ? m : n;
+  int64_t c_num = trans ? n : m;
 
   auto* dev_ctx =
       phi::DeviceContextPool::Instance().GetByPlace(phi::CPUPlace());
@@ -315,34 +565,27 @@ void GemvTest(int m, int n, bool trans) {
   T* data_b = dev_ctx->template Alloc<T>(&vec_b);
   vec_c.Resize({c_num});
   T* data_c = dev_ctx->template Alloc<T>(&vec_c);
-  for (int i = 0; i < mat_a.numel(); ++i) {
+  for (int64_t i = 0; i < mat_a.numel(); ++i) {
     data_a[i] = static_cast<T>(i);
   }
-  for (int i = 0; i < vec_b.numel(); ++i) {
+  for (int64_t i = 0; i < vec_b.numel(); ++i) {
     data_b[i] = static_cast<T>(i);
   }
 
-  GetBlas<T>(*dev_ctx).GEMV(trans,
-                            static_cast<int>(m),
-                            static_cast<int>(n),
-                            1.,
-                            data_a,
-                            data_b,
-                            0.,
-                            data_c);
+  GetBlas<T>(*dev_ctx).GEMV(trans, m, n, 1., data_a, data_b, 0., data_c);
 
   if (!trans) {
-    for (int i = 0; i < m; ++i) {
+    for (int64_t i = 0; i < m; ++i) {
       T sum = 0.0;
-      for (int j = 0; j < n; ++j) {
+      for (int64_t j = 0; j < n; ++j) {
         sum += data_a[i * n + j] * data_b[j];
       }
       ASSERT_FLOAT_EQ(data_c[i], sum);
     }
   } else {
-    for (int i = 0; i < n; ++i) {
+    for (int64_t i = 0; i < n; ++i) {
       T sum = 0.0;
-      for (int j = 0; j < m; ++j) {
+      for (int64_t j = 0; j < m; ++j) {
         sum += data_a[j * n + i] * data_b[j];
       }
       ASSERT_FLOAT_EQ(data_c[i], sum);

--- a/test/cpp/phi/kernels/test_math_function.cu
+++ b/test/cpp/phi/kernels/test_math_function.cu
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
+
 #include "gtest/gtest.h"
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/core/tensor_utils.h"
@@ -455,7 +457,7 @@ TEST(math_function, gemm_trans_cublas_fp16) {
 }
 
 template <typename T>
-void GemvTest(int m, int n, bool trans) {
+void GemvTest(int64_t m, int64_t n, bool trans) {
   phi::DenseTensor mat_a;
   phi::DenseTensor vec_b;
   phi::DenseTensor vec_c;
@@ -476,39 +478,32 @@ void GemvTest(int m, int n, bool trans) {
   T* g_data_b = g_vec_b.mutable_data<T>(vec_b.dims(), gpu_place);
   T* g_data_c = g_vec_c.mutable_data<T>(vec_c.dims(), gpu_place);
 
-  for (int i = 0; i < mat_a.numel(); ++i) {
+  for (int64_t i = 0; i < mat_a.numel(); ++i) {
     data_a[i] = static_cast<T>(i);
   }
-  for (int i = 0; i < vec_b.numel(); ++i) {
+  for (int64_t i = 0; i < vec_b.numel(); ++i) {
     data_b[i] = static_cast<T>(i);
   }
 
   phi::Copy(*context, mat_a, gpu_place, true, &g_mat_a);
   phi::Copy(*context, vec_b, gpu_place, true, &g_vec_b);
 
-  GetBlas<T>(*context).GEMV(trans,
-                            static_cast<int>(m),
-                            static_cast<int>(n),
-                            1.,
-                            g_data_a,
-                            g_data_b,
-                            0.,
-                            g_data_c);
+  GetBlas<T>(*context).GEMV(trans, m, n, 1., g_data_a, g_data_b, 0., g_data_c);
 
   phi::Copy(*context, g_vec_c, cpu_place, true, &vec_c);
 
   if (!trans) {
-    for (int i = 0; i < m; ++i) {
+    for (int64_t i = 0; i < m; ++i) {
       T sum = 0.0;
-      for (int j = 0; j < n; ++j) {
+      for (int64_t j = 0; j < n; ++j) {
         sum += data_a[i * n + j] * data_b[j];
       }
       ASSERT_FLOAT_EQ(data_c[i], sum);
     }
   } else {
-    for (int i = 0; i < n; ++i) {
+    for (int64_t i = 0; i < n; ++i) {
       T sum = 0.0;
-      for (int j = 0; j < m; ++j) {
+      for (int64_t j = 0; j < m; ++j) {
         sum += data_a[j * n + i] * data_b[j];
       }
       ASSERT_FLOAT_EQ(data_c[i], sum);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

本 PR 主要将 Paddle BLAS 封装层中 GEMM 及其相关接口的矩阵维度参数从 `int` 扩展为 `int64_t`，避免 Tensor 的 64 位维度在进入 BLAS 接口前被提前转换为 `int`，从而发生静默截断或溢出。

具体修改如下：

| API | 修改内容 |
| ---- | -------- |
| `GEMM` | 将 `M`、`N`、`K` 以及 `lda`、`ldb`、`ldc` 从 `int` 修改为 `int64_t`，覆盖 `bool` 和 `CBLAS_TRANSPOSE` 两组重载。 |
| `MatMul` | 将裸指针版本的 `M`、`N`、`K` 修改为 `int64_t`；Tensor 版本直接使用 `DDim` 提供的 64 位维度，不再提前转换为 `int`。 |
| `BatchedGEMM` | 将 `M`、`N`、`K` 和 `batchCount` 修改为 `int64_t`，并同步调整 CPU、CUDA 和 HIP 实现。 |
| `BatchedGEMMWithHead` | 将 `W1`、`H1`、`W2`、`H2` 和 `batchCount` 修改为 `int64_t`，避免多头矩阵拆分过程中的维度和偏移计算发生 32 位溢出。 |
| `MatMulWithHead` | 将 `head_number` 修改为 `int64_t`，并将子矩阵维度、leading dimension 和内存偏移统一调整为 64 位计算。 |
| `GEMV` | 将 `M`、`N` 修改为 `int64_t`，使矩阵向量乘法可以直接接收 Tensor 的 64 位维度。 |
| `GEMM_ALLOC` | 将 MKL packed GEMM 的 `M`、`N`、`K` 参数修改为 `int64_t`。 |
| `GEMM_PACK` | 将 `M`、`N`、`K` 和 `ld` 参数修改为 `int64_t`。 |
| `GEMM_COMPUTE` | 将 `M`、`N`、`K` 以及 `lda`、`ldb`、`ldc` 参数修改为 `int64_t`。 |

对于底层仍采用 LP64 接口、只接受 32 位整数的 CPU BLAS、cuBLAS 和 rocBLAS 实现，本 PR 在真正调用底层库前统一进行范围检查，并在确认参数不超过 `INT_MAX` 后安全转换为 `int`。这样可以保证：

1. Paddle BLAS 公共接口能够完整接收 `int64_t` 维度。
2. 不会在调用链上游发生未经检查的隐式缩窄。
3. 当前后端不支持对应的大维度时，会抛出明确异常，而不是产生截断后的错误计算。
4. 后续接入支持 64 位维度的 BLAS 后端时，无需再次修改上层接口。

同时同步调整了相关调用链：

- `matmul` 普通 BLAS 路径直接传递 64 位 Tensor 维度。
- `FCFunctor` 和 `FC Kernel` 使用 `int64_t` 传递 `M`、`N`、`K`；对于仍只支持 `int` 的 CPU JIT bias/relu 和 GPU bias kernel，在实际边界进行检查和转换。
- `search_compute` 中的 GEMM 辅助接口使用 `int64_t` 传递矩阵维度和 leading dimension。
- GPU `ColwiseSum`、`RowwiseSum` 的 GEMV 调用不再在调用前转换为 `int`。
- MKL packed GRU 路径使用 `int64_t` `frame_size` 调用 packed GEMM 接口，并同步调整相关 CPU GRU helper 的维度计算。

此外，补充了 CPU/CUDA BLAS 接口测试，覆盖：

- `int64_t` 类型维度下的 `MatMul`、`GEMM`、`GEMV` 和 `BatchedGEMM` 正常计算。
- LP64 后端收到超过 `INT_MAX` 的维度或 leading dimension 时能够正确抛出异常。


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否