### PR TITLE
[Operator Mechanism] Fix paddle.compat.min/max gradient indexing

### DIFF
--- a/paddle/phi/kernels/gpu/min_max_with_index_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/min_max_with_index_grad_kernel.cu
@@ -30,9 +30,13 @@ using EnableIfNonInteger =
     typename std::enable_if<!std::is_integral<T>::value, int>::type;
 
 // Here if keepdim=True, this will fallback to a simplified version of
-// take_along_axis. However, if keepdim=False (by default), indices will
-// not have equal rank will the input values (and values_grad), therefore
-// needs an unsqueeze operation by shallow copying indices and Resize
+// take_along_axis. However, if keepdim=False (by default), indices and
+// values_grad will not have equal rank with the input, therefore both of
+// them need an unsqueeze operation by shallow copying and Resize.
+// values_grad must be unsqueezed together with indices: the scatter functor
+// walks the index tensor with the input rank and reads values_grad through
+// `src.strides()[i]`, so a lower-rank values_grad makes every stride shift
+// by one dim (only dim == rank-1 happens to be unaffected).
 #define DEFINE_WITH_INDEX_GRAD_KERNEL(OpType)                                \
   template <typename T, typename Context, EnableIfNonInteger<T> = 0>         \
   void OpType##WithIndexGradKernel(const Context& dev_ctx,                   \
@@ -53,15 +57,21 @@ using EnableIfNonInteger =
       dim_val += x.dims().size();                                            \
     }                                                                        \
     DenseTensor shallow_copied_inds(indices);                                \
+    DenseTensor shallow_copied_grad(values_grad);                            \
     if (!keepdim) {                                                          \
-      auto indices_dim = x.dims();                                           \
-      indices_dim[dim_val] = 1;                                              \
-      shallow_copied_inds.Resize(indices_dim);                               \
+      auto unsqueezed_dims = x.dims();                                       \
+      unsqueezed_dims[dim_val] = 1;                                          \
+      shallow_copied_inds.Resize(unsqueezed_dims);                           \
+      shallow_copied_grad.Resize(unsqueezed_dims);                           \
     }                                                                        \
     funcs::SetConstant<Context, T> functor;                                  \
     functor(dev_ctx, x_grad, static_cast<T>(0));                             \
-    funcs::gpu_scatter_add_kernel<T, int64_t>(                               \
-        *x_grad, dim_val, shallow_copied_inds, values_grad, true, dev_ctx);  \
+    funcs::gpu_scatter_add_kernel<T, int64_t>(*x_grad,                       \
+                                              dim_val,                       \
+                                              shallow_copied_inds,           \
+                                              shallow_copied_grad,           \
+                                              true,                          \
+                                              dev_ctx);                      \
   }                                                                          \
   template <typename T, typename Context, EnableIfInteger<T> = 0>            \
   void OpType##WithIndexGradKernel(const Context& dev_ctx,                   \

--- a/test/legacy_test/test_compat_minmax.py
+++ b/test/legacy_test/test_compat_minmax.py
@@ -122,6 +122,51 @@ class TestCompatMinMaxBase(unittest.TestCase):
         result[0].backward()
         np.testing.assert_allclose(data.grad.numpy(), expected_grad2, atol=1e-6)
 
+    def test_case2_grad_distinct_grad_outputs(self):
+        """Backward with keepdim=False and a non-trailing dim.
+
+        A uniform (all-ones) upstream gradient cannot distinguish a wrong
+        grad_outputs indexing, because every element read is 1. The GPU
+        min/max_with_index_grad kernel walks the unsqueezed indices with the
+        input rank and reads values_grad through its strides, so values_grad
+        must be unsqueezed as well; otherwise every stride shifts by one dim
+        (only dim == rank - 1 happens to be unaffected). Feed grad_outputs
+        with pairwise distinct elements to lock that down.
+        """
+        shape = [2, 3, 4]
+        numel = int(np.prod(shape))
+        # gcd(7, 24) == 1, so this is a permutation of range(numel): all
+        # elements differ and argmin/argmax is unambiguous (no ties).
+        x_np = ((np.arange(numel) * 7) % numel).astype('float64').reshape(shape)
+        reduce_index = (
+            np.argmin if self.test_op_name.endswith("min") else np.argmax
+        )
+
+        for dim in (0, 1, -2):
+            axis = dim % len(shape)
+            out_shape = [s for i, s in enumerate(shape) if i != axis]
+            dy_np = (np.arange(1, int(np.prod(out_shape)) + 1) * 0.5).reshape(
+                out_shape
+            )
+            expected_grad = np.zeros(shape)
+            np.put_along_axis(
+                expected_grad,
+                np.expand_dims(reduce_index(x_np, axis=axis), axis=axis),
+                np.expand_dims(dy_np, axis=axis),
+                axis=axis,
+            )
+
+            data = paddle.to_tensor(x_np, stop_gradient=False)
+            result = self.test_op(data, dim=dim)
+            self.assertEqual(result.values.shape, out_shape)
+            result.values.backward(paddle.to_tensor(dy_np))
+            np.testing.assert_allclose(
+                data.grad.numpy(),
+                expected_grad,
+                atol=1e-6,
+                err_msg=f"{self.test_op_name} backward mismatch at dim={dim}",
+            )
+
     def test_case3_elementwise(self):
         x = paddle.to_tensor([[1, 5], [4, 2]], dtype='float32')
         y = paddle.to_tensor([[3, 2], [1, 6]], dtype='float32')


### PR DESCRIPTION
### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
修复 `paddle.compat.min/max(input, dim=..., keepdim=False)` 在 GPU 上沿非末尾维度反向传播时，上游梯度 stride 与已扩维 indices 的 rank 不一致而导致的梯度索引错误。实现将 `values_grad` 与 `indices` 一并扩维，并新增非均匀上游梯度回归测试，覆盖正轴和负轴。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是。变化仅限上述错误路径；修复后梯度与 `paddle.compat.min/max` 返回的索引一致。验证方式为新增非均匀上游梯度用例，覆盖 `min`、`max` 以及非末尾正负轴。