### PR TITLE
[VMM] Add GPU memory history recorder with Python stack capture (#79609)

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -456,6 +456,7 @@ paddle::small_vector<std::vector<paddle::Tensor>, egr::kSlotSmallVectorSize> {}:
    // * 'Global_XXXGradNode' will not only cover execution time of this function, but also include gradient
    //    accumulation when the output(s) of corresponding forward OP are shared by other OP(s), which may have extra accumulation overhead than 'Local_XXXGradNode'.
   phi::RecordEvent grad_node_record_event_inner(\"Local_{}\", phi::TracerEventType::OperatorInner, 1);
+  paddle::memory::MemLabelGuard __mem_op_label(this->name_.c_str());
 
   // Fill Zero For GradIn Tensors
 {}
@@ -775,6 +776,7 @@ NODE_CC_FILE_TEMPLATE = """
 #include "paddle/fluid/prim/utils/utils.h"
 #include "paddle/common/flags.h"
 #include "paddle/phi/core/memory/stats.h"
+#include "paddle/phi/core/memory/allocation/memory_history_recorder.h"
 #include "paddle/phi/api/lib/data_transform.h"
 COMMON_DECLARE_bool(check_nan_inf);
 COMMON_DECLARE_bool(check_cuda_error);
@@ -811,6 +813,7 @@ FORWARD_CC_FILE_TEMPLATE = """
 
 #include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/phi/core/platform/profiler/event_tracing.h"
+#include "paddle/phi/core/memory/allocation/memory_history_recorder.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/fluid/eager/nan_inf_utils.h"
 #include "paddle/fluid/eager/utils.h"
@@ -2363,7 +2366,7 @@ class DygraphForwardFunctionGenerator(DygraphFunctionGeneratorBase):
                 inputs_call_args_str_tmp = ", ".join(self.inputs_call_list_tmp)
                 forward_call_str = f"{indent}{api_out_type} api_result = paddle::experimental::{namespace}{function_name}({inputs_call_args_str_tmp});"
 
-        dygraph_event_str = f'{indent}phi::RecordEvent dygraph_entrance_record_event("{forward_api_name} dygraph", phi::TracerEventType::Operator, 1);\n'
+        dygraph_event_str = f'{indent}phi::RecordEvent dygraph_entrance_record_event("{forward_api_name} dygraph", phi::TracerEventType::Operator, 1);\n{indent}paddle::memory::MemLabelGuard __mem_op_label("{forward_api_name}");\n'
         log_memory_info_str = f'{indent}paddle::memory::LogDeviceMemoryStats(egr::Controller::Instance().GetExpectedPlace(), "{forward_api_name}");'
         forward_ad_function_name = GetDygraphForwardFunctionName(
             forward_api_name

--- a/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/python_c_gen.py
@@ -180,6 +180,11 @@ PyObject * eager_api_{}(PyObject *self, PyObject *args, PyObject *kwargs) {{
 {}
     // Parse predefined_out if needed
 {}
+    // Capture the Python dispatch stack for the memory-history recorder while
+    // the GIL is still held (near-zero cost when recording is disabled). The
+    // RAII guard pushes the id for the whole op (incl. the GIL-released kernel
+    // section) and pops it on scope exit / exception unwind.
+    paddle::memory::MemStackGuard __mem_stack_guard(paddle::pybind::CaptureCurrentPyStack());
     tstate = PyEval_SaveThread();
 
     // Set Device ID
@@ -258,6 +263,7 @@ PYTHON_C_WRAPPER_TEMPLATE = """
 #include "paddle/fluid/pybind/eager_op_function.h"
 #include "paddle/fluid/pybind/arg_pre_process.h"
 #include "paddle/fluid/pybind/args_mapper.h"
+#include "paddle/fluid/pybind/mem_py_stack.h"
 namespace paddle {{
 namespace pybind {{
 

--- a/paddle/fluid/eager/pylayer/py_layer_node.cc
+++ b/paddle/fluid/eager/pylayer/py_layer_node.cc
@@ -21,6 +21,7 @@
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/pybind/eager.h"
 #include "paddle/fluid/pybind/eager_utils.h"
+#include "paddle/fluid/pybind/mem_py_stack.h"
 #include "paddle/phi/api/all.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/platform/device_context.h"
@@ -45,6 +46,11 @@ GradNodePyLayer::operator()(
     egr::CUDAErrorCheck("GradNodePyLayer begin");
   }
   pybind11::gil_scoped_acquire gil;
+  // Capture the Python stack (GIL held) so allocations during this PyLayer
+  // backward that don't flow through an eager _C_ops dispatch are attributed to
+  // the backward call site; inner _C_ops push/pop finer stacks on top.
+  paddle::memory::MemStackGuard __mem_stack_guard(
+      paddle::pybind::CaptureCurrentPyStack());
   if (VLOG_IS_ON(2)) egr::LogIndent::Instance().IncreaseIndentLevel();
   VLOG(3) << "Running Eager Backward Node: " << name();
   if (FLAGS_call_stack_level == 3) {

--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -145,6 +145,7 @@ set(PYBIND_SRCS
     python_callable_registry.cc
     arg_pre_process.cc
     args_mapper.cc
+    mem_py_stack.cc
     size.cc)
 
 if(WITH_DISTRIBUTE)

--- a/paddle/fluid/pybind/eager_legacy_op_function_generator.cc
+++ b/paddle/fluid/pybind/eager_legacy_op_function_generator.cc
@@ -115,6 +115,7 @@ static PyObject * %s(PyObject *self, PyObject *args, PyObject *kwargs)
     %s
     framework::AttributeMap attrs;
     ConstructAttrMapFromPyArgs("%s", args, %d, PyTuple_GET_SIZE(args) , attrs);
+    paddle::memory::MemStackGuard __mem_stack_guard(paddle::pybind::CaptureCurrentPyStack());
     tstate = PyEval_SaveThread();
     %s
     PyEval_RestoreThread(tstate);
@@ -483,6 +484,7 @@ int run_legacy_generator(int argc, char* argv[]) {
       "\"paddle/fluid/pybind/exception.h\"",
       "\"paddle/fluid/pybind/op_function_common.h\"",
       "\"paddle/fluid/pybind/eager_legacy_custom_python_api.h\"",
+      "\"paddle/fluid/pybind/mem_py_stack.h\"",
       "\"paddle/fluid/pybind/eager.h\""};
 
   std::ofstream out(argv[1], std::ios::out);

--- a/paddle/fluid/pybind/eager_py_layer.cc
+++ b/paddle/fluid/pybind/eager_py_layer.cc
@@ -29,6 +29,7 @@ limitations under the License. */
 #include "paddle/fluid/pybind/eager.h"
 #include "paddle/fluid/pybind/eager_utils.h"
 #include "paddle/fluid/pybind/exception.h"
+#include "paddle/fluid/pybind/mem_py_stack.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/compat/convert_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
@@ -202,6 +203,13 @@ PyObject* pylayer_method_apply(PyObject* cls,
                                PyObject* kwargs) {
   EAGER_TRY
   SetPythonStack();
+  // Capture the Python dispatch stack for the memory-history recorder while the
+  // GIL is held. The RAII guard keeps this PyLayer's call-site stack active for
+  // the whole forward (including allocations that don't flow through an eager
+  // _C_ops dispatch, e.g. custom ops / comm buffers); inner _C_ops push/pop
+  // their own finer stacks on top. Near-zero cost when recording is disabled.
+  paddle::memory::MemStackGuard __mem_stack_guard(
+      paddle::pybind::CaptureCurrentPyStack());
   std::string classname =
       std::string(reinterpret_cast<PyTypeObject*>(cls)->tp_name);
   std::string forward_stack;

--- a/paddle/fluid/pybind/mem_py_stack.cc
+++ b/paddle/fluid/pybind/mem_py_stack.cc
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/pybind/mem_py_stack.h"
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace paddle {
+namespace pybind {
+
+namespace {
+
+// One resolved-at-snapshot frame: the (interned, alive) code object plus the
+// line number captured at dispatch time. We deliberately do NOT build strings
+// on the hot path.
+struct Frame {
+  PyCodeObject* code;  // borrowed here; kept alive by interned_ (INCREF'd once)
+  int line;
+};
+
+// Upper bound on distinct stacks kept, to bound host memory. Once reached,
+// CaptureCurrentPyStack returns 0 (falls back to op_name) instead of interning
+// more.
+constexpr size_t kMaxUniqueStacks = 200000;
+
+// Whether frame walking/interning is active. Independent from recording being
+// enabled: both must be true to capture.
+std::atomic<bool> g_capture_enabled{false};
+
+std::mutex g_mu;
+// stack_id (1-based) -> frame vector. Index 0 of the vector is stack_id 1.
+std::vector<std::vector<Frame>> g_stacks;
+// hash -> candidate stack_ids (collisions resolved by full frame compare).
+std::unordered_map<uint64_t, std::vector<uint64_t>> g_hash_index;
+// Unique code objects held alive (one INCREF each) so raw pointers stay valid
+// as map keys / frame refs for the whole recording session.
+std::unordered_set<PyCodeObject*> g_interned;
+
+uint64_t HashFrames(const std::vector<Frame>& frames) {
+  // FNV-1a over (code pointer, line) pairs.
+  uint64_t h = 1469598103934665603ULL;
+  auto mix = [&h](uint64_t v) {
+    for (int i = 0; i < 8; ++i) {
+      h ^= (v & 0xff);
+      h *= 1099511628211ULL;
+      v >>= 8;
+    }
+  };
+  for (const auto& f : frames) {
+    mix(reinterpret_cast<uint64_t>(f.code));
+    mix(static_cast<uint64_t>(static_cast<uint32_t>(f.line)));
+  }
+  return h;
+}
+
+bool FramesEqual(const std::vector<Frame>& a, const std::vector<Frame>& b) {
+  if (a.size() != b.size()) return false;
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (a[i].code != b[i].code || a[i].line != b[i].line) return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+void SetMemPyStackCaptureEnabled(bool enabled) {
+  g_capture_enabled.store(enabled, std::memory_order_relaxed);
+}
+
+uint64_t CaptureCurrentPyStack() {
+  // Cheap early-out: single relaxed atomic read(s) when disabled.
+  if (!paddle::memory::MemHistoryEnabled()) return 0;
+  if (!g_capture_enabled.load(std::memory_order_relaxed)) return 0;
+
+  // Caller holds the GIL. Walk frames innermost -> outermost. PyFrame_GetCode
+  // and PyFrame_GetBack return new references; we release the temporary frame /
+  // code references at the end and separately INCREF codes that we newly
+  // intern.
+  std::vector<Frame> frames;
+  std::vector<PyCodeObject*> temp_code_refs;
+  PyFrameObject* f = PyEval_GetFrame();  // borrowed
+  Py_XINCREF(f);                         // own our iteration reference
+  while (f != nullptr) {
+    int line = PyFrame_GetLineNumber(f);
+    PyCodeObject* code = PyFrame_GetCode(f);  // new ref
+    frames.push_back(Frame{code, line});
+    temp_code_refs.push_back(code);
+    PyFrameObject* back = PyFrame_GetBack(f);  // new ref
+    Py_DECREF(f);
+    f = back;
+  }
+
+  uint64_t result = 0;
+  if (!frames.empty()) {
+    uint64_t h = HashFrames(frames);
+    std::lock_guard<std::mutex> lock(g_mu);
+    auto it = g_hash_index.find(h);
+    if (it != g_hash_index.end()) {
+      for (uint64_t sid : it->second) {
+        if (FramesEqual(g_stacks[sid - 1], frames)) {
+          result = sid;
+          break;
+        }
+      }
+    }
+    if (result == 0 && g_stacks.size() < kMaxUniqueStacks) {
+      // Intern any not-yet-seen code objects (one INCREF each, session-lived).
+      for (const auto& fr : frames) {
+        if (g_interned.insert(fr.code).second) {
+          Py_INCREF(fr.code);
+        }
+      }
+      g_stacks.push_back(frames);
+      result = g_stacks.size();  // 1-based
+      g_hash_index[h].push_back(result);
+    }
+  }
+
+  // Release the temporary references obtained during the walk. Interned codes
+  // survive via their separate INCREF above.
+  for (PyCodeObject* code : temp_code_refs) {
+    Py_DECREF(code);
+  }
+  return result;
+}
+
+::pybind11::list ResolveStack(uint64_t stack_id) {
+  namespace py = ::pybind11;
+  py::list out;
+  if (stack_id == 0) return out;
+  std::lock_guard<std::mutex> lock(g_mu);
+  if (stack_id > g_stacks.size()) return out;
+  const auto& frames = g_stacks[stack_id - 1];
+  for (const auto& fr : frames) {  // innermost first
+    py::dict d;
+    const char* fn = PyUnicode_AsUTF8(fr.code->co_filename);
+    const char* nm = PyUnicode_AsUTF8(fr.code->co_name);
+    d["filename"] = fn ? fn : "";
+    d["name"] = nm ? nm : "";
+    d["line"] = fr.line;
+    out.append(d);
+  }
+  return out;
+}
+
+void ClearMemPyStacks() {
+  // Caller holds the GIL, so Py_DECREF is safe.
+  std::lock_guard<std::mutex> lock(g_mu);
+  for (PyCodeObject* code : g_interned) {
+    Py_DECREF(code);
+  }
+  g_interned.clear();
+  g_stacks.clear();
+  g_hash_index.clear();
+}
+
+}  // namespace pybind
+}  // namespace paddle

--- a/paddle/fluid/pybind/mem_py_stack.h
+++ b/paddle/fluid/pybind/mem_py_stack.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "paddle/phi/core/memory/allocation/memory_history_recorder.h"
+#include "pybind11/pybind11.h"
+
+// Python call-stack capture for the GPU memory-history recorder. All Python
+// C-API access lives here so that phi core (the allocator hot path) stays free
+// of any Python dependency. See design: capture at op dispatch while the GIL is
+// still held, intern to an opaque stack_id, resolve to frames at snapshot time.
+
+namespace paddle {
+namespace pybind {
+
+// Capture the current Python call stack (innermost frame first) and return an
+// interned, deduplicated opaque id (0 == nothing captured). CALLER MUST HOLD
+// THE GIL. Cheap no-op (a single relaxed atomic read) when recording or stack
+// capture is disabled. Called from the eager python_c wrappers just before
+// PyEval_SaveThread releases the GIL.
+uint64_t CaptureCurrentPyStack();
+
+// Resolve a previously captured stack_id into a list of frame dicts
+// ``{filename, name, line}`` (innermost first). Empty list for id 0 or unknown.
+// CALLER MUST HOLD THE GIL (invoked from the pybind snapshot builder).
+::pybind11::list ResolveStack(uint64_t stack_id);
+
+// Drop all interned stacks and Py_DECREF every interned code object. CALLER
+// MUST HOLD THE GIL. Invoked when (re)configuring recording from Python.
+void ClearMemPyStacks();
+
+// Toggle whether CaptureCurrentPyStack actually walks/interns frames. When
+// false, capture is a single atomic read returning 0.
+void SetMemPyStackCaptureEnabled(bool enabled);
+
+}  // namespace pybind
+}  // namespace paddle

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -228,6 +228,7 @@ limitations under the License. */
 #include "paddle/fluid/prim/utils/static/static_tensor_operants.h"
 #include "paddle/fluid/primitive/base/decomp_trans.h"
 #include "paddle/fluid/pybind/eager_utils.h"
+#include "paddle/fluid/pybind/mem_py_stack.h"
 #include "paddle/fluid/pybind/op_function_common.h"
 #include "paddle/phi/api/ext/op_meta_info.h"
 #include "paddle/phi/api/include/operants_manager.h"
@@ -3806,6 +3807,135 @@ All parameter, weight, gradient are variables in Paddle.
   });
   m.def("get_compact_size", [](int device_id) {
     return paddle::memory::GetCompactSize(GPUPlace(device_id));
+  });
+  m.def(
+      "gpu_record_memory_history",
+      [](bool enabled,
+         size_t max_entries,
+         bool capture_stacks,
+         size_t stacks_min_size) {
+        // Reconfigure the pybind-layer Python-stack capture. Clearing the
+        // interned store on both enable and disable keeps code-object refcounts
+        // balanced and avoids stale stacks leaking across sessions. Must run
+        // with the GIL held (Py_DECREF inside ClearMemPyStacks); pybind holds
+        // it here.
+        paddle::pybind::ClearMemPyStacks();
+        paddle::memory::SetMemStackMinSize(stacks_min_size);
+        paddle::pybind::SetMemPyStackCaptureEnabled(enabled && capture_stacks);
+        paddle::memory::MemoryHistoryRecorder::Instance().SetEnabled(
+            enabled, max_entries);
+      },
+      py::arg("enabled"),
+      py::arg("max_entries"),
+      py::arg("capture_stacks") = false,
+      py::arg("stacks_min_size") = 0);
+  m.def("gpu_annotate_memory_history", [](const std::string &msg) {
+    paddle::memory::MemoryHistoryRecorder::Instance().Annotate(msg);
+  });
+  m.def("gpu_memory_snapshot", []() -> py::dict {
+    auto action_to_str =
+        [](paddle::memory::MemHistoryAction a) -> const char * {
+      switch (a) {
+        case paddle::memory::MemHistoryAction::kAlloc:
+          return "alloc";
+        case paddle::memory::MemHistoryAction::kFreeRequested:
+          return "free_requested";
+        case paddle::memory::MemHistoryAction::kFreeCompleted:
+          return "free_completed";
+        case paddle::memory::MemHistoryAction::kSegmentAlloc:
+          return "segment_alloc";
+        case paddle::memory::MemHistoryAction::kSegmentFree:
+          return "segment_free";
+        case paddle::memory::MemHistoryAction::kSegmentMap:
+          return "segment_map";
+        case paddle::memory::MemHistoryAction::kSegmentUnmap:
+          return "segment_unmap";
+        case paddle::memory::MemHistoryAction::kOom:
+          return "oom";
+        case paddle::memory::MemHistoryAction::kSnapshot:
+          return "snapshot";
+        case paddle::memory::MemHistoryAction::kAnnotation:
+          return "annotation";
+      }
+      return "unknown";
+    };
+    int device_count = phi::backends::gpu::GetGPUDeviceCount();
+    py::list segments;
+    py::list device_traces;
+    for (int dev = 0; dev < device_count; ++dev) {
+      // Segments: reuse existing block layout. One inner block group is
+      // treated as one memory_viz segment.
+      auto groups = paddle::memory::AllBlockInfoOfAllocator(GPUPlace(dev));
+      for (auto &group : groups) {
+        if (group.empty()) continue;
+        size_t total_size = 0;
+        size_t allocated_size = 0;
+        py::list blocks;
+        uintptr_t seg_addr = std::get<1>(group.front());
+        for (auto &blk : group) {
+          size_t bsize = std::get<0>(blk);
+          uintptr_t baddr = std::get<1>(blk);
+          bool is_free = std::get<2>(blk);
+          total_size += bsize;
+          if (!is_free) allocated_size += bsize;
+          py::dict block;
+          block["address"] = baddr;
+          block["size"] = bsize;
+          block["requested_size"] = bsize;
+          block["state"] = is_free ? "inactive" : "active_allocated";
+          block["frames"] = py::list();
+          blocks.append(block);
+        }
+        py::dict seg;
+        seg["device"] = dev;
+        seg["address"] = seg_addr;
+        seg["total_size"] = total_size;
+        seg["allocated_size"] = allocated_size;
+        seg["active_size"] = allocated_size;
+        seg["requested_size"] = total_size;
+        seg["stream"] = 0;
+        seg["segment_type"] = "large";
+        seg["is_expandable"] = true;
+        seg["blocks"] = blocks;
+        seg["frames"] = py::list();
+        segments.append(seg);
+      }
+      // Device traces: unified event timeline for this device.
+      py::list traces;
+      auto entries = paddle::memory::GpuMemoryHistoryTrace(GPUPlace(dev));
+      for (auto &e : entries) {
+        py::dict te;
+        te["action"] = action_to_str(e.action);
+        te["addr"] = e.addr;
+        te["size"] = e.size;
+        te["stream"] = e.stream;
+        te["time_us"] = e.time_us;
+        // Keep op_name as an independent field so viz can still group by op
+        // even when a full Python stack is present.
+        te["op_name"] = e.op_name;
+        if (e.stack_id != 0) {
+          // Full Python dispatch stack (innermost first). Runs under the GIL in
+          // this pybind call, so touching Python objects is safe.
+          te["frames"] = paddle::pybind::ResolveStack(e.stack_id);
+        } else if (e.op_name.empty()) {
+          te["frames"] = py::list();
+        } else {
+          py::list frames;
+          py::dict fr;
+          fr["filename"] = "";
+          fr["name"] = e.op_name;
+          fr["line"] = 0;
+          frames.append(fr);
+          te["frames"] = frames;
+        }
+        traces.append(te);
+      }
+      device_traces.append(traces);
+    }
+    py::dict result;
+    result["segments"] = segments;
+    result["device_traces"] = device_traces;
+    return result;
   });
 #endif
 #ifdef PADDLE_WITH_CUSTOM_DEVICE

--- a/paddle/phi/core/memory/allocation/CMakeLists.txt
+++ b/paddle/phi/core/memory/allocation/CMakeLists.txt
@@ -14,6 +14,7 @@ set(ALLOCATOR_SRCS
     memory_block.cc
     memory_block_desc.cc
     meta_cache.cc
+    memory_history_recorder.cc
     buddy_allocator.cc
     system_allocator.cc)
 

--- a/paddle/phi/core/memory/allocation/allocator.h
+++ b/paddle/phi/core/memory/allocation/allocator.h
@@ -27,6 +27,7 @@
 #include "paddle/phi/core/allocator.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/memory/allocation/inlined_vector.h"
+#include "paddle/phi/core/memory/allocation/memory_history_recorder.h"
 #include "paddle/phi/core/memory/allocation/spin_lock.h"
 #include "paddle/phi/core/platform/device/gpu/gpu_types.h"
 
@@ -266,6 +267,17 @@ class PADDLE_API MultiScalePoolAllocator : public Allocator {
       RecordAlloc(allocator_instance, id, size);
       allocation->set_id(id);
     }
+    if (MemHistoryEnabled()) {
+      // Record the actual block size (rounded up to alignment_, 256B on GPU),
+      // not the request: kFreeRequested / kFreeCompleted report the same, so
+      // using `size` here would make a pair disagree (alloc=1 vs free=256).
+      RecordMemHistory(MemHistoryAction::kAlloc,
+                       place_.GetDeviceId(),
+                       reinterpret_cast<uintptr_t>(allocation->ptr()),
+                       allocation->size(),
+                       allocation->id(),
+                       0);
+    }
     return allocation;
   };
   // Free an allocation from small_allocator or large_allocator.
@@ -274,6 +286,14 @@ class PADDLE_API MultiScalePoolAllocator : public Allocator {
       uint64_t id = allocation->id();
       uintptr_t allocator_instance = reinterpret_cast<uintptr_t>(this);
       RecordFree(allocator_instance, id, allocation->size());
+    }
+    if (MemHistoryEnabled()) {
+      RecordMemHistory(MemHistoryAction::kFreeCompleted,
+                       place_.GetDeviceId(),
+                       reinterpret_cast<uintptr_t>(allocation->ptr()),
+                       allocation->size(),
+                       allocation->id(),
+                       0);
     }
     auto* decorated_allocation = static_cast<Allocation*>(allocation);
     decorated_allocation->PopDecoratedAllocator();

--- a/paddle/phi/core/memory/allocation/memory_history_recorder.cc
+++ b/paddle/phi/core/memory/allocation/memory_history_recorder.cc
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/memory/allocation/memory_history_recorder.h"
+
+#include <mutex>
+
+#include "paddle/phi/core/os_info.h"
+
+namespace paddle {
+namespace memory {
+
+namespace {
+// All state stays internal to this TU: exported data does not work here (see
+// MemHistoryEnabled in the header), and thread_local data cannot carry a dll
+// interface on MSVC (C2492). Consumers go through the exported functions.
+std::atomic<bool> g_mem_history_enabled{false};
+std::atomic<size_t> g_mem_stack_min_size{0};
+thread_local std::vector<const char*> g_mem_op_label_stack;
+thread_local std::vector<uint64_t> g_mem_stack_id_stack;
+}  // namespace
+
+bool MemHistoryEnabled() {
+  return g_mem_history_enabled.load(std::memory_order_relaxed);
+}
+
+void SetMemStackMinSize(size_t min_size) {
+  g_mem_stack_min_size.store(min_size, std::memory_order_relaxed);
+}
+
+std::vector<const char*>& MemOpLabelStack() { return g_mem_op_label_stack; }
+
+std::vector<uint64_t>& MemStackIdStack() { return g_mem_stack_id_stack; }
+
+MemoryHistoryRecorder& MemoryHistoryRecorder::Instance() {
+  static MemoryHistoryRecorder instance;
+  return instance;
+}
+
+MemoryHistoryRecorder::DeviceRing& MemoryHistoryRecorder::EnsureDevice(
+    int device) {
+  if (static_cast<size_t>(device) >= rings_.size()) {
+    rings_.resize(device + 1);
+  }
+  if (rings_[device] == nullptr) {
+    rings_[device] = std::make_unique<DeviceRing>();
+  }
+  return *rings_[device];
+}
+
+void MemoryHistoryRecorder::SetEnabled(bool enabled, size_t max_entries) {
+  if (!enabled) {
+    // Publish the disable BEFORE clearing. The ring lock's release/acquire then
+    // guarantees that a writer reaching its critical section after the clear
+    // observes it and drops its event instead of resurrecting a cleared ring.
+    g_mem_history_enabled.store(false, std::memory_order_relaxed);
+  }
+  {
+    std::lock_guard<SpinLock> lock(rings_lock_);
+    // Disabling forces the capacity to 0 whatever the caller passed (Python
+    // sends its default max_entries even when disabling), so both the fast
+    // reject and the in-lock check in Record() bail out afterwards.
+    capacity_.store(enabled ? max_entries : 0, std::memory_order_relaxed);
+    for (auto& ring : rings_) {
+      if (ring == nullptr) continue;
+      std::lock_guard<SpinLock> ring_lock(ring->lock);
+      ring->buf.clear();
+      ring->next = 0;
+      ring->full = false;
+    }
+  }
+  if (enabled) {
+    // Publish the enable last, so no writer enters with a stale capacity.
+    g_mem_history_enabled.store(true, std::memory_order_relaxed);
+  }
+}
+
+void MemoryHistoryRecorder::Record(const MemHistoryTraceEntry& entry) {
+  if (entry.device < 0) return;
+  // Fast reject before touching any lock.
+  if (capacity_.load(std::memory_order_relaxed) == 0) return;
+
+  DeviceRing* ring = nullptr;
+  {
+    std::lock_guard<SpinLock> lock(rings_lock_);
+    ring = &EnsureDevice(entry.device);
+  }
+
+  std::lock_guard<SpinLock> ring_lock(ring->lock);
+  // Re-check the enabled state here: SetEnabled() publishes a disable before
+  // clearing the rings under this same lock, so anything arriving after the
+  // clear must drop its event -- otherwise a straggler that passed the check in
+  // RecordMemHistory() could make events reappear after recording was stopped.
+  if (!MemHistoryEnabled()) return;
+  // Re-read the capacity too: keeps the size check and the modulo consistent,
+  // honours a capacity lowered while we took locks, and the zero check must be
+  // repeated or `% cap` could divide by zero.
+  const size_t cap = capacity_.load(std::memory_order_relaxed);
+  if (cap == 0) return;
+  if (ring->buf.size() < cap) {
+    // Not yet at capacity: append.
+    ring->buf.push_back(entry);
+  } else {
+    // At capacity: circular overwrite of the oldest entry.
+    ring->buf[ring->next] = entry;
+    ring->next = (ring->next + 1) % cap;
+    ring->full = true;
+  }
+}
+
+void MemoryHistoryRecorder::Annotate(const std::string& msg) {
+  if (!MemHistoryEnabled()) return;
+  // Snapshot the set of existing device rings first; don't hold rings_lock_
+  // across Record() (which re-acquires it and would deadlock the SpinLock).
+  std::vector<int> devices;
+  {
+    std::lock_guard<SpinLock> lock(rings_lock_);
+    for (size_t i = 0; i < rings_.size(); ++i) {
+      if (rings_[i] != nullptr) devices.push_back(static_cast<int>(i));
+    }
+  }
+  uint64_t now = phi::PosixInNsec() / 1000;
+  for (int dev : devices) {
+    MemHistoryTraceEntry entry;
+    entry.action = MemHistoryAction::kAnnotation;
+    entry.device = dev;
+    entry.addr = 0;
+    entry.size = 0;
+    entry.id = 0;
+    entry.stream = 0;
+    entry.time_us = now;
+    entry.op_name = msg;
+    Record(entry);
+  }
+}
+
+std::vector<MemHistoryTraceEntry> MemoryHistoryRecorder::GetTrace(int device) {
+  if (device < 0) return {};
+  DeviceRing* ring = nullptr;
+  {
+    std::lock_guard<SpinLock> lock(rings_lock_);
+    if (static_cast<size_t>(device) >= rings_.size() ||
+        rings_[device] == nullptr) {
+      return {};
+    }
+    ring = rings_[device].get();
+  }
+
+  std::lock_guard<SpinLock> ring_lock(ring->lock);
+  std::vector<MemHistoryTraceEntry> out;
+  out.reserve(ring->buf.size());
+  if (ring->full) {
+    // Oldest-first: start at next, wrap around.
+    for (size_t i = 0; i < ring->buf.size(); ++i) {
+      out.push_back(ring->buf[(ring->next + i) % ring->buf.size()]);
+    }
+  } else {
+    out = ring->buf;
+  }
+  return out;
+}
+
+void MemoryHistoryRecorder::Clear() {
+  std::lock_guard<SpinLock> lock(rings_lock_);
+  for (auto& ring : rings_) {
+    if (ring == nullptr) continue;
+    std::lock_guard<SpinLock> ring_lock(ring->lock);
+    ring->buf.clear();
+    ring->next = 0;
+    ring->full = false;
+  }
+}
+
+void RecordMemHistory(MemHistoryAction action,
+                      int device,
+                      uintptr_t addr,
+                      size_t size,
+                      uint64_t id,
+                      uint64_t stream) {
+  if (!MemHistoryEnabled()) return;
+  MemHistoryTraceEntry entry;
+  entry.action = action;
+  entry.device = device;
+  entry.addr = addr;
+  entry.size = size;
+  entry.id = id;
+  entry.stream = stream;
+  entry.time_us = phi::PosixInNsec() / 1000;
+  const char* label = CurrentMemOpLabel();
+  if (label != nullptr) entry.op_name = label;
+  if (action == MemHistoryAction::kAlloc &&
+      size >= g_mem_stack_min_size.load(std::memory_order_relaxed)) {
+    // Pure thread_local read: no GIL, no lock. The id was stamped at op /
+    // PyLayer dispatch (pybind layer) while the GIL was still held.
+    entry.stack_id = CurrentMemStackId();
+  }
+  MemoryHistoryRecorder::Instance().Record(entry);
+}
+
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/phi/core/memory/allocation/memory_history_recorder.h
+++ b/paddle/phi/core/memory/allocation/memory_history_recorder.h
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paddle/common/macros.h"
+#include "paddle/phi/core/memory/allocation/spin_lock.h"
+
+namespace paddle {
+namespace memory {
+
+// Actions recorded in the unified GPU memory history timeline.
+enum class MemHistoryAction {
+  kAlloc,
+  kFreeRequested,
+  kFreeCompleted,
+  kSegmentAlloc,
+  kSegmentFree,
+  kSegmentMap,
+  kSegmentUnmap,
+  kOom,
+  kSnapshot,
+  kAnnotation,
+};
+
+// A single event in the per-device memory history ring buffer.
+struct MemHistoryTraceEntry {
+  MemHistoryAction action;
+  int device;
+  uintptr_t addr;
+  size_t size;
+  uint64_t id;
+  uint64_t stream;
+  uint64_t time_us;
+  std::string op_name;  // Innermost op label (see MemOpLabelStack()).
+  // Opaque id of the captured Python dispatch stack (interned in the pybind
+  // layer, resolved to frames at snapshot time). 0 == no stack captured
+  // (recording disabled, size below threshold, or a non-dispatch/backward
+  // allocation). Only populated for kAlloc events.
+  uint64_t stack_id = 0;
+};
+
+// Whether recording is on. Checked at every hook site. Exported as a function,
+// not as the underlying atomic: PADDLE_API expands to dllexport in every target
+// (PADDLE_DLL_EXPORT is set project-wide), so exported *data* is emitted as a
+// plain extern in consumers and never resolves against phi.dll's __imp_ symbol.
+PADDLE_API bool MemHistoryEnabled();
+
+// Record a memory history event into the recorder for `device`. Cheap no-op
+// when recording is disabled (guarded internally as well). Out-of-line so that
+// the allocator hot path only inlines the enabled check.
+void PADDLE_API RecordMemHistory(MemHistoryAction action,
+                                 int device,
+                                 uintptr_t addr,
+                                 size_t size,
+                                 uint64_t id,
+                                 uint64_t stream);
+
+// Per-thread stack of the op name currently executing on this thread. In eager
+// mode the op dispatch -> kernel -> Alloc chain is synchronous on one thread,
+// so the innermost (back) label is the op that triggered an allocation.
+// Entries are static string literals (or member strings alive for the guard's
+// lifetime); we store raw `const char*` to avoid per-op heap traffic.
+// Reached through an exported accessor because thread_local data cannot carry
+// a dll interface on MSVC (C2492); only called when recording is enabled.
+PADDLE_API std::vector<const char*>& MemOpLabelStack();
+
+// Returns the innermost op label active on this thread, or nullptr if none.
+inline const char* CurrentMemOpLabel() {
+  auto& stack = MemOpLabelStack();
+  return stack.empty() ? nullptr : stack.back();
+}
+
+// Per-thread stack of the opaque Python-dispatch-stack id captured at op /
+// PyLayer entry (in the pybind layer, while the GIL is still held, before
+// PyEval_SaveThread). The allocator hot path only reads the innermost id --
+// it never touches Python, so recording stays lock/GIL-free and deadlock-free.
+//
+// This is a STACK (not a flat slot) mirroring MemOpLabelStack(): an outer
+// entry point (e.g. PyLayer.apply, a legacy collective op) pushes the call-site
+// stack, and nested eager ops push their own finer stacks on top and pop back
+// on exit. So an allocation made directly by an outer wrapper (a comm buffer,
+// a raw C++ alloc between nested ops) still inherits the wrapper's stack
+// instead of falling back to 0. 0 == no stack captured.
+PADDLE_API std::vector<uint64_t>& MemStackIdStack();
+
+// Returns the innermost captured stack id active on this thread, or 0 if none.
+inline uint64_t CurrentMemStackId() {
+  auto& stack = MemStackIdStack();
+  return stack.empty() ? 0 : stack.back();
+}
+
+// RAII guard pushed at op-dispatch / PyLayer entry (while the GIL is held).
+// Pushes only when recording is enabled (captured at construction so push/pop
+// stay balanced even if recording is toggled mid-op); zero-overhead (one
+// relaxed atomic load) when disabled. Mirrors MemLabelGuard.
+class MemStackGuard {
+ public:
+  explicit MemStackGuard(uint64_t stack_id) : active_(MemHistoryEnabled()) {
+    if (active_) MemStackIdStack().push_back(stack_id);
+  }
+  ~MemStackGuard() {
+    if (active_) {
+      auto& stack = MemStackIdStack();
+      if (!stack.empty()) stack.pop_back();
+    }
+  }
+  MemStackGuard(const MemStackGuard&) = delete;
+  MemStackGuard& operator=(const MemStackGuard&) = delete;
+
+ private:
+  bool active_;
+};
+
+// Minimum allocation size (bytes) for which a Python stack is attributed. Set
+// once per recording session, so a plain exported setter (see MemHistoryEnabled
+// above for why data itself is not exported).
+PADDLE_API void SetMemStackMinSize(size_t min_size);
+
+// RAII guard pushed at op-dispatch entry (forward and backward). Pushes only
+// when recording is enabled (captured at construction so push/pop stay
+// balanced even if recording is toggled mid-op); zero-overhead (one relaxed
+// atomic load) when disabled.
+class MemLabelGuard {
+ public:
+  explicit MemLabelGuard(const char* name) : active_(MemHistoryEnabled()) {
+    if (active_) MemOpLabelStack().push_back(name);
+  }
+  ~MemLabelGuard() {
+    if (active_) {
+      auto& stack = MemOpLabelStack();
+      if (!stack.empty()) stack.pop_back();
+    }
+  }
+  MemLabelGuard(const MemLabelGuard&) = delete;
+  MemLabelGuard& operator=(const MemLabelGuard&) = delete;
+
+ private:
+  bool active_;
+};
+
+// Per-device fixed-capacity ring buffer of memory history events. Modeled on
+// torch's RingBuffer: once full, new entries overwrite the oldest in a circular
+// fashion. GetTrace() returns entries in chronological (oldest-first) order.
+// Exported: called from pybind.cc, outside the phi DLL.
+class PADDLE_API MemoryHistoryRecorder {
+ public:
+  static MemoryHistoryRecorder& Instance();
+
+  // Enable/disable recording. When enabling, (re)sets the per-device ring
+  // capacity to `max_entries` and clears any previously recorded events.
+  void SetEnabled(bool enabled, size_t max_entries);
+
+  // Append an event to the ring for `device`. No-op if recording is disabled.
+  void Record(const MemHistoryTraceEntry& entry);
+
+  // Insert a user annotation (a named time-marker, e.g. "backward begin") into
+  // every device ring that currently exists, stamped with the current time.
+  // No-op if recording is disabled. Used to mark
+  // forward/backward/step/recompute boundaries on the memory timeline.
+  void Annotate(const std::string& msg);
+
+  // Return the events for `device` in chronological order. Empty if `device`
+  // is out of range or nothing has been recorded.
+  std::vector<MemHistoryTraceEntry> GetTrace(int device);
+
+  // Drop all recorded events across all devices (keeps capacity/enabled state).
+  void Clear();
+
+ private:
+  MemoryHistoryRecorder() = default;
+
+  struct DeviceRing {
+    std::vector<MemHistoryTraceEntry> buf;
+    size_t next = 0;
+    bool full = false;
+    SpinLock lock;
+  };
+
+  // Grow rings_ so that index `device` is valid. Caller must hold rings_lock_.
+  DeviceRing& EnsureDevice(int device);
+
+  std::vector<std::unique_ptr<DeviceRing>> rings_;
+  SpinLock rings_lock_;
+  // Written by SetEnabled() under rings_lock_ but read by Record() without it
+  // (a reconfigure from Python races with allocations), so it must be atomic.
+  // Relaxed suffices: buf/next are only touched under the per-ring lock.
+  std::atomic<size_t> capacity_{0};
+};
+
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/phi/core/memory/allocation/stream_safe_cuda_allocator.cc
+++ b/paddle/phi/core/memory/allocation/stream_safe_cuda_allocator.cc
@@ -23,6 +23,7 @@
 #include "paddle/common/flags.h"
 #include "paddle/phi/api/profiler/event_tracing.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
+#include "paddle/phi/core/memory/allocation/memory_history_recorder.h"
 #include "paddle/phi/core/memory/allocation/retry_allocator.h"
 #include "paddle/phi/core/memory/allocation/stat_allocator.h"
 #include "paddle/phi/core/memory/allocation/vmm_allocator_v2_types.h"
@@ -225,6 +226,26 @@ void ClearGpuLastError() {
 #endif
 }
 
+// Whether `allocator` routes through MultiScalePoolAllocator, the only place
+// kAlloc / kFreeCompleted are emitted (the VMM V1 stack). Gates the
+// kFreeRequested hook so other stacks never record unmatched free events.
+bool UnderlyingRecordsMemHistory(
+    const std::shared_ptr<Allocator>& allocator) {  // NOLINT
+  if (allocator == nullptr) {
+    return false;
+  }
+  if (dynamic_cast<MultiScalePoolAllocator*>(allocator.get()) != nullptr) {
+    return true;
+  }
+  if (auto* retry = dynamic_cast<RetryAllocator*>(allocator.get())) {
+    return UnderlyingRecordsMemHistory(retry->GetUnderLyingAllocator());
+  }
+  if (auto* stat = dynamic_cast<StatAllocator*>(allocator.get())) {
+    return UnderlyingRecordsMemHistory(stat->GetUnderLyingAllocator());
+  }
+  return false;
+}
+
 }  // namespace
 
 StreamSafeCUDAAllocation::StreamSafeCUDAAllocation(
@@ -389,6 +410,8 @@ StreamSafeCUDAAllocator::StreamSafeCUDAAllocator(
     bool in_cuda_graph_capturing)
     : underlying_allocator_(std::move(underlying_allocator)),
       vmm_v2_allocator_(GetVMMV2MultiPoolAllocator(underlying_allocator_)),
+      underlying_records_mem_history_(
+          UnderlyingRecordsMemHistory(underlying_allocator_)),
       place_(place),
       default_stream_(default_stream),
       in_cuda_graph_capturing_(in_cuda_graph_capturing) {
@@ -612,6 +635,17 @@ void StreamSafeCUDAAllocator::FreeImpl(phi::Allocation* allocation) {
                           9 /*level*/);
   StreamSafeCUDAAllocation* stream_safe_cuda_allocation =
       static_cast<StreamSafeCUDAAllocation*>(allocation);
+
+  if (underlying_records_mem_history_ && memory::MemHistoryEnabled()) {
+    memory::RecordMemHistory(
+        memory::MemHistoryAction::kFreeRequested,
+        allocation->place().GetDeviceId(),
+        reinterpret_cast<uintptr_t>(allocation->ptr()),
+        allocation->size(),
+        0,
+        reinterpret_cast<uint64_t>(
+            stream_safe_cuda_allocation->GetOwningStream()));
+  }
 
   VLOG(8) << "Try free allocation " << stream_safe_cuda_allocation->ptr();
   if (stream_safe_cuda_allocation->CanBeFreed()) {

--- a/paddle/phi/core/memory/allocation/stream_safe_cuda_allocator.h
+++ b/paddle/phi/core/memory/allocation/stream_safe_cuda_allocator.h
@@ -115,6 +115,9 @@ class StreamSafeCUDAAllocator
 
   std::shared_ptr<Allocator> underlying_allocator_;
   VMMAutoGrowthBestFitMultiPoolAllocatorV2 *vmm_v2_allocator_{nullptr};
+  // True iff the underlying stack is VMM V1 (MultiScalePoolAllocator), the only
+  // one emitting kAlloc / kFreeCompleted. Resolved once at construction.
+  bool underlying_records_mem_history_{false};
   GPUPlace place_;
   gpuStream_t default_stream_;
   std::list<StreamSafeCUDAAllocation *> unfreed_allocations_;

--- a/paddle/phi/core/memory/mem_utils.cc
+++ b/paddle/phi/core/memory/mem_utils.cc
@@ -215,6 +215,10 @@ std::vector<size_t> GetCompactSize(const GPUPlace& place) {
   return allocate_compact_visitor.GetCompactSize();
 }
 
+std::vector<MemHistoryTraceEntry> GpuMemoryHistoryTrace(const GPUPlace& place) {
+  return MemoryHistoryRecorder::Instance().GetTrace(place.GetDeviceId());
+}
+
 #endif
 
 }  // namespace memory

--- a/paddle/phi/core/memory/mem_utils.h
+++ b/paddle/phi/core/memory/mem_utils.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "paddle/phi/core/memory/allocation/allocator.h"
+#include "paddle/phi/core/memory/allocation/memory_history_recorder.h"
 #include "paddle/phi/core/memory/allocation/spin_lock.h"
 #include "paddle/phi/core/memory/allocation/vmm_ipc_allocation.h"
 
@@ -121,6 +122,13 @@ GetAllocateEvent(const GPUPlace& place);
 
 // Get compact count and size when start FLAGS_enable_compact_mem.
 PADDLE_API extern std::vector<size_t> GetCompactSize(const GPUPlace& place);
+
+// Get the unified memory history trace (ALLOC / FREE_REQUESTED /
+// FREE_COMPLETED events) for the given device, in chronological order. Only
+// populated when memory history recording is enabled via
+// MemoryHistoryRecorder::SetEnabled.
+PADDLE_API extern std::vector<MemHistoryTraceEntry> GpuMemoryHistoryTrace(
+    const GPUPlace& place);
 #endif
 
 }  // namespace memory

--- a/python/paddle/device/cuda/__init__.py
+++ b/python/paddle/device/cuda/__init__.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from typing import TYPE_CHECKING, NoReturn, Union
 
 from typing_extensions import TypeAlias
@@ -524,6 +525,109 @@ def memory_reserved(device: _CudaPlaceLike | None = None) -> int:
         )
     device_id = extract_cuda_device_id(device, op_name=name)
     return core.device_memory_stat_current_value("Reserved", device_id)
+
+
+def _record_memory_history(
+    enabled="all",
+    context="all",
+    stacks="all",
+    max_entries=sys.maxsize,
+    device=None,
+    stacks_min_size=0,
+):
+    '''
+    Enable/disable recording of the GPU memory allocation history, producing a
+    timeline of ALLOC / FREE_REQUESTED / FREE_COMPLETED events that can be
+    captured with :func:`_snapshot` and rendered by the PyTorch memory_viz tool
+    (https://pytorch.org/memory_viz).
+
+    The signature mirrors ``torch.cuda.memory._record_memory_history`` for
+    compatibility.
+
+    .. note::
+        Only the VMM V1 allocator stack is supported
+        (``FLAGS_use_virtual_memory_auto_growth=1``); enabling recording
+        without it raises :class:`RuntimeError`. The ``kFreeRequested`` hook
+        additionally checks the real allocator type, since the facade silently
+        falls back to the default allocator when the device reports no
+        virtual-address-management support.
+
+    Args:
+        enabled: Truthy to start recording, falsy (``None``/``False``) to stop.
+        context: Ignored (reserved for stack-capture granularity).
+        stacks: ``"python"`` or ``"all"`` captures the Python call stack of the
+            op that triggered each allocation (innermost frame first); any other
+            value disables stack capture. Captured only on the
+            forward/op-dispatch path; backward allocations fall back to the op
+            label (``op_name``).
+        max_entries: Maximum number of events retained per device (ring
+            buffer). The default is effectively unbounded, which lets the ring
+            grow until host memory is exhausted -- pass an explicit bound for
+            long runs (each entry costs ~88 bytes).
+        device: Ignored (recording is global across devices).
+        stacks_min_size: Only capture a Python stack for allocations of at least
+            this many bytes (default ``0`` == capture for all sizes). Smaller
+            allocations get an empty ``frames`` list / ``stack_id == 0``.
+    '''
+    if not core.is_compiled_with_cuda():
+        return
+    flag = 'FLAGS_use_virtual_memory_auto_growth'
+    if enabled and not paddle.get_flags(flag)[flag]:
+        raise RuntimeError(
+            'GPU memory history recording is only implemented for the VMM V1 '
+            f'allocator stack. Set {flag}=1 before the first allocation.'
+        )
+    capture_stacks = bool(enabled) and str(stacks) in ("python", "all")
+    core.gpu_record_memory_history(
+        bool(enabled),
+        int(min(max_entries, 2**31)),
+        capture_stacks,
+        int(stacks_min_size),
+    )
+
+
+def _annotate_memory_history(message):
+    '''
+    Insert a named time-marker into the GPU memory history (a zero-size event
+    recorded on every active device ring at the current time). Use it to mark
+    phase boundaries such as ``"step 3 backward begin"`` or ``"recompute replay
+    layer12"``;
+
+    Args:
+        message: A short string describing the marker.
+    '''
+    if core.is_compiled_with_cuda():
+        core.gpu_annotate_memory_history(str(message))
+
+
+def _snapshot(device=None):
+    '''
+    Return a snapshot of the current GPU memory state as a dict compatible with
+    the PyTorch memory_viz schema:
+    ``{"segments": [...], "device_traces": [[...], ...]}``.
+
+    Args:
+        device: Ignored (the snapshot covers all devices).
+    '''
+    if core.is_compiled_with_cuda():
+        return core.gpu_memory_snapshot()
+    return {"segments": [], "device_traces": []}
+
+
+def _dump_snapshot(filename="paddle_memory_snapshot.pickle", device=None):
+    '''
+    Pickle the result of :func:`_snapshot` to ``filename``. The resulting file
+    can be opened directly with the PyTorch memory_viz tool
+    (https://pytorch.org/memory_viz).
+
+    Args:
+        filename: Output path for the pickle file.
+        device: Ignored (the snapshot covers all devices).
+    '''
+    import pickle
+
+    with open(filename, "wb") as f:
+        pickle.dump(_snapshot(device), f)
 
 
 def _set_current_stream(stream: Stream) -> core.CUDAStream:

--- a/test/cpp/fluid/memory/CMakeLists.txt
+++ b/test/cpp/fluid/memory/CMakeLists.txt
@@ -15,6 +15,10 @@ cc_test(
   buffered_allocator_test
   SRCS buffered_allocator_test.cc
   DEPS phi common)
+cc_test(
+  memory_history_recorder_test
+  SRCS memory_history_recorder_test.cc
+  DEPS phi common)
 
 if(WITH_GPU)
   nv_test(
@@ -231,6 +235,17 @@ if(WITH_GPU)
     nv_test(
       multi_scale_allocator_test
       SRCS multi_scale_allocator_test.cc
+      DEPS phi common)
+  endif()
+endif()
+
+if(WITH_GPU)
+  if(WIN32)
+    message(STATUS "Skip memory_history_hook_test on Windows")
+  else()
+    nv_test(
+      memory_history_hook_test
+      SRCS memory_history_hook_test.cc
       DEPS phi common)
   endif()
 endif()

--- a/test/cpp/fluid/memory/memory_history_hook_test.cc
+++ b/test/cpp/fluid/memory/memory_history_hook_test.cc
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end coverage of the memory-history hooks inside
+// MultiScalePoolAllocator (the VMM V1 stack, the only one instrumented).
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paddle/phi/core/memory/allocation/allocator.h"
+#include "paddle/phi/core/memory/allocation/cuda_virtual_mem_allocator.h"
+#include "paddle/phi/core/memory/allocation/memory_history_recorder.h"
+#include "paddle/phi/core/memory/allocation/virtual_memory_auto_growth_best_fit_allocator.h"
+#include "paddle/phi/core/platform/device/gpu/gpu_info.h"
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+class MemoryHistoryHookTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto cuda_small =
+        std::make_shared<CUDAVirtualMemAllocator>(phi::GPUPlace(0));
+    auto cuda_large =
+        std::make_shared<CUDAVirtualMemAllocator>(phi::GPUPlace(0));
+    auto small = std::make_shared<VirtualMemoryAutoGrowthBestFitAllocator>(
+        cuda_small, platform::GpuMinChunkSize(), phi::GPUPlace(0));
+    auto large = std::make_shared<VirtualMemoryAutoGrowthBestFitAllocator>(
+        cuda_large, platform::GpuMinChunkSize(), phi::GPUPlace(0));
+    allocator_ =
+        std::make_shared<VirtualMemoryAutoGrowthBestFitMultiScalePoolAllocator>(
+            small, large, platform::GpuMinChunkSize(), phi::GPUPlace(0));
+    MemoryHistoryRecorder::Instance().SetEnabled(false, 0);
+  }
+
+  void TearDown() override {
+    MemoryHistoryRecorder::Instance().SetEnabled(false, 0);
+  }
+
+  // Events of one action, in chronological order.
+  std::vector<MemHistoryTraceEntry> EventsOf(MemHistoryAction action) {
+    std::vector<MemHistoryTraceEntry> out;
+    for (auto& e : MemoryHistoryRecorder::Instance().GetTrace(0)) {
+      if (e.action == action) out.push_back(e);
+    }
+    return out;
+  }
+
+  size_t alignment() const { return platform::GpuMinChunkSize(); }
+
+  std::shared_ptr<VirtualMemoryAutoGrowthBestFitMultiScalePoolAllocator>
+      allocator_;
+};
+
+TEST_F(MemoryHistoryHookTest, NoEventsWhileDisabled) {
+  { auto allocation = allocator_->Allocate(1024); }
+  EXPECT_TRUE(MemoryHistoryRecorder::Instance().GetTrace(0).empty());
+}
+
+TEST_F(MemoryHistoryHookTest, AllocAndFreeAreRecorded) {
+  MemoryHistoryRecorder::Instance().SetEnabled(true, 1024);
+
+  uintptr_t addr = 0;
+  size_t reported_size = 0;
+  {
+    auto allocation = allocator_->Allocate(1024);
+    addr = reinterpret_cast<uintptr_t>(allocation->ptr());
+    reported_size = allocation->size();
+    ASSERT_NE(addr, 0u);
+
+    auto allocs = EventsOf(MemHistoryAction::kAlloc);
+    ASSERT_EQ(allocs.size(), 1u);
+    EXPECT_EQ(allocs[0].addr, addr);
+    EXPECT_EQ(allocs[0].size, reported_size);
+    EXPECT_EQ(allocs[0].device, 0);
+    // Free is only recorded once the allocation goes out of scope.
+    EXPECT_TRUE(EventsOf(MemHistoryAction::kFreeCompleted).empty());
+  }
+
+  auto frees = EventsOf(MemHistoryAction::kFreeCompleted);
+  ASSERT_EQ(frees.size(), 1u);
+  EXPECT_EQ(frees[0].addr, addr);
+  EXPECT_EQ(frees[0].size, reported_size);
+}
+
+TEST_F(MemoryHistoryHookTest, AllocAndFreeSizesAgreeForTinyRequest) {
+  // Regression guard: the alloc hook must report the actual block size, not the
+  // caller's request. A 1-byte request is rounded up to the allocator alignment
+  // (256B on GPU), and the free hooks report allocation->size(); recording the
+  // raw request would make the pair disagree (alloc=1 vs free=256) and would
+  // under-state occupancy in the address-space view.
+  MemoryHistoryRecorder::Instance().SetEnabled(true, 1024);
+
+  { auto allocation = allocator_->Allocate(1); }
+
+  auto allocs = EventsOf(MemHistoryAction::kAlloc);
+  auto frees = EventsOf(MemHistoryAction::kFreeCompleted);
+  ASSERT_EQ(allocs.size(), 1u);
+  ASSERT_EQ(frees.size(), 1u);
+  EXPECT_EQ(allocs[0].size, frees[0].size);
+  EXPECT_EQ(allocs[0].addr, frees[0].addr);
+  EXPECT_GE(allocs[0].size, alignment());
+  EXPECT_EQ(allocs[0].size % alignment(), 0u);
+}
+
+TEST_F(MemoryHistoryHookTest, OpLabelIsAttachedToAllocation) {
+  MemoryHistoryRecorder::Instance().SetEnabled(true, 1024);
+  {
+    MemLabelGuard label("matmul");
+    auto allocation = allocator_->Allocate(4096);
+  }
+  auto allocs = EventsOf(MemHistoryAction::kAlloc);
+  ASSERT_EQ(allocs.size(), 1u);
+  EXPECT_EQ(allocs[0].op_name, "matmul");
+}
+
+TEST_F(MemoryHistoryHookTest, SmallAndLargeRequestsAreBothRecorded) {
+  MemoryHistoryRecorder::Instance().SetEnabled(true, 1024);
+  {
+    // Routed to the small and the large pool respectively; both go through the
+    // same hook in MultiScalePoolAllocator.
+    auto small = allocator_->Allocate(64);
+    auto large = allocator_->Allocate(4 << 20);
+    EXPECT_NE(small->ptr(), large->ptr());
+  }
+  EXPECT_EQ(EventsOf(MemHistoryAction::kAlloc).size(), 2u);
+  EXPECT_EQ(EventsOf(MemHistoryAction::kFreeCompleted).size(), 2u);
+}
+
+TEST_F(MemoryHistoryHookTest, EventsAreOrderedAndTimestamped) {
+  MemoryHistoryRecorder::Instance().SetEnabled(true, 1024);
+  { auto allocation = allocator_->Allocate(2048); }
+
+  auto trace = MemoryHistoryRecorder::Instance().GetTrace(0);
+  ASSERT_GE(trace.size(), 2u);
+  EXPECT_EQ(trace.front().action, MemHistoryAction::kAlloc);
+  EXPECT_EQ(trace.back().action, MemHistoryAction::kFreeCompleted);
+  EXPECT_GT(trace.front().time_us, 0u);
+  EXPECT_TRUE(std::is_sorted(
+      trace.begin(), trace.end(), [](const auto& a, const auto& b) {
+        return a.time_us < b.time_us;
+      }));
+}
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/test/cpp/fluid/memory/memory_history_recorder_test.cc
+++ b/test/cpp/fluid/memory/memory_history_recorder_test.cc
@@ -1,0 +1,444 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/memory/allocation/memory_history_recorder.h"
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace paddle {
+namespace memory {
+
+namespace {
+
+MemHistoryTraceEntry MakeEntry(MemHistoryAction action,
+                               int device,
+                               uintptr_t addr,
+                               size_t size) {
+  MemHistoryTraceEntry entry;
+  entry.action = action;
+  entry.device = device;
+  entry.addr = addr;
+  entry.size = size;
+  entry.id = 0;
+  entry.stream = 0;
+  entry.time_us = 0;
+  return entry;
+}
+
+}  // namespace
+
+class MemoryHistoryRecorderTest : public ::testing::Test {
+ protected:
+  // The recorder is a process-wide singleton, so every test starts from a
+  // known state and leaves recording off for the next one.
+  void SetUp() override {
+    MemoryHistoryRecorder::Instance().SetEnabled(false, 0);
+    SetMemStackMinSize(0);
+  }
+  void TearDown() override {
+    MemoryHistoryRecorder::Instance().SetEnabled(false, 0);
+    SetMemStackMinSize(0);
+  }
+};
+
+TEST_F(MemoryHistoryRecorderTest, DisabledByDefault) {
+  EXPECT_FALSE(MemHistoryEnabled());
+  // RecordMemHistory must be a no-op while disabled.
+  RecordMemHistory(MemHistoryAction::kAlloc, 0, 0x1000, 128, 1, 0);
+  EXPECT_TRUE(MemoryHistoryRecorder::Instance().GetTrace(0).empty());
+}
+
+TEST_F(MemoryHistoryRecorderTest, EnableThenRecordAndRead) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 16);
+  EXPECT_TRUE(MemHistoryEnabled());
+
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0x1000, 256));
+  rec.Record(MakeEntry(MemHistoryAction::kFreeRequested, 0, 0x1000, 256));
+  rec.Record(MakeEntry(MemHistoryAction::kFreeCompleted, 0, 0x1000, 256));
+
+  auto trace = rec.GetTrace(0);
+  ASSERT_EQ(trace.size(), 3u);
+  EXPECT_EQ(trace[0].action, MemHistoryAction::kAlloc);
+  EXPECT_EQ(trace[1].action, MemHistoryAction::kFreeRequested);
+  EXPECT_EQ(trace[2].action, MemHistoryAction::kFreeCompleted);
+  EXPECT_EQ(trace[0].addr, 0x1000u);
+  EXPECT_EQ(trace[0].size, 256u);
+}
+
+TEST_F(MemoryHistoryRecorderTest, RingWrapsAroundOldestFirst) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 4);
+  for (uintptr_t i = 0; i < 6; ++i) {
+    rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0x100 + i, 8));
+  }
+
+  // Capacity is 4, so the two oldest events are overwritten and the result is
+  // still returned oldest-first.
+  auto trace = rec.GetTrace(0);
+  ASSERT_EQ(trace.size(), 4u);
+  EXPECT_EQ(trace[0].addr, 0x102u);
+  EXPECT_EQ(trace[1].addr, 0x103u);
+  EXPECT_EQ(trace[2].addr, 0x104u);
+  EXPECT_EQ(trace[3].addr, 0x105u);
+}
+
+TEST_F(MemoryHistoryRecorderTest, ZeroCapacityRecordsNothing) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 0);
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0x1000, 128));
+  EXPECT_TRUE(rec.GetTrace(0).empty());
+}
+
+TEST_F(MemoryHistoryRecorderTest, NegativeDeviceIsIgnored) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, -1, 0x1000, 128));
+  EXPECT_TRUE(rec.GetTrace(-1).empty());
+  EXPECT_TRUE(rec.GetTrace(0).empty());
+}
+
+TEST_F(MemoryHistoryRecorderTest, UnknownDeviceReturnsEmptyTrace) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0x1000, 128));
+  // Ring for device 7 was never created.
+  EXPECT_TRUE(rec.GetTrace(7).empty());
+}
+
+TEST_F(MemoryHistoryRecorderTest, RingsArePerDevice) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0xA000, 32));
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 1, 0xB000, 64));
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 1, 0xB100, 64));
+
+  ASSERT_EQ(rec.GetTrace(0).size(), 1u);
+  ASSERT_EQ(rec.GetTrace(1).size(), 2u);
+  EXPECT_EQ(rec.GetTrace(0)[0].addr, 0xA000u);
+  EXPECT_EQ(rec.GetTrace(1)[1].size, 64u);
+}
+
+TEST_F(MemoryHistoryRecorderTest, SetEnabledClearsPreviousEvents) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0x1000, 128));
+  ASSERT_EQ(rec.GetTrace(0).size(), 1u);
+
+  // Re-arming must drop everything recorded so far, otherwise a new session
+  // would inherit a stale prefix.
+  rec.SetEnabled(true, 8);
+  EXPECT_TRUE(rec.GetTrace(0).empty());
+}
+
+TEST_F(MemoryHistoryRecorderTest, DisableClearsEventsAndFlag) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0x1000, 128));
+  rec.SetEnabled(false, 0);
+  EXPECT_FALSE(MemHistoryEnabled());
+  EXPECT_TRUE(rec.GetTrace(0).empty());
+}
+
+TEST_F(MemoryHistoryRecorderTest, ClearKeepsCapacityAndEnabledState) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0x1000, 128));
+  rec.Clear();
+  EXPECT_TRUE(rec.GetTrace(0).empty());
+  EXPECT_TRUE(MemHistoryEnabled());
+
+  // Still usable after Clear(): capacity was preserved.
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0x2000, 64));
+  ASSERT_EQ(rec.GetTrace(0).size(), 1u);
+  EXPECT_EQ(rec.GetTrace(0)[0].addr, 0x2000u);
+}
+
+TEST_F(MemoryHistoryRecorderTest, AnnotateMarksEveryExistingRing) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  // Annotate only reaches rings that already exist, so touch two devices.
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0x1000, 128));
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 1, 0x2000, 128));
+
+  rec.Annotate("gstep 7 begin");
+
+  for (int dev : {0, 1}) {
+    auto trace = rec.GetTrace(dev);
+    ASSERT_EQ(trace.size(), 2u) << "device " << dev;
+    EXPECT_EQ(trace[1].action, MemHistoryAction::kAnnotation);
+    EXPECT_EQ(trace[1].op_name, "gstep 7 begin");
+    EXPECT_EQ(trace[1].size, 0u);
+    EXPECT_EQ(trace[1].addr, 0u);
+    EXPECT_GT(trace[1].time_us, 0u);
+  }
+}
+
+TEST_F(MemoryHistoryRecorderTest, AnnotateIsNoOpWhenDisabled) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0x1000, 128));
+  rec.SetEnabled(false, 8);
+  rec.Annotate("ignored");
+  EXPECT_TRUE(rec.GetTrace(0).empty());
+}
+
+// ---------------------------------------------------------------------------
+// Per-thread op label / Python-stack-id guards
+// ---------------------------------------------------------------------------
+
+TEST_F(MemoryHistoryRecorderTest, LabelGuardIsNoOpWhenDisabled) {
+  {
+    MemLabelGuard guard("matmul");
+    EXPECT_EQ(CurrentMemOpLabel(), nullptr);
+  }
+  EXPECT_EQ(CurrentMemOpLabel(), nullptr);
+  EXPECT_TRUE(MemOpLabelStack().empty());
+}
+
+TEST_F(MemoryHistoryRecorderTest, LabelGuardNestsAndPops) {
+  MemoryHistoryRecorder::Instance().SetEnabled(true, 8);
+  EXPECT_EQ(CurrentMemOpLabel(), nullptr);
+  {
+    MemLabelGuard outer("fused_moe");
+    ASSERT_NE(CurrentMemOpLabel(), nullptr);
+    EXPECT_STREQ(CurrentMemOpLabel(), "fused_moe");
+    {
+      MemLabelGuard inner("matmul");
+      EXPECT_STREQ(CurrentMemOpLabel(), "matmul");
+    }
+    // Innermost label restored after the nested scope exits.
+    EXPECT_STREQ(CurrentMemOpLabel(), "fused_moe");
+  }
+  EXPECT_EQ(CurrentMemOpLabel(), nullptr);
+}
+
+TEST_F(MemoryHistoryRecorderTest, StackGuardIsNoOpWhenDisabled) {
+  {
+    MemStackGuard guard(42);
+    EXPECT_EQ(CurrentMemStackId(), 0u);
+  }
+  EXPECT_EQ(CurrentMemStackId(), 0u);
+  EXPECT_TRUE(MemStackIdStack().empty());
+}
+
+TEST_F(MemoryHistoryRecorderTest, StackGuardNestsAndPops) {
+  MemoryHistoryRecorder::Instance().SetEnabled(true, 8);
+  EXPECT_EQ(CurrentMemStackId(), 0u);
+  {
+    MemStackGuard outer(11);
+    EXPECT_EQ(CurrentMemStackId(), 11u);
+    {
+      MemStackGuard inner(22);
+      EXPECT_EQ(CurrentMemStackId(), 22u);
+    }
+    // An outer wrapper (e.g. PyLayer.apply) stays active between nested ops.
+    EXPECT_EQ(CurrentMemStackId(), 11u);
+  }
+  EXPECT_EQ(CurrentMemStackId(), 0u);
+}
+
+TEST_F(MemoryHistoryRecorderTest, GuardsStayBalancedWhenToggledMidScope) {
+  MemoryHistoryRecorder::Instance().SetEnabled(true, 8);
+  {
+    MemLabelGuard label("op");
+    MemStackGuard stack(5);
+    // Turning recording off inside the guarded scope must not unbalance the
+    // pop in the destructor.
+    MemoryHistoryRecorder::Instance().SetEnabled(false, 8);
+  }
+  EXPECT_TRUE(MemOpLabelStack().empty());
+  EXPECT_TRUE(MemStackIdStack().empty());
+}
+
+// ---------------------------------------------------------------------------
+// RecordMemHistory: label / stack-id attribution and the size threshold
+// ---------------------------------------------------------------------------
+
+TEST_F(MemoryHistoryRecorderTest, RecordMemHistoryPicksUpLabelAndStackId) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  {
+    MemLabelGuard label("gaussian_random");
+    MemStackGuard stack(99);
+    RecordMemHistory(MemHistoryAction::kAlloc, 0, 0x3000, 512, 7, 0);
+  }
+  auto trace = rec.GetTrace(0);
+  ASSERT_EQ(trace.size(), 1u);
+  EXPECT_EQ(trace[0].op_name, "gaussian_random");
+  EXPECT_EQ(trace[0].stack_id, 99u);
+  EXPECT_EQ(trace[0].id, 7u);
+  EXPECT_GT(trace[0].time_us, 0u);
+}
+
+TEST_F(MemoryHistoryRecorderTest, StackIdOnlyAttachedToAllocEvents) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  {
+    MemStackGuard stack(77);
+    RecordMemHistory(MemHistoryAction::kFreeCompleted, 0, 0x3000, 512, 0, 0);
+  }
+  auto trace = rec.GetTrace(0);
+  ASSERT_EQ(trace.size(), 1u);
+  EXPECT_EQ(trace[0].stack_id, 0u);
+}
+
+TEST_F(MemoryHistoryRecorderTest, StackMinSizeGatesStackAttribution) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  SetMemStackMinSize(1024);
+  {
+    MemStackGuard stack(55);
+    // Below the threshold: no stack recorded.
+    RecordMemHistory(MemHistoryAction::kAlloc, 0, 0x1000, 512, 0, 0);
+    // At/above the threshold: stack recorded.
+    RecordMemHistory(MemHistoryAction::kAlloc, 0, 0x2000, 1024, 0, 0);
+  }
+  auto trace = rec.GetTrace(0);
+  ASSERT_EQ(trace.size(), 2u);
+  EXPECT_EQ(trace[0].stack_id, 0u);
+  EXPECT_EQ(trace[1].stack_id, 55u);
+}
+
+TEST_F(MemoryHistoryRecorderTest, RecordMemHistoryWithoutGuardsIsUntagged) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  RecordMemHistory(MemHistoryAction::kAlloc, 0, 0x4000, 64, 0, 0);
+  auto trace = rec.GetTrace(0);
+  ASSERT_EQ(trace.size(), 1u);
+  EXPECT_TRUE(trace[0].op_name.empty());
+  EXPECT_EQ(trace[0].stack_id, 0u);
+}
+
+TEST_F(MemoryHistoryRecorderTest, StreamIsPreserved) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 8);
+  RecordMemHistory(MemHistoryAction::kFreeRequested, 0, 0x5000, 64, 0, 0xDEAD);
+  auto trace = rec.GetTrace(0);
+  ASSERT_EQ(trace.size(), 1u);
+  EXPECT_EQ(trace[0].stream, 0xDEADu);
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+TEST_F(MemoryHistoryRecorderTest, RecordAfterDisableIsDropped) {
+  // Deterministic form of the disable race: a writer that already passed the
+  // enabled check in RecordMemHistory() lands in Record() only after recording
+  // was stopped. Python disables with its default (non-zero) max_entries, so a
+  // capacity-only check would let the event through and events would reappear
+  // after `_record_memory_history(enabled=None)` returned.
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 1024);
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0x1000, 128));
+  ASSERT_EQ(rec.GetTrace(0).size(), 1u);
+
+  rec.SetEnabled(false, 1u << 20);
+  rec.Record(MakeEntry(MemHistoryAction::kAlloc, 0, 0x2000, 128));
+  EXPECT_TRUE(rec.GetTrace(0).empty());
+}
+
+TEST_F(MemoryHistoryRecorderTest, ToggleWhileRecordingLeavesNoEventsAfterOff) {
+  // Stress form of the same guarantee: once the last SetEnabled(false) returns
+  // and the writers have drained, no event may remain. Probabilistic by nature,
+  // and worth running under TSAN as well.
+  auto& rec = MemoryHistoryRecorder::Instance();
+  std::atomic<bool> stop{false};
+  std::vector<std::thread> writers;
+  for (int t = 0; t < 4; ++t) {
+    writers.emplace_back([&stop, t] {
+      for (uintptr_t i = 0; !stop.load(std::memory_order_relaxed); ++i) {
+        // Mirrors the allocator hook sites: check the flag, then record.
+        if (MemHistoryEnabled()) {
+          RecordMemHistory(
+              MemHistoryAction::kAlloc, t % 2, 0x1000 + i, 128, 0, 0);
+        }
+      }
+    });
+  }
+
+  for (int i = 0; i < 500; ++i) {
+    rec.SetEnabled(true, 1024);
+    // Non-zero max_entries on the disable path, exactly like the Python API.
+    rec.SetEnabled(false, 1u << 20);
+  }
+  stop.store(true, std::memory_order_relaxed);
+  for (auto& th : writers) th.join();
+
+  EXPECT_FALSE(MemHistoryEnabled());
+  for (int dev : {0, 1}) {
+    EXPECT_TRUE(rec.GetTrace(dev).empty()) << "device " << dev;
+  }
+}
+
+TEST_F(MemoryHistoryRecorderTest, LabelStacksAreThreadLocal) {
+  auto& rec = MemoryHistoryRecorder::Instance();
+  rec.SetEnabled(true, 64);
+  MemLabelGuard outer("main_thread_op");
+  MemStackGuard outer_stack(1);
+
+  std::thread worker([] {
+    // A different thread starts with empty stacks even though the main thread
+    // is inside a guarded scope.
+    EXPECT_EQ(CurrentMemOpLabel(), nullptr);
+    EXPECT_EQ(CurrentMemStackId(), 0u);
+    MemLabelGuard guard("worker_op");
+    EXPECT_STREQ(CurrentMemOpLabel(), "worker_op");
+  });
+  worker.join();
+
+  EXPECT_STREQ(CurrentMemOpLabel(), "main_thread_op");
+  EXPECT_EQ(CurrentMemStackId(), 1u);
+}
+
+TEST_F(MemoryHistoryRecorderTest, ReconfigureConcurrentlyWithRecording) {
+  // Regression guard: `capacity_` is written by SetEnabled() under rings_lock_
+  // and read by Record() outside of it, so it must be atomic and the ring must
+  // never exceed the requested bound. Run under TSAN to also catch the race.
+  auto& rec = MemoryHistoryRecorder::Instance();
+  constexpr size_t kCap = 64;
+  rec.SetEnabled(true, kCap);
+
+  std::atomic<bool> stop{false};
+  std::vector<std::thread> recorders;
+  for (int t = 0; t < 4; ++t) {
+    recorders.emplace_back([&rec, &stop, t] {
+      for (uintptr_t i = 0; !stop.load(std::memory_order_relaxed); ++i) {
+        rec.Record(MakeEntry(MemHistoryAction::kAlloc, t % 2, 0x1000 + i, 128));
+      }
+    });
+  }
+
+  for (int i = 0; i < 200; ++i) {
+    // Includes a zero capacity, which Record() must reject instead of
+    // computing `% 0`.
+    rec.SetEnabled(true, (i % 3 == 0) ? 8 : kCap);
+    rec.SetEnabled(true, 0);
+  }
+  rec.SetEnabled(true, kCap);
+  stop.store(true, std::memory_order_relaxed);
+  for (auto& th : recorders) th.join();
+
+  for (int dev : {0, 1}) {
+    EXPECT_LE(rec.GetTrace(dev).size(), kCap) << "device " << dev;
+  }
+}
+
+}  // namespace memory
+}  // namespace paddle

--- a/test/legacy_test/test_memory_history_recorder.py
+++ b/test/legacy_test/test_memory_history_recorder.py
@@ -1,0 +1,220 @@
+#   Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pickle
+import platform
+import tempfile
+import unittest
+
+import paddle
+
+_VMM_FLAG = 'FLAGS_use_virtual_memory_auto_growth'
+
+# The GPU allocator is built lazily on the first allocation, so the VMM V1 stack
+# has to be selected before anything touches device memory -- hence module
+# scope rather than setUp().
+if paddle.is_compiled_with_cuda():
+    paddle.set_flags({_VMM_FLAG: 1})
+
+
+def _skip() -> bool:
+    return (
+        (not paddle.is_compiled_with_cuda())
+        or paddle.is_compiled_with_rocm()
+        or platform.system() == "Windows"
+    )
+
+
+@unittest.skipIf(
+    _skip(), "memory history recording requires the CUDA VMM V1 allocator"
+)
+class TestMemoryHistoryRecorder(unittest.TestCase):
+    def tearDown(self):
+        # Never leave recording on for the next test: it is process-global.
+        paddle.device.cuda._record_memory_history(enabled=None)
+
+    def _traces(self):
+        snapshot = paddle.device.cuda._snapshot()
+        self.assertIn("segments", snapshot)
+        self.assertIn("device_traces", snapshot)
+        self.assertGreater(len(snapshot["device_traces"]), 0)
+        return snapshot["device_traces"][0]
+
+    def test_requires_vmm_allocator_flag(self):
+        # Enabling without the VMM V1 allocator must fail loudly rather than
+        # arm a recorder that cannot produce allocation events.
+        paddle.set_flags({_VMM_FLAG: 0})
+        try:
+            with self.assertRaises(RuntimeError):
+                paddle.device.cuda._record_memory_history(enabled="all")
+        finally:
+            paddle.set_flags({_VMM_FLAG: 1})
+
+    def test_disable_is_allowed_without_the_flag(self):
+        # Turning recording off must never raise, whatever the flag says.
+        paddle.set_flags({_VMM_FLAG: 0})
+        try:
+            paddle.device.cuda._record_memory_history(enabled=None)
+        finally:
+            paddle.set_flags({_VMM_FLAG: 1})
+
+    def test_alloc_and_free_events_are_recorded(self):
+        paddle.device.cuda._record_memory_history(
+            enabled="all", max_entries=100000
+        )
+        tensor = paddle.zeros(shape=[1024], dtype="float32")
+        del tensor
+
+        traces = self._traces()
+        actions = [e["action"] for e in traces]
+        self.assertIn("alloc", actions)
+        self.assertIn("free_completed", actions)
+
+        for event in traces:
+            self.assertIn("addr", event)
+            self.assertIn("size", event)
+            self.assertIn("stream", event)
+            self.assertIn("time_us", event)
+            self.assertIn("op_name", event)
+            self.assertIn("frames", event)
+
+    def test_alloc_and_free_report_the_same_size(self):
+        # The alloc hook records the actual block size, so an alloc/free pair
+        # for one address must agree (a raw request size would not).
+        paddle.device.cuda._record_memory_history(
+            enabled="all", max_entries=100000
+        )
+        tensor = paddle.zeros(shape=[7], dtype="float32")
+        del tensor
+
+        sizes = {}
+        for event in self._traces():
+            if event["action"] == "alloc":
+                sizes[event["addr"]] = event["size"]
+            elif event["action"] == "free_completed":
+                if event["addr"] in sizes:
+                    self.assertEqual(sizes[event["addr"]], event["size"])
+        self.assertGreater(len(sizes), 0)
+
+    def test_annotation_marker(self):
+        paddle.device.cuda._record_memory_history(
+            enabled="all", max_entries=100000
+        )
+        # A marker is only appended to rings that already exist.
+        tensor = paddle.zeros(shape=[64], dtype="float32")
+        paddle.device.cuda._annotate_memory_history("gstep 3 begin")
+        del tensor
+
+        markers = [e for e in self._traces() if e["action"] == "annotation"]
+        self.assertEqual(len(markers), 1)
+        self.assertEqual(markers[0]["op_name"], "gstep 3 begin")
+        self.assertEqual(markers[0]["size"], 0)
+
+    def test_annotation_without_recording_is_a_no_op(self):
+        paddle.device.cuda._record_memory_history(enabled=None)
+        paddle.device.cuda._annotate_memory_history("ignored")
+        self.assertEqual(len(self._traces()), 0)
+
+    def test_disable_clears_recorded_events(self):
+        paddle.device.cuda._record_memory_history(
+            enabled="all", max_entries=100000
+        )
+        tensor = paddle.zeros(shape=[64], dtype="float32")
+        del tensor
+        self.assertGreater(len(self._traces()), 0)
+
+        # Disabling drops the rings, so a snapshot has to be taken first.
+        paddle.device.cuda._record_memory_history(enabled=None)
+        self.assertEqual(len(self._traces()), 0)
+
+    def test_max_entries_bounds_the_ring(self):
+        max_entries = 8
+        paddle.device.cuda._record_memory_history(
+            enabled="all", max_entries=max_entries
+        )
+        for _ in range(64):
+            tensor = paddle.zeros(shape=[32], dtype="float32")
+            del tensor
+        self.assertLessEqual(len(self._traces()), max_entries)
+
+    def test_python_stack_is_captured(self):
+        paddle.device.cuda._record_memory_history(
+            enabled="all", stacks="all", max_entries=100000
+        )
+        tensor = paddle.zeros(shape=[128], dtype="float32")
+        del tensor
+
+        allocs = [e for e in self._traces() if e["action"] == "alloc"]
+        self.assertGreater(len(allocs), 0)
+        # A resolved Python stack has several frames; the op_name fallback
+        # produces exactly one.
+        deepest = max(len(e["frames"]) for e in allocs)
+        self.assertGreater(deepest, 1)
+        for event in allocs:
+            for frame in event["frames"]:
+                self.assertIn("filename", frame)
+                self.assertIn("name", frame)
+                self.assertIn("line", frame)
+
+    def test_stacks_disabled_falls_back_to_op_name(self):
+        paddle.device.cuda._record_memory_history(
+            enabled="all", stacks="none", max_entries=100000
+        )
+        tensor = paddle.zeros(shape=[128], dtype="float32")
+        del tensor
+
+        allocs = [e for e in self._traces() if e["action"] == "alloc"]
+        self.assertGreater(len(allocs), 0)
+        for event in allocs:
+            self.assertLessEqual(len(event["frames"]), 1)
+
+    def test_stacks_min_size_skips_small_allocations(self):
+        paddle.device.cuda._record_memory_history(
+            enabled="all",
+            stacks="all",
+            max_entries=100000,
+            stacks_min_size=1 << 30,
+        )
+        tensor = paddle.zeros(shape=[128], dtype="float32")
+        del tensor
+
+        allocs = [e for e in self._traces() if e["action"] == "alloc"]
+        self.assertGreater(len(allocs), 0)
+        # Every allocation is far below the threshold, so no stack is attached.
+        for event in allocs:
+            self.assertLessEqual(len(event["frames"]), 1)
+
+    def test_dump_snapshot_roundtrip(self):
+        paddle.device.cuda._record_memory_history(
+            enabled="all", max_entries=100000
+        )
+        tensor = paddle.zeros(shape=[256], dtype="float32")
+        del tensor
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "snapshot.pickle")
+            paddle.device.cuda._dump_snapshot(path)
+            self.assertTrue(os.path.exists(path))
+            with open(path, "rb") as f:
+                loaded = pickle.load(f)
+
+        self.assertIn("segments", loaded)
+        self.assertIn("device_traces", loaded)
+        actions = [e["action"] for e in loaded["device_traces"][0]]
+        self.assertIn("alloc", actions)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* [VMM] Add GPU memory history recorder with Python stack capture

* fix review comments

* Add runtime error and simplify comments

<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->


### Description
<!-- Describe what you’ve done -->


### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
