### PR TITLE
Avoid duplicate history checks in Python stack capture

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -184,7 +184,9 @@ PyObject * eager_api_{}(PyObject *self, PyObject *args, PyObject *kwargs) {{
     // the GIL is still held (near-zero cost when recording is disabled). The
     // RAII guard pushes the id for the whole op (incl. the GIL-released kernel
     // section) and pops it on scope exit / exception unwind.
-    paddle::memory::MemStackGuard __mem_stack_guard(paddle::pybind::CaptureCurrentPyStack());
+    const auto __mem_stack_capture = paddle::pybind::CaptureCurrentPyStack();
+    paddle::memory::MemStackGuard __mem_stack_guard(
+        __mem_stack_capture.active, __mem_stack_capture.stack_id);
     tstate = PyEval_SaveThread();
 
     // Set Device ID

--- a/paddle/fluid/eager/pylayer/py_layer_node.cc
+++ b/paddle/fluid/eager/pylayer/py_layer_node.cc
@@ -49,8 +49,9 @@ GradNodePyLayer::operator()(
   // Capture the Python stack (GIL held) so allocations during this PyLayer
   // backward that don't flow through an eager _C_ops dispatch are attributed to
   // the backward call site; inner _C_ops push/pop finer stacks on top.
-  paddle::memory::MemStackGuard __mem_stack_guard(
-      paddle::pybind::CaptureCurrentPyStack());
+  const auto __mem_stack_capture = paddle::pybind::CaptureCurrentPyStack();
+  paddle::memory::MemStackGuard __mem_stack_guard(__mem_stack_capture.active,
+                                                  __mem_stack_capture.stack_id);
   if (VLOG_IS_ON(2)) egr::LogIndent::Instance().IncreaseIndentLevel();
   VLOG(3) << "Running Eager Backward Node: " << name();
   if (FLAGS_call_stack_level == 3) {

--- a/paddle/fluid/pybind/eager_legacy_op_function_generator.cc
+++ b/paddle/fluid/pybind/eager_legacy_op_function_generator.cc
@@ -115,7 +115,9 @@ static PyObject * %s(PyObject *self, PyObject *args, PyObject *kwargs)
     %s
     framework::AttributeMap attrs;
     ConstructAttrMapFromPyArgs("%s", args, %d, PyTuple_GET_SIZE(args) , attrs);
-    paddle::memory::MemStackGuard __mem_stack_guard(paddle::pybind::CaptureCurrentPyStack());
+    const auto __mem_stack_capture = paddle::pybind::CaptureCurrentPyStack();
+    paddle::memory::MemStackGuard __mem_stack_guard(
+        __mem_stack_capture.active, __mem_stack_capture.stack_id);
     tstate = PyEval_SaveThread();
     %s
     PyEval_RestoreThread(tstate);

--- a/paddle/fluid/pybind/eager_py_layer.cc
+++ b/paddle/fluid/pybind/eager_py_layer.cc
@@ -208,8 +208,9 @@ PyObject* pylayer_method_apply(PyObject* cls,
   // the whole forward (including allocations that don't flow through an eager
   // _C_ops dispatch, e.g. custom ops / comm buffers); inner _C_ops push/pop
   // their own finer stacks on top. Near-zero cost when recording is disabled.
-  paddle::memory::MemStackGuard __mem_stack_guard(
-      paddle::pybind::CaptureCurrentPyStack());
+  const auto __mem_stack_capture = paddle::pybind::CaptureCurrentPyStack();
+  paddle::memory::MemStackGuard __mem_stack_guard(__mem_stack_capture.active,
+                                                  __mem_stack_capture.stack_id);
   std::string classname =
       std::string(reinterpret_cast<PyTypeObject*>(cls)->tp_name);
   std::string forward_stack;

--- a/paddle/fluid/pybind/mem_py_stack.cc
+++ b/paddle/fluid/pybind/mem_py_stack.cc
@@ -83,10 +83,10 @@ void SetMemPyStackCaptureEnabled(bool enabled) {
   g_capture_enabled.store(enabled, std::memory_order_relaxed);
 }
 
-uint64_t CaptureCurrentPyStack() {
-  // Cheap early-out: single relaxed atomic read(s) when disabled.
-  if (!paddle::memory::MemHistoryEnabled()) return 0;
-  if (!g_capture_enabled.load(std::memory_order_relaxed)) return 0;
+MemStackCapture CaptureCurrentPyStack() {
+  const bool active = paddle::memory::MemHistoryEnabled();
+  if (!active) return {false, 0};
+  if (!g_capture_enabled.load(std::memory_order_relaxed)) return {true, 0};
 
   // Caller holds the GIL. Walk frames innermost -> outermost. PyFrame_GetCode
   // and PyFrame_GetBack return new references; we release the temporary frame /
@@ -137,7 +137,7 @@ uint64_t CaptureCurrentPyStack() {
   for (PyCodeObject* code : temp_code_refs) {
     Py_DECREF(code);
   }
-  return result;
+  return {true, result};
 }
 
 ::pybind11::list ResolveStack(uint64_t stack_id) {

--- a/paddle/fluid/pybind/mem_py_stack.h
+++ b/paddle/fluid/pybind/mem_py_stack.h
@@ -28,12 +28,16 @@
 namespace paddle {
 namespace pybind {
 
-// Capture the current Python call stack (innermost frame first) and return an
-// interned, deduplicated opaque id (0 == nothing captured). CALLER MUST HOLD
-// THE GIL. Cheap no-op (a single relaxed atomic read) when recording or stack
-// capture is disabled. Called from the eager python_c wrappers just before
-// PyEval_SaveThread releases the GIL.
-uint64_t CaptureCurrentPyStack();
+struct MemStackCapture {
+  bool active;
+  uint64_t stack_id;
+};
+
+// Capture the current Python call stack (innermost frame first). `active`
+// reports whether memory history was enabled at the call site, while stack_id
+// is 0 when stack capture is disabled or no stack was captured. CALLER MUST
+// HOLD THE GIL. Called just before PyEval_SaveThread releases the GIL.
+MemStackCapture CaptureCurrentPyStack();
 
 // Resolve a previously captured stack_id into a list of frame dicts
 // ``{filename, name, line}`` (innermost first). Empty list for id 0 or unknown.

--- a/paddle/phi/core/memory/allocation/memory_history_recorder.h
+++ b/paddle/phi/core/memory/allocation/memory_history_recorder.h
@@ -109,12 +109,11 @@ inline uint64_t CurrentMemStackId() {
 }
 
 // RAII guard pushed at op-dispatch / PyLayer entry (while the GIL is held).
-// Pushes only when recording is enabled (captured at construction so push/pop
-// stay balanced even if recording is toggled mid-op); zero-overhead (one
-// relaxed atomic load) when disabled. Mirrors MemLabelGuard.
+// `active` is the recording-state snapshot taken during stack capture, keeping
+// push/pop balanced if recording is toggled mid-op without reading it twice.
 class MemStackGuard {
  public:
-  explicit MemStackGuard(uint64_t stack_id) : active_(MemHistoryEnabled()) {
+  MemStackGuard(bool active, uint64_t stack_id) : active_(active) {
     if (active_) MemStackIdStack().push_back(stack_id);
   }
   ~MemStackGuard() {

--- a/test/cpp/fluid/memory/memory_history_recorder_test.cc
+++ b/test/cpp/fluid/memory/memory_history_recorder_test.cc
@@ -230,7 +230,7 @@ TEST_F(MemoryHistoryRecorderTest, LabelGuardNestsAndPops) {
 
 TEST_F(MemoryHistoryRecorderTest, StackGuardIsNoOpWhenDisabled) {
   {
-    MemStackGuard guard(42);
+    MemStackGuard guard(false, 42);
     EXPECT_EQ(CurrentMemStackId(), 0u);
   }
   EXPECT_EQ(CurrentMemStackId(), 0u);
@@ -241,10 +241,10 @@ TEST_F(MemoryHistoryRecorderTest, StackGuardNestsAndPops) {
   MemoryHistoryRecorder::Instance().SetEnabled(true, 8);
   EXPECT_EQ(CurrentMemStackId(), 0u);
   {
-    MemStackGuard outer(11);
+    MemStackGuard outer(true, 11);
     EXPECT_EQ(CurrentMemStackId(), 11u);
     {
-      MemStackGuard inner(22);
+      MemStackGuard inner(true, 22);
       EXPECT_EQ(CurrentMemStackId(), 22u);
     }
     // An outer wrapper (e.g. PyLayer.apply) stays active between nested ops.
@@ -257,7 +257,7 @@ TEST_F(MemoryHistoryRecorderTest, GuardsStayBalancedWhenToggledMidScope) {
   MemoryHistoryRecorder::Instance().SetEnabled(true, 8);
   {
     MemLabelGuard label("op");
-    MemStackGuard stack(5);
+    MemStackGuard stack(true, 5);
     // Turning recording off inside the guarded scope must not unbalance the
     // pop in the destructor.
     MemoryHistoryRecorder::Instance().SetEnabled(false, 8);
@@ -275,7 +275,7 @@ TEST_F(MemoryHistoryRecorderTest, RecordMemHistoryPicksUpLabelAndStackId) {
   rec.SetEnabled(true, 8);
   {
     MemLabelGuard label("gaussian_random");
-    MemStackGuard stack(99);
+    MemStackGuard stack(true, 99);
     RecordMemHistory(MemHistoryAction::kAlloc, 0, 0x3000, 512, 7, 0);
   }
   auto trace = rec.GetTrace(0);
@@ -290,7 +290,7 @@ TEST_F(MemoryHistoryRecorderTest, StackIdOnlyAttachedToAllocEvents) {
   auto& rec = MemoryHistoryRecorder::Instance();
   rec.SetEnabled(true, 8);
   {
-    MemStackGuard stack(77);
+    MemStackGuard stack(true, 77);
     RecordMemHistory(MemHistoryAction::kFreeCompleted, 0, 0x3000, 512, 0, 0);
   }
   auto trace = rec.GetTrace(0);
@@ -303,7 +303,7 @@ TEST_F(MemoryHistoryRecorderTest, StackMinSizeGatesStackAttribution) {
   rec.SetEnabled(true, 8);
   SetMemStackMinSize(1024);
   {
-    MemStackGuard stack(55);
+    MemStackGuard stack(true, 55);
     // Below the threshold: no stack recorded.
     RecordMemHistory(MemHistoryAction::kAlloc, 0, 0x1000, 512, 0, 0);
     // At/above the threshold: stack recorded.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
优化 memory history Python stack capture 的运行时开销。

  当 memory history 关闭时，CaptureCurrentPyStack() 与 MemStackGuard 原本会重复检查 MemHistoryEnabled()。本次修改引入 MemStackCapture 状态快照，由 stack capture 一次性返回 recorder 是否启用及 stack_id，MemStackGuard 复用该状态，避免重复检查。

  同时统一更新 eager op、legacy eager op 及 PyLayer 前向/反向调用点，并保留以下语义：

  - recorder 关闭时仅执行一次状态检查并快速返回；
  - recorder 开启但 Python stack capture 关闭时，仍然压入 stack_id = 0，避免错误继承外层 stack；
  - guard 生命周期内 recorder 开关变化时，仍能保证 push/pop 平衡；
  - 补充 MemStackGuard 关闭态、嵌套调用及运行时切换场景测试。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否