### PR TITLE
[release/3.4][Cpp API Compatibility] Support dtype caster and CUDA opt-in shared memory

### DIFF
--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -164,6 +164,7 @@ PyObject* ToPyObject(const phi::distributed::TensorDistAttr* value);
 PyObject* ToPyObject(const phi::distributed::ProcessMesh* value);
 PyObject* ToPyObject(const phi::distributed::Placements& value);
 PyObject* ToPyObject(const phi::SelectedRows* value);
+PADDLE_API PyObject* ToPyObject(const DataType& dtype);
 PyObject* ToPyObject(const paddle::framework::proto::VarType::Type& dtype);
 PyObject* ToPyObject(const paddle::framework::proto::VarType& type);
 PyObject* ToPyObject(const std::vector<DataType>& dtypes);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3722,6 +3722,11 @@ All parameter, weight, gradient are variables in Paddle.
       .def_property_readonly(
           "multi_processor_count",
           [](const gpuDeviceProp &prop) { return prop.multiProcessorCount; })
+#if defined(PADDLE_WITH_CUDA)
+      .def_property_readonly(
+          "shared_memory_per_block_optin",
+          [](const gpuDeviceProp &prop) { return prop.sharedMemPerBlockOptin; })
+#endif
       .def_property_readonly(
           "is_multi_gpu_board",
           [](const gpuDeviceProp &prop) { return prop.isMultiGpuBoard; })

--- a/paddle/phi/api/include/compat/torch/csrc/api/include/torch/python.h
+++ b/paddle/phi/api/include/compat/torch/csrc/api/include/torch/python.h
@@ -17,12 +17,14 @@
 // https://github.com/pytorch/pytorch/blob/main/LICENSE
 
 #pragma once
+
 #include <ATen/Device.h>
 #include <ATen/ops/arange.h>
 #include <ATen/ops/empty_strided.h>
 #include <c10/util/Exception.h>
 #include <torch/types.h>
 #include <utils/scalar_type_conversion.h>
+#include <utility>
 
 #if !defined(PADDLE_ON_INFERENCE) && !defined(PADDLE_NO_PYTHON)
 // Python bindings for the C++ frontend (includes Python.h)
@@ -48,3 +50,39 @@ inline PyObject* getTHPDtype(c10::ScalarType dtype) {
 namespace torch {
 using torch::python::detail::getTHPDtype;
 }  // namespace torch
+
+namespace pybind11::detail {
+
+template <>
+struct type_caster<c10::ScalarType> {
+ public:
+  PYBIND11_TYPE_CASTER(c10::ScalarType, _("torch.dtype"));
+
+  type_caster() : value(c10::ScalarType::Float) {}
+
+  bool load(handle src, bool convert) {
+    make_caster<phi::DataType> dtype_caster;
+    if (!dtype_caster.load(src, convert)) {
+      return false;
+    }
+
+    const auto dtype = cast_op<phi::DataType&&>(std::move(dtype_caster));
+    switch (dtype) {
+#define PD_DTYPE_TO_SCALAR_TYPE_CASE_(_cpp_type, _pd_dtype, _scalar_type) \
+  case phi::DataType::_pd_dtype:                                          \
+    value = c10::ScalarType::_scalar_type;                                \
+    return true;
+      FOREACH_PADDLE_AND_TORCH_DTYPES(PD_DTYPE_TO_SCALAR_TYPE_CASE_)
+#undef PD_DTYPE_TO_SCALAR_TYPE_CASE_
+      default:
+        return false;
+    }
+  }
+
+  static handle cast(const c10::ScalarType& src, return_value_policy, handle) {
+    return handle(paddle::pybind::ToPyObject(
+        compat::_PD_AtenScalarTypeToPhiDataType(src)));
+  }
+};
+
+}  // namespace pybind11::detail

--- a/paddle/utils/pybind.h
+++ b/paddle/utils/pybind.h
@@ -58,7 +58,7 @@ PyObject* ToPyObject(const paddle::Tensor& value,
 // Internal use only, switch tensor_operants_mode to phi
 void EnableTensorOperantsToPhiMode();
 
-PyObject* ToPyObject(const phi::DataType& dtype);
+PADDLE_API PyObject* ToPyObject(const phi::DataType& dtype);
 
 }  // namespace pybind
 }  // namespace paddle

--- a/test/compat/test_device_apis.py
+++ b/test/compat/test_device_apis.py
@@ -141,6 +141,15 @@ class TestDeviceAPIs(unittest.TestCase):
         props_int = paddle.device.get_device_properties(paddle.CUDAPlace(0))
         self.assertIsNotNone(props_int)
 
+    def test_get_device_properties_cuda_optin_shared_memory(self):
+        if not core.is_compiled_with_cuda():
+            self.skipTest("CUDA not available")
+        if core.is_compiled_with_rocm():
+            self.skipTest("ROCm does not support CUDA opt-in shared memory")
+        props = paddle.device.get_device_properties()
+        self.assertIsInstance(props.shared_memory_per_block_optin, int)
+        self.assertGreater(props.shared_memory_per_block_optin, 0)
+
     def test_get_device_properties_customdevice(self):
         """Test get_device_properties with custom device."""
         if not is_custom_device():

--- a/test/cpp_extension/custom_extension.cc
+++ b/test/cpp_extension/custom_extension.cc
@@ -17,6 +17,7 @@
 
 #include "custom_power.h"  // NOLINT
 #include "paddle/extension.h"
+#include "torch/extension.h"
 
 paddle::Tensor custom_sub(paddle::Tensor x, paddle::Tensor y);
 
