### PR TITLE
[CI] Probe DCU runner Results/Blob connectivity

### DIFF
--- a/.github/scripts/github-actions-endpoint-probe.sh
+++ b/.github/scripts/github-actions-endpoint-probe.sh
@@ -44,6 +44,21 @@ timestamp() {
   date -u '+%Y-%m-%dT%H:%M:%SZ'
 }
 
+emit_annotation() {
+  local level="$1"
+  local title="$2"
+  local message="$3"
+
+  if [[ "${GITHUB_ACTIONS:-false}" != "true" ]]; then
+    return
+  fi
+
+  message="${message//'%'/'%25'}"
+  message="${message//$'\r'/'%0D'}"
+  message="${message//$'\n'/'%0A'}"
+  echo "::${level} title=${title}::${message}"
+}
+
 url_host() {
   local value="${1#*://}"
   printf '%s\n' "${value%%/*}"
@@ -88,12 +103,98 @@ curl_probe() {
   echo "curl_exit=${rc} ${result}"
   if (( rc != 0 )); then
     echo "RESULT: FAIL"
+    emit_annotation error "${label} IPv${family} unreachable" "${result}"
     FAILURES=$((FAILURES + 1))
   else
     # Any HTTP response proves that DNS, TCP and TLS reached the service. Some
     # unauthenticated health endpoints may intentionally return 4xx.
     echo "RESULT: PASS (transport reachable)"
   fi
+}
+
+probe_results_storage_host() {
+  local host="$1"
+  local result
+  local rc
+
+  set +e
+  result="$(curl -4 --silent --show-error --output /dev/null \
+    --connect-timeout 5 \
+    --max-time 10 \
+    --write-out 'http=%{http_code} remote_ip=%{remote_ip} dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s total=%{time_total}s' \
+    "https://${host}/" 2>&1)"
+  rc=$?
+  set -e
+
+  echo "${host}: curl_exit=${rc} ${result}"
+  if (( rc != 0 )); then
+    emit_annotation error "Azure Blob transport unreachable" "${host}: ${result}"
+    return 1
+  fi
+
+  emit_annotation notice "Azure Blob transport reachable" "${host}: ${result}"
+}
+
+probe_results_storage_accounts() {
+  local meta_file
+  local probe_dir
+  local token="${GITHUB_TOKEN:-}"
+  local index=0
+  local host
+  local curl_args=(
+    --fail
+    --silent
+    --show-error
+    --connect-timeout "$CONNECT_TIMEOUT"
+    --max-time "$MAX_TIME"
+    -H 'Accept: application/vnd.github+json'
+    -H 'X-GitHub-Api-Version: 2022-11-28'
+  )
+  local -a hosts=()
+  local -a pids=()
+
+  echo
+  echo "[$(timestamp)] GitHub Results Azure Blob account probes"
+  meta_file="$(mktemp)"
+  probe_dir="$(mktemp -d)"
+  if [[ -n "$token" ]]; then
+    curl_args+=(-H "Authorization: Bearer ${token}")
+  fi
+
+  if ! curl "${curl_args[@]}" https://api.github.com/meta --output "$meta_file"; then
+    echo "RESULT: FAIL (unable to retrieve GitHub meta domains)"
+    emit_annotation error "GitHub meta domains unavailable" "/meta request failed"
+    FAILURES=$((FAILURES + 1))
+    rm -rf "$probe_dir"
+    rm -f "$meta_file"
+    return
+  fi
+
+  while IFS= read -r host; do
+    hosts+=("$host")
+    probe_results_storage_host "$host" > "${probe_dir}/${index}.log" 2>&1 &
+    pids+=("$!")
+    index=$((index + 1))
+  done < <(
+    grep -oE 'productionresultssa[0-9]+\.blob\.core\.windows\.net' "$meta_file" \
+      | sort -u
+  )
+
+  if (( index == 0 )); then
+    echo "RESULT: FAIL (no Results Azure Blob domains found in GitHub meta data)"
+    emit_annotation error "Azure Blob domain list empty" "No productionresultssa host was found"
+    FAILURES=$((FAILURES + 1))
+  fi
+
+  for ((index = 0; index < ${#hosts[@]}; index++)); do
+    if ! wait "${pids[index]}"; then
+      FAILURES=$((FAILURES + 1))
+    fi
+    cat "${probe_dir}/${index}.log"
+  done
+
+  rm -rf "$probe_dir"
+  rm -f "$meta_file"
 }
 
 probe_persisted_job_log_blob() {
@@ -136,6 +237,7 @@ probe_persisted_job_log_blob() {
   if (( rc != 0 )); then
     echo "GitHub log redirect request failed with curl exit ${rc}"
     echo "RESULT: FAIL"
+    emit_annotation error "Job log redirect unavailable" "GitHub API curl exit ${rc}"
     FAILURES=$((FAILURES + 1))
     rm -f "$headers"
     return
@@ -147,6 +249,7 @@ probe_persisted_job_log_blob() {
   if [[ -z "$location" ]]; then
     echo "No redirect URL was returned. Confirm that job ${job_id} exists and its log Blob is present."
     echo "RESULT: FAIL"
+    emit_annotation error "Job log Blob redirect missing" "Job ${job_id} returned no Location header"
     FAILURES=$((FAILURES + 1))
     return
   fi
@@ -168,9 +271,11 @@ probe_persisted_job_log_blob() {
   echo "curl_exit=${rc} ${result}"
   if (( rc != 0 )); then
     echo "RESULT: FAIL"
+    emit_annotation error "Signed job log Blob unreachable" "${blob_host}: ${result}"
     FAILURES=$((FAILURES + 1))
   else
     echo "RESULT: PASS (GitHub log Blob reachable)"
+    emit_annotation notice "Signed job log Blob reachable" "${blob_host}: ${result}"
   fi
 }
 
@@ -195,6 +300,7 @@ main() {
     fi
   done
 
+  probe_results_storage_accounts
   probe_persisted_job_log_blob
 
   echo

--- a/.github/scripts/github-actions-endpoint-probe.sh
+++ b/.github/scripts/github-actions-endpoint-probe.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+# Probe the network paths used by a self-hosted GitHub Actions runner.
+#
+# Optional environment variables:
+#   PROBE_CONNECT_TIMEOUT  TCP/TLS connect timeout in seconds (default: 10)
+#   PROBE_MAX_TIME         Total timeout for each request in seconds (default: 30)
+#   PROBE_IPV6             Set to 1 to run additional IPv6 probes
+#   PROBE_REPORT_FILE      Report path (default: $GITHUB_WORKSPACE/actions-network-probe.log)
+#   BLOB_PROBE_JOB_ID      A completed job whose persisted log is known to exist
+#   GITHUB_TOKEN           Token with Actions read permission, supplied by the workflow
+
+set -uo pipefail
+
+CONNECT_TIMEOUT="${PROBE_CONNECT_TIMEOUT:-10}"
+MAX_TIME="${PROBE_MAX_TIME:-30}"
+PROBE_IPV6="${PROBE_IPV6:-0}"
+REPORT_FILE="${PROBE_REPORT_FILE:-${GITHUB_WORKSPACE:-$PWD}/actions-network-probe.log}"
+FAILURES=0
+
+ENDPOINTS=(
+  "GitHub API|https://api.github.com/zen"
+  "Codeload|https://codeload.github.com/_ping"
+  "Actions token|https://vstoken.actions.githubusercontent.com/_apis/health"
+  "Actions pipelines|https://pipelines.actions.githubusercontent.com/_apis/health"
+  "Actions results|https://results-receiver.actions.githubusercontent.com/health"
+)
+
+timestamp() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+url_host() {
+  local value="${1#*://}"
+  printf '%s\n' "${value%%/*}"
+}
+
+resolve_host() {
+  local host="$1"
+
+  echo "DNS records for ${host}:"
+  if command -v getent >/dev/null 2>&1; then
+    getent ahosts "$host" 2>&1 | awk '!seen[$0]++ { print "  " $0 }' || true
+  elif command -v nslookup >/dev/null 2>&1; then
+    nslookup "$host" 2>&1 | sed 's/^/  /' || true
+  else
+    echo "  SKIP: neither getent nor nslookup is installed"
+  fi
+}
+
+curl_probe() {
+  local family="$1"
+  local label="$2"
+  local url="$3"
+  local host
+  local result
+  local rc
+
+  host="$(url_host "$url")"
+  echo
+  echo "[$(timestamp)] ${label} (IPv${family})"
+  echo "URL: ${url}"
+  resolve_host "$host"
+
+  set +e
+  result="$(curl "-${family}" --silent --show-error --output /dev/null \
+    --connect-timeout "$CONNECT_TIMEOUT" \
+    --max-time "$MAX_TIME" \
+    --write-out 'http=%{http_code} remote_ip=%{remote_ip} dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s total=%{time_total}s' \
+    "$url" 2>&1)"
+  rc=$?
+  set -e
+
+  echo "curl_exit=${rc} ${result}"
+  if (( rc != 0 )); then
+    echo "RESULT: FAIL"
+    FAILURES=$((FAILURES + 1))
+  else
+    # Any HTTP response proves that DNS, TCP and TLS reached the service. Some
+    # unauthenticated health endpoints may intentionally return 4xx.
+    echo "RESULT: PASS (transport reachable)"
+  fi
+}
+
+probe_persisted_job_log_blob() {
+  local job_id="${BLOB_PROBE_JOB_ID:-}"
+  local repository="${GITHUB_REPOSITORY:-}"
+  local token="${GITHUB_TOKEN:-}"
+  local headers
+  local api_url
+  local location
+  local blob_host
+  local result
+  local rc
+
+  echo
+  echo "[$(timestamp)] Persisted job-log Blob probe"
+
+  if [[ -z "$job_id" ]]; then
+    echo "RESULT: SKIP (BLOB_PROBE_JOB_ID is not set)"
+    return
+  fi
+  if [[ -z "$repository" || -z "$token" ]]; then
+    echo "RESULT: SKIP (GITHUB_REPOSITORY or GITHUB_TOKEN is unavailable)"
+    return
+  fi
+
+  headers="$(mktemp)"
+  api_url="https://api.github.com/repos/${repository}/actions/jobs/${job_id}/logs"
+
+  set +e
+  curl --silent --show-error --output /dev/null --dump-header "$headers" \
+    --connect-timeout "$CONNECT_TIMEOUT" \
+    --max-time "$MAX_TIME" \
+    -H 'Accept: application/vnd.github+json' \
+    -H "Authorization: Bearer ${token}" \
+    -H 'X-GitHub-Api-Version: 2022-11-28' \
+    "$api_url"
+  rc=$?
+  set -e
+
+  if (( rc != 0 )); then
+    echo "GitHub log redirect request failed with curl exit ${rc}"
+    echo "RESULT: FAIL"
+    FAILURES=$((FAILURES + 1))
+    rm -f "$headers"
+    return
+  fi
+
+  location="$(awk 'BEGIN { IGNORECASE=1 } /^location:/ { sub(/^[^:]*:[[:space:]]*/, ""); sub(/\r$/, ""); print }' "$headers" | tail -n 1)"
+  rm -f "$headers"
+
+  if [[ -z "$location" ]]; then
+    echo "No redirect URL was returned. Confirm that job ${job_id} exists and its log Blob is present."
+    echo "RESULT: FAIL"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  blob_host="$(url_host "$location")"
+  echo "Redirect host: ${blob_host}"
+  echo "The signed redirect URL is intentionally not printed."
+  resolve_host "$blob_host"
+
+  set +e
+  result="$(curl -4 --head --silent --show-error --output /dev/null \
+    --connect-timeout "$CONNECT_TIMEOUT" \
+    --max-time "$MAX_TIME" \
+    --write-out 'http=%{http_code} remote_ip=%{remote_ip} dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s total=%{time_total}s' \
+    "$location" 2>&1)"
+  rc=$?
+  set -e
+
+  echo "curl_exit=${rc} ${result}"
+  if (( rc != 0 )); then
+    echo "RESULT: FAIL"
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "RESULT: PASS (GitHub log Blob reachable)"
+  fi
+}
+
+main() {
+  local entry
+  local label
+  local url
+
+  echo "GitHub Actions network probe"
+  echo "Started: $(timestamp)"
+  echo "Runner: ${RUNNER_NAME:-unknown}"
+  echo "Repository: ${GITHUB_REPOSITORY:-unknown}"
+  echo "Run: ${GITHUB_RUN_ID:-unknown}, attempt: ${GITHUB_RUN_ATTEMPT:-unknown}"
+  echo "Connect timeout: ${CONNECT_TIMEOUT}s; request timeout: ${MAX_TIME}s"
+
+  for entry in "${ENDPOINTS[@]}"; do
+    label="${entry%%|*}"
+    url="${entry#*|}"
+    curl_probe 4 "$label" "$url"
+    if [[ "$PROBE_IPV6" == "1" ]]; then
+      curl_probe 6 "$label" "$url"
+    fi
+  done
+
+  probe_persisted_job_log_blob
+
+  echo
+  echo "Finished: $(timestamp)"
+  echo "Transport failures: ${FAILURES}"
+  echo "Report: ${REPORT_FILE}"
+  echo "The workflow's upload-artifact step separately tests a real Blob upload."
+
+  if (( FAILURES > 0 )); then
+    return 1
+  fi
+}
+
+mkdir -p "$(dirname "$REPORT_FILE")"
+set +e
+main "$@" 2>&1 | tee "$REPORT_FILE"
+status=${PIPESTATUS[0]}
+set -e
+exit "$status"

--- a/.github/scripts/github-actions-endpoint-probe.sh
+++ b/.github/scripts/github-actions-endpoint-probe.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Probe the network paths used by a self-hosted GitHub Actions runner.
 #
 # Optional environment variables:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,9 +76,8 @@ jobs:
   dcu:
     name: Linux-DCU
     uses: ./.github/workflows/_Linux-DCU.yml
-    needs: [clone, build-docker]
     with:
-      docker_dcu_image: ${{ needs.build-docker.outputs.docker_dcu_image }}
+      docker_dcu_image: ccr-2vdh3abv-pub.cnc.bj.baidubce.com/ci/paddle:72adba73076aaefadfc3a879930c9484
       clone-can-skip: ${{ needs.clone.outputs.can-skip }}
 
   cpu:

--- a/.github/workflows/_Linux-DCU.yml
+++ b/.github/workflows/_Linux-DCU.yml
@@ -44,7 +44,7 @@ jobs:
     env:
       TASK: paddle-CI-${{ github.event.pull_request.number }}-dcu_build
     runs-on:
-      group: HK-CPU
+      group: dcu-test
     timeout-minutes: 180
     steps:
       - name: Check docker image and run container

--- a/.github/workflows/github-actions-network-probe.yml
+++ b/.github/workflows/github-actions-network-probe.yml
@@ -1,0 +1,68 @@
+name: GitHub Actions network probe
+
+on:
+  workflow_dispatch:
+    inputs:
+      blob_probe_job_id:
+        description: "Completed job ID whose persisted log is known to exist"
+        required: false
+        default: "91620902034"
+        type: string
+  pull_request:
+    paths:
+      - .github/scripts/github-actions-endpoint-probe.sh
+      - .github/workflows/github-actions-network-probe.yml
+      - .github/workflows/CI.yml
+      - .github/workflows/_Linux-DCU.yml
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  probe:
+    name: DCU runner Results/Blob probe
+    runs-on:
+      group: dcu-test
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout probe script
+        uses: actions/checkout@v6
+
+      - name: Probe GitHub Actions endpoints and an existing log Blob
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          BLOB_PROBE_JOB_ID: ${{ inputs.blob_probe_job_id || '91620902034' }}
+          PROBE_CONNECT_TIMEOUT: "10"
+          PROBE_MAX_TIME: "30"
+          PROBE_IPV6: "0"
+        run: bash .github/scripts/github-actions-endpoint-probe.sh
+
+      - name: Create Blob upload payload
+        if: always()
+        run: |
+          dd if=/dev/urandom of="${RUNNER_TEMP}/blob-probe.bin" bs=1M count=8 status=none
+          ls -lh "${RUNNER_TEMP}/blob-probe.bin" actions-network-probe.log
+
+      # This performs a real upload through GitHub Results Service and its
+      # dynamically assigned Azure Blob endpoint. It is the closest workflow-
+      # level probe for the runner's end-of-job log upload path.
+      - name: Upload through GitHub Results and Azure Blob
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: actions-network-probe-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            actions-network-probe.log
+            ${{ runner.temp }}/blob-probe.bin
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+      - name: End marker
+        if: always()
+        run: |
+          echo "Last visible workflow step finished at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+          echo "Compare this timestamp with the job completed_at timestamp."
+          echo "A large gap after this line indicates runner finalization/log-upload delay."

--- a/.github/workflows/github-actions-network-probe.yml
+++ b/.github/workflows/github-actions-network-probe.yml
@@ -71,6 +71,27 @@ jobs:
           fi
           ls -lh "${RUNNER_TEMP}/blob-probe.bin" actions-network-probe.log
 
+      - name: Start HTTPS socket monitor
+        if: always()
+        run: |
+          set -euo pipefail
+          monitor_log="${RUNNER_TEMP}/blob-socket-monitor.log"
+          nohup bash -c '
+            while true; do
+              date -u "+timestamp=%Y-%m-%dT%H:%M:%SZ"
+              if command -v ss >/dev/null 2>&1; then
+                ss -Htnpo
+              elif command -v netstat >/dev/null 2>&1; then
+                netstat -ant
+              else
+                echo "Neither ss nor netstat is installed."
+                exit 1
+              fi
+              sleep 2
+            done
+          ' > "${monitor_log}" 2>&1 < /dev/null &
+          echo "$!" > "${RUNNER_TEMP}/blob-socket-monitor.pid"
+
       # This performs a real upload through GitHub Results Service and its
       # dynamically assigned Azure Blob endpoint. It is the closest workflow-
       # level probe for the runner's end-of-job log upload path.
@@ -82,9 +103,36 @@ jobs:
           path: |
             actions-network-probe.log
             ${{ runner.temp }}/blob-probe.bin
+            ${{ runner.temp }}/blob-socket-monitor.log
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
+
+      - name: Summarize HTTPS sockets during upload
+        if: always()
+        run: |
+          set -euo pipefail
+          monitor_log="${RUNNER_TEMP}/blob-socket-monitor.log"
+          monitor_pid_file="${RUNNER_TEMP}/blob-socket-monitor.pid"
+          if [[ -s "${monitor_pid_file}" ]]; then
+            monitor_pid="$(< "${monitor_pid_file}")"
+            kill "${monitor_pid}" 2>/dev/null || true
+            wait "${monitor_pid}" 2>/dev/null || true
+          fi
+
+          if [[ ! -s "${monitor_log}" ]]; then
+            echo "::error title=HTTPS socket monitor unavailable::No socket samples were recorded"
+            exit 1
+          fi
+
+          syn_sent="$(awk '$1 == "SYN-SENT" && $5 ~ /:443$/ { count++ } END { print count + 0 }' "${monitor_log}")"
+          established="$(awk '$1 == "ESTAB" && $5 ~ /:443$/ { count++ } END { print count + 0 }' "${monitor_log}")"
+          max_send_q="$(awk '$1 == "ESTAB" && $5 ~ /:443$/ && $3 > max { max=$3 } END { print max + 0 }' "${monitor_log}")"
+          peers="$(awk '$5 ~ /:443$/ { print $5 }' "${monitor_log}" | sort -u | paste -sd, -)"
+          summary="syn_sent_samples=${syn_sent} established_samples=${established} max_send_queue=${max_send_q} peers=${peers:-none}"
+          echo "${summary}"
+          echo "::notice title=HTTPS socket states during Blob upload::${summary}"
+          tail -n 100 "${monitor_log}"
 
       - name: End marker
         if: always()

--- a/.github/workflows/github-actions-network-probe.yml
+++ b/.github/workflows/github-actions-network-probe.yml
@@ -78,6 +78,52 @@ jobs:
         if: always()
         run: timeout 8 bash -c 'exec 3<>/dev/tcp/productionresultssa12.blob.core.windows.net/443'
 
+      - name: Packet capture - prerequisites
+        id: pcap_prereq
+        if: always()
+        run: |
+          set -euo pipefail
+          command -v tcpdump
+          if (( EUID != 0 )); then
+            sudo -n true
+          fi
+
+      - name: Packet capture - outbound SYN leaves host
+        if: always() && steps.pcap_prereq.outcome == 'success'
+        run: |
+          set -euo pipefail
+          host=productionresultssa2.blob.core.windows.net
+          ip="$(getent ahostsv4 "${host}" | awk 'NR == 1 { print $1 }')"
+          pcap=(tcpdump)
+          if (( EUID != 0 )); then
+            pcap=(sudo -n tcpdump)
+          fi
+          timeout 8 "${pcap[@]}" -i any -nn -c 1 \
+            "dst host ${ip} and tcp dst port 443" \
+            > "${RUNNER_TEMP}/blob-outbound-syn.log" 2>&1 &
+          pcap_pid=$!
+          sleep 1
+          timeout 3 bash -c 'exec 3<>/dev/tcp/productionresultssa2.blob.core.windows.net/443' || true
+          wait "${pcap_pid}"
+
+      - name: Packet capture - inbound reply reaches host
+        if: always() && steps.pcap_prereq.outcome == 'success'
+        run: |
+          set -euo pipefail
+          host=productionresultssa2.blob.core.windows.net
+          ip="$(getent ahostsv4 "${host}" | awk 'NR == 1 { print $1 }')"
+          pcap=(tcpdump)
+          if (( EUID != 0 )); then
+            pcap=(sudo -n tcpdump)
+          fi
+          timeout 8 "${pcap[@]}" -i any -nn -c 1 \
+            "src host ${ip} and tcp src port 443" \
+            > "${RUNNER_TEMP}/blob-inbound-reply.log" 2>&1 &
+          pcap_pid=$!
+          sleep 1
+          timeout 3 bash -c 'exec 3<>/dev/tcp/productionresultssa2.blob.core.windows.net/443' || true
+          wait "${pcap_pid}"
+
       - name: Blob sa2 - TLS handshake
         if: always()
         run: |

--- a/.github/workflows/github-actions-network-probe.yml
+++ b/.github/workflows/github-actions-network-probe.yml
@@ -28,21 +28,47 @@ jobs:
 
     steps:
       - name: Checkout probe script
+        id: checkout
+        continue-on-error: true
         uses: actions/checkout@v6
 
+      - name: Fetch probe script when checkout failed
+        if: steps.checkout.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PROBE_SOURCE_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          PROBE_SOURCE_REF: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          probe_script="${RUNNER_TEMP}/github-actions-endpoint-probe.sh"
+          api_url="https://api.github.com/repos/${PROBE_SOURCE_REPOSITORY}/contents/.github/scripts/github-actions-endpoint-probe.sh?ref=${PROBE_SOURCE_REF}"
+          curl --fail --silent --show-error --location \
+            --connect-timeout 10 --max-time 30 \
+            -H 'Accept: application/vnd.github.raw+json' \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "${api_url}" --output "${probe_script}"
+          chmod +x "${probe_script}"
+          echo "PROBE_SCRIPT=${probe_script}" >> "${GITHUB_ENV}"
+
       - name: Probe GitHub Actions endpoints and an existing log Blob
+        if: always()
         env:
           GITHUB_TOKEN: ${{ github.token }}
           BLOB_PROBE_JOB_ID: ${{ inputs.blob_probe_job_id || '91620902034' }}
           PROBE_CONNECT_TIMEOUT: "10"
           PROBE_MAX_TIME: "30"
           PROBE_IPV6: "0"
-        run: bash .github/scripts/github-actions-endpoint-probe.sh
+        run: bash "${PROBE_SCRIPT:-.github/scripts/github-actions-endpoint-probe.sh}"
 
       - name: Create Blob upload payload
         if: always()
         run: |
+          set -euo pipefail
           dd if=/dev/urandom of="${RUNNER_TEMP}/blob-probe.bin" bs=1M count=8 status=none
+          if [[ ! -f actions-network-probe.log ]]; then
+            echo "Endpoint probe report was unavailable." > actions-network-probe.log
+          fi
           ls -lh "${RUNNER_TEMP}/blob-probe.bin" actions-network-probe.log
 
       # This performs a real upload through GitHub Results Service and its

--- a/.github/workflows/github-actions-network-probe.yml
+++ b/.github/workflows/github-actions-network-probe.yml
@@ -51,6 +51,100 @@ jobs:
           chmod +x "${probe_script}"
           echo "PROBE_SCRIPT=${probe_script}" >> "${GITHUB_ENV}"
 
+      # These storage accounts were assigned to failed DCU jobs during this
+      # investigation. Separate steps preserve the failed network layer in the
+      # job timeline even when the job-log Blob itself cannot be uploaded.
+      - name: Blob accounts - DNS
+        if: always()
+        run: |
+          set -euo pipefail
+          for host in \
+            productionresultssa2.blob.core.windows.net \
+            productionresultssa4.blob.core.windows.net \
+            productionresultssa12.blob.core.windows.net; do
+            echo "DNS records for ${host}:"
+            getent ahostsv4 "${host}"
+          done
+
+      - name: Blob sa2 - TCP 443
+        if: always()
+        run: timeout 8 bash -c 'exec 3<>/dev/tcp/productionresultssa2.blob.core.windows.net/443'
+
+      - name: Blob sa4 - TCP 443
+        if: always()
+        run: timeout 8 bash -c 'exec 3<>/dev/tcp/productionresultssa4.blob.core.windows.net/443'
+
+      - name: Blob sa12 - TCP 443
+        if: always()
+        run: timeout 8 bash -c 'exec 3<>/dev/tcp/productionresultssa12.blob.core.windows.net/443'
+
+      - name: Blob sa2 - TLS handshake
+        if: always()
+        run: |
+          timeout 12 openssl s_client \
+            -connect productionresultssa2.blob.core.windows.net:443 \
+            -servername productionresultssa2.blob.core.windows.net \
+            -brief < /dev/null
+
+      - name: Blob sa4 - TLS handshake
+        if: always()
+        run: |
+          timeout 12 openssl s_client \
+            -connect productionresultssa4.blob.core.windows.net:443 \
+            -servername productionresultssa4.blob.core.windows.net \
+            -brief < /dev/null
+
+      - name: Blob sa12 - TLS handshake
+        if: always()
+        run: |
+          timeout 12 openssl s_client \
+            -connect productionresultssa12.blob.core.windows.net:443 \
+            -servername productionresultssa12.blob.core.windows.net \
+            -brief < /dev/null
+
+      - name: Blob sa2 - HTTP response
+        if: always()
+        run: |
+          curl -4 --silent --show-error --output /dev/null \
+            --connect-timeout 5 --max-time 10 \
+            --write-out 'http=%{http_code} remote_ip=%{remote_ip} dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s total=%{time_total}s\n' \
+            https://productionresultssa2.blob.core.windows.net/
+
+      - name: Blob sa4 - HTTP response
+        if: always()
+        run: |
+          curl -4 --silent --show-error --output /dev/null \
+            --connect-timeout 5 --max-time 10 \
+            --write-out 'http=%{http_code} remote_ip=%{remote_ip} dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s total=%{time_total}s\n' \
+            https://productionresultssa4.blob.core.windows.net/
+
+      - name: Blob sa12 - HTTP response
+        if: always()
+        run: |
+          curl -4 --silent --show-error --output /dev/null \
+            --connect-timeout 5 --max-time 10 \
+            --write-out 'http=%{http_code} remote_ip=%{remote_ip} dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s total=%{time_total}s\n' \
+            https://productionresultssa12.blob.core.windows.net/
+
+      - name: Signed job-log Blob - HTTP GET
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          headers="$(mktemp)"
+          api_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/jobs/91620902034/logs"
+          curl --silent --show-error --output /dev/null --dump-header "${headers}" \
+            --connect-timeout 5 --max-time 15 \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "${api_url}"
+          location="$(awk 'BEGIN { IGNORECASE=1 } /^location:/ { sub(/^[^:]*:[[:space:]]*/, ""); sub(/\r$/, ""); print }' "${headers}" | tail -n 1)"
+          [[ -n "${location}" ]]
+          curl -4 --fail --head --silent --show-error --output /dev/null \
+            --connect-timeout 5 --max-time 15 "${location}"
+
       - name: Probe GitHub Actions endpoints and an existing log Blob
         if: always()
         env:


### PR DESCRIPTION
## What changed

- Route the Linux DCU build to the `dcu-test` runner group and use the fixed diagnostic image.
- Add a bounded endpoint probe for GitHub Actions control-plane services.
- Follow a known job-log redirect to test the dynamically assigned Azure Blob host without printing its SAS URL.
- Probe every `productionresultssa*.blob.core.windows.net` account currently published by GitHub `/meta`.
- Upload an 8 MiB artifact to exercise a real GitHub Results/Azure Blob upload.
- Sample HTTPS socket states during the upload and persist the classification in Check annotations.
- Print an end marker so the final visible step can be compared with the job `completed_at` timestamp.

## Why

Linux DCU jobs frequently spend a long time after the last visible step. Runner diagnostics show repeated 30-second Azure Blob upload timeouts while draining the final Results queue. This temporary diagnostic workflow separates control-plane reachability, Blob download, Blob upload, and hidden runner-finalization delay.

## Findings

- The Results WebSocket and console/timeline uploads succeed; every Azure SDK Blob upload retries four times and times out after about 127 seconds.
- The 8 MiB artifact probe reported `Upload progress stalled`, then spent 10m33s after `Complete job` before the job was marked complete.
- A real cancelled DCU job deleted its container in 7 seconds, then spent 4m39s in `Complete job`.
- Failed DCU log uploads were assigned to storage accounts `productionresultssa2`, `productionresultssa4`, and `productionresultssa12`; all corresponding log Blobs are absent.
- During the same test window, runner `paddle-1` successfully persisted its job log to `productionresultssa2`. This isolates the fault to the DCU runner's outbound path rather than the Azure storage account.
- On `paddle-dcu-2-2`, DNS resolution succeeds for `sa2`, `sa4`, and `sa12`, but every TCP/443 probe consumes the full 8-second timeout. TLS, HTTP, and signed Blob GET probes consequently fail.
- A fixed-IP host capture saw no outbound SYN while the TCP socket timed out. The runner host's `PADDLE_SEC_OUTPUT` chain ended in a default `DROP`; its counter increased by exactly four 60-byte packets during the four SYN attempts.
- `/root/paddle_iptables_script.sh`, run by cron every 10 minutes, rebuilds that chain from an explicit DNS-to-IP allowlist. It listed the apex `blob.core.windows.net`, which does not expand or resolve GitHub's Results storage subdomains, so the assigned `productionresultssa*` addresses fell through to the final `DROP`.
- The root cause is therefore the runner host's incomplete, periodically regenerated IP allowlist—not GitHub, Azure Storage, runner cleanup, DNS, TLS, PAT authentication, or an upstream network outage.

## Applied runner change

- Backed up `/root/paddle_iptables_script.sh`.
- Replaced the ineffective apex entry with Bash expansion for `productionresultssa0` through `productionresultssa19`, restricted to TCP/443.
- Regenerated `PADDLE_SEC_INPUT`, `PADDLE_SEC_OUTPUT`, and `PADDLE_SEC_FORWARD`; the existing cron job will continue refreshing the resolved addresses every 10 minutes.
- The allowlist remains domain-driven rather than pinning the current Azure IPs.

## Validation

- `bash -n .github/scripts/github-actions-endpoint-probe.sh`
- YAML parse for all modified workflow files
- `git diff --check`
- Local endpoint probe completed with zero transport failures
- All 20 current Results Blob storage accounts completed DNS, TCP, TLS, and HTTP locally
- Known persisted job log redirected to `productionresultssa12.blob.core.windows.net` and returned HTTP 200
- After the runner firewall fix, rerun attempt 2 (job `91696614094`) completed in 39 seconds instead of timing out around 20 minutes.
- TCP, TLS, and HTTP probes passed for `sa2`, `sa4`, and `sa12`; all 20 Results storage accounts returned an HTTP response.
- The signed persisted-log Blob GET returned HTTP 200.
- The real 8 MiB artifact upload completed and finalized in 5 seconds; artifact `8857105120` is present at 8,402,067 bytes.
- `End marker`, checkout post-processing, and `Complete job` all completed at `13:12:44Z`; the API marked the job complete at `13:12:51Z`, eliminating the previous multi-minute finalization stall.
- The diagnostic job conclusion is failure only because its optional packet-capture prerequisite requires passwordless `sudo`; every network and upload validation step succeeded.

This is a diagnostic PR and is intentionally opened as a draft.
