### PR TITLE
[Cherry-Pick][Operator Mechanism]Add CUDA stride-1 index gradient kernel

### DIFF
--- a/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
@@ -15,6 +15,9 @@
 #include "paddle/phi/kernels/index_elementwise_get_grad_kernel.h"
 
 #include "paddle/common/enforce.h"
+#ifdef PADDLE_WITH_CUDA
+#include "paddle/phi/backends/gpu/cuda/cuda_device_function.h"
+#endif
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -249,6 +252,82 @@ __global__ void IndexingBackwardKernel(const int64_t* sorted_indices,
   }
 }
 
+// The sliceSize == 1 case can reduce all duplicate gradients with one warp.
+// This mirrors the specialized CUDA path used by PyTorch and avoids routing
+// the reduction through the generic feature-unrolled kernel.
+template <typename scalar_t>
+__global__ void IndexingBackwardKernelStride1(const int64_t* sorted_indices,
+                                              const int64_t* indices,
+                                              const scalar_t* grad_output,
+                                              scalar_t* grad_weight,
+                                              int64_t numel,
+                                              int64_t stride,
+                                              int64_t stride_before,
+                                              int64_t outer_dim,
+                                              bool accumulate) {
+  using opmath_t = typename MPTypeTrait<scalar_t>::Type;
+
+  for (int64_t z = blockIdx.z; z < outer_dim; z += gridDim.z) {
+    for (int64_t idx =
+             static_cast<int64_t>(blockIdx.x) * blockDim.y + threadIdx.y;
+         idx < numel;
+         idx += static_cast<int64_t>(gridDim.x) * blockDim.y) {
+      const int64_t current_index = sorted_indices[idx];
+      if (idx != 0 && current_index == sorted_indices[idx - 1]) {
+        continue;
+      }
+
+      int64_t num_duplicates = 1;
+      while (idx + num_duplicates < numel &&
+             sorted_indices[idx + num_duplicates] == current_index) {
+        ++num_duplicates;
+      }
+
+      const int64_t weight_row = current_index * stride + z * stride_before;
+      const opmath_t scale = static_cast<opmath_t>(1.0);
+
+      if (!accumulate) {
+        if (threadIdx.x == 0) {
+          const int64_t grad_row =
+              indices[idx + num_duplicates - 1] * stride + z * numel * stride;
+          grad_weight[weight_row] = static_cast<scalar_t>(
+              static_cast<opmath_t>(grad_output[grad_row]) * scale);
+        }
+      } else {
+        opmath_t gradient = static_cast<opmath_t>(0.0);
+        const int lane = threadIdx.x;
+        const int64_t num_warp_passes = num_duplicates / WARP_SIZE;
+
+        for (int64_t i = 0; i < num_warp_passes; ++i) {
+          const int64_t duplicate_idx = idx + i * WARP_SIZE + lane;
+          const int64_t grad_row =
+              indices[duplicate_idx] * stride + z * numel * stride;
+          gradient += static_cast<opmath_t>(grad_output[grad_row]) * scale;
+        }
+
+        unsigned mask = 0;
+        CREATE_SHFL_MASK(mask, true);
+        for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+          gradient = gradient +
+                     backends::gpu::CudaShuffleDownSync(mask, gradient, offset);
+        }
+
+        if (lane == 0) {
+          for (int64_t i = num_warp_passes * WARP_SIZE; i < num_duplicates;
+               ++i) {
+            const int64_t duplicate_idx = idx + i;
+            const int64_t grad_row =
+                indices[duplicate_idx] * stride + z * numel * stride;
+            gradient += static_cast<opmath_t>(grad_output[grad_row]) * scale;
+          }
+          grad_weight[weight_row] = static_cast<scalar_t>(
+              static_cast<opmath_t>(grad_weight[weight_row]) + gradient);
+        }
+      }
+    }
+  }
+}
+
 template <typename T, typename IndexT>
 void IndexPutWithSortKernel(const GPUContext& dev_ctx,
                             const DenseTensor& input,
@@ -363,16 +442,29 @@ void IndexPutWithSortKernel(const GPUContext& dev_ctx,
                  static_cast<int64_t>(max_grid_size[2])));
     dim3 block(WARP_SIZE, INDICES_PER_BLOCK);
 
