### PR TITLE
[Operator Mechanism] Fix IndexType overflow of big tensor in elementwise grad kernel

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise_grad_base.h
+++ b/paddle/phi/kernels/funcs/elementwise_grad_base.h
@@ -650,8 +650,9 @@ static __global__ void FastCommonGradBroadcastCUDAKernelHeight(const T *x,
   __shared__ T sdata[BLOCK_Y][BLOCK_X + 1];
 
   T val(0);
-  IndexType width_stride = GRID_NUM_X * BLOCK_NUM_X;
-  IndexType idx = THREAD_ID_X + BLOCK_NUM_X * BLOCK_ID_X;
+  IndexType width_stride = static_cast<IndexType>(GRID_NUM_X) * BLOCK_NUM_X;
+  IndexType idx =
+      THREAD_ID_X + static_cast<IndexType>(BLOCK_NUM_X) * BLOCK_ID_X;
   IndexType full_width =
       (w & (~((uint64_t)(BLOCK_X - 1)))) + ((w & (BLOCK_X - 1)) ? BLOCK_X : 0);
   IndexType full_height =
@@ -862,8 +863,9 @@ static __global__ void FastElemwiseGradBroadcast1CUDAKernel(
   __shared__ T sdata[BLOCK_Y][BLOCK_X + 1];
 
   T val(0);
-  IndexType width_stride = GRID_NUM_X * BLOCK_NUM_X;
-  IndexType idx = THREAD_ID_X + BLOCK_NUM_X * BLOCK_ID_X;
+  IndexType width_stride = static_cast<IndexType>(GRID_NUM_X) * BLOCK_NUM_X;
+  IndexType idx =
+      THREAD_ID_X + static_cast<IndexType>(BLOCK_NUM_X) * BLOCK_ID_X;
   IndexType full_width =
       (w & (~((uint64_t)(BLOCK_X - 1)))) + ((w & (BLOCK_X - 1)) ? BLOCK_X : 0);
   IndexType full_height =
@@ -1544,8 +1546,10 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
                                    int max_dim,
                                    bool is_x_large) {
     int axis = broadcast_pos[0];
-    size_t pre = std::accumulate(
-        out_dims_array, out_dims_array + axis, 1, std::multiplies<int64_t>());
+    size_t pre = std::accumulate(out_dims_array,
+                                 out_dims_array + axis,
+                                 static_cast<int64_t>(1),
+                                 std::multiplies<int64_t>());
     size_t mid = 1;
     size_t post = 1;
 
@@ -1987,7 +1991,7 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
                                                             y_threads,
                                                             dy_op);
     } else {
-      CommonGradBroadcastCUDAKernel<int32_t, T, DY_OP, Tout>
+      CommonGradBroadcastCUDAKernel<uint32_t, T, DY_OP, Tout>
           <<<y_blocks, y_block_size, 0, dev_ctx.stream()>>>(x_strides_array_gpu,
                                                             y_strides_array_gpu,
                                                             out_dims_array_gpu,

--- a/paddle/phi/kernels/gpu/elementwise_grad.h
+++ b/paddle/phi/kernels/gpu/elementwise_grad.h
@@ -189,7 +189,15 @@ void ElementwiseMixedPrecisionAddGrad(const GPUContext &dev_ctx,
   dim3 grid_dim(grid_size, 1, 1);
   dim3 block_dim(block_size, 1, 1);
 
-  if (size < std::numeric_limits<int>::max()) {
+  // The largest intermediate is the tail start of the highest-numbered
+  // thread, `loop * vec_size + tid`, whose upper bound is
+  // `main_size + (grid_size * block_size - 1)`; the strided increments
+  // `i += stride` are bounded by `(size - 1) + grid_size * block_size`. Both
+  // are covered by `size + grid_size * block_size <= INT_MAX`.
+  //
+  // Avoid `loop * vec_size + tid` overflow when `size % vec_size` != 0.
+  const int64_t index_span = static_cast<int64_t>(grid_size) * block_size;
+  if (size + index_span <= std::numeric_limits<int>::max()) {
     MixedPrecisionElemwiseAddGradCUDAKernel<T_dy, int>
         <<<grid_dim, block_dim, 0, dev_ctx.stream()>>>(
             dout_data, static_cast<int>(size), dx_data, dy_data);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism

### PR Types
Bug fixes 

### Description
<!-- Describe what you’ve done -->
`paddle/phi/kernels/funcs/elementwise_grad_base.h`
1. int64索引路径下 width_stride = GRID_NUM_X * BLOCK_NUM_X 先在 32 位完成乘法再转宽类型，w ≥ 2^32 时回绕；补 static_cast<IndexType> 使乘法在目标宽度下进行。
2. host侧std::accumulate初值为 int，导致维度前缀乘积按32位截断；改为 static_cast<int64_t>(1)与代码内其他 std::accumulate统一。
3. `CommonGradBroadcastCUDAKernel`在dy分支实例化的IndexType类型由int32_t改为uint32_t，与dx分支一致（当前未越界，属一致性/UB 加固）。

`paddle/phi/kernels/gpu/elementwise_grad.h`
`MixedPrecisionElemwiseAddGradCUDAKernel`在numel接近INT32_MAX且不被4整除时尾部循环会溢出，在`MixedPrecisionElemwiseAddGradCUDAKernel`中增加index_span限制int32的选择

### 是否引起精度变化
否