### PR TITLE
Fix truncated_gaussian_random bug in large tensor

### DIFF
--- a/paddle/phi/kernels/gpu/truncated_gaussian_random_kernel.cu
+++ b/paddle/phi/kernels/gpu/truncated_gaussian_random_kernel.cu
@@ -25,6 +25,7 @@
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/distribution_helper.h"
 
 namespace phi {
 
@@ -56,33 +57,20 @@ struct GPUTruncatedNormal {
 };
 
 template <typename T, typename MT>
-struct TruncatedNormalOffset {
+struct TruncatedNormalTransform {
   MT mean, std, a, b;
   MT a_normal_cdf;
   MT b_normal_cdf;
-  unsigned int seed;
-  MT numeric_min;
-  int offset_;
 
-  __host__ __device__ TruncatedNormalOffset(
-      MT mean, MT std, MT numeric_min, int seed, int offset, MT a, MT b)
-      : mean(mean),
-        std(std),
-        seed(seed),
-        numeric_min(numeric_min),
-        offset_(offset),
-        a(a),
-        b(b) {
+  HOSTDEVICE TruncatedNormalTransform(MT mean, MT std, MT a, MT b)
+      : mean(mean), std(std), a(a), b(b) {
     a_normal_cdf = (1.0 + erff((a - mean) / std / sqrtf(2.0))) / 2.0;
     b_normal_cdf = (1.0 + erff((b - mean) / std / sqrtf(2.0))) / 2.0;
   }
 
-  __host__ __device__ T operator()(const unsigned int n) const {
-    thrust::minstd_rand rng;
-    rng.seed(seed);
-    thrust::uniform_real_distribution<MT> dist(numeric_min, 1);
-    rng.discard(n + offset_);
-    MT value = dist(rng);
+  // Inverts the CDF of the truncated distribution, mapping a uniform sample in
+  // (0, 1] onto [a, b].
+  HOSTDEVICE inline T operator()(MT value) const {
     auto p = a_normal_cdf + (b_normal_cdf - a_normal_cdf) * value;
     MT ret = std::sqrt(2.0) * erfinvf(2 * p - 1) * std + mean;
     return static_cast<T>(std::clamp(ret, a, b));
@@ -103,28 +91,17 @@ void TruncatedGaussianRandomKernel(const Context& dev_ctx,
 
   using MT = typename MPTypeTrait<T>::Type;
 
-  thrust::counting_iterator<int64_t> index_sequence_begin(0);
-  int64_t size = out->numel();
-
-  auto gen_cuda = dev_ctx.GetGenerator();
   if (seed == 0) {
-    // use global Generator seed
-    auto seed_offset = gen_cuda->IncrementOffset(1);
-    uint64_t seed = seed_offset.first;
-    uint64_t offset = seed_offset.second;
-    thrust::transform(
-        index_sequence_begin,
-        index_sequence_begin + size,
-        thrust::device_ptr<T>(data),
-        TruncatedNormalOffset<T, MT>(mean,
-                                     std,
-                                     std::numeric_limits<MT>::min(),
-                                     seed,
-                                     size * offset,
-                                     a,
-                                     b));
+    funcs::uniform_distribution<MT> dist;
+    TruncatedNormalTransform<T, MT> trans(static_cast<MT>(mean),
+                                          static_cast<MT>(std),
+                                          static_cast<MT>(a),
+                                          static_cast<MT>(b));
+    funcs::distribution_and_transform<T>(dev_ctx, out, dist, trans);
   } else {
     // use OP seed
+    thrust::counting_iterator<int64_t> index_sequence_begin(0);
+    int64_t size = out->numel();
     thrust::transform(
         index_sequence_begin,
         index_sequence_begin + size,

--- a/test/legacy_test/test_truncated_gaussian_random_op.py
+++ b/test/legacy_test/test_truncated_gaussian_random_op.py
@@ -219,5 +219,116 @@ class TestTruncatedGaussianRandomOpBf16(TestTruncatedGaussianRandomOp):
             )
 
 
+class TestTruncatedGaussianRandomOpGlobalSeed(TestTruncatedGaussianRandomOp):
+    """seed == 0 draws from the global generator, a separate kernel branch that
+    none of the op-seed cases above reaches."""
+
+    def setUp(self):
+        super().setUp()
+        self.attrs["seed"] = 0
+
+
+class TestTruncatedGaussianRandomOpGlobalSeedFp64(
+    TestTruncatedGaussianRandomOpFp64
+):
+    def setUp(self):
+        super().setUp()
+        self.attrs["seed"] = 0
+
+
+class TestTruncatedGaussianRandomOpGlobalSeedBf16(
+    TestTruncatedGaussianRandomOpBf16
+):
+    def setUp(self):
+        super().setUp()
+        self.attrs["seed"] = 0
+
+
+def head_tail_fingerprint(tensor, n=512):
+    """Byte signature of a tensor's head and tail.
+
+    Stream reuse shows up as *byte-identical* tensors, so slicing is enough to
+    spot a repeat while keeping the memory footprint independent of how many
+    draws are compared.
+    """
+    return tensor[:n].numpy().tobytes() + tensor[-n:].numpy().tobytes()
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not compiled with CUDA",
+)
+class TestTruncatedGaussianRandomNoStreamReuse(unittest.TestCase):
+    """Large-scale initialization must never hand out the same numbers twice.
+
+    The CUDA kernel used to seed a 31-bit LCG (``thrust::minstd_rand``) and to
+    pass ``numel * offset`` through an ``int``, with ``offset`` advanced by only
+    one per call. Consecutive draws on the same generator therefore wrapped
+    around and repeated byte for byte every ``2**32 / numel`` calls -- a scale
+    that real model initialization reaches easily.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+        paddle.set_device('gpu')
+        paddle.seed(2026)
+
+    def tearDown(self):
+        paddle.enable_static()
+
+    def draw(self, buf):
+        paddle.nn.init.trunc_normal_(buf, mean=0.0, std=0.02)
+        return buf
+
+    def assert_draws_unique(self, numel, num_calls):
+        buf = paddle.empty([numel], dtype='float32')
+        first_seen = {}
+        duplicates = []
+        for call in range(1, num_calls + 1):
+            fingerprint = head_tail_fingerprint(self.draw(buf))
+            if fingerprint in first_seen:
+                duplicates.append((first_seen[fingerprint], call))
+            else:
+                first_seen[fingerprint] = call
+        self.assertEqual(
+            duplicates,
+            [],
+            f"truncated_gaussian_random reused its random stream: with "
+            f"numel={numel} these pairs of draws are identical: {duplicates}",
+        )
+
+    def test_no_repeat_across_one_offset_wraparound(self):
+        # 2**32 / 2**22 == 1024 calls was the old repeat period; go past it.
+        numel = 1 << 22
+        self.assert_draws_unique(numel, (1 << 32) // numel + 8)
+
+    def test_no_repeat_at_moe_expert_weight_scale(self):
+        # numel of grouped_gemm_experts.weight1 under EP=64 in the report; the
+        # old period was 2**32 / 2**26 == 64 calls, so every 32nd MoE layer got
+        # a byte-identical copy of an earlier one.
+        numel = 1 << 26
+        self.assert_draws_unique(numel, (1 << 32) // numel + 8)
+
+    def test_no_shifted_repeat_at_half_a_wraparound(self):
+        """Half a wraparound used to repeat the sequence shifted by two.
+
+        ``2**31 % (2**31 - 2) == 2``, so the draw ``2**31 / numel`` calls later
+        was the earlier draw moved over by two elements -- a repeat that a plain
+        equality check does not catch.
+        """
+        numel = 1 << 22
+        buf = paddle.empty([numel], dtype='float32')
+        first = self.draw(buf).numpy().copy()
+        for _ in range((1 << 31) // numel - 1):
+            self.draw(buf)
+        later = self.draw(buf).numpy()
+        for shift in range(5):
+            self.assertFalse(
+                np.array_equal(first[shift:], later[: numel - shift]),
+                f"truncated_gaussian_random repeated an earlier draw shifted "
+                f"by {shift} elements after half an offset wraparound",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
When the element number exceeds 2^31, truncated_gaussian_random kernel will generate repeated values.

This PR fix this bug.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否