### PR TITLE
[Operator Mechanism] Support addmm out_dtype for CUDA

### DIFF
--- a/paddle/fluid/pybind/arg_pre_process.cc
+++ b/paddle/fluid/pybind/arg_pre_process.cc
@@ -321,8 +321,8 @@ void GridSamplePreProcess(pir::Value* x,
   return;
 }
 
-// Addmm broadcast validation for dygraph
-void AddmmPreProcess(Tensor* input, Tensor* x, Tensor* y) {
+// Addmm inplace shape validation for dygraph
+void AddmmInplacePreProcess(Tensor* input, Tensor* x, Tensor* y) {
   auto input_shape = input->dims();
   auto x_shape = x->dims();
   auto y_shape = y->dims();
@@ -342,6 +342,23 @@ void AddmmPreProcess(Tensor* input, Tensor* x, Tensor* y) {
           "The dimension of y should be 2 but received y's shape: [%s]",
           y_shape));
 
+  PADDLE_ENFORCE_EQ(
+      input->dtype(),
+      x->dtype(),
+      phi::errors::InvalidArgument(
+          "The dtypes of input and x must be the same for addmm_, but "
+          "received input dtype = %s and x dtype = %s.",
+          input->dtype(),
+          x->dtype()));
+  PADDLE_ENFORCE_EQ(
+      input->dtype(),
+      y->dtype(),
+      phi::errors::InvalidArgument(
+          "The dtypes of input and y must be the same for addmm_, but "
+          "received input dtype = %s and y dtype = %s.",
+          input->dtype(),
+          y->dtype()));
+
   // Validate x's width equals y's height
   PADDLE_ENFORCE_EQ(x_shape[1],
                     y_shape[0],
@@ -352,34 +369,56 @@ void AddmmPreProcess(Tensor* input, Tensor* x, Tensor* y) {
                         x_shape,
                         y_shape));
 
-  // Validate input shape broadcast compatibility
-  if (input_shape.size() == 2) {
-    ValidateBroadcastDim(input_shape[0],
-                         x_shape[0],
-                         "The dimension 0 of input must be equal to x's "
-                         "dimension 0, or must be 1.");
-    ValidateBroadcastDim(input_shape[1],
-                         y_shape[1],
-                         "The dimension 1 of input must be equal to y's "
-                         "dimension 1, or must be 1.");
-  } else if (input_shape.size() == 1) {
-    ValidateBroadcastDim(input_shape[0],
-                         y_shape[1],
-                         "The dimension 0 of input must be equal to y's "
-                         "dimension 1, or must be 1.");
-  } else {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("The dimension of input should be 2 or 1 "
-                                     "but received input's shape: [%ld].",
-                                     input_shape.size()));
-  }
+  PADDLE_ENFORCE_EQ(
+      input_shape.size(),
+      2,
+      phi::errors::InvalidArgument(
+          "The dimension of input must be 2 for addmm_, but received input's "
+          "shape: [%s].",
+          input_shape));
+  PADDLE_ENFORCE_EQ(
+      input_shape[0],
+      x_shape[0],
+      phi::errors::InvalidArgument(
+          "The first dimension of input must equal the addmm output's first "
+          "dimension, but received input's shape = [%s], x's shape = [%s].",
+          input_shape,
+          x_shape));
+  PADDLE_ENFORCE_EQ(
+      input_shape[1],
+      y_shape[1],
+      phi::errors::InvalidArgument(
+          "The second dimension of input must equal the addmm output's second "
+          "dimension, but received input's shape = [%s], y's shape = [%s].",
+          input_shape,
+          y_shape));
 }
 
-// Addmm broadcast validation for static graph
-void AddmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y) {
+// Addmm inplace shape validation for static graph
+void AddmmInplacePreProcess(pir::Value* input, pir::Value* x, pir::Value* y) {
   auto input_shape = pir::GetShapeFromValue(*input);
   auto x_shape = pir::GetShapeFromValue(*x);
   auto y_shape = pir::GetShapeFromValue(*y);
+
+  auto input_dtype = pir::GetValueDtype(*input);
+  auto x_dtype = pir::GetValueDtype(*x);
+  auto y_dtype = pir::GetValueDtype(*y);
+  PADDLE_ENFORCE_EQ(
+      input_dtype,
+      x_dtype,
+      phi::errors::InvalidArgument(
+          "The dtypes of input and x must be the same for addmm_, but "
+          "received input dtype = %s and x dtype = %s.",
+          input_dtype,
+          x_dtype));
+  PADDLE_ENFORCE_EQ(
+      input_dtype,
+      y_dtype,
+      phi::errors::InvalidArgument(
+          "The dtypes of input and y must be the same for addmm_, but "
+          "received input dtype = %s and y dtype = %s.",
+          input_dtype,
+          y_dtype));
 
   // Validate x and y are 2D
   PADDLE_ENFORCE_EQ(
@@ -397,34 +436,44 @@ void AddmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y) {
           y_shape.size()));
 
   // Validate x's width equals y's height
-  PADDLE_ENFORCE_EQ(x_shape[1],
-                    y_shape[0],
-                    phi::errors::InvalidArgument(
-                        "The input Variable x's width must be equal with "
-                        "Variable y's height. "
-                        "But received x's shape[1] = %d, y's shape[0] = %d.",
-                        x_shape[1],
-                        y_shape[0]));
-  // Validate input shape broadcast compatibility
-  if (input_shape.size() == 2) {
-    ValidateBroadcastDim(input_shape[0],
-                         x_shape[0],
-                         "The dimension 0 of input must be equal to x's "
-                         "dimension 0, or must be 1.");
-    ValidateBroadcastDim(input_shape[1],
-                         y_shape[1],
-                         "The dimension 1 of input must be equal to y's "
-                         "dimension 1, or must be 1.");
-  } else if (input_shape.size() == 1) {
-    ValidateBroadcastDim(input_shape[0],
-                         y_shape[1],
-                         "The dimension 0 of input must be equal to y's "
-                         "dimension 1, or must be 1.");
-  } else {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("The dimension of input should be 2 or 1 "
-                                     "but received input's dimension: %ld.",
-                                     input_shape.size()));
+  if (x_shape[1] >= 0 && y_shape[0] >= 0) {
+    PADDLE_ENFORCE_EQ(
+        x_shape[1],
+        y_shape[0],
+        phi::errors::InvalidArgument(
+            "The input Variable x's width must be equal with Variable y's "
+            "height. But received x's shape[1] = %d, y's shape[0] = %d.",
+            x_shape[1],
+            y_shape[0]));
+  }
+  PADDLE_ENFORCE_EQ(
+      input_shape.size(),
+      2,
+      phi::errors::InvalidArgument(
+          "The dimension of input must be 2 for addmm_, but received input's "
+          "dimension: %ld.",
+          input_shape.size()));
+  if (input_shape[0] >= 0 && x_shape[0] >= 0) {
+    PADDLE_ENFORCE_EQ(
+        input_shape[0],
+        x_shape[0],
+        phi::errors::InvalidArgument(
+            "The first dimension of input must equal the addmm output's first "
+            "dimension, but received input's shape[0] = %d and x's shape[0] "
+            "= %d.",
+            input_shape[0],
+            x_shape[0]));
+  }
+  if (input_shape[1] >= 0 && y_shape[1] >= 0) {
+    PADDLE_ENFORCE_EQ(
+        input_shape[1],
+        y_shape[1],
+        phi::errors::InvalidArgument(
+            "The second dimension of input must equal the addmm output's "
+            "second dimension, but received input's shape[1] = %d and y's "
+            "shape[1] = %d.",
+            input_shape[1],
+            y_shape[1]));
   }
 }
 

--- a/paddle/fluid/pybind/arg_pre_process.h
+++ b/paddle/fluid/pybind/arg_pre_process.h
@@ -64,11 +64,11 @@ void GridSamplePreProcess(Value* x,
                           std::string* padding_mode,
                           bool* align_corners);
 
