### PR TITLE
[Performance] paddle.save supports protocol=5 with zero-copy

### DIFF
--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import collections
 import copyreg
+import ctypes
 import dataclasses
 import os
 import pickle
@@ -77,7 +78,7 @@ if TYPE_CHECKING:
 
     class _SaveOptions(TypedDict):
         use_binary_format: NotRequired[bool]
-        pickle_protocol: NotRequired[Literal[2, 3, 4]]
+        pickle_protocol: NotRequired[Literal[2, 3, 4, 5]]
 
 
 __all__ = []
@@ -97,7 +98,7 @@ def clear_async_save_task_queue() -> None:
 def async_save(
     obj: object,
     path: str | BytesIO,
-    protocol: Literal[2, 3, 4] = 4,
+    protocol: Literal[2, 3, 4, 5] = 5,
     sync_other_task: bool = False,
     **configs: Unpack[_EmptyDict],
 ) -> None:
@@ -111,8 +112,8 @@ def async_save(
         obj(Object) : The object to be saved.
         path(str|BytesIO) : The path/buffer of the object to be saved.
           If saved in the current directory, the input path string will be used as the file name.
-        protocol(int, optional): The protocol version of pickle module must be greater than 1 and less than 5.
-                                 Default: 4
+        protocol(int, optional): The protocol version of pickle module must be greater than 1 and less than 6.
+                                 Default: 5
         sync_other_task(bool) : Determine whether to wait other async save task to be finished before this one be put in queue.
         **configs(dict, optional): compatible argument to paddle.save, but will be overridden by default setting.
     Examples:
@@ -163,6 +164,20 @@ def async_save(
     async_save_queue.append(t)
 
 
+def _value_to_numpy(value):
+    """Get the numpy copy or view (if satisfied) of the value."""
+    if (
+        isinstance(value, core.eager.Tensor)
+        and value.is_contiguous()
+        and (value.place.is_cpu_place() or value.place.is_cuda_pinned_place())
+    ):
+        # Use zero-copy if the tensor is in DRAM and contiguous.
+        if value.dtype == paddle.float32:
+            buf = (ctypes.c_float * value.size).from_address(value.data_ptr())
+            return np.frombuffer(buf, dtype=np.float32).reshape(value.shape)
+    return np.array(value.cpu())
+
+
 def _build_saved_state_dict(state_dict):
     save_dict = {}
     name_table = {}
@@ -181,7 +196,7 @@ def _build_saved_state_dict(state_dict):
                     and core.is_compiled_with_custom_device('npu')
                 ):
                     value = paddle._C_ops.npu_identity(value, -1)
-                save_dict[key] = np.array(value.cpu())
+                save_dict[key] = _value_to_numpy(value)
             name_table[key] = value.name
         else:
             save_dict[key] = value
@@ -427,9 +442,9 @@ def _pickle_save(obj, f, protocol):
             f"The 'protocol' MUST be `int`, but received {type(protocol)}"
         )
 
-    if protocol < 2 or protocol > 4:
+    if protocol < 2 or protocol > 5:
         raise ValueError(
-            f"Expected 1<'protocol'<5, but received protocol={protocol}"
+            f"Expected 1<'protocol'<6, but received protocol={protocol}"
         )
 
     def reduce_varbase(self):