@@ -60,6 +61,12 @@ paddle::optional<paddle::Tensor> optional_tensor(bool return_option = false) {
   return t;
 }
 
+int64_t scalar_type_value(c10::ScalarType dtype) {
+  return static_cast<int64_t>(dtype);
+}
+
+c10::ScalarType scalar_type_round_trip(c10::ScalarType dtype) { return dtype; }
+
 PYBIND11_MODULE(PADDLE_EXTENSION_NAME, m) {
   m.def("custom_add", &custom_add, "exp(x) + exp(y)");
   m.def("custom_optional_add", &custom_optional_add, "exp(x) + optional(y)");
@@ -69,6 +76,8 @@ PYBIND11_MODULE(PADDLE_EXTENSION_NAME, m) {
   m.def(
       "optional_tensor", &optional_tensor, "returned Tensor might be optional");
   m.def("relu_cuda_forward", &relu_cuda_forward, "relu(x)");
+  m.def("scalar_type_value", &scalar_type_value);
+  m.def("scalar_type_round_trip", &scalar_type_round_trip);
 
   py::class_<Power>(m, "Power")
       .def(py::init<int, int>())

--- a/test/cpp_extension/test_cpp_extension_setup.py
+++ b/test/cpp_extension/test_cpp_extension_setup.py
@@ -66,6 +66,7 @@ class TestCppExtensionSetupInstall(unittest.TestCase):
         self._test_extension_class()
         self._test_nullable_tensor()
         self._test_optional_tensor()
+        self._test_scalar_type_caster()
 
     def _test_extension_function_plain(self):
         import custom_cpp_extension
@@ -151,6 +152,36 @@ class TestCppExtensionSetupInstall(unittest.TestCase):
             x_np,
             err_msg=f'extension out: {x},\n numpy out: {x_np}',
         )
+
+    def _test_scalar_type_caster(self):
+        import custom_cpp_extension
+
+        expected_values = {
+            paddle.uint8: 0,
+            paddle.int8: 1,
+            paddle.int16: 2,
+            paddle.int32: 3,
+            paddle.int64: 4,
+            paddle.float16: 5,
+            paddle.float32: 6,
+            paddle.float64: 7,
+            paddle.complex64: 9,
+            paddle.complex128: 10,
+            paddle.bool: 11,
+            paddle.bfloat16: 15,
+            paddle.float8_e5m2: 23,
+            paddle.float8_e4m3fn: 24,
+            paddle.uint16: 27,
+            paddle.uint32: 28,
+        }
+        for dtype, expected_value in expected_values.items():
+            self.assertIs(
+                custom_cpp_extension.scalar_type_round_trip(dtype), dtype
+            )
+            self.assertEqual(
+                custom_cpp_extension.scalar_type_value(dtype),
+                expected_value,
+            )
 
     def _test_cuda_relu(self):
         import custom_cpp_extension


### PR DESCRIPTION
### PR Category

Execute Infrastructure

### PR Types

Bug fixes

### Description

Torch 兼容自定义算子可能会在 pybind11 接口中使用 `c10::ScalarType`，并在选择 CUDA kernel 启动配置时读取 `torch.cuda.get_device_properties(...).shared_memory_per_block_optin`。Paddle compat 此前缺少这两项桥接能力，导致下游项目必须各自维护 dtype caster 和 CUDA Driver API fallback。

本 PR 将兼容逻辑收敛到 Paddle 框架边界：

- 新增 pybind11 `type_caster<c10::ScalarType>`：Python 对象加载复用 Paddle 现有的 `phi::DataType` caster，dtype 映射复用 Paddle/Torch 公共映射表，返回值通过现有 Paddle pybind 工具转换。
- 在 `_gpuDeviceProperties` 上将 CUDA `gpuDeviceProp::sharedMemPerBlockOptin` 暴露为 `shared_memory_per_block_optin`。该 binding 由 `PADDLE_WITH_CUDA` 保护，不改变 HIP、XPU 或 Custom Device 的属性接口。
- 增加最小 C++ extension 回归测试，覆盖 compat 映射中的 16 个 dtype 的参数加载和返回值转换。
- 扩展 CUDA device-properties 单测，校验 opt-in shared-memory 字段为正整数。

完成后，Torch-facing 自定义算子可以保持原有 dtype 签名和设备属性访问方式，不再需要项目内的 Paddle 专用 workaround。

验证：

- `prek run --files <changed files>`：全部通过，包括 ast-grep、copyright、typos、ruff、clang-format 和 cpplint。
- 使用 develop compat 头文件，基于修改后的 Paddle build-tree runtime 构建并加载聚焦 C++ extension：compat 映射中的 16 种 dtype 参数/返回值往返全部通过。
- `TestDeviceAPIs.test_get_device_properties_cuda`：通过；测试机器 NVIDIA B30Z 返回 `shared_memory_per_block_optin=232448`。
- 在 release/3.4 上，修改后的 Paddle `libpaddle.so` target 以及删除本地 dtype caster、CUDA Driver fallback 后的 MoonEP extension 均重新构建成功；真实 VMM allocation 可接受上述 12 种 dtype。
- 隔离 release/3.4 其他无关的 distributed/Stream 兼容缺口后，MoonEP 双卡 planning/dispatch/combine 代表用例 3/3 通过，grad-reduce 12/12 通过。
- `git diff --check`：通过。

### 是否引起精度变化

否

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.6 sol xhigh)</sup>
</div>


---

Cherry-pick of #79570 (authored by @SigureMo) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79570 <!-- For pass CI -->