### PR TITLE
fix: replace bare except with specific exception type in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ def parse_input_command(input_parameters):
     )
     try:
         dist.parse_command_line()
-    except:
+    except Exception:
         print(
             f"An error occurred while parsing the parameters, {dist.script_args}"
         )


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with specific exception type in setup.py to improve code quality and follow Python best practices.

## Changes

- `setup.py`: `except:` → `except Exception:` (command line parsing)

## Impact

- Improves exception handling specificity
- Prevents catching unintended exceptions (SystemExit, KeyboardInterrupt)
- Follows Python best practices for exception handling
- No functional changes, only error handling improvements

## Testing

- Local environment limitations - relying on CI/CD automated testing
- All changes are exception handling improvements with no logic changes