### PR TITLE
Add symmetric GEMM for muon update

### DIFF
--- a/python/paddle/optimizer/muon.py
+++ b/python/paddle/optimizer/muon.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import functools
 import logging
 import math
 import os
@@ -117,6 +118,77 @@ _NS_COEFFICIENT_SETS = {
 }
 
 # ------------------------------------------------------------------
+# Symmetric-GEMM (SYRK) fast path for Newton-Schulz
+# ------------------------------------------------------------------
+
+# The first two matmuls of a Newton-Schulz step have symmetric outputs
+# (``X @ X.T`` and ``A @ A`` with A symmetric), so a SYRK-style kernel only
+# has to compute the lower triangle and mirror-write the upper one. That cuts
+# 1/4 (thin fragments) to 1/3 (square fragments) of the step's FLOPs.
+#
+# quack needs 16-byte alignment on every stride-1 dimension, i.e. 8 elements
+# for fp16/bf16. That covers *both* edges of the fragment: an unaligned short
+# edge trips the (m, m) output ("Invalid mD.strides[0]") and an unaligned long
+# edge trips the (m, n) input ("Invalid mA.strides[0]"), since the long edge is
+# the contiguous K dimension of ``X @ X.T``. Both are hard raises, so the gate
+# has to reject them rather than let the first step die.
+_SYRK_EDGE_ALIGNMENT = 8
+# Major compute capabilities with a CuTe symmetric-GEMM kernel.
+_SYRK_SUPPORTED_MAJOR_CAPABILITIES = (9, 10, 11)
+# fp16/bf16 go through the kernel bit-identically to cuBLAS. fp32 also runs,
+# but its MMA is tf32-grade: measured 6.4e-5 relative error against an fp64
+# reference where paddle.matmul gives 1.8e-6. ns_matmul_dtype=float32 is only
+# ever chosen to *get* that precision (it is the pre-Ampere fallback), so
+# quietly trading it away would defeat the point -- keep fp32 on cuBLAS.
+_SYRK_SUPPORTED_DTYPES = (paddle.bfloat16, paddle.float16)
+
+
+@functools.cache
+def _load_symmetric_gemm():
+    """Return quack's ``gemm_symmetric``, caching the lookup.
+
+    quack is a CuTe-DSL package written against ``torch``, so it is imported
+    inside ``paddle.use_compat_guard`` to proxy ``import torch`` to Paddle. The
+    guard is only needed for the import: the kernel wrappers bind the proxy
+    module at import time, so calls afterwards need no active compat scope.
+    """
+    try:
+        with paddle.use_compat_guard(
+            enable=True, scope={"quack", "cutlass", "triton"}, silent=True
+        ):
+            from quack.gemm_interface import gemm_symmetric
+    except Exception as e:
+        raise RuntimeError(
+            "Muon(use_symmetric_gemm=True) needs quack's symmetric GEMM, but "
+            "'from quack.gemm_interface import gemm_symmetric' failed with "
+            f"{type(e).__name__}: {e}. Install quack-kernels>=0.3.7, or "
+            "import paddlefleet_ops first, which vendors it."
+        ) from e
+    return gemm_symmetric
+
+
+def _symmetric_gemm_is_profitable(shape, dtype, min_short_edge, min_step_flops):
+    """Whether the symmetric-GEMM path beats cuBLAS for this NS fragment.
+
+    *shape* is the post-transpose Newton-Schulz input, i.e. ``(m, n)`` or
+    ``(batch, m, n)``; *dtype* is the matmul dtype. *min_short_edge* and
+    *min_step_flops* are the caller's thresholds, i.e. the ``Muon``
+    constructor arguments of the same name.
+    """
+    if dtype not in _SYRK_SUPPORTED_DTYPES:
+        return False
+    m, n = shape[-2], shape[-1]
+    if m > n:
+        m, n = n, m
+    if m < min_short_edge:
+        return False
+    if m % _SYRK_EDGE_ALIGNMENT or n % _SYRK_EDGE_ALIGNMENT:
+        return False
+    batch = shape[0] if len(shape) == 3 else 1
+    return batch * (4 * m * m * n + 2 * m**3) >= min_step_flops
+
+
+# ------------------------------------------------------------------
 # Default parameter classification
 # ------------------------------------------------------------------
 
@@ -213,6 +285,19 @@ class Muon(Optimizer):
             iterations. ``None`` = auto-detect: bfloat16 on Ampere+ (capability
             >= 8.0), float32 on V100 and older. Pass ``paddle.float32``
             explicitly to force float32. Default: ``None``.
+        use_symmetric_gemm (bool): Compute the two symmetric matmuls of each
+            Newton-Schulz step with quack's SYRK-style ``gemm_symmetric``
+            kernel. Default: ``False``.
+        symmetric_gemm_min_short_edge (int): Minimum short edge of a
+            Newton-Schulz fragment for the symmetric-GEMM path. Below this the
+            kernel cannot fill the GPU and loses to cuBLAS. Only consulted when
+            ``use_symmetric_gemm=True``. The default was measured on sm_10x;
+            raise or lower it if the crossover point moves. Default: ``1024``.
+        symmetric_gemm_min_step_flops (float): Minimum FLOPs of one full
+            Newton-Schulz step, ``batch * (4 * m^2 * n + 2 * m^3)``, for the
+            symmetric-GEMM path. Screens out fragments too small to amortise
+            the launch overhead. Only consulted when
+            ``use_symmetric_gemm=True``. Default: ``2e11``.
         multi_precision (bool): Maintain FP32 master weights when training in
             BF16/FP16. Default: ``False``.
         name (str | None): Optional name for the optimizer instance.
