### PR TITLE
[CI] Rerun approval checks after approve

### DIFF
--- a/.github/actions/rerun-workflow/action.yml
+++ b/.github/actions/rerun-workflow/action.yml
@@ -12,7 +12,10 @@ inputs:
     required: true
   PR_ID:
     description: 'Pull Request ID'
-    required: true
+    required: false
+  HEAD_SHA:
+    description: 'Commit SHA to rerun workflow jobs for'
+    required: false
   JOB_NAME:
     description: 'Job name to rerun'
     required: true
@@ -27,4 +30,5 @@ runs:
         OWNER: ${{ inputs.OWNER }}
         REPO: ${{ inputs.REPO }}
         PR_ID: ${{ inputs.PR_ID }}
+        HEAD_SHA: ${{ inputs.HEAD_SHA }}
         JOB_NAME: ${{ inputs.JOB_NAME }}

--- a/.github/actions/rerun-workflow/rerun.sh
+++ b/.github/actions/rerun-workflow/rerun.sh
@@ -14,8 +14,15 @@
 
 set -e
 
-COMMIT_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_ID" | jq -r '.head.sha')
+if [ -n "${HEAD_SHA:-}" ]; then
+  COMMIT_SHA="$HEAD_SHA"
+elif [ -n "${PR_ID:-}" ]; then
+  COMMIT_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_ID" | jq -r '.head.sha')
+else
+  echo "Either HEAD_SHA or PR_ID is required."
+  exit 1
+fi
 
 echo "Commit SHA: $COMMIT_SHA"
 

--- a/.github/workflows/approval-review-signal.yml
+++ b/.github/workflows/approval-review-signal.yml
@@ -1,0 +1,19 @@
+name: Approval Review Signal
+run-name: Approval Review Signal / ${{ github.event.review.state }} / PR-${{ github.event.pull_request.number }}
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+jobs:
+  signal:
+    runs-on:
+      group: APPROVAL
+    steps:
+      - name: Record review update
+        run: |
+          echo "Review state: ${{ github.event.review.state }}"
+          echo "Pull request: ${{ github.event.pull_request.number }}"
+          echo "Head SHA: ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/approval-review-signal.yml
+++ b/.github/workflows/approval-review-signal.yml
@@ -1,14 +1,14 @@
 name: Approval Review Signal
-run-name: Approval Review Signal / ${{ github.event.review.state }} / ${{ github.event.review.user.login }} / PR-${{ github.event.pull_request.number }}
 
 on:
   pull_request_review:
-    types: [submitted]
+    types: [submitted, dismissed]
 
 permissions: {}
 
 jobs:
   signal:
+    if: ${{ github.event.action == 'dismissed' || github.event.review.state == 'approved' }}
     runs-on:
       group: APPROVAL
     steps:

--- a/.github/workflows/approval-review-signal.yml
+++ b/.github/workflows/approval-review-signal.yml
@@ -1,5 +1,5 @@
 name: Approval Review Signal
-run-name: Approval Review Signal / ${{ github.event.review.state }} / PR-${{ github.event.pull_request.number }}
+run-name: Approval Review Signal / ${{ github.event.review.state }} / ${{ github.event.review.user.login }} / PR-${{ github.event.pull_request.number }}
 
 on:
   pull_request_review:
@@ -15,5 +15,6 @@ jobs:
       - name: Record review update
         run: |
           echo "Review state: ${{ github.event.review.state }}"
+          echo "Reviewer: ${{ github.event.review.user.login }}"
           echo "Pull request: ${{ github.event.pull_request.number }}"
           echo "Head SHA: ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -365,7 +365,7 @@ jobs:
           JOB_NAME: 'Windows-OPENBLAS / Check bypass / Check bypass'
 
   rerun-on-approval:
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number != null && github.event.workflow_run.display_title == format('Approval Review Signal / approved / PR-{0}', github.event.workflow_run.pull_requests[0].number) }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number != null && github.event.workflow_run.display_title == format('Approval Review Signal / approved / risemeup1111 / PR-{0}', github.event.workflow_run.pull_requests[0].number) }}
     runs-on:
       group: APPROVAL
     steps:

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -3,12 +3,18 @@ name: Re-run
 on:
   issue_comment:
     types: [created]
