### PR TITLE
Fix the double registration of the shared layer in VPP mode

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -1129,7 +1129,10 @@ class PipelineLayer(nn.Layer):
                                 for _, param in obj:
                                     param.is_firstly_shared = True
                     else:
-                        self.add_sublayer(str(layer_index), instance)
+                        # when vpp is enabled, layer instance will be registered
+                        # by `run_function.append(instance)` as a sublayer of PipelineLayerChunk
+                        if self._num_virtual_pipeline_stages == 1:
+                            self.add_sublayer(str(layer_index), instance)
                         self._alias_shared_layer(
                             instance, self.shared_layers[layer.layer_name]
                         )

--- a/test/collective/fleet/hybrid_parallel_shared_submodule_weight_only.py
+++ b/test/collective/fleet/hybrid_parallel_shared_submodule_weight_only.py
@@ -85,6 +85,44 @@ class SharedSubmodulePipe(PipelineLayer):
         super().__init__(layers=layers, seg_method='layer:LocalLayer', **kwargs)
 
 
+class VPPSharedSubmodulePipe(PipelineLayer):
+    """Shared submodule layers spread across two virtual chunks.
+
+    The second shared layer is deliberately placed inside (rather than at the
+    beginning of) the second chunk.  Before the VPP registration fix this made
+    the layer appear both under the chunk and as a direct child of the root
+    PipelineLayer.
+    """
+
+    def __init__(self, **kwargs):
+        layers = [
+            SharedLayerDesc(
+                'shared_transformer',
+                TransformerLayer,
+                shared_weight_attr='transformer_layer_weights',
+                shared_submodule_weight_only=True,
+            ),
+            LayerDesc(LocalLayer),
+            LayerDesc(LocalLayer),
+            LayerDesc(nn.Identity),
+            SharedLayerDesc(
+                'shared_transformer',
+                MTPLayer,
+                shared_weight_attr='transformer_layer_weights',
+                shared_submodule_weight_only=True,
+            ),
+            LayerDesc(LocalLayer),
+            LayerDesc(LocalLayer),
+            LayerDesc(nn.Identity),
+        ]
+        super().__init__(
+            layers=layers,
+            seg_method='layer:LocalLayer',
+            num_virtual_pipeline_stages=2,
+            **kwargs,
+        )
+
+
 class TestSharedSubmoduleWeightOnly(unittest.TestCase):
     def setUp(self):
         strategy = fleet.DistributedStrategy()
@@ -123,6 +161,43 @@ class TestSharedSubmoduleWeightOnly(unittest.TestCase):
                 source_params[name],
                 f'{name} should be aliased to the source transformer layer.',
             )
+
+    def test_shared_submodule_weight_only_vpp_mapping(self):
+        hcg = fleet.get_hybrid_communicate_group()
+        model = VPPSharedSubmodulePipe(topology=hcg.topology())
+
+        chunks = model.get_model_chunks()
+        self.assertIsNotNone(chunks)
+        self.assertEqual(len(chunks), 2)
+
+        # Both shared instances are on stage 0.  Stage 1 has no matching
+        # SharedLayerDesc and therefore has nothing to validate here.
+        if hcg.get_stage_id() != 0:
+            return
+
+        source_layer = next(
+            layer for layer in chunks[0] if isinstance(layer, TransformerLayer)
+        )
+        dest_layer = next(
+            layer for layer in chunks[1] if isinstance(layer, MTPLayer)
+        )
+
+        source_params = dict(source_layer.named_parameters())
+        for name, param in dest_layer.transformer_layer.named_parameters():
+            self.assertIs(
+                param,
+                source_params[name],
+                f'{name} should be aliased to the source transformer layer.',
+            )
+
+        # The VPP instance must be registered by PipelineLayerChunk.append,
+        # not as an additional direct child of the root PipelineLayer.
+        self.assertTrue(
+            any(layer is dest_layer for _, layer in chunks[1].named_children())
+        )
+        self.assertFalse(
+            any(layer is dest_layer for _, layer in model.named_children())
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category

Distributed Strategy

### PR Types

Bug fixes

### Description

修复 Pipeline Parallel VPP 模式下 `SharedLayerDesc(shared_submodule_weight_only=True)` 的 layer mapping 问题。

在 VPP 模式下，shared layer instance 应由对应的 `PipelineLayerChunk` 注册。原逻辑会将后续 shared instance 额外注册到 `PipelineLayer` 根节点，导致同一个 layer 同时出现在 root 和 chunk 中，造成模型层级及参数映射异常。

本次修改：

- VPP 模式下由 `PipelineLayerChunk` 负责注册 shared layer instance；
- 保留非 VPP 模式下后续 shared instance 的原有 root 注册逻辑；
- 增加 VPP shared submodule weight-only 场景测试，验证参数 alias 关系及 root/chunk 注册位置。

### 是否引起精度变化

否
