### PR TITLE
[Cpp API Compatibility] Unwrap `StorageHolderView` in `record_stream`

### DIFF
--- a/paddle/phi/api/include/compat/ATen/ops/record_stream.h
+++ b/paddle/phi/api/include/compat/ATen/ops/record_stream.h
@@ -16,6 +16,7 @@
 
 #include <ATen/core/Tensor.h>
 #include <c10/core/Device.h>
+#include <c10/core/Storage.h>
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 #include <c10/cuda/CUDAStream.h>
 #endif
@@ -29,17 +30,36 @@ inline void Tensor::record_stream(at::Stream s) const {
            "tensor implementation.");
   PD_CHECK(dense_tensor->place().GetType() != phi::AllocationType::CPU,
            "record_stream is not supported for CPU tensors.");
+  PD_CHECK(dense_tensor->place() == s.device()._PD_GetInner(),
+           "record_stream requires the tensor and stream to use the same "
+           "device, but got tensor on ",
+           dense_tensor->place(),
+           " and stream on ",
+           s.device(),
+           ".");
+
+  auto holder = dense_tensor->Holder();
+  if (auto storage_holder =
+          std::dynamic_pointer_cast<c10::StorageHolderView>(holder)) {
+    auto storage_impl = storage_holder->get_impl();
+    PD_CHECK(storage_impl != nullptr,
+             "record_stream cannot resolve a StorageHolderView without a "
+             "StorageImpl.");
+    holder = storage_impl->data_allocation_;
+  }
+  PD_CHECK(holder != nullptr,
+           "record_stream requires tensor storage backed by a "
+           "phi::Allocation.");
 #if (defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) && \
     !defined(PADDLE_WITH_CUSTOM_DEVICE)
   paddle::memory::RecordStream(
-      dense_tensor->Holder(), reinterpret_cast<gpuStream_t>(s.native_handle()));
+      holder, reinterpret_cast<gpuStream_t>(s.native_handle()));
 #elif defined(PADDLE_WITH_XPU)
-  paddle::memory::RecordStream(dense_tensor->Holder(),
+  paddle::memory::RecordStream(holder,
                                reinterpret_cast<XPUStream>(s.native_handle()));
 #elif defined(PADDLE_WITH_CUSTOM_DEVICE)
   paddle::memory::RecordStream(
-      dense_tensor->Holder(),
-      reinterpret_cast<phi::stream::stream_t>(s.native_handle()));
+      holder, reinterpret_cast<phi::stream::stream_t>(s.native_handle()));
 #else
   (void)s;
   (void)dense_tensor;

--- a/test/cpp/compat/ATen_record_stream_test.cc
+++ b/test/cpp/compat/ATen_record_stream_test.cc
@@ -18,12 +18,55 @@
 #include <ATen/ops/record_stream.h>
 #include <c10/core/Device.h>
 #include <c10/core/Stream.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <thread>
+
 #include "ATen/ATen.h"
 #include "gtest/gtest.h"
