### PR TITLE
[CI] Enable DCU C++20 toolchain baseline

### DIFF
--- a/cmake/hip.cmake
+++ b/cmake/hip.cmake
@@ -198,7 +198,7 @@ list(APPEND HIP_CXX_FLAGS -Wno-missing-braces)
 list(APPEND HIP_CXX_FLAGS -Wno-sometimes-uninitialized)
 list(APPEND HIP_CXX_FLAGS -Wno-deprecated-copy)
 list(APPEND HIP_CXX_FLAGS -Wno-pessimizing-move)
-list(APPEND HIP_CXX_FLAGS -std=c++17)
+list(APPEND HIP_CXX_FLAGS -std=c++20)
 list(APPEND HIP_CXX_FLAGS --gpu-max-threads-per-block=1024)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description

跟进任务 issue：https://github.com/PaddlePaddle/Paddle/issues/79384

本 PR 是 DCU C++20 CI 拆分后的上层改动，依赖镜像 PR #79600。#79600 负责提供 GCC 12.2 DCU 镜像及运行时集成；

- `cmake/hip.cmake`：将 HIP 编译参数从 `-std=c++17` 切换为 `-std=c++20`。

当前依赖关系：

`develop` <- #79600（DCU GCC 12.2 镜像与运行时）<- #79646（HIP C++20）

### 是否引起精度变化
否
