### PR TITLE
[Execute Infrastructure] Optimize parallel third-party submodule initialization

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -52,7 +52,8 @@ if(NOT WITH_SETUP_INSTALL)
 
   if(WITH_OPENVINO)
     execute_process(
-      COMMAND git submodule update --init --depth=1 third_party/openvino
+      COMMAND git submodule update --init --jobs=8 --depth=1
+              third_party/openvino
       WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}
       RESULT_VARIABLE result_var)
     # List of modules to be deleted
@@ -84,7 +85,7 @@ if(NOT WITH_SETUP_INSTALL)
         RESULT_VARIABLE git_rm_result)
     endforeach()
     execute_process(
-      COMMAND git submodule update --init --recursive
+      COMMAND git submodule update --init --recursive --jobs=8
       WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}
       RESULT_VARIABLE result_var)
   else()
@@ -92,17 +93,24 @@ if(NOT WITH_SETUP_INSTALL)
       COMMAND git submodule status
       WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}
       OUTPUT_VARIABLE submodule_list
-      RESULT_VARIABLE result_var)
-    string(REGEX MATCHALL "third_party/[^ )\n]+" submodule_paths
-                 "${submodule_list}")
-    foreach(submodule IN LISTS submodule_paths)
-      if(NOT submodule STREQUAL "third_party/openvino")
-        execute_process(
-          COMMAND git submodule update --init --recursive ${submodule}
-          WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}
-          RESULT_VARIABLE result_var)
-      endif()
-    endforeach()
+      RESULT_VARIABLE submodule_status_result)
+    if(NOT submodule_status_result EQUAL 0)
+      set(result_var ${submodule_status_result})
+    else()
+      string(REGEX MATCHALL "third_party/[^ )\n]+" submodule_paths
+                   "${submodule_list}")
+      set(submodule_update_paths)
+      foreach(submodule IN LISTS submodule_paths)
+        if(NOT submodule STREQUAL "third_party/openvino")
+          list(APPEND submodule_update_paths ${submodule})
+        endif()
+      endforeach()
+      execute_process(
+        COMMAND git submodule update --init --recursive --jobs=8
+                ${submodule_update_paths}
+        WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}
+        RESULT_VARIABLE result_var)
+    endif()
   endif()
   if(NOT result_var EQUAL 0)
     if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
- OpenVINO 子模块初始化增加并行参数：
  ```diff
  - COMMAND git submodule update --init --depth=1 third_party/openvino
  + COMMAND git submodule update --init --jobs=8 --depth=1 third_party/openvino
  ```
- OpenVINO 分支的递归子模块初始化增加并行参数：
  ```diff
  - COMMAND git submodule update --init --recursive
  + COMMAND git submodule update --init --recursive --jobs=8
  ```
- 非 OpenVINO 子模块由逐个更新改为收集路径后一次并行更新：
  ```diff
  - execute_process(COMMAND git submodule update --init --recursive ${submodule})
  + execute_process(
  +   COMMAND git submodule update --init --recursive --jobs=8
  +           ${submodule_update_paths})
  ```
- 增加 `git submodule status` 失败处理，并保留错误码进入统一错误处理：
  ```diff
  - RESULT_VARIABLE result_var)
  + RESULT_VARIABLE submodule_status_result)
  + if(NOT submodule_status_result EQUAL 0)
  +   set(result_var ${submodule_status_result})
  + endif()
  ```

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否