+#include "paddle/phi/core/memory/allocation/allocator_facade.h"
 #include "torch/all.h"
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 #include <c10/cuda/CUDAFunctions.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
+#endif
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+namespace {
+
+using StreamCallbackGate = std::atomic<bool>;
+
+#ifdef PADDLE_WITH_HIP
+void BlockingStreamCallback(hipStream_t /*stream*/,
+                            hipError_t /*status*/,
+                            void* user_data) {
+  auto* gate = static_cast<StreamCallbackGate*>(user_data);
+  while (!gate->load(std::memory_order_acquire)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+#else
+void CUDART_CB BlockingStreamCallback(void* user_data) {
+  auto* gate = static_cast<StreamCallbackGate*>(user_data);
+  while (!gate->load(std::memory_order_acquire)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+#endif
+
+class CallbackGateRelease final {
+ public:
+  explicit CallbackGateRelease(StreamCallbackGate* gate) : gate_(gate) {}
+  ~CallbackGateRelease() { gate_->store(true, std::memory_order_release); }
+
+ private:
+  StreamCallbackGate* gate_;
+};
+
+}  // namespace
 #endif
 
 class RecordStreamTest : public ::testing::Test {
@@ -58,6 +101,101 @@ TEST_F(RecordStreamTest, CudaTensorCurrentCudaStream) {
   auto stream = at::cuda::getCurrentCUDAStream();
   // record_stream should not throw
   EXPECT_NO_THROW(cuda_tensor.record_stream(stream));
+}
+
+TEST_F(RecordStreamTest, StorageHolderViewKeepsNonDefaultStreamAlive) {
+  if (!at::cuda::is_available()) {
+    return;
+  }
+  auto& facade = paddle::memory::allocation::AllocatorFacade::Instance();
+  if (!facade.IsStreamSafeCUDAAllocatorUsed() &&
+      !facade.IsCUDAMallocAsyncAllocatorUsed()) {
+    return;
+  }
+
+  auto current_stream = at::cuda::getCurrentCUDAStream();
+  auto other_stream = at::cuda::getStreamFromPool(
+      /*isHighPriority=*/false, current_stream.device_index());
+  for (int i = 0; i < 32 && other_stream == current_stream; ++i) {
+    other_stream = at::cuda::getStreamFromPool(
+        /*isHighPriority=*/false, current_stream.device_index());
+  }
+  ASSERT_NE(other_stream, current_stream);
+
+  StreamCallbackGate gate{false};
+  CallbackGateRelease release_gate(&gate);
+  void* original_ptr = nullptr;
+  constexpr int64_t kElements = 1 << 20;
+  constexpr size_t kBytes = kElements * sizeof(float);
+  {
+    at::Tensor tensor = at::empty(
+        {kElements}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+    (void)tensor.storage();
+    auto dense = std::dynamic_pointer_cast<phi::DenseTensor>(
+        tensor._PD_GetInner().impl());
+    ASSERT_NE(dense, nullptr);
+    ASSERT_NE(
+        std::dynamic_pointer_cast<c10::StorageHolderView>(dense->Holder()),
+        nullptr);
+    original_ptr = tensor.data_ptr();
+
+#ifdef PADDLE_WITH_HIP
+    C10_CUDA_CHECK(hipStreamAddCallback(
+        other_stream.stream(), BlockingStreamCallback, &gate, 0));
+    C10_CUDA_CHECK(
+        hipMemsetAsync(original_ptr, 0, kBytes, other_stream.stream()));
+#else
+    C10_CUDA_CHECK(cudaLaunchHostFunc(
+        other_stream.stream(), BlockingStreamCallback, &gate));
+    C10_CUDA_CHECK(
+        cudaMemsetAsync(original_ptr, 0, kBytes, other_stream.stream()));
+#endif
+    EXPECT_NO_THROW(tensor.record_stream(other_stream.unwrap()));
+  }
+
+  at::Tensor replacement = at::empty(
+      {kElements}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+  EXPECT_NE(replacement.data_ptr(), original_ptr)
+      << "record_stream must defer reuse while non-default stream work is "
+         "pending";
+
+  gate.store(true, std::memory_order_release);
+  EXPECT_NO_THROW(other_stream.synchronize());
+}
+
+TEST_F(RecordStreamTest, StorageHolderViewWithoutAllocationFailsLoudly) {
+  if (!at::cuda::is_available()) {
+    return;
+  }
+  auto stream = at::cuda::getCurrentCUDAStream();
+  at::Tensor tensor =
+      at::empty({4}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+  c10::Storage storage = tensor.storage();
+  auto dense =
+      std::dynamic_pointer_cast<phi::DenseTensor>(tensor._PD_GetInner().impl());
+  ASSERT_NE(dense, nullptr);
+  ASSERT_NE(std::dynamic_pointer_cast<c10::StorageHolderView>(dense->Holder()),
+            nullptr);
+
+  storage.set_data_ptr_noswap(
+      c10::DataPtr(reinterpret_cast<void*>(static_cast<uintptr_t>(1)),
+                   c10::Device(c10::DeviceType::CUDA, stream.device_index())));
+  EXPECT_THROW(tensor.record_stream(stream.unwrap()), std::exception);
+}
+
+TEST_F(RecordStreamTest, RejectsStreamFromAnotherDevice) {
+  if (c10::cuda::device_count() < 2) {
+    return;
+  }
+  c10::cuda::CUDAGuard guard(0);
+  at::Tensor tensor = at::empty(
+      {4},
+      at::TensorOptions().dtype(at::kFloat).device(c10::Device(at::kCUDA, 0)));
+  auto other_device_stream = at::cuda::getStreamFromPool(
+      /*isHighPriority=*/false, /*device_index=*/1);
+
+  EXPECT_THROW(tensor.record_stream(other_device_stream.unwrap()),
+               std::exception);
 }
 
 // --- Happy path: CUDA tensor + default CUDA stream should succeed ---


### PR DESCRIPTION
### PR Category

Execute Infrastructure

### PR Types

Bug fixes

### Description

在对 [PaddlePaddle/Paddle#78826](https://github.com/PaddlePaddle/Paddle/pull/78826) 的合入后代码进行只读审计时，发现 `TensorBase::storage()` 会将 `DenseTensor` holder 替换为 `StorageHolderView`。compat `Tensor::record_stream()` 原先直接把该 view 交给 `AllocatorFacade`；facade 只能识别 allocator 产生的具体 stream-safe allocation，因此无法为真实底层 allocation 登记非默认 stream 生命周期。维护者随后补充了与 #78826 关联的实际回归信号：使用 develop Paddle 编译的 `paddlefleet_ops` 在业务模型上出现 CUDA 719，而 release/3.4 不出现，QA 已二分关联到 #78826；当前补丁是否能修复该业务回归仍待验证。本 PR 针对代码层面的异步生命周期缺陷提供最小补丁。

本 PR 保持最小 compat 范围：

- 在 compat `record_stream` 单点识别 `StorageHolderView`，通过现有 `get_impl()` 取得当前 `StorageImpl::data_allocation_`，再进入原有 allocator facade；不修改 `phi::Allocation`、allocator facade 或 GPU/XPU/Custom Device allocator 分派。
- 对缺少 `StorageImpl` 或底层 `phi::Allocation` 的 holder 显式报错，避免静默丢失生命周期登记。
- 在进入 allocator 前校验 tensor 与 stream 的 device/index 一致，提前拒绝跨卡 stream。
- 增加 `StorageHolderView` 非默认 CUDA stream 待执行工作期间禁止内存复用、无底层 allocation 报错及跨设备 stream 拒绝的回归测试。
- 测试在未启用 stream-aware allocator 时使用兼容 GTest 1.8.1 的 early return，修复 Windows MSVC 对 `GTEST_SKIP()` 的 C3861 编译错误。

最终 diff 仅包含：

- `paddle/phi/api/include/compat/ATen/ops/record_stream.h`
- `test/cpp/compat/ATen_record_stream_test.cc`

验证：

- `prek run --files <rewrite-touched files>`：全部通过（包含 ast-grep、copyright、clang-format、cpplint、typos 等）。
- 使用现有 Paddle CPU compile command 和当前 workspace overlay 对 `ATen_record_stream_test.cc` 进行语法编译：通过。
- 额外启用 `-DPADDLE_WITH_CUSTOM_KERNEL` 语法编译：通过。
- `git diff --check`：通过。

本机为 Apple Silicon macOS，无 CUDA/HIP 设备与工具链，因此真实 non-default-stream CUDA 生命周期、CUDA Graph capture/replay 及多卡运行测试未在本地执行，需要由平台 CI 验证。解包后仍进入现有 graph-aware stream-safe allocator 路径，相关 allocator 实现未改动。DataPtr-only storage 没有可供 allocator 回调的底层 `phi::Allocation`，会显式报错。

审计中的 CUDA `resize_` growth 问题不包含在本 PR 中，将作为独立 follow-up 处理。

@SigureMo Please review this PR when you have time. Thanks!

### 是否引起精度变化

否