-// Addmm broadcast validation for dygraph
-void AddmmPreProcess(Tensor* input, Tensor* x, Tensor* y);
+// Addmm inplace shape validation for dygraph.
+void AddmmInplacePreProcess(Tensor* input, Tensor* x, Tensor* y);
 
-// Addmm broadcast validation for static graph
-void AddmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y);
+// Addmm inplace shape validation for static graph.
+void AddmmInplacePreProcess(pir::Value* input, pir::Value* x, pir::Value* y);
 
 // Baddbmm broadcast validation for dygraph
 void BaddbmmPreProcess(Tensor* input, Tensor* x, Tensor* y);

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -130,6 +130,42 @@ void AddmmInferMeta(const MetaTensor& input,
                               "But received y's dimension = [%d].",
                               ndim_y));
 
+  if (x_dims[1] >= 0 && y_dims[0] >= 0) {
+    PADDLE_ENFORCE_EQ(
+        x_dims[1],
+        y_dims[0],
+        errors::InvalidArgument(
+            "Input(X)'s width must equal Input(Y)'s height, but received %d "
+            "and %d.",
+            x_dims[1],
+            y_dims[0]));
+  }
+
+  auto check_broadcast_dim =
+      [](int64_t actual, int64_t expected, const char* message) {
+        if (actual >= 0 && expected >= 0) {
+          PADDLE_ENFORCE_EQ(actual == 1 || actual == expected,
+                            true,
+                            errors::InvalidArgument(message, actual, expected));
+        }
+      };
+  if (ndim_input == 2) {
+    check_broadcast_dim(input_dims[0],
+                        x_dims[0],
+                        "Input(input)'s first dimension must be 1 or match "
+                        "Input(X)'s first dimension, but received %d and %d.");
+    check_broadcast_dim(input_dims[1],
+                        y_dims[1],
+                        "Input(input)'s second dimension must be 1 or match "
+                        "Input(Y)'s second dimension, but received %d and %d.");
+  } else {
+    check_broadcast_dim(input_dims[0],
+                        y_dims[1],
+                        "The dimension of one-dimensional Input(input) must be "
+                        "1 or match Input(Y)'s second dimension, but received "
+                        "%d and %d.");
+  }
+
   std::vector<int64_t> output_dims;
   output_dims.push_back(x_dims[0]);
   output_dims.push_back(y_dims[1]);
@@ -178,45 +214,6 @@ void AddmmOutDtypeInferMeta(const MetaTensor& input,
           out_dtype));
 
   AddmmInferMeta(input, x, y, beta, alpha, out);
-
-  const auto input_dims = input.dims();
-  const auto x_dims = x.dims();
-  const auto y_dims = y.dims();
-  if (x_dims[1] >= 0 && y_dims[0] >= 0) {
-    PADDLE_ENFORCE_EQ(
-        x_dims[1],
-        y_dims[0],
-        errors::InvalidArgument(
-            "Input(X)'s width must equal Input(Y)'s height, but received %d "
-            "and %d.",
-            x_dims[1],
-            y_dims[0]));
-  }
-
-  auto check_broadcast_dim =
-      [](int64_t actual, int64_t expected, const char* message) {
-        if (actual >= 0 && expected >= 0) {
-          PADDLE_ENFORCE_EQ(actual == 1 || actual == expected,
-                            true,
-                            errors::InvalidArgument(message, actual, expected));
-        }
-      };
-  if (input_dims.size() == 2) {
-    check_broadcast_dim(input_dims[0],
-                        x_dims[0],
-                        "Input(input)'s first dimension must be 1 or match "
-                        "Input(X)'s first dimension, but received %d and %d.");
-    check_broadcast_dim(input_dims[1],
-                        y_dims[1],
-                        "Input(input)'s second dimension must be 1 or match "
-                        "Input(Y)'s second dimension, but received %d and %d.");
-  } else {
-    check_broadcast_dim(input_dims[0],
-                        y_dims[1],
-                        "The dimension of one-dimensional Input(input) must be "
-                        "1 or match Input(Y)'s second dimension, but received "
-                        "%d and %d.");
-  }
 
   out->set_dtype(DataType::FLOAT32);
 }

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -139,6 +139,88 @@ void AddmmInferMeta(const MetaTensor& input,
   out->set_dtype(input.dtype());
 }
 
