### PR TITLE
[CI] Remove skip-skill checks from workflows

### DIFF
--- a/.github/workflows/CI-Build.yml
+++ b/.github/workflows/CI-Build.yml
@@ -16,37 +16,12 @@ env:
   COMMIT_ID: ${{ github.event.pull_request.head.sha }}
 
 jobs:
-  check-skill:
-    name: Check file paths
-    if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on:
-      group: APPROVAL
-    continue-on-error: true
-    permissions:
-      contents: read
-      actions: read
-    outputs:
-      can-skip: ${{ steps.skip-skill.outputs.should-skip || 'false' }}
-    steps:
-      - name: Cleanup
-        run: |
-          rm -rf * .[^.]*
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Run skip check
-        id: skip-skill
-        uses: ./.github/actions/skip-skill
-        with:
-          ignore-paths: '.agents/skills/**'
-
   clone:
     name: Clone-linux
-    needs: check-skill
     uses: ./.github/workflows/_Clone-linux.yml
     with:
       clone_dir: Paddle-build
       workflow-name: 'CI-build'
-      skill-can-skip: ${{ needs.check-skill.outputs.can-skip }}
 
   build-docker:
     name: build docker images

--- a/.github/workflows/CI-Build.yml
+++ b/.github/workflows/CI-Build.yml
@@ -16,12 +16,37 @@ env:
   COMMIT_ID: ${{ github.event.pull_request.head.sha }}
 
 jobs:
+  check-skill:
+    name: Check file paths
+    if: ${{ github.repository_owner == 'PaddlePaddle' }}
+    runs-on:
+      group: APPROVAL-test
+    continue-on-error: true
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      can-skip: ${{ steps.skip-skill.outputs.should-skip || 'false' }}
+    steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run skip check
+        id: skip-skill
+        uses: ./.github/actions/skip-skill
+        with:
+          ignore-paths: '.agents/skills/**'
+
   clone:
     name: Clone-linux
+    needs: check-skill
     uses: ./.github/workflows/_Clone-linux.yml
     with:
       clone_dir: Paddle-build
       workflow-name: 'CI-build'
+      skill-can-skip: ${{ needs.check-skill.outputs.can-skip }}
 
   build-docker:
     name: build docker images

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -16,33 +16,9 @@ env:
   COMMIT_ID: ${{ github.event.pull_request.head.sha }}
 
 jobs:
-  check-skill:
-    name: Check file paths
-    if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on:
-      group: APPROVAL
-    permissions:
-      contents: read
-    outputs:
-      can-skip: ${{ steps.skip-skill.outputs.should-skip }}
-    steps:
-      - name: Cleanup
-        run: |
-          rm -rf * .[^.]*
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Run skip check
-        id: skip-skill
-        uses: ./.github/actions/skip-skill
-        with:
-          ignore-paths: '.agents/skills/**'
-
   clone:
     name: Clone-windows
-    needs: check-skill
     uses: ./.github/workflows/_Clone-windows.yml
-    with:
-      skill-can-skip: ${{ needs.check-skill.outputs.can-skip }}
 
   win-openblas:
     name: Windows-OPENBLAS

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -16,9 +16,33 @@ env:
   COMMIT_ID: ${{ github.event.pull_request.head.sha }}
 
 jobs:
+  check-skill:
+    name: Check file paths
+    if: ${{ github.repository_owner == 'PaddlePaddle' }}
+    runs-on:
+      group: APPROVAL-test
+    permissions:
+      contents: read
+    outputs:
+      can-skip: ${{ steps.skip-skill.outputs.should-skip }}
+    steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run skip check
+        id: skip-skill
+        uses: ./.github/actions/skip-skill
+        with:
+          ignore-paths: '.agents/skills/**'
+
   clone:
     name: Clone-windows
+    needs: check-skill
     uses: ./.github/workflows/_Clone-windows.yml
+    with:
+      skill-can-skip: ${{ needs.check-skill.outputs.can-skip }}
 
   win-openblas:
     name: Windows-OPENBLAS

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,34 +16,11 @@ env:
   COMMIT_ID: ${{ github.event.pull_request.head.sha }}
 
 jobs:
-  check-skill:
-    name: Check file paths
-    if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on:
-      group: APPROVAL
-    permissions:
-      contents: read
-    outputs:
-      can-skip: ${{ steps.skip-skill.outputs.should-skip }}
-    steps:
-      - name: Cleanup
-        run: |
-          rm -rf * .[^.]*
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Run skip check
-        id: skip-skill
-        uses: ./.github/actions/skip-skill
-        with:
-          ignore-paths: '.agents/skills/**'
-
   clone:
     name: Clone-linux
