### PR TITLE
[CI] Enable NPU C++20 toolchain baseline

### DIFF
--- a/.github/workflows/_Linux-NPU.yml
+++ b/.github/workflows/_Linux-NPU.yml
@@ -103,6 +103,7 @@ jobs:
           FLAGS_allocator_strategy: naive_best_fit
           FLAGS_npu_storage_format: 0
           TEST_IMPORTANT: "ON"
+          CXXFLAGS: "-std=c++20"
           PADDLE_BRANCH: ${{ github.event.pull_request.base.ref }}
           home_dir: ${{ github.workspace }}/../../../..
         run: |
@@ -145,6 +146,7 @@ jobs:
             -e FLAGS_allocator_strategy \
             -e FLAGS_npu_storage_format \
             -e TEST_IMPORTANT \
+            -e CXXFLAGS \
             -e PADDLE_BRANCH \
             -e CI_name \
             -w /paddle --network host ${docker_image} /bin/bash
@@ -175,6 +177,10 @@ jobs:
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           source ~/.bashrc
           set -x
+          gcc --version
+          g++ --version
+          cmake --version
+          printf "static_assert(__cplusplus >= 202002L);\n" | g++ ${CXXFLAGS} -x c++ -c -o /tmp/npu_cxx20_probe.o -
           echo "::group::Install dependencies"
           python -m pip install PyGithub
           python -m pip install wheel

--- a/.github/workflows/_Linux-NPU.yml
+++ b/.github/workflows/_Linux-NPU.yml
@@ -177,10 +177,6 @@ jobs:
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           source ~/.bashrc
           set -x
-          gcc --version
-          g++ --version
-          cmake --version
-          printf "static_assert(__cplusplus >= 202002L);\n" | g++ ${CXXFLAGS} -x c++ -c -o /tmp/npu_cxx20_probe.o -
           echo "::group::Install dependencies"
           python -m pip install PyGithub
           python -m pip install wheel

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,9 +112,6 @@ jobs:
             if [ $name == "docker_dcu" ]; then
                 md5_value="76937a563116f6008c8ca4cb4f592759"
             fi
-            if [ $name == "docker_npu" ]; then
-                md5_value="a3793bdeea5ae881a0c1eaf4d7c30c64"
-            fi
             docker_image="ccr-2vdh3abv-pub.cnc.bj.baidubce.com/ci/paddle:${md5_value}"
             declare "${name}_image=${docker_image}"
             echo "${name}_image=${docker_image}" >> $GITHUB_OUTPUT

--- a/tools/dockerfile/Dockerfile.develop.npu
+++ b/tools/dockerfile/Dockerfile.develop.npu
@@ -17,7 +17,12 @@ WORKDIR /usr/local/Ascend
 # install CANN requirement
 # https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/700alpha003/softwareinstall/instg/instg_0026.html
 RUN apt-get update -y && apt-get install -y zlib1g zlib1g-dev libsqlite3-dev openssl libssl-dev libffi-dev libbz2-dev \
-    libxslt1-dev unzip pciutils net-tools libblas-dev gfortran libblas3 liblapack-dev liblapack3 libopenblas-dev zstd
+    libxslt1-dev unzip pciutils net-tools libblas-dev gcc-12 g++-12 gfortran-12 libblas3 liblapack-dev liblapack3 \
+    libopenblas-dev zstd
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 120 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 120 && \
+    update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-12 120
 
 RUN pip3.10 install --upgrade pip setuptools wheel
 


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Devs

### Description

当前 Linux-NPU 镜像基于 `ubuntu20-npu-base-x86_64-gcc84`，PaddleCustomDevice NPU 插件构建没有显式启用 C++20。此外，`docker.yml` 固定覆盖了 NPU 镜像的内容哈希，因此即使修改 NPU Dockerfile，CI 仍会复用旧的 GCC 8.4 镜像。

#### 编译边界

当前 NPU CI 不会在 NPU 镜像中重新编译 Paddle 主体：`Linux-CPU` job 先构建并上传同一 PR 的 Paddle CPU wheel，`Linux-NPU` job 等待该任务完成后，在 NPU 镜像中下载并安装这个 wheel，再编译和测试 PaddleCustomDevice NPU 插件。

因此，本 PR 验证的是 GCC 12/C++20、CANN headers、Paddle CPU wheel 与 PaddleCustomDevice 的插件构建兼容性，不覆盖 Paddle 主体在 NPU 镜像中的源码编译。Paddle 主体仍由通用 Linux CPU/build CI 构建。

#### 改动

本 PR 保留现有 Ubuntu 20 与 CANN 8.0.T113 组合，只收敛 NPU 插件的 host 编译链路：

- 在 NPU 开发镜像中安装并切换到 GCC/G++/GFortran 12；
- 移除 NPU 镜像的固定哈希，让 Dockerfile 内容变化触发新镜像构建；
- 将 `CXXFLAGS=-std=c++20` 传入 NPU 容器，使 PaddleCustomDevice 插件实际按 C++20 编译。

该改动覆盖 #79384 中的 NPU CI 工具链升级项，不升级 CANN 或 Ubuntu。

#### 关联

- Part of #79384
- Host C++20 baseline: #79260
- Common-path C++20 compile probe: #79445
- DCU C++20 toolchain work: #79421
- PaddleCustomDevice NPU CI entry: https://github.com/PaddlePaddle/PaddleCustomDevice/blob/develop/backends/npu/tools/pr_ci_npu.sh

#### 验证

- `prek`
- `git diff --check`
- GitHub Actions YAML 解析
- 修改的 workflow shell 块执行 `bash -n`
- Ubuntu 20 toolchain PPA 中 `gcc-12`、`g++-12`、`gfortran-12` 包存在性检查

本地没有可用的 NPU/CANN 环境，完整镜像构建与 NPU 实机测试以 PR CI 为准。

### 是否引起精度变化
否。该 PR 仅调整 NPU CI host 编译工具链与编译标准，不修改算子实现或数值逻辑。
