### PR TITLE
[CI] Rerun approval checks after approve

### DIFF
--- a/.github/workflows/approval-review-signal.yml
+++ b/.github/workflows/approval-review-signal.yml
@@ -1,0 +1,19 @@
+name: Approval Review Signal
+run-name: Approval Review Signal / ${{ github.event.review.state }} / PR-${{ github.event.pull_request.number }}
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+jobs:
+  signal:
+    runs-on:
+      group: APPROVAL
+    steps:
+      - name: Record review update
+        run: |
+          echo "Review state: ${{ github.event.review.state }}"
+          echo "Pull request: ${{ github.event.pull_request.number }}"
+          echo "Head SHA: ${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/approval-review-signal.yml
+++ b/.github/workflows/approval-review-signal.yml
@@ -1,5 +1,4 @@
 name: Approval Review Signal
-run-name: Approval Review Signal / ${{ github.event.review.state }} / PR-${{ github.event.pull_request.number }}
 
 on:
   pull_request_review:
@@ -9,6 +8,7 @@ permissions: {}
 
 jobs:
   signal:
+    if: ${{ github.event.review.state == 'approved' }}
     runs-on:
       group: APPROVAL
     steps:

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -3,12 +3,18 @@ name: Re-run
 on:
   issue_comment:
     types: [created]
-  pull_request_review:
-    types: [submitted]
+  workflow_run:
+    workflows: ["Approval Review Signal"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
 
 jobs:
   re-run:
-    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/re-run')  && github.event.comment.user.login == github.event.issue.user.login }}
+    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/re-run') && github.event.comment.user.login == github.event.issue.user.login }}
     runs-on:
       group: APPROVAL
     steps:
@@ -29,7 +35,7 @@ jobs:
           JOB_NAME: 'all-failed'
 
       - name: Rerun Approval
-        if: ${{ contains(github.event.comment.body, 'approval') }}
+        if: ${{ contains(github.event.comment.body, '/re-run approval') }}
         uses: ./.github/actions/rerun-workflow
         with:
           PR_ID: ${{ github.event.issue.number }}
@@ -39,7 +45,7 @@ jobs:
           JOB_NAME: 'Check approval'
 
       - name: Rerun Bot Approval Required
-        if: ${{ contains(github.event.comment.body, 'bot-approval-required') }}
+        if: ${{ contains(github.event.comment.body, '/re-run bot-approval-required') }}
         uses: ./.github/actions/rerun-workflow
         with:
           PR_ID: ${{ github.event.issue.number }}
@@ -359,7 +365,7 @@ jobs:
           JOB_NAME: 'Windows-OPENBLAS / Check bypass / Check bypass'
 
   rerun-on-approval:
-    if: ${{ github.event_name == 'pull_request_review' && github.event.review.state == 'approved' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number != null && github.event.workflow_run.display_title == format('Approval Review Signal / approved / PR-{0}', github.event.workflow_run.pull_requests[0].number) }}
     runs-on:
       group: APPROVAL
     steps:
@@ -368,11 +374,13 @@ jobs:
           rm -rf * .[^.]*
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Rerun Approval
         uses: ./.github/actions/rerun-workflow
         with:
-          PR_ID: ${{ github.event.pull_request.number }}
+          PR_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
@@ -381,7 +389,7 @@ jobs:
       - name: Rerun Bot Approval Required
         uses: ./.github/actions/rerun-workflow
         with:
-          PR_ID: ${{ github.event.pull_request.number }}
+          PR_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -365,7 +365,7 @@ jobs:
           JOB_NAME: 'Windows-OPENBLAS / Check bypass / Check bypass'
 
   rerun-on-approval:
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number != null && github.event.workflow_run.display_title == format('Approval Review Signal / approved / PR-{0}', github.event.workflow_run.pull_requests[0].number) }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number != null }}
     runs-on:
       group: APPROVAL
     steps:

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -3,10 +3,12 @@ name: Re-run
 on:
   issue_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   re-run:
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/re-run')  && github.event.comment.user.login == github.event.issue.user.login }}
+    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/re-run')  && github.event.comment.user.login == github.event.issue.user.login }}
     runs-on:
       group: APPROVAL
     steps:
@@ -35,6 +37,16 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           JOB_NAME: 'Check approval'
+
+      - name: Rerun Bot Approval Required
+        if: ${{ contains(github.event.comment.body, 'bot-approval-required') }}
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Require review-bot approval'
 
       - name: Rerun Codestyle-check
         if: ${{ contains(github.event.comment.body, 'codestyle') }}
@@ -345,3 +357,32 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           JOB_NAME: 'Windows-OPENBLAS / Check bypass / Check bypass'
+
+  rerun-on-approval:
+    if: ${{ github.event_name == 'pull_request_review' && github.event.review.state == 'approved' }}
+    runs-on:
+      group: APPROVAL
+    steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Rerun Approval
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Check approval'
+
+      - name: Rerun Bot Approval Required
+        uses: ./.github/actions/rerun-workflow
+        with:
+          PR_ID: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          JOB_NAME: 'Require review-bot approval'


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Improvements

### Description
Base this PR on commit `cf5209483dcaae8fa5724d32e7b78a84de35a565` and remove the fragile `workflow_run.display_title` check.

The review signal workflow now gates success on `approved` reviews, so the privileged `workflow_run` rerun job only needs to check the signal workflow completed successfully before rerunning `Check approval` and `Require review-bot approval`.

### 是否引起精度变化
否