### PR TITLE
[CI] Rerun approval checks by head sha

### DIFF
--- a/.github/actions/rerun-workflow/action.yml
+++ b/.github/actions/rerun-workflow/action.yml
@@ -12,7 +12,10 @@ inputs:
     required: true
   PR_ID:
     description: 'Pull Request ID'
-    required: true
+    required: false
+  HEAD_SHA:
+    description: 'Commit SHA to rerun workflow jobs for'
+    required: false
   JOB_NAME:
     description: 'Job name to rerun'
     required: true
@@ -27,4 +30,5 @@ runs:
         OWNER: ${{ inputs.OWNER }}
         REPO: ${{ inputs.REPO }}
         PR_ID: ${{ inputs.PR_ID }}
+        HEAD_SHA: ${{ inputs.HEAD_SHA }}
         JOB_NAME: ${{ inputs.JOB_NAME }}

--- a/.github/actions/rerun-workflow/action.yml
+++ b/.github/actions/rerun-workflow/action.yml
@@ -12,10 +12,7 @@ inputs:
     required: true
   PR_ID:
     description: 'Pull Request ID'
-    required: false
-  HEAD_SHA:
-    description: 'Commit SHA to rerun workflow jobs for'
-    required: false
+    required: true
   JOB_NAME:
     description: 'Job name to rerun'
     required: true
@@ -30,5 +27,4 @@ runs:
         OWNER: ${{ inputs.OWNER }}
         REPO: ${{ inputs.REPO }}
         PR_ID: ${{ inputs.PR_ID }}
-        HEAD_SHA: ${{ inputs.HEAD_SHA }}
         JOB_NAME: ${{ inputs.JOB_NAME }}

--- a/.github/actions/rerun-workflow/rerun.sh
+++ b/.github/actions/rerun-workflow/rerun.sh
@@ -14,8 +14,15 @@
 
 set -e
 
-COMMIT_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_ID" | jq -r '.head.sha')
+if [ -n "${HEAD_SHA:-}" ]; then
+  COMMIT_SHA="$HEAD_SHA"
+elif [ -n "${PR_ID:-}" ]; then
+  COMMIT_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_ID" | jq -r '.head.sha')
+else
+  echo "Either HEAD_SHA or PR_ID is required."
+  exit 1
+fi
 
 echo "Commit SHA: $COMMIT_SHA"
 

--- a/.github/actions/rerun-workflow/rerun.sh
+++ b/.github/actions/rerun-workflow/rerun.sh
@@ -14,15 +14,8 @@
 
 set -e
 
-if [ -n "${HEAD_SHA:-}" ]; then
-  COMMIT_SHA="$HEAD_SHA"
-elif [ -n "${PR_ID:-}" ]; then
-  COMMIT_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-    "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_ID" | jq -r '.head.sha')
-else
-  echo "Either HEAD_SHA or PR_ID is required."
-  exit 1
-fi
+COMMIT_SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+  "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_ID" | jq -r '.head.sha')
 
 echo "Commit SHA: $COMMIT_SHA"
 

--- a/.github/workflows/approval-review-signal.yml
+++ b/.github/workflows/approval-review-signal.yml
@@ -17,3 +17,12 @@ jobs:
           echo "Review state: ${{ github.event.review.state }}"
           echo "Pull request: ${{ github.event.pull_request.number }}"
           echo "Head SHA: ${{ github.event.pull_request.head.sha }}"
+      - name: Save pull request number
+        run: |
+          mkdir -p "${RUNNER_TEMP}/approval-review-signal"
+          echo "${{ github.event.pull_request.number }}" > "${RUNNER_TEMP}/approval-review-signal/pr_number"
+      - name: Upload pull request number
+        uses: actions/upload-artifact@v4
+        with:
+          name: approval-review-signal
+          path: ${{ runner.temp }}/approval-review-signal/pr_number

--- a/.github/workflows/approval-review-signal.yml
+++ b/.github/workflows/approval-review-signal.yml
@@ -17,12 +17,3 @@ jobs:
           echo "Review state: ${{ github.event.review.state }}"
           echo "Pull request: ${{ github.event.pull_request.number }}"
           echo "Head SHA: ${{ github.event.pull_request.head.sha }}"