@@ -247,6 +332,9 @@ class Muon(Optimizer):
         multi_precision=False,
         name=None,
         muon_max_group_bytes=2 * 1024 * 1024 * 1024,  # Max 2GB per group
+        use_symmetric_gemm=False,
+        symmetric_gemm_min_short_edge=1024,
+        symmetric_gemm_min_step_flops=2e11,
         **kwargs,
     ):
         if parameters is None:
@@ -324,6 +412,41 @@ class Muon(Optimizer):
             )
         else:
             self._ns_matmul_dtype = ns_matmul_dtype
+        # Symmetric-GEMM fast path. Validate eagerly so a misconfiguration is
+        # a constructor error instead of a silent fallback at the first step.
+        self._use_symmetric_gemm = use_symmetric_gemm
+        self._symmetric_gemm_min_short_edge = symmetric_gemm_min_short_edge
+        self._symmetric_gemm_min_step_flops = symmetric_gemm_min_step_flops
+        if use_symmetric_gemm:
+            if (
+                symmetric_gemm_min_short_edge <= 0
+                or symmetric_gemm_min_step_flops <= 0
+            ):
+                raise ValueError(
+                    "symmetric_gemm_min_short_edge and "
+                    "symmetric_gemm_min_step_flops must be positive, got "
+                    f"{symmetric_gemm_min_short_edge} and "
+                    f"{symmetric_gemm_min_step_flops}."
+                )
+            if self._ns_matmul_dtype not in _SYRK_SUPPORTED_DTYPES:
+                raise ValueError(
+                    "use_symmetric_gemm=True requires bfloat16 or float16 "
+                    "Newton-Schulz matmuls, got "
+                    f"ns_matmul_dtype={self._ns_matmul_dtype}. The symmetric "
+                    "kernel does run on float32, but only at tf32-grade "
+                    "precision, which defeats the reason to pick float32."
+                )
+            cap = (
+                paddle.device.cuda.get_device_capability()
+                if paddle.is_compiled_with_cuda()
+                else (0, 0)
+            )
+            if cap[0] not in _SYRK_SUPPORTED_MAJOR_CAPABILITIES:
+                raise ValueError(
+                    "use_symmetric_gemm=True requires a GPU with compute "
+                    f"capability 9.x/10.x/11.x, got {cap[0]}.{cap[1]}."
+                )
+            _load_symmetric_gemm()
         self._default_dict.update(defaults)
 
     # ------------------------------------------------------------------
@@ -402,6 +525,9 @@ class Muon(Optimizer):
         eps=1e-9,
         ns_coeffs=None,
         ns_matmul_dtype=paddle.bfloat16,
+        use_symmetric_gemm=False,
+        symmetric_gemm_min_short_edge=None,
+        symmetric_gemm_min_step_flops=None,
     ):
         """Approximate the matrix sign function via Newton-Schulz iteration.
 
@@ -414,6 +540,12 @@ class Muon(Optimizer):
                 If None, uses the "simple" preset.
             ns_matmul_dtype: Dtype for matmul iterations. Defaults to
                 bfloat16. Pass paddle.float32 for V100 compatibility.
+            use_symmetric_gemm: Allow the symmetric-GEMM fast path. It is
+                taken only if this shape clears the profitability thresholds.
+            symmetric_gemm_min_short_edge: Short-edge threshold of that gate.
+                Required when use_symmetric_gemm=True.
+            symmetric_gemm_min_step_flops: Per-step FLOPs threshold of that
+                gate. Required when use_symmetric_gemm=True.
         """
         if X.ndim < 2 or X.ndim > 3:
             raise ValueError(
@@ -442,10 +574,24 @@ class Muon(Optimizer):
         )
         X = X_flat.reshape(orig_shape).astype(ns_matmul_dtype)
 
+        symmetric = use_symmetric_gemm and _symmetric_gemm_is_profitable(
+            X.shape,
+            X.dtype,
+            symmetric_gemm_min_short_edge,
+            symmetric_gemm_min_step_flops,
+        )
         if X.ndim == 3:
-            ns_step_fn = Muon._batched_newton_schulz_step
+            ns_step_fn = (
+                Muon._batched_newton_schulz_step_symmetric
+                if symmetric
+                else Muon._batched_newton_schulz_step
+            )
         else:
-            ns_step_fn = Muon._newton_schulz_step
+            ns_step_fn = (
+                Muon._newton_schulz_step_symmetric
+                if symmetric
+                else Muon._newton_schulz_step
+            )
 
         for i in range(steps):
             a, b, c = coeff_sets[i % len(coeff_sets)]
@@ -470,6 +616,22 @@ class Muon(Optimizer):
         B = paddle.baddbmm(A, A, A, beta=b, alpha=c)
         X = paddle.baddbmm(X, B, X, beta=a, alpha=1.0)
         return X
+
+    @staticmethod
+    def _newton_schulz_step_symmetric(X, a, b, c):
+        """2D Newton-Schulz step, symmetric products on the SYRK kernel."""
+        gemm_symmetric = _load_symmetric_gemm()
+        A = gemm_symmetric(X, paddle.transpose(X, perm=[1, 0]))
+        B = gemm_symmetric(A, A, C=A, beta=b, alpha=c)
+        return paddle.addmm(input=X, x=B, y=X, beta=a, alpha=1.0)
+
+    @staticmethod
+    def _batched_newton_schulz_step_symmetric(X, a, b, c):
+        """3D Newton-Schulz step, symmetric products on the SYRK kernel."""
+        gemm_symmetric = _load_symmetric_gemm()
+        A = gemm_symmetric(X, paddle.transpose(X, perm=[0, 2, 1]))
+        B = gemm_symmetric(A, A, C=A, beta=b, alpha=c)
+        return paddle.baddbmm(X, B, X, beta=a, alpha=1.0)
 
     @staticmethod
     def _scaling_fn(orthogonal_update, version, extra_scale_factor=1.0):
