### PR TITLE
[Build] Fix missing dependencies for fused CUDA tests

### DIFF
--- a/test/cpp/fluid/fused/CMakeLists.txt
+++ b/test/cpp/fluid/fused/CMakeLists.txt
@@ -7,11 +7,25 @@ if(WITH_GPU OR WITH_ROCM)
     nv_test(
       test_fused_residual_dropout_bias
       SRCS fused_residual_dropout_bias_test.cu
-      DEPS tensor op_registry dropout_op generated_op phi common)
+      DEPS tensor
+           op_registry
+           dropout_op
+           generated_op
+           phi
+           common
+           conditional_block_op
+           executor)
     nv_test(
       test_fused_dropout_act_bias
       SRCS fused_dropout_act_bias_test.cu
-      DEPS tensor op_registry dropout_op generated_op phi common)
+      DEPS tensor
+           op_registry
+           dropout_op
+           generated_op
+           phi
+           common
+           conditional_block_op
+           executor)
     nv_test(
       test_fused_layernorm_residual_dropout_bias
       SRCS fused_layernorm_residual_dropout_bias_test.cu
@@ -21,11 +35,19 @@ if(WITH_GPU OR WITH_ROCM)
            generated_op
            phi
            common
+           conditional_block_op
+           executor
            ${CINN_DEPS})
     nv_test(
       test_cudnn_norm_conv
       SRCS cudnn_norm_conv_test.cc
-      DEPS generated_op tensor op_registry phi common)
+      DEPS generated_op
+           tensor
+           op_registry
+           phi
+           common
+           conditional_block_op
+           executor)
     paddle_test(test_cudnn_bn_add_relu SRCS cudnn_bn_add_relu_test.cc)
   endif()
 endif()


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Bug fixes

### Description
Coverage builds exposed an undefined reference to `ExecutorPrepareContext::~ExecutorPrepareContext()` while linking four fused CUDA tests. These tests use generated operators whose static dependency chain reaches `conditional_block_op` and `executor`, but the targets did not declare those dependencies directly. With `-O0`, archive ordering made the missing dependencies visible.

This PR adds `conditional_block_op` and `executor` only to the `DEPS` of:

- `test_fused_residual_dropout_bias`
- `test_fused_dropout_act_bias`
- `test_fused_layernorm_residual_dropout_bias`
- `test_cudnn_norm_conv`

The earlier global `nv_test` link-group expansion has been removed. The final change does not modify `cmake/generic.cmake`, Paddle runtime behavior, public APIs, unrelated CUDA tests, or other platform link rules.

Validation:

- All four affected CUDA test targets link successfully.
- All four corresponding CTests pass.
- Link command inspection confirms `conditional_block_op` and `executor` are explicit dependencies of the fused targets and are not added to unrelated `cudnn_desc_test`.
- Official Coverage builds pass on the rebased head commit `8e0cf8738f`.
- `uvx prek run --all-files` passes.
- `git diff --check` passes.
- Tests were not disabled and build parallelism was not reduced.

### 是否引起精度变化
否