### PR TITLE
[Security] Harden CIFAR and Flowers dataset loading 

### DIFF
--- a/python/paddle/dataset/cifar.py
+++ b/python/paddle/dataset/cifar.py
@@ -27,7 +27,6 @@ images per class.
 
 """
 
-import os
 import pickle
 import tarfile
 
@@ -53,22 +52,15 @@ def reader_creator(filename, sub_name, cycle=False, md5sum=None):
         for sample, label in zip(data, labels):
             yield (sample / 255.0).astype(numpy.float32), int(label)
 
-    verified_stat = None
-
     def reader():
-        nonlocal verified_stat
-        if md5sum is not None:
-            stat = os.stat(filename)
-            current_stat = (stat.st_mtime_ns, stat.st_size)
-            if verified_stat != current_stat:
+        while True:
+            if md5sum is not None:
                 file_md5 = paddle.dataset.common.md5file(filename)
                 if file_md5 != md5sum:
                     raise ValueError(
                         "Loading unverified CIFAR pickle archive disabled. "
                         f"Please use the official MD5 {md5sum}."
                     )
-                verified_stat = current_stat
-        while True:
             with tarfile.open(filename, mode='r') as f:
                 names = (
                     each_item.name

--- a/python/paddle/vision/datasets/cifar.py
+++ b/python/paddle/vision/datasets/cifar.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import os
 import pickle
 import tarfile
-from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
@@ -53,15 +52,9 @@ MODE_FLAG_MAP = {
 }
 
 
-@lru_cache(maxsize=8)
-def _cached_md5file(path, _mtime_ns, _size):
-    return md5file(path)
-
-
 def _check_local_cifar_md5(path, expected_md5):
     path = os.path.abspath(path)
-    stat = os.stat(path)
-    file_md5 = _cached_md5file(path, stat.st_mtime_ns, stat.st_size)
+    file_md5 = md5file(path)
     if file_md5 != expected_md5:
         raise ValueError(
             "Loading unverified local CIFAR pickle archive is disabled. "

--- a/test/legacy_test/test_dataset_security.py
+++ b/test/legacy_test/test_dataset_security.py
@@ -19,6 +19,7 @@ import tempfile
 import unittest
 from unittest import mock
 
+import paddle.dataset.cifar as dataset_cifar
 import paddle.vision.datasets.cifar as vision_cifar
 from paddle.dataset.cifar import CIFAR10_MD5, CIFAR100_MD5, reader_creator
 from paddle.utils.download import _safe_extract_tar
@@ -68,12 +69,12 @@ class TestCifarSecurity(unittest.TestCase):
             ):
                 list(reader())
 
-    def _count_local_cifar_md5_calls(
+    def _count_vision_cifar_md5_calls(
         self,
         data_file,
         dataset_cls=Cifar10,
         md5sum=CIFAR10_MD5,
-        mutate=None,
+        iterations=2,
     ):
         md5_calls = []
 
@@ -81,58 +82,96 @@ class TestCifarSecurity(unittest.TestCase):
             md5_calls.append(path)
             return md5sum
 
-        vision_cifar._cached_md5file.cache_clear()
-        try:
-            with (
-                mock.patch.object(vision_cifar, 'md5file', fake_md5file),
-                mock.patch.object(
-                    dataset_cls,
-                    '_load_data',
-                    lambda dataset: setattr(dataset, 'data', []),
-                ),
-            ):
+        with (
+            mock.patch.object(vision_cifar, 'md5file', fake_md5file),
+            mock.patch.object(
+                dataset_cls,
+                '_load_data',
+                lambda dataset: setattr(dataset, 'data', []),
+            ),
+        ):
+            for _ in range(iterations):
                 dataset_cls(data_file=data_file, download=False)
-                if mutate is not None:
-                    mutate()
-                dataset_cls(data_file=data_file, download=False)
-        finally:
-            vision_cifar._cached_md5file.cache_clear()
 
         return len(md5_calls)
 
-    def test_local_archive_md5_cache_reuses_unchanged_file(self):
+    def test_local_archive_md5_rechecks_each_load(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             data_file = os.path.join(tmpdir, 'cifar-10-python.tar.gz')
             self._write_tar(data_file)
 
-            self.assertEqual(self._count_local_cifar_md5_calls(data_file), 1)
+            self.assertEqual(self._count_vision_cifar_md5_calls(data_file), 2)
 
-    def test_cifar100_local_archive_md5_cache_reuses_unchanged_file(self):
+    def test_cifar100_local_archive_md5_rechecks_each_load(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             data_file = os.path.join(tmpdir, 'cifar-100-python.tar.gz')
             self._write_tar(data_file)
 
             self.assertEqual(
-                self._count_local_cifar_md5_calls(
+                self._count_vision_cifar_md5_calls(
                     data_file,
                     dataset_cls=Cifar100,
                     md5sum=CIFAR100_MD5,
                 ),
-                1,
+                2,
             )
 
-    def test_local_archive_md5_cache_refreshes_changed_file(self):
+    def test_vision_cifar_rejects_second_load_after_content_changes(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             data_file = os.path.join(tmpdir, 'cifar-10-python.tar.gz')
             self._write_tar(data_file)
+            md5_results = [CIFAR10_MD5, 'bad-md5']
 
-            def mutate():
-                with open(data_file, 'ab') as f:
-                    f.write(b'changed')
+            def fake_md5file(path):
+                return md5_results.pop(0)
 
-            self.assertEqual(
-                self._count_local_cifar_md5_calls(data_file, mutate=mutate), 2
+            with (
+                mock.patch.object(vision_cifar, 'md5file', fake_md5file),
+                mock.patch.object(
+                    Cifar10,
+                    '_load_data',
+                    lambda dataset: setattr(dataset, 'data', []),
+                ),
+            ):
+                Cifar10(data_file=data_file, download=False)
+                with self.assertRaisesRegex(
+                    ValueError,
+                    'unverified local CIFAR pickle archive|official archive|MD5',
+                ):
+                    Cifar10(data_file=data_file, download=False)
+
+    def test_legacy_reader_rechecks_md5_on_each_invocation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = os.path.join(tmpdir, 'cifar-10-python.tar.gz')
+            self._write_tar(data_file)
+            md5_results = [CIFAR10_MD5, 'bad-md5']
+            md5_calls = []
+
+            def fake_md5file(path):
+                md5_calls.append(path)
+                return md5_results.pop(0)
+
+            reader = reader_creator(
+                data_file,
+                'data_batch',
+                md5sum=CIFAR10_MD5,
             )
+
+            with (
+                mock.patch.object(
+                    dataset_cifar.pickle,
+                    'load',
+                    lambda *args, **kwargs: {b'data': [], b'labels': []},
+                ),
+                mock.patch('paddle.dataset.common.md5file', fake_md5file),
+            ):
+                list(reader())
+                with self.assertRaisesRegex(
+                    ValueError, 'unverified CIFAR pickle archive|official MD5'
+                ):
+                    list(reader())
+
+            self.assertEqual(len(md5_calls), 2)
 
 
 class TestFlowersSafeExtractTar(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Security

### Description

#### 问题背景

`paddle.vision.datasets.Cifar10` / `Cifar100` 以及旧版 `paddle.dataset.cifar` 在读取 CIFAR 数据集时，会从 tar 归档中取出 batch 文件并通过 `pickle.load()` 反序列化。由于 pickle 格式本身不适合处理不可信输入，如果用户传入的本地 CIFAR 数据包被篡改，加载数据集时可能触发恶意代码执行。

另外，Flowers 数据集在解压 tar 归档时也需要防护非安全成员，例如路径穿越、符号链接、硬链接和特殊文件，避免恶意归档在解压阶段写出到目标目录之外或创建非预期文件。

#### 主要修改

- 对 `paddle.vision.datasets.Cifar10` / `Cifar100` 的本地 `data_file` 路径增加官方 MD5 校验。
- 当本地 CIFAR 归档文件不存在时，提前抛出明确错误。
- 当本地 CIFAR 归档文件的 MD5 与官方值不一致时，拒绝继续加载，避免进入 `pickle.load()`。
- 移除 CIFAR 本地归档 MD5 校验缓存，确保每次加载前都重新计算实际文件 MD5，避免同一进程内文件被替换后绕过校验。
- 对旧版 `paddle.dataset.cifar.reader_creator` 增加 MD5 校验，并在 `train10` / `test10` / `train100` / `test100` 中传入官方 MD5。
- 移除旧版 CIFAR reader 中基于 `mtime` 和 `size` 的校验缓存，确保每次打开 tar 前都会重新校验。
- 为 Flowers 数据集使用安全 tar 解压逻辑，拒绝或跳过路径穿越、符号链接、硬链接和特殊文件等不安全成员。
- 增加安全回归测试，覆盖未验证本地 CIFAR 归档被拒绝、缺失文件报错、旧版 reader 校验、每次加载重新校验 MD5，以及 Flowers 安全解压行为。

#### 修复效果

该修改可以阻止用户通过本地 `data_file` 加载被篡改的 CIFAR tar 包，从而降低因不安全 `pickle` 反序列化导致的任意代码执行风险。

同时，Flowers 数据集解压过程会过滤或拒绝不安全 tar 成员，降低恶意归档造成路径穿越写文件、链接文件写出或特殊文件创建的风险。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否