@@ -633,6 +795,9 @@ class Muon(Optimizer):
                     eps=epsilon,
                     ns_coeffs=self._ns_coeffs,
                     ns_matmul_dtype=self._ns_matmul_dtype,
+                    use_symmetric_gemm=self._use_symmetric_gemm,
+                    symmetric_gemm_min_short_edge=self._symmetric_gemm_min_short_edge,
+                    symmetric_gemm_min_step_flops=self._symmetric_gemm_min_step_flops,
                 )
                 scaled = Muon._scaling_fn(
                     ns_out, version, self._muon_extra_scale_factor

--- a/test/ai_edited_test/test_ai_optimizer_muon.py
+++ b/test/ai_edited_test/test_ai_optimizer_muon.py
@@ -18,17 +18,62 @@
 # Covered module: paddle/optimizer/muon.py
 # Uncovered lines: 135,141,232,236,238,245,307,308,344,345,346,347,348,349,351,356,414,415,417,546,547,548,549,589,602,609,657,662,684,685
 
+import os
+import sys
+import types
 import unittest
+from unittest import mock
 
 import numpy as np
 
 import paddle
+from paddle.optimizer import muon as muon_module
 from paddle.optimizer.muon import (
     _NS_COEFFICIENT_SETS,
     Muon,
     MuonParamInfo,
     _default_should_use_muon,
+    _load_symmetric_gemm,
+    _symmetric_gemm_is_profitable,
 )
+
+# Muon's default profitability thresholds, i.e. the defaults of
+# ``symmetric_gemm_min_short_edge`` and ``symmetric_gemm_min_step_flops``.
+# ``TestMuonSymmetricGemmInit.test_thresholds_default_to_documented_values``
+# pins these against the constructor so the two cannot drift apart.
+SYRK_DEFAULTS = (1024, 2e11)
+
+
+def fake_gemm_symmetric(A, B, C=None, alpha=1.0, beta=0.0):
+    """Dense stand-in for quack's ``gemm_symmetric``.
+
+    Mirrors the public contract ``beta * C + alpha * (A @ B)`` with plain
+    matmuls, so the Newton-Schulz plumbing can be tested without a GPU or a
+    quack install.
+    """
+    out = alpha * paddle.matmul(A, B)
+    if C is not None:
+        out = out + beta * C
+    return out
+
+
+def quack_symmetric_gemm_blocker():
+    """Why the real quack kernel cannot run here, or None if it can.
+
+    Returning the reason instead of a bool keeps the skip auditable: a
+    pipeline that is *supposed* to cover the production path can tell
+    "no GPU in this job" apart from "quack failed to import".
+    """
+    if not paddle.is_compiled_with_cuda():
+        return "paddle is not compiled with CUDA"
+    cap = paddle.device.cuda.get_device_capability()
+    if cap[0] not in (9, 10, 11):
+        return f"compute capability {cap[0]}.{cap[1]} has no CuTe SYRK kernel"
+    try:
+        _load_symmetric_gemm()
+    except RuntimeError as e:
+        return str(e)
+    return None
 
 
 class TestDefaultShouldUseMuon(unittest.TestCase):
@@ -337,6 +382,605 @@ class TestMuonLrRatio(unittest.TestCase):
             rtol=1e-5,
             atol=1e-6,
         )