+void AddmmOutDtypeInferMeta(const MetaTensor& input,
+                            const MetaTensor& x,
+                            const MetaTensor& y,
+                            DataType out_dtype,
+                            double beta,
+                            double alpha,
+                            MetaTensor* out) {
+  PADDLE_ENFORCE_EQ(
+      out_dtype,
+      DataType::FLOAT32,
+      errors::InvalidArgument(
+          "The out_dtype of paddle.addmm currently only supports float32."));
+  PADDLE_ENFORCE_EQ(
+      x.dtype() == DataType::FLOAT16 || x.dtype() == DataType::BFLOAT16,
+      true,
+      errors::InvalidArgument(
+          "The out_dtype of paddle.addmm currently only supports float16 or "
+          "bfloat16 Input(X), but received %s.",
+          x.dtype()));
+  PADDLE_ENFORCE_EQ(
+      y.dtype(),
+      x.dtype(),
+      errors::InvalidArgument(
+          "Input(X) and Input(Y) must have the same dtype when out_dtype is "
+          "specified for paddle.addmm, but received %s and %s.",
+          x.dtype(),
+          y.dtype()));
+  PADDLE_ENFORCE_EQ(
+      input.dtype() == x.dtype() || input.dtype() == out_dtype,
+      true,
+      errors::InvalidArgument(
+          "Input(input) must have the same dtype as Input(X) or out_dtype "
+          "when out_dtype is specified for paddle.addmm, but received %s, %s "
+          "and %s respectively.",
+          input.dtype(),
+          x.dtype(),
+          out_dtype));
+
+  AddmmInferMeta(input, x, y, beta, alpha, out);
+
+  const auto input_dims = input.dims();
+  const auto x_dims = x.dims();
+  const auto y_dims = y.dims();
+  if (x_dims[1] >= 0 && y_dims[0] >= 0) {
+    PADDLE_ENFORCE_EQ(
+        x_dims[1],
+        y_dims[0],
+        errors::InvalidArgument(
+            "Input(X)'s width must equal Input(Y)'s height, but received %d "
+            "and %d.",
+            x_dims[1],
+            y_dims[0]));
+  }
+
+  auto check_broadcast_dim =
+      [](int64_t actual, int64_t expected, const char* message) {
+        if (actual >= 0 && expected >= 0) {
+          PADDLE_ENFORCE_EQ(actual == 1 || actual == expected,
+                            true,
+                            errors::InvalidArgument(message, actual, expected));
+        }
+      };
+  if (input_dims.size() == 2) {
+    check_broadcast_dim(input_dims[0],
+                        x_dims[0],
+                        "Input(input)'s first dimension must be 1 or match "
+                        "Input(X)'s first dimension, but received %d and %d.");
+    check_broadcast_dim(input_dims[1],
+                        y_dims[1],
+                        "Input(input)'s second dimension must be 1 or match "
+                        "Input(Y)'s second dimension, but received %d and %d.");
+  } else {
+    check_broadcast_dim(input_dims[0],
+                        y_dims[1],
+                        "The dimension of one-dimensional Input(input) must be "
+                        "1 or match Input(Y)'s second dimension, but received "
+                        "%d and %d.");
+  }
+
+  out->set_dtype(DataType::FLOAT32);
+}
+
 void BaddbmmInferMeta(const MetaTensor& input,
                       const MetaTensor& x,
                       const MetaTensor& y,

--- a/paddle/phi/infermeta/ternary.h
+++ b/paddle/phi/infermeta/ternary.h
@@ -48,6 +48,14 @@ PADDLE_API void AddmmInferMeta(const MetaTensor& input,
                                double alpha,
                                MetaTensor* out);
 
+PADDLE_API void AddmmOutDtypeInferMeta(const MetaTensor& input,
+                                       const MetaTensor& x,
+                                       const MetaTensor& y,
+                                       DataType out_dtype,
+                                       double beta,
+                                       double alpha,
+                                       MetaTensor* out);
+
 PADDLE_API void BaddbmmInferMeta(const MetaTensor& input,
                                  const MetaTensor& x,
                                  const MetaTensor& y,

--- a/paddle/phi/kernels/addmm_kernel.h
+++ b/paddle/phi/kernels/addmm_kernel.h
@@ -27,4 +27,14 @@ void AddmmKernel(const Context& dev_ctx,
                  double alpha,
                  DenseTensor* out);
 
+template <typename T, typename Context>
+void AddmmOutDtypeKernel(const Context& dev_ctx,
+                         const DenseTensor& input,
+                         const DenseTensor& x,
+                         const DenseTensor& y,
+                         DataType out_dtype,
+                         double beta,
+                         double alpha,
+                         DenseTensor* out);
+
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/addmm_kernel.cu
+++ b/paddle/phi/kernels/gpu/addmm_kernel.cu
@@ -26,3 +26,12 @@ PD_REGISTER_KERNEL(addmm,
                    double,
                    phi::float16,
                    phi::bfloat16) {}
+
+PD_REGISTER_KERNEL(addmm_out_dtype,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::AddmmOutDtypeKernel,
+                   phi::float16,
+                   phi::bfloat16) {
+  kernel->OutputAt(0).SetDataType(phi::DataType::FLOAT32);
+}

--- a/paddle/phi/kernels/impl/addmm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/addmm_kernel_impl.h
@@ -20,6 +20,8 @@ limitations under the License. */
 
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/kernels/addmm_kernel.h"
+#include "paddle/phi/kernels/cast_kernel.h"
+#include "paddle/phi/kernels/contiguous_kernel.h"
 #include "paddle/phi/kernels/expand_kernel.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/for_range.h"
@@ -153,6 +155,123 @@ void AddmmKernel(const Context& dev_ctx,
               out->data<T>(),
               y_dims[1]);
   }
+}
+
+template <typename T, typename Context>
+void AddmmOutDtypeKernel(const Context& dev_ctx,
+                         const DenseTensor& input,
+                         const DenseTensor& x,
+                         const DenseTensor& y,
+                         DataType out_dtype,
+                         double beta,
+                         double alpha,
+                         DenseTensor* out) {
+#if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP)
+  PADDLE_ENFORCE_EQ(
+      out_dtype,
+      DataType::FLOAT32,
+      errors::InvalidArgument(
+          "The out_dtype of paddle.addmm currently only supports float32."));
+  PADDLE_ENFORCE_EQ(
+      x.dtype() == DataType::FLOAT16 || x.dtype() == DataType::BFLOAT16,
+      true,
+      errors::InvalidArgument(
+          "The out_dtype of paddle.addmm currently only supports float16 or "
+          "bfloat16 Input(X)."));
+  PADDLE_ENFORCE_EQ(
+      x.dtype(),
+      y.dtype(),
+      errors::InvalidArgument(
+          "Input(X) and Input(Y) must have the same dtype when out_dtype is "
+          "specified for paddle.addmm."));
+  PADDLE_ENFORCE_EQ(
+      input.dtype() == x.dtype() || input.dtype() == DataType::FLOAT32,
+      true,
+      errors::InvalidArgument(
+          "Input(input) must have the same dtype as Input(X) or float32 when "
+          "out_dtype is specified for paddle.addmm."));
+
+  const auto input_dims = input.dims();
+  const auto x_dims = x.dims();
+  const auto y_dims = y.dims();
+  PADDLE_ENFORCE_EQ(
+      input_dims.size() == 1 || input_dims.size() == 2,
+      true,
+      errors::InvalidArgument(
+          "The dimension of input must be 1 or 2 when out_dtype is specified "
+          "for paddle.addmm."));
+  PADDLE_ENFORCE_EQ(
+      x_dims.size(),
+      2,
+      errors::InvalidArgument(
+          "The dimension of x must be 2 when out_dtype is specified for "
+          "paddle.addmm."));
+  PADDLE_ENFORCE_EQ(
+      y_dims.size(),
+      2,
+      errors::InvalidArgument(
+          "The dimension of y must be 2 when out_dtype is specified for "
+          "paddle.addmm."));
+  PADDLE_ENFORCE_EQ(
+      x_dims[1],
+      y_dims[0],
+      errors::InvalidArgument(
+          "Input(X)'s width must equal Input(Y)'s height when out_dtype is "
+          "specified for paddle.addmm."));
+
+  DenseTensor input_2d(input);
+  if (input_dims.size() == 1) {
+    input_2d.Resize({1, input_dims[0]});
+  }
+
+  DenseTensor input_float;
+  const DenseTensor* input_ptr = &input_2d;
+  if (input.dtype() != DataType::FLOAT32) {
+    input_float = Cast<T, Context>(dev_ctx, input_2d, DataType::FLOAT32);
+    input_ptr = &input_float;
+  }
+
+  ExpandKernel<float>(
+      dev_ctx, *input_ptr, IntArray({x_dims[0], y_dims[1]}), out);
+  if (out->numel() == 0) {
+    return;
+  }
+  if (x.numel() == 0 || y.numel() == 0) {
+    funcs::ForRange<Context> for_range(dev_ctx, out->numel());
+    AddmmScaleFunctor<float> functor(beta, out->data<float>());
+    for_range(functor);
+    return;
+  }
+
+  DenseTensor x_contiguous;
+  DenseTensor y_contiguous;
+  const DenseTensor* x_ptr = &x;
+  const DenseTensor* y_ptr = &y;
+  if (!x.meta().is_contiguous()) {
+    ContiguousKernel<T, Context>(dev_ctx, x, &x_contiguous);
+    x_ptr = &x_contiguous;
+  }
+  if (!y.meta().is_contiguous()) {
+    ContiguousKernel<T, Context>(dev_ctx, y, &y_contiguous);
+    y_ptr = &y_contiguous;
+  }
+
+  funcs::Blas<Context> blas(dev_ctx);
+  blas.GEMM(CblasNoTrans,
+            CblasNoTrans,
+            x_dims[0],
+            y_dims[1],
+            x_dims[1],
+            static_cast<float>(alpha),
+            x_ptr->data<T>(),
+            y_ptr->data<T>(),
+            static_cast<float>(beta),
+            out->data<float>());
+#else
+  PADDLE_THROW(errors::Unimplemented(
+      "The out_dtype of paddle.addmm currently only supports CUDA float16 or "
+      "bfloat16 inputs."));
+#endif
 }
 
 }  // namespace phi

--- a/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
@@ -19,6 +19,16 @@
   invoke : add_n_impl(inputs)
   backward : add_n_grad
 
+- op : addmm_out_dtype
+  args : (Tensor input, Tensor x, Tensor y, DataType out_dtype, double beta=1.0, double alpha=1.0)
+  output : Tensor(out)
+  infer_meta :
+    func : AddmmOutDtypeInferMeta
+  kernel :
+    func : addmm_out_dtype
+    data_type : x
+  traits : paddle::dialect::ForwardOnlyTrait
+
 - op : arange
   args : (Tensor start, Tensor end, Tensor step, DataType dtype, Place place={})
   output : Tensor(out)

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -125,21 +125,13 @@
   args_alias :
     use_default_mapping : True
 
-- op : addmm
-  name : [paddle.addmm, paddle.Tensor.addmm]
-  args_alias :
-    x : [mat1]
-    y : [mat2]
-  pre_process :
-    func : AddmmPreProcess(input, x, y)
-
 - op : addmm_
   name : [paddle.addmm_, paddle.Tensor.addmm_]
   args_alias :
     x : [mat1]
     y : [mat2]
   pre_process :