@@ -790,7 +805,7 @@ def _save_binary_var(obj, path):
 def save(
     obj: _StateDict | NestedStructure[Tensor] | Program,
     path: str | BytesIO,
-    protocol: Literal[2, 3, 4] = 4,
+    protocol: Literal[2, 3, 4, 5] = 5,
     **configs: Unpack[_SaveOptions],
 ) -> None:
     '''
@@ -812,8 +827,8 @@ def save(
         obj(Object) : The object to be saved.
         path(str|BytesIO) : The path/buffer of the object to be saved.
           If saved in the current directory, the input path string will be used as the file name.
-        protocol(int, optional): The protocol version of pickle module must be greater than 1 and less than 5.
-                                 Default: 4
+        protocol(int, optional): The protocol version of pickle module must be greater than 1 and less than 6.
+                                 Default: 5
         **configs(dict, optional): optional keyword arguments. The following options are currently supported:
           use_binary_format(bool): When the saved object is static graph variable, you can specify ``use_binary_for_var``.
           If True, save the file in the c++ binary format when saving a single static graph variable; otherwise, save it in pickle format.
@@ -1020,9 +1035,9 @@ def _legacy_save(obj, path, protocol=2):
             f"The 'protocol' MUST be `int`, but received {type(protocol)}"
         )
 
-    if protocol < 2 or protocol > 4:
+    if protocol < 2 or protocol > 5:
         raise ValueError(
-            f"Expected 1<'protocol'<5, but received protocol={protocol}"
+            f"Expected 1<'protocol'<6, but received protocol={protocol}"
         )
 
     if _is_file_path(path):

--- a/test/legacy_test/test_paddle_save_load.py
+++ b/test/legacy_test/test_paddle_save_load.py
@@ -124,22 +124,24 @@ class TestSaveLoadLargeParameters(unittest.TestCase):
 class TestSaveLoadPickle(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(
+            self.temp_dir.name,
+            "test_paddle_save_load_pickle_protocol",
+            "layer.pdparams",
+        )
+
+        # enable dygraph mode
+        paddle.disable_static()
+        # create network
+        layer = LinearNet()
+        self.save_dict = layer.state_dict()
 
     def tearDown(self):
         self.temp_dir.cleanup()
 
     def test_pickle_protocol(self):
-        # enable dygraph mode
-        paddle.disable_static()
-        # create network
-        layer = LinearNet()
-        save_dict = layer.state_dict()
-
-        path = os.path.join(
-            self.temp_dir.name,
-            "test_paddle_save_load_pickle_protocol",
-            "layer.pdparams",
-        )
+        save_dict = self.save_dict
+        path = self.path
 
         with self.assertRaises(ValueError):
             paddle.save(save_dict, path, 2.0)
@@ -148,14 +150,31 @@ class TestSaveLoadPickle(unittest.TestCase):
             paddle.save(save_dict, path, 1)
 
         with self.assertRaises(ValueError):
-            paddle.save(save_dict, path, 5)
+            paddle.save(save_dict, path, 6)
 
-        protocols = [2, 3, 4]
+        protocols = [2, 3, 4, 5]
         for protocol in protocols:
             paddle.save(save_dict, path, pickle_protocol=protocol)
             dict_load = paddle.load(path)
             # compare results before and after saving
             for key, value in save_dict.items():
+                np.testing.assert_array_equal(
+                    dict_load[key].numpy(), value.numpy()
+                )
+
+    def test_pickle_zero_copy(self):
+        """Test zero-copy for cpu/pinned tensor with protocol=5"""
+        places = ["cpu"]
+        if paddle.base.core.is_compiled_with_cuda():
+            places += ["pin_memory"]
+        for place in places:
+            save_dict = {
+                k: getattr(v, place)() for k, v in self.save_dict.items()
+            }
+            paddle.save(save_dict, self.path, protocol=5)
+            dict_load = paddle.load(self.path)
+            # compare results before and after saving
+            for key, value in self.save_dict.items():
                 np.testing.assert_array_equal(
                     dict_load[key].numpy(), value.numpy()
                 )
@@ -376,7 +395,7 @@ class TestSaveLoadAny(unittest.TestCase):
         with self.assertRaises(ValueError):
             paddle.save(tensor, path, pickle_protocol='3')
         with self.assertRaises(ValueError):
-            paddle.save(tensor, path, pickle_protocol=5)
+            paddle.save(tensor, path, pickle_protocol=6)
         paddle.save(tensor, path)
         t_dygraph = paddle.load(path)
         np_dygraph = paddle.load(path, return_numpy=True)


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Performance Optimization


### PR Types
Performance


### Description
1. paddle.save 支持 protocol=5，该等级对 numpy array 的存储做了 zero-copy 优化
2. 对类型为 float32 且已经在 DRAM（包括 cpu 和 pin）的场景做了 zero-copy 优化

### protocol升级到5不会对线上业务有任何兼容性问题
* 因为 pickle 是自解压格式，保存用什么版本都不影响解压，解压侧（paddle.load）会自适应
* python 官方文档明确 python>=3.8 即支持 protocol=5，当前 paddle 最低要求 python3.10
* 为了用户无感升级，本 PR 直接将 protocol 默认值改成 5，用户代码（formers、fleet）无需修改

### 性能提升

| 场景 | 旧用时 | 旧带宽 | 新用时 | 新带宽 | 性能提升 |
| --- | --- | --- | --- | --- | :-: | 
| 单卡单进程保存4G | 16.4s | 0.244GB/s | 2.23s | 1.79GB/s | <b>7.3x</b>
| 8卡并行保存每卡4G | 16.9s | 0.237GB/s | 2.90s | 1.38GB/s | <b>5.8x</b>

上述实验也说明，8 卡并行保存并不会对`/dev/shm`造成太大的压力，瓶颈不在于 8 卡总保存量太大，而在于单卡保存 4G 本身就太慢

### 是否引起精度变化
否