+
+
+class TestSymmetricGemmProfitability(unittest.TestCase):
+    """测试 _symmetric_gemm_is_profitable 门控
+    Test the _symmetric_gemm_is_profitable gate"""
+
+    def test_supported_dtypes(self):
+        """测试 bf16/fp16 通过门控，fp32/fp64 被拒绝
+        Test bf16/fp16 pass the gate while fp32/fp64 are rejected"""
+        shape = [16, 2048, 2048]
+        for dtype, expected in (
+            (paddle.bfloat16, True),
+            (paddle.float16, True),
+            (paddle.float32, False),
+            (paddle.float64, False),
+        ):
+            self.assertEqual(
+                _symmetric_gemm_is_profitable(shape, dtype, *SYRK_DEFAULTS),
+                expected,
+                msg=str(dtype),
+            )
+
+    def test_large_batched_shapes_are_profitable(self):
+        """测试大 batch 形状通过门控
+        Test large batched shapes clear the gate"""
+        for shape in ([16, 4096, 8192], [64, 2048, 2048], [16, 1024, 4096]):
+            self.assertTrue(
+                _symmetric_gemm_is_profitable(
+                    shape, paddle.bfloat16, *SYRK_DEFAULTS
+                ),
+                msg=str(shape),
+            )
+
+    def test_large_2d_shape_is_profitable(self):
+        """测试无 batch 维的大矩阵通过门控
+        Test an unbatched large matrix clears the gate"""
+        self.assertTrue(
+            _symmetric_gemm_is_profitable(
+                [4096, 8192], paddle.bfloat16, *SYRK_DEFAULTS
+            )
+        )
+
+    def test_short_edge_is_the_row_dimension(self):
+        """测试短边为行维时同样按短边判定
+        Test the gate uses the short edge even when it is the row dim"""
+        self.assertTrue(
+            _symmetric_gemm_is_profitable(
+                [16, 8192, 2048], paddle.bfloat16, *SYRK_DEFAULTS
+            )
+        )
+        self.assertFalse(
+            _symmetric_gemm_is_profitable(
+                [16, 4096, 512], paddle.bfloat16, *SYRK_DEFAULTS
+            )
+        )
+
+    def test_short_edge_below_minimum(self):
+        """测试短边小于阈值时不走 SYRK
+        Test a short edge below the threshold stays on cuBLAS"""
+        for shape in ([111, 512, 4096], [16, 512, 1024], [6, 64, 1024]):
+            self.assertFalse(
+                _symmetric_gemm_is_profitable(
+                    shape, paddle.bfloat16, *SYRK_DEFAULTS
+                ),
+                msg=str(shape),
+            )
+
+    def test_short_edge_not_aligned(self):
+        """测试短边非 8 元素对齐时不走 SYRK
+        Test an unaligned short edge stays on cuBLAS"""
+        self.assertFalse(
+            _symmetric_gemm_is_profitable(
+                [16, 1036, 8192], paddle.bfloat16, *SYRK_DEFAULTS
+            )
+        )
+
+    def test_long_edge_not_aligned(self):
+        """测试长边（K 维）非 8 元素对齐时不走 SYRK
+        Test an unaligned long edge (the K dim) stays on cuBLAS
+
+        The long edge is the contiguous dimension of ``X @ X.T``, so quack
+        raises ``Invalid mA.strides[0]`` on it just like it does on the output
+        for an unaligned short edge.
+        """
+        for shape in ([4096, 4097], [4096, 4100], [16, 2048, 4097]):
+            self.assertFalse(
+                _symmetric_gemm_is_profitable(
+                    shape, paddle.bfloat16, *SYRK_DEFAULTS
+                ),
+                msg=str(shape),
+            )
+        # Same fragment with the long edge padded back to alignment passes.
+        self.assertTrue(
+            _symmetric_gemm_is_profitable(
+                [4096, 4104], paddle.bfloat16, *SYRK_DEFAULTS
+            )
+        )
+
+    def test_flops_below_threshold(self):
+        """测试单次调用 FLOPs 不足时不走 SYRK
+        Test too few per-call FLOPs stays on cuBLAS"""
+        self.assertFalse(
+            _symmetric_gemm_is_profitable(
+                [1, 1024, 1024], paddle.bfloat16, *SYRK_DEFAULTS
+            )
+        )
+        self.assertFalse(
+            _symmetric_gemm_is_profitable(
+                [1024, 4096], paddle.bfloat16, *SYRK_DEFAULTS
+            )
+        )
+
+    def test_thresholds_are_caller_supplied(self):
+        """测试门控完全由调用方传入的阈值决定
+        Test the gate is driven entirely by the caller's thresholds
+
+        There is no module-level default: the same shape flips verdict purely
+        on the thresholds handed in, which is what makes them configurable
+        from ``Muon.__init__``.
+        """
+        shape = [1024, 4096]  # rejected under Muon's defaults
+        self.assertFalse(
+            _symmetric_gemm_is_profitable(
+                shape, paddle.bfloat16, *SYRK_DEFAULTS
+            )
+        )
+        self.assertTrue(
+            _symmetric_gemm_is_profitable(shape, paddle.bfloat16, 512, 1)
+        )
+        # Raising either threshold alone rejects an otherwise passing shape.
+        shape = [4096, 8192]
+        self.assertTrue(
+            _symmetric_gemm_is_profitable(
+                shape, paddle.bfloat16, *SYRK_DEFAULTS
+            )
+        )
+        self.assertFalse(
+            _symmetric_gemm_is_profitable(shape, paddle.bfloat16, 8192, 2e11)
+        )
+        self.assertFalse(
+            _symmetric_gemm_is_profitable(shape, paddle.bfloat16, 1024, 1e30)
+        )
+
+    def test_alignment_is_not_configurable(self):
+        """测试对齐要求不受阈值配置影响
+        Test the alignment requirement is unaffected by threshold overrides
+
+        Alignment is a hard kernel constraint, not a tuning knob, so lowering
+        the thresholds must not let an unaligned fragment through.
+        """
+        self.assertFalse(
+            _symmetric_gemm_is_profitable([1036, 8192], paddle.bfloat16, 8, 1)
+        )
+
+
+class TestLoadSymmetricGemm(unittest.TestCase):
+    """测试 _load_symmetric_gemm 的导入与缓存
+    Test _load_symmetric_gemm import handling and caching"""
+
+    def setUp(self):
+        _load_symmetric_gemm.cache_clear()
+
+    def tearDown(self):
+        _load_symmetric_gemm.cache_clear()
+
+    def test_import_failure_raises_runtime_error(self):
+        """测试 quack 不可导入时抛出带指引的 RuntimeError
+        Test an actionable RuntimeError when quack cannot be imported"""
+        blocked = {"quack": None, "quack.gemm_interface": None}
+        with (
+            mock.patch.dict(sys.modules, blocked),
+            self.assertRaises(RuntimeError) as ctx,
+        ):
+            _load_symmetric_gemm()
+        self.assertIn("quack-kernels", str(ctx.exception))
+        self.assertIsNotNone(ctx.exception.__cause__)
+
+    def test_import_success_is_cached(self):
+        """测试导入成功后结果被缓存，不再重复导入
+        Test a successful lookup is cached instead of re-imported"""
+        module = types.ModuleType("quack.gemm_interface")
+        module.gemm_symmetric = fake_gemm_symmetric
+        injected = {
+            "quack": types.ModuleType("quack"),
+            "quack.gemm_interface": module,
+        }
+        with mock.patch.dict(sys.modules, injected):
+            self.assertIs(_load_symmetric_gemm(), fake_gemm_symmetric)
+        # quack is gone from sys.modules again, the cache must still serve it.
+        self.assertIs(_load_symmetric_gemm(), fake_gemm_symmetric)
+        self.assertEqual(_load_symmetric_gemm.cache_info().currsize, 1)
+
+
+class TestMuonSymmetricGemmInit(unittest.TestCase):
+    """测试 use_symmetric_gemm 的构造期校验
+    Test constructor validation of use_symmetric_gemm"""
+
+    def _param(self):
+        p = paddle.create_parameter(shape=[8, 8], dtype='float32')
+        p.stop_gradient = False
+        return p
+
+    def test_disabled_by_default(self):
+        """测试默认不开启对称 GEMM
+        Test the symmetric GEMM path is off by default"""
+        opt = Muon(parameters=[self._param()])
+        self.assertFalse(opt._use_symmetric_gemm)
+
+    def test_rejects_float32_ns_matmul_dtype(self):
+        """测试 ns_matmul_dtype=float32 时被拒绝
+        Test ns_matmul_dtype=float32 is rejected"""
+        with self.assertRaises(ValueError) as ctx:
+            Muon(
+                parameters=[self._param()],
+                use_symmetric_gemm=True,
+                ns_matmul_dtype=paddle.float32,
+            )
+        self.assertIn("bfloat16 or float16", str(ctx.exception))
+
+    def test_rejects_unsupported_capability(self):
+        """测试算力不支持的 GPU 被拒绝
+        Test a GPU without a CuTe symmetric kernel is rejected"""
+        with (
+            mock.patch.object(
+                paddle, "is_compiled_with_cuda", return_value=True
+            ),
+            mock.patch.object(
+                paddle.device.cuda, "get_device_capability", return_value=(8, 0)
+            ),
+            self.assertRaises(ValueError) as ctx,
+        ):
+            Muon(
+                parameters=[self._param()],
+                use_symmetric_gemm=True,
+                ns_matmul_dtype=paddle.bfloat16,
+            )
+        self.assertIn("compute capability", str(ctx.exception))
+
+    def test_rejects_cpu_only_build(self):
+        """测试非 CUDA 编译时被拒绝
+        Test a build without CUDA is rejected"""
+        with (
+            mock.patch.object(
+                paddle, "is_compiled_with_cuda", return_value=False
+            ),
+            self.assertRaises(ValueError) as ctx,
+        ):
+            Muon(
+                parameters=[self._param()],
+                use_symmetric_gemm=True,
+                ns_matmul_dtype=paddle.bfloat16,
+            )
+        self.assertIn("0.0", str(ctx.exception))
+
+    def test_enabled_loads_kernel_eagerly(self):
+        """测试条件满足时开启，并在构造期预加载 kernel
+        Test the kernel is loaded eagerly once the config is valid"""
+        loader = mock.Mock(return_value=fake_gemm_symmetric)
+        with (
+            mock.patch.object(
+                paddle, "is_compiled_with_cuda", return_value=True
+            ),
+            mock.patch.object(
+                paddle.device.cuda, "get_device_capability", return_value=(9, 0)
+            ),
+            mock.patch.object(muon_module, "_load_symmetric_gemm", loader),
+        ):
+            opt = Muon(
+                parameters=[self._param()],
+                use_symmetric_gemm=True,
+                ns_matmul_dtype=paddle.bfloat16,
+            )
+        self.assertTrue(opt._use_symmetric_gemm)
+        loader.assert_called_once_with()
+
+    def test_thresholds_default_to_documented_values(self):
+        """测试阈值默认值与文档一致
+        Test the threshold defaults match the documented values
+
+        The gate tests drive ``_symmetric_gemm_is_profitable`` with
+        ``SYRK_DEFAULTS``; this is what keeps that tuple honest.
+        """
+        opt = Muon(parameters=[self._param()])
+        self.assertEqual(
+            (
+                opt._symmetric_gemm_min_short_edge,
+                opt._symmetric_gemm_min_step_flops,
+            ),
+            SYRK_DEFAULTS,
+        )
+
+    def test_thresholds_are_configurable(self):
+        """测试阈值可由用户配置
+        Test the thresholds can be overridden by the user"""
+        with (
+            mock.patch.object(
+                paddle, "is_compiled_with_cuda", return_value=True
+            ),
+            mock.patch.object(
+                paddle.device.cuda, "get_device_capability", return_value=(9, 0)
+            ),
+            mock.patch.object(
+                muon_module,
+                "_load_symmetric_gemm",
+                mock.Mock(return_value=fake_gemm_symmetric),
+            ),
+        ):
+            opt = Muon(
+                parameters=[self._param()],
+                use_symmetric_gemm=True,
+                ns_matmul_dtype=paddle.bfloat16,
+                symmetric_gemm_min_short_edge=512,
+                symmetric_gemm_min_step_flops=1e9,
+            )
+        self.assertEqual(opt._symmetric_gemm_min_short_edge, 512)
+        self.assertEqual(opt._symmetric_gemm_min_step_flops, 1e9)
+
+    def test_rejects_non_positive_thresholds(self):
+        """测试非正阈值被拒绝
+        Test non-positive thresholds are rejected"""
+        for kwargs in (
+            {"symmetric_gemm_min_short_edge": 0},
+            {"symmetric_gemm_min_short_edge": -1},
+            {"symmetric_gemm_min_step_flops": 0},
+            {"symmetric_gemm_min_step_flops": -1e9},
+        ):
+            with (
+                mock.patch.object(
+                    paddle, "is_compiled_with_cuda", return_value=True
+                ),
+                mock.patch.object(
+                    paddle.device.cuda,
+                    "get_device_capability",
+                    return_value=(9, 0),
+                ),
+                self.assertRaises(ValueError) as ctx,
+            ):
+                Muon(
+                    parameters=[self._param()],
+                    use_symmetric_gemm=True,
+                    ns_matmul_dtype=paddle.bfloat16,
+                    **kwargs,
+                )
+            self.assertIn("must be positive", str(ctx.exception))
+
+    def test_thresholds_unvalidated_when_path_disabled(self):
+        """测试未开启对称 GEMM 时不校验阈值
+        Test the thresholds are not validated while the path is disabled"""
+        opt = Muon(
+            parameters=[self._param()],
+            symmetric_gemm_min_short_edge=0,
+            symmetric_gemm_min_step_flops=0,
+        )
+        self.assertFalse(opt._use_symmetric_gemm)
+
+
+class TestSymmetricNewtonSchulzStep(unittest.TestCase):
+    """测试对称 Newton-Schulz 迭代步
+    Test the symmetric Newton-Schulz step implementations"""
+
+    COEFFS = (3.4445, -4.7750, 2.0315)
+
+    def setUp(self):
+        paddle.seed(2026)
+        self.loader = mock.patch.object(
+            muon_module,
+            "_load_symmetric_gemm",
+            return_value=fake_gemm_symmetric,
+        )
+        self.loader.start()
+        self.addCleanup(self.loader.stop)
+
+    def test_2d_step_matches_dense_step(self):
+        """测试 2D 对称步与稠密步数值一致
+        Test the 2D symmetric step matches the dense step"""
+        x = paddle.randn([8, 16], dtype='float32') / 4.0
+        got = Muon._newton_schulz_step_symmetric(x, *self.COEFFS)
+        ref = Muon._newton_schulz_step(x, *self.COEFFS)
+        np.testing.assert_allclose(
+            got.numpy(), ref.numpy(), rtol=1e-5, atol=1e-6
+        )
+
+    def test_3d_step_matches_dense_step(self):
+        """测试 3D 对称步与稠密步数值一致
+        Test the batched symmetric step matches the dense step"""
+        x = paddle.randn([3, 8, 16], dtype='float32') / 4.0
+        got = Muon._batched_newton_schulz_step_symmetric(x, *self.COEFFS)
+        ref = Muon._batched_newton_schulz_step(x, *self.COEFFS)
+        np.testing.assert_allclose(
+            got.numpy(), ref.numpy(), rtol=1e-5, atol=1e-6
+        )
+
+
+class TestZeropowerSymmetricDispatch(unittest.TestCase):
+    """测试 _zeropower_via_newtonschulz5 的对称路径选择
+    Test symmetric-path dispatch inside _zeropower_via_newtonschulz5"""
+
+    def setUp(self):
+        paddle.seed(2026)
+        self.calls = []
+
+        def counting_gemm(A, B, C=None, alpha=1.0, beta=0.0):
+            self.calls.append(tuple(A.shape))
+            return fake_gemm_symmetric(A, B, C=C, alpha=alpha, beta=beta)
+
+        patches = [
+            mock.patch.object(
+                muon_module, "_load_symmetric_gemm", return_value=counting_gemm
+            ),
+            # fp32 never takes this path in production; allow it here so the
+            # dispatch can be exercised on a CPU-sized tensor.
+            mock.patch.object(
+                muon_module, "_SYRK_SUPPORTED_DTYPES", (paddle.float32,)
+            ),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    # Loose enough that the tiny shapes below clear the gate.
+    LOOSE = (8, 1)
+
+    def _run(self, shape, use_symmetric_gemm, thresholds=LOOSE):
+        x = paddle.randn(shape, dtype='float32')
+        return Muon._zeropower_via_newtonschulz5(
+            x,
+            steps=2,
+            ns_matmul_dtype=paddle.float32,
+            use_symmetric_gemm=use_symmetric_gemm,
+            symmetric_gemm_min_short_edge=thresholds[0],
+            symmetric_gemm_min_step_flops=thresholds[1],
+        ), x
+
+    def test_2d_takes_symmetric_path(self):
+        """测试 2D 输入命中门控时走对称 kernel
+        Test a 2D input that clears the gate uses the symmetric kernel"""
+        got, x = self._run([8, 16], True)
+        self.assertEqual(len(self.calls), 4)
+        ref = Muon._zeropower_via_newtonschulz5(
+            x, steps=2, ns_matmul_dtype=paddle.float32
+        )
+        np.testing.assert_allclose(
+            got.numpy(), ref.numpy(), rtol=1e-5, atol=1e-6
+        )
+
+    def test_3d_takes_symmetric_path(self):
+        """测试 3D 输入命中门控时走对称 kernel
+        Test a 3D input that clears the gate uses the symmetric kernel"""
+        got, x = self._run([2, 8, 16], True)
+        self.assertEqual(len(self.calls), 4)
+        ref = Muon._zeropower_via_newtonschulz5(
+            x, steps=2, ns_matmul_dtype=paddle.float32
+        )
+        np.testing.assert_allclose(
+            got.numpy(), ref.numpy(), rtol=1e-5, atol=1e-6
+        )
+
+    def test_disabled_flag_keeps_dense_path(self):
+        """测试 use_symmetric_gemm=False 时不调用对称 kernel
+        Test the symmetric kernel is untouched when the flag is off"""
+        self._run([8, 16], False)
+        self.assertEqual(self.calls, [])
+
+    def test_unprofitable_shape_keeps_dense_path(self):
+        """测试形状未过门控时回退到 cuBLAS 路径
+        Test a shape that fails the gate falls back to the dense path"""
+        self._run([8, 16], True, thresholds=SYRK_DEFAULTS)
+        self.assertEqual(self.calls, [])
+
+    def test_each_threshold_gates_independently(self):
+        """测试两个阈值各自都能拦住对称路径
+        Test either threshold on its own can keep the dense path
+
+        Also covers that both values are really threaded through
+        ``_zeropower_via_newtonschulz5`` rather than read from elsewhere.
+        """
+        self._run([8, 16], True, thresholds=(1024, 1))
+        self.assertEqual(self.calls, [])
+        self._run([8, 16], True, thresholds=(8, 1e30))
+        self.assertEqual(self.calls, [])
+        self._run([8, 16], True, thresholds=(8, 1))
+        self.assertEqual(len(self.calls), 4)
+
+
+class TestSymmetricGemmRealKernel(unittest.TestCase):
+    """测试真实 quack kernel（生产路径，非 mock）
+    Test the real quack kernel, i.e. the production path, unmocked
+
+    Every other symmetric-GEMM test replaces ``gemm_symmetric`` with a dense
+    stand-in, so only this class covers ``use_compat_guard`` importing, the
+    Paddle/DLPack hand-off and the sm90/100/110 kernel itself. It skips where
+    that hardware or quack is missing -- set
+    ``PADDLE_MUON_REQUIRE_SYMMETRIC_GEMM=1`` on the pipeline that owns this
+    coverage to turn the skip into a failure so it cannot go unnoticed.
+    """
+
+    REQUIRE_ENV = "PADDLE_MUON_REQUIRE_SYMMETRIC_GEMM"
+
+    def setUp(self):
+        blocker = quack_symmetric_gemm_blocker()
+        if blocker is not None:
+            if os.environ.get(self.REQUIRE_ENV) == "1":
+                self.fail(
+                    f"{self.REQUIRE_ENV}=1 demands the real quack symmetric "
+                    f"GEMM regression, but it cannot run: {blocker}"
+                )
+            self.skipTest(f"real quack symmetric GEMM unavailable: {blocker}")
+        paddle.seed(2026)
+
+    def test_kernel_output_is_exactly_symmetric(self):
+        """测试 kernel 的镜像写回给出严格对称结果
+        Test the mirror write-back yields an exactly symmetric result"""
+        gemm_symmetric = _load_symmetric_gemm()
+        shape = [4, 2048, 4096]
+        x = (paddle.randn(shape, dtype='float32') / shape[-1] ** 0.5).astype(
+            'bfloat16'
+        )
+        out = gemm_symmetric(x, paddle.transpose(x, perm=[0, 2, 1]))
+        ref = paddle.matmul(x, x, transpose_y=True)
+        upper = paddle.transpose(out, perm=[0, 2, 1])
+        self.assertEqual(
+            (out.astype('float32') - upper.astype('float32'))
+            .abs()
+            .max()
+            .item(),
+            0.0,
+        )
+        np.testing.assert_allclose(
+            out.astype('float32').numpy(),
+            ref.astype('float32').numpy(),
+            rtol=5e-3,
+            atol=5e-3,
+        )
+
+    def test_gate_rejects_shapes_the_kernel_cannot_take(self):
+        """测试门控拒绝的非对齐形状确实会让 kernel 报错
+        Test the shapes the gate rejects really do break the kernel
+
+        Guards the gate against drift: if quack ever relaxes its alignment
+        rules this fails, and the gate can be loosened deliberately.
+        """
+        gemm_symmetric = _load_symmetric_gemm()
+        for shape in ([1024, 4100], [1028, 4096]):
+            self.assertFalse(
+                _symmetric_gemm_is_profitable(
+                    shape, paddle.bfloat16, *SYRK_DEFAULTS
+                ),
+                msg=str(shape),
+            )
+            x = paddle.randn(shape, dtype='float32').astype('bfloat16')
+            with self.assertRaises(ValueError):
+                gemm_symmetric(x, paddle.transpose(x, perm=[1, 0]))
+
+    def test_newton_schulz_matches_cublas(self):
+        """测试 5 步 NS 迭代在两条路径上结果一致
+        Test a 5-step NS iteration agrees between both paths"""
+        shape = [16, 2048, 2048]
+        x = (paddle.randn(shape, dtype='float32') / shape[-1] ** 0.5).astype(
+            'bfloat16'
+        )
+        ref = Muon._zeropower_via_newtonschulz5(
+            x, steps=5, ns_matmul_dtype=paddle.bfloat16
+        )
+        got = Muon._zeropower_via_newtonschulz5(
+            x,
+            steps=5,
+            ns_matmul_dtype=paddle.bfloat16,
+            use_symmetric_gemm=True,
+            symmetric_gemm_min_short_edge=SYRK_DEFAULTS[0],
+            symmetric_gemm_min_step_flops=SYRK_DEFAULTS[1],
+        )
+        np.testing.assert_allclose(
+            got.astype('float32').numpy(),
+            ref.astype('float32').numpy(),
+            rtol=5e-3,
+            atol=5e-3,
+        )
+
+    def test_optimizer_step_matches_cublas(self):
+        """测试整步优化器更新在两条路径上结果一致
+        Test a full optimizer step agrees between both paths"""
+        updates = []
+        for use_symmetric_gemm in (False, True):
+            paddle.seed(2026)
+            p = paddle.create_parameter(shape=[4096, 8192], dtype='float32')
+            p.stop_gradient = False
+            opt = Muon(
+                learning_rate=0.02,
+                parameters=[p],
+                muon_exclude_patterns=['embed', 'bias', 'lm_head'],
+                use_symmetric_gemm=use_symmetric_gemm,
+            )
+            before = p.numpy().copy()
+            p.grad = paddle.randn(p.shape, dtype='float32') * 0.01
+            opt.step()
+            self.assertTrue(bool(paddle.isfinite(p).all()))
+            updates.append(p.numpy() - before)
+        self.assertGreater(np.abs(updates[0]).max(), 0.0)
+        np.testing.assert_allclose(updates[1], updates[0], rtol=1e-3, atol=1e-6)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Performance

### Description
<!-- Describe what you’ve done -->
新增symmetric gemm，加速muon update计算。

调用quack里面的symmetric gemm kernel实现。

#### 门控（有条件调用）
| 条件 | 阈值 | 依据 |
|---|---|---|
| 短边 `m` | `>= 1024` | 扫 m 实测 512 → 0.31x、1024 → 0.78x、2048 → 1.02x |
| 单个 NS 步的 FLOPs `B(4m²n+2m³)` | `>= 2e11` | quack 每次 5 步 NS 调用有 ~1.0 ms 固定开销（≈0.2 ms/步），而 cuBLAS 只有 ~0.30 ms |
| 两边都对齐 `m % 8` 且 `n % 8` | `== 0` | quack 要求每个 stride-1 维 16B 对齐 |
| dtype | bf16 / fp16 | fp32 也能跑，但精度掉到 tf32 档 |

#### 性能收益
| shape (B,m,n) | 单步 FLOPs | base ms | sym ms | 加速比 | 理论上限 | 效率 |
|---|---|---|---|---|---|---|
| (128, 2048, 2048) | 6.6e12 | 29.341 | 21.026 | **1.395x** | 1.500 | 93.0% |
| (80, 2048, 2048) | 4.1e12 | 18.194 | 13.324 | **1.365x** | 1.500 | 91.0% |
| (64, 2048, 2048) | 3.3e12 | 14.613 | 10.884 | **1.343x** | 1.500 | 89.5% |
| (16, 4096, 8192) | 1.1e13 | 41.556 | 31.350 | **1.326x** | 1.429 | 92.8% |
| (5, 4096, 8192) | 3.4e12 | 13.314 | 10.184 | 1.307x | 1.429 | 91.5% |
| (64, 2048, 4096) | 5.5e12 | 23.950 | 18.488 | 1.295x | 1.429 | 90.7% |
| (6, 4096, 16384) | 7.4e12 | 28.682 | 22.318 | 1.285x | 1.385 | 92.8% |
| (42, 2048, 4096) | 3.6e12 | 15.610 | 12.188 | 1.281x | 1.429 | 89.7% |
| (1, 4096, 14336) | 1.1e12 | 4.208 | 3.338 | 1.260x | 1.391 | 90.6% |
| (32, 2048, 4096) | 2.7e12 | 11.687 | 9.326 | 1.253x | 1.429 | 87.7% |
| (10, 2048, 4096) | 8.6e11 | 3.748 | 3.009 | 1.246x | 1.429 | 87.2% |
| (16, 2048, 2048) | 8.2e11 | 3.578 | 2.893 | 1.237x | 1.500 | 82.5% |
| (37, 1024, 1024) | 2.4e11 | 1.254 | 1.020 | 1.229x | 1.500 | 81.9% |
| (43, 1024, 4096) | 8.3e11 | 4.425 | 3.801 | 1.164x | 1.385 | 84.1% |
| (20, 2048, 4096) | 1.7e12 | 6.469 | 5.646 | 1.146x | 1.429 | 80.2% |
| (2, 4096, 4096) | 8.2e11 | 2.723 | 2.385 | 1.142x | 1.500 | 76.1% |
| (16, 1024, 4096) | 3.1e11 | 1.674 | 1.593 | 1.051x | 1.385 | 75.9% |

**没有一个放行的 shape 出现回退**：区间 1.05x ~ 1.40x，中位数 ~1.26x，效率
（实测 / 理论上限）76% ~ 93%。规律很干净——单步 FLOPs 越大效率越高，最赚的四个都是
大 batch 的方阵或近方阵；垫底的 `16×1024×4096`（单步 3.1e11）和 `2×4096×4096`
（batch 只有 2）都是固定开销摊不掉的类型，轮间波动也最大（12% / 11%），实际处在
"打平到小赚"之间。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

同一个输入、同一套 5 步 NS，跑三条路径并互相对照：

| 记号 | 路径 |
|---|---|
| `base` | cuBLAS，bf16 / fp16（改动前的路径） |
| `sym` | quack，bf16 / fp16（落地路径，门控强制打开使小 shape 也能测） |
| `ref` | cuBLAS，**fp64**（ground truth） |

之所以要三条，是因为要把两件容易混在一起的事分开：
**①两条路径之间的差异**、**②bf16/fp16 相对 fp64 的舍入误差**。

| shape (B,m,n) | dtype | `sym` vs `base` max\|Δ\| | `base` vs fp64 rel | `sym` vs fp64 rel | asym cuBLAS | asym quack |
|---|---|---|---|---|---|---|
| (1, 2048, 4096) | bf16 | **0** | 1.47e-02 | 1.47e-02 | 0 | 0 |
| (1, 2048, 4096) | fp16 | **0** | 2.03e-03 | 2.03e-03 | 0 | 0 |
| (1, 4096, 4096) | bf16 | **0** | 1.45e-02 | 1.45e-02 | 0 | 0 |
| (1, 4096, 4096) | fp16 | **0** | 1.87e-03 | 1.87e-03 | 0 | 0 |
| (4, 1024, 4096) | bf16 | **0** | 1.92e-02 | 1.92e-02 | 0 | 0 |
| (4, 1024, 4096) | fp16 | **0** | 2.50e-03 | 2.50e-03 | 0 | 0 |
| (8, 2048, 2048) | bf16 | **0** | 1.65e-02 | 1.65e-02 | 0 | 0 |
| (8, 2048, 2048) | fp16 | **0** | 1.92e-03 | 1.92e-03 | 0 | 0 |
| (2, 2048, 8192) | bf16 | **0** | 1.65e-02 | 1.65e-02 | 0 | 0 |
| (2, 2048, 8192) | fp16 | **0** | 2.07e-03 | 2.07e-03 | 0 | 0 |
| (1, 4096, 8192) | bf16 | **0** | 1.58e-02 | 1.58e-02 | 0 | 0 |
| (1, 4096, 8192) | fp16 | **0** | 1.83e-03 | 1.83e-03 | 0 | 0 |