### PR TITLE
[Flex_CheckPoint]: Support high-dim-reshard for flex_ckpt

### DIFF
--- a/python/paddle/distributed/flex_checkpoint/dcp/utils.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/utils.py
@@ -192,18 +192,16 @@ def minimal_nd_slice(shape, flat_start, flat_end):
     start_idx = unravel_index(flat_start, shape)
     end_idx = unravel_index(flat_end - 1, shape)
     min_slices = []
+    prefix_has_diverged = False
     for axis in range(len(shape)):
-        if axis == 0:
-            s = start_idx[axis]
-            e = end_idx[axis] + 1
+        if prefix_has_diverged:
+            s = 0
+            e = shape[axis]
         else:
-            if start_idx[axis - 1] == end_idx[axis - 1]:
-                s = min(start_idx[axis], end_idx[axis])
-                e = max(start_idx[axis], end_idx[axis]) + 1
-            else:
-                s = 0
-                e = shape[axis]
+            s = min(start_idx[axis], end_idx[axis])
+            e = max(start_idx[axis], end_idx[axis]) + 1
         min_slices.append((s, e))
+        prefix_has_diverged |= start_idx[axis] != end_idx[axis]
     return min_slices, start_idx, end_idx
 
 

--- a/test/auto_parallel/hybrid_strategy/CMakeLists.txt
+++ b/test/auto_parallel/hybrid_strategy/CMakeLists.txt
@@ -28,6 +28,13 @@ if((WITH_GPU) AND (LINUX))
 endif()
 if((WITH_GPU) AND (LINUX))
   py_test_modules(
+    test_high_dim_reshard MODULES test_high_dim_reshard ENVS
+    "http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python")
+  set_tests_properties(test_high_dim_reshard PROPERTIES TIMEOUT "300" LABELS
+                                                        "RUN_TYPE=HYBRID")
+endif()
+if((WITH_GPU) AND (LINUX))
+  py_test_modules(
     test_semi_auto_parallel_c_cross_entropy MODULES
     test_semi_auto_parallel_c_cross_entropy ENVS
     "http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python")

--- a/test/auto_parallel/hybrid_strategy/high_dim_reshard_worker.py
+++ b/test/auto_parallel/hybrid_strategy/high_dim_reshard_worker.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import os
+
+import numpy as np
+import paddle
+import paddle.distributed as dist
+from paddle.distributed import load_state_dict, save_state_dict
+from paddle.distributed.flex_checkpoint.dcp.sharded_weight import ShardedWeight
+
+
+# Keep 240 elements while reducing the logical tensor to three dimensions.
+GLOBAL_SHAPE = (2, 10, 12)
+NUMEL = int(np.prod(GLOBAL_SHAPE))
+
+# The source and destination ranges deliberately cross several flattened
+# dimension boundaries.  The final case also isolates the last element.
+CASES = (
+    ("cross_axis", (0, 25), (25, NUMEL), (0, 121), (121, NUMEL)),
+    ("exact_axis_boundary", (0, 120), (120, NUMEL), (0, 60), (60, NUMEL)),
+    ("last_element", (0, NUMEL - 1), (NUMEL - 1, NUMEL), (0, 1), (1, NUMEL)),
+)
+
+
+def global_tensor(case_index):
+    return paddle.arange(NUMEL, dtype="int64").reshape(GLOBAL_SHAPE) + (
+        case_index * NUMEL
+    )
+
+
+def make_weight(key, tensor, flat_range):
+    return ShardedWeight(
+        key=key,
+        local_tensor=tensor,
+        local_shape=GLOBAL_SHAPE,
+        global_shape=GLOBAL_SHAPE,
+        global_offset=(0,) * len(GLOBAL_SHAPE),
+        is_flattened=True,
+        flattened_range=slice(*flat_range),
+    )
+
+
+def save_case(ckpt_path):
+    rank = dist.get_rank()
+    state_dict = {}
+    for case_index, (name, rank0_start, rank1_start, _, _) in enumerate(CASES):
+        start, end = rank0_start if rank == 0 else rank1_start
+        flat = paddle.flatten(global_tensor(case_index))
+        state_dict[name] = make_weight(
+            name, flat[start:end], (start, end)
+        )
+    save_state_dict(state_dict, ckpt_path)
+    dist.barrier()
+
+
+def load_case(ckpt_path, comm_method):
+    rank = dist.get_rank()
+    state_dict = {}
+    expected = {}
+    for case_index, (name, _, _, rank0_end, rank1_end) in enumerate(CASES):
+        start, end = rank0_end if rank == 0 else rank1_end
+        local_tensor = paddle.zeros([end - start], dtype="int64")
+        state_dict[name] = make_weight(name, local_tensor, (start, end))
+        expected[name] = paddle.flatten(global_tensor(case_index))[start:end]
+
+    load_state_dict(state_dict, ckpt_path, comm_method=comm_method)
+    dist.barrier()
+    for name, weight in state_dict.items():
+        np.testing.assert_array_equal(
+            weight.local_tensor.numpy(), expected[name].numpy(), err_msg=name
+        )
+
+
+if __name__ == "__main__":
+    mode = os.environ["high_dim_mode"]
+    ckpt_path = os.environ["high_dim_ckpt_path"]
+    if mode == "save":
+        save_case(ckpt_path)
+    elif mode == "load":
+        load_case(ckpt_path, os.environ["high_dim_comm_method"])
+    else:
+        raise ValueError(f"Unsupported high_dim_mode: {mode}")

