### PR TITLE
[Cherry-Pick][Distributed] Add P2P_ISSUED pipeline-parallel micro-step hook location

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -327,6 +327,14 @@ class PipelineParallelMicroStepLocations(Enum):
     FORWARD_END = 'forward_end'
     BACKWARD_BEGIN = 'backward_begin'
     BACKWARD_END = 'backward_end'
+    # Raised after the P2P ops of a micro-step have been *issued* but before
+    # their wait handles are consumed. Hooks registered here run on the
+    # calculation stream after the isend/irecv have already recorded their
+    # cross-stream event, so their kernels can overlap the NCCL send/recv.
+    # Only raised when the schedule uses `_p2p_ops` (batch_p2p_comm=False),
+    # because `_batched_p2p_ops` runs the NCCL kernel on the calc stream and
+    # can never overlap with compute.
+    P2P_ISSUED = 'p2p_issued'
 
 
 # A callback class for managing hooks at different stages of a pipeline parallel process.
@@ -338,6 +346,7 @@ class PipelineParallelMicroStepCallback:
             PipelineParallelMicroStepLocations.FORWARD_END: [],
             PipelineParallelMicroStepLocations.BACKWARD_BEGIN: [],
             PipelineParallelMicroStepLocations.BACKWARD_END: [],
+            PipelineParallelMicroStepLocations.P2P_ISSUED: [],
         }
 
     def register_hook(
@@ -359,7 +368,7 @@ class PipelineParallelMicroStepCallback:
             AssertionError: If the specified location is not a valid micro-step location.
         """
         assert location in self.hooks, (
-            f"Invalid location '{location}'. Valid locations are 'forward_begin', 'forward_end', 'backward_begin', or 'backward_end'."
+            f"Invalid location '{location}'. Valid locations are 'forward_begin', 'forward_end', 'backward_begin', 'backward_end', or 'p2p_issued'."
         )
         self.hooks[location].append(hook)
 
@@ -377,7 +386,7 @@ class PipelineParallelMicroStepCallback:
             AssertionError: If the specified location is not a valid micro-step location.
         """
         assert location in self.hooks, (
-            f"Invalid location '{location}'. Valid locations are 'forward_begin', 'forward_end', 'backward_begin', or 'backward_end'."
+            f"Invalid location '{location}'. Valid locations are 'forward_begin', 'forward_end', 'backward_begin', 'backward_end', or 'p2p_issued'."
         )
         for hook in self.hooks[location]:
             hook(**kwargs)
@@ -397,6 +406,27 @@ def register_global_pipeline_parallel_hook(
     Registering global hooks for pipeline parallelism.
     """
     pipeline_parallel_callbacks_.register_hook(location, hook)
+
+
+def _raise_p2p_issued_and_wait(callbacks, wait_handles, output_tensor, step_id):
+    """Raise ``P2P_ISSUED`` between issuing the forward p2p ops and waiting.
+
+    Hooks registered at this location are enqueued on the calculation stream
+    after ``isend`` / ``irecv`` have recorded their cross-stream event, so their
+    kernels can overlap the NCCL send/recv. ``wait_handles`` is None when
+    ``batch_p2p_comm=True``, because ``_batched_p2p_ops`` already ran the
+    communication on the calculation stream: no overlap is possible there, but
+    the location is still raised so that hooks relying on it for correctness
+    are not silently skipped.
+    """
+    callbacks.on_location(
+        PipelineParallelMicroStepLocations.P2P_ISSUED,
+        output_tensor=output_tensor,
+        step_id=step_id,
+    )
+    if wait_handles is not None:
+        for wait_handle in wait_handles:
+            wait_handle.wait()
 
 
 class NoPipelineParallel(MetaParallelBase):
@@ -3873,11 +3903,26 @@ class VPPFhenBInBalancedMemory(PipelineParallelWithInterleaveFthenB):
             ):
                 recv_prev = False
 
-            input_tensor = self._p2p_helper.send_forward_recv_forward(
-                output_tensor,
-                recv_prev=recv_prev,
-                batch_p2p_comm=self._use_batch_p2p_comm,
-                skip_check_meta=not self.training,
+            # NOTE: when `_p2p_ops` is in use (batch_p2p_comm=False) the NCCL
+            # send/recv lives on its own comm stream, gated by an event that
+            # `isend`/`irecv` records on the calculation stream at issue time.
+            # Deferring the wait and raising P2P_ISSUED here lets hook kernels
+            # be enqueued *after* that event, so they overlap the send/recv.
+            # `overlap_p2p_comm=True` is safe for both paths: with
+            # batch_p2p_comm=True the ops run on the calculation stream and no
+            # wait handle comes back, so this degrades to raising the location
+            # without any deferral.
+            input_tensor, fw_wait_handles = (
+                self._p2p_helper.send_forward_recv_forward(
+                    output_tensor,
+                    recv_prev=recv_prev,
+                    batch_p2p_comm=self._use_batch_p2p_comm,
+                    overlap_p2p_comm=True,
+                    skip_check_meta=not self.training,
+                )
+            )
+            _raise_p2p_issued_and_wait(
+                self.callbacks, fw_wait_handles, output_tensor, micro_step
             )
             if self.is_pipeline_first_stage(ignore_virtual=True):
                 if input_tensor is not None:
@@ -3922,10 +3967,22 @@ class VPPFhenBInBalancedMemory(PipelineParallelWithInterleaveFthenB):
 
             # NOTE: `send_forward_recv_backward` is intentionally unused to
             # prevent hanging bugs in dynamic shape mode.
-            self._p2p_helper.send_forward(
+            # The P2P_ISSUED hook is raised between `send_forward` and
+            # `recv_backward` on purpose: `recv_backward` waits on a grad that
+            # only exists after the downstream stage finishes its backward, so
+            # its inline wait would stall the calc stream and any hook placed
+            # after it could not overlap the forward send.
+            fw_send_wait_handles = self._p2p_helper.send_forward(
                 output_tensor,
                 self.is_pipeline_last_stage(ignore_virtual=True),
                 batch_p2p_comm=self._use_batch_p2p_comm,
+                overlap_p2p_comm=True,
+            )
+            _raise_p2p_issued_and_wait(
+                self.callbacks,
+                fw_send_wait_handles,
+                output_tensor,
+                forward_micro_step_id,
             )
             output_tensor_grad = self._p2p_helper.recv_backward(
                 self.is_pipeline_last_stage(ignore_virtual=True),

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
@@ -886,14 +886,16 @@ class P2pHelper:
         pp_last_stage,
         batch_p2p_comm=True,
         skip_check_meta=False,
+        overlap_p2p_comm=False,
     ):
         global _timers
         if _timers is not None:
             _timers("send_forward").start()
 
+        wait_handles = None
         if not pp_last_stage:
             self._send_meta(output_tensor, skip_check_meta=skip_check_meta)
-            _p2p_helper(
+            _, _, wait_handles = _p2p_helper(
                 tensor_send_next=output_tensor,
                 tensor_send_prev=None,
                 recv_prev=False,
@@ -901,12 +903,16 @@ class P2pHelper:
                 send_recv_meta=self._send_recv_meta,
                 batch_p2p_comm=batch_p2p_comm,
                 dynamic_shape=self._dynamic_shape,
+                wait_on_reqs=(not overlap_p2p_comm),
             )
             if self._dynamic_shape:
                 self._dynamic_cnt += 1
 
         if _timers is not None:
             _timers("send_forward").stop()
+
+        if overlap_p2p_comm:
+            return wait_handles
 
     def send_backward(
         self,

--- a/test/collective/fleet/CMakeLists.txt
+++ b/test/collective/fleet/CMakeLists.txt
@@ -979,3 +979,17 @@ if(WITH_NCCL)
     set_tests_properties(test_parallel_dygraph_muon PROPERTIES TIMEOUT "400")
   endif()
 endif()
+if(LOCAL_ALL_ARCH AND LOCAL_ALL_PLAT)
+  py_test_modules(
+    test_pipeline_parallel_micro_step_hooks MODULES
+    test_pipeline_parallel_micro_step_hooks ENVS
+    "http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python")
+endif()
+if((WITH_GPU) AND (LINUX))
+  py_test_modules(
+    test_pipeline_parallel_p2p_issued_hook MODULES
+    test_pipeline_parallel_p2p_issued_hook ENVS
+    "http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python")
+  set_tests_properties(test_pipeline_parallel_p2p_issued_hook
+                       PROPERTIES TIMEOUT "500" LABELS "RUN_TYPE=HYBRID")
+endif()

--- a/test/collective/fleet/hybrid_parallel_pp_p2p_issued_hook.py
+++ b/test/collective/fleet/hybrid_parallel_pp_p2p_issued_hook.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cover the ``P2P_ISSUED`` micro-step hook of ``VPPFhenBInBalancedMemory``.
+
+The hook is raised after the forward P2P ops of a micro-step have been issued
+but before their wait handles are consumed, so that a user hook can enqueue
+kernels that overlap the NCCL send/recv. This test checks that
+
+* the location fires exactly once per micro-step of the schedule,
+* the ``output_tensor`` handed to the hook is the tensor being sent,
+* enqueuing real compute in the hook does not corrupt the pipeline, i.e. the
+  training loss still matches the ``forward_only`` schedule's loss,
+
+for both ``use_batch_p2p_comm=False`` (the overlapping path) and
+``use_batch_p2p_comm=True`` (no overlap possible, hook still raised).
+"""
+
+import os
+import random
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle import nn
+from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_parallel import LayerDesc, PipelineLayer
+from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+    PipelineParallelMicroStepLocations,
+    pipeline_parallel_callbacks_,
+    register_global_pipeline_parallel_hook,
+)
+from paddle.nn import Layer
+
+batch_size = 8
+micro_batch_size = 2
+accumulate_steps = batch_size // micro_batch_size
+length = 8
+# `VPPFhenBInBalancedMemory` is picked when the model is interleaved and
+# `pp_degree <= accumulate_steps < 2 * pp_degree`, and its `_check_sanity`
+# additionally requires `pp_degree > 2`.
+pipeline_parallel_size = 4
+num_virtual_pipeline_stages = 2
+transformer_layer_num = pipeline_parallel_size * num_virtual_pipeline_stages
+vocab_size = 128
+hidden_size = 16
+
+
+def set_random_seed(seed, dp_id):
+    random.seed(seed)
+    np.random.seed(seed + dp_id)
+    paddle.seed(seed + dp_id)
+
+
+class EmbeddingPipe(Layer):
+    def __init__(self):
+        super().__init__()
+        self.word_embeddings = nn.Embedding(vocab_size, hidden_size)
+
+    def forward(self, x):
+        return self.word_embeddings(x)
+
+
+class MlpPipe(Layer):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class CriterionPipe(Layer):
+    def forward(self, out, label):
+        return out.mean()
+
+
+class ModelPipe(PipelineLayer):
+    def __init__(self, topology):
+        descs = [LayerDesc(EmbeddingPipe)]
+        descs += [LayerDesc(MlpPipe) for _ in range(transformer_layer_num)]
+        super().__init__(
+            layers=descs,
+            loss_fn=CriterionPipe(),
+            topology=topology,
+            num_virtual_pipeline_stages=num_virtual_pipeline_stages,
+            seg_method="layer:MlpPipe",
+        )
+
+
+class P2pIssuedHookRecorder:
+    """Counts hook firings and enqueues real GPU work in the overlap window."""
+
+    def __init__(self):
+        self.calls = []
+        self.probe = paddle.ones([8, 8], dtype="float32")
+
+    def __call__(self, output_tensor=None, step_id=None):
+        # Real kernels, enqueued on the calculation stream after the p2p ops
+        # have been issued -- exactly what the location exists for.
+        self.probe = paddle.matmul(self.probe, self.probe) / 8.0
+        self.calls.append((step_id, output_tensor))
+
+    def reset(self):
+        self.calls = []
+
+
+class TestP2pIssuedHook(unittest.TestCase):
+    def setUp(self):
+        self.use_batch_p2p_comm = (
+            os.getenv("USE_BATCH_P2P_COMM", "False").lower() == "true"
+        )
+        strategy = fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": pipeline_parallel_size,
+            "pp_configs": {
+                "best_unbalanced_scheduler": True,
+                "use_batch_p2p_comm": self.use_batch_p2p_comm,
+            },
+        }
+        strategy.pipeline_configs = {
+            "accumulate_steps": accumulate_steps,
+            "micro_batch_size": micro_batch_size,
+        }
+        fleet.init(is_collective=True, strategy=strategy)
+
+    def test_p2p_issued_hook(self):
+        hcg = fleet.get_hybrid_communicate_group()
+        set_random_seed(1024, hcg.get_data_parallel_rank())
+
+        model = ModelPipe(hcg.topology())
+        optimizer = paddle.optimizer.SGD(
+            learning_rate=0.001, parameters=model.parameters()
+        )
+        model = fleet.distributed_model(model)
+        optimizer = fleet.distributed_optimizer(optimizer)
+
+        self.assertEqual(
+            model._get_scheduler_name(), "VPPFhenBInBalancedMemory"
+        )
+        self.assertEqual(model._use_batch_p2p_comm, self.use_batch_p2p_comm)
+
+        location = PipelineParallelMicroStepLocations.P2P_ISSUED
+        recorder = P2pIssuedHookRecorder()
+        registered = len(pipeline_parallel_callbacks_.hooks[location])
+        register_global_pipeline_parallel_hook(location, recorder)
+        try:
+            self.assertEqual(
+                len(pipeline_parallel_callbacks_.hooks[location]),
+                registered + 1,
+            )
+            # every micro-step of every model chunk issues one forward send
+            expected_calls = accumulate_steps * num_virtual_pipeline_stages
+            for _ in range(3):
+                x_data = np.random.randint(
+                    0, vocab_size, size=[batch_size, length]
+                )
+                x = paddle.to_tensor(x_data)
+                x.stop_gradient = True
+
+                # forward_only falls back to the FthenB schedule, which does
+                # not raise the location: it doubles as the reference loss.
+                recorder.reset()
+                e_loss = model.eval_batch([x, x], True)
+                self.assertEqual(recorder.calls, [])
+
+                loss = model.train_batch([x, x], optimizer)
+                self.assertEqual(len(recorder.calls), expected_calls)
+                self.assertEqual(
+                    sorted(step_id for step_id, _ in recorder.calls),
+                    list(range(expected_calls)),
+                )
+                # the hook always sees the tensor of the micro-step that was
+                # just issued (an activation, or the loss on the last stage,
+                # which raises the location without sending anything)
+                for _, output_tensor in recorder.calls:
+                    self.assertIsNotNone(output_tensor)
+
+                # the deferred wait must not corrupt the tensors in flight
+                np.testing.assert_allclose(
+                    loss.numpy(), e_loss.numpy(), rtol=1e-5
+                )
+        finally:
+            del pipeline_parallel_callbacks_.hooks[location][registered:]
+        self.assertEqual(
+            len(pipeline_parallel_callbacks_.hooks[location]), registered
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/test_pipeline_parallel_micro_step_hooks.py
+++ b/test/collective/fleet/test_pipeline_parallel_micro_step_hooks.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from paddle.distributed.fleet.meta_parallel import pipeline_parallel as pp_mod
+from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+    PipelineParallelMicroStepCallback,
+    PipelineParallelMicroStepLocations,
+    _raise_p2p_issued_and_wait,
+    register_global_pipeline_parallel_hook,
+)
+from paddle.distributed.fleet.meta_parallel.pp_utils import (
+    p2p_communication as p2p_mod,
+)
+from paddle.distributed.fleet.meta_parallel.pp_utils.p2p_communication import (
+    P2pHelper,
+)
+
+PLACEHOLDER = "placeholder"
+
+
+class TestMicroStepLocations(unittest.TestCase):
+    def test_p2p_issued_enum_member(self):
+        self.assertEqual(
+            PipelineParallelMicroStepLocations.P2P_ISSUED.value, 'p2p_issued'
+        )
+        self.assertIs(
+            PipelineParallelMicroStepLocations('p2p_issued'),
+            PipelineParallelMicroStepLocations.P2P_ISSUED,
+        )
+
+    def test_registry_contains_all_locations(self):
+        callbacks = PipelineParallelMicroStepCallback()
+        self.assertEqual(
+            set(callbacks.hooks.keys()),
+            set(PipelineParallelMicroStepLocations),
+        )
+        self.assertEqual(
+            callbacks.hooks[PipelineParallelMicroStepLocations.P2P_ISSUED], []
+        )
+
+    def test_register_and_fire(self):
+        callbacks = PipelineParallelMicroStepCallback()
+        calls = []
+
+        callbacks.register_hook(
+            PipelineParallelMicroStepLocations.P2P_ISSUED,
+            lambda **kw: calls.append(('first', kw)),
+        )
+        callbacks.register_hook(
+            PipelineParallelMicroStepLocations.P2P_ISSUED,
+            lambda **kw: calls.append(('second', kw)),
+        )
+        # a hook on another location must not be triggered by P2P_ISSUED
+        callbacks.register_hook(
+            PipelineParallelMicroStepLocations.FORWARD_END,
+            lambda **kw: calls.append(('forward_end', kw)),
+        )
+
+        callbacks.on_location(
+            PipelineParallelMicroStepLocations.P2P_ISSUED,
+            output_tensor=PLACEHOLDER,
+            step_id=7,
+        )
+
+        # hooks run in registration order, and only for this location
+        self.assertEqual([name for name, _ in calls], ['first', 'second'])
+        for _, kwargs in calls:
+            self.assertEqual(
+                kwargs, {'output_tensor': PLACEHOLDER, 'step_id': 7}
+            )
+
+    def test_no_hook_registered_is_noop(self):
+        callbacks = PipelineParallelMicroStepCallback()
+        callbacks.on_location(
+            PipelineParallelMicroStepLocations.P2P_ISSUED,
+            output_tensor=None,
+            step_id=0,
+        )
+
+    def test_invalid_location_message_lists_p2p_issued(self):
+        callbacks = PipelineParallelMicroStepCallback()
+        with self.assertRaises(AssertionError) as ctx:
+            callbacks.register_hook('not_a_location', lambda **kw: None)
+        self.assertIn('p2p_issued', str(ctx.exception))
+
+        with self.assertRaises(AssertionError) as ctx:
+            callbacks.on_location('not_a_location')
+        self.assertIn('p2p_issued', str(ctx.exception))
+
+    def test_global_registration(self):
+        location = PipelineParallelMicroStepLocations.P2P_ISSUED
+        global_hooks = pp_mod.pipeline_parallel_callbacks_.hooks[location]
+        before = len(global_hooks)
+        fired = []
+        try:
+            register_global_pipeline_parallel_hook(
+                location, lambda **kw: fired.append(kw)
+            )
+            self.assertEqual(len(global_hooks), before + 1)
+            pp_mod.pipeline_parallel_callbacks_.on_location(
+                location, output_tensor=None, step_id=3
+            )
+            self.assertEqual(fired, [{'output_tensor': None, 'step_id': 3}])
+        finally:
+            del global_hooks[before:]
+        self.assertEqual(len(global_hooks), before)
+
+
+class _FakeReq:
+    def __init__(self, log, name):
+        self._log = log
+        self._name = name
+
+    def wait(self):
+        self._log.append(self._name)
+
+
+class TestSendForwardOverlapP2pComm(unittest.TestCase):
+    """`P2pHelper.send_forward` must be able to defer its wait handles.
+
+    The `P2P_ISSUED` hook is only useful if the send can be issued without
+    being waited on inline, so `overlap_p2p_comm=True` has to forward
+    `wait_on_reqs=False` to `_p2p_helper` and hand the handles back to the
+    caller instead of consuming them.
+    """
+
+    def setUp(self):
+        self.calls = []
+        self.waited = []
+        self.handles = [_FakeReq(self.waited, 'req0')]
+
+        def fake_p2p_helper(**kwargs):
+            self.calls.append(kwargs)
+            reqs = None if kwargs['wait_on_reqs'] else self.handles
+            return None, None, reqs
+
+        self._orig = p2p_mod._p2p_helper
+        p2p_mod._p2p_helper = fake_p2p_helper
+
+        self.helper = P2pHelper(use_cache=True, dynamic_shape=False)
+        # `_send_meta` talks to the pipeline process group, which is out of
+        # scope here: this test only pins down the wait-handle plumbing.
+        self.meta_sent = []
+        self.helper._send_meta = lambda *args, **kwargs: self.meta_sent.append(
+            (args, kwargs)
+        )
+
+    def tearDown(self):
+        p2p_mod._p2p_helper = self._orig
+
+    def test_default_waits_inline_and_returns_none(self):
+        ret = self.helper.send_forward(
+            PLACEHOLDER, pp_last_stage=False, batch_p2p_comm=False
+        )
+        self.assertIsNone(ret)
+        self.assertEqual(len(self.calls), 1)
+        self.assertTrue(self.calls[0]['wait_on_reqs'])
+        self.assertIs(self.calls[0]['tensor_send_next'], PLACEHOLDER)
+        self.assertFalse(self.calls[0]['batch_p2p_comm'])
+        self.assertEqual(len(self.meta_sent), 1)
+        self.assertEqual(self.waited, [])
+
+    def test_overlap_returns_handles_without_waiting(self):
+        handles = self.helper.send_forward(
+            PLACEHOLDER,
+            pp_last_stage=False,
+            batch_p2p_comm=False,
+            overlap_p2p_comm=True,
+        )
+        self.assertEqual(len(self.calls), 1)
+        self.assertFalse(self.calls[0]['wait_on_reqs'])
+        # nothing has been waited on yet: that is the caller's job, after the
+        # P2P_ISSUED hook has enqueued its kernels.
+        self.assertEqual(self.waited, [])
+        self.assertIs(handles, self.handles)
+        for handle in handles:
+            handle.wait()
+        self.assertEqual(self.waited, ['req0'])
+
+    def test_batch_p2p_comm_yields_no_handles(self):
+        # `_batched_p2p_ops` runs on the calculation stream, so `_p2p_helper`
+        # returns no requests and `send_forward` must degrade gracefully.
+        def fake_p2p_helper(**kwargs):
+            self.calls.append(kwargs)
+            return None, None, None
+
+        p2p_mod._p2p_helper = fake_p2p_helper
+        handles = self.helper.send_forward(
+            PLACEHOLDER,
+            pp_last_stage=False,
+            batch_p2p_comm=True,
+            overlap_p2p_comm=True,
+        )
+        self.assertIsNone(handles)
+        self.assertTrue(self.calls[0]['batch_p2p_comm'])
+
+    def test_last_stage_sends_nothing(self):
+        for overlap in (False, True):
+            handles = self.helper.send_forward(
+                PLACEHOLDER,
+                pp_last_stage=True,
+                batch_p2p_comm=False,
+                overlap_p2p_comm=overlap,
+            )
+            self.assertIsNone(handles)
+        self.assertEqual(self.calls, [])
+        self.assertEqual(self.meta_sent, [])
+
+    def test_skip_check_meta_is_forwarded(self):
+        self.helper.send_forward(
+            PLACEHOLDER,
+            pp_last_stage=False,
+            batch_p2p_comm=False,
+            skip_check_meta=True,
+            overlap_p2p_comm=True,
+        )
+        self.assertEqual(self.meta_sent[0][1].get('skip_check_meta'), True)
+
+
+class TestRaiseP2pIssuedAndWait(unittest.TestCase):
+    """The hook must run *before* the deferred wait handles are consumed.
+
+    This is the whole point of the location: if the wait happened first the
+    hook's kernels could no longer overlap the send/recv.
+    """
+
+    def setUp(self):
+        self.log = []
+        self.callbacks = PipelineParallelMicroStepCallback()
+        self.callbacks.register_hook(
+            PipelineParallelMicroStepLocations.P2P_ISSUED,
+            lambda **kw: self.log.append(('hook', kw)),
+        )
+
+    def test_hook_runs_before_every_wait(self):
+        handles = [_FakeReq(self.log, 'req0'), _FakeReq(self.log, 'req1')]
+        _raise_p2p_issued_and_wait(
+            self.callbacks, handles, PLACEHOLDER, step_id=5
+        )
+        self.assertEqual(
+            self.log,
+            [
+                ('hook', {'output_tensor': PLACEHOLDER, 'step_id': 5}),
+                'req0',
+                'req1',
+            ],
+        )
+
+    def test_no_handles_still_raises_the_location(self):
+        # the batch_p2p_comm=True path: communication already ran on the
+        # calculation stream, so `_p2p_helper` returns no requests
+        _raise_p2p_issued_and_wait(self.callbacks, None, PLACEHOLDER, step_id=0)
+        self.assertEqual(
+            self.log, [('hook', {'output_tensor': PLACEHOLDER, 'step_id': 0})]
+        )
+
+    def test_empty_handle_list(self):
+        _raise_p2p_issued_and_wait(self.callbacks, [], None, step_id=1)
+        self.assertEqual(
+            self.log, [('hook', {'output_tensor': None, 'step_id': 1})]
+        )
+
+    def test_without_hooks_only_waits(self):
+        callbacks = PipelineParallelMicroStepCallback()
+        handles = [_FakeReq(self.log, 'req0')]
+        _raise_p2p_issued_and_wait(callbacks, handles, PLACEHOLDER, step_id=2)
+        self.assertEqual(self.log, ['req0'])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/test_pipeline_parallel_p2p_issued_hook.py
+++ b/test/collective/fleet/test_pipeline_parallel_p2p_issued_hook.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import collective.test_communication_api_base as test_base
+
+
+class TestPipelineParallelP2pIssuedHook(test_base.CommunicationTestDistBase):
+    def setUp(self):
+        # `VPPFhenBInBalancedMemory` asserts `pp_degree > 2`, so the schedule
+        # that raises `P2P_ISSUED` needs at least 4 ranks.
+        super().setUp(num_of_devices=4, timeout=300, nnode=1)
+        self._default_envs = {}
+        # False exercises `_p2p_ops`, where the wait handles are deferred so
+        # the hook can overlap the send/recv; True exercises `_batched_p2p_ops`,
+        # where the location is raised without any deferral.
+        self._changeable_envs = {"USE_BATCH_P2P_COMM": ["False", "True"]}
+
+    def test_p2p_issued_hook(self):
+        envs_list = test_base.gen_product_envs_list(
+            self._default_envs, self._changeable_envs
+        )
+        for envs in envs_list:
+            self.run_test_case(
+                "hybrid_parallel_pp_p2p_issued_hook.py",
+                user_defined_envs=envs,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/testslist.csv
+++ b/test/collective/fleet/testslist.csv
@@ -78,3 +78,5 @@ test_layer_spec,,,,,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_schedule_node,,,,,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_muon_sharding_no_hook_overlap,,GPU,400,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,WITH_NCCL
 test_parallel_dygraph_muon,,GPU,400,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,WITH_NCCL
+test_pipeline_parallel_micro_step_hooks,,,,,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
+test_pipeline_parallel_p2p_issued_hook,LINUX,GPU,500,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

New features

### Description
devPR:https://github.com/PaddlePaddle/Paddle/pull/79690
Cherry-pick #79690 到 `release/3.4`。原 PR 已合入 develop（squash commit `16786f7f52`）。

#### 为什么需要这个改动

流水线并行的用户代码经常有一段「与主干反向无关的旁路计算」需要藏进通信里，例如某个辅助 loss 分支：它的梯度不流回主干权重之外的部分，因此可以在前向阶段就把 loss 和它的反向一起算完。但当前框架没有可用的挂载点：

- `FORWARD_END` 看起来合适，实际不行。`isend` / `irecv` 在**发起时刻**就在计算流上记录了一个事件，并让 pp group 的通信流等这个事件。所有在发起之前入队的 kernel 都被这个事件覆盖，于是 NCCL kernel 会等它们跑完，而不是与它们并发；挂在 `FORWARD_END` 的 hook 只能把 send/recv 往后推，得不到重叠。
- 要拿到重叠，kernel 必须在「事件已记录」之后、「wait 之前」入队。这个窗口目前只存在于 `WeightGradStore.pop()` 附近的硬编码逻辑里，外部无法使用。

本 PR 把这个窗口开放成一个标准的 micro-step hook 位置。

#### 改动内容

1. **新增 hook 位置** `PipelineParallelMicroStepLocations.P2P_ISSUED`，并在 `PipelineParallelMicroStepCallback` 的 hook 注册表中加入对应条目。语义：某个 micro-step 的前向 p2p 已经**发起**、其 wait handle 尚未消费。

2. **新增模块级 helper** `_raise_p2p_issued_and_wait(callbacks, wait_handles, output_tensor, step_id)`：先抛 `P2P_ISSUED`，再逐个 `wait_handle.wait()`。把「发起 → 抛 hook → wait」这个顺序收敛到一个函数里，既避免在调度器里重复三行样板代码，也让这段逻辑可以在单进程里直接做单测。

3. **`VPPFhenBInBalancedMemory` 的两个前向 p2p 调用点** 改为延迟 wait：
   - warmup / startup 循环里的 `send_forward_recv_forward`；
   - steady 1F1B 循环里的 `send_forward`（这里 hook 特意放在 `send_forward` 与 `recv_backward` **之间**：`recv_backward` 等的是下游 stage 反向产出的梯度，它的 inline wait 一定会卡住计算流，放在它之后的 hook 无法与前向 send 重叠）。

   两处都传 `overlap_p2p_comm=True`。这对两条路径都是安全的：`batch_p2p_comm=True` 时 `_batched_p2p_ops` 本来就把通信跑在计算流上、不会返回 wait handle，此时相当于只抛 hook、不做任何延迟。

4. **`P2pHelper.send_forward` 增加 `overlap_p2p_comm` 参数**（与已有的 `send_forward_recv_forward` 对齐）：为 `True` 时 `wait_on_reqs=False` 并把 wait handles 返回给调用方，否则行为与原来完全一致。

5. **单测**：新增 `test_pipeline_parallel_micro_step_hooks.py`（单卡，覆盖枚举/注册表/helper 的 wait 与不 wait 两条分支）、`hybrid_parallel_pp_p2p_issued_hook.py` + `test_pipeline_parallel_p2p_issued_hook.py`（多卡，验证 hook 在真实 VPP 调度下的触发次数与时机），并登记到 `CMakeLists.txt` / `testslist.csv`。

#### 与 develop 的差异（冲突解决说明）

develop 上带有 `block_cache_meta` / `_block_atten_res_opt`（Atten res cache，#79517），`release/3.4` 没有这个特性，`_send_meta` 也没有 `block_cache_meta` 形参。因此本次 cherry-pick 摘除了：

- `send_forward` / `send_forward_recv_forward` 调用中的 `block_cache_meta=meta_to_send` 实参；
- warmup 循环里 `recv_meta = self._p2p_helper.get_recv_block_cache_meta() if (self._block_atten_res_opt and recv_prev) else None` 整段。

除此之外与 develop 逐字一致。

#### 兼容性

默认没有任何 hook 注册到 `P2P_ISSUED`，此时 `_raise_p2p_issued_and_wait` 只是把原来的 inline wait 换成一次空回调 + 同样的 wait，调度顺序和通信语义都不变。

### 是否引起精度变化

否。不涉及任何计算 kernel 或数值逻辑，只改变 hook 抛出位置与 wait handle 的消费时机。
