### PR TITLE
[Cherry-Pick][Operator Mechanism] Fix large tensor index overflow in transpose and softmax

### DIFF
--- a/paddle/phi/backends/gpu/gpu_utils.h
+++ b/paddle/phi/backends/gpu/gpu_utils.h
@@ -94,7 +94,7 @@ EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Dim3<IndexType> ConvertTensorIndex(
 #pragma unroll
   for (int i = 2; i >= 0; --i) {
     IndexType new_index = index / dims[i];
-    tensor_index[i] = static_cast<int>(index - dims[i] * new_index);
+    tensor_index[i] = index - dims[i] * new_index;
     index = new_index;
   }
   return tensor_index;

--- a/paddle/phi/kernels/funcs/transpose_function.cuh
+++ b/paddle/phi/kernels/funcs/transpose_function.cuh
@@ -111,8 +111,10 @@ __global__ void TilingSwapDim1And2(const T* __restrict__ input,
   // Align dim to Tiles
   Dim3<IndexType> tile_aligned_input_dim = {
       input_dims[0],
-      (input_dims[1] + TileX - 1) / TileX,
-      (input_dims[2] + TileY - 1) / TileY,
+      input_dims[1] / TileX +
+          static_cast<IndexType>(input_dims[1] % TileX != 0),
+      input_dims[2] / TileY +
+          static_cast<IndexType>(input_dims[2] % TileY != 0),
   };
 
   // Converts block idx to tile index, each block process a tile
@@ -725,7 +727,7 @@ struct TransposeSimple {
                   const std::vector<int32_t>& perm,
                   DenseTensor* out,
                   const int64_t numel) {
-    if (numel >= std::numeric_limits<int32_t>::max() / 2) {
+    if (numel >= std::numeric_limits<int32_t>::max()) {
       return RunImpl<int64_t>(dev_ctx, in, perm, out);
     } else {
       return RunImpl<int32_t>(dev_ctx, in, perm, out);

--- a/paddle/phi/kernels/funcs/transpose_function.cuh
+++ b/paddle/phi/kernels/funcs/transpose_function.cuh
@@ -1009,8 +1009,9 @@ __global__ void VectorizedPermuteKernel(PermuteParams<IndexT, Rank> params,
       reinterpret_cast<const VecT* __restrict__>(src_data);
   VecT* vec_dst = reinterpret_cast<VecT*>(dst_data);
 
-  IndexT tid = blockIdx.x * blockDim.x + threadIdx.x;
-  for (IndexT i = tid; i < count; i += blockDim.x * gridDim.x) {
+  IndexT tid = static_cast<IndexT>(blockIdx.x) * blockDim.x + threadIdx.x;
+  IndexT stride = static_cast<IndexT>(blockDim.x) * gridDim.x;
+  for (IndexT i = tid; i < count; i += stride) {
     params.dst_index_helper.OffsetToIndex(i, dst_index);
 
 #pragma unroll
@@ -1036,8 +1037,9 @@ __global__ void GeneralPermuteKernel(PermuteParams<IndexT, Rank> params,
   IndexT dst_index[VecSize][Rank];
 
   // Vectorized load data.
-  IndexT tid = blockIdx.x * blockDim.x + threadIdx.x;
-  for (IndexT idx = tid; idx < main_cnt; idx += blockDim.x * gridDim.x) {
+  IndexT tid = static_cast<IndexT>(blockIdx.x) * blockDim.x + threadIdx.x;
+  IndexT stride = static_cast<IndexT>(blockDim.x) * gridDim.x;
+  for (IndexT idx = tid; idx < main_cnt; idx += stride) {
     VecT vec_data;
     IndexT vec_idx = idx * VecSize;
 
@@ -1436,7 +1438,7 @@ inline void PermuteAndTranspose(
                                        phi::gpuMemcpyDeviceToDevice,
                                        dev_ctx.stream());
   } else {
-    if (count < std::numeric_limits<uint32_t>::max()) {
+    if (count < std::numeric_limits<uint32_t>::max() / 2) {
       PermuteDispatch<T, uint32_t>(dev_ctx,
                                    static_cast<uint32_t>(count),
                                    &classifier,

--- a/paddle/phi/kernels/funcs/transpose_function.cuh
+++ b/paddle/phi/kernels/funcs/transpose_function.cuh
@@ -506,8 +506,10 @@ void SwapDim1And2InNarrow(const GPUContext& d,
   // Here finally get proper long X short tile size.
   Dim3<IndexType> input_dims_aligned = {
       input_dims[0],
-      (input_dims[1] + select_tile_size_i - 1) / select_tile_size_i,
-      (input_dims[2] + select_tile_size_j - 1) / select_tile_size_j,
+      input_dims[1] / select_tile_size_i +
+          static_cast<IndexType>(input_dims[1] % select_tile_size_i != 0),
+      input_dims[2] / select_tile_size_j +
+          static_cast<IndexType>(input_dims[2] % select_tile_size_j != 0),
   };
 
   IndexType total_tiles_count = input_dims_aligned[0];
@@ -723,7 +725,7 @@ struct TransposeSimple {
                   const std::vector<int32_t>& perm,
                   DenseTensor* out,
                   const int64_t numel) {
-    if (numel >= std::numeric_limits<int32_t>::max()) {
+    if (numel >= std::numeric_limits<int32_t>::max() / 2) {
       return RunImpl<int64_t>(dev_ctx, in, perm, out);
     } else {
       return RunImpl<int32_t>(dev_ctx, in, perm, out);
@@ -1103,7 +1105,9 @@ struct TransposeDataWriter {
         for (int i = 0; i < ReadSize; ++i) {
           int tile_tail = tile_y * ReadSize + i;
           int major_share_idx = share_tile + tile_tail;
-          IndexT row_in_mat = (blockIdx.x * kColTile + tile_tail) * col_stride;
+          IndexT row_in_mat =
+              (static_cast<IndexT>(blockIdx.x) * kColTile + tile_tail) *
+              col_stride;
 #pragma unroll
           for (int j = 0; j < WriteSize; ++j) {
             tmp_data[i].val[j] = s_data[j * kColStride + major_share_idx];
@@ -1129,7 +1133,8 @@ struct TransposeDataWriter<T, IndexT, ReadSize, 1> {
       const int cols_range = (blockIdx.x < round_tile_cols)
                                  ? kTileSize
                                  : (cols - round_tile_cols * kTileSize);
-      const IndexT row_tile = blockIdx.x * kTileSize * ReadSize;
+      const IndexT row_tile =
+          static_cast<IndexT>(blockIdx.x) * kTileSize * ReadSize;
       const IndexT write_offset = blockIdx.z * chs_stride + col_in_mat;
       const int shared_tile = threadIdx.x * kShareCol * ReadSize;
 #pragma unroll
@@ -1161,7 +1166,8 @@ struct TransposeDataReader {
         reinterpret_cast<const VecT* __restrict__>(src);
     VecT* v_shared = reinterpret_cast<VecT*>(s_shared);
 
-    const IndexT col_in_mat = blockIdx.x * kTileSize + threadIdx.x;
+    const IndexT col_in_mat =
+        static_cast<IndexT>(blockIdx.x) * kTileSize + threadIdx.x;
     if (col_in_mat < cols_thresh) {
       const int row_range = (blockIdx.y < round_tile_rows)
                                 ? RowTile

--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -2102,6 +2102,7 @@ __global__ void SpatialSoftMaxForward(
   auto sdata = reinterpret_cast<AccT*>(shared_mem);
   const IndexType outer_stride = D * dim_size;
   const IndexType dim_stride = D;
+  const IndexType inner_stride = static_cast<IndexType>(blockDim.y) * gridDim.y;
 
   for (IndexType outer_index = blockIdx.x; outer_index < N;
        outer_index += gridDim.x) {
@@ -2110,7 +2111,7 @@ __global__ void SpatialSoftMaxForward(
                                      static_cast<IndexType>(blockDim.y) +
                                  static_cast<IndexType>(threadIdx.y);
          inner_index < D;
-         inner_index += blockDim.y * gridDim.y) {
+         inner_index += inner_stride) {
       const IndexType data_offset = outer_offset + inner_index;
       if (blockDim.x > 1) {
         AccT max_input = std::numeric_limits<AccT>::lowest();
@@ -2168,6 +2169,7 @@ __global__ void SpatialSoftMaxBackward(T* gradInput,
   auto sdata = reinterpret_cast<AccT*>(shared_mem);
   const IndexType outer_stride = D * dim_size;
   const IndexType dim_stride = D;
+  const IndexType inner_stride = static_cast<IndexType>(blockDim.y) * gridDim.y;
 
   for (IndexType outer_index = blockIdx.x; outer_index < N;
        outer_index += gridDim.x) {
@@ -2176,7 +2178,7 @@ __global__ void SpatialSoftMaxBackward(T* gradInput,
                                      static_cast<IndexType>(blockDim.y) +
                                  static_cast<IndexType>(threadIdx.y);
          inner_index < D;
-         inner_index += blockDim.y * gridDim.y) {
+         inner_index += inner_stride) {
       const IndexType data_offset = outer_offset + inner_index;
       if (blockDim.x > 1) {
         AccT sum = 0;
@@ -2762,7 +2764,7 @@ void SoftmaxForwardCUDAKernelDriverImpl(const GPUContext& dev_ctx,
         dim > std::numeric_limits<int32_t>::max() ||
         D > std::numeric_limits<int32_t>::max()) {
       int dim_log2 = static_cast<int>(Log2Ceil(dim));
-      IndexType dim_ceil = 1 << dim_log2;
+      IndexType dim_ceil = IndexType{1} << dim_log2;
       int warp_size =
           (dim_ceil < PADDLE_WARP_SIZE) ? dim_ceil : PADDLE_WARP_SIZE;
       int batches_per_warp = (dim_ceil <= PADDLE_WARP_SIZE) ? 2 : 1;
@@ -2832,7 +2834,7 @@ void SoftmaxForwardCUDAKernelDriver(const GPUContext& dev_ctx,
 #if defined(PADDLE_WITH_CUDA)
   if (FLAGS_use_accuracy_compatible_kernel) {
     if (LogMode) {
-      if (out->numel() >= std::numeric_limits<int32_t>::max()) {
+      if (out->numel() >= std::numeric_limits<int32_t>::max() / 2) {
         SoftmaxForwardCUDAKernelCompatible<T,
                                            int64_t,
                                            true,
@@ -2846,7 +2848,7 @@ void SoftmaxForwardCUDAKernelDriver(const GPUContext& dev_ctx,
             dev_ctx, x, input_axis, out);
       }
     } else {
-      if (out->numel() >= std::numeric_limits<int32_t>::max()) {
+      if (out->numel() >= std::numeric_limits<int32_t>::max() / 2) {
         SoftmaxForwardCUDAKernelCompatible<T,
                                            int64_t,
                                            false,
@@ -2861,7 +2863,7 @@ void SoftmaxForwardCUDAKernelDriver(const GPUContext& dev_ctx,
       }
     }
   } else {
-    if (x.numel() >= std::numeric_limits<int32_t>::max()) {
+    if (x.numel() >= std::numeric_limits<int32_t>::max() / 2) {
       SoftmaxForwardCUDAKernelDriverImpl<T, int64_t, LogMode>(
           dev_ctx, x, input_axis, out);
     } else {
@@ -2870,7 +2872,7 @@ void SoftmaxForwardCUDAKernelDriver(const GPUContext& dev_ctx,
     }
   }
 #else
-  if (x.numel() >= std::numeric_limits<int32_t>::max()) {
+  if (x.numel() >= std::numeric_limits<int32_t>::max() / 2) {
     SoftmaxForwardCUDAKernelDriverImpl<T, int64_t, LogMode>(
         dev_ctx, x, input_axis, out);
   } else {
@@ -2902,7 +2904,7 @@ void SoftmaxBackwardCUDAKernelDriverImpl(const GPUContext& dev_ctx,
         dim > std::numeric_limits<int32_t>::max() ||
         D > std::numeric_limits<int32_t>::max()) {
       int dim_log2 = Log2Ceil(dim);
-      IndexType dim_ceil = 1 << dim_log2;
+      IndexType dim_ceil = IndexType{1} << dim_log2;
       int warp_size =
           (dim_ceil < PADDLE_WARP_SIZE) ? dim_ceil : PADDLE_WARP_SIZE;
       int batches_per_warp = (dim_ceil <= PADDLE_WARP_SIZE * 4) ? 2 : 1;
@@ -2970,7 +2972,7 @@ void SoftmaxBackwardCUDAKernelDriver(const GPUContext& dev_ctx,
 #if defined(PADDLE_WITH_CUDA)
   if (FLAGS_use_accuracy_compatible_kernel) {
     if (LogMode) {
-      if (out.numel() >= std::numeric_limits<int32_t>::max()) {
+      if (out.numel() >= std::numeric_limits<int32_t>::max() / 2) {
         SoftmaxBackwardCUDAKernelCompatible<T,
                                             int64_t,
                                             true,
@@ -2988,7 +2990,7 @@ void SoftmaxBackwardCUDAKernelDriver(const GPUContext& dev_ctx,
       tmp.Resize(dout.dims());
       dev_ctx.Alloc<T>(&tmp);
       phi::MultiplyKernel<T>(dev_ctx, dout, out, &tmp);
-      if (out.numel() >= std::numeric_limits<int32_t>::max()) {
+      if (out.numel() >= std::numeric_limits<int32_t>::max() / 2) {
         SoftmaxBackwardCUDAKernelCompatible<T,
                                             int64_t,
                                             false,
@@ -3003,7 +3005,7 @@ void SoftmaxBackwardCUDAKernelDriver(const GPUContext& dev_ctx,
       }
     }
   } else {
-    if (out.numel() >= std::numeric_limits<int32_t>::max()) {
+    if (out.numel() >= std::numeric_limits<int32_t>::max() / 2) {
       SoftmaxBackwardCUDAKernelDriverImpl<T, int64_t, LogMode>(
           dev_ctx, out, dout, input_axis, dx);
     } else {
@@ -3012,7 +3014,7 @@ void SoftmaxBackwardCUDAKernelDriver(const GPUContext& dev_ctx,
     }
   }
 #else
-  if (out.numel() >= std::numeric_limits<int32_t>::max()) {
+  if (out.numel() >= std::numeric_limits<int32_t>::max() / 2) {
     SoftmaxBackwardCUDAKernelDriverImpl<T, int64_t, LogMode>(
         dev_ctx, out, dout, input_axis, dx);
   } else {

--- a/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
+++ b/paddle/phi/kernels/gpudnn/softmax_gpudnn.h
@@ -1621,7 +1621,7 @@ __device__ __forceinline__ void WriteResultsVectorized(
   using LoadT = AlignedVector<T, VecSize>;
   using StoreT = AlignedVector<T, VecSize>;
 
-  int offset = threadIdx.x;
+  IndexType offset = threadIdx.x;
 
   // If the data is unaligned, each thread processes a single value and
   // proceeds, ensuring that subsequent reads and writes become aligned.
@@ -1751,7 +1751,7 @@ template <int VecSize,
           template <typename, typename, typename>
           class Function,
           typename IndexType>
-__device__ __forceinline__ void WriteResults(int classes,
+__device__ __forceinline__ void WriteResults(IndexType classes,
                                              T* gradInput,
                                              const T* output,
                                              const T* gradOut,
@@ -2550,7 +2550,9 @@ void dispatch_host_softmax_forward(const GPUContext& dev_ctx,
       (!(reinterpret_cast<uintptr_t>(out_data) % SOFTMAX_ALIGN_BYTES));
   can_use_smem &= !(dim_size % VecSize);
 
-  int32_t potential_reg_cnt = (dim_size + block.x - 1) / block.x;
+  int64_t potential_reg_cnt =
+      static_cast<int64_t>(dim_size) / block.x +
+      static_cast<int64_t>(static_cast<int64_t>(dim_size) % block.x != 0);
   if (potential_reg_cnt < 10) {
     switch (potential_reg_cnt) {
 #define LAUNCH_SOFTMAX_FORWARD_REG(kRegCnt)                       \


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

、## 问题概述

在检查的两份文件中，共确认两类问题：

- transpose 中一处 tile ceil-div 加法溢出和一处 uint32 grid-stride loop 回绕；
- softmax 中八个 dispatch 入口下游存在 int32 grid-stride loop 回绕风险。

相关修复已提交 PR。

## 范围

- `paddle/phi/kernels/funcs/transpose_function.cuh:726-728`
- `paddle/phi/kernels/funcs/transpose_function.cuh:1439-1447`
- `paddle/phi/kernels/gpudnn/softmax_gpudnn.h:2874-2885`
- `paddle/phi/kernels/gpudnn/softmax_gpudnn.h:2888-2899`
- `paddle/phi/kernels/gpudnn/softmax_gpudnn.h:2903-2908`
- `paddle/phi/kernels/gpudnn/softmax_gpudnn.h:2912-2917`
- `paddle/phi/kernels/gpudnn/softmax_gpudnn.h:3012-3023`
- `paddle/phi/kernels/gpudnn/softmax_gpudnn.h:3030-3041`
- `paddle/phi/kernels/gpudnn/softmax_gpudnn.h:3045-3050`
- `paddle/phi/kernels/gpudnn/softmax_gpudnn.h:3054-3059`

## 结论

### 1. `transpose_function.cuh`：tile ceil-div 加法溢出（line 726-728）

- tile 数原来使用 `(dim + tile - 1) / tile` 计算；
- 当 `IndexType=int32_t` 且 `dim` 接近 `INT32_MAX` 时，`dim + tile - 1` 会在除法前溢出；
- 已修改为 `dim / tile + (dim % tile != 0)`，避免中间加法溢出。

### 2. `transpose_function.cuh`：uint32 grid-stride loop 回绕（line 1439-1447）

- `VectorizedPermuteKernel` 和 `GeneralPermuteKernel` 使用 `i += blockDim.x * gridDim.x`；
- `IndexT=uint32_t` 时，`stride` 乘法或后续加法可能发生 `uint32` 回绕，使循环重新进入并访问错误索引；
- 已收紧 `uint32` dispatch 范围，并确保 `tid` 和 `stride` 按 `IndexT` 计算。

### 3. `softmax_gpudnn.h`：八个 dispatch 入口存在 int32 grid-stride loop 风险

分别覆盖：

- compatible log-softmax forward；
- compatible softmax forward；
- CUDA 普通 softmax/log-softmax forward；
- HIP 普通 softmax/log-softmax forward；
- compatible log-softmax backward；
- compatible softmax backward；
- CUDA 普通 softmax/log-softmax backward；
- HIP 普通 softmax/log-softmax backward。

具体问题如下：

- 这些入口原来仅根据 `numel < INT32_MAX` 选择 `IndexType=int32_t`；
- 下游循环中的 `offset += blockDim.x`、`low_id += blockDim.x * gridDim.x` 等更新可能在最后一次迭代后超过 `INT32_MAX`，回绕为负数；
- 回绕后的负索引仍满足循环条件判断，随后可能产生负偏移访问；
- 八处 dispatch 均已将 `int32` 路径阈值收紧为 `INT32_MAX / 2`，使可能发生索引回绕的大 Tensor 提前切换到 `int64` 索引。

devPR:https://github.com/PaddlePaddle/Paddle/pull/79582
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否