-      - name: Save pull request number
-        run: |
-          mkdir -p "${RUNNER_TEMP}/approval-review-signal"
-          echo "${{ github.event.pull_request.number }}" > "${RUNNER_TEMP}/approval-review-signal/pr_number"
-      - name: Upload pull request number
-        uses: actions/upload-artifact@v4
-        with:
-          name: approval-review-signal
-          path: ${{ runner.temp }}/approval-review-signal/pr_number

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -365,7 +365,7 @@ jobs:
           JOB_NAME: 'Windows-OPENBLAS / Check bypass / Check bypass'
 
   rerun-on-approval:
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_sha != '' }}
     runs-on:
       group: APPROVAL
     steps:
@@ -376,46 +376,20 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
-      - name: Download pull request number
-        uses: actions/download-artifact@v5
-        continue-on-error: true
-        with:
-          name: approval-review-signal
-          path: ${{ runner.temp }}/approval-review-signal
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Read pull request number
-        id: pr
-        run: |
-          FILE="${{ runner.temp }}/approval-review-signal/pr_number"
-          if [ ! -f "$FILE" ]; then
-            echo "No pull request number artifact found; skipping rerun."
-            echo "pr_id=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          PR_ID=$(tr -d '[:space:]' < "$FILE")
-          if ! echo "$PR_ID" | grep -Eq '^[0-9]+$'; then
-            echo "Invalid PR number: $PR_ID"
-            exit 1
-          fi
-          echo "pr_id=$PR_ID" >> "$GITHUB_OUTPUT"
 
       - name: Rerun Approval
-        if: ${{ steps.pr.outputs.pr_id != '' }}
         uses: ./.github/actions/rerun-workflow
         with:
-          PR_ID: ${{ steps.pr.outputs.pr_id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           JOB_NAME: 'Check approval'
 
       - name: Rerun Bot Approval Required
-        if: ${{ steps.pr.outputs.pr_id != '' }}
         uses: ./.github/actions/rerun-workflow
         with:
-          PR_ID: ${{ steps.pr.outputs.pr_id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -365,7 +365,7 @@ jobs:
           JOB_NAME: 'Windows-OPENBLAS / Check bypass / Check bypass'
 
   rerun-on-approval:
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_sha != '' }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
     runs-on:
       group: APPROVAL
     steps:
@@ -376,20 +376,46 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
+      - name: Download pull request number
+        uses: actions/download-artifact@v5
+        continue-on-error: true
+        with:
+          name: approval-review-signal
+          path: ${{ runner.temp }}/approval-review-signal
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Read pull request number
+        id: pr
+        run: |
+          FILE="${{ runner.temp }}/approval-review-signal/pr_number"
+          if [ ! -f "$FILE" ]; then
+            echo "No pull request number artifact found; skipping rerun."
+            echo "pr_id=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_ID=$(tr -d '[:space:]' < "$FILE")
+          if ! echo "$PR_ID" | grep -Eq '^[0-9]+$'; then
+            echo "Invalid PR number: $PR_ID"
+            exit 1
+          fi
+          echo "pr_id=$PR_ID" >> "$GITHUB_OUTPUT"
 
       - name: Rerun Approval
+        if: ${{ steps.pr.outputs.pr_id != '' }}
         uses: ./.github/actions/rerun-workflow
         with:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_ID: ${{ steps.pr.outputs.pr_id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           JOB_NAME: 'Check approval'
 
       - name: Rerun Bot Approval Required
+        if: ${{ steps.pr.outputs.pr_id != '' }}
         uses: ./.github/actions/rerun-workflow
         with:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_ID: ${{ steps.pr.outputs.pr_id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -365,7 +365,7 @@ jobs:
           JOB_NAME: 'Windows-OPENBLAS / Check bypass / Check bypass'
 
   rerun-on-approval:
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number != null }}
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_sha != '' }}
     runs-on:
       group: APPROVAL
     steps:
@@ -380,7 +380,7 @@ jobs:
       - name: Rerun Approval
         uses: ./.github/actions/rerun-workflow
         with:
-          PR_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
@@ -389,7 +389,7 @@ jobs:
       - name: Rerun Bot Approval Required
         uses: ./.github/actions/rerun-workflow
         with:
-          PR_ID: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
Use the approved PR's `head_sha` again when rerunning approval workflows.

This restores the previous working scheme: `rerun.yml` reads `github.event.workflow_run.head_sha` for the approval signal workflow and passes it into the rerun helper so the rerun targets the original commit directly.

Validation: `git diff --check`, `bash -n .github/actions/rerun-workflow/rerun.sh`, YAML parse for the changed workflows.

### 是否引起精度变化
否