--- a/test/auto_parallel/hybrid_strategy/high_dim_reshard_worker.py
+++ b/test/auto_parallel/hybrid_strategy/high_dim_reshard_worker.py
@@ -6,11 +6,11 @@
 import os
 
 import numpy as np
+
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import load_state_dict, save_state_dict
 from paddle.distributed.flex_checkpoint.dcp.sharded_weight import ShardedWeight
-
 
 # Keep 240 elements while reducing the logical tensor to three dimensions.
 GLOBAL_SHAPE = (2, 10, 12)
@@ -49,9 +49,7 @@ def save_case(ckpt_path):
     for case_index, (name, rank0_start, rank1_start, _, _) in enumerate(CASES):
         start, end = rank0_start if rank == 0 else rank1_start
         flat = paddle.flatten(global_tensor(case_index))
-        state_dict[name] = make_weight(
-            name, flat[start:end], (start, end)
-        )
+        state_dict[name] = make_weight(name, flat[start:end], (start, end))
     save_state_dict(state_dict, ckpt_path)
     dist.barrier()
 

--- a/test/auto_parallel/hybrid_strategy/test_high_dim_reshard.py
+++ b/test/auto_parallel/hybrid_strategy/test_high_dim_reshard.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import os
+import tempfile
+import unittest
+
+import collective.test_communication_api_base as test_base
+
+
+os.environ["FLAGS_enable_pir_api"] = "0"
+
+
+class TestHighDimReshard(test_base.CommunicationTestDistBase):
+    """End-to-end two-device FlexCheckpoint test for high-dimensional slices."""
+
+    def test_high_dim_reshard_two_devices(self):
+        with tempfile.TemporaryDirectory() as ckpt_dir:
+            envs = {
+                "device_num": "2",
+                "high_dim_ckpt_path": ckpt_dir,
+                "high_dim_mode": "save",
+            }
+            super().setUp(num_of_devices=2, timeout=180, nnode=1)
+            self.run_test_case("high_dim_reshard_worker.py", envs)
+
+            for comm_method in ("broadcast", "send_recv", "grouped_send_recv"):
+                envs = {
+                    "device_num": "2",
+                    "high_dim_ckpt_path": ckpt_dir,
+                    "high_dim_mode": "load",
+                    "high_dim_comm_method": comm_method,
+                }
+                super().setUp(num_of_devices=2, timeout=180, nnode=1)
+                self.run_test_case("high_dim_reshard_worker.py", envs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/auto_parallel/hybrid_strategy/test_high_dim_reshard.py
+++ b/test/auto_parallel/hybrid_strategy/test_high_dim_reshard.py
@@ -9,7 +9,6 @@ import unittest
 
 import collective.test_communication_api_base as test_base
 
-
 os.environ["FLAGS_enable_pir_api"] = "0"
 
 

--- a/test/auto_parallel/hybrid_strategy/testslist.csv
+++ b/test/auto_parallel/hybrid_strategy/testslist.csv
@@ -2,6 +2,7 @@ name,os,arch,timeout,run_type,launcher,num_port,run_serial,envs,conditions
 test_semi_auto_parallel_hybrid_strategy,LINUX,GPU,300,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_save_load_state_dict,LINUX,GPU,400,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_flexcheckpoint_merge,LINUX,GPU,120,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,
+test_high_dim_reshard,LINUX,GPU,300,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_semi_auto_parallel_c_cross_entropy,LINUX,GPU,120,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_cross_mesh_reshard,LINUX,GPU,120,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_semi_auto_parallel_llama_model_amp,LINUX,GPU,180,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category

Auto Parallel

### PR Types

Bug fixes

### Description

Fix an incorrect minimal bounding slice computation in FlexCheckpoint (dcp) for logical shapes with **3 or more dimensions**, so that flattened parameters can be resharded correctly at any rank.

**Problem**

`minimal_nd_slice` (`python/paddle/distributed/flex_checkpoint/dcp/utils.py`) maps a flattened range `[flat_start, flat_end)` back to the minimal N-D slice that covers it. The old implementation only checked whether the **immediately preceding** axis had diverged:

```python
if start_idx[axis - 1] == end_idx[axis - 1]:
    s = min(start_idx[axis], end_idx[axis])
    e = max(start_idx[axis], end_idx[axis]) + 1
else:
    s, e = 0, shape[axis]
```

This happens to hold for 2-D, but not for 3-D and above: as soon as **any** higher axis diverges, the current axis must span its full range. When a higher axis diverges while the immediately preceding axis happens to be identical, the old logic wrongly narrows the current axis and the resulting slice no longer covers the whole flattened range.

Example with `shape = (2, 10, 12)` and range `[25, 155)`:

- `start_idx = (0, 2, 1)`, `end_idx = (1, 2, 10)`
- axis 0 → `(0, 2)`
- axis 1: `start_idx[0] != end_idx[0]`, so full range `(0, 10)`
- axis 2: `start_idx[1] == end_idx[1] == 2`, so wrongly narrowed to `(1, 11)`

Flat index 36, i.e. `(0, 3, 0)`, lies inside the range but its last-axis index 0 falls outside `(1, 11)`. Since the slice does not cover the real range, the offsets later derived by `flat_range_in_min_slice` are shifted as well, so loading reads wrong data or hits a shape mismatch.

**Change**

Track a cumulative `prefix_has_diverged` flag: once any higher axis has `start_idx[axis] != end_idx[axis]`, every following axis takes its full range; otherwise the axis is narrowed by min/max. Using min/max for axis 0 is equivalent to the previous special case (`flat_start < flat_end` guarantees `start_idx[0] <= end_idx[0]`), so all axes can now be handled by a single uniform branch.

**Tests**

Add `test/auto_parallel/hybrid_strategy/test_high_dim_reshard.py` and `high_dim_reshard_worker.py`, an end-to-end two-device test that validates `save_state_dict` / `load_state_dict` resharding with `GLOBAL_SHAPE = (2, 10, 12)`:

- Three sharding patterns: crossing axis boundaries (`cross_axis`), landing exactly on an axis boundary (`exact_axis_boundary`), and isolating a single element (`last_element`)
- Save and load use different shardings, so resharding is actually exercised
- Verified for all three comm methods: `broadcast`, `send_recv`, `grouped_send_recv`
- Element-wise comparison against expected values via `np.testing.assert_array_equal`

The test fails before the fix and passes after it.

### 是否引起精度变化

否
