### PR TITLE
[CMake] modernize Python discovery with FindPython

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,7 +319,6 @@ option(WITH_XBYAK "Compile with xbyak support" ON)
 option(WITH_INFERENCE_API_TEST
        "Test fluid inference C++ high-level api interface" OFF)
 option(WITH_NVTX "Paddle with nvtx for profiler" OFF)
-option(PY_VERSION "Compile PaddlePaddle with python3 support" ${PY_VERSION})
 option(WITH_DGC "Use DGC(Deep Gradient Compression) or not" ${WITH_DISTRIBUTE})
 option(
   SANITIZER_TYPE
@@ -410,9 +409,15 @@ endif()
 unset(WITH_RECORD_BUILDTIME CACHE)
 
 # PY_VERSION
+set(PY_VERSION
+    "${PY_VERSION}"
+    CACHE STRING "Minimum Python version used to build Paddle")
+set_property(CACHE PY_VERSION PROPERTY TYPE STRING)
 if(NOT PY_VERSION)
-  set(PY_VERSION 3.10)
-elseif(${PY_VERSION} VERSION_LESS 3.10)
+  set(PY_VERSION
+      3.10
+      CACHE STRING "Minimum Python version used to build Paddle" FORCE)
+elseif(PY_VERSION VERSION_LESS 3.10)
   message(FATAL_ERROR "Paddle only supports Python version >= 3.10 now")
 endif()
 set(PYBIND11_PYTHON_VERSION ${PY_VERSION})

--- a/cmake/external/cutlass.cmake
+++ b/cmake/external/cutlass.cmake
@@ -25,10 +25,6 @@ include_directories("${CUTLASS_SOURCE_DIR}/tools/util/include/")
 add_definitions("-DPADDLE_WITH_CUTLASS")
 add_definitions("-DSPCONV_WITH_CUTLASS=0")
 
-if(NOT PYTHON_EXECUTABLE)
-  find_package(Python REQUIRED COMPONENTS Interpreter)
-endif()
-
 ExternalProject_Add(
   extern_cutlass
   ${EXTERNAL_PROJECT_LOG_ARGS}

--- a/cmake/external/python.cmake
+++ b/cmake/external/python.cmake
@@ -16,64 +16,45 @@ include(python_module)
 
 check_py_version(${PY_VERSION})
 
-# Find Python with minimum PY_VERSION specified or will raise error!
-find_package(PythonInterp ${PY_VERSION} REQUIRED)
-find_package(PythonLibs ${PY_VERSION} REQUIRED)
-
-if(WIN32)
-  execute_process(
-    COMMAND
-      "${PYTHON_EXECUTABLE}" "-c"
-      "from distutils import sysconfig as s;import sys;import struct;
-print(sys.prefix);
-print(s.get_config_var('LDVERSION') or s.get_config_var('VERSION'));
-"
-    RESULT_VARIABLE _PYTHON_SUCCESS
-    OUTPUT_VARIABLE _PYTHON_VALUES
-    ERROR_VARIABLE _PYTHON_ERROR_VALUE)
-
-  if(NOT _PYTHON_SUCCESS EQUAL 0)
-    set(PYTHONLIBS_FOUND FALSE)
-    return()
+foreach(name EXECUTABLE INCLUDE_DIR LIBRARY)
+  if(PYTHON_${name} AND NOT Python_${name})
+    set(Python_${name} "${PYTHON_${name}}")
   endif()
+endforeach()
+if(PYTHON_NUMPY_INCLUDE_DIR AND NOT Python_NumPy_INCLUDE_DIR)
+  set(Python_NumPy_INCLUDE_DIR "${PYTHON_NUMPY_INCLUDE_DIR}")
+endif()
 
-  # Convert the process output into a list
-  string(REGEX REPLACE ";" "\\\\;" _PYTHON_VALUES ${_PYTHON_VALUES})
-  string(REGEX REPLACE "\n" ";" _PYTHON_VALUES ${_PYTHON_VALUES})
-  list(GET _PYTHON_VALUES 0 PYTHON_PREFIX)
-  list(GET _PYTHON_VALUES 1 PYTHON_LIBRARY_SUFFIX)
+set(Python_FIND_STRATEGY LOCATION)
+set(Python_FIND_VIRTUALENV FIRST)
+if(POLICY CMP0190)
+  cmake_policy(SET CMP0190 NEW)
+endif()
+if(POLICY CMP0201)
+  cmake_policy(SET CMP0201 NEW)
+endif()
+find_package(Python ${PY_VERSION} REQUIRED COMPONENTS Interpreter Development
+                                                      NumPy)
 
-  # Make sure all directory separators are '/'
-  string(REGEX REPLACE "\\\\" "/" PYTHON_PREFIX ${PYTHON_PREFIX})
+# Transitional outputs keep dependent stacked PRs buildable while call sites
+# migrate to modern result variables and imported targets.
+set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}")
+set(PYTHON_INCLUDE_DIR "${Python_INCLUDE_DIRS}")
+set(PYTHON_INCLUDE_DIRS "${Python_INCLUDE_DIRS}")
+set(PYTHON_LIBRARY "${Python_LIBRARY}")
+set(PYTHON_LIBRARIES "${Python_LIBRARIES}")
+set(PYTHON_NUMPY_INCLUDE_DIR "${Python_NumPy_INCLUDE_DIRS}")
+set(PYTHONINTERP_FOUND "${Python_Interpreter_FOUND}")
 
-  set(PYTHON_LIBRARY "${PYTHON_PREFIX}/libs/Python${PYTHON_LIBRARY_SUFFIX}.lib")
-
-  # when run in a venv, PYTHON_PREFIX points to it. But the libraries remain in the
-  # original python installation. They may be found relative to PYTHON_INCLUDE_DIR.
-  if(NOT EXISTS "${PYTHON_LIBRARY}")
-    get_filename_component(_PYTHON_ROOT ${PYTHON_INCLUDE_DIR} DIRECTORY)
-    set(PYTHON_LIBRARY
-        "${_PYTHON_ROOT}/libs/Python${PYTHON_LIBRARY_SUFFIX}.lib")
-  endif()
-
-  # raise an error if the python libs are still not found.
-  if(NOT EXISTS "${PYTHON_LIBRARY}")
-    message(FATAL_ERROR "Python libraries not found")
-  endif()
-  set(PYTHON_LIBRARIES "${PYTHON_LIBRARY}")
-endif(WIN32)
-
-# Fixme: Maybe find a static library. Get SHARED/STATIC by FIND_PACKAGE.
-add_library(python SHARED IMPORTED GLOBAL)
-set_property(TARGET python PROPERTY IMPORTED_LOCATION ${PYTHON_LIBRARIES})
+add_library(python INTERFACE IMPORTED GLOBAL)
+target_link_libraries(python INTERFACE Python::Module)
 
 set(py_env "")
-if(PYTHONINTERP_FOUND)
+if(Python_Interpreter_FOUND)
   find_python_module(pip REQUIRED)
   find_python_module(numpy REQUIRED)
   find_python_module(wheel REQUIRED)
   find_python_module(google.protobuf REQUIRED)
-  find_package(NumPy REQUIRED)
   if(${PY_GOOGLE.PROTOBUF_VERSION} AND ${PY_GOOGLE.PROTOBUF_VERSION}
                                        VERSION_LESS "3.0.0")
     message(
@@ -81,7 +62,7 @@ if(PYTHONINTERP_FOUND)
         "Found Python Protobuf ${PY_GOOGLE.PROTOBUF_VERSION} < 3.0.0, "
         "please use pip to upgrade protobuf. pip install -U protobuf")
   endif()
-endif(PYTHONINTERP_FOUND)
+endif()
 
 include_directories(${PYTHON_INCLUDE_DIR})
 include_directories(${PYTHON_NUMPY_INCLUDE_DIR})

--- a/cmake/python_module.cmake
+++ b/cmake/python_module.cmake
@@ -13,7 +13,7 @@ function(find_python_module module)
     # it's a .so file.
     execute_process(
       COMMAND
-        "${PYTHON_EXECUTABLE}" "-c"
+        "${Python_EXECUTABLE}" "-c"
         "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
       RESULT_VARIABLE _${module}_status
       OUTPUT_VARIABLE _${module}_location
@@ -30,7 +30,7 @@ function(find_python_module module)
   endif()
 
   execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" "-c"
+    COMMAND "${Python_EXECUTABLE}" "-c"
             "import sys, ${module}; sys.stdout.write(${module}.__version__)"
     OUTPUT_VARIABLE _${module}_version
     RESULT_VARIABLE _${module}_status


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Bug fixes

### Description
这是 Python CMake 现代化 stacked PR 的第 1/4 层。

Paddle 当前分别调用 `FindPythonInterp` 与 `FindPythonLibs`。CMake 3.18 的旧 `FindPythonLibs` 会从虚拟环境路径推导开发库位置，无法发现 uv 管理的基础 CPython，导致已激活 venv 时仍出现 `PYTHON_LIBRARY-NOTFOUND`。

本层将 Python 解释器、Development 与 NumPy 统一交给 CMake 3.18 已支持的 `FindPython` 一次性发现，并设置 `LOCATION`/`FIRST` 搜索策略。`PY_VERSION` 改为 STRING cache；原有 `PYTHON_EXECUTABLE`、`PYTHON_INCLUDE_DIR`、`PYTHON_LIBRARY` 与 `PYTHON_NUMPY_INCLUDE_DIR` 继续作为兼容输入。为保证 stack 中该层可独立配置，暂时保留旧结果输出和 `python` 过渡 target，后续层逐步删除。

兼容边界仅使用 CMake 3.18 API；对 CMake 4.1/4.2 的 CMP0190、CMP0201 使用存在性保护。已用 CMake 3.18.0 完成 uv Python 3.12 发现回归与完整 CPU CMake 配置，全部 `prek` hook 通过。

Stack: 1/4，base 为 `develop`。

### 是否引起精度变化
否