-    IndexingBackwardKernel<T, UNROLL>
-        <<<grid, block, 0, stream>>>(sorted_indices.data<IndexT>(),
-                                     orig_indices.data<IndexT>(),
-                                     expandedValue.data<T>(),
-                                     src_.data<T>(),
-                                     num_indices,
-                                     sliceSize,
-                                     strideBefore,
-                                     nElemBefore,
-                                     true);
+    if (sliceSize == 1) {
+      IndexingBackwardKernelStride1<T>
+          <<<grid, block, 0, stream>>>(sorted_indices.data<IndexT>(),
+                                       orig_indices.data<IndexT>(),
+                                       expandedValue.data<T>(),
+                                       src_.data<T>(),
+                                       num_indices,
+                                       sliceSize,
+                                       strideBefore,
+                                       nElemBefore,
+                                       accumulate);
+    } else {
+      IndexingBackwardKernel<T, UNROLL>
+          <<<grid, block, 0, stream>>>(sorted_indices.data<IndexT>(),
+                                       orig_indices.data<IndexT>(),
+                                       expandedValue.data<T>(),
+                                       src_.data<T>(),
+                                       num_indices,
+                                       sliceSize,
+                                       strideBefore,
+                                       nElemBefore,
+                                       accumulate);
+    }
 
     if (permuted) {
       DenseTensor transposed_src;

--- a/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_elementwise_get_grad_kernel.cu
@@ -265,7 +265,7 @@ __global__ void IndexingBackwardKernelStride1(const int64_t* sorted_indices,
                                               int64_t stride_before,
                                               int64_t outer_dim,
                                               bool accumulate) {
-  using opmath_t = typename MPTypeTrait<scalar_t>::Type;
+  using opmath_t = typename phi::dtype::MPTypeTrait<scalar_t>::Type;
 
   for (int64_t z = blockIdx.z; z < outer_dim; z += gridDim.z) {
     for (int64_t idx =

--- a/test/legacy_test/test_index_elementwise_grad.py
+++ b/test/legacy_test/test_index_elementwise_grad.py
@@ -214,6 +214,39 @@ class TestIndexElementwiseGradAllIndex(unittest.TestCase):
         paddle.enable_static()
 
 
+@unittest.skipUnless(
+    paddle.device.is_compiled_with_cuda(), 'CUDA is required for this test.'
+)
+class TestIndexElementwiseGetGradStride1(unittest.TestCase):
+    def test_duplicate_index_warp_boundaries(self):
+        paddle.disable_static(place=paddle.CUDAPlace(0))
+
+        try:
+            for num_duplicates in (1, 32, 33):
+                with self.subTest(num_duplicates=num_duplicates):
+                    index_np = np.array(
+                        [11, *([7] * num_duplicates), 3], dtype=np.int64
+                    )
+                    out_grad_np = np.linspace(
+                        0.25, 1.25, index_np.size, dtype=np.float32
+                    )
+                    expected_grad = np.zeros([16], dtype=np.float32)
+                    np.add.at(expected_grad, index_np, out_grad_np)
+
+                    x = paddle.zeros([16], dtype='float32')
+                    x.stop_gradient = False
+                    index = paddle.to_tensor(index_np)
+                    out_grad = paddle.to_tensor(out_grad_np)
+
+                    x[index].backward(out_grad)
+
+                    np.testing.assert_allclose(
+                        x.grad.numpy(), expected_grad, rtol=1e-6, atol=1e-6
+                    )
+        finally:
+            paddle.enable_static()
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
#### 背景

高级索引反向会先对 linear index 排序，使写入相同目标位置的 index 连续排列，再归约这些 index 对应的梯度。

这里的 `sliceSize` 表示每个 index 对应的连续 feature 数量，不是 Tensor 的物理 stride。PyTorch CUDA 会根据 `sliceSize` 选择不同的归约路径：

| `sliceSize` | PyTorch CUDA 路径 | 线程分工 |
|---:|---|---|
| `1` | `indexing_backward_kernel_stride_1` | 一个 warp 负责一个重复 index 组；各 lane 并行读取 duplicate，使用 warp shuffle 归约 |
| `2~32` | `indexing_backward_kernel_small_stride` | 一个线程负责一个 feature，并顺序累加该 feature 的所有 duplicate |
| `>32` | `indexing_backward_kernel<scalar_t, 4>` | 一个 warp 按 feature 维度分工；每个线程展开处理最多 4 个 feature，较大的 feature 切片由多个 grid tile 处理 |

其中模板参数 `4` 是 feature 维度的 unroll factor，不表示 `stride == 4`。

#### Paddle 原有实现

Paddle 原来对所有 `sliceSize` 统一使用：

```cpp
IndexingBackwardKernel<T, 4>
```

该通用 kernel 中，一个 warp 负责一个 sorted index 组，warp 内各 lane 负责不同的 feature，同一 feature 的重复 index 由对应 lane 顺序累加。这个策略适合包含多个 feature 的切片，但当 `sliceSize == 1` 时，只有 lane 0 对应有效 feature，其余 31 个 lane 不参与重复梯度归约。

```text
Paddle 原有路径：

所有 sliceSize
    -> IndexingBackwardKernel<T, 4>

sliceSize == 1 时：
    lane 0    -> feature 0
    lane 1~31 -> 无有效 feature
```

#### 本次修改

本次新增 `IndexingBackwardKernelStride1<T>`，并按 `sliceSize` 分发：

```text
sliceSize == 1 -> IndexingBackwardKernelStride1<T>
sliceSize > 1  -> IndexingBackwardKernel<T, 4>
```

专用 kernel 仍由一个 warp 负责一个重复 index 组，但将 32 个 lane 用于并行读取 duplicate，再通过 warp shuffle 求和；不足 32 个的尾部元素由 lane 0 补充累加并写回。
该修改复用现有的 linear index、排序和数据布局，不改变前向行为以及 `sliceSize > 1` 的通用路径。

devPR:https://github.com/PaddlePaddle/Paddle/pull/79648
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是