### PR TITLE
[Cherry-Pick][Operator Mechanism] Make view dtype forward only

### DIFF
--- a/paddle/phi/kernels/stride/view_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/view_grad_kernel.cc
@@ -36,25 +36,8 @@ void ViewShapeGradKernel(const Context& dev_ctx,
   ReshapeStridedKernel(dev_ctx, out_grad, vectorize(input.dims()), input_grad);
 }
 
-template <typename Context>
-void ViewDtypeGradKernel(const Context& dev_ctx,
-                         const DenseTensor& input,
-                         const DenseTensor& out_grad,
-                         DataType dtype,
-                         DenseTensor* input_grad) {
-  if (!FLAGS_use_stride_kernel) {
-    PADDLE_THROW(common::errors::Fatal(
-        "FLAGS_use_stride_kernel is closed. Strided kernel "
-        "be called, something wrong has happened!"));
-  }
-  ViewDtypeKernel<Context>(dev_ctx, out_grad, input.dtype(), input_grad);
-}
 }  // namespace phi
 
 PD_REGISTER_KERNEL_FOR_ALL_BACKEND_DTYPE(view_shape_grad,
                                          STRIDED,
                                          phi::ViewShapeGradKernel) {}
-
-PD_REGISTER_KERNEL_FOR_ALL_BACKEND_DTYPE(view_dtype_grad,
-                                         STRIDED,
-                                         phi::ViewDtypeGradKernel) {}

--- a/paddle/phi/kernels/view_grad_kernel.h
+++ b/paddle/phi/kernels/view_grad_kernel.h
@@ -24,11 +24,4 @@ void ViewShapeGradKernel(const Context& dev_ctx,
                          const DenseTensor& out_grad,
                          const std::vector<int64_t>& dims,
                          DenseTensor* input_grad);
-
-template <typename Context>
-void ViewDtypeGradKernel(const Context& dev_ctx,
-                         const DenseTensor& input,
-                         const DenseTensor& out_grad,
-                         DataType dtype,
-                         DenseTensor* input_grad);
 }  // namespace phi

--- a/paddle/phi/ops/yaml/backward.yaml
+++ b/paddle/phi/ops/yaml/backward.yaml
@@ -4157,18 +4157,6 @@
     data_type : x
   composite: var_grad(x, out_grad, axis, keepdim, unbiased, correction, x_grad)
 
-- backward_op : view_dtype_grad
-  forward : view_dtype (Tensor input, DataType dtype) -> Tensor(out)
-  args : (Tensor input, Tensor out_grad, DataType dtype)
-  output : Tensor(input_grad)
-  infer_meta :
-    func : StridedUnChangedInferMeta
-    param : [input]
-  kernel :
-    func : view_dtype_grad
-    data_type : out_grad
-  no_need_buffer: input
-
 - backward_op : view_shape_double_grad
   forward : view_shape_grad (Tensor input, Tensor grad_out, int64_t[] dims) -> Tensor(grad_input)
   args : (Tensor grad_input_grad, int64_t[] dims)

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -5955,8 +5955,8 @@
   kernel :
     func : view_dtype
     data_type : input
-  backward : view_dtype_grad
   no_need_buffer : input
+  traits : paddle::dialect::ForwardOnlyTrait
   interfaces : paddle::dialect::InferSymbolicShapeInterface
 
 - op : view_shape

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -8144,8 +8144,6 @@ def view(
             shape_or_dtype, (core.VarDesc.VarType, core.DataType)
         ):
             shape_or_dtype = convert_np_dtype_to_dtype_(shape_or_dtype)
-        if x.dtype == shape_or_dtype:
-            return x
         return _C_ops.view_dtype(x, shape_or_dtype)
 
 

--- a/test/legacy_test/test_stride.py
+++ b/test/legacy_test/test_stride.py
@@ -1125,9 +1125,11 @@ class TestViewGrad(unittest.TestCase):
         paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
         x = paddle.randn([2, 4], dtype="float32", requires_grad=True)
 
-        out = x.view(paddle.uint8)
+        out_uint8 = x.view(paddle.uint8)
+        out_float32 = x.view(paddle.float32)
 
-        self.assertTrue(out.stop_gradient)
+        self.assertTrue(out_uint8.stop_gradient)
+        self.assertTrue(out_float32.stop_gradient)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_stride.py
+++ b/test/legacy_test/test_stride.py
@@ -1120,6 +1120,15 @@ class TestViewGrad(unittest.TestCase):
         x_grad_expected = paddle.full_like(x, 1.0)
         self.assertEqual((x.grad == x_grad_expected).all(), True)
 
+    def test_view_dtype_is_forward_only(self):
+        paddle.disable_static()
+        paddle.base.set_flags({"FLAGS_use_stride_kernel": True})
+        x = paddle.randn([2, 4], dtype="float32", requires_grad=True)
+
+        out = x.view(paddle.uint8)
+
+        self.assertTrue(out.stop_gradient)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
view_shape 和 view_dtype 虽然都使用 view 语义，但它们的数学含义不同。

view_shape 只改变 Tensor 的 shape、stride 和索引关系，不改变元素的数值含义。例如：

```python
x = [[1, 2, 3],
     [4, 5, 6]]

y = x.view([3, 2])
```

这只是重新排列同一批数值，因此其梯度可以通过将 out_grad reshape 回输入 shape 得到：

```python
input_grad = out_grad.reshape(input.shape)
```

而 view_dtype 并不是数值类型转换，而是将相同的底层 bit pattern 按另一种 dtype 重新解释。例如 float32 -> int32 是 bit reinterpretation，而不是数值转换。该操作通常不具备连续、稳定且有意义的数值导数，且输出可能是整型或布尔类型。

因此，本 PR 将 view_dtype 调整为 forward-only；view_shape 的反向行为保持不变。

#### Changes

- 从 `ops.yaml` 中移除 `view_dtype` 的 backward 配置。
- 从 `backward.yaml` 中移除 `view_dtype_grad` 定义。
- 删除 `ViewDtypeGradKernel` 及其 kernel 注册。
- 为 `view_dtype` 添加 `ForwardOnlyTrait`。
- 删除 Python API 中同 dtype 时直接返回原 Tensor 的 fast path，使所有 `view(dtype)` 调用遵循统一的 forward-only 语义。
- 增加同 dtype 和异 dtype 两种场景的 `stop_gradient` 测试。

devPR:https://github.com/PaddlePaddle/Paddle/pull/79654
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否