### PR TITLE
fix: replace bare except with specific exception types in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ def parse_input_command(input_parameters):
     )
     try:
         dist.parse_command_line()
-    except:
+    except Exception:
         print(
             f"An error occurred while parsing the parameters, {dist.script_args}"
         )
@@ -305,7 +305,7 @@ def git_commit() -> str:
             .communicate()[0]
             .strip()
         )
-    except:
+    except (OSError, subprocess.SubprocessError):
         git_commit = 'Unknown'
     git_commit = git_commit.decode('utf-8')
     return str(git_commit)
@@ -486,7 +486,7 @@ def is_tagged() -> bool:
             .strip()
         )
         git_tag = git_tag.decode()
-    except:
+    except (OSError, subprocess.SubprocessError):
         return False
     if str(git_tag).replace('v', '') == env_dict.get("PADDLE_VERSION"):
         return True
@@ -1440,9 +1440,9 @@ def build_cutlass3_src_code():
             .communicate()[0]
             .strip()
         )
-    except:
+    except (OSError, subprocess.SubprocessError) as e:
         git_commit = 'Unknown'
-        raise Exception("obtain commit id of third_party cutlass failed")
+        raise Exception(f"obtain commit id of third_party cutlass failed: {e}") from e
     commit_id = str(git_commit.decode())
     command = (
         'cd '


### PR DESCRIPTION
## Summary
This PR fixes 4 bare \except:\ clauses in \setup.py\ by replacing them with specific exception types, following Python best practices (PEP 8).

## Problem
Bare \except:\ clauses catch \BaseException\ including \SystemExit\, \KeyboardInterrupt\, and \GeneratorExit\, which can mask serious errors and make debugging difficult. This is a code quality issue that violates Python best practices.

## Changes
- **Line 112**: \except:\ → \except Exception:\ (command line parsing)
- **Line 308**: \except:\ → \except (OSError, subprocess.SubprocessError):\ (git commit retrieval)
- **Line 489**: \except:\ → \except (OSError, subprocess.SubprocessError):\ (git tag check)
- **Line 1443**: \except:\ → \except (OSError, subprocess.SubprocessError) as e:\ (cutlass build)
  - Also preserves original exception context with \rom e\

## Impact
- **Risk**: Low - Only changes exception handling, no logic changes
- **Benefits**: 
  - Prevents catching \SystemExit\ and \KeyboardInterrupt\
  - Improves error diagnosis and debugging
  - Follows Python best practices (PEP 8)
- **Compatibility**: Fully backward compatible

---

**Note**: Local environment limitations prevent full dynamic testing, relying on CI/CD automated testing for validation.