### PR TITLE
[Cpp API Compatibility] Support `at::scalar_tensor`

### DIFF
--- a/paddle/phi/api/include/compat/ATen/Functions.h
+++ b/paddle/phi/api/include/compat/ATen/Functions.h
@@ -58,6 +58,7 @@
 #include <ATen/ops/rename.h>
 #include <ATen/ops/reshape.h>
 #include <ATen/ops/resize.h>
+#include <ATen/ops/scalar_tensor.h>
 #include <ATen/ops/select.h>
 #include <ATen/ops/slice.h>
 #include <ATen/ops/sparse_coo_tensor.h>

--- a/paddle/phi/api/include/compat/ATen/ops/scalar_tensor.h
+++ b/paddle/phi/api/include/compat/ATen/ops/scalar_tensor.h
@@ -32,7 +32,13 @@ inline at::Tensor scalar_tensor(const at::Scalar& scalar,
                                 ::std::optional<at::Layout> layout,
                                 ::std::optional<at::Device> device,
                                 ::std::optional<bool> pin_memory) {
-  return at::full({}, scalar, dtype, layout, device, pin_memory);
+  auto options =
+      at::TensorOptions()
+          .dtype(dtype.value_or(c10::get_default_dtype_as_scalartype()))
+          .layout(layout)
+          .device(device.value_or(at::kCPU))
+          .pinned_memory(pin_memory);
+  return scalar_tensor(scalar, options);
 }
 
 }  // namespace at

--- a/paddle/phi/api/include/compat/ATen/ops/scalar_tensor.h
+++ b/paddle/phi/api/include/compat/ATen/ops/scalar_tensor.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <ATen/ops/full.h>
+#include <c10/core/Scalar.h>
+#include <c10/core/TensorOptions.h>
+
+#include <optional>
+
+namespace at {
+
+inline at::Tensor scalar_tensor(const at::Scalar& scalar,
+                                at::TensorOptions options = {}) {
+  return at::full({}, scalar, options);
+}
+
+inline at::Tensor scalar_tensor(const at::Scalar& scalar,
+                                ::std::optional<at::ScalarType> dtype,
+                                ::std::optional<at::Layout> layout,
+                                ::std::optional<at::Device> device,
+                                ::std::optional<bool> pin_memory) {
+  return at::full({}, scalar, dtype, layout, device, pin_memory);
+}
+
+}  // namespace at

--- a/test/cpp/compat/ATen_factory_default_dtype_test.cc
+++ b/test/cpp/compat/ATen_factory_default_dtype_test.cc
@@ -17,6 +17,7 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/full.h>
 #include <ATen/ops/ones.h>
+#include <ATen/ops/scalar_tensor.h>
 #include <ATen/ops/zeros.h>
 #include <c10/core/DefaultDtype.h>
 #include <c10/core/ScalarTypeToTypeMeta.h>
@@ -143,6 +144,28 @@ TEST(ATenFactoryDefaultDtypeTest, FullNulloptDtypeUsesCurrentDefault) {
   ASSERT_EQ(symint_tensor.scalar_type(), at::kDouble);
   ASSERT_DOUBLE_EQ(tensor.data_ptr<double>()[0], 1.25);
   ASSERT_DOUBLE_EQ(symint_tensor.data_ptr<double>()[0], 2.5);
+}
+
+TEST(ATenFactoryDefaultDtypeTest, ScalarTensorCreatesZeroDimTensor) {
+  at::Tensor tensor = at::scalar_tensor(
+      42, at::TensorOptions().dtype(at::kLong).device(at::kCPU));
+
+  ASSERT_EQ(tensor.dim(), 0);
+  ASSERT_EQ(tensor.scalar_type(), at::kLong);
+  ASSERT_EQ(tensor.device().type(), at::kCPU);
+  ASSERT_EQ(tensor.item<int64_t>(), 42);
+}
+
+TEST(ATenFactoryDefaultDtypeTest,
+     ScalarTensorOptionalArgumentsUseCurrentDefaultDtype) {
+  DefaultDtypeGuard guard(at::kDouble);
+
+  at::Tensor tensor =
+      at::scalar_tensor(1.25, std::nullopt, std::nullopt, at::kCPU, false);
+
+  ASSERT_EQ(tensor.dim(), 0);
+  ASSERT_EQ(tensor.scalar_type(), at::kDouble);
+  ASSERT_DOUBLE_EQ(tensor.item<double>(), 1.25);
 }
 
 TEST(ATenFactoryDefaultDtypeTest, OnesNulloptDtypeUsesCurrentDefault) {

--- a/test/cpp/compat/ATen_factory_default_dtype_test.cc
+++ b/test/cpp/compat/ATen_factory_default_dtype_test.cc
@@ -162,10 +162,16 @@ TEST(ATenFactoryDefaultDtypeTest,
 
   at::Tensor tensor =
       at::scalar_tensor(1.25, std::nullopt, std::nullopt, at::kCPU, false);
+  at::Tensor strided_tensor =
+      at::scalar_tensor(2.5, std::nullopt, at::kStrided, at::kCPU, false);
 
   ASSERT_EQ(tensor.dim(), 0);
   ASSERT_EQ(tensor.scalar_type(), at::kDouble);
   ASSERT_DOUBLE_EQ(tensor.item<double>(), 1.25);
+  ASSERT_EQ(strided_tensor.dim(), 0);
+  ASSERT_EQ(strided_tensor.scalar_type(), at::kDouble);
+  ASSERT_EQ(strided_tensor.layout(), at::kStrided);
+  ASSERT_DOUBLE_EQ(strided_tensor.item<double>(), 2.5);
 }
 
 TEST(ATenFactoryDefaultDtypeTest, OnesNulloptDtypeUsesCurrentDefault) {


### PR DESCRIPTION
### PR Category

Execute Infrastructure

### PR Types

Bug fixes

### Description

- 在与 PyTorch 对齐的公开路径 `ATen/ops/scalar_tensor.h` 中补充 `at::scalar_tensor` 的 `TensorOptions` 和 optional arguments 两种 overload，并复用现有 `at::full` 实现零维 Tensor 创建。
- 从 `ATen/Functions.h` 导出该接口，保持 `ATen/ATen.h -> ATen/Functions.h -> ATen/ops/scalar_tensor.h` 的 include 链与 PyTorch 一致。
- 在现有 factory default-dtype 测试中覆盖显式 `int64` options 和默认浮点 dtype 两种行为。

### 是否引起精度变化

否

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.6 sol xhigh)</sup>
</div>