-    needs: check-skill
     uses: ./.github/workflows/_Clone-linux.yml
     with:
       workflow-name: 'CI'
-      skill-can-skip: ${{ needs.check-skill.outputs.can-skip }}
 
   build-docker:
     name: build docker images

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,11 +16,34 @@ env:
   COMMIT_ID: ${{ github.event.pull_request.head.sha }}
 
 jobs:
+  check-skill:
+    name: Check file paths
+    if: ${{ github.repository_owner == 'PaddlePaddle' }}
+    runs-on:
+      group: APPROVAL-test
+    permissions:
+      contents: read
+    outputs:
+      can-skip: ${{ steps.skip-skill.outputs.should-skip }}
+    steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run skip check
+        id: skip-skill
+        uses: ./.github/actions/skip-skill
+        with:
+          ignore-paths: '.agents/skills/**'
+
   clone:
     name: Clone-linux
+    needs: check-skill
     uses: ./.github/workflows/_Clone-linux.yml
     with:
       workflow-name: 'CI'
+      skill-can-skip: ${{ needs.check-skill.outputs.can-skip }}
 
   build-docker:
     name: build docker images

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -29,12 +29,37 @@ defaults:
     shell: bash
 
 jobs:
+  check-skill:
+    name: Check file paths
+    if: ${{ github.repository_owner == 'PaddlePaddle' }}
+    runs-on:
+      group: APPROVAL-test
+    continue-on-error: true
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      can-skip: ${{ steps.skip-skill.outputs.should-skip || 'false' }}
+    steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run skip check
+        id: skip-skill
+        uses: ./.github/actions/skip-skill
+        with:
+          ignore-paths: '.agents/skills/**'
+
   clone:
     name: Coverage clone
+    needs: check-skill
     uses: ./.github/workflows/_Clone-linux.yml
     with:
       workflow-name: "coverage"
       clone_dir: Paddle-coverage
+      skill-can-skip: ${{ needs.check-skill.outputs.can-skip }}
 
   build-docker:
     name: Coverage build docker

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -29,37 +29,12 @@ defaults:
     shell: bash
 
 jobs:
-  check-skill:
-    name: Check file paths
-    if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on:
-      group: APPROVAL
-    continue-on-error: true
-    permissions:
-      contents: read
-      actions: read
-    outputs:
-      can-skip: ${{ steps.skip-skill.outputs.should-skip || 'false' }}
-    steps:
-      - name: Cleanup
-        run: |
-          rm -rf * .[^.]*
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Run skip check
-        id: skip-skill
-        uses: ./.github/actions/skip-skill
-        with:
-          ignore-paths: '.agents/skills/**'
-
   clone:
     name: Coverage clone
-    needs: check-skill
     uses: ./.github/workflows/_Clone-linux.yml
     with:
       workflow-name: "coverage"
       clone_dir: Paddle-coverage
-      skill-can-skip: ${{ needs.check-skill.outputs.can-skip }}
 
   build-docker:
     name: Coverage build docker

--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -30,12 +30,43 @@ defaults:
     shell: bash
 
 jobs:
+  check-skill:
+    name: Check file paths
+    if: ${{ github.repository_owner == 'PaddlePaddle' }}
+    runs-on:
+      group: APPROVAL-test
+    continue-on-error: true
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      can-skip: ${{ steps.skip-skill.outputs.should-skip }}
+    steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run skip check
+        id: skip-skill
+        uses: ./.github/actions/skip-skill
+        with:
+          ignore-paths: '.agents/skills/**'
+      - name: Print outputs
+        if: always()
+        run: |
+          echo "=== check-skill outputs ==="
+          echo "steps.skip-skill.outputs.should-skip: '${{ steps.skip-skill.outputs.should-skip }}'"
+          echo "============================"
+
   clone:
     name: Coverage clone
+    needs: [check-skill]
     uses: ./.github/workflows/_Clone-linux.yml
     with:
       workflow-name: "coverage"
       clone_dir: h-ci
+      skill-can-skip: ${{ needs.check-skill.outputs.can-skip }}
 
   check-bypass:
     name: Check bypass
@@ -226,8 +257,8 @@ jobs:
 
   test:
     name: Coverage test
