### PR TITLE
[release/3.4][CI] Remove unused develop wheel fetching

### DIFF
--- a/ci/run_setup.sh
+++ b/ci/run_setup.sh
@@ -350,36 +350,23 @@ if [[ "$CI_name" == "build" && "$is_pr" == "true" ]]; then
     rm -f ${PADDLE_ROOT}/build/python/dist/*.whl && rm -f ${PADDLE_ROOT}/build/python/build/.timestamp
 
     git checkout $BRANCH
-    dev_commit=`git log -2|grep -w 'commit'|awk '{print $2}'`
-    for commit_id in $dev_commit
-    do
-    dev_url="https://xly-devops.bj.bcebos.com/PR/build_whl/0/${commit_id}/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl"
-    url_return=`curl -s -m 5 -IL ${dev_url} |awk 'NR==1{print $2}'`
-      if [ "$url_return" == '200' ];then
-        break
-      fi
-    done
-    if [ "$url_return" == '200' ];then
-        mkdir ${PADDLE_ROOT}/build/dev_whl && wget -q -P ${PADDLE_ROOT}/build/dev_whl ${dev_url}
-        cp ${PADDLE_ROOT}/build/dev_whl/paddlepaddle_gpu-0.0.0-cp310-cp310-linux_x86_64.whl ${PADDLE_ROOT}/build/python/dist
-    else
-        cp -r ${PADDLE_ROOT}/build /tmp/
-        if [[ ${cmake_change} ]];then
-            rm -rf ${PADDLE_ROOT}/build/Makefile ${PADDLE_ROOT}/build/CMakeCache.txt ${PADDLE_ROOT}/build/build.ninja
-            rm -rf ${PADDLE_ROOT}/build/third_party
-        fi
-        git checkout $BRANCH
-        git submodule update --init
-        run_setup "rerun-cmake bdist_wheel"
-        rm -rf ${PADDLE_ROOT}/build
-        mv /tmp/build ${PADDLE_ROOT}
-        if [ ! -d "${PADDLE_ROOT}/build/python/dist/" ]; then
-            mkdir ${PADDLE_ROOT}/build/python/dist/
-        fi
-        mv ${PADDLE_ROOT}/dist/*.whl ${PADDLE_ROOT}/build/python/dist/
-        mkdir ${PADDLE_ROOT}/build/dev_whl && cp ${PADDLE_ROOT}/build/python/dist/*.whl ${PADDLE_ROOT}/build/dev_whl
-        git checkout test
+    git submodule update
+    cp -r ${PADDLE_ROOT}/build /tmp/
+    if [[ ${cmake_change} ]];then
+        rm -rf ${PADDLE_ROOT}/build/Makefile ${PADDLE_ROOT}/build/CMakeCache.txt ${PADDLE_ROOT}/build/build.ninja
+        rm -rf ${PADDLE_ROOT}/build/third_party
     fi
+    git checkout $BRANCH
+    git submodule update --init
+    run_setup "rerun-cmake bdist_wheel"
+    rm -rf ${PADDLE_ROOT}/build
+    mv /tmp/build ${PADDLE_ROOT}
+    if [ ! -d "${PADDLE_ROOT}/build/python/dist/" ]; then
+        mkdir ${PADDLE_ROOT}/build/python/dist/
+    fi
+    mv ${PADDLE_ROOT}/dist/*.whl ${PADDLE_ROOT}/build/python/dist/
+    mkdir ${PADDLE_ROOT}/build/dev_whl && cp ${PADDLE_ROOT}/build/python/dist/*.whl ${PADDLE_ROOT}/build/dev_whl
+    git checkout test
 
     generate_api_spec "" "DEV"
 fi


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->

Environment Adaptation

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->

Bug fixes

### Description
<!-- Describe what you’ve done -->

清除无用的从 develop pre-built wheel 链接获取的逻辑，最近 curl bos 无结果的链接返回结果变成了首行 200、第三行才是 404，导致误进入拉取 pre-built wheel 的分支，进而导致 build 流水线失败，本 PR 将这段无用的逻辑清理掉，以确保构建能够正确进行

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->

否

---

Cherry-pick of #79625 (authored by @swgu98) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79625 <!-- For pass CI -->