### PR TITLE
[release/3.4][Compat] Add `CallableProxyModule` to support proxyed `torch.device` as type hints

### DIFF
--- a/python/paddle/compat/proxy.py
+++ b/python/paddle/compat/proxy.py
@@ -102,6 +102,29 @@ class ProxyModule(types.ModuleType):
         return getattr(self._original_module, name)
 
 
+class CallableProxyModule(ProxyModule):
+    """
+    Preserve callability for modules whose type defines ``__call__``.
+
+    ``callable(obj)`` does not consult ``obj.__getattr__("__call__")``. It checks the
+    type-level call slot instead, so callable modules need a dedicated proxy subtype.
+    """
+
+    def __call__(self, *args, **kwargs):
+        return self._original_module(*args, **kwargs)
+
+
+def _create_proxy_module(
+    original_module: types.ModuleType,
+    proxy_name: str,
+    overrides: dict[str, OverriddenAttribute],
+) -> ProxyModule:
+    """Wrap callable modules with a callable proxy and plain modules with ProxyModule."""
+    if callable(original_module):
+        return CallableProxyModule(original_module, proxy_name, overrides)
+    return ProxyModule(original_module, proxy_name, overrides)
+
+
 GLOBAL_OVERRIDES: dict[str, OverriddenAttribute] = {
     "torch.relu": LazyImportOverriddenAttribute("paddle.nn.functional.relu"),
 }
@@ -339,7 +362,9 @@ class TorchProxyMetaFinder:
 
             def create_module(self, spec):
                 # Create a new module object that will act as the "torch..." module.
-                mod = ProxyModule(self._source, self._target_name, overrides)
+                mod = _create_proxy_module(
+                    self._source, self._target_name, overrides
+                )
                 # Preserve file/path information for tooling/debugging.
                 mod.__file__ = getattr(self._source, "__file__", None)
                 if is_pkg:
@@ -359,7 +384,7 @@ class TorchProxyMetaFinder:
                     if k in overrides:
                         continue
                     if isinstance(v, types.ModuleType):
-                        v = ProxyModule(
+                        v = _create_proxy_module(
                             v,
                             f"{self._target_name}.{k}",
                             {

--- a/test/compat/test_torch_proxy.py
+++ b/test/compat/test_torch_proxy.py
@@ -175,5 +175,25 @@ class TestFakeInterface(unittest.TestCase):
         self.assertTrue(hasattr(fake_gen, "manual_seed"))
 
 
+class TestDeviceAsTypeHints(unittest.TestCase):
+    @paddle.compat.use_torch_proxy_guard()
+    def test_device_as_type_hints(self):
+        from typing import Optional
+
+        import torch
+
+        def fn(x: Optional[torch.device]):  # noqa: FA100
+            return x
+
+        self.assertTrue(callable(torch.device))
+        self.assertEqual(fn.__annotations__["x"], Optional[torch.device])
+        cpu_device = torch.device("cpu")
+        self.assertEqual(str(cpu_device), "cpu")
+        self.assertEqual(
+            torch.device.is_compiled_with_xpu(),
+            paddle.device.is_compiled_with_xpu(),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Devs

### Description
<!-- Describe what you’ve done -->

添加 `CallableProxyModule`，用于支持原本为 callable 的 module，比如 `paddle.device` 原本是 `DeviceModule` 用于同时支持 `paddle.device(...)` 和 `paddle.device.xxx` 的用法，在这种情况下，`paddle.device` 本身因为是 `callable`，意外地是可以作为 `Optional[T]`、`Union[T, U]` 中的 `T` 的，因为 python 这里会检查 `T` 是类型或者是 `callable`

虽然我们的 `ProxyModule` 会使用 `__getattr__` 将原始对象的 `__call__` 代理出来，但是实际上 `callable` 不看对象是否有 `__call__`，而不是看对象本身，这就导致简单地 proxy `__call__` 是行不通的了，因此这里为 `callable` 对象单独分法一个 `ProxyModule` 以确保这种场景仍能不经修改的情况下生效

<sup>This PR is co-authored with @codex (gpt-5.4)</sup>

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否

---

Cherry-pick of #78735 (authored by @SigureMo) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/78735 <!-- For pass CI -->