### PR TITLE
[Cherry-Pick][Operator Mechanism] Fix CUDA illegal memory access in mixed precision add grad

### DIFF
--- a/paddle/phi/kernels/gpu/elementwise_grad.h
+++ b/paddle/phi/kernels/gpu/elementwise_grad.h
@@ -211,6 +211,24 @@ void DefaultMixedPrecisionAddGrad(const GPUContext &dev_ctx,
   using T_dout = float;
   using T_dx = float;
 
+  if (dout.numel() == 0) {
+    if (dx) {
+      if (dx->numel() == 0) {
+        dev_ctx.template Alloc<T_dx>(dx);
+      } else {
+        Full<T_dx, GPUContext>(dev_ctx, dx->dims(), 0, dx);
+      }
+    }
+    if (dy) {
+      if (dy->numel() == 0) {
+        dev_ctx.template Alloc<T_dy>(dy);
+      } else {
+        Full<T_dy, GPUContext>(dev_ctx, dy->dims(), 0, dy);
+      }
+    }
+    return;
+  }
+
   auto *dout_data = dout.data<T_dout>();
 
   // dx
@@ -240,7 +258,7 @@ void DefaultMixedPrecisionAddGrad(const GPUContext &dev_ctx,
       CastKernel<T_dout>(dev_ctx, dout, dy->dtype(), dy);
     } else {
       DenseTensor dy_fp32;
-      dy_fp32.Resize(dout.dims());
+      dy_fp32.Resize(dy->dims());
       dev_ctx.template Alloc<float>(&dy_fp32);
       std::vector<int> reduce_dims =
           funcs::GetReduceDim(y.dims(), dout.dims(), axis);

--- a/test/legacy_test/test_add_op.py
+++ b/test/legacy_test/test_add_op.py
@@ -46,6 +46,36 @@ class TestPaddleAddZeroSize(unittest.TestCase):
                 self.assertEqual(x.grad.dtype, x_dtype)
                 self.assertEqual(y.grad.dtype, y_dtype)
 
+    def test_0size_broadcast_mixed_precision_backward(self):
+        mixed_precision_dtypes = [
+            y_dtype
+            for x_dtype, y_dtype in self.dtype_pairs
+            if x_dtype != y_dtype
+        ]
+        shape_pairs = [([0, 3], [3]), ([3], [1, 0, 3])]
+
+        for y_dtype in mixed_precision_dtypes:
+            for x_shape, y_shape in shape_pairs:
+                with self.subTest(msg=f"float32{x_shape} + {y_dtype}{y_shape}"):
+                    x = paddle.randn(x_shape, dtype=paddle.float32)
+                    y = paddle.randn(y_shape, dtype=y_dtype)
+                    x.stop_gradient = False
+                    y.stop_gradient = False
+
+                    out = paddle.add(x, y)
+                    out.backward()
+
+                    self.assertEqual(x.grad.shape, x_shape)
+                    self.assertEqual(y.grad.shape, y_shape)
+                    self.assertEqual(x.grad.dtype, paddle.float32)
+                    self.assertEqual(y.grad.dtype, y_dtype)
+                    for grad in (x.grad, y.grad):
+                        if grad.numel() > 0:
+                            np.testing.assert_array_equal(
+                                paddle.cast(grad, paddle.float32).numpy(),
+                                np.zeros(grad.shape, dtype=np.float32),
+                            )
+
 
 class TestPaddleAddBackward(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
devPR:https://github.com/PaddlePaddle/Paddle/pull/79575

修复 GPU 下 `paddle.add` / `paddle.Tensor.__add__` 在 mixed precision broadcast backward 场景中遇到 zero-size `dout` 时可能触发 CUDA illegal memory access 的问题。

复现代码：

```python
import paddle

paddle.set_device("gpu")

x = paddle.zeros([1, 0, 24], dtype="float32")
y = paddle.zeros([24], dtype="bfloat16")
x.stop_gradient = False
y.stop_gradient = False

out = x + y
out.backward()
```

该问题出现在 GPU `add_grad` 的 mixed precision 特化路径中。当输入为 `float32 + float16/bfloat16`，且 broadcast 后的 `dout.numel() == 0` 时，`DefaultMixedPrecisionAddGrad` 仍会继续进入 reduce/cast 逻辑。对于需要生成非空 `dy` 梯度的 broadcast 场景，这条路径将会访问异常并触发 CUDA 700。

本 PR 的修复内容：

1. 在 `DefaultMixedPrecisionAddGrad` 中增加 `dout.numel() == 0` 的提前返回逻辑：
   - 对 zero-size grad 仅分配输出；
   - 对非 zero-size broadcast grad 填充 0；
   - 避免继续进入 GPU reduce/cast kernel。

2. 修正 mixed precision broadcast `dy` 梯度中间 Tensor 的 shape：
   - `dy_fp32` 用于承载 reduce 后、cast 前的 `dy` 梯度；
   - 其 shape 应与 `dy->dims()` 一致，而不是 `dout.dims()`。

3. 新增 zero-size broadcast mixed precision backward 回归测试：
   - 覆盖 `float32 + float16` 和 `float32 + bfloat16`；
   - 覆盖 `[0, 3] + [3]` 与 `[3] + [1, 0, 3]` 两类 broadcast 方向；
   - 校验梯度 shape 和 dtype，非空梯度应为 0。

静态排查其他路径后，未发现问题：

- XPU `MixedPrecisionAddGradKernel` 已有等价 zero-size 保护，不需要修改。
- OneDNN elementwise grad 已有 `dout.numel() == 0` 保护，不需要修改。
- CPU add grad 走通用实现，未发现类似 GPU mixed precision 特化路径。
- GPU subtract/multiply/divide 未发现类似 mixed precision add 特化路径。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