-  pull_request_review:
-    types: [submitted]
+  workflow_run:
+    workflows: ["Approval Review Signal"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
 
 jobs:
   re-run:
-    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/re-run')  && github.event.comment.user.login == github.event.issue.user.login }}
+    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/re-run') && github.event.comment.user.login == github.event.issue.user.login }}
     runs-on:
       group: APPROVAL
     steps:
@@ -29,7 +35,7 @@ jobs:
           JOB_NAME: 'all-failed'
 
       - name: Rerun Approval
-        if: ${{ contains(github.event.comment.body, 'approval') }}
+        if: ${{ contains(github.event.comment.body, '/re-run approval') }}
         uses: ./.github/actions/rerun-workflow
         with:
           PR_ID: ${{ github.event.issue.number }}
@@ -39,7 +45,7 @@ jobs:
           JOB_NAME: 'Check approval'
 
       - name: Rerun Bot Approval Required
-        if: ${{ contains(github.event.comment.body, 'bot-approval-required') }}
+        if: ${{ contains(github.event.comment.body, '/re-run bot-approval-required') }}
         uses: ./.github/actions/rerun-workflow
         with:
           PR_ID: ${{ github.event.issue.number }}
@@ -359,7 +365,7 @@ jobs:
           JOB_NAME: 'Windows-OPENBLAS / Check bypass / Check bypass'
 
   rerun-on-approval:
-    if: ${{ github.event_name == 'pull_request_review' && github.event.review.state == 'approved' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number != null && github.event.workflow_run.display_title == format('Approval Review Signal / approved / PR-{0}', github.event.workflow_run.pull_requests[0].number) }}
     runs-on:
       group: APPROVAL
     steps:
@@ -368,11 +374,13 @@ jobs:
           rm -rf * .[^.]*
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Rerun Approval
         uses: ./.github/actions/rerun-workflow
         with:
-          PR_ID: ${{ github.event.pull_request.number }}
+          PR_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
@@ -381,7 +389,7 @@ jobs:
       - name: Rerun Bot Approval Required
         uses: ./.github/actions/rerun-workflow
         with:
-          PR_ID: ${{ github.event.pull_request.number }}
+          PR_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -365,7 +365,7 @@ jobs:
           JOB_NAME: 'Windows-OPENBLAS / Check bypass / Check bypass'
 
   rerun-on-approval:
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number != null && github.event.workflow_run.display_title == format('Approval Review Signal / approved / risemeup1111 / PR-{0}', github.event.workflow_run.pull_requests[0].number) }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_sha != '' }}
     runs-on:
       group: APPROVAL
     steps:
@@ -380,7 +380,7 @@ jobs:
       - name: Rerun Approval
         uses: ./.github/actions/rerun-workflow
         with:
-          PR_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
@@ -389,7 +389,7 @@ jobs:
       - name: Rerun Bot Approval Required
         uses: ./.github/actions/rerun-workflow
         with:
-          PR_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -3,10 +3,12 @@ name: Re-run
 on:
   issue_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   re-run:
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/re-run')  && github.event.comment.user.login == github.event.issue.user.login }}
+    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/re-run')  && github.event.comment.user.login == github.event.issue.user.login }}
     runs-on:
       group: APPROVAL
     steps:
@@ -35,6 +37,16 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           JOB_NAME: 'Check approval'
+
+      - name: Rerun Bot Approval Required
+        if: ${{ contains(github.event.comment.body, 'bot-approval-required') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Require review-bot approval'
 
       - name: Rerun Codestyle-check
         if: ${{ contains(github.event.comment.body, 'codestyle') }}
@@ -345,3 +357,32 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           JOB_NAME: 'Windows-OPENBLAS / Check bypass / Check bypass'
+
+  rerun-on-approval:
+    if: ${{ github.event_name == 'pull_request_review' && github.event.review.state == 'approved' }}
+    runs-on:
+      group: APPROVAL
+    steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Rerun Approval
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Check approval'
+
+      - name: Rerun Bot Approval Required
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Require review-bot approval'


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description
Split approval rerun into a trusted two-step flow:

- `Approval Review Signal` listens to `pull_request_review` `submitted` and `dismissed`, runs on the `APPROVAL` runner group, and only succeeds for approved/dismissed review updates.
- `rerun.yml` listens to `workflow_run` from that signal workflow, uses `actions: write`, checks out only the default branch, and reruns approval checks by `workflow_run.head_sha` instead of `workflow_run.pull_requests` or `display_title`.
- `rerun-workflow` now accepts either `HEAD_SHA` or `PR_ID`, so the workflow_run path can use head SHA while manual `/re-run ...` commands keep the existing PR lookup path.
- Keep manual `/re-run approval` and `/re-run bot-approval-required` commands, with exact matching so they do not cross-trigger.

### 是否引起精度变化
否