-    func : AddmmPreProcess(input, x, y)
+    func : AddmmInplacePreProcess(input, x, y)
 
 - op : baddbmm
   name : [paddle.baddbmm, paddle.Tensor.baddbmm]

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -4702,59 +4702,6 @@ def i1e(
 
 
 @add_doc_and_signature
-def addmm(
-    input: Tensor,
-    x: Tensor,
-    y: Tensor,
-    beta: float = 1.0,
-    alpha: float = 1.0,
-    name: str | None = None,
-    *,
-    out: Tensor | None = None,
-) -> Tensor:
-    r"""
-    Perform matrix multiplication for input $x$ and $y$.
-    $input$ is added to the final result.
-    The equation is:
-
-    ..  math::
-        Out = alpha * x * y + beta * input
-
-    $Input$, $x$ and $y$ can carry the LoD (Level of Details) information, or not. But the output only shares the LoD information with input $input$.
-
-    Args:
-        input (Tensor): The input Tensor to be added to the final result.
-        x (Tensor): The first input Tensor for matrix multiplication. Alias: ``mat1``.
-        y (Tensor): The second input Tensor for matrix multiplication. Alias: ``mat2``.
-        beta (float, optional): Coefficient of $input$, default is 1.
-        alpha (float, optional): Coefficient of $x*y$, default is 1.
-        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
-    Keyword args:
-        out (Tensor, optional): The output Tensor. If set, the result will be stored in this Tensor. Default: None.
-
-    Returns:
-        Tensor: The output Tensor of addmm.
-
-    Examples:
-        .. code-block:: pycon
-
-            >>> import paddle
-
-            >>> x = paddle.ones([2, 2])
-            >>> y = paddle.ones([2, 2])
-            >>> input = paddle.ones([2, 2])
-
-            >>> out = paddle.addmm(input=input, x=x, y=y, beta=0.5, alpha=5.0)
-
-            >>> print(out)
-            Tensor(shape=[2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [[10.50000000, 10.50000000],
-             [10.50000000, 10.50000000]])
-    """
-    ...
-
-
-@add_doc_and_signature
 def addmm_(
     input: Tensor,
     x: Tensor,

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2383,30 +2383,9 @@ def addmm(
             core.DataType.BFLOAT16,
             core.VarDesc.VarType.BF16,
         )
-        if out_dtype not in float32_dtypes:
-            raise TypeError(
-                "The out_dtype of paddle.addmm currently only supports paddle.float32."
-            )
         if x.dtype not in supported_input_dtypes:
             raise TypeError(
                 "The out_dtype of paddle.addmm currently only supports float16 or bfloat16 x."
-            )
-        if y.dtype not in supported_input_dtypes:
-            raise TypeError(
-                "The out_dtype of paddle.addmm currently only supports float16 or bfloat16 y."
-            )
-        if x.dtype != y.dtype:
-            raise TypeError(
-                "The x and y of paddle.addmm must have the same dtype when out_dtype is specified."
-            )
-        input_is_float32 = input.dtype in float32_dtypes
-        if input.dtype not in supported_input_dtypes and not input_is_float32:
-            raise TypeError(
-                "The input of paddle.addmm must have the same dtype as x or float32 when out_dtype is specified."
-            )
-        if input.dtype != x.dtype and not input_is_float32:
-            raise TypeError(
-                "The input of paddle.addmm must have the same dtype as x or float32 when out_dtype is specified."
             )
         if out is not None and out.dtype not in float32_dtypes:
             raise TypeError(

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import builtins
 import math
 import numbers
 import warnings
@@ -31,7 +32,6 @@ from paddle._C_ops import (  # noqa: F401
     acos_,
     acosh,
     acosh_,
-    addmm,
     addmm_,
     all,
     amax,
@@ -122,6 +122,7 @@ from paddle.base.libpaddle import DataType
 from paddle.common_ops_import import VarDesc, dygraph_utils
 from paddle.pir import Value
 from paddle.utils.decorator_utils import (
+    addmm_compat_decorator,
     nansum_decorator,
     param_one_alias,
     param_two_alias,
@@ -2333,6 +2334,194 @@ def mm(
         return out
 
 
+@addmm_compat_decorator
+@param_two_alias(["x", "mat1"], ["y", "mat2"])
+def addmm(
+    input: Tensor,
+    x: Tensor,
+    y: Tensor,
+    out_dtype: DTypeLike | None = None,
+    name: str | None = None,
+    *,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+    out: Tensor | None = None,
+) -> Tensor:
+    r"""
+    Perform matrix multiplication for ``x`` and ``y`` and add ``input``.
+
+    The equation is ``out = beta * input + alpha * (x @ y)``. The input
+    tensor can be one- or two-dimensional and is broadcast to the matrix
+    result when needed.
+
+    Args:
+        input (Tensor): The input Tensor to be added to the final result.
+        x (Tensor): The first matrix. Alias: ``mat1``.
+        y (Tensor): The second matrix. Alias: ``mat2``.
+        out_dtype (DTypeLike|None, optional): The output dtype. Currently only
+            ``paddle.float32`` is supported for float16/bfloat16 inputs on
+            CUDA. A numeric fourth positional argument is interpreted as the
+            legacy ``beta`` argument. Default: None.
+        name (str|None, optional): Name for the operation. Default: None.
+
+    Keyword Args:
+        beta (float, optional): Coefficient of ``input``. Default: 1.0.
+        alpha (float, optional): Coefficient of ``x @ y``. Default: 1.0.
+        out (Tensor|None, optional): The output Tensor. Default: None.
+
+    Returns:
+        Tensor: The matrix multiplication result with the broadcasted input
+            added. Its dtype is ``out_dtype`` when specified, otherwise it is
+            the input dtype.
+    """
+    input_shape = input.shape
+    x_shape = x.shape
+    y_shape = y.shape
+
+    if not len(x_shape) == len(y_shape) == 2:
+        raise ValueError(
+            f"The dimension of x, y should be 2 but receive x's shape: {x_shape}, "
+            f"y's shape: {y_shape}"
+        )
+
+    if x_shape[1] >= 0 and y_shape[0] >= 0 and x_shape[1] != y_shape[0]:
+        raise ValueError(
+            "The input Variable x's width must be equal with Variable y's "
+            f"height. But received x's shape = {x_shape}, y's shape = {y_shape}."
+        )
+
+    def _broadcastable(actual, expected):
+        return actual < 0 or expected < 0 or actual in (1, expected)
+
+    if len(input_shape) == 2:
+        if not _broadcastable(input_shape[0], x_shape[0]):
+            raise ValueError(
+                "The dimension 0 of input must be equal to x's dimension 0, "
+                "or must be 1."
+            )
+        if not _broadcastable(input_shape[1], y_shape[1]):
+            raise ValueError(
+                "The dimension 1 of input must be equal to y's dimension 1, "
+                "or must be 1."
+            )
+    elif len(input_shape) == 1:
+        if not _broadcastable(input_shape[0], y_shape[1]):
+            raise ValueError(
+                "The dimension 0 of input must be equal to y's dimension 1, "
+                "or must be 1."
+            )
+    else:
+        raise ValueError(
+            f"The dimension of input should be 2 or 1 but receive input's shape: {input_shape}"
+        )
+
+    if out_dtype is not None:
+        out_dtype = convert_nptype_to_datatype_or_vartype(out_dtype)
+        float32_dtypes = (core.DataType.FLOAT32, core.VarDesc.VarType.FP32)
+        supported_input_dtypes = (
+            core.DataType.FLOAT16,
+            core.VarDesc.VarType.FP16,
+            core.DataType.BFLOAT16,
+            core.VarDesc.VarType.BF16,
+        )
+        if out_dtype not in float32_dtypes:
+            raise TypeError(
+                "The out_dtype of paddle.addmm currently only supports paddle.float32."
+            )
+        if x.dtype not in supported_input_dtypes:
+            raise TypeError(
+                "The out_dtype of paddle.addmm currently only supports float16 or bfloat16 x."
+            )
+        if y.dtype not in supported_input_dtypes:
+            raise TypeError(
+                "The out_dtype of paddle.addmm currently only supports float16 or bfloat16 y."
+            )
+        if x.dtype != y.dtype:
+            raise TypeError(
+                "The x and y of paddle.addmm must have the same dtype when out_dtype is specified."
+            )
+        input_is_float32 = input.dtype in float32_dtypes
+        if input.dtype not in supported_input_dtypes and not input_is_float32:
+            raise TypeError(
+                "The input of paddle.addmm must have the same dtype as x or float32 when out_dtype is specified."
+            )
+        if input.dtype != x.dtype and not input_is_float32:
+            raise TypeError(
+                "The input of paddle.addmm must have the same dtype as x or float32 when out_dtype is specified."
+            )
+        if out is not None and out.dtype not in float32_dtypes:
+            raise TypeError(
+                "The out tensor dtype must be paddle.float32 when out_dtype is paddle.float32."
+            )
+        if not in_dynamic_mode():
+            raise NotImplementedError(
+                "The out_dtype of paddle.addmm currently only supports dynamic graph."
+            )
+        if (
+            not paddle.is_compiled_with_cuda()
+            or paddle.is_compiled_with_rocm()
+            or not input.place.is_gpu_place()
+            or not x.place.is_gpu_place()
+            or not y.place.is_gpu_place()
+            or (out is not None and not out.place.is_gpu_place())
+        ):
+            raise NotImplementedError(
+                "The out_dtype of paddle.addmm currently only supports CUDA tensors."
+            )
+
+        if (
+            out is not None
+            and paddle.is_grad_enabled()
+            and builtins.any(
+                not tensor.stop_gradient for tensor in (input, x, y, out)
+            )
+        ):
+            raise RuntimeError(
+                "addmm(): functions with out=... arguments don't support "
+                "automatic differentiation, but one of the arguments requires grad."
+            )
+        return _C_ops.addmm_out_dtype(
+            input, x, y, out_dtype, beta, alpha, out=out
+        )
+
+    if (
+        out is not None
+        and paddle.is_grad_enabled()
+        and builtins.any(
+            not tensor.stop_gradient for tensor in (input, x, y, out)
+        )
+    ):
+        raise RuntimeError(
+            "addmm(): functions with out=... arguments don't support automatic "
+            "differentiation, but one of the arguments requires grad."
+        )
+
+    if in_dynamic_mode():
+        return _C_ops.addmm(input, x, y, beta, alpha, out=out)
+
+    if in_pir_mode():
+        return _C_ops.addmm(input, x, y, beta, alpha, out=out)
+
+    inputs = {'Input': input, 'X': x, 'Y': y}
+    attrs = {'Alpha': alpha, 'Beta': beta}
+    helper = LayerHelper('addmm', **locals())
+    check_variable_and_dtype(
+        input, 'Input', ['float16', 'float32', 'float64', 'uint16'], 'addmm'
+    )
+    check_variable_and_dtype(
+        x, 'X', ['float16', 'float32', 'float64', 'uint16'], 'addmm'
+    )
+    check_variable_and_dtype(
+        y, 'Y', ['float16', 'float32', 'float64', 'uint16'], 'addmm'
+    )
+    if out is None:
+        out = helper.create_variable_for_type_inference(dtype=x.dtype)
+    helper.append_op(
+        type='addmm', inputs=inputs, attrs=attrs, outputs={'Out': out}
+    )
+    return out
+
+
 def addmv(
     input: Tensor,
     mat: Tensor,
@@ -2372,7 +2561,11 @@ def addmv(
             >>> out = paddle.addmv(input, mat, vec)
     """
     result = addmm(
-        input.unsqueeze(-1), mat, vec.unsqueeze(-1), beta, alpha
+        input.unsqueeze(-1),
+        mat,
+        vec.unsqueeze(-1),
+        beta=beta,
+        alpha=alpha,
     ).squeeze(-1)
     if out is not None:
         paddle.assign(result, out)
@@ -2432,7 +2625,13 @@ def addr(
             >>> vec2 = paddle.randn([4])
             >>> out = paddle.addr(input, vec1, vec2)
     """
-    result = addmm(input, vec1.unsqueeze(-1), vec2.unsqueeze(0), beta, alpha)
+    result = addmm(
+        input,
+        vec1.unsqueeze(-1),
+        vec2.unsqueeze(0),
+        beta=beta,
+        alpha=alpha,
+    )
     if out is not None:
         paddle.assign(result, out)
         return out

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2374,47 +2374,6 @@ def addmm(
             added. Its dtype is ``out_dtype`` when specified, otherwise it is
             the input dtype.
     """
-    input_shape = input.shape
-    x_shape = x.shape
-    y_shape = y.shape
-
-    if not len(x_shape) == len(y_shape) == 2:
-        raise ValueError(
-            f"The dimension of x, y should be 2 but receive x's shape: {x_shape}, "
-            f"y's shape: {y_shape}"
-        )
-
-    if x_shape[1] >= 0 and y_shape[0] >= 0 and x_shape[1] != y_shape[0]:
-        raise ValueError(
-            "The input Variable x's width must be equal with Variable y's "
-            f"height. But received x's shape = {x_shape}, y's shape = {y_shape}."
-        )
-
-    def _broadcastable(actual, expected):
-        return actual < 0 or expected < 0 or actual in (1, expected)
-
-    if len(input_shape) == 2:
-        if not _broadcastable(input_shape[0], x_shape[0]):
-            raise ValueError(
-                "The dimension 0 of input must be equal to x's dimension 0, "
-                "or must be 1."
-            )
-        if not _broadcastable(input_shape[1], y_shape[1]):
-            raise ValueError(
-                "The dimension 1 of input must be equal to y's dimension 1, "
-                "or must be 1."
-            )
-    elif len(input_shape) == 1:
-        if not _broadcastable(input_shape[0], y_shape[1]):
-            raise ValueError(
-                "The dimension 0 of input must be equal to y's dimension 1, "
-                "or must be 1."
-            )
-    else:
-        raise ValueError(
-            f"The dimension of input should be 2 or 1 but receive input's shape: {input_shape}"
-        )
-
     if out_dtype is not None:
         out_dtype = convert_nptype_to_datatype_or_vartype(out_dtype)
         float32_dtypes = (core.DataType.FLOAT32, core.VarDesc.VarType.FP32)
@@ -2469,21 +2428,6 @@ def addmm(
                 "The out_dtype of paddle.addmm currently only supports CUDA tensors."
             )
 
-        if (
-            out is not None
-            and paddle.is_grad_enabled()
-            and builtins.any(
-                not tensor.stop_gradient for tensor in (input, x, y, out)
-            )
-        ):
-            raise RuntimeError(
-                "addmm(): functions with out=... arguments don't support "
-                "automatic differentiation, but one of the arguments requires grad."
-            )
-        return _C_ops.addmm_out_dtype(
-            input, x, y, out_dtype, beta, alpha, out=out
-        )
-
     if (
         out is not None
         and paddle.is_grad_enabled()
@@ -2494,6 +2438,11 @@ def addmm(
         raise RuntimeError(
             "addmm(): functions with out=... arguments don't support automatic "
             "differentiation, but one of the arguments requires grad."
+        )
+
+    if out_dtype is not None:
+        return _C_ops.addmm_out_dtype(
+            input, x, y, out_dtype, beta, alpha, out=out
         )
 
     if in_dynamic_mode():

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import functools
 import inspect
+import numbers
 import warnings
 from collections.abc import Callable, Iterable
 from typing import Any, TypeVar, cast
@@ -219,6 +220,40 @@ def param_two_alias(
         return wrapper
 
     return decorator
+
+
+def addmm_compat_decorator(
+    func: Callable[_InputT, _RetT],
+) -> Callable[_InputT, _RetT]:
+    """Preserve the legacy positional ``beta``, ``alpha``, and ``name``.
+
+    The public signature follows PyTorch by putting ``out_dtype`` in the
+    fourth position and making ``beta`` and ``alpha`` keyword-only. Numeric
+    fourth positional arguments still use Paddle's legacy argument order.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
+        if len(args) >= 4 and isinstance(args[3], numbers.Number):
+            legacy_args = args[3:]
+            if len(legacy_args) > 3:
+                raise TypeError(
+                    "addmm() received too many positional arguments"
+                )
+            for name, value in zip(
+                ("beta", "alpha", "name")[: len(legacy_args)],
+                legacy_args,
+            ):
+                if name in kwargs:
+                    raise TypeError(
+                        f"addmm() got multiple values for argument '{name}'"
+                    )
+                kwargs[name] = value
+            args = args[:3]
+        return func(*args, **kwargs)
+
+    wrapper.__signature__ = inspect.signature(func)
+    return cast("Callable[_InputT, _RetT]", wrapper)
 
 
 def lp_pool_layer_decorator(

--- a/test/legacy_test/test_addmm_op.py
+++ b/test/legacy_test/test_addmm_op.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import unittest
 
 import numpy as np
@@ -27,13 +28,17 @@ from paddle import base
 from paddle.base import Program, core, program_guard
 
 
+def addmm_api_for_op_test(input, x, y, beta=1.0, alpha=1.0):
+    return paddle.addmm(input, x, y, beta=beta, alpha=alpha)
+
+
 class TestAddMMOp(OpTest):
     # test basic
     def setUp(self):
         self.op_type = "addmm"
         self.prim_op_type = "comp"
-        self.python_api = paddle.addmm
-        self.public_python_api = paddle.addmm
+        self.python_api = addmm_api_for_op_test
+        self.public_python_api = addmm_api_for_op_test
         self.init_dtype_type()
         self.inputs = {
             'Input': np.random.random((100, 1)).astype(self.dtype),
@@ -103,7 +108,7 @@ class TestAddMMFP16Op(TestAddMMOp):
 class TestAddMMBF16Op(OpTest):
     def setUp(self):
         self.op_type = "addmm"
-        self.python_api = paddle.addmm
+        self.python_api = addmm_api_for_op_test
         self.init_dtype_type()
         self.inputs = {
             'Input': np.random.random((100, 1)).astype(self.np_dtype),
@@ -250,8 +255,8 @@ class TestAddMMOp2(TestAddMMOp):
     def setUp(self):
         self.op_type = "addmm"
         self.prim_op_type = "comp"
-        self.python_api = paddle.addmm
-        self.public_python_api = paddle.addmm
+        self.python_api = addmm_api_for_op_test
+        self.public_python_api = addmm_api_for_op_test
         self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {
@@ -274,8 +279,8 @@ class TestAddMMOp3(OpTest):
     def setUp(self):
         self.op_type = "addmm"
         self.prim_op_type = "comp"
-        self.python_api = paddle.addmm
-        self.public_python_api = paddle.addmm
+        self.python_api = addmm_api_for_op_test
+        self.public_python_api = addmm_api_for_op_test
         self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {
@@ -328,8 +333,8 @@ class TestAddMMOp4(OpTest):
     def setUp(self):
         self.op_type = "addmm"
         self.prim_op_type = "comp"
-        self.python_api = paddle.addmm
-        self.public_python_api = paddle.addmm
+        self.python_api = addmm_api_for_op_test
+        self.public_python_api = addmm_api_for_op_test
         self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {
@@ -565,11 +570,278 @@ class TestAddMMAPI(unittest.TestCase):
         paddle.enable_static()
 
 
+class TestAddmmOutDtypeDynamicOnly(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+
+    def tearDown(self):
+        paddle.enable_static()
+
+    def _skip_if_no_fp16_cuda(self):
+        if not paddle.is_compiled_with_cuda() or paddle.is_compiled_with_rocm():
+            self.skipTest("CUDA is required for addmm out_dtype")
+        if paddle.device.cuda.get_device_capability() < (5, 3):
+            self.skipTest(
+                "FP16 addmm out_dtype requires CUDA compute capability >= 5.3"
+            )
+
+    def _skip_if_no_bf16_cuda(self):
+        if not paddle.is_compiled_with_cuda() or paddle.is_compiled_with_rocm():
+            self.skipTest("CUDA is required for addmm out_dtype")
+        if paddle.device.cuda.get_device_capability()[0] < 8:
+            self.skipTest(
+                "BF16 addmm out_dtype requires CUDA compute capability >= 8"
+            )
+
+    def test_signature_and_legacy_positional_args(self):
+        parameters = inspect.signature(paddle.addmm).parameters
+        self.assertEqual(
+            list(parameters),
+            [
+                'input',
+                'x',
+                'y',
+                'out_dtype',
+                'name',
+                'beta',
+                'alpha',
+                'out',
+            ],
+        )
+        for parameter in ('out_dtype', 'name'):
+            self.assertEqual(
+                parameters[parameter].kind,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        for parameter in ('beta', 'alpha', 'out'):
+            self.assertEqual(
+                parameters[parameter].kind,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+
+        input = paddle.randn([3, 5], dtype='float32')
+        x = paddle.randn([3, 4], dtype='float32')
+        y = paddle.randn([4, 5], dtype='float32')
+        result = paddle.addmm(input, x, y, 0.5, 1.5, 'legacy_addmm')
+        expected = paddle.addmm(input, x, y, beta=0.5, alpha=1.5)
+        np.testing.assert_allclose(
+            result.numpy(), expected.numpy(), rtol=1e-5, atol=1e-5
+        )
+
+    def test_normal_and_out_without_out_dtype(self):
+        input = paddle.randn([3, 5], dtype='float32')
+        x = paddle.randn([3, 4], dtype='float32')
+        y = paddle.randn([4, 5], dtype='float32')
+        expected = input + paddle.mm(x, y)
+
+        result = paddle.addmm(input, x, y)
+        np.testing.assert_allclose(result.numpy(), expected.numpy(), rtol=1e-5)
+
+        out = paddle.empty([3, 5], dtype='float32')
+        result = paddle.addmm(input, x, y, out=out)
+        np.testing.assert_allclose(result.numpy(), expected.numpy(), rtol=1e-5)
+        np.testing.assert_allclose(out.numpy(), expected.numpy(), rtol=1e-5)
+
+    def test_fp16_to_fp32(self):
+        self._skip_if_no_fp16_cuda()
+        input = paddle.randn([5], dtype='float16')
+        x = paddle.randn([3, 4], dtype='float16')
+        y = paddle.randn([4, 5], dtype='float16')
+        result = paddle.addmm(
+            input, x, y, beta=0.5, alpha=1.5, out_dtype=paddle.float32
+        )
+        expected = paddle.addmm(
+            input.astype('float32'),
+            x.astype('float32'),
+            y.astype('float32'),
+            beta=0.5,
+            alpha=1.5,
+        )
+        self.assertEqual(result.dtype, paddle.float32)
+        np.testing.assert_allclose(
+            result.numpy(), expected.numpy(), rtol=1e-3, atol=1e-3
+        )
+
+    def test_fp16_to_fp32_positional_args(self):
+        self._skip_if_no_fp16_cuda()
+        input = paddle.randn([5], dtype='float16')
+        x = paddle.randn([3, 4], dtype='float16')
+        y = paddle.randn([4, 5], dtype='float16')
+        result = paddle.addmm(
+            input,
+            x,
+            y,
+            paddle.float32,
+            'addmm_positional',
+            beta=0.5,
+            alpha=1.5,
+        )
+        expected = paddle.addmm(
+            input.astype('float32'),
+            x.astype('float32'),
+            y.astype('float32'),
+            beta=0.5,
+            alpha=1.5,
+        )
+        self.assertEqual(result.dtype, paddle.float32)
+        np.testing.assert_allclose(
+            result.numpy(), expected.numpy(), rtol=1e-3, atol=1e-3
+        )
+
+    def test_fp16_to_fp32_with_float32_input_and_out(self):
+        self._skip_if_no_fp16_cuda()
+        input = paddle.randn([1, 5], dtype='float32')
+        x = paddle.randn([3, 4], dtype='float16')
+        y = paddle.randn([4, 5], dtype='float16')
+        out = paddle.empty([3, 5], dtype='float32')
+        result = paddle.addmm(
+            input,
+            x,
+            y,
+            beta=0.25,
+            alpha=2.0,
+            out_dtype=paddle.float32,
+            out=out,
+        )
+        expected = paddle.addmm(
+            input,
+            x.astype('float32'),
+            y.astype('float32'),
+            beta=0.25,
+            alpha=2.0,
+        )
+        np.testing.assert_allclose(
+            result.numpy(), expected.numpy(), rtol=1e-3, atol=1e-3
+        )
+        np.testing.assert_allclose(
+            out.numpy(), expected.numpy(), rtol=1e-3, atol=1e-3
+        )
+
+    def test_bf16_to_fp32(self):
+        self._skip_if_no_bf16_cuda()
+        input = paddle.randn([3, 5], dtype='bfloat16')
+        x = paddle.randn([3, 4], dtype='bfloat16')
+        y = paddle.randn([4, 5], dtype='bfloat16')
+        result = paddle.addmm(input, x, y, out_dtype=paddle.float32)
+        expected = paddle.addmm(
+            input.astype('float32'),
+            x.astype('float32'),
+            y.astype('float32'),
+        )
+        self.assertEqual(result.dtype, paddle.float32)
+        np.testing.assert_allclose(
+            result.numpy(), expected.numpy(), rtol=1e-2, atol=1e-2
+        )
+
+    def test_out_dtype_is_forward_only(self):
+        self._skip_if_no_fp16_cuda()
+        input = paddle.randn([3, 5], dtype='float16')
+        x = paddle.randn([3, 4], dtype='float16')
+        y = paddle.randn([4, 5], dtype='float16')
+        input.stop_gradient = False
+        x.stop_gradient = False
+        y.stop_gradient = False
+        result = paddle.addmm(input, x, y, out_dtype=paddle.float32)
+        self.assertTrue(result.stop_gradient)
+
+    def test_out_rejects_autograd(self):
+        input = paddle.randn([3, 5], dtype='float32')
+        x = paddle.randn([3, 4], dtype='float32')
+        y = paddle.randn([4, 5], dtype='float32')
+        out = paddle.empty([3, 5], dtype='float32')
+        x.stop_gradient = False
+        with self.assertRaises(RuntimeError):
+            paddle.addmm(input, x, y, out=out)
+
+        with paddle.no_grad():
+            paddle.addmm(input, x, y, out=out)
+
+    def test_out_dtype_rejects_unsupported_cases(self):
+        input = paddle.randn([3, 5], dtype='float16')
+        x = paddle.randn([3, 4], dtype='float16')
+        y = paddle.randn([4, 5], dtype='float16')
+        with self.assertRaises(TypeError):
+            paddle.addmm(input, x, y, out_dtype=paddle.float16)
+        with self.assertRaises(TypeError):
+            paddle.addmm(
+                input,
+                x,
+                y,
+                out_dtype=paddle.float32,
+                out=paddle.empty([3, 5], dtype='float16'),
+            )
+        with self.assertRaises(TypeError):
+            paddle.addmm(
+                input,
+                x,
+                y.astype('bfloat16'),
+                out_dtype=paddle.float32,
+            )
+
+    def test_out_dtype_rejects_cpu(self):
+        place = paddle.CPUPlace()
+        input = paddle.to_tensor(np.ones([3, 5], dtype=np.float16), place=place)
+        x = paddle.to_tensor(np.ones([3, 4], dtype=np.float16), place=place)
+        y = paddle.to_tensor(np.ones([4, 5], dtype=np.float16), place=place)
+
+        with self.assertRaisesRegex(
+            NotImplementedError, "only supports CUDA tensors"
+        ):
+            paddle.addmm(input, x, y, out_dtype=paddle.float32)
+
+    def test_invalid_dtype_is_checked_before_device(self):
+        place = paddle.CPUPlace()
+        input = paddle.to_tensor(np.ones([3, 5], dtype=np.float32), place=place)
+        x = paddle.to_tensor(np.ones([3, 4], dtype=np.float32), place=place)
+        y = paddle.to_tensor(np.ones([4, 5], dtype=np.float32), place=place)
+
+        with self.assertRaisesRegex(TypeError, "float16 or bfloat16 x"):
+            paddle.addmm(input, x, y, out_dtype=paddle.float32)
+
+    @unittest.skipUnless(
+        paddle.is_compiled_with_rocm(),
+        "ROCm is required for the addmm out_dtype backend check",
+    )
+    def test_out_dtype_rejects_rocm(self):
+        place = paddle.CUDAPlace(0)
+        input = paddle.to_tensor(np.ones([3, 5], dtype=np.float16), place=place)
+        x = paddle.to_tensor(np.ones([3, 4], dtype=np.float16), place=place)
+        y = paddle.to_tensor(np.ones([4, 5], dtype=np.float16), place=place)
+
+        with self.assertRaisesRegex(
+            NotImplementedError, "only supports CUDA tensors"
+        ):
+            paddle.addmm(input, x, y, out_dtype=paddle.float32)
+
+    def test_inplace_requires_exact_output_shape(self):
+        input = paddle.ones([3, 5], dtype='float32')
+        x = paddle.ones([3, 4], dtype='float32')
+        y = paddle.ones([4, 5], dtype='float32')
+        result = paddle.addmm_(input, x, y)
+        np.testing.assert_array_equal(result.numpy(), np.full([3, 5], 5.0))
+
+        with self.assertRaises(ValueError):
+            paddle.addmm_(paddle.ones([5]), x, y)
+        with self.assertRaises(ValueError):
+            paddle.addmm_(input, x, y, out_dtype=paddle.float32)
+
+    def test_static_out_dtype_fails_closed(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
+            input = paddle.static.data('input', [3, 5], dtype='float16')
+            x = paddle.static.data('x', [3, 4], dtype='float16')
+            y = paddle.static.data('y', [4, 5], dtype='float16')
+            with self.assertRaises(NotImplementedError):
+                paddle.addmm(input, x, y, out_dtype=paddle.float32)
+
+
 class TestAddmmOp_ZeroSize(OpTest):
     def setUp(self):
         self.op_type = "addmm"
-        self.python_api = paddle.addmm
-        self.public_python_api = paddle.addmm
+        self.python_api = addmm_api_for_op_test
+        self.public_python_api = addmm_api_for_op_test
         self.init_dtype_type()
         self.init_input()
         self.attrs = {

--- a/test/legacy_test/test_addmm_op.py
+++ b/test/legacy_test/test_addmm_op.py
@@ -401,9 +401,9 @@ class TestAddMMAPI(unittest.TestCase):
         y_data = np.ones([3, 2], dtype=np.float32)
 
         with paddle.pir_utils.OldIrGuard():
-            main = Program()
-            startup = Program()
-            with program_guard(main, startup):
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
                 input = paddle.static.data(
                     name='legacy_input', shape=[2, 2], dtype='float32'
                 )

--- a/test/legacy_test/test_addmm_op.py
+++ b/test/legacy_test/test_addmm_op.py
@@ -756,12 +756,10 @@ class TestAddmmOutDtypeDynamicOnly(unittest.TestCase):
         with paddle.no_grad():
             paddle.addmm(input, x, y, out=out)
 
-    def test_out_dtype_rejects_unsupported_cases(self):
+    def test_out_dtype_rejects_invalid_out(self):
         input = paddle.randn([3, 5], dtype='float16')
         x = paddle.randn([3, 4], dtype='float16')
         y = paddle.randn([4, 5], dtype='float16')
-        with self.assertRaises(TypeError):
-            paddle.addmm(input, x, y, out_dtype=paddle.float16)
         with self.assertRaises(TypeError):
             paddle.addmm(
                 input,
@@ -770,11 +768,26 @@ class TestAddmmOutDtypeDynamicOnly(unittest.TestCase):
                 out_dtype=paddle.float32,
                 out=paddle.empty([3, 5], dtype='float16'),
             )
-        with self.assertRaises(TypeError):
+
+    def test_out_dtype_infermeta_rejects_unsupported_dtypes(self):
+        self._skip_if_no_fp16_cuda()
+        input = paddle.randn([3, 5], dtype='float16')
+        x = paddle.randn([3, 4], dtype='float16')
+        y = paddle.randn([4, 5], dtype='float16')
+        with self.assertRaisesRegex(ValueError, "only supports float32"):
+            paddle.addmm(input, x, y, out_dtype=paddle.float16)
+        with self.assertRaisesRegex(ValueError, "must have the same dtype"):
             paddle.addmm(
                 input,
                 x,
-                y.astype('bfloat16'),
+                y.astype('float32'),
+                out_dtype=paddle.float32,
+            )
+        with self.assertRaisesRegex(ValueError, r"same dtype as Input\(X\)"):
+            paddle.addmm(
+                input.astype('float64'),
+                x,
+                y,
                 out_dtype=paddle.float32,
             )
 

--- a/test/legacy_test/test_addmm_op.py
+++ b/test/legacy_test/test_addmm_op.py
@@ -394,6 +394,54 @@ class TestAddMMOp5(unittest.TestCase):
 
 
 class TestAddMMAPI(unittest.TestCase):
+    def test_legacy_static_api(self):
+        paddle.enable_static()
+        input_data = np.ones([2, 2], dtype=np.float32)
+        x_data = np.ones([2, 3], dtype=np.float32)
+        y_data = np.ones([3, 2], dtype=np.float32)
+
+        with paddle.pir_utils.OldIrGuard():
+            main = Program()
+            startup = Program()
+            with program_guard(main, startup):
+                input = paddle.static.data(
+                    name='legacy_input', shape=[2, 2], dtype='float32'
+                )
+                x = paddle.static.data(
+                    name='legacy_x', shape=[2, 3], dtype='float32'
+                )
+                y = paddle.static.data(
+                    name='legacy_y', shape=[3, 2], dtype='float32'
+                )
+
+                result = paddle.addmm(input, x, y, beta=0.5, alpha=2.0)
+
+                out = main.global_block().create_var(
+                    name='legacy_out',
+                    shape=[2, 2],
+                    dtype='float32',
+                )
+                out.stop_gradient = True
+                result_with_out = paddle.addmm(
+                    input, x, y, beta=0.5, alpha=2.0, out=out
+                )
+                self.assertIs(result_with_out, out)
+
+            executor = base.Executor(base.CPUPlace())
+            result_value, out_value = executor.run(
+                main,
+                feed={
+                    'legacy_input': input_data,
+                    'legacy_x': x_data,
+                    'legacy_y': y_data,
+                },
+                fetch_list=[result, out],
+            )
+
+        expected = 0.5 * input_data + 2.0 * np.matmul(x_data, y_data)
+        np.testing.assert_allclose(result_value, expected)
+        np.testing.assert_allclose(out_value, expected)
+
     def test_float64_scale_precision(self):
         paddle.disable_static()
 
@@ -627,6 +675,45 @@ class TestAddmmOutDtypeDynamicOnly(unittest.TestCase):
         np.testing.assert_allclose(
             result.numpy(), expected.numpy(), rtol=1e-5, atol=1e-5
         )
+
+    def test_legacy_positional_arg_errors(self):
+        input = paddle.randn([3, 5], dtype='float32')
+        x = paddle.randn([3, 4], dtype='float32')
+        y = paddle.randn([4, 5], dtype='float32')
+
+        with self.assertRaisesRegex(
+            TypeError, "received too many positional arguments"
+        ):
+            paddle.addmm(
+                input,
+                x,
+                y,
+                0.5,
+                1.5,
+                'legacy_addmm',
+                'extra',
+            )
+
+        conflict_cases = (
+            ('beta', (0.5,), 1.0),
+            ('alpha', (0.5, 1.5), 1.0),
+            ('name', (0.5, 1.5, 'legacy_addmm'), 'duplicate_name'),
+        )
+        for name, legacy_args, keyword_value in conflict_cases:
+            with (
+                self.subTest(name=name),
+                self.assertRaisesRegex(
+                    TypeError,
+                    rf"multiple values for argument '{name}'",
+                ),
+            ):
+                paddle.addmm(
+                    input,
+                    x,
+                    y,
+                    *legacy_args,
+                    **{name: keyword_value},
+                )
 
     def test_normal_and_out_without_out_dtype(self):
         input = paddle.randn([3, 5], dtype='float32')


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

为 `paddle.addmm` 增加 `out_dtype` 功能，使 CUDA 环境下的 FP16/BF16 矩阵乘法可以直接输出 FP32 结果，满足混合精度计算中对输出精度的需求。

#### 背景

当前 `paddle.addmm` 的输出数据类型通常由输入张量决定。当 `x` 和 `y` 使用 FP16 或 BF16 时，用户需要先手动将输入转换为 FP32，再执行矩阵乘法，增加了额外的数据转换和显存开销。此次改动提供显式的 `out_dtype=paddle.float32` 参数，由底层算子直接完成计算和输出类型处理。

#### 主要改动

- 新增 `addmm_out_dtype` 动态图算子，并补充对应的 InferMeta、Kernel 声明和 CUDA Kernel 注册。
- 支持以下输入组合：
  - `x`、`y` 均为 FP16，输出为 FP32；
  - `x`、`y` 均为 BF16，输出为 FP32；
  - `input` 可以与 `x` 使用相同数据类型，也可以使用 FP32；
  - `out` 张量在指定时必须为 FP32。
- 在 InferMeta 中增加数据类型、矩阵维度、输入广播关系和输出数据类型检查。
- 在 CUDA Kernel 中：
  - 对非 FP32 的 `input` 进行必要的数据类型转换；
  - 保留 `input` 的一维输入和二维输入语义；
  - 支持输入广播以及 `beta`、`alpha` 缩放；
  - 对非连续的 `x`、`y` 进行 contiguous 处理；
  - 对空矩阵和零尺寸输出进行处理；
  - 使用 GPU BLAS 完成 FP16/BF16 输入到 FP32 输出的 GEMM 计算。
- 将 `paddle.addmm` 调整为手写 Python API，以支持新的参数签名和运行时校验。
- 保留 `x`/`mat1`、`y`/`mat2` 参数别名。
- 通过兼容装饰器保留旧版 `beta`、`alpha`、`name` 的位置参数调用方式，避免已有用户代码因签名调整受到影响。
- 保留未指定 `out_dtype` 时的原有动态图库、PIR 和静态图执行路径。
- 明确限制 `out_dtype` 当前仅支持动态 CUDA 非 ROCm 环境；CPU、ROCm、静态图以及不支持的数据类型会抛出明确异常。
- `out_dtype` 路径为 forward-only，不注册反向计算；同时保持 `out` 参数与自动微分限制的一致性。
- 调整 `addmm_` 的前处理逻辑：
  - 原地操作要求 `input` 与输出形状完全一致，不允许通过广播改变输入形状；
  - 增加 `input`、`x`、`y` 数据类型一致性检查；
  - 区分普通 `addmm` 和原地版本的前处理函数。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否