-    needs: [build, check-bypass]
-    if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' }}
+    needs: [build, check-bypass, check-skill]
+    if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' && needs.check-skill.outputs.can-skip != 'true' }}
     runs-on:
       group: H-Coverage
     timeout-minutes: 120
@@ -355,8 +386,8 @@ jobs:
 
   fleet-build:
     name: Build Fleet whl
-    needs: [build, check-bypass]
-    if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' }}
+    needs: [build, check-bypass, check-skill]
+    if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' && needs.check-skill.outputs.can-skip != 'true' }}
     runs-on:
       group: GZ_BD-CPU
     timeout-minutes: 60
@@ -582,8 +613,8 @@ jobs:
 
   fleet-multi-card_test:
     name: Fleet Unit test (multi-card)
-    needs: [build, fleet-build, check-bypass]
-    if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' }}
+    needs: [build, fleet-build, check-bypass, check-skill]
+    if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' && needs.check-skill.outputs.can-skip != 'true' }}
     runs-on:
       group: Fleet-H-multi-card
     timeout-minutes: 120

--- a/.github/workflows/H-Coverage.yml
+++ b/.github/workflows/H-Coverage.yml
@@ -30,43 +30,12 @@ defaults:
     shell: bash
 
 jobs:
-  check-skill:
-    name: Check file paths
-    if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on:
-      group: APPROVAL
-    continue-on-error: true
-    permissions:
-      contents: read
-      actions: read
-    outputs:
-      can-skip: ${{ steps.skip-skill.outputs.should-skip }}
-    steps:
-      - name: Cleanup
-        run: |
-          rm -rf * .[^.]*
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Run skip check
-        id: skip-skill
-        uses: ./.github/actions/skip-skill
-        with:
-          ignore-paths: '.agents/skills/**'
-      - name: Print outputs
-        if: always()
-        run: |
-          echo "=== check-skill outputs ==="
-          echo "steps.skip-skill.outputs.should-skip: '${{ steps.skip-skill.outputs.should-skip }}'"
-          echo "============================"
-
   clone:
     name: Coverage clone
-    needs: [check-skill]
     uses: ./.github/workflows/_Clone-linux.yml
     with:
       workflow-name: "coverage"
       clone_dir: h-ci
-      skill-can-skip: ${{ needs.check-skill.outputs.can-skip }}
 
   check-bypass:
     name: Check bypass
@@ -257,8 +226,8 @@ jobs:
 
   test:
     name: Coverage test
-    needs: [build, check-bypass, check-skill]
-    if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' && needs.check-skill.outputs.can-skip != 'true' }}
+    needs: [build, check-bypass]
+    if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: H-Coverage
     timeout-minutes: 120
@@ -386,8 +355,8 @@ jobs:
 
   fleet-build:
     name: Build Fleet whl
-    needs: [build, check-bypass, check-skill]
-    if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' && needs.check-skill.outputs.can-skip != 'true' }}
+    needs: [build, check-bypass]
+    if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: GZ_BD-CPU
     timeout-minutes: 60
@@ -613,8 +582,8 @@ jobs:
 
   fleet-multi-card_test:
     name: Fleet Unit test (multi-card)
-    needs: [build, fleet-build, check-bypass, check-skill]
-    if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' && needs.check-skill.outputs.can-skip != 'true' }}
+    needs: [build, fleet-build, check-bypass]
+    if: ${{ needs.build.outputs.can-skip != 'true' && needs.check-bypass.outputs.can-skip != 'true' }}
     runs-on:
       group: Fleet-H-multi-card
     timeout-minutes: 120


### PR DESCRIPTION
### PR Category

Execute Infrastructure

### PR Types

Bug fixes

### Description

Remove the `check-skill` / `Check file paths` job from the CI, CI-Windows, CI-Build, Coverage, and H-Coverage workflows.

The skip check performed a second checkout with full history (`fetch-depth: 0`). When GitHub fetch throughput degraded, this blocked the workflow dependency chain for tens of minutes before the actual CI jobs could start.

The clone workflows now start directly and use their existing default `skill-can-skip=false`, so regular CI execution is preserved. H-Coverage dependencies and conditions were updated to remove the deleted job output.

### Verification

- Parsed all five modified workflow files as YAML.
- Verified no `check-skill`, `skip-skill`, or `needs.check-skill` references remain in `.github/workflows`.
- Ran `git diff --check`.

### 是否引起精度变化

否
