### PR TITLE
[Operator Mechanism] Fix premature i0 overflow

### DIFF
--- a/paddle/phi/kernels/impl/bessel_grad_kernel_cuda_impl.h
+++ b/paddle/phi/kernels/impl/bessel_grad_kernel_cuda_impl.h
@@ -44,7 +44,9 @@ struct CudaI0GradFunctor {
     auto len = std::get<1>(coeff_pair_B);
     MT y = (MT{32.0} / x) - MT{2.0};
 
-    const MT i1_out = (std::exp(x) * Chbevl<MT>(y, B, len)) / std::sqrt(x);
+    const MT half_exp = std::exp(x / MT{2.0});
+    const MT i1_out =
+        half_exp * (Chbevl<MT>(y, B, len) / std::sqrt(x)) * half_exp;
     const MT i1_data = (mp_x < MT{0.0}) ? -i1_out : i1_out;
 
     return static_cast<T>(i1_data * mp_out_grad);

--- a/paddle/phi/kernels/impl/bessel_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/bessel_grad_kernel_impl.h
@@ -51,7 +51,9 @@ struct I0GradFunctor {
       auto len = std::get<1>(coeff_pair_B);
       MT y = (MT{32.0} / x) - MT{2.0};
 
-      const MT i1_out = (std::exp(x) * Chbevl<MT>(y, B, len)) / std::sqrt(x);
+      const MT half_exp = std::exp(x / MT{2.0});
+      const MT i1_out =
+          half_exp * (Chbevl<MT>(y, B, len) / std::sqrt(x)) * half_exp;
       const MT i1_data = (mp_x < MT{0.0}) ? -i1_out : i1_out;
       output_x_grad_[idx] = static_cast<T>(i1_data * mp_out_grad);
     }

--- a/paddle/phi/kernels/impl/bessel_kernel_cuda_impl.h
+++ b/paddle/phi/kernels/impl/bessel_kernel_cuda_impl.h
@@ -97,7 +97,9 @@ struct CudaI0Functor {
     auto len = std::get<1>(coeff_pair_B);
     MT y = (MT{32.0} / x) - MT{2.0};
 
-    return static_cast<T>(std::exp(x) * Chbevl<T>(y, B, len) / std::sqrt(x));
+    const MT half_exp = std::exp(x / MT{2.0});
+    return static_cast<T>(
+        half_exp * (Chbevl<T>(y, B, len) / std::sqrt(x)) * half_exp);
   }
 };
 

--- a/paddle/phi/kernels/impl/bessel_kernel_impl.h
+++ b/paddle/phi/kernels/impl/bessel_kernel_impl.h
@@ -136,8 +136,9 @@ struct I0Functor {
       auto len = std::get<1>(coeff_pair_B);
       T y = (T{32.0} / x) - T{2.0};
 
-      output_[idx] =
-          static_cast<T>(std::exp(x) * Chbevl<T>(y, B, len) / std::sqrt(x));
+      const T half_exp = std::exp(x / T{2.0});
+      output_[idx] = static_cast<T>(
+          half_exp * (Chbevl<T>(y, B, len) / std::sqrt(x)) * half_exp);
     }
   }
 

--- a/test/legacy_test/test_i0_op.py
+++ b/test/legacy_test/test_i0_op.py
@@ -103,6 +103,67 @@ class TestI0Float64OverEightCase(TestI0API):
     DATA = [9, 10, 11, 12]
 
 
+class TestI0Float64LargeInputCase(unittest.TestCase):
+    DTYPE = "float64"
+    X = np.array([713.0, 713.0], dtype=DTYPE)
+    OUT_GRAD = np.array([1.0, 0.0], dtype=DTYPE)
+    EXPECTED = np.array(
+        [6.705128263670996e307, 6.705128263670996e307], dtype=DTYPE
+    )
+    EXPECTED_GRAD = np.array(
+        [6.7004245591864025e307, 0.0], dtype=DTYPE
+    )
+
+    def setUp(self):
+        self.place = get_places()
+
+    def _check_result(self, out, x_grad):
+        self.assertTrue(np.isfinite(out).all())
+        self.assertTrue(np.isfinite(x_grad).all())
+        np.testing.assert_allclose(
+            out, self.EXPECTED, rtol=1e-13, atol=0.0
+        )
+        np.testing.assert_allclose(
+            x_grad, self.EXPECTED_GRAD, rtol=1e-13, atol=0.0
+        )
+
+    def test_api_static(self):
+        for place in self.place:
+            paddle.enable_static()
+            with paddle.static.program_guard(paddle.static.Program()):
+                x = paddle.static.data(
+                    name="x", shape=self.X.shape, dtype=self.DTYPE
+                )
+                x.stop_gradient = False
+                out_grad = paddle.static.data(
+                    name="out_grad",
+                    shape=self.OUT_GRAD.shape,
+                    dtype=self.DTYPE,
+                )
+                out = paddle.i0(x)
+                x_grad = paddle.static.gradients(out, x, out_grad)[0]
+                exe = paddle.static.Executor(place)
+                out_result, grad_result = exe.run(
+                    paddle.static.default_main_program(),
+                    feed={"x": self.X, "out_grad": self.OUT_GRAD},
+                    fetch_list=[out, x_grad],
+                )
+            paddle.disable_static()
+            self._check_result(out_result, grad_result)
+
+    def test_api_dygraph(self):
+        for place in self.place:
+            paddle.disable_static(place)
+            x = paddle.to_tensor(self.X, stop_gradient=False)
+            out_grad = paddle.to_tensor(self.OUT_GRAD)
+            out = paddle.i0(x)
+            x_grad = paddle.grad(out, x, grad_outputs=out_grad)[0]
+            out_result = out.numpy()
+            grad_result = x_grad.numpy()
+            paddle.enable_static()
+            self._check_result(out_result, grad_result)
+
+
 class TestI0Op(OpTest):
     def setUp(self) -> None:
         self.op_type = "i0"


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Bug fixes

### Description
Avoids intermediate overflow in `paddle.i0` and its `i0_grad` path for large finite `float64` inputs by evaluating the exponential as two `exp(x / 2)` factors around the scaled Bessel approximation. Applies the calculation to CPU and CUDA.

The regression test uses independent finite oracles for `I0(713)` and `I1(713)`, and verifies both unit and zero upstream gradients.

Fixes https://github.com/PaddlePaddle/Paddle/issues/79618

Validation:
- compiled and ran the CPU forward and gradient functors at `713.0`
- instantiated and ran the CUDA forward and gradient functors with host-side compilation at `713.0`
- verified finite unit gradients and zero upstream gradients
- `python3 -m py_compile test/legacy_test/test_i0_op.py`
- `git diff --check`

A full Paddle runtime and CUDA device build were not available locally.

### 是否引起精度变化
是
