### PR TITLE
[Cherry-Pick][Operator Mechanism] Guard layer_norm against int32 overflow

### DIFF
--- a/paddle/phi/kernels/gpu/layer_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_grad_kernel.cu
@@ -43,6 +43,7 @@ static inline LayerNormGadKernelVariant LayerNormGradKernelDispatch(
 #if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
   if (FLAGS_use_apex_layer_norm_kernel) {
     if (hidden_size <= std::numeric_limits<uint32_t>::max() &&
+        x_numel <= std::numeric_limits<uint32_t>::max() &&
         funcs::fast_ln_v2::has_fast_ln_v2_bwd_kernel(
             weight_type,
             input_type,

--- a/paddle/phi/kernels/gpu/layer_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/layer_norm_kernel.cu
@@ -446,7 +446,8 @@ void LaunchLayerNormKernel(const Context& dev_ctx,
   IMPL_LAYER_NORM_WELFORD_CASE(index_t, scale_t, is_same_, 2); \
   IMPL_LAYER_NORM_WELFORD_CASE(index_t, scale_t, is_same_, 1);
 
-  if (rows < std::numeric_limits<int32_t>::max()) {
+  const int64_t max_int32 = std::numeric_limits<int32_t>::max();
+  if (rows <= max_int32 / cols) {
     if (is_same_type) {
       switch (vec_size) { IMPL_LAYER_NORM_WELFORD(int32_t, T, true); }
     } else {
@@ -516,6 +517,7 @@ static inline LayerNormKernelVariant LayerNormKernelDispatch(
 #if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
   if (FLAGS_use_apex_layer_norm_kernel) {
     if (hidden_size <= std::numeric_limits<uint32_t>::max() &&
+        x_numel <= std::numeric_limits<uint32_t>::max() &&
         funcs::fast_ln_v2::has_fast_ln_v2_fwd_kernel(
             weight_type,
             input_type,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
devPR:https://github.com/PaddlePaddle/Paddle/pull/79584

本 PR 修复 layer_norm GPU kernel 在大 tensor 场景下部分 fast path 可能进入 int32 索引实现的问题。

当前 layer_norm 的 fast-v2 路径已存在部分 int32 约束，如 `x_numel <= UINT32_MAX`；但对于 forced apex fast-v2 分支仅检查 `hidden_size <= UINT32_MAX`，可能在 `FLAGS_use_apex_layer_norm_kernel` 开启时总元素数 `x_numel` 超过 int32 ，从而将超大 tensor 送入不支持超过 uint32 索引的 kernel。

此外，在 `FLAGS_use_fast_math` fallback 中仅检查里 `rows < INT32_MAX`，但实际 kernel 为 row-major 形式，需要进一步检查 `rows * cols` 是否超过 int32。

主要改动：
- `paddle/phi/kernels/gpu/layer_norm_kernel.cu`：为 layer_norm 前向 forced apex fast-v2 分支补充 `x_numel <= UINT32_MAX` 约束检查。
- `paddle/phi/kernels/gpu/layer_norm_grad_kernel.cu`：为 layer_norm 反向 forced apex fast-v2 分支补充 `x_numel <= UINT32_MAX` 约束检查。
- `paddle/phi/kernels/gpu/layer_norm_kernel.cu`：将 fast-math fallback 的条件从只判断 `rows < INT32_MAX` 改为判断 `rows * cols <= INT32_MAX`，超过时则进入 `int64_t` 路径。

该修复避免大 tensor 在 fast-v2 或 fast-math 路径中发生内部索引溢出，未改变小 tensor 进入 fast path 的行为。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否
