### PR TITLE
[Operator Mechanism] Support baddbmm out_dtype for CUDA

### DIFF
--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
+++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/multiary_infer_sym.cc
@@ -241,10 +241,10 @@ bool BaddbmmOpInferSymbolicShape(
   auto ndim_x = x_shape.shape().size();
   auto ndim_y = y_shape.shape().size();
 
-  PADDLE_ENFORCE_EQ(ndim_input == 3 || ndim_input == 2,
-                    true,
+  PADDLE_ENFORCE_LE(ndim_input,
+                    3,
                     common::errors::InvalidArgument(
-                        "The input tensor input's dimension must be 3 or 2. "
+                        "The input tensor input's dimension must not exceed 3. "
                         "But received input's dimension = [%d].",
                         ndim_input));
   PADDLE_ENFORCE_EQ(ndim_x,
@@ -274,18 +274,9 @@ bool BaddbmmOpInferSymbolicShape(
                               y_shape.shape()[0]);  // batch size
   infer_context->AddEqualCstr(x_shape.shape()[2], y_shape.shape()[1]);
 
-  if (ndim_input == 3) {
-    infer_context->AddBroadcastableCstr(input_shape.shape()[0],
-                                        x_shape.shape()[0]);  // batch size
-    infer_context->AddBroadcastableCstr(input_shape.shape()[1],
-                                        x_shape.shape()[1]);
-    infer_context->AddBroadcastableCstr(input_shape.shape()[2],
-                                        y_shape.shape()[2]);
-  } else if (ndim_input == 2) {
-    infer_context->AddBroadcastableCstr(input_shape.shape()[0],
-                                        x_shape.shape()[0]);
-    infer_context->AddBroadcastableCstr(input_shape.shape()[1],
-                                        y_shape.shape()[2]);
+  for (size_t i = 0; i < ndim_input; ++i) {
+    infer_context->AddBroadcastableCstr(input_shape.shape()[i],
+                                        output_shape[3 - ndim_input + i]);
   }
 
   return true;
@@ -293,7 +284,22 @@ bool BaddbmmOpInferSymbolicShape(
 
 bool Baddbmm_OpInferSymbolicShape(
     pir::Operation *op, pir::InferSymbolicShapeContext *infer_context) {
-  return BaddbmmOpInferSymbolicShape(op, infer_context);
+  const auto &input_shape =
+      infer_context->GetShapeOrDataForValue(op->operand_source(0));
+  PADDLE_ENFORCE_EQ(
+      input_shape.shape().size(),
+      3,
+      common::errors::InvalidArgument(
+          "The input tensor input's dimension must be 3 for baddbmm_."));
+  BaddbmmOpInferSymbolicShape(op, infer_context);
+  const auto &x_shape =
+      infer_context->GetShapeOrDataForValue(op->operand_source(1));
+  const auto &y_shape =
+      infer_context->GetShapeOrDataForValue(op->operand_source(2));
+  infer_context->AddEqualCstr(input_shape.shape()[0], x_shape.shape()[0]);
+  infer_context->AddEqualCstr(input_shape.shape()[1], x_shape.shape()[1]);
+  infer_context->AddEqualCstr(input_shape.shape()[2], y_shape.shape()[2]);
+  return true;
 }
 
 bool BatchFcOpInferSymbolicShape(

--- a/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_rule/composite.h
@@ -1418,8 +1418,7 @@ Tensor baddbmm_decomp(const Tensor& input,
                       const Tensor& x,
                       const Tensor& y,
                       const double beta,
-                      const double alpha,
-                      const DataType out_dtype) {
+                      const double alpha) {
   int64_t batch_size = x.shape()[0];
   Tensor x_y_mat;
   if (batch_size == 0) {

--- a/paddle/fluid/pybind/arg_pre_process.cc
+++ b/paddle/fluid/pybind/arg_pre_process.cc
@@ -428,132 +428,71 @@ void AddmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y) {
   }
 }
 
-// Baddbmm broadcast validation for dygraph
-void BaddbmmPreProcess(Tensor* input, Tensor* x, Tensor* y) {
+// Baddbmm inplace shape validation for dygraph
+void BaddbmmInplacePreProcess(Tensor* input, Tensor* x, Tensor* y) {
   auto input_shape = input->dims();
   auto x_shape = x->dims();
   auto y_shape = y->dims();
 
-  // Validate x and y are 3D
   PADDLE_ENFORCE_EQ(
-      x_shape.size(),
+      input_shape.size(),
       3,
       phi::errors::InvalidArgument(
-          "The dimension of x should be 3 but received x's shape size: %d.",
-          x_shape.size()));
+          "The dimension of input must be 3 for baddbmm_, but received "
+          "input's shape: [%s].",
+          input_shape));
 
-  PADDLE_ENFORCE_EQ(
-      y_shape.size(),
-      3,
-      phi::errors::InvalidArgument(
-          "The dimension of y should be 3 but received y's shape size: %d.",
-          y_shape.size()));
-
-  // Validate x's width equals y's height
-  PADDLE_ENFORCE_EQ(x_shape[2],
-                    y_shape[1],
-                    phi::errors::InvalidArgument(
-                        "The input Variable x's width must be equal with "
-                        "Variable y's height. "
-                        "But received x's shape[2] = %d, y's shape[1] = %d.",
-                        x_shape[2],
-                        y_shape[1]));
-
-  // Validate input shape broadcast compatibility
-  if (input_shape.size() == 3) {
-    ValidateBroadcastDim(input_shape[0],
-                         x_shape[0],
-                         "The dimension 0 of input must be equal to x's "
-                         "dimension 0, or must be 1.");
-    ValidateBroadcastDim(input_shape[1],
-                         x_shape[1],
-                         "The dimension 1 of input must be equal to x's "
-                         "dimension 1, or must be 1.");
-    ValidateBroadcastDim(input_shape[2],
-                         y_shape[2],
-                         "The dimension 2 of input must be equal to y's "
-                         "dimension 2, or must be 1.");
-  } else if (input_shape.size() == 2) {
-    ValidateBroadcastDim(input_shape[0],
-                         x_shape[1],
-                         "The dimension 0 of input must be equal to x's "
-                         "dimension 1, or must be 1.");
-    ValidateBroadcastDim(input_shape[1],
-                         y_shape[2],
-                         "The dimension 1 of input must be equal to y's "
-                         "dimension 2, or must be 1.");
-  } else {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("The dimension of input should be "
-                                     "3 or 2 but received input's "
-                                     "dimension: %ld.",
-                                     input_shape.size()));
+  // InferMeta reports malformed matrix inputs without indexing invalid dims.
+  if (x_shape.size() != 3 || y_shape.size() != 3) {
+    return;
   }
+  PADDLE_ENFORCE_EQ(
+      input_shape[0],
+      x_shape[0],
+      phi::errors::InvalidArgument(
+          "The batch dimension of input must match the baddbmm_ output."));
+  PADDLE_ENFORCE_EQ(
+      input_shape[1],
+      x_shape[1],
+      phi::errors::InvalidArgument(
+          "The row dimension of input must match the baddbmm_ output."));
+  PADDLE_ENFORCE_EQ(
+      input_shape[2],
+      y_shape[2],
+      phi::errors::InvalidArgument(
+          "The column dimension of input must match the baddbmm_ output."));
 }
 
-// Baddbmm broadcast validation for static graph
-void BaddbmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y) {
+// Baddbmm inplace shape validation for static graph
+void BaddbmmInplacePreProcess(pir::Value* input, pir::Value* x, pir::Value* y) {
   auto input_shape = pir::GetShapeFromValue(*input);
   auto x_shape = pir::GetShapeFromValue(*x);
   auto y_shape = pir::GetShapeFromValue(*y);
 
-  // Validate x and y are 3D
   PADDLE_ENFORCE_EQ(
-      x_shape.size(),
+      input_shape.size(),
       3,
       phi::errors::InvalidArgument(
-          "The dimension of x should be 3 but received x's shape size: %d",
-          x_shape.size()));
+          "The dimension of input must be 3 for baddbmm_, but received %d.",
+          input_shape.size()));
 
-  PADDLE_ENFORCE_EQ(
-      y_shape.size(),
-      3,
-      phi::errors::InvalidArgument(
-          "The dimension of y should be 3 but received y's shape size: %d",
-          y_shape.size()));
-
-  // Validate x's width equals y's height
-  if (x_shape[2] >= 0 && y_shape[1] >= 0) {
-    PADDLE_ENFORCE_EQ(x_shape[2],
-                      y_shape[1],
-                      phi::errors::InvalidArgument(
-                          "The input Variable x's width must be equal with "
-                          "Variable y's height. "
-                          "But received x's shape[2] = %d, y's shape[1] = %d.",
-                          x_shape[2],
-                          y_shape[1]));
+  // InferMeta reports malformed matrix inputs without indexing invalid dims.
+  if (x_shape.size() != 3 || y_shape.size() != 3) {
+    return;
   }
-
-  // Validate input shape broadcast compatibility
-  if (input_shape.size() == 3) {
-    ValidateBroadcastDim(input_shape[0],
-                         x_shape[0],
-                         "The dimension 0 of input must be equal to x's "
-                         "dimension 0, or must be 1.");
-    ValidateBroadcastDim(input_shape[1],
-                         x_shape[1],
-                         "The dimension 1 of input must be equal to x's "
-                         "dimension 1, or must be 1.");
-    ValidateBroadcastDim(input_shape[2],
-                         y_shape[2],
-                         "The dimension 2 of input must be equal to y's "
-                         "dimension 2, or must be 1.");
-  } else if (input_shape.size() == 2) {
-    ValidateBroadcastDim(input_shape[0],
-                         x_shape[1],
-                         "The dimension 0 of input must be equal to x's "
-                         "dimension 1, or must be 1.");
-    ValidateBroadcastDim(input_shape[1],
-                         y_shape[2],
-                         "The dimension 1 of input must be equal to y's "
-                         "dimension 2, or must be 1.");
-  } else {
-    PADDLE_THROW(
-        phi::errors::InvalidArgument("The dimension of input should be "
-                                     "3 or 2 but received input's "
-                                     "dimension: %ld.",
-                                     input_shape.size()));
-  }
+  const auto enforce_equal_if_known = [](int64_t actual, int64_t expected) {
+    if (actual < 0 || expected < 0) {
+      return;
+    }
+    PADDLE_ENFORCE_EQ(
+        actual,
+        expected,
+        phi::errors::InvalidArgument(
+            "The input shape must exactly match the baddbmm_ output shape."));
+  };
+  enforce_equal_if_known(input_shape[0], x_shape[0]);
+  enforce_equal_if_known(input_shape[1], x_shape[1]);
+  enforce_equal_if_known(input_shape[2], y_shape[2]);
 }
 
 void PixelShufflePreProcess(std::string* data_format) {

--- a/paddle/fluid/pybind/arg_pre_process.h
+++ b/paddle/fluid/pybind/arg_pre_process.h
@@ -70,11 +70,11 @@ void AddmmPreProcess(Tensor* input, Tensor* x, Tensor* y);
 // Addmm broadcast validation for static graph
 void AddmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y);
 
-// Baddbmm broadcast validation for dygraph
-void BaddbmmPreProcess(Tensor* input, Tensor* x, Tensor* y);
+// Baddbmm inplace shape validation for dygraph
+void BaddbmmInplacePreProcess(Tensor* input, Tensor* x, Tensor* y);
 
-// Baddbmm broadcast validation for static graph
-void BaddbmmPreProcess(pir::Value* input, pir::Value* x, pir::Value* y);
+// Baddbmm inplace shape validation for static graph
+void BaddbmmInplacePreProcess(pir::Value* input, pir::Value* x, pir::Value* y);
 
 // Renorm preprocessing: handle negative axis
 void NegativeAxisPreProcess(Tensor* x, int* axis);

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -14,6 +14,8 @@ limitations under the License. */
 
 #include "paddle/phi/infermeta/ternary.h"
 
+#include <array>
+
 #include "glog/logging.h"
 
 #include "paddle/common/ddim.h"
@@ -144,15 +146,10 @@ void BaddbmmInferMeta(const MetaTensor& input,
                       const MetaTensor& y,
                       double beta,
                       double alpha,
-                      phi::DataType out_dtype,
                       MetaTensor* out) {
-  auto input_dims = input.dims();
-  auto x_dims = x.dims();
-  auto y_dims = y.dims();
-
-  auto ndim_input = input_dims.size();
-  auto ndim_x = x_dims.size();
-  auto ndim_y = y_dims.size();
+  const auto input_dims = input.dims();
+  const auto x_dims = x.dims();
+  const auto y_dims = y.dims();
 
   PADDLE_ENFORCE_EQ(
       input.dtype(),
@@ -171,53 +168,177 @@ void BaddbmmInferMeta(const MetaTensor& input,
           input.dtype(),
           y.dtype()));
 
-  VLOG(3) << "baddbmm operator input.shape=" << input_dims
-          << " x.shape=" << x_dims << " y.shape=" << y_dims << " beta=" << beta
-          << " alpha=" << alpha << " ndim_input=" << ndim_input
-          << " ndim_x=" << ndim_x << " ndim_y=" << ndim_y;
-
-  PADDLE_ENFORCE_EQ(
-      ndim_input == 2 || ndim_input == 3,
-      true,
-      errors::InvalidArgument(
-          "The input tensor must be 2-D or 3-D, but received shape %s.",
-          input_dims));
-  PADDLE_ENFORCE_EQ(
-      ndim_x,
+  PADDLE_ENFORCE_LE(
+      input_dims.size(),
       3,
       errors::InvalidArgument(
-          "The tensor x must be 3-D, but received shape %s.", x_dims));
+          "The input tensor input's dimension must not exceed 3, but "
+          "received %d.",
+          input_dims.size()));
   PADDLE_ENFORCE_EQ(
-      ndim_y,
+      x_dims.size(),
       3,
       errors::InvalidArgument(
-          "The tensor y must be 3-D, but received shape %s.", y_dims));
-
-  const auto same_or_unknown = [](int64_t lhs, int64_t rhs) {
-    return lhs < 0 || rhs < 0 || lhs == rhs;
-  };
+          "The input tensor x's dimension must be 3, but received %d.",
+          x_dims.size()));
   PADDLE_ENFORCE_EQ(
-      same_or_unknown(x_dims[0], y_dims[0]) &&
-          same_or_unknown(x_dims[2], y_dims[1]),
-      true,
+      y_dims.size(),
+      3,
       errors::InvalidArgument(
-          "The first two dimensions of y must be [%d, %d], but received "
-          "x's shape %s and y's shape %s.",
-          x_dims[0],
-          x_dims[2],
-          x_dims,
-          y_dims));
+          "The input tensor y's dimension must be 3, but received %d.",
+          y_dims.size()));
 
-  std::vector<int64_t> output_dims{x_dims[0], x_dims[1], y_dims[2]};
-
-  out->set_dims(make_ddim(output_dims));
-  out->share_lod(input);
-  // Set output dtype based on out_dtype parameter
-  if (out_dtype != phi::DataType::UNDEFINED) {
-    out->set_dtype(out_dtype);
-  } else {
-    out->set_dtype(input.dtype());
+  if (x_dims[0] >= 0 && y_dims[0] >= 0) {
+    PADDLE_ENFORCE_EQ(
+        x_dims[0],
+        y_dims[0],
+        errors::InvalidArgument(
+            "Input(X) and Input(Y) must have the same batch size, but "
+            "received %d and %d.",
+            x_dims[0],
+            y_dims[0]));
   }
+  if (x_dims[2] >= 0 && y_dims[1] >= 0) {
+    PADDLE_ENFORCE_EQ(
+        x_dims[2],
+        y_dims[1],
+        errors::InvalidArgument(
+            "Input(X)'s width must equal Input(Y)'s height, but received %d "
+            "and %d.",
+            x_dims[2],
+            y_dims[1]));
+  }
+
+  const std::array<int64_t, 3> output_dims = {x_dims[0], x_dims[1], y_dims[2]};
+  const auto input_rank = input_dims.size();
+  for (int64_t i = 0; i < input_rank; ++i) {
+    const auto input_dim = input_dims[i];
+    const auto output_dim = output_dims[3 - input_rank + i];
+    if (input_dim >= 0 && output_dim >= 0) {
+      PADDLE_ENFORCE_EQ(
+          input_dim == 1 || input_dim == output_dim,
+          true,
+          errors::InvalidArgument(
+              "Input(input)'s dimension %d must be 1 or match output "
+              "dimension %d, but received %d and %d.",
+              i,
+              3 - input_rank + i,
+              input_dim,
+              output_dim));
+    }
+  }
+
+  out->set_dims(make_ddim({output_dims[0], output_dims[1], output_dims[2]}));
+  out->share_lod(input);
+  out->set_dtype(input.dtype());
+}
+
+void BaddbmmOutDtypeInferMeta(const MetaTensor& input,
+                              const MetaTensor& x,
+                              const MetaTensor& y,
+                              DataType out_dtype,
+                              double beta,
+                              double alpha,
+                              MetaTensor* out) {
+  const auto input_dims = input.dims();
+  const auto x_dims = x.dims();
+  const auto y_dims = y.dims();
+
+  PADDLE_ENFORCE_EQ(
+      x.dtype(),
+      y.dtype(),
+      errors::InvalidArgument(
+          "Input(X) and Input(Y) must have the same dtype when out_dtype is "
+          "specified for paddle.baddbmm, but received %s and %s.",
+          x.dtype(),
+          y.dtype()));
+  PADDLE_ENFORCE_EQ(
+      out_dtype,
+      DataType::FLOAT32,
+      errors::InvalidArgument(
+          "The mixed out_dtype path of paddle.baddbmm only supports float32, "
+          "but received %s.",
+          out_dtype));
+  PADDLE_ENFORCE_EQ(
+      x.dtype() == DataType::FLOAT16 || x.dtype() == DataType::BFLOAT16,
+      true,
+      errors::InvalidArgument(
+          "The mixed out_dtype path of paddle.baddbmm only supports float16 "
+          "or bfloat16 Input(X), but received %s.",
+          x.dtype()));
+  PADDLE_ENFORCE_EQ(
+      input.dtype() == x.dtype() || input.dtype() == out_dtype,
+      true,
+      errors::InvalidArgument(
+          "Input(input)'s dtype must match Input(X)'s dtype or out_dtype, "
+          "but received %s, %s and %s respectively.",
+          input.dtype(),
+          x.dtype(),
+          out_dtype));
+
+  PADDLE_ENFORCE_LE(
+      input_dims.size(),
+      3,
+      errors::InvalidArgument(
+          "The input tensor input's dimension must not exceed 3, but "
+          "received %d.",
+          input_dims.size()));
+  PADDLE_ENFORCE_EQ(
+      x_dims.size(),
+      3,
+      errors::InvalidArgument(
+          "The input tensor x's dimension must be 3, but received %d.",
+          x_dims.size()));
+  PADDLE_ENFORCE_EQ(
+      y_dims.size(),
+      3,
+      errors::InvalidArgument(
+          "The input tensor y's dimension must be 3, but received %d.",
+          y_dims.size()));
+
+  if (x_dims[0] >= 0 && y_dims[0] >= 0) {
+    PADDLE_ENFORCE_EQ(
+        x_dims[0],
+        y_dims[0],
+        errors::InvalidArgument(
+            "Input(X) and Input(Y) must have the same batch size, but "
+            "received %d and %d.",
+            x_dims[0],
+            y_dims[0]));
+  }
+  if (x_dims[2] >= 0 && y_dims[1] >= 0) {
+    PADDLE_ENFORCE_EQ(
+        x_dims[2],
+        y_dims[1],
+        errors::InvalidArgument(
+            "Input(X)'s width must equal Input(Y)'s height, but received %d "
+            "and %d.",
+            x_dims[2],
+            y_dims[1]));
+  }
+
+  const std::array<int64_t, 3> output_dims = {x_dims[0], x_dims[1], y_dims[2]};
+  const auto input_rank = input_dims.size();
+  for (int64_t i = 0; i < input_rank; ++i) {
+    const auto input_dim = input_dims[i];
+    const auto output_dim = output_dims[3 - input_rank + i];
+    if (input_dim >= 0 && output_dim >= 0) {
+      PADDLE_ENFORCE_EQ(
+          input_dim == 1 || input_dim == output_dim,
+          true,
+          errors::InvalidArgument(
+              "Input(input)'s dimension %d must be 1 or match output "
+              "dimension %d, but received %d and %d.",
+              i,
+              3 - input_rank + i,
+              input_dim,
+              output_dim));
+    }
+  }
+
+  out->set_dims(make_ddim({output_dims[0], output_dims[1], output_dims[2]}));
+  out->share_lod(input);
+  out->set_dtype(out_dtype);
 }
 
 void AffineChannelInferMeta(const MetaTensor& x,

--- a/paddle/phi/infermeta/ternary.h
+++ b/paddle/phi/infermeta/ternary.h
@@ -53,8 +53,15 @@ PADDLE_API void BaddbmmInferMeta(const MetaTensor& input,
                                  const MetaTensor& y,
                                  double beta,
                                  double alpha,
-                                 DataType out_dtype,
                                  MetaTensor* out);
+
+PADDLE_API void BaddbmmOutDtypeInferMeta(const MetaTensor& input,
+                                         const MetaTensor& x,
+                                         const MetaTensor& y,
+                                         DataType out_dtype,
+                                         double beta,
+                                         double alpha,
+                                         MetaTensor* out);
 
 PADDLE_API void AffineChannelInferMeta(const MetaTensor& x,
                                        const MetaTensor& scale,

--- a/paddle/phi/kernels/baddbmm_kernel.h
+++ b/paddle/phi/kernels/baddbmm_kernel.h
@@ -25,7 +25,16 @@ void BaddbmmKernel(const Context& dev_ctx,
                    const DenseTensor& y,
                    double beta,
                    double alpha,
-                   DataType out_dtype,
                    DenseTensor* out);
+
+template <typename T, typename Context>
+void BaddbmmOutDtypeKernel(const Context& dev_ctx,
+                           const DenseTensor& input,
+                           const DenseTensor& x,
+                           const DenseTensor& y,
+                           DataType out_dtype,
+                           double beta,
+                           double alpha,
+                           DenseTensor* out);
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/baddbmm_kernel.cu
+++ b/paddle/phi/kernels/gpu/baddbmm_kernel.cu
@@ -26,3 +26,12 @@ PD_REGISTER_KERNEL(baddbmm,
                    double,
                    phi::float16,
                    phi::bfloat16) {}
+
+PD_REGISTER_KERNEL(baddbmm_out_dtype,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::BaddbmmOutDtypeKernel,
+                   phi::float16,
+                   phi::bfloat16) {
+  kernel->OutputAt(0).SetDataType(phi::DataType::FLOAT32);
+}

--- a/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
@@ -19,9 +19,7 @@ limitations under the License. */
 
 #include "paddle/common/flags.h"
 #include "paddle/phi/common/amp_type_traits.h"
-#include "paddle/phi/core/visit_type.h"
 #include "paddle/phi/kernels/baddbmm_grad_kernel.h"
-#include "paddle/phi/kernels/cast_kernel.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/for_range.h"
 #include "paddle/phi/kernels/reduce_sum_kernel.h"
@@ -65,23 +63,16 @@ void BaddbmmGradKernel(const Context& dev_ctx,
                        DenseTensor* x_grad,
                        DenseTensor* y_grad) {
   using MPType = typename MPTypeTrait<T>::Type;
-  const auto compute_dtype = CppTypeToDataType<T>::Type();
-  DenseTensor cast_out_grad;
-  const DenseTensor* compute_out_grad = &out_grad;
-  if (out_grad.dtype() != compute_dtype) {
-    PD_VISIT_FLOATING_AND_HALF_TYPES(
-        out_grad.dtype(), "BaddbmmGradCastOutGrad", ([&] {
-          cast_out_grad =
-              Cast<data_t, Context>(dev_ctx, out_grad, compute_dtype);
-        }));
-    compute_out_grad = &cast_out_grad;
-  }
-  const DenseTensor& grad = *compute_out_grad;
+  const DenseTensor& grad = out_grad;
 
   auto input_dims = input.dims();
   auto in_dims = input_dims;
-  if (input.dims().size() == 2) {
-    in_dims = {1, input.dims()[0], input.dims()[1]};
+  if (input_dims.size() < 3) {
+    std::vector<int64_t> padded_dims(3 - input_dims.size(), 1);
+    const auto input_dims_vec = common::vectorize(input_dims);
+    padded_dims.insert(
+        padded_dims.end(), input_dims_vec.begin(), input_dims_vec.end());
+    in_dims = common::make_ddim(padded_dims);
     if (input_grad) {
       input_grad->Resize(in_dims);
     }
@@ -137,7 +128,7 @@ void BaddbmmGradKernel(const Context& dev_ctx,
     BCopyOrScaleFunctor<T> functor(
         beta, input_grad->data<T>(), input_grad->data<T>(), total_elems);
     for_range(functor);
-    if (input.dims().size() == 2) {
+    if (input_dims.size() < 3) {
       input_grad->Resize(input_dims);
     }
   }

--- a/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/baddbmm_grad_kernel_impl.h
@@ -63,7 +63,6 @@ void BaddbmmGradKernel(const Context& dev_ctx,
                        DenseTensor* x_grad,
                        DenseTensor* y_grad) {
   using MPType = typename MPTypeTrait<T>::Type;
-  const DenseTensor& grad = out_grad;
 
   auto input_dims = input.dims();
   auto in_dims = input_dims;
@@ -82,7 +81,7 @@ void BaddbmmGradKernel(const Context& dev_ctx,
   VLOG(3) << "alpha: " << alpha << " beta: " << beta;
 
   if (input_grad != nullptr) {
-    input_grad->set_lod(grad.lod());
+    input_grad->set_lod(out_grad.lod());
   }
   if (x_grad != nullptr) {
     x_grad->set_lod(x.lod());
@@ -95,9 +94,9 @@ void BaddbmmGradKernel(const Context& dev_ctx,
   if (input_grad) {
     dev_ctx.template Alloc<T>(input_grad);
     total_elems = in_dims[0] * in_dims[1] * in_dims[2];
-    bool batch_compress = in_dims[0] != grad.dims()[0];
-    bool row_compress = in_dims[1] != grad.dims()[1];
-    bool col_compress = in_dims[2] != grad.dims()[2];
+    bool batch_compress = in_dims[0] != out_grad.dims()[0];
+    bool row_compress = in_dims[1] != out_grad.dims()[1];
+    bool col_compress = in_dims[2] != out_grad.dims()[2];
     std::vector<int64_t> reduce_dims;
     if (batch_compress) {
       reduce_dims.push_back(0);
@@ -109,18 +108,22 @@ void BaddbmmGradKernel(const Context& dev_ctx,
       reduce_dims.push_back(2);
     }
 
-    if (grad.numel() == 0) {
+    if (out_grad.numel() == 0) {
       funcs::ForRange<Context> for_range(dev_ctx, total_elems);
       BCopyOrScaleFunctor<T> functor(
           0, nullptr, input_grad->data<T>(), total_elems);
       for_range(functor);
     } else if (!reduce_dims.empty()) {
-      SumKernel<T, Context>(
-          dev_ctx, grad, IntArray(reduce_dims), grad.dtype(), true, input_grad);
+      SumKernel<T, Context>(dev_ctx,
+                            out_grad,
+                            IntArray(reduce_dims),
+                            out_grad.dtype(),
+                            true,
+                            input_grad);
     } else {
       funcs::ForRange<Context> for_range(dev_ctx, total_elems);
       BCopyOrScaleFunctor<T> functor(
-          1, grad.data<T>(), input_grad->data<T>(), total_elems);
+          1, out_grad.data<T>(), input_grad->data<T>(), total_elems);
       for_range(functor);
     }
 
@@ -157,7 +160,7 @@ void BaddbmmGradKernel(const Context& dev_ctx,
                        K_dim,
                        N_dim,
                        gemm_alpha,
-                       grad.data<T>(),
+                       out_grad.data<T>(),
                        y.data<T>(),
                        zero,
                        x_grad->data<T>(),
@@ -175,7 +178,7 @@ void BaddbmmGradKernel(const Context& dev_ctx,
                        K_dim,
                        N_dim,
                        gemm_alpha,
-                       grad.data<T>(),
+                       out_grad.data<T>(),
                        y.data<T>(),
                        zero,
                        x_grad->data<T>(),
@@ -216,7 +219,7 @@ void BaddbmmGradKernel(const Context& dev_ctx,
                        M_dim,
                        gemm_alpha,
                        x.data<T>(),
-                       grad.data<T>(),
+                       out_grad.data<T>(),
                        zero,
                        y_grad->data<T>(),
                        B_dim,
@@ -234,7 +237,7 @@ void BaddbmmGradKernel(const Context& dev_ctx,
                        M_dim,
                        gemm_alpha,
                        x.data<T>(),
-                       grad.data<T>(),
+                       out_grad.data<T>(),
                        zero,
                        y_grad->data<T>(),
                        B_dim,

--- a/paddle/phi/kernels/impl/baddbmm_kernel_impl.h
+++ b/paddle/phi/kernels/impl/baddbmm_kernel_impl.h
@@ -21,6 +21,7 @@ limitations under the License. */
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/kernels/baddbmm_kernel.h"
 #include "paddle/phi/kernels/cast_kernel.h"
+#include "paddle/phi/kernels/contiguous_kernel.h"
 #include "paddle/phi/kernels/expand_kernel.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/for_range.h"
@@ -49,15 +50,18 @@ void BaddbmmKernel(const Context& dev_ctx,
                    const DenseTensor& y,
                    double beta,
                    double alpha,
-                   DataType out_dtype,
                    DenseTensor* out) {
   auto input_dims = input.dims();
   auto x_dims = x.dims();
   auto y_dims = y.dims();
 
   DenseTensor input_3d(input);
-  if (input.dims().size() == 2) {
-    input_dims = {1, input.dims()[0], input.dims()[1]};
+  if (input_dims.size() < 3) {
+    std::vector<int64_t> padded_dims(3 - input_dims.size(), 1);
+    const auto input_dims_vec = common::vectorize(input_dims);
+    padded_dims.insert(
+        padded_dims.end(), input_dims_vec.begin(), input_dims_vec.end());
+    input_dims = common::make_ddim(padded_dims);
     input_3d.Resize(input_dims);
   }
 
@@ -144,9 +148,6 @@ void BaddbmmKernel(const Context& dev_ctx,
   // return before the bcast_dims integer division below, which would divide by
   // zero (SIGFPE) when a broadcast input dim is 0.
   if (out->numel() == 0) {
-    if (out_dtype != DataType::UNDEFINED && out_dtype != out->dtype()) {
-      CastKernel<T>(dev_ctx, *out, out_dtype, out);
-    }
     return;
   }
   auto blas = funcs::GetBlas<Context, T>(dev_ctx);
@@ -164,9 +165,6 @@ void BaddbmmKernel(const Context& dev_ctx,
     funcs::ForRange<Context> for_range(dev_ctx, out->numel());
     BaddbmmScaleFunctor<T> functor(beta, out->data<T>());
     for_range(functor);
-    if (out_dtype != DataType::UNDEFINED && out_dtype != out->dtype()) {
-      CastKernel<T>(dev_ctx, *out, out_dtype, out);
-    }
     return;
   }
 
@@ -235,11 +233,149 @@ void BaddbmmKernel(const Context& dev_ctx,
       // x_dims[2] == y_dims[1]
     }
   }
+}
 
-  // Handle out_dtype conversion if specified
-  if (out_dtype != DataType::UNDEFINED && out_dtype != out->dtype()) {
-    CastKernel<T>(dev_ctx, *out, out_dtype, out);
+template <typename T, typename Context>
+void BaddbmmOutDtypeKernel(const Context& dev_ctx,
+                           const DenseTensor& input,
+                           const DenseTensor& x,
+                           const DenseTensor& y,
+                           DataType out_dtype,
+                           double beta,
+                           double alpha,
+                           DenseTensor* out) {
+#if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP)
+  PADDLE_ENFORCE_EQ(
+      x.dtype(),
+      y.dtype(),
+      errors::InvalidArgument(
+          "Input(X) and Input(Y) must have the same dtype when out_dtype is "
+          "specified for paddle.baddbmm."));
+  PADDLE_ENFORCE_EQ(
+      out_dtype,
+      DataType::FLOAT32,
+      errors::InvalidArgument(
+          "The mixed out_dtype path of paddle.baddbmm only supports "
+          "float32."));
+  PADDLE_ENFORCE_EQ(
+      x.dtype() == DataType::FLOAT16 || x.dtype() == DataType::BFLOAT16,
+      true,
+      errors::InvalidArgument(
+          "The mixed out_dtype path of paddle.baddbmm only supports float16 "
+          "or bfloat16 Input(X)."));
+  PADDLE_ENFORCE_EQ(
+      input.dtype() == x.dtype() || input.dtype() == out_dtype,
+      true,
+      errors::InvalidArgument(
+          "Input(input)'s dtype must match Input(X)'s dtype or out_dtype when "
+          "out_dtype is specified for paddle.baddbmm."));
+
+  auto input_dims = input.dims();
+  const auto x_dims = x.dims();
+  const auto y_dims = y.dims();
+  PADDLE_ENFORCE_LE(
+      input_dims.size(),
+      3,
+      errors::InvalidArgument(
+          "The dimension of input must not exceed 3 when out_dtype is "
+          "specified for paddle.baddbmm."));
+  PADDLE_ENFORCE_EQ(
+      x_dims.size(),
+      3,
+      errors::InvalidArgument(
+          "The dimension of x must be 3 when out_dtype is specified for "
+          "paddle.baddbmm."));
+  PADDLE_ENFORCE_EQ(
+      y_dims.size(),
+      3,
+      errors::InvalidArgument(
+          "The dimension of y must be 3 when out_dtype is specified for "
+          "paddle.baddbmm."));
+  PADDLE_ENFORCE_EQ(
+      x_dims[0],
+      y_dims[0],
+      errors::InvalidArgument(
+          "Input(X) and Input(Y) must have the same batch size when out_dtype "
+          "is specified for paddle.baddbmm."));
+  PADDLE_ENFORCE_EQ(
+      x_dims[2],
+      y_dims[1],
+      errors::InvalidArgument(
+          "Input(X)'s width must equal Input(Y)'s height when out_dtype is "
+          "specified for paddle.baddbmm."));
+  DenseTensor input_3d(input);
+  if (input_dims.size() < 3) {
+    std::vector<int64_t> padded_dims(3 - input_dims.size(), 1);
+    const auto input_dims_vec = common::vectorize(input_dims);
+    padded_dims.insert(
+        padded_dims.end(), input_dims_vec.begin(), input_dims_vec.end());
+    input_dims = common::make_ddim(padded_dims);
+    input_3d.Resize(input_dims);
   }
+
+  DenseTensor input_float;
+  const DenseTensor* input_ptr = &input_3d;
+  if (input.dtype() != DataType::FLOAT32) {
+    input_float = Cast<T, Context>(dev_ctx, input_3d, DataType::FLOAT32);
+    input_ptr = &input_float;
+  }
+
+  ExpandKernel<float>(
+      dev_ctx, *input_ptr, IntArray({x_dims[0], x_dims[1], y_dims[2]}), out);
+  if (out->numel() == 0) {
+    return;
+  }
+  if (x.numel() == 0 || y.numel() == 0) {
+    funcs::ForRange<Context> for_range(dev_ctx, out->numel());
+    BaddbmmScaleFunctor<float> functor(beta, out->data<float>());
+    for_range(functor);
+    return;
+  }
+
+  DenseTensor x_contiguous;
+  DenseTensor y_contiguous;
+  const DenseTensor* x_ptr = &x;
+  const DenseTensor* y_ptr = &y;
+  if (!x.meta().is_contiguous()) {
+    ContiguousKernel<T, Context>(dev_ctx, x, &x_contiguous);
+    x_ptr = &x_contiguous;
+  }
+  if (!y.meta().is_contiguous()) {
+    ContiguousKernel<T, Context>(dev_ctx, y, &y_contiguous);
+    y_ptr = &y_contiguous;
+  }
+
+  funcs::Blas<Context> blas(dev_ctx);
+  if (x_dims[0] == 1) {
+    blas.GEMM(CblasNoTrans,
+              CblasNoTrans,
+              x_dims[1],
+              y_dims[2],
+              x_dims[2],
+              static_cast<float>(alpha),
+              x_ptr->data<T>(),
+              y_ptr->data<T>(),
+              static_cast<float>(beta),
+              out->data<float>());
+  } else {
+    blas.BatchedGEMM(CblasNoTrans,
+                     CblasNoTrans,
+                     x_dims[1],
+                     y_dims[2],
+                     x_dims[2],
+                     static_cast<float>(alpha),
+                     x_ptr->data<T>(),
+                     y_ptr->data<T>(),
+                     static_cast<float>(beta),
+                     out->data<float>(),
+                     x_dims[0],
+                     x_dims[1] * x_dims[2],
+                     x_dims[2] * y_dims[2]);
+  }
+#else
+  PADDLE_THROW(errors::Unimplemented(
+      "The out_dtype of paddle.baddbmm currently only supports CUDA."));
+#endif
 }
 
 }  // namespace phi

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -256,7 +256,7 @@
   inplace : (out_grad -> x_grad)
 
 - backward_op : baddbmm_grad
-  forward : baddbmm (Tensor input, Tensor x, Tensor y, double beta=1.0, double alpha=1.0, DataType out_dtype=DataType::UNDEFINED) -> Tensor(out)
+  forward : baddbmm (Tensor input, Tensor x, Tensor y, double beta=1.0, double alpha=1.0) -> Tensor(out)
   args : (Tensor input, Tensor x, Tensor y, Tensor out_grad, double alpha, double beta)
   output : Tensor(input_grad), Tensor(x_grad), Tensor(y_grad)
   infer_meta :

--- a/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
+++ b/paddle/phi/ops/yaml/inconsistent/dygraph_ops.yaml
@@ -43,6 +43,16 @@
   backward : assign_grad
   inplace : (x -> out)
 
+- op : baddbmm_out_dtype
+  args : (Tensor input, Tensor x, Tensor y, DataType out_dtype, double beta=1.0, double alpha=1.0)
+  output : Tensor(out)
+  infer_meta :
+    func : BaddbmmOutDtypeInferMeta
+  kernel :
+    func : baddbmm_out_dtype
+    data_type : x
+  traits : paddle::dialect::ForwardOnlyTrait
+
 - op : batch_norm
   args : (Tensor x, Tensor mean, Tensor variance, Tensor scale, Tensor bias, bool is_test, float momentum, float epsilon, str data_format, bool use_global_stats, bool trainable_statistics)
   output : Tensor(out), Tensor(mean_out), Tensor(variance_out), Tensor(saved_mean), Tensor(saved_variance), Tensor(reserve_space)

--- a/paddle/phi/ops/yaml/legacy/static_backward.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_backward.yaml
@@ -38,7 +38,7 @@
   invoke : assign(out_grad)
 
 - backward_op : baddbmm_grad
-  forward : baddbmm (Tensor input, Tensor x, Tensor y, float beta=1.0, float alpha=1.0, DataType out_dtype=DataType::UNDEFINED) -> Tensor(out)
+  forward : baddbmm (Tensor input, Tensor x, Tensor y, float beta=1.0, float alpha=1.0) -> Tensor(out)
   args : (Tensor input, Tensor x, Tensor y, Tensor out_grad, float alpha, float beta)
   output : Tensor(input_grad), Tensor(x_grad), Tensor(y_grad)
   infer_meta :

--- a/paddle/phi/ops/yaml/legacy/static_ops.yaml
+++ b/paddle/phi/ops/yaml/legacy/static_ops.yaml
@@ -87,7 +87,7 @@
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : baddbmm
-  args : (Tensor input, Tensor x, Tensor y, float beta=1.0, float alpha=1.0, DataType out_dtype=DataType::UNDEFINED)
+  args : (Tensor input, Tensor x, Tensor y, float beta=1.0, float alpha=1.0)
   output : Tensor(out)
   infer_meta :
     func : BaddbmmInferMeta

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -566,7 +566,7 @@
   traits : paddle::dialect::ForwardOnlyTrait
 
 - op : baddbmm
-  args : (Tensor input, Tensor x, Tensor y, double beta=1.0, double alpha=1.0, DataType out_dtype=DataType::UNDEFINED)
+  args : (Tensor input, Tensor x, Tensor y, double beta=1.0, double alpha=1.0)
   output : Tensor(out)
   infer_meta :
     func : BaddbmmInferMeta

--- a/paddle/phi/ops/yaml/python_api_info.yaml
+++ b/paddle/phi/ops/yaml/python_api_info.yaml
@@ -141,21 +141,13 @@
   pre_process :
     func : AddmmPreProcess(input, x, y)
 
-- op : baddbmm
-  name : [paddle.baddbmm, paddle.Tensor.baddbmm]
-  args_alias :
-    x : [batch1]
-    y : [batch2]
-  pre_process :
-    func : BaddbmmPreProcess(input, x, y)
-
 - op : baddbmm_
   name : [paddle.baddbmm_, paddle.Tensor.baddbmm_]
   args_alias :
     x : [batch1]
     y : [batch2]
   pre_process :
-    func : BaddbmmPreProcess(input, x, y)
+    func : BaddbmmInplacePreProcess(input, x, y)
 
 - op : cross
   name : [paddle.cross, paddle.Tensor.cross]

--- a/python/paddle/_paddle_docs.py
+++ b/python/paddle/_paddle_docs.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Literal
 
-    import paddle
     from paddle import Tensor
     from paddle._typing import DataLayout2D, DTypeLike
 
@@ -4726,69 +4725,12 @@ def addmm_(
 
 
 @add_doc_and_signature
-def baddbmm(
-    input: Tensor,
-    x: Tensor,
-    y: Tensor,
-    beta: float = 1.0,
-    alpha: float = 1.0,
-    out_dtype: paddle.dtype | None = None,
-    name: str | None = None,
-    *,
-    out: Tensor | None = None,
-) -> Tensor:
-    r"""
-    Perform batch matrix multiplication for input :math:`x` and :math:`y`.
-    :math:`input` is added to the final result.
-    The equation is:
-    .. math::
-        out = \beta \times input + \alpha \times x \times y
-    where :math:`\beta` and :math:`\alpha` are scaling factors.
-    Args:
-        input (Tensor): The input tensor to be added to the final result. It should be a 2-D or 3-D tensor.
-            Data type should be float16, float32, float64, uint16.
-        x (Tensor): The first batch of matrices to be multiplied. It should be a 3-D tensor with shape [b, n, p].
-            Data type should be float16, float32, float64, uint16.
-            Alias: ``batch1``.
-        y (Tensor): The second batch of matrices to be multiplied. It should be a 3-D tensor with shape [b, p, m].
-            Data type should be float16, float32, float64, uint16.
-            Alias: ``batch2``.
-        beta (float, optional): The scaling factor for input. Default: 1.0.
-        alpha (float, optional): The scaling factor for x @ y. Default: 1.0.
-        out_dtype (paddle.dtype|None, optional): The desired data type of the returned tensor. If None, the output tensor will have the same data type as input. Default: None.
-        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
-    Keyword args:
-        out (Tensor, optional): The output Tensor. If set, the result will be stored in this Tensor. Default: None.
-    Returns:
-        Tensor: The output tensor should be a 3-D tensor with shape [b, n, m].
-    Examples:
-        .. code-block:: pycon
-
-            >>> import paddle
-
-            >>> x = paddle.ones([2, 2, 2])
-            >>> y = paddle.ones([2, 2, 2])
-            >>> input = paddle.ones([2, 2, 2])
-
-            >>> out = paddle.baddbmm(input=input, x=x, y=y, beta=0.5, alpha=5.0)
-            >>> out
-            Tensor(shape=[2, 2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
-            [[[10.50000000, 10.50000000],
-              [10.50000000, 10.50000000]],
-             [[10.50000000, 10.50000000],
-              [10.50000000, 10.50000000]]])
-    """
-    ...
-
-
-@add_doc_and_signature
 def baddbmm_(
     input: Tensor,
     x: Tensor,
     y: Tensor,
     beta: float = 1.0,
     alpha: float = 1.0,
-    out_dtype: paddle.dtype | None = None,
     name: str | None = None,
 ) -> Tensor:
     r"""

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2558,6 +2558,15 @@ def baddbmm(
                 "CUDA tensors."
             )
 
+        if paddle.is_grad_enabled() and builtins.any(
+            not tensor.stop_gradient for tensor in (input, x, y)
+        ):
+            raise RuntimeError(
+                "baddbmm(): out_dtype does not support automatic "
+                "differentiation, but one of the input tensors requires "
+                "grad."
+            )
+
     if (
         out is not None
         and paddle.is_grad_enabled()

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2581,12 +2581,14 @@ def baddbmm(
         )
 
     if out_dtype is not None:
-        return _C_ops.baddbmm_out_dtype(
+        result = _C_ops.baddbmm_out_dtype(
             input, x, y, out_dtype, beta, alpha, out=out
         )
+        return out if out is not None else result
 
     if in_dynamic_or_pir_mode():
-        return _C_ops.baddbmm(input, x, y, beta, alpha, out=out)
+        result = _C_ops.baddbmm(input, x, y, beta, alpha, out=out)
+        return out if out is not None else result
 
     check_variable_and_dtype(
         input,

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import builtins
 import math
 import numbers
 import warnings
@@ -47,7 +48,6 @@ from paddle._C_ops import (  # noqa: F401
     atan_,
     atanh,
     atanh_,
-    baddbmm,
     baddbmm_,
     bitwise_left_shift,
     bitwise_left_shift_,
@@ -122,6 +122,7 @@ from paddle.base.libpaddle import DataType
 from paddle.common_ops_import import VarDesc, dygraph_utils
 from paddle.pir import Value
 from paddle.utils.decorator_utils import (
+    baddbmm_compat_decorator,
     bmm_compat_decorator,
     nansum_decorator,
     param_one_alias,
@@ -2453,6 +2454,153 @@ def bmm(
         type='bmm',
         inputs={'X': x, 'Y': y},
         outputs={'Out': out},
+    )
+    return out
+
+
+@baddbmm_compat_decorator
+@param_two_alias(["x", "batch1"], ["y", "batch2"])
+def baddbmm(
+    input: Tensor,
+    x: Tensor,
+    y: Tensor,
+    out_dtype: DTypeLike | None = None,
+    name: str | None = None,
+    *,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+    out: Tensor | None = None,
+) -> Tensor:
+    r"""
+    Perform batch matrix multiplication for input :math:`x` and :math:`y`.
+    :math:`input` is added to the final result. The equation is:
+
+    .. math::
+
+        out = \beta \times input + \alpha \times x \times y
+
+    where :math:`\beta` and :math:`\alpha` are scaling factors.
+
+    Args:
+        input (Tensor): The input tensor to be added to the final result. It
+            must be broadcastable to the result and may have zero to three
+            dimensions. Its data type should be float16, float32, float64, or
+            bfloat16.
+        x (Tensor): The first batch of matrices to be multiplied. It should be
+            a 3-D tensor with shape ``[b, n, p]``. Alias: ``batch1``.
+        y (Tensor): The second batch of matrices to be multiplied. It should be
+            a 3-D tensor with shape ``[b, p, m]``. Alias: ``batch2``.
+        out_dtype (paddle.dtype|None, optional): The desired data type of the
+            returned tensor. Currently only ``paddle.float32`` is supported
+            for CUDA float16/bfloat16 matrix inputs. This path is forward-only.
+            A numeric fourth positional argument is interpreted as the legacy
+            ``beta`` argument.
+            Default: None.
+        name (str|None, optional): Name for the operation. Default: None.
+
+    Keyword Args:
+        beta (float, optional): The scaling factor for input. Default: 1.0.
+        alpha (float, optional): The scaling factor for x @ y. Default: 1.0.
+        out (Tensor|None, optional): The output Tensor. Default: None.
+
+    Returns:
+        Tensor: A 3-D tensor with shape ``[b, n, m]``.
+
+    Examples:
+        .. code-block:: pycon
+
+            >>> import paddle
+
+            >>> x = paddle.ones([2, 2, 2])
+            >>> y = paddle.ones([2, 2, 2])
+            >>> input = paddle.ones([2, 2, 2])
+            >>> paddle.baddbmm(input=input, x=x, y=y, beta=0.5, alpha=5.0)
+            Tensor(shape=[2, 2, 2], dtype=float32, place=Place(cpu), stop_gradient=True,
+            [[[10.50000000, 10.50000000],
+              [10.50000000, 10.50000000]],
+             [[10.50000000, 10.50000000],
+              [10.50000000, 10.50000000]]])
+    """
+    if out_dtype is not None:
+        out_dtype = convert_nptype_to_datatype_or_vartype(out_dtype)
+        float32_dtypes = (core.DataType.FLOAT32, core.VarDesc.VarType.FP32)
+        supported_input_dtypes = (
+            core.DataType.FLOAT16,
+            core.VarDesc.VarType.FP16,
+            core.DataType.BFLOAT16,
+            core.VarDesc.VarType.BF16,
+        )
+        if x.dtype not in supported_input_dtypes:
+            raise TypeError(
+                "The out_dtype of paddle.baddbmm currently only supports "
+                "float16 or bfloat16 x."
+            )
+        if out is not None and out.dtype not in float32_dtypes:
+            raise TypeError(
+                "The out tensor dtype must be paddle.float32 when out_dtype "
+                "is paddle.float32."
+            )
+        if not in_dynamic_mode():
+            raise NotImplementedError(
+                "The out_dtype of paddle.baddbmm currently only supports "
+                "dynamic graph."
+            )
+        if (
+            not paddle.is_compiled_with_cuda()
+            or paddle.is_compiled_with_rocm()
+            or not input.place.is_gpu_place()
+            or not x.place.is_gpu_place()
+            or not y.place.is_gpu_place()
+            or (out is not None and not out.place.is_gpu_place())
+        ):
+            raise NotImplementedError(
+                "The out_dtype of paddle.baddbmm currently only supports "
+                "CUDA tensors."
+            )
+
+    if (
+        out is not None
+        and paddle.is_grad_enabled()
+        and builtins.any(
+            not tensor.stop_gradient for tensor in (input, x, y, out)
+        )
+    ):
+        raise RuntimeError(
+            "baddbmm(): functions with out=... arguments don't support "
+            "automatic differentiation, but one of the arguments requires "
+            "grad."
+        )
+
+    if out_dtype is not None:
+        return _C_ops.baddbmm_out_dtype(
+            input, x, y, out_dtype, beta, alpha, out=out
+        )
+
+    if in_dynamic_or_pir_mode():
+        return _C_ops.baddbmm(input, x, y, beta, alpha, out=out)
+
+    check_variable_and_dtype(
+        input,
+        'Input',
+        ['float16', 'float32', 'float64', 'uint16'],
+        'baddbmm',
+    )
+    check_variable_and_dtype(
+        x, 'X', ['float16', 'float32', 'float64', 'uint16'], 'baddbmm'
+    )
+    check_variable_and_dtype(
+        y, 'Y', ['float16', 'float32', 'float64', 'uint16'], 'baddbmm'
+    )
+
+    helper = LayerHelper('baddbmm', **locals())
+    if out is None:
+        out = helper.create_variable_for_type_inference(dtype=input.dtype)
+    attrs = {'Alpha': alpha, 'Beta': beta}
+    helper.append_op(
+        type='baddbmm',
+        inputs={'Input': input, 'X': x, 'Y': y},
+        outputs={'Out': out},
+        attrs=attrs,
     )
     return out
 

--- a/python/paddle/utils/decorator_utils.py
+++ b/python/paddle/utils/decorator_utils.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import functools
 import inspect
+import numbers
 import warnings
 from collections.abc import Callable, Iterable
 from typing import Any, TypeVar, cast
@@ -239,6 +240,40 @@ def bmm_compat_decorator(
         if len(args) == 3 and isinstance(args[2], str) and "name" not in kwargs:
             kwargs["name"] = args[2]
             args = args[:2]
+        return func(*args, **kwargs)
+
+    wrapper.__signature__ = inspect.signature(func)
+    return cast("Callable[_InputT, _RetT]", wrapper)
+
+
+def baddbmm_compat_decorator(
+    func: Callable[_InputT, _RetT],
+) -> Callable[_InputT, _RetT]:
+    """Preserve legacy positional ``beta``, ``alpha``, ``out_dtype``, and
+    ``name``.
+
+    The public signature follows PyTorch by putting ``out_dtype`` in the
+    fourth position and making ``beta`` and ``alpha`` keyword-only. A numeric
+    fourth positional argument continues to use Paddle's legacy argument
+    order.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: _InputT.args, **kwargs: _InputT.kwargs) -> _RetT:
+        if len(args) >= 4 and isinstance(args[3], numbers.Number):
+            legacy_args = args[3:]
+            legacy_names = ("beta", "alpha", "out_dtype", "name")
+            if len(legacy_args) > len(legacy_names):
+                raise TypeError(
+                    "baddbmm() received too many positional arguments"
+                )
+            for name, value in zip(legacy_names, legacy_args):
+                if name in kwargs:
+                    raise TypeError(
+                        f"baddbmm() got multiple values for argument '{name}'"
+                    )
+                kwargs[name] = value
+            args = args[:3]
         return func(*args, **kwargs)
 
     wrapper.__signature__ = inspect.signature(func)

--- a/test/legacy_test/test_api_compatibility_part1.py
+++ b/test/legacy_test/test_api_compatibility_part1.py
@@ -2029,17 +2029,25 @@ class TestBaddbmmAPI(unittest.TestCase):
         np.testing.assert_allclose(ref_out_2d, out8.numpy(), rtol=1e-6)
         paddle.enable_static()
 
-    def test_error(self):
-        """Test invalid input dimensions that should raise ValueError."""
+    def test_1d_input(self):
         paddle.disable_static()
-        x = paddle.to_tensor(self.np_x)
-        y = paddle.to_tensor(self.np_y)
+        try:
+            x = paddle.to_tensor(self.np_x)
+            y = paddle.to_tensor(self.np_y)
 
-        # Test 1D input (invalid)
-        input_1d = paddle.to_tensor(np.random.rand(3).astype('float32'))
-        with self.assertRaises(ValueError):
-            paddle.baddbmm(input_1d, x, y)
-        paddle.enable_static()
+            # A 1-D input is right-aligned with the output's last dimension.
+            input_1d = paddle.to_tensor(np.random.rand(3).astype('float32'))
+            out = paddle.baddbmm(input_1d, x, y)
+            expected = input_1d.numpy() + self.np_x @ self.np_y
+            np.testing.assert_allclose(out.numpy(), expected, rtol=1e-6)
+
+            invalid_input = paddle.to_tensor(
+                np.random.rand(2).astype('float32')
+            )
+            with self.assertRaises(ValueError):
+                paddle.baddbmm(invalid_input, x, y)
+        finally:
+            paddle.enable_static()
 
     def test_static_Compatibility(self):
         paddle.enable_static()

--- a/test/legacy_test/test_baddbmm_op.py
+++ b/test/legacy_test/test_baddbmm_op.py
@@ -761,9 +761,9 @@ class TestBaddBmmAPI(unittest.TestCase):
     def test_normal_backward_without_out_dtype(self):
         paddle.disable_static()
         try:
-            input = paddle.ones([2, 2, 2], stop_gradient=False)
-            x = paddle.ones([2, 2, 2], stop_gradient=False)
-            y = paddle.ones([2, 2, 2], stop_gradient=False)
+            input = paddle.ones([2, 2, 2], requires_grad=True)
+            x = paddle.ones([2, 2, 2], requires_grad=True)
+            y = paddle.ones([2, 2, 2], requires_grad=True)
 
             result = paddle.baddbmm(input, x, y, beta=0.5, alpha=2.0)
             self.assertEqual(result.dtype, paddle.float32)
@@ -805,7 +805,7 @@ class TestBaddBmmAPI(unittest.TestCase):
     def test_out_rejects_autograd(self):
         paddle.disable_static()
         try:
-            input = paddle.ones([2, 2, 2], stop_gradient=False)
+            input = paddle.ones([2, 2, 2], requires_grad=True)
             x = paddle.ones([2, 2, 2])
             y = paddle.ones([2, 2, 2])
             out = paddle.empty([2, 2, 2])
@@ -824,7 +824,7 @@ class TestBaddBmmAPI(unittest.TestCase):
             x = paddle.ones([2, 3, 4])
             y = paddle.ones([2, 4, 5])
             for shape, expected_grad in [((), 60.0), ((5,), 12.0)]:
-                input = paddle.ones(shape, stop_gradient=False)
+                input = paddle.ones(shape, requires_grad=True)
                 result = paddle.baddbmm(input, x, y, beta=2.0)
                 self.assertEqual(result.shape, [2, 3, 5])
                 result.sum().backward()
@@ -955,8 +955,6 @@ class TestBaddBmmAPI(unittest.TestCase):
             y = paddle.ones([batch_size, 5, 4], dtype=dtype).transpose(
                 [0, 2, 1]
             )
-            x.stop_gradient = False
-            y.stop_gradient = False
 
             for input_dtype in (dtype, paddle.float32):
                 input = paddle.ones([5], dtype=input_dtype)
@@ -969,7 +967,6 @@ class TestBaddBmmAPI(unittest.TestCase):
                     out_dtype=paddle.float32,
                 )
                 self.assertEqual(result.dtype, paddle.float32)
-                self.assertTrue(result.stop_gradient)
                 np.testing.assert_allclose(
                     result.numpy(), 8.5, rtol=1e-5, atol=1e-5
                 )
@@ -1025,6 +1022,47 @@ class TestBaddBmmAPI(unittest.TestCase):
         try:
             paddle.set_device('gpu')
             self._check_mixed_out_dtype(paddle.float16)
+        finally:
+            paddle.enable_static()
+
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda() or paddle.is_compiled_with_rocm(),
+        "CUDA is required for baddbmm out_dtype",
+    )
+    def test_out_dtype_rejects_autograd(self):
+        if not core.is_float16_supported(paddle.CUDAPlace(0)):
+            self.skipTest("Float16 is not supported")
+        paddle.disable_static()
+        try:
+            paddle.set_device('gpu')
+            for grad_input in ('input', 'x', 'y'):
+                tensors = {
+                    'input': paddle.ones([5], dtype=paddle.float16),
+                    'x': paddle.ones([2, 3, 4], dtype=paddle.float16),
+                    'y': paddle.ones([2, 4, 5], dtype=paddle.float16),
+                }
+                tensors[grad_input].stop_gradient = False
+                with (
+                    self.subTest(grad_input=grad_input),
+                    self.assertRaisesRegex(
+                        RuntimeError,
+                        "out_dtype does not support automatic differentiation",
+                    ),
+                ):
+                    paddle.baddbmm(
+                        tensors['input'],
+                        tensors['x'],
+                        tensors['y'],
+                        out_dtype=paddle.float32,
+                    )
+
+            input = paddle.ones([5], dtype=paddle.float16, requires_grad=True)
+            x = paddle.ones([2, 3, 4], dtype=paddle.float16, requires_grad=True)
+            y = paddle.ones([2, 4, 5], dtype=paddle.float16, requires_grad=True)
+            with paddle.no_grad():
+                result = paddle.baddbmm(input, x, y, out_dtype=paddle.float32)
+            self.assertTrue(result.stop_gradient)
+            np.testing.assert_array_equal(result.numpy(), 5.0)
         finally:
             paddle.enable_static()
 

--- a/test/legacy_test/test_baddbmm_op.py
+++ b/test/legacy_test/test_baddbmm_op.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import unittest
 
 import numpy as np
@@ -28,13 +29,17 @@ from paddle.base import Program, core, program_guard
 from paddle.framework import in_pir_mode
 
 
+def baddbmm_api_for_op_test(input, x, y, beta=1.0, alpha=1.0):
+    return paddle.baddbmm(input, x, y, beta=beta, alpha=alpha)
+
+
 class TestBaddBmmOp(OpTest):
     # test basic
     def setUp(self):
         self.op_type = "baddbmm"
         self.prim_op_type = "comp"
-        self.python_api = paddle.baddbmm
-        self.public_python_api = paddle.baddbmm
+        self.python_api = baddbmm_api_for_op_test
+        self.public_python_api = baddbmm_api_for_op_test
         self.init_dtype_type()
         self.inputs = {
             'Input': np.random.random((2, 10, 5)).astype(self.dtype),
@@ -96,7 +101,7 @@ class TestBaddBmmOp(OpTest):
 class TestBaddBmmFP16Op(OpTest):
     def setUp(self):
         self.op_type = "baddbmm"
-        self.python_api = paddle.baddbmm
+        self.python_api = baddbmm_api_for_op_test
         self.init_dtype_type()
         self.inputs = {
             'Input': np.random.random((1, 10, 10)).astype(self.dtype),
@@ -139,7 +144,7 @@ class TestBaddBmmFP16Op(OpTest):
 class TestBaddBmmBF16Op(OpTest):
     def setUp(self):
         self.op_type = "baddbmm"
-        self.python_api = paddle.baddbmm
+        self.python_api = baddbmm_api_for_op_test
         self.init_dtype_type()
         self.inputs = {
             'Input': np.random.random((2, 50, 1)).astype(self.dtype),
@@ -206,15 +211,34 @@ class TestBaddBmmOpError(unittest.TestCase):
             )
 
             paddle.enable_static()
-            # The input dtype of baddbmm_op must be float32 or float64.
+            # The legacy static API rejects unsupported dtypes before appending
+            # the operator.
+            with paddle.pir_utils.OldIrGuard():
+                main = paddle.static.Program()
+                startup = paddle.static.Program()
+                with paddle.static.program_guard(main, startup):
+                    int_input = paddle.static.data(
+                        name='int_input',
+                        shape=[2, 4, 4],
+                        dtype="int32",
+                    )
+                    x3 = paddle.static.data(
+                        name='x3', shape=[2, 4, 4], dtype="int32"
+                    )
+                    x4 = paddle.static.data(
+                        name='x4', shape=[2, 4, 4], dtype="int32"
+                    )
+                    self.assertRaises(
+                        TypeError, paddle.baddbmm, int_input, x3, x4
+                    )
+
+            # Shape errors are validated by InferMeta with otherwise valid
+            # input dtypes.
             input = paddle.static.data(
                 name='input',
                 shape=[2, 4, 4],
-                dtype="int32",
+                dtype="float32",
             )
-            x3 = paddle.static.data(name='x3', shape=[2, 4, 4], dtype="int32")
-            x4 = paddle.static.data(name='x4', shape=[2, 4, 4], dtype="int32")
-            self.assertRaises(TypeError, paddle.baddbmm, input, x3, x4)
             # x and y dimension mismatch
             x5 = paddle.static.data(
                 name='x5',
@@ -298,8 +322,8 @@ class TestBaddBmmOp2(TestBaddBmmOp):
     def setUp(self):
         self.op_type = "baddbmm"
         self.prim_op_type = "comp"
-        self.python_api = paddle.baddbmm
-        self.public_python_api = paddle.baddbmm
+        self.python_api = baddbmm_api_for_op_test
+        self.public_python_api = baddbmm_api_for_op_test
         self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {
@@ -322,8 +346,8 @@ class TestBaddBmmOp3(OpTest):
     def setUp(self):
         self.op_type = "baddbmm"
         self.prim_op_type = "comp"
-        self.python_api = paddle.baddbmm
-        self.public_python_api = paddle.baddbmm
+        self.python_api = baddbmm_api_for_op_test
+        self.public_python_api = baddbmm_api_for_op_test
         self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {
@@ -377,8 +401,8 @@ class TestBaddBmmOp4(OpTest):
     def setUp(self):
         self.op_type = "baddbmm"
         self.prim_op_type = "comp"
-        self.python_api = paddle.baddbmm
-        self.public_python_api = paddle.baddbmm
+        self.python_api = baddbmm_api_for_op_test
+        self.public_python_api = baddbmm_api_for_op_test
         self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {
@@ -407,9 +431,6 @@ class TestBaddBmmOp4(OpTest):
         self.check_output(check_pir=True, check_prim_pir=True)
 
     def test_check_grad_normal(self):
-        self.inputs['Input'] = np.broadcast_to(
-            self.inputs['Input'][:, np.newaxis, :], (1, 50, 15)
-        )
         self.check_grad(
             ['Input', 'X', 'Y'], 'Out', check_pir=True, check_prim_pir=True
         )
@@ -421,9 +442,6 @@ class TestBaddBmmOp4(OpTest):
         self.check_grad(['Y'], 'Out', no_grad_set=None, check_pir=True)
 
     def test_check_grad_input(self):
-        self.inputs['Input'] = np.broadcast_to(
-            self.inputs['Input'][:, np.newaxis, :], (1, 50, 15)
-        )
         self.check_grad(
             ['Input'],
             'Out',
@@ -638,6 +656,47 @@ class TestBaddBmmAPI(unittest.TestCase):
 
         paddle.enable_static()
 
+    def test_legacy_static_api(self):
+        paddle.enable_static()
+        input_data = np.ones([2, 2, 2], dtype=np.float32)
+        x_data = np.ones([2, 2, 3], dtype=np.float32)
+        y_data = np.ones([2, 3, 2], dtype=np.float32)
+
+        with paddle.pir_utils.OldIrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                input = paddle.static.data(
+                    'legacy_input', [2, 2, 2], dtype='float32'
+                )
+                x = paddle.static.data('legacy_x', [2, 2, 3], dtype='float32')
+                y = paddle.static.data('legacy_y', [2, 3, 2], dtype='float32')
+                result = paddle.baddbmm(input, x, y, beta=0.5, alpha=2.0)
+
+                out = main.global_block().create_var(
+                    name='legacy_out', shape=[2, 2, 2], dtype='float32'
+                )
+                out.stop_gradient = True
+                returned = paddle.baddbmm(
+                    input, x, y, beta=0.5, alpha=2.0, out=out
+                )
+                self.assertIs(returned, out)
+
+            executor = base.Executor(base.CPUPlace())
+            result_value, out_value = executor.run(
+                main,
+                feed={
+                    'legacy_input': input_data,
+                    'legacy_x': x_data,
+                    'legacy_y': y_data,
+                },
+                fetch_list=[result, out],
+            )
+
+        expected = 0.5 * input_data + 2.0 * np.matmul(x_data, y_data)
+        np.testing.assert_allclose(result_value, expected)
+        np.testing.assert_allclose(out_value, expected)
+
     def test_api_out(self):
         if in_pir_mode():
             self.skipTest("PIR not support out tensor")
@@ -699,126 +758,429 @@ class TestBaddBmmAPI(unittest.TestCase):
 
         paddle.enable_static()
 
-    def test_api_out_dtype(self):
-        """Test out_dtype parameter for baddbmm"""
-        data_x = np.ones((2, 2, 2)).astype(np.float32)
-        data_y = np.ones((2, 2, 2)).astype(np.float32)
-        data_input = np.ones((2, 2, 2)).astype(np.float32)
-        data_alpha = 0.1
-        data_beta = 1.0
+    def test_normal_backward_without_out_dtype(self):
+        paddle.disable_static()
+        try:
+            input = paddle.ones([2, 2, 2], stop_gradient=False)
+            x = paddle.ones([2, 2, 2], stop_gradient=False)
+            y = paddle.ones([2, 2, 2], stop_gradient=False)
+
+            result = paddle.baddbmm(input, x, y, beta=0.5, alpha=2.0)
+            self.assertEqual(result.dtype, paddle.float32)
+            self.assertFalse(result.stop_gradient)
+            result.sum().backward()
+            np.testing.assert_array_equal(input.grad.numpy(), 0.5)
+            np.testing.assert_array_equal(x.grad.numpy(), 4.0)
+            np.testing.assert_array_equal(y.grad.numpy(), 4.0)
+
+            method_result = input.detach().baddbmm(x.detach(), y.detach())
+            np.testing.assert_array_equal(method_result.numpy(), 3.0)
+        finally:
+            paddle.enable_static()
+
+    def test_out_dtype_rejects_unsupported_conversion(self):
+        paddle.disable_static()
+        try:
+            input = paddle.ones([2, 2, 2])
+            x = paddle.ones([2, 2, 2])
+            y = paddle.ones([2, 2, 2])
+            with self.assertRaisesRegex(TypeError, "float16 or bfloat16 x"):
+                paddle.baddbmm(input, x, y, out_dtype=paddle.float64)
+        finally:
+            paddle.enable_static()
+
+    def test_normal_and_out_without_out_dtype(self):
+        paddle.disable_static()
+        try:
+            input = paddle.ones([2, 2, 2])
+            x = paddle.ones([2, 2, 2])
+            y = paddle.ones([2, 2, 2])
+            out = paddle.empty([2, 2, 2], dtype=paddle.float32)
+            result = paddle.baddbmm(input, x, y, out=out)
+            self.assertIs(result, out)
+            np.testing.assert_array_equal(out.numpy(), 3.0)
+        finally:
+            paddle.enable_static()
+
+    def test_out_rejects_autograd(self):
+        paddle.disable_static()
+        try:
+            input = paddle.ones([2, 2, 2], stop_gradient=False)
+            x = paddle.ones([2, 2, 2])
+            y = paddle.ones([2, 2, 2])
+            out = paddle.empty([2, 2, 2])
+            with self.assertRaisesRegex(RuntimeError, "don't support"):
+                paddle.baddbmm(input, x, y, out=out)
+
+            with paddle.no_grad():
+                result = paddle.baddbmm(input, x, y, out=out)
+            self.assertIs(result, out)
+        finally:
+            paddle.enable_static()
+
+    def test_scalar_and_vector_input_backward(self):
+        paddle.disable_static()
+        try:
+            x = paddle.ones([2, 3, 4])
+            y = paddle.ones([2, 4, 5])
+            for shape, expected_grad in [((), 60.0), ((5,), 12.0)]:
+                input = paddle.ones(shape, stop_gradient=False)
+                result = paddle.baddbmm(input, x, y, beta=2.0)
+                self.assertEqual(result.shape, [2, 3, 5])
+                result.sum().backward()
+                self.assertEqual(input.grad.shape, list(shape))
+                np.testing.assert_array_equal(input.grad.numpy(), expected_grad)
+        finally:
+            paddle.enable_static()
+
+    def test_inplace_requires_exact_shape_and_dtype(self):
+        paddle.disable_static()
+        try:
+            x = paddle.ones([2, 3, 4])
+            y = paddle.ones([2, 4, 5])
+
+            input = paddle.ones([2, 3, 5])
+            result = paddle.baddbmm_(input, x, y)
+            self.assertIs(result, input)
+
+            with self.assertRaises(ValueError):
+                paddle.baddbmm_(paddle.ones([3, 5]), x, y)
+            with self.assertRaises(ValueError):
+                paddle.baddbmm_(paddle.ones([1, 3, 5]), x, y)
+            with self.assertRaises((TypeError, ValueError)):
+                paddle.baddbmm_(
+                    paddle.ones([2, 3, 5], dtype=paddle.float64), x, y
+                )
+            with self.assertRaises(TypeError):
+                paddle.baddbmm_(input, x, y, out_dtype=paddle.float32)
+        finally:
+            paddle.enable_static()
+
+    def test_signature_and_tensor_method(self):
+        parameters = inspect.signature(paddle.baddbmm).parameters
+        self.assertEqual(
+            list(parameters),
+            [
+                'input',
+                'x',
+                'y',
+                'out_dtype',
+                'name',
+                'beta',
+                'alpha',
+                'out',
+            ],
+        )
+        for parameter in ('out_dtype', 'name'):
+            self.assertEqual(
+                parameters[parameter].kind,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        for parameter in ('beta', 'alpha', 'out'):
+            self.assertEqual(
+                parameters[parameter].kind,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
 
         paddle.disable_static()
+        try:
+            input = paddle.ones([2, 2, 2])
+            x = paddle.ones([2, 2, 2])
+            y = paddle.ones([2, 2, 2])
+            result = input.baddbmm(batch1=x, batch2=y)
+            np.testing.assert_array_equal(result.numpy(), 3.0)
 
-        x = paddle.to_tensor(data_x, stop_gradient=False)
-        y = paddle.to_tensor(data_y, stop_gradient=False)
-        input = paddle.to_tensor(data_input, stop_gradient=False)
+            legacy_result = paddle.baddbmm(input, x, y, 0.5, 2.0)
+            expected = paddle.baddbmm(input, x, y, beta=0.5, alpha=2.0)
+            np.testing.assert_array_equal(
+                legacy_result.numpy(), expected.numpy()
+            )
+        finally:
+            paddle.enable_static()
 
-        # Test with out_dtype=float64
-        paddle_output = paddle.tensor.baddbmm(
-            input=input,
-            x=x,
-            y=y,
-            beta=data_beta,
-            alpha=data_alpha,
-            out_dtype=paddle.float64,
+    def test_legacy_positional_arg_errors(self):
+        paddle.disable_static()
+        try:
+            input = paddle.ones([2, 2, 2])
+            x = paddle.ones([2, 2, 2])
+            y = paddle.ones([2, 2, 2])
+
+            with self.assertRaisesRegex(
+                TypeError, "received too many positional arguments"
+            ):
+                paddle.baddbmm(
+                    input,
+                    x,
+                    y,
+                    0.5,
+                    2.0,
+                    None,
+                    'legacy_baddbmm',
+                    'extra',
+                )
+
+            conflict_cases = (
+                ('beta', (0.5,), 1.0),
+                ('alpha', (0.5, 2.0), 1.0),
+                ('out_dtype', (0.5, 2.0, paddle.float32), paddle.float32),
+                (
+                    'name',
+                    (0.5, 2.0, None, 'legacy_baddbmm'),
+                    'duplicate_name',
+                ),
+            )
+            for name, legacy_args, keyword_value in conflict_cases:
+                with (
+                    self.subTest(name=name),
+                    self.assertRaisesRegex(
+                        TypeError,
+                        rf"multiple values for argument '{name}'",
+                    ),
+                ):
+                    paddle.baddbmm(
+                        input,
+                        x,
+                        y,
+                        *legacy_args,
+                        **{name: keyword_value},
+                    )
+        finally:
+            paddle.enable_static()
+
+    def _check_mixed_out_dtype(self, dtype):
+        for batch_size in (1, 2):
+            x = paddle.ones([batch_size, 4, 3], dtype=dtype).transpose(
+                [0, 2, 1]
+            )
+            y = paddle.ones([batch_size, 5, 4], dtype=dtype).transpose(
+                [0, 2, 1]
+            )
+            x.stop_gradient = False
+            y.stop_gradient = False
+
+            for input_dtype in (dtype, paddle.float32):
+                input = paddle.ones([5], dtype=input_dtype)
+                result = paddle.baddbmm(
+                    input,
+                    x,
+                    y,
+                    beta=0.5,
+                    alpha=2.0,
+                    out_dtype=paddle.float32,
+                )
+                self.assertEqual(result.dtype, paddle.float32)
+                self.assertTrue(result.stop_gradient)
+                np.testing.assert_allclose(
+                    result.numpy(), 8.5, rtol=1e-5, atol=1e-5
+                )
+
+        x = paddle.ones([2, 3, 4], dtype=dtype)
+        y = paddle.ones([2, 4, 5], dtype=dtype)
+        input = paddle.ones([5], dtype=paddle.float32)
+        out = paddle.empty([2, 3, 5], dtype=paddle.float32)
+        returned = paddle.baddbmm(
+            input,
+            x.detach(),
+            y.detach(),
+            beta=0.5,
+            alpha=2.0,
+            out_dtype=paddle.float32,
+            out=out,
         )
-        numpy_output = data_beta * data_input + data_alpha * np.matmul(
-            data_x, data_y
+        self.assertIs(returned, out)
+        np.testing.assert_allclose(out.numpy(), 8.5, rtol=1e-5, atol=1e-5)
+
+        positional_result = paddle.baddbmm(
+            input,
+            x,
+            y,
+            paddle.float32,
+            'baddbmm_positional',
+            beta=0.5,
+            alpha=2.0,
         )
-
-        # Check that output dtype is float64
-        self.assertEqual(paddle_output.dtype, paddle.float64)
-        # Check that the values are correct
-        np.testing.assert_allclose(
-            numpy_output, paddle_output.numpy(), rtol=1e-05
+        legacy_result = paddle.baddbmm(
+            input,
+            x,
+            y,
+            0.5,
+            2.0,
+            paddle.float32,
+            'legacy_baddbmm',
         )
+        for result in (positional_result, legacy_result):
+            self.assertEqual(result.dtype, paddle.float32)
+            np.testing.assert_allclose(
+                result.numpy(), 8.5, rtol=1e-5, atol=1e-5
+            )
 
-        paddle_output.sum().backward()
-        self.assertEqual(input.grad.dtype, paddle.float32)
-        self.assertEqual(x.grad.dtype, paddle.float32)
-        self.assertEqual(y.grad.dtype, paddle.float32)
-        np.testing.assert_allclose(input.grad.numpy(), data_beta)
-        np.testing.assert_allclose(x.grad.numpy(), data_alpha * 2)
-        np.testing.assert_allclose(y.grad.numpy(), data_alpha * 2)
-
-        # Test with out_dtype=None (should use input dtype)
-        paddle_output_none = paddle.tensor.baddbmm(
-            input=input,
-            x=x,
-            y=y,
-            beta=data_beta,
-            alpha=data_alpha,
-            out_dtype=None,
-        )
-        self.assertEqual(paddle_output_none.dtype, paddle.float32)
-
-        paddle.enable_static()
-
-    def test_api_out_dtype_fp16(self):
-        """Test out_dtype parameter with float16"""
-        if not (core.is_compiled_with_cuda() or is_custom_device()):
-            self.skipTest("CUDA is not available")
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda() or paddle.is_compiled_with_rocm(),
+        "CUDA is required for baddbmm out_dtype",
+    )
+    def test_mixed_out_dtype_fp16(self):
         if not core.is_float16_supported(paddle.CUDAPlace(0)):
             self.skipTest("Float16 is not supported")
-
-        data_x = np.ones((2, 2, 2)).astype(np.float32)
-        data_y = np.ones((2, 2, 2)).astype(np.float32)
-        data_input = np.ones((2, 2, 2)).astype(np.float32)
-        data_alpha = 0.5
-        data_beta = 1.0
-
         paddle.disable_static()
-        paddle.set_device('gpu')
+        try:
+            paddle.set_device('gpu')
+            self._check_mixed_out_dtype(paddle.float16)
+        finally:
+            paddle.enable_static()
 
-        x = paddle.to_tensor(data_x, stop_gradient=False)
-        y = paddle.to_tensor(data_y, stop_gradient=False)
-        input = paddle.to_tensor(data_input, stop_gradient=False)
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda() or paddle.is_compiled_with_rocm(),
+        "CUDA is required for baddbmm out_dtype",
+    )
+    def test_mixed_out_dtype_bf16(self):
+        if not core.is_bfloat16_supported(paddle.CUDAPlace(0)):
+            self.skipTest("BFloat16 is not supported")
+        paddle.disable_static()
+        try:
+            paddle.set_device('gpu')
+            self._check_mixed_out_dtype(paddle.bfloat16)
+        finally:
+            paddle.enable_static()
 
-        # Test with out_dtype=float16
-        paddle_output = paddle.tensor.baddbmm(
-            input=input,
-            x=x,
-            y=y,
-            beta=data_beta,
-            alpha=data_alpha,
-            out_dtype=paddle.float16,
-        )
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda() or paddle.is_compiled_with_rocm(),
+        "CUDA is required for baddbmm out_dtype",
+    )
+    def test_out_dtype_infermeta_validation(self):
+        if not core.is_float16_supported(paddle.CUDAPlace(0)):
+            self.skipTest("Float16 is not supported")
+        paddle.disable_static()
+        try:
+            paddle.set_device('gpu')
+            input = paddle.ones([2, 3, 5], dtype=paddle.float16)
+            x = paddle.ones([2, 3, 4], dtype=paddle.float16)
+            y = paddle.ones([2, 4, 5], dtype=paddle.float16)
 
-        # Check that output dtype is float16
-        self.assertEqual(paddle_output.dtype, paddle.float16)
+            with self.assertRaisesRegex(ValueError, "only supports float32"):
+                paddle.baddbmm(input, x, y, out_dtype=paddle.float16)
+            with self.assertRaisesRegex(ValueError, "must have the same dtype"):
+                paddle.baddbmm(
+                    input,
+                    x,
+                    y.astype('float32'),
+                    out_dtype=paddle.float32,
+                )
+            with self.assertRaisesRegex(ValueError, "must match Input\\(X\\)"):
+                paddle.baddbmm(
+                    input.astype('float64'),
+                    x,
+                    y,
+                    out_dtype=paddle.float32,
+                )
+            with self.assertRaisesRegex(ValueError, "dimension must be 3"):
+                paddle.baddbmm(
+                    input,
+                    x,
+                    paddle.ones([4, 5], dtype=paddle.float16),
+                    out_dtype=paddle.float32,
+                )
+        finally:
+            paddle.enable_static()
 
-        numpy_output = data_beta * data_input + data_alpha * np.matmul(
-            data_x, data_y
-        )
-        np.testing.assert_allclose(
-            numpy_output, paddle_output.numpy(), rtol=1e-02, atol=1e-02
-        )
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda() or paddle.is_compiled_with_rocm(),
+        "CUDA is required for baddbmm out_dtype",
+    )
+    def test_mixed_out_dtype_zero_k(self):
+        if not core.is_float16_supported(paddle.CUDAPlace(0)):
+            self.skipTest("Float16 is not supported")
+        paddle.disable_static()
+        try:
+            paddle.set_device('gpu')
+            input = paddle.full([5], float('nan'), dtype=paddle.float32)
+            x = paddle.empty([2, 3, 0], dtype=paddle.float16)
+            y = paddle.empty([2, 0, 5], dtype=paddle.float16)
+            result = paddle.baddbmm(
+                input, x, y, beta=0.0, out_dtype=paddle.float32
+            )
+            np.testing.assert_array_equal(result.numpy(), 0.0)
+        finally:
+            paddle.enable_static()
 
-        paddle_output.sum().backward()
-        self.assertEqual(input.grad.dtype, paddle.float32)
-        self.assertEqual(x.grad.dtype, paddle.float32)
-        self.assertEqual(y.grad.dtype, paddle.float32)
+    @unittest.skipIf(
+        not core.is_compiled_with_cuda() or paddle.is_compiled_with_rocm(),
+        "CUDA is required for baddbmm out_dtype",
+    )
+    def test_mixed_out_dtype_empty_output(self):
+        if not core.is_float16_supported(paddle.CUDAPlace(0)):
+            self.skipTest("Float16 is not supported")
+        paddle.disable_static()
+        try:
+            paddle.set_device('gpu')
+            cases = [
+                ([0, 3, 5], [0, 3, 4], [0, 4, 5]),
+                ([2, 0, 5], [2, 0, 4], [2, 4, 5]),
+                ([2, 3, 0], [2, 3, 4], [2, 4, 0]),
+            ]
+            for input_shape, x_shape, y_shape in cases:
+                for input_dtype in (paddle.float16, paddle.float32):
+                    with self.subTest(
+                        input_shape=input_shape, input_dtype=input_dtype
+                    ):
+                        input = paddle.empty(input_shape, dtype=input_dtype)
+                        x = paddle.empty(x_shape, dtype=paddle.float16)
+                        y = paddle.empty(y_shape, dtype=paddle.float16)
+                        result = paddle.baddbmm(
+                            input,
+                            x,
+                            y,
+                            out_dtype=paddle.float32,
+                        )
+                        self.assertEqual(result.shape, input_shape)
+                        self.assertEqual(result.dtype, paddle.float32)
+                        self.assertEqual(result.numel(), 0)
+        finally:
+            paddle.enable_static()
 
-        fp16_input = paddle.ones([2, 2, 2], dtype=paddle.float16)
-        fp16_x = paddle.ones([2, 2, 2], dtype=paddle.float16)
-        fp16_y = paddle.ones([2, 2, 2], dtype=paddle.float16)
-        fp16_input.stop_gradient = False
-        fp16_x.stop_gradient = False
-        fp16_y.stop_gradient = False
-        fp32_output = paddle.tensor.baddbmm(
-            input=fp16_input,
-            x=fp16_x,
-            y=fp16_y,
-            beta=data_beta,
-            alpha=data_alpha,
-            out_dtype=paddle.float32,
-        )
-        fp32_output.sum().backward()
-        self.assertEqual(fp16_input.grad.dtype, paddle.float16)
-        self.assertEqual(fp16_x.grad.dtype, paddle.float16)
-        self.assertEqual(fp16_y.grad.dtype, paddle.float16)
+    def test_out_dtype_rejects_invalid_out(self):
+        paddle.disable_static()
+        try:
+            input = paddle.ones([2, 3, 5], dtype=paddle.float16)
+            x = paddle.ones([2, 3, 4], dtype=paddle.float16)
+            y = paddle.ones([2, 4, 5], dtype=paddle.float16)
+            out = paddle.empty([2, 3, 5], dtype=paddle.float16)
+            with self.assertRaisesRegex(TypeError, "must be paddle.float32"):
+                paddle.baddbmm(input, x, y, out_dtype=paddle.float32, out=out)
+        finally:
+            paddle.enable_static()
 
+    def test_out_dtype_rejects_cpu(self):
+        paddle.disable_static()
+        try:
+            place = paddle.CPUPlace()
+            input = paddle.to_tensor(
+                np.ones([2, 3, 5], dtype=np.float16), place=place
+            )
+            x = paddle.to_tensor(
+                np.ones([2, 3, 4], dtype=np.float16), place=place
+            )
+            y = paddle.to_tensor(
+                np.ones([2, 4, 5], dtype=np.float16), place=place
+            )
+            with self.assertRaisesRegex(
+                NotImplementedError, "only supports CUDA tensors"
+            ):
+                paddle.baddbmm(input, x, y, out_dtype=paddle.float32)
+        finally:
+            paddle.enable_static()
+
+    def test_static_out_dtype_fails_closed(self):
         paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
+            input = paddle.static.data(
+                'mixed_input', [2, 3, 5], dtype='float16'
+            )
+            x = paddle.static.data('mixed_x', [2, 3, 4], dtype='float16')
+            y = paddle.static.data('mixed_y', [2, 4, 5], dtype='float16')
+            with self.assertRaises(NotImplementedError):
+                paddle.baddbmm(input, x, y, out_dtype=paddle.float32)
 
     def test_2d_input_without_input_grad(self):
         paddle.disable_static()
@@ -932,8 +1294,8 @@ class TestBaddBmmBatch1Op(OpTest):
     def setUp(self):
         self.op_type = "baddbmm"
         self.prim_op_type = "comp"
-        self.python_api = paddle.baddbmm
-        self.public_python_api = paddle.baddbmm
+        self.python_api = baddbmm_api_for_op_test
+        self.public_python_api = baddbmm_api_for_op_test
         self.init_dtype_type()
         self.inputs = {
             'Input': np.random.random((1, 10, 10)).astype(self.dtype),
@@ -1000,8 +1362,8 @@ class TestBaddBmmBatch1Op2(TestBaddBmmBatch1Op):
     def setUp(self):
         self.op_type = "baddbmm"
         self.prim_op_type = "comp"
-        self.python_api = paddle.baddbmm
-        self.public_python_api = paddle.baddbmm
+        self.python_api = baddbmm_api_for_op_test
+        self.public_python_api = baddbmm_api_for_op_test
         self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {

--- a/test/legacy_test/test_baddbmm_op.py
+++ b/test/legacy_test/test_baddbmm_op.py
@@ -431,6 +431,9 @@ class TestBaddBmmOp4(OpTest):
         self.check_output(check_pir=True, check_prim_pir=True)
 
     def test_check_grad_normal(self):
+        self.inputs['Input'] = np.broadcast_to(
+            self.inputs['Input'][:, np.newaxis, :], (1, 50, 15)
+        )
         self.check_grad(
             ['Input', 'X', 'Y'], 'Out', check_pir=True, check_prim_pir=True
         )
@@ -442,6 +445,9 @@ class TestBaddBmmOp4(OpTest):
         self.check_grad(['Y'], 'Out', no_grad_set=None, check_pir=True)
 
     def test_check_grad_input(self):
+        self.inputs['Input'] = np.broadcast_to(
+            self.inputs['Input'][:, np.newaxis, :], (1, 50, 15)
+        )
         self.check_grad(
             ['Input'],
             'Out',
@@ -851,7 +857,7 @@ class TestBaddBmmAPI(unittest.TestCase):
                 paddle.baddbmm_(
                     paddle.ones([2, 3, 5], dtype=paddle.float64), x, y
                 )
-            with self.assertRaises(TypeError):
+            with self.assertRaises((TypeError, ValueError)):
                 paddle.baddbmm_(input, x, y, out_dtype=paddle.float32)
         finally:
             paddle.enable_static()

--- a/test/legacy_test/test_baddbmm_op.py
+++ b/test/legacy_test/test_baddbmm_op.py
@@ -406,9 +406,9 @@ class TestBaddBmmOp4(OpTest):
         self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {
-            'Input': np.random.random((1, 15)).astype(self.dtype),
-            'X': np.random.random((1, 50, 10)).astype(self.dtype),
-            'Y': np.random.random((1, 10, 15)).astype(self.dtype),
+            'Input': np.random.random((1, 100)).astype(self.dtype),
+            'X': np.random.random((1, 10, 10)).astype(self.dtype),
+            'Y': np.random.random((1, 10, 100)).astype(self.dtype),
         }
         self.attrs = {
             'Alpha': 0.5,
@@ -418,7 +418,7 @@ class TestBaddBmmOp4(OpTest):
         self.outputs = {
             'Out': self.attrs['Beta']
             * np.broadcast_to(
-                self.inputs['Input'][:, np.newaxis, :], (1, 50, 15)
+                self.inputs['Input'][:, np.newaxis, :], (1, 10, 100)
             )
             + self.attrs['Alpha']
             * np.matmul(self.inputs['X'], self.inputs['Y'])
@@ -431,9 +431,6 @@ class TestBaddBmmOp4(OpTest):
         self.check_output(check_pir=True, check_prim_pir=True)
 
     def test_check_grad_normal(self):
-        self.inputs['Input'] = np.broadcast_to(
-            self.inputs['Input'][:, np.newaxis, :], (1, 50, 15)
-        )
         self.check_grad(
             ['Input', 'X', 'Y'], 'Out', check_pir=True, check_prim_pir=True
         )
@@ -445,9 +442,6 @@ class TestBaddBmmOp4(OpTest):
         self.check_grad(['Y'], 'Out', no_grad_set=None, check_pir=True)
 
     def test_check_grad_input(self):
-        self.inputs['Input'] = np.broadcast_to(
-            self.inputs['Input'][:, np.newaxis, :], (1, 50, 15)
-        )
         self.check_grad(
             ['Input'],
             'Out',

--- a/test/legacy_test/test_baddbmm_op.py
+++ b/test/legacy_test/test_baddbmm_op.py
@@ -862,6 +862,50 @@ class TestBaddBmmAPI(unittest.TestCase):
         finally:
             paddle.enable_static()
 
+    def test_inplace_infer_symbolic_shape(self):
+        from paddle.base.libpaddle import pir
+
+        input_data = np.ones([2, 3, 5], dtype=np.float32)
+        x_data = np.ones([2, 3, 4], dtype=np.float32)
+        y_data = np.ones([2, 4, 5], dtype=np.float32)
+
+        paddle.enable_static()
+        with paddle.pir_utils.IrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                input = paddle.static.data(
+                    'symbolic_input', [None, None, None], dtype='float32'
+                )
+                x = paddle.static.data(
+                    'symbolic_x', [None, None, 4], dtype='float32'
+                )
+                y = paddle.static.data(
+                    'symbolic_y', [None, 4, None], dtype='float32'
+                )
+                out = paddle.baddbmm_(input, x, y, beta=0.5, alpha=2.0)
+
+            op_names = [op.name() for op in main.global_block().ops]
+            self.assertIn('pd_op.baddbmm_', op_names)
+
+            pm = pir.PassManager()
+            pir.infer_symbolic_shape_pass(pm, main)
+            pm.run(main)
+
+            executor = paddle.static.Executor(paddle.CPUPlace())
+            (actual,) = executor.run(
+                main,
+                feed={
+                    'symbolic_input': input_data,
+                    'symbolic_x': x_data,
+                    'symbolic_y': y_data,
+                },
+                fetch_list=[out],
+            )
+
+        expected = 0.5 * input_data + 2.0 * np.matmul(x_data, y_data)
+        np.testing.assert_allclose(actual, expected, rtol=1e-6)
+
     def test_signature_and_tensor_method(self):
         parameters = inspect.signature(paddle.baddbmm).parameters
         self.assertEqual(


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes 

### Description

本 PR 参考 `addmm` 和 `bmm` 的实现方式，为 `paddle.baddbmm` 增加独立的 CUDA `out_dtype` 执行路径，并修正原有 `baddbmm` 中通过计算完成后再 cast 实现 `out_dtype` 的问题。

**保留自动生成的** **`baddbmm_`**

`baddbmm_` 仍通过 `python_api_info.yaml` 自动生成，并继续支持 `batch1` 和 `batch2` 参数别名。

原来的 `BaddbmmPreProcess` 同时服务于 `baddbmm` 和 `baddbmm_`，其中包含广播检查，但 inplace 操作不能通过广播改变 `input` 的形状。因此本 PR：

- 从自动生成配置中移除普通 `baddbmm`。
- 将预处理函数调整为仅供 inplace API 使用的 `BaddbmmInplacePreProcess`。
- 要求 `baddbmm_` 的 `input` 必须为 3 维。
- 要求 `input` 的形状与矩阵乘法结果 `[B, M, N]` 完全一致。
- 保持 `input`、`x` 和 `y` 使用相同 dtype 的约束。
- 从 `baddbmm_` 的生成签名中移除不适用于 inplace API 的 `out_dtype` 参数。

PIR symbolic shape inference 也为 `baddbmm_` 增加了对应的精确形状约束。

**删除普通** **`baddbmm`** **中错误的** **`out_dtype`** **实现**

原实现直接在普通 `baddbmm` 算子中增加 `out_dtype` 参数，先使用输入 dtype 完成计算，再将最终结果 cast 到目标 dtype。这不能提供真正的 FP32 输出计算语义，例如 FP16/BF16 输入仍然会先按原精度完成计算。

本 PR 从以下位置删除该实现：

- 从 `ops.yaml` 和 `legacy/static_ops.yaml` 的普通 `baddbmm` 参数中删除 `out_dtype`。
- 从新旧 IR 的 `baddbmm_grad` forward signature 中删除 `out_dtype`。
- 从 `BaddbmmInferMeta` 和 `BaddbmmKernel` 的函数签名中删除 `out_dtype`。
- 删除普通 Kernel 末尾将结果 cast 到 `out_dtype` 的逻辑。
- 删除反向 Kernel 中为 mixed-dtype `out_grad` 增加的临时 cast 逻辑。
- 从自动生成的 `baddbmm` 文档和 `baddbmm_` 签名中删除对应参数。

普通 `baddbmm` 现在始终输出与 `input` 相同的 dtype，并继续支持完整的反向计算。

**支持 0 至 3 维** **`input`**

普通 `baddbmm` 的 `input` 维度限制由仅支持 2/3 维扩展为支持 0 至 3 维：

- 0-D scalar
- 1-D vector
- 2-D matrix
- 3-D batched tensor

`input` 按右对齐规则与输出 `[B, M, N]` 进行广播，每个对应维度必须为 `1` 或与输出维度相同。

该规则已同步到：

- `BaddbmmInferMeta`
- PIR symbolic shape inference
- 前向 Kernel
- 反向 Kernel

前向和反向计算会为低于 3 维的 `input` 补齐前导维度，并在计算完成后恢复原始梯度形状。同时补充了 scalar、vector、matrix、batch input 的前向和反向测试。

**独立实现** **`baddbmm_out_dtype`**

本 PR 新增独立的 `baddbmm_out_dtype` 算子，而不是继续复用普通 `baddbmm`：

- 在 `inconsistent/dygraph_ops.yaml` 中注册 forward-only 算子。
- 新增独立的 `BaddbmmOutDtypeInferMeta`。
- 新增 CUDA `BaddbmmOutDtypeKernel`。
- 输出 Tensor 直接分配为 FP32，并使用 mixed-precision GEMM 写入 FP32 输出。
- 支持非连续的 `x` 和 `y`。
- 支持 zero-K 以及 `B`、`M`、`N` 为零的空输出情况。
- 不注册 backward，明确保持 forward-only 语义。

当前 mixed-dtype 路径的限制如下：

- 仅支持 CUDA，不支持 CPU 或 ROCm。
- 仅支持动态图。
- `out_dtype` 必须为 `paddle.float32`。
- `x` 和 `y` 必须具有相同 dtype。
- `x` 和 `y` 仅支持 `float16` 或 `bfloat16`。
- `input` 可以与 `x/y` dtype 相同，也可以直接为 `float32`。
- `out` Tensor 必须为 CUDA FP32 Tensor。

Python API 根据 `out_dtype` 是否为空进行分发：

- `out_dtype=None` 调用普通 `_C_ops.baddbmm`，保留前向和反向能力。
- 指定 `out_dtype` 时调用 `_C_ops.baddbmm_out_dtype`。

公开签名将 `beta` 和 `alpha` 调整为 keyword-only 参数，同时增加兼容装饰器，继续支持 Paddle 原有的位置参数顺序：

`beta -> alpha -> out_dtype -> name`

测试覆盖 FP16/BF16 到 FP32、不同 input dtype、非连续输入、`out=`、非法 dtype/place、静态图拒绝、zero-K、空输出、旧位置参数兼容及普通路径反向计算。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否