### PR TITLE
[Operator Mechanism]Add 64-bit strided BatchGEMM dispatch

### DIFF
--- a/paddle/phi/backends/dynload/cublas.h
+++ b/paddle/phi/backends/dynload/cublas.h
@@ -153,8 +153,19 @@ CUBLAS_WORKSPACE_ROUTINE(DECLARE_DYNAMIC_LOAD_CUBLAS_WRAP)
   __macro(cublasDgemm_v2_64);                \
   __macro(cublasCgemm_v2_64);                \
   __macro(cublasZgemm_v2_64);                \
+  __macro(cublasSgemmStridedBatched_64);     \
+  __macro(cublasDgemmStridedBatched_64);     \
+  __macro(cublasCgemmStridedBatched_64);     \
+  __macro(cublasZgemmStridedBatched_64);     \
   __macro(cublasGemmStridedBatchedEx_64);    \
-  __macro(cublasGemmEx_64);
+  __macro(cublasGemmEx_64);                  \
+  __macro(cublasSgemmBatched_64);            \
+  __macro(cublasDgemmBatched_64);            \
+  __macro(cublasGemmBatchedEx_64);           \
+  __macro(cublasStrsm_v2_64);                \
+  __macro(cublasDtrsm_v2_64);                \
+  __macro(cublasCtrsm_v2_64);                \
+  __macro(cublasZtrsm_v2_64);
 
 CUBLAS_BLAS_ROUTINE_EACH_R5(DECLARE_DYNAMIC_LOAD_CUBLAS_WRAP)
 #endif

--- a/paddle/phi/kernels/funcs/blas/blas.h
+++ b/paddle/phi/kernels/funcs/blas/blas.h
@@ -168,34 +168,34 @@ class Blas {
 #ifdef PADDLE_WITH_MKLML  // @{ Group MKLML: class Blas
   template <typename T>
   T* GEMM_ALLOC(const CBLAS_IDENTIFIER id,
-                const int M,
-                const int N,
-                const int K) const;
+                int64_t M,
+                int64_t N,
+                int64_t K) const;
 
   template <typename T>
   void GEMM_PACK(const CBLAS_IDENTIFIER id,
                  const CBLAS_TRANSPOSE trans,
-                 int M,
-                 int N,
-                 int K,
+                 int64_t M,
+                 int64_t N,
+                 int64_t K,
                  const T alpha,
                  const T* src,
-                 const int ld,
+                 int64_t ld,
                  T* dst) const;
 
   template <typename T>
   void GEMM_COMPUTE(int transA,
                     int transB,
-                    int M,
-                    int N,
-                    int K,
+                    int64_t M,
+                    int64_t N,
+                    int64_t K,
                     const T* A,
-                    const int lda,
+                    int64_t lda,
                     const T* B,
-                    const int ldb,
+                    int64_t ldb,
                     T beta,
                     T* C,
-                    const int ldc) const;
+                    int64_t ldc) const;
 
   template <typename T>
   void GEMM_FREE(T* data) const;
@@ -207,7 +207,7 @@ class Blas {
                       const DenseTensor& mat_b,
                       const MatDescriptor& dim_b,
                       T alpha,
-                      int head_number,
+                      int64_t head_number,
                       DenseTensor* mat_out,
                       T beta,
                       bool mat_y_split_vertical) const;
@@ -222,19 +222,15 @@ class Blas {
                       const DenseTensor& mat_b,
                       const MatDescriptor& dim_b,
                       T alpha,
-                      int head_number,
+                      int64_t head_number,
                       DenseTensor* mat_out,
                       T beta,
                       bool mat_y_split_vertical) const;
 #endif
 
   template <typename T>
-  void MatMul(const int M,
-              const int N,
-              const int K,
-              const T* A,
-              const T* B,
-              T* C) const;
+  void MatMul(
+      int64_t M, int64_t N, int64_t K, const T* A, const T* B, T* C) const;
 
   template <typename T>
   void MatMul(const DenseTensor& mat_a,
@@ -357,31 +353,31 @@ class Blas {
   template <typename T>
   void BatchedGEMM(CBLAS_TRANSPOSE transA,
                    CBLAS_TRANSPOSE transB,
-                   int M,
-                   int N,
-                   int K,
+                   int64_t M,
+                   int64_t N,
+                   int64_t K,
                    T alpha,
                    const T** A,
                    const T** B,
                    T beta,
                    T** C,
-                   int batchCount) const;
+                   int64_t batchCount) const;
 
 #if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA) && \
     !defined(PADDLE_WITH_HIP)
   template <typename T>
   void BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                            CBLAS_TRANSPOSE transB,
-                           int W1,
-                           int H1,
-                           int W2,
-                           int H2,
+                           int64_t W1,
+                           int64_t H1,
+                           int64_t W2,
+                           int64_t H2,
                            T alpha,
                            const T* A,
                            const T* B,
                            T beta,
                            T* C,
-                           int batchCount,
+                           int64_t batchCount,
                            int64_t strideA,
                            int64_t strideB,
                            int64_t head_number,
@@ -393,16 +389,16 @@ class Blas {
   template <typename T>
   void BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                            CBLAS_TRANSPOSE transB,
-                           int W1,
-                           int H1,
-                           int W2,
-                           int H2,
+                           int64_t W1,
+                           int64_t H1,
+                           int64_t W2,
+                           int64_t H2,
                            T alpha,
                            const T* A,
                            const T* B,
                            T beta,
                            T* C,
-                           int batchCount,
+                           int64_t batchCount,
                            int64_t strideA,
                            int64_t strideB,
                            int64_t head_number,

--- a/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
@@ -608,7 +608,7 @@ struct CUBlas<phi::float16> {
                             cudaDataType_t Ctype,
                             int64_t ldc,
                             int64_t batchCount,
-                            cudaDataType_t computeType) {
+                            cublasComputeType_t computeType) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
     cublasGemmAlgo_t algo = CUBLAS_GEMM_DFALT;
     if (dev_ctx->tensor_core_available()) {
@@ -4365,7 +4365,7 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                         CUDA_R_16F,
                                         ldc,
                                         batchCount,
-                                        CUDA_R_32F);
+                                        CUBLAS_COMPUTE_32F);
     return;
   }
   const int m = detail::to_blas_int(M, "BatchedGEMM M");
@@ -4468,7 +4468,7 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                                CUDA_R_16BF,
                                                ldc,
                                                batchCount,
-                                               CUDA_R_32F,
+                                               CUBLAS_COMPUTE_32F,
                                                algo));
     });
     return;

--- a/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
@@ -31,7 +31,6 @@
 
 COMMON_DECLARE_bool(cublas_allow_tf32);
 COMMON_DECLARE_bool(gemm_use_half_precision_compute_type);
-COMMON_DECLARE_bool(use_legacy_gemm);
 
 namespace phi {
 namespace funcs {
@@ -178,8 +177,65 @@ inline void GemmEx64(phi::GPUContext *dev_ctx,
   });
 #else
   PADDLE_THROW(common::errors::Unimplemented(
-      "cublasGemmEx_64 is not supported on cuda < 12.3"));
-#endif
+      "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
+}
+
+inline void GemmStridedBatchedEx64(const phi::GPUContext *dev_ctx,
+                                   cublasOperation_t transa,
+                                   cublasOperation_t transb,
+                                   int64_t m,
+                                   int64_t n,
+                                   int64_t k,
+                                   const void *alpha,
+                                   const void *A,
+                                   cudaDataType_t Atype,
+                                   int64_t lda,
+                                   int64_t strideA,
+                                   const void *B,
+                                   cudaDataType_t Btype,
+                                   int64_t ldb,
+                                   int64_t strideB,
+                                   const void *beta,
+                                   void *C,
+                                   cudaDataType_t Ctype,
+                                   int64_t ldc,
+                                   int64_t strideC,
+                                   int64_t batchCount,
+                                   cublasComputeType_t computeType,
+                                   cublasGemmAlgo_t algo) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+  dev_ctx->TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cublasGemmStridedBatchedEx_64(handle,
+                                                    transa,
+                                                    transb,
+                                                    m,
+                                                    n,
+                                                    k,
+                                                    alpha,
+                                                    A,
+                                                    Atype,
+                                                    lda,
+                                                    strideA,
+                                                    B,
+                                                    Btype,
+                                                    ldb,
+                                                    strideB,
+                                                    beta,
+                                                    C,
+                                                    Ctype,
+                                                    ldc,
+                                                    strideC,
+                                                    batchCount,
+                                                    computeType,
+                                                    algo));
+  });
+#else
+  PADDLE_THROW(common::errors::Unimplemented(
+      "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+      "Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
 }
 
 }  // namespace detail
@@ -235,6 +291,16 @@ struct CUBlas<float> {
   }
 
   template <typename... ARGS>
+  static void GEMM_BATCH_64(ARGS... args) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasSgemmBatched_64(args...));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS batched GEMM requires CUDA 12.3 or later on Linux."));
+#endif
+  }
+
+  template <typename... ARGS>
   static void GEMM_STRIDED_BATCH(ARGS... args) {
 #if CUDA_VERSION >= 8000
     PADDLE_ENFORCE_GPU_SUCCESS(
@@ -246,8 +312,30 @@ struct CUBlas<float> {
   }
 
   template <typename... ARGS>
+  static void GEMM_STRIDED_BATCH_64(ARGS... args) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cublasSgemmStridedBatched_64(args...));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
+#endif
+  }
+
+  template <typename... ARGS>
   static void TRSM(ARGS... args) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasStrsm(args...));
+  }
+
+  template <typename... ARGS>
+  static void TRSM_64(ARGS... args) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasStrsm_v2_64(args...));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS TRSM requires CUDA 12.3 or later on Linux."));
+#endif
   }
 
   template <typename... ARGS>
@@ -329,6 +417,16 @@ struct CUBlas<double> {
   }
 
   template <typename... ARGS>
+  static void GEMM_BATCH_64(ARGS... args) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasDgemmBatched_64(args...));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS batched GEMM requires CUDA 12.3 or later on Linux."));
+#endif
+  }
+
+  template <typename... ARGS>
   static void GEMM_STRIDED_BATCH(ARGS... args) {
 #if CUDA_VERSION >= 8000
     PADDLE_ENFORCE_GPU_SUCCESS(
@@ -340,8 +438,30 @@ struct CUBlas<double> {
   }
 
   template <typename... ARGS>
+  static void GEMM_STRIDED_BATCH_64(ARGS... args) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(
+        phi::dynload::cublasDgemmStridedBatched_64(args...));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
+#endif
+  }
+
+  template <typename... ARGS>
   static void TRSM(ARGS... args) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasDtrsm(args...));
+  }
+
+  template <typename... ARGS>
+  static void TRSM_64(ARGS... args) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasDtrsm_v2_64(args...));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS TRSM requires CUDA 12.3 or later on Linux."));
+#endif
   }
 
   template <typename... ARGS>
@@ -469,6 +589,62 @@ struct CUBlas<phi::float16> {
         "cublasGemmBatchedEx is not supported on cuda <= 7.5"));
 #endif
   }
+
+  static void GEMM_BATCH_64(phi::GPUContext *dev_ctx,
+                            cublasOperation_t transa,
+                            cublasOperation_t transb,
+                            int64_t m,
+                            int64_t n,
+                            int64_t k,
+                            const float *alpha,
+                            const float16 **A,
+                            cudaDataType_t Atype,
+                            int64_t lda,
+                            const float16 **B,
+                            cudaDataType_t Btype,
+                            int64_t ldb,
+                            const float *beta,
+                            float16 **C,
+                            cudaDataType_t Ctype,
+                            int64_t ldc,
+                            int64_t batchCount,
+                            cudaDataType_t computeType) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    cublasGemmAlgo_t algo = CUBLAS_GEMM_DFALT;
+    if (dev_ctx->tensor_core_available()) {
+      algo = CUBLAS_GEMM_DFALT_TENSOR_OP;
+    }
+    thrust::device_vector<const void *> A_ptr(A, A + batchCount);
+    thrust::device_vector<const void *> B_ptr(B, B + batchCount);
+    thrust::device_vector<void *> C_ptr(C, C + batchCount);
+    dev_ctx->TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
+      PADDLE_ENFORCE_GPU_SUCCESS(
+          phi::dynload::cublasGemmBatchedEx_64(handle,
+                                               transa,
+                                               transb,
+                                               m,
+                                               n,
+                                               k,
+                                               alpha,
+                                               A_ptr.data().get(),
+                                               Atype,
+                                               lda,
+                                               B_ptr.data().get(),
+                                               Btype,
+                                               ldb,
+                                               beta,
+                                               C_ptr.data().get(),
+                                               Ctype,
+                                               ldc,
+                                               batchCount,
+                                               computeType,
+                                               algo));
+    });
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS batched GEMM requires CUDA 12.3 or later on Linux."));
+#endif
+  }
 #endif
 
   static void GEMM_STRIDED_BATCH(cublasHandle_t handle,
@@ -513,6 +689,54 @@ struct CUBlas<phi::float16> {
     PADDLE_THROW(common::errors::Unimplemented(
         "HgemmStridedBatched is not supported on cuda <= 7.5"));
 #endif
+  }
+
+  static void GEMM_STRIDED_BATCH_64(const phi::GPUContext *dev_ctx,
+                                    cublasOperation_t transa,
+                                    cublasOperation_t transb,
+                                    int64_t m,
+                                    int64_t n,
+                                    int64_t k,
+                                    const void *alpha,
+                                    const void *A,
+                                    cudaDataType_t Atype,
+                                    int64_t lda,
+                                    int64_t strideA,
+                                    const void *B,
+                                    cudaDataType_t Btype,
+                                    int64_t ldb,
+                                    int64_t strideB,
+                                    const void *beta,
+                                    void *C,
+                                    cudaDataType_t Ctype,
+                                    int64_t ldc,
+                                    int64_t strideC,
+                                    int64_t batchCount,
+                                    cublasComputeType_t computeType,
+                                    cublasGemmAlgo_t algo) {
+    detail::GemmStridedBatchedEx64(dev_ctx,
+                                   transa,
+                                   transb,
+                                   m,
+                                   n,
+                                   k,
+                                   alpha,
+                                   A,
+                                   Atype,
+                                   lda,
+                                   strideA,
+                                   B,
+                                   Btype,
+                                   ldb,
+                                   strideB,
+                                   beta,
+                                   C,
+                                   Ctype,
+                                   ldc,
+                                   strideC,
+                                   batchCount,
+                                   computeType,
+                                   algo);
   }
 
   // NOTES: GEMM_EX can use Tensor Core to accelerate matrix multiply.
@@ -693,6 +917,54 @@ struct CUBlas<phi::bfloat16> {
                      ldc,
                      computeType);
   }
+
+  static void GEMM_STRIDED_BATCH_64(const phi::GPUContext *dev_ctx,
+                                    cublasOperation_t transa,
+                                    cublasOperation_t transb,
+                                    int64_t m,
+                                    int64_t n,
+                                    int64_t k,
+                                    const void *alpha,
+                                    const void *A,
+                                    cudaDataType_t Atype,
+                                    int64_t lda,
+                                    int64_t strideA,
+                                    const void *B,
+                                    cudaDataType_t Btype,
+                                    int64_t ldb,
+                                    int64_t strideB,
+                                    const void *beta,
+                                    void *C,
+                                    cudaDataType_t Ctype,
+                                    int64_t ldc,
+                                    int64_t strideC,
+                                    int64_t batchCount,
+                                    cublasComputeType_t computeType,
+                                    cublasGemmAlgo_t algo) {
+    detail::GemmStridedBatchedEx64(dev_ctx,
+                                   transa,
+                                   transb,
+                                   m,
+                                   n,
+                                   k,
+                                   alpha,
+                                   A,
+                                   Atype,
+                                   lda,
+                                   strideA,
+                                   B,
+                                   Btype,
+                                   ldb,
+                                   strideB,
+                                   beta,
+                                   C,
+                                   Ctype,
+                                   ldc,
+                                   strideC,
+                                   batchCount,
+                                   computeType,
+                                   algo);
+  }
 };
 
 template <>
@@ -773,6 +1045,50 @@ struct CUBlas<phi::complex64> {
         incY));
   }
 
+  static void GEMM_STRIDED_BATCH_64(cublasHandle_t handle,
+                                    cublasOperation_t transa,
+                                    cublasOperation_t transb,
+                                    int64_t m,
+                                    int64_t n,
+                                    int64_t k,
+                                    const phi::complex64 *alpha,
+                                    const phi::complex64 *A,
+                                    int64_t lda,
+                                    long long int strideA,  // NOLINT
+                                    const phi::complex64 *B,
+                                    int64_t ldb,
+                                    long long int strideB,  // NOLINT
+                                    const phi::complex64 *beta,
+                                    phi::complex64 *C,
+                                    int64_t ldc,
+                                    long long int strideC,  // NOLINT
+                                    int64_t batchCount) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasCgemmStridedBatched_64(
+        handle,
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        reinterpret_cast<const cuFloatComplex *>(alpha),
+        reinterpret_cast<const cuFloatComplex *>(A),
+        lda,
+        strideA,
+        reinterpret_cast<const cuFloatComplex *>(B),
+        ldb,
+        strideB,
+        reinterpret_cast<const cuFloatComplex *>(beta),
+        reinterpret_cast<cuFloatComplex *>(C),
+        ldc,
+        strideC,
+        batchCount));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
+#endif
+  }
   static void GEMM_STRIDED_BATCH(cublasHandle_t handle,
                                  cublasOperation_t transa,
                                  cublasOperation_t transb,
@@ -919,6 +1235,38 @@ struct CUBlas<phi::complex64> {
         lda,
         reinterpret_cast<cuFloatComplex *>(B),
         ldb));
+  }
+
+  static void TRSM_64(cublasHandle_t handle,
+                      cublasSideMode_t side,
+                      cublasFillMode_t uplo,
+                      cublasOperation_t transa,
+                      cublasDiagType_t diag,
+                      int64_t m,
+                      int64_t n,
+                      const phi::complex64 *alpha,
+                      const phi::complex64 *A,
+                      int64_t lda,
+                      phi::complex64 *B,
+                      int64_t ldb) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasCtrsm_v2_64(
+        handle,
+        side,
+        uplo,
+        transa,
+        diag,
+        m,
+        n,
+        reinterpret_cast<const cuFloatComplex *>(alpha),
+        reinterpret_cast<const cuFloatComplex *>(A),
+        lda,
+        reinterpret_cast<cuFloatComplex *>(B),
+        ldb));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS TRSM requires CUDA 12.3 or later on Linux."));
+#endif
   }
 
   static void TRSM_BATCH(cublasHandle_t handle,
@@ -1147,6 +1495,50 @@ struct CUBlas<phi::complex128> {
 #endif
   }
 
+  static void GEMM_STRIDED_BATCH_64(cublasHandle_t handle,
+                                    cublasOperation_t transa,
+                                    cublasOperation_t transb,
+                                    int64_t m,
+                                    int64_t n,
+                                    int64_t k,
+                                    const phi::complex128 *alpha,
+                                    const phi::complex128 *A,
+                                    int64_t lda,
+                                    long long int strideA,  // NOLINT
+                                    const phi::complex128 *B,
+                                    int64_t ldb,
+                                    long long int strideB,  // NOLINT
+                                    const phi::complex128 *beta,
+                                    phi::complex128 *C,
+                                    int64_t ldc,
+                                    long long int strideC,  // NOLINT
+                                    int64_t batchCount) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasZgemmStridedBatched_64(
+        handle,
+        transa,
+        transb,
+        m,
+        n,
+        k,
+        reinterpret_cast<const cuDoubleComplex *>(alpha),
+        reinterpret_cast<const cuDoubleComplex *>(A),
+        lda,
+        strideA,
+        reinterpret_cast<const cuDoubleComplex *>(B),
+        ldb,
+        strideB,
+        reinterpret_cast<const cuDoubleComplex *>(beta),
+        reinterpret_cast<cuDoubleComplex *>(C),
+        ldc,
+        strideC,
+        batchCount));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
+#endif
+  }
   static void GEMM(cublasHandle_t handle,
                    cublasOperation_t transa,
                    cublasOperation_t transb,
@@ -1249,6 +1641,38 @@ struct CUBlas<phi::complex128> {
         lda,
         reinterpret_cast<cuDoubleComplex *>(B),
         ldb));
+  }
+
+  static void TRSM_64(cublasHandle_t handle,
+                      cublasSideMode_t side,
+                      cublasFillMode_t uplo,
+                      cublasOperation_t transa,
+                      cublasDiagType_t diag,
+                      int64_t m,
+                      int64_t n,
+                      const phi::complex128 *alpha,
+                      const phi::complex128 *A,
+                      int64_t lda,
+                      phi::complex128 *B,
+                      int64_t ldb) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasZtrsm_v2_64(
+        handle,
+        side,
+        uplo,
+        transa,
+        diag,
+        m,
+        n,
+        reinterpret_cast<const cuDoubleComplex *>(alpha),
+        reinterpret_cast<const cuDoubleComplex *>(A),
+        lda,
+        reinterpret_cast<cuDoubleComplex *>(B),
+        ldb));
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS TRSM requires CUDA 12.3 or later on Linux."));
+#endif
   }
 
   static void TRSM_BATCH(cublasHandle_t handle,
@@ -1495,7 +1919,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
 
   // Use FP16 input/output with FP32 accumulation.
   auto &cuda_ctx = const_cast<phi::GPUContext &>(dev_ctx_);
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas =
+      M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
     CUBlas<phi::float16>::GEMM_EX_64(&cuda_ctx,
                                      cuTransB,
@@ -1517,8 +1943,8 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                      CUBLAS_COMPUTE_32F);
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "GEMM_EX_64 is not supported on cuda < 12.3"));
-#endif  // CUDA_VERSION >= 12030
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
   } else {
     CheckGEMMNSize(N);
     CUBlas<phi::float16>::GEMM_EX(&cuda_ctx,
@@ -1707,7 +2133,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
 
   auto &cuda_ctx = const_cast<phi::GPUContext &>(dev_ctx_);
   // Use FP16 input/output with FP32 accumulation.
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas =
+      M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
     CUBlas<phi::float16>::GEMM_EX_64(&cuda_ctx,
                                      cuTransB,
@@ -1729,8 +2157,8 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                      CUBLAS_COMPUTE_32F);
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "GEMM_EX_64 is not supported on cuda < 12.3"));
-#endif  // CUDA_VERSION >= 12030
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
   } else {
     CheckGEMMNSize(N);
     CUBlas<phi::float16>::GEMM_EX(&cuda_ctx,
@@ -1815,7 +2243,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
           dev_ctx_.GetComputeCapability()));
 
   auto &cuda_ctx = const_cast<phi::GPUContext &>(dev_ctx_);
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas =
+      M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
     CUBlas<phi::float16>::GEMM_EX_64(&cuda_ctx,
                                      cuTransB,
@@ -1837,8 +2267,8 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                      CUBLAS_COMPUTE_32F);
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "64-bit FP16 GEMM_EX requires CUDA 12.3 or later on Linux."));
-#endif  // CUDA_VERSION >= 12030
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
   } else {
     CheckGEMMNSize(N);
     CUBlas<phi::float16>::GEMM_EX(&cuda_ctx,
@@ -1925,7 +2355,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   float h_beta = static_cast<float>(beta);
   auto &cuda_ctx = const_cast<phi::GPUContext &>(dev_ctx_);
 
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas =
+      M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
     CUBlas<phi::bfloat16>::GEMM_EX_64(&cuda_ctx,
                                       cuTransB,
@@ -1947,8 +2379,8 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                       CUBLAS_COMPUTE_32F);
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "cublasGemmEx_64 is not supported on cuda < 12.3"));
-#endif  // CUDA_VERSION >= 12030
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
   } else {
     CheckGEMMNSize(N);
     CUBlas<phi::bfloat16>::GEMM_EX(&cuda_ctx,
@@ -2012,7 +2444,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
           dev_ctx_.GetComputeCapability()));
 
   auto &cuda_ctx = const_cast<phi::GPUContext &>(dev_ctx_);
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas =
+      M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
     CUBlas<phi::bfloat16>::GEMM_EX_64(&cuda_ctx,
                                       cuTransB,
@@ -2034,8 +2468,8 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                       CUBLAS_COMPUTE_32F);
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "cublasGemmEx_64 is not supported on cuda < 12.3"));
-#endif  // CUDA_VERSION >= 12030
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
   } else {
     CheckGEMMNSize(N);
     CUBlas<phi::bfloat16>::GEMM_EX(&cuda_ctx,
@@ -2100,7 +2534,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
   float h_beta = beta;
 
   auto &cuda_ctx = const_cast<phi::GPUContext &>(dev_ctx_);
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas =
+      M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
     CUBlas<phi::bfloat16>::GEMM_EX_64(&cuda_ctx,
                                       cuTransB,
@@ -2122,8 +2558,8 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                       CUBLAS_COMPUTE_32F);
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "cublasGemmEx_64 is not supported on cuda < 12.3"));
-#endif  // CUDA_VERSION >= 12030
+        "64-bit cuBLAS GEMM requires CUDA 12.3 or later on Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
   } else {
     CheckGEMMNSize(N);
     CUBlas<phi::bfloat16>::GEMM_EX(&cuda_ctx,
@@ -2186,7 +2622,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
           "but received %d",
           dev_ctx_.GetComputeCapability()));
 
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas =
+      M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
     dev_ctx_.CublasCall([&](cublasHandle_t handle) {
       CUBlas<phi::complex64>::GEMM_64(handle,
@@ -2262,7 +2700,9 @@ inline void Blas<phi::GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
           "but received %d",
           dev_ctx_.GetComputeCapability()));
 
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas =
+      M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
     dev_ctx_.CublasCall([&](cublasHandle_t handle) {
       CUBlas<phi::complex128>::GEMM_64(handle,
@@ -2687,7 +3127,8 @@ void Blas<phi::GPUContext>::GEMV(bool trans_a,
   detail::check_blas_int64(N, "GEMV N");
   cublasOperation_t cuTransA = !trans_a ? CUBLAS_OP_T : CUBLAS_OP_N;
 
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
     dev_ctx_.CublasCall([&](cublasHandle_t handle) {
       CUBlas<T>::GEMV_64(
@@ -2770,13 +3211,73 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE ||
+                                    batchCount > INT_MAX_VALUE;
 #if CUDA_VERSION >= 9010
-  if ((std::is_same<T, float>::value) || std::is_same<T, phi::float16>::value) {
+  if constexpr (std::is_same<T, float>::value) {
+    if (requires_64_bit_blas) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+      detail::CublasCallWithTF32MathMode(&dev_ctx_, [&](cublasHandle_t handle) {
+        CUBlas<T>::GEMM_STRIDED_BATCH_64(handle,
+                                         cuTransB,
+                                         cuTransA,
+                                         N,
+                                         M,
+                                         K,
+                                         &alpha,
+                                         B,
+                                         ldb,
+                                         strideB,
+                                         A,
+                                         lda,
+                                         strideA,
+                                         &beta,
+                                         C,
+                                         ldc,
+                                         strideC,
+                                         batchCount);
+      });
+      return;
+#else
+      PADDLE_THROW(common::errors::Unimplemented(
+          "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later "
+          "on Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
+    }
+    const int m = detail::to_blas_int(M, "BatchedGEMM M");
+    const int n = detail::to_blas_int(N, "BatchedGEMM N");
+    const int k = detail::to_blas_int(K, "BatchedGEMM K");
+    const int batch_count =
+        detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+    detail::CublasCallWithTF32MathMode(&dev_ctx_, [&](cublasHandle_t handle) {
+      CUBlas<T>::GEMM_STRIDED_BATCH(handle,
+                                    cuTransB,
+                                    cuTransA,
+                                    n,
+                                    m,
+                                    k,
+                                    &alpha,
+                                    B,
+                                    static_cast<int>(ldb),
+                                    strideB,
+                                    A,
+                                    static_cast<int>(lda),
+                                    strideA,
+                                    &beta,
+                                    C,
+                                    static_cast<int>(ldc),
+                                    strideC,
+                                    batch_count);
+    });
+  } else if constexpr (std::is_same<T, phi::float16>::value) {
     cublasGemmAlgo_t algo = CUBLAS_GEMM_DFALT;
-    bool use_tensor_op_math = std::is_same<T, float>::value
-                                  ? FLAGS_cublas_allow_tf32
-                                  : dev_ctx_.tensor_core_available();
+    bool use_tensor_op_math = dev_ctx_.tensor_core_available();
     if (use_tensor_op_math) {
       algo = CUBLAS_GEMM_DFALT_TENSOR_OP;
     }
@@ -2785,7 +3286,7 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
     VLOG(4) << "use_half_precision_compute_type: "
             << FLAGS_gemm_use_half_precision_compute_type;
 
-    auto fp = std::is_same<T, float>::value ? CUDA_R_32F : CUDA_R_16F;
+    auto fp = CUDA_R_16F;
 #if CUDA_VERSION >= 11000
     auto compute_type = CUBLAS_COMPUTE_32F;
 #else
@@ -2796,9 +3297,10 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
     float h_beta = static_cast<float>(beta);
     void *a = static_cast<void *>(&h_alpha);
     void *b = static_cast<void *>(&h_beta);
-    // set ComputeType as CUDA_R_32F for fp16, for better accuracy
-    if (FLAGS_gemm_use_half_precision_compute_type == true &&
-        std::is_same<T, phi::float16>::value) {
+    // Keep ComputeType at fp32 for better accuracy unless fp16 accumulation is
+    // requested. alpha/beta are already T here, so pass them directly.
+    if (FLAGS_gemm_use_half_precision_compute_type &&
+        dev_ctx_.GetComputeCapability() >= 70) {
       a = static_cast<void *>(&alpha);
       b = static_cast<void *>(&beta);
 #if CUDA_VERSION >= 11000
@@ -2807,38 +3309,36 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       compute_type = CUDA_R_16F;
 #endif
     }
-    if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE) {
+    if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
-      detail::CublasCallForGemmEx<T>(&dev_ctx_, [&](cublasHandle_t handle) {
-        PADDLE_ENFORCE_GPU_SUCCESS(
-            phi::dynload::cublasGemmStridedBatchedEx_64(handle,
-                                                        cuTransB,
-                                                        cuTransA,
-                                                        N,
-                                                        M,
-                                                        K,
-                                                        a,
-                                                        B,
-                                                        fp,
-                                                        ldb,
-                                                        strideB,
-                                                        A,
-                                                        fp,
-                                                        lda,
-                                                        strideA,
-                                                        b,
-                                                        C,
-                                                        fp,
-                                                        ldc,
-                                                        strideC,
-                                                        batchCount,
-                                                        compute_type,
-                                                        algo));
-      });
+      CUBlas<T>::GEMM_STRIDED_BATCH_64(&dev_ctx_,
+                                       cuTransB,
+                                       cuTransA,
+                                       N,
+                                       M,
+                                       K,
+                                       a,
+                                       B,
+                                       fp,
+                                       ldb,
+                                       strideB,
+                                       A,
+                                       fp,
+                                       lda,
+                                       strideA,
+                                       b,
+                                       C,
+                                       fp,
+                                       ldc,
+                                       strideC,
+                                       batchCount,
+                                       compute_type,
+                                       algo);
 #else
       PADDLE_THROW(common::errors::Unimplemented(
-          "cublasGemmStridedBatchedEx_64 is not supported on cuda < 12.3"));
-#endif  // CUDA_VERSION >= 12030
+          "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later "
+          "on Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
     } else {
       detail::CublasCallForGemmEx<T>(&dev_ctx_, [&](cublasHandle_t handle) {
         PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasGemmStridedBatchedEx(
@@ -2869,53 +3369,59 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
     }
   } else {
 #endif  // CUDA_VERSION >= 9010
+    if (requires_64_bit_blas) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+      dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+        CUBlas<T>::GEMM_STRIDED_BATCH_64(handle,
+                                         cuTransB,
+                                         cuTransA,
+                                         N,
+                                         M,
+                                         K,
+                                         &alpha,
+                                         B,
+                                         ldb,
+                                         strideB,
+                                         A,
+                                         lda,
+                                         strideA,
+                                         &beta,
+                                         C,
+                                         ldc,
+                                         strideC,
+                                         batchCount);
+      });
+      return;
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
+    }
+    const int m = detail::to_blas_int(M, "BatchedGEMM M");
+    const int n = detail::to_blas_int(N, "BatchedGEMM N");
+    const int k = detail::to_blas_int(K, "BatchedGEMM K");
+    const int batch_count =
+        detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
     dev_ctx_.CublasCall([&](cublasHandle_t handle) {
-#if defined(PADDLE_WITH_CUDA) && !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
-      if (N == 1 && ldc >= std::max<int64_t>(1, M) && !FLAGS_use_legacy_gemm) {
-        // No transpose result in these case, align with torch's behaviour.
-        // TODO(Pan Zhaowu): Integrate proper stride support for arbitrary input
-        // tensor.
-        CUBlas<T>::GEMM_STRIDED_BATCH(
-            handle,
-            (cuTransA == CUBLAS_OP_T) ? CUBLAS_OP_N : CUBLAS_OP_T,
-            (cuTransB == CUBLAS_OP_T) ? CUBLAS_OP_N : CUBLAS_OP_T,
-            static_cast<int>(M),
-            static_cast<int>(N),
-            static_cast<int>(K),
-            &alpha,
-            A,
-            static_cast<int>(lda),
-            strideA,
-            B,
-            static_cast<int>(ldb),
-            strideB,
-            &beta,
-            C,
-            static_cast<int>(ldc),
-            strideC,
-            static_cast<int>(batchCount));
-      } else  // NOLINT
-#endif
-      {
-        CUBlas<T>::GEMM_STRIDED_BATCH(handle,
-                                      cuTransB,
-                                      cuTransA,
-                                      static_cast<int>(N),
-                                      static_cast<int>(M),
-                                      static_cast<int>(K),
-                                      &alpha,
-                                      B,
-                                      static_cast<int>(ldb),
-                                      strideB,
-                                      A,
-                                      static_cast<int>(lda),
-                                      strideA,
-                                      &beta,
-                                      C,
-                                      static_cast<int>(ldc),
-                                      strideC,
-                                      static_cast<int>(batchCount));
-      }
+      CUBlas<T>::GEMM_STRIDED_BATCH(handle,
+                                    cuTransB,
+                                    cuTransA,
+                                    n,
+                                    m,
+                                    k,
+                                    &alpha,
+                                    B,
+                                    static_cast<int>(ldb),
+                                    strideB,
+                                    A,
+                                    static_cast<int>(lda),
+                                    strideA,
+                                    &beta,
+                                    C,
+                                    static_cast<int>(ldc),
+                                    strideC,
+                                    batch_count);
     });
 
 #if CUDA_VERSION >= 9010
@@ -2947,13 +3453,75 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE ||
+                                    batchCount > INT_MAX_VALUE;
 #if CUDA_VERSION >= 9010
-  if ((std::is_same<T, float>::value) || std::is_same<T, phi::float16>::value) {
+  if constexpr (std::is_same<T, float>::value) {
+    T h_alpha = static_cast<T>(alpha);
+    T h_beta = static_cast<T>(beta);
+    if (requires_64_bit_blas) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+      detail::CublasCallWithTF32MathMode(&dev_ctx_, [&](cublasHandle_t handle) {
+        CUBlas<T>::GEMM_STRIDED_BATCH_64(handle,
+                                         cuTransB,
+                                         cuTransA,
+                                         N,
+                                         M,
+                                         K,
+                                         &h_alpha,
+                                         B,
+                                         ldb,
+                                         strideB,
+                                         A,
+                                         lda,
+                                         strideA,
+                                         &h_beta,
+                                         C,
+                                         ldc,
+                                         strideC,
+                                         batchCount);
+      });
+      return;
+#else
+      PADDLE_THROW(common::errors::Unimplemented(
+          "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later "
+          "on Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
+    }
+    const int m = detail::to_blas_int(M, "BatchedGEMM M");
+    const int n = detail::to_blas_int(N, "BatchedGEMM N");
+    const int k = detail::to_blas_int(K, "BatchedGEMM K");
+    const int batch_count =
+        detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+    detail::CublasCallWithTF32MathMode(&dev_ctx_, [&](cublasHandle_t handle) {
+      CUBlas<T>::GEMM_STRIDED_BATCH(handle,
+                                    cuTransB,
+                                    cuTransA,
+                                    n,
+                                    m,
+                                    k,
+                                    &h_alpha,
+                                    B,
+                                    static_cast<int>(ldb),
+                                    strideB,
+                                    A,
+                                    static_cast<int>(lda),
+                                    strideA,
+                                    &h_beta,
+                                    C,
+                                    static_cast<int>(ldc),
+                                    strideC,
+                                    batch_count);
+    });
+  } else if constexpr (std::is_same<T, phi::float16>::value) {
     cublasGemmAlgo_t algo = CUBLAS_GEMM_DFALT;
-    bool use_tensor_op_math = std::is_same<T, float>::value
-                                  ? FLAGS_cublas_allow_tf32
-                                  : dev_ctx_.tensor_core_available();
+    bool use_tensor_op_math = dev_ctx_.tensor_core_available();
     if (use_tensor_op_math) {
       algo = CUBLAS_GEMM_DFALT_TENSOR_OP;
     }
@@ -2962,7 +3530,7 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
     VLOG(4) << "use_half_precision_compute_type: "
             << FLAGS_gemm_use_half_precision_compute_type;
 
-    auto fp = std::is_same<T, float>::value ? CUDA_R_32F : CUDA_R_16F;
+    auto fp = CUDA_R_16F;
 #if CUDA_VERSION >= 11000
     auto compute_type = CUBLAS_COMPUTE_32F;
 #else
@@ -2971,13 +3539,17 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
 
     float h_alpha = static_cast<float>(alpha);
     float h_beta = static_cast<float>(beta);
+    phi::float16 t_alpha = static_cast<phi::float16>(alpha);
+    phi::float16 t_beta = static_cast<phi::float16>(beta);
     void *a = static_cast<void *>(&h_alpha);
     void *b = static_cast<void *>(&h_beta);
-    // set ComputeType as CUDA_R_32F for fp16, for better accuracy
-    if (FLAGS_gemm_use_half_precision_compute_type == true &&
-        std::is_same<T, phi::float16>::value) {
-      a = static_cast<void *>(&alpha);
-      b = static_cast<void *>(&beta);
+    // Keep ComputeType at fp32 for better accuracy unless fp16 accumulation is
+    // requested. cuBLAS reads alpha/beta with the width of computeType, so the
+    // fp16 path must be handed fp16 scalars, not the U-typed originals.
+    if (FLAGS_gemm_use_half_precision_compute_type &&
+        dev_ctx_.GetComputeCapability() >= 70) {
+      a = static_cast<void *>(&t_alpha);
+      b = static_cast<void *>(&t_beta);
 #if CUDA_VERSION >= 11000
       compute_type = CUBLAS_COMPUTE_16F;
 #else
@@ -2985,39 +3557,36 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
 #endif
     }
 
-    if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-        batchCount > INT_MAX_VALUE) {
+    if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
-      detail::CublasCallForGemmEx<T>(&dev_ctx_, [&](cublasHandle_t handle) {
-        PADDLE_ENFORCE_GPU_SUCCESS(
-            phi::dynload::cublasGemmStridedBatchedEx_64(handle,
-                                                        cuTransB,
-                                                        cuTransA,
-                                                        N,
-                                                        M,
-                                                        K,
-                                                        a,
-                                                        B,
-                                                        fp,
-                                                        ldb,
-                                                        strideB,
-                                                        A,
-                                                        fp,
-                                                        lda,
-                                                        strideA,
-                                                        b,
-                                                        C,
-                                                        fp,
-                                                        ldc,
-                                                        strideC,
-                                                        batchCount,
-                                                        compute_type,
-                                                        algo));
-      });
+      CUBlas<T>::GEMM_STRIDED_BATCH_64(&dev_ctx_,
+                                       cuTransB,
+                                       cuTransA,
+                                       N,
+                                       M,
+                                       K,
+                                       a,
+                                       B,
+                                       fp,
+                                       ldb,
+                                       strideB,
+                                       A,
+                                       fp,
+                                       lda,
+                                       strideA,
+                                       b,
+                                       C,
+                                       fp,
+                                       ldc,
+                                       strideC,
+                                       batchCount,
+                                       compute_type,
+                                       algo);
 #else
       PADDLE_THROW(common::errors::Unimplemented(
-          "cublasGemmStridedBatchedEx_64 is not supported on cuda < 12.3"));
-#endif  // CUDA_VERSION >= 12030
+          "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later "
+          "on Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
     } else {
       detail::CublasCallForGemmEx<T>(&dev_ctx_, [&](cublasHandle_t handle) {
         PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cublasGemmStridedBatchedEx(
@@ -3051,13 +3620,48 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
     T h_alpha = static_cast<T>(alpha);
     T h_beta = static_cast<T>(beta);
 
+    if (requires_64_bit_blas) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+      dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+        CUBlas<T>::GEMM_STRIDED_BATCH_64(handle,
+                                         cuTransB,
+                                         cuTransA,
+                                         N,
+                                         M,
+                                         K,
+                                         &h_alpha,
+                                         B,
+                                         ldb,
+                                         strideB,
+                                         A,
+                                         lda,
+                                         strideA,
+                                         &h_beta,
+                                         C,
+                                         ldc,
+                                         strideC,
+                                         batchCount);
+      });
+      return;
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
+    }
+    const int m = detail::to_blas_int(M, "BatchedGEMM M");
+    const int n = detail::to_blas_int(N, "BatchedGEMM N");
+    const int k = detail::to_blas_int(K, "BatchedGEMM K");
+    const int batch_count =
+        detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+
     dev_ctx_.CublasCall([&](cublasHandle_t handle) {
       CUBlas<T>::GEMM_STRIDED_BATCH(handle,
                                     cuTransB,
                                     cuTransA,
-                                    static_cast<int>(N),
-                                    static_cast<int>(M),
-                                    static_cast<int>(K),
+                                    n,
+                                    m,
+                                    k,
                                     &h_alpha,
                                     B,
                                     static_cast<int>(ldb),
@@ -3069,7 +3673,7 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                     C,
                                     static_cast<int>(ldc),
                                     strideC,
-                                    static_cast<int>(batchCount));
+                                    batch_count);
     });
 
 #if CUDA_VERSION >= 9010
@@ -3103,6 +3707,10 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
 
   float h_alpha = static_cast<float>(alpha);
@@ -3114,39 +3722,39 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
     algo = CUBLAS_GEMM_DFALT_TENSOR_OP;
   }
   VLOG(5) << "use_tensor_op_math: " << (use_tensor_op_math ? "True" : "False");
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE ||
+                                    batchCount > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
-    dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
-      PADDLE_ENFORCE_GPU_SUCCESS(
-          phi::dynload::cublasGemmStridedBatchedEx_64(handle,
-                                                      cuTransB,
-                                                      cuTransA,
-                                                      N,
-                                                      M,
-                                                      K,
-                                                      &h_alpha,
-                                                      B,
-                                                      CUDA_R_16BF,
-                                                      ldb,
-                                                      strideB,
-                                                      A,
-                                                      CUDA_R_16BF,
-                                                      lda,
-                                                      strideA,
-                                                      &h_beta,
-                                                      C,
-                                                      CUDA_R_16BF,
-                                                      ldc,
-                                                      strideC,
-                                                      batchCount,
-                                                      CUBLAS_COMPUTE_32F,
-                                                      algo));
-    });
+    CUBlas<phi::bfloat16>::GEMM_STRIDED_BATCH_64(&dev_ctx_,
+                                                 cuTransB,
+                                                 cuTransA,
+                                                 N,
+                                                 M,
+                                                 K,
+                                                 &h_alpha,
+                                                 B,
+                                                 CUDA_R_16BF,
+                                                 ldb,
+                                                 strideB,
+                                                 A,
+                                                 CUDA_R_16BF,
+                                                 lda,
+                                                 strideA,
+                                                 &h_beta,
+                                                 C,
+                                                 CUDA_R_16BF,
+                                                 ldc,
+                                                 strideC,
+                                                 batchCount,
+                                                 CUBLAS_COMPUTE_32F,
+                                                 algo);
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "cublasGemmStridedBatchedEx_64 is not supported on cuda < 12.3"));
-#endif  // CUDA_VERSION >= 12030
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
   } else {
     dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
       PADDLE_ENFORCE_GPU_SUCCESS(
@@ -3208,6 +3816,10 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
 
   float h_alpha = alpha;
@@ -3219,39 +3831,39 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
     algo = CUBLAS_GEMM_DFALT_TENSOR_OP;
   }
   VLOG(5) << "use_tensor_op_math: " << (use_tensor_op_math ? "True" : "False");
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE ||
+                                    batchCount > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
-    dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
-      PADDLE_ENFORCE_GPU_SUCCESS(
-          phi::dynload::cublasGemmStridedBatchedEx_64(handle,
-                                                      cuTransB,
-                                                      cuTransA,
-                                                      N,
-                                                      M,
-                                                      K,
-                                                      &h_alpha,
-                                                      B,
-                                                      CUDA_R_16BF,
-                                                      ldb,
-                                                      strideB,
-                                                      A,
-                                                      CUDA_R_16BF,
-                                                      lda,
-                                                      strideA,
-                                                      &h_beta,
-                                                      C,
-                                                      CUDA_R_16BF,
-                                                      ldc,
-                                                      strideC,
-                                                      batchCount,
-                                                      CUBLAS_COMPUTE_32F,
-                                                      algo));
-    });
+    CUBlas<phi::bfloat16>::GEMM_STRIDED_BATCH_64(&dev_ctx_,
+                                                 cuTransB,
+                                                 cuTransA,
+                                                 N,
+                                                 M,
+                                                 K,
+                                                 &h_alpha,
+                                                 B,
+                                                 CUDA_R_16BF,
+                                                 ldb,
+                                                 strideB,
+                                                 A,
+                                                 CUDA_R_16BF,
+                                                 lda,
+                                                 strideA,
+                                                 &h_beta,
+                                                 C,
+                                                 CUDA_R_16BF,
+                                                 ldc,
+                                                 strideC,
+                                                 batchCount,
+                                                 CUBLAS_COMPUTE_32F,
+                                                 algo);
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "cublasGemmStridedBatchedEx_64 is not supported on cuda < 12.3"));
-#endif  // CUDA_VERSION >= 12030
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
   } else {
     dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
       PADDLE_ENFORCE_GPU_SUCCESS(
@@ -3311,6 +3923,10 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
 
   PADDLE_ENFORCE_GE(
@@ -3321,7 +3937,7 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
           "capability >= 53, but received %d",
           dev_ctx_.GetComputeCapability()));
 
-  cublasGemmAlgo_t algo = CUBLAS_GEMM_DEFAULT;
+  cublasGemmAlgo_t algo = CUBLAS_GEMM_DFALT;
 #if CUDA_VERSION >= 9000
   bool use_tensor_op_math = dev_ctx_.tensor_core_available();
   if (use_tensor_op_math) {
@@ -3335,38 +3951,38 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   auto compute_type = CUDA_R_32F;
 #endif
 
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE ||
+                                    batchCount > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
-    dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
-      PADDLE_ENFORCE_GPU_SUCCESS(
-          phi::dynload::cublasGemmStridedBatchedEx_64(handle,
-                                                      cuTransB,
-                                                      cuTransA,
-                                                      N,
-                                                      M,
-                                                      K,
-                                                      &alpha,
-                                                      B,
-                                                      CUDA_R_16F,
-                                                      ldb,
-                                                      strideB,
-                                                      A,
-                                                      CUDA_R_16F,
-                                                      lda,
-                                                      strideA,
-                                                      &beta,
-                                                      C,
-                                                      CUDA_R_32F,
-                                                      ldc,
-                                                      strideC,
-                                                      batchCount,
-                                                      compute_type,
-                                                      algo));
-    });
+    CUBlas<phi::float16>::GEMM_STRIDED_BATCH_64(&dev_ctx_,
+                                                cuTransB,
+                                                cuTransA,
+                                                N,
+                                                M,
+                                                K,
+                                                &alpha,
+                                                B,
+                                                CUDA_R_16F,
+                                                ldb,
+                                                strideB,
+                                                A,
+                                                CUDA_R_16F,
+                                                lda,
+                                                strideA,
+                                                &beta,
+                                                C,
+                                                CUDA_R_32F,
+                                                ldc,
+                                                strideC,
+                                                batchCount,
+                                                compute_type,
+                                                algo);
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "cublasGemmStridedBatchedEx_64 is not supported on cuda < 12.3"));
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
 #endif  // CUDA_VERSION >= 12030 && defined(__linux__)
   } else {
     dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
@@ -3426,6 +4042,10 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (transB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
 
   PADDLE_ENFORCE_GE(
@@ -3436,45 +4056,45 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
           "capability >= 80, but received %d",
           dev_ctx_.GetComputeCapability()));
 
-  cublasGemmAlgo_t algo = CUBLAS_GEMM_DEFAULT;
+  cublasGemmAlgo_t algo = CUBLAS_GEMM_DFALT;
   bool use_tensor_op_math = dev_ctx_.tensor_core_available();
   if (use_tensor_op_math) {
     algo = CUBLAS_GEMM_DFALT_TENSOR_OP;
   }
   VLOG(5) << "use_tensor_op_math: " << (use_tensor_op_math ? "True" : "False");
 
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE ||
+                                    batchCount > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
 #if CUDA_VERSION >= 12030 && defined(__linux__)
-    dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
-      PADDLE_ENFORCE_GPU_SUCCESS(
-          phi::dynload::cublasGemmStridedBatchedEx_64(handle,
-                                                      cuTransB,
-                                                      cuTransA,
-                                                      N,
-                                                      M,
-                                                      K,
-                                                      &alpha,
-                                                      B,
-                                                      CUDA_R_16BF,
-                                                      ldb,
-                                                      strideB,
-                                                      A,
-                                                      CUDA_R_16BF,
-                                                      lda,
-                                                      strideA,
-                                                      &beta,
-                                                      C,
-                                                      CUDA_R_32F,
-                                                      ldc,
-                                                      strideC,
-                                                      batchCount,
-                                                      CUBLAS_COMPUTE_32F,
-                                                      algo));
-    });
+    CUBlas<phi::bfloat16>::GEMM_STRIDED_BATCH_64(&dev_ctx_,
+                                                 cuTransB,
+                                                 cuTransA,
+                                                 N,
+                                                 M,
+                                                 K,
+                                                 &alpha,
+                                                 B,
+                                                 CUDA_R_16BF,
+                                                 ldb,
+                                                 strideB,
+                                                 A,
+                                                 CUDA_R_16BF,
+                                                 lda,
+                                                 strideA,
+                                                 &beta,
+                                                 C,
+                                                 CUDA_R_32F,
+                                                 ldc,
+                                                 strideC,
+                                                 batchCount,
+                                                 CUBLAS_COMPUTE_32F,
+                                                 algo);
 #else
     PADDLE_THROW(common::errors::Unimplemented(
-        "cublasGemmStridedBatchedEx_64 is not supported on cuda < 12.3"));
+        "64-bit cuBLAS strided batched GEMM requires CUDA 12.3 or later on "
+        "Linux."));
 #endif  // CUDA_VERSION >= 12030 && defined(__linux__)
   } else {
     dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
@@ -3515,18 +4135,19 @@ template <>
 template <typename T>
 void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                         CBLAS_TRANSPOSE transB,
-                                        int M,
-                                        int N,
-                                        int K,
+                                        int64_t M,
+                                        int64_t N,
+                                        int64_t K,
                                         T alpha,
                                         const T **A,
                                         const T **B,
                                         T beta,
                                         T **C,
-                                        int batchCount) const {
-  for (int k = 0; k < batchCount; ++k) {
+                                        int64_t batchCount) const {
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
+  for (int64_t i = 0; i < batchCount; ++i) {
     this->template GEMM<T>(
-        transA, transB, M, N, K, alpha, A[k], B[k], beta, C[k]);
+        transA, transB, M, N, K, alpha, A[i], B[i], beta, C[i]);
   }
 }
 
@@ -3535,20 +4156,24 @@ template <>
 template <>
 inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                                CBLAS_TRANSPOSE transB,
-                                               int M,
-                                               int N,
-                                               int K,
+                                               int64_t M,
+                                               int64_t N,
+                                               int64_t K,
                                                double alpha,
                                                const double **A,
                                                const double **B,
                                                double beta,
                                                double **C,
-                                               int batchCount) const {
+                                               int64_t batchCount) const {
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
-  int lda = (transA == CblasNoTrans) ? K : M;
-  int ldb = (transB == CblasNoTrans) ? N : K;
-  int ldc = N;
+  const int64_t lda = (transA == CblasNoTrans) ? K : M;
+  const int64_t ldb = (transB == CblasNoTrans) ? N : K;
+  const int64_t ldc = N;
   cublasOperation_t cuTransA =
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
@@ -3557,22 +4182,50 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   thrust::device_vector<const double *> B_ptr(B, B + batchCount);
   thrust::device_vector<double *> C_ptr(C, C + batchCount);
 
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE ||
+                                    batchCount > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
+    dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+      CUBlas<double>::GEMM_BATCH_64(handle,
+                                    cuTransB,
+                                    cuTransA,
+                                    N,
+                                    M,
+                                    K,
+                                    &alpha,
+                                    B_ptr.data().get(),
+                                    ldb,
+                                    A_ptr.data().get(),
+                                    lda,
+                                    &beta,
+                                    C_ptr.data().get(),
+                                    ldc,
+                                    batchCount);
+    });
+    return;
+  }
+  const int m = detail::to_blas_int(M, "BatchedGEMM M");
+  const int n = detail::to_blas_int(N, "BatchedGEMM N");
+  const int k = detail::to_blas_int(K, "BatchedGEMM K");
+  const int batch_count =
+      detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
     CUBlas<double>::GEMM_BATCH(handle,
                                cuTransB,
                                cuTransA,
-                               N,
-                               M,
-                               K,
+                               n,
+                               m,
+                               k,
                                &alpha,
                                B_ptr.data().get(),
-                               ldb,
+                               static_cast<int>(ldb),
                                A_ptr.data().get(),
-                               lda,
+                               static_cast<int>(lda),
                                &beta,
                                C_ptr.data().get(),
-                               ldc,
-                               batchCount);
+                               static_cast<int>(ldc),
+                               batch_count);
   });
 }
 
@@ -3580,20 +4233,24 @@ template <>
 template <>
 inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                                CBLAS_TRANSPOSE transB,
-                                               int M,
-                                               int N,
-                                               int K,
+                                               int64_t M,
+                                               int64_t N,
+                                               int64_t K,
                                                float alpha,
                                                const float **A,
                                                const float **B,
                                                float beta,
                                                float **C,
-                                               int batchCount) const {
+                                               int64_t batchCount) const {
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
-  int lda = (transA == CblasNoTrans) ? K : M;
-  int ldb = (transB == CblasNoTrans) ? N : K;
-  int ldc = N;
+  const int64_t lda = (transA == CblasNoTrans) ? K : M;
+  const int64_t ldb = (transB == CblasNoTrans) ? N : K;
+  const int64_t ldc = N;
   cublasOperation_t cuTransA =
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
@@ -3602,22 +4259,50 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   thrust::device_vector<const float *> B_ptr(B, B + batchCount);
   thrust::device_vector<float *> C_ptr(C, C + batchCount);
 
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE ||
+                                    batchCount > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
+    dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+      CUBlas<float>::GEMM_BATCH_64(handle,
+                                   cuTransB,
+                                   cuTransA,
+                                   N,
+                                   M,
+                                   K,
+                                   &alpha,
+                                   B_ptr.data().get(),
+                                   ldb,
+                                   A_ptr.data().get(),
+                                   lda,
+                                   &beta,
+                                   C_ptr.data().get(),
+                                   ldc,
+                                   batchCount);
+    });
+    return;
+  }
+  const int m = detail::to_blas_int(M, "BatchedGEMM M");
+  const int n = detail::to_blas_int(N, "BatchedGEMM N");
+  const int k = detail::to_blas_int(K, "BatchedGEMM K");
+  const int batch_count =
+      detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
     CUBlas<float>::GEMM_BATCH(handle,
                               cuTransB,
                               cuTransA,
-                              N,
-                              M,
-                              K,
+                              n,
+                              m,
+                              k,
                               &alpha,
                               B_ptr.data().get(),
-                              ldb,
+                              static_cast<int>(ldb),
                               A_ptr.data().get(),
-                              lda,
+                              static_cast<int>(lda),
                               &beta,
                               C_ptr.data().get(),
-                              ldc,
-                              batchCount);
+                              static_cast<int>(ldc),
+                              batch_count);
   });
 }
 
@@ -3625,20 +4310,24 @@ template <>
 template <>
 inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                                CBLAS_TRANSPOSE transB,
-                                               int M,
-                                               int N,
-                                               int K,
+                                               int64_t M,
+                                               int64_t N,
+                                               int64_t K,
                                                phi::float16 alpha,
                                                const phi::float16 **A,
                                                const phi::float16 **B,
                                                phi::float16 beta,
                                                phi::float16 **C,
-                                               int batchCount) const {
+                                               int64_t batchCount) const {
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
-  int lda = (transA == CblasNoTrans) ? K : M;
-  int ldb = (transB == CblasNoTrans) ? N : K;
-  int ldc = N;
+  const int64_t lda = (transA == CblasNoTrans) ? K : M;
+  const int64_t ldb = (transB == CblasNoTrans) ? N : K;
+  const int64_t ldc = N;
   cublasOperation_t cuTransA =
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
@@ -3654,24 +4343,54 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   float f_alpha = static_cast<float>(alpha);
   float f_beta = static_cast<float>(beta);
   auto &cuda_ctx = const_cast<phi::GPUContext &>(dev_ctx_);
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE ||
+                                    batchCount > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
+    CUBlas<phi::float16>::GEMM_BATCH_64(&cuda_ctx,
+                                        cuTransB,
+                                        cuTransA,
+                                        N,
+                                        M,
+                                        K,
+                                        &f_alpha,
+                                        B,
+                                        CUDA_R_16F,
+                                        ldb,
+                                        A,
+                                        CUDA_R_16F,
+                                        lda,
+                                        &f_beta,
+                                        C,
+                                        CUDA_R_16F,
+                                        ldc,
+                                        batchCount,
+                                        CUDA_R_32F);
+    return;
+  }
+  const int m = detail::to_blas_int(M, "BatchedGEMM M");
+  const int n = detail::to_blas_int(N, "BatchedGEMM N");
+  const int k = detail::to_blas_int(K, "BatchedGEMM K");
+  const int batch_count =
+      detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   CUBlas<phi::float16>::GEMM_BATCH(&cuda_ctx,
                                    cuTransB,
                                    cuTransA,
-                                   N,
-                                   M,
-                                   K,
+                                   n,
+                                   m,
+                                   k,
                                    &f_alpha,
                                    B,
                                    CUDA_R_16F,
-                                   ldb,
+                                   static_cast<int>(ldb),
                                    A,
                                    CUDA_R_16F,
-                                   lda,
+                                   static_cast<int>(lda),
                                    &f_beta,
                                    C,
                                    CUDA_R_16F,
-                                   ldc,
-                                   batchCount,
+                                   static_cast<int>(ldc),
+                                   batch_count,
                                    CUDA_R_32F);
 }
 
@@ -3679,21 +4398,25 @@ template <>
 template <>
 inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                                CBLAS_TRANSPOSE transB,
-                                               int M,
-                                               int N,
-                                               int K,
+                                               int64_t M,
+                                               int64_t N,
+                                               int64_t K,
                                                phi::bfloat16 alpha,
                                                const phi::bfloat16 **A,
                                                const phi::bfloat16 **B,
                                                phi::bfloat16 beta,
                                                phi::bfloat16 **C,
-                                               int batchCount) const {
+                                               int64_t batchCount) const {
 #if CUDA_VERSION >= 11000
+  detail::check_blas_int64(M, "BatchedGEMM M");
+  detail::check_blas_int64(N, "BatchedGEMM N");
+  detail::check_blas_int64(K, "BatchedGEMM K");
+  detail::check_blas_int64(batchCount, "BatchedGEMM batchCount");
   // Note that cublas follows fortran order, so the order is different from
   // the cblas convention.
-  int lda = (transA == CblasNoTrans) ? K : M;
-  int ldb = (transB == CblasNoTrans) ? N : K;
-  int ldc = N;
+  const int64_t lda = (transA == CblasNoTrans) ? K : M;
+  const int64_t ldb = (transB == CblasNoTrans) ? N : K;
+  const int64_t ldc = N;
   cublasOperation_t cuTransA =
       (transA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
@@ -3710,7 +4433,7 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   float f_alpha = static_cast<float>(alpha);
   float f_beta = static_cast<float>(beta);
 
-  cublasGemmAlgo_t algo = CUBLAS_GEMM_DEFAULT;
+  cublasGemmAlgo_t algo = CUBLAS_GEMM_DFALT;
   bool use_tensor_op_math = dev_ctx_.tensor_core_available();
   if (use_tensor_op_math) {
     algo = CUBLAS_GEMM_DFALT_TENSOR_OP;
@@ -3720,26 +4443,65 @@ inline void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   thrust::device_vector<const void *> A_ptr(A, A + batchCount);
   thrust::device_vector<const void *> B_ptr(B, B + batchCount);
   thrust::device_vector<void *> C_ptr(C, C + batchCount);
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    K > INT_MAX_VALUE ||
+                                    batchCount > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
+#if CUDA_VERSION >= 12030 && defined(__linux__)
+    dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
+      PADDLE_ENFORCE_GPU_SUCCESS(
+          phi::dynload::cublasGemmBatchedEx_64(handle,
+                                               cuTransB,
+                                               cuTransA,
+                                               N,
+                                               M,
+                                               K,
+                                               &f_alpha,
+                                               B_ptr.data().get(),
+                                               CUDA_R_16BF,
+                                               ldb,
+                                               A_ptr.data().get(),
+                                               CUDA_R_16BF,
+                                               lda,
+                                               &f_beta,
+                                               C_ptr.data().get(),
+                                               CUDA_R_16BF,
+                                               ldc,
+                                               batchCount,
+                                               CUDA_R_32F,
+                                               algo));
+    });
+    return;
+#else
+    PADDLE_THROW(common::errors::Unimplemented(
+        "64-bit cuBLAS batched GEMM requires CUDA 12.3 or later on Linux."));
+#endif  // CUDA_VERSION >= 12030 && defined(__linux__)
+  }
+  const int m = detail::to_blas_int(M, "BatchedGEMM M");
+  const int n = detail::to_blas_int(N, "BatchedGEMM N");
+  const int k = detail::to_blas_int(K, "BatchedGEMM K");
+  const int batch_count =
+      detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   dev_ctx_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
     PADDLE_ENFORCE_GPU_SUCCESS(
         phi::dynload::cublasGemmBatchedEx(handle,
                                           cuTransB,
                                           cuTransA,
-                                          N,
-                                          M,
-                                          K,
+                                          n,
+                                          m,
+                                          k,
                                           &f_alpha,
                                           B_ptr.data().get(),
                                           CUDA_R_16BF,
-                                          ldb,
+                                          static_cast<int>(ldb),
                                           A_ptr.data().get(),
                                           CUDA_R_16BF,
-                                          lda,
+                                          static_cast<int>(lda),
                                           &f_beta,
                                           C_ptr.data().get(),
                                           CUDA_R_16BF,
-                                          ldc,
-                                          batchCount,
+                                          static_cast<int>(ldc),
+                                          batch_count,
                                           CUDA_R_32F,
                                           algo));
   });
@@ -3765,10 +4527,10 @@ void Blas<phi::GPUContext>::TRSM(CBLAS_SIDE side,
                                  int64_t lda,
                                  T *B,
                                  int64_t ldb) const {
-  const int m = detail::to_blas_int(M, "TRSM M");
-  const int n = detail::to_blas_int(N, "TRSM N");
-  const int lda_int = detail::to_blas_int(lda, "TRSM lda");
-  const int ldb_int = detail::to_blas_int(ldb, "TRSM ldb");
+  detail::check_blas_int64(M, "TRSM M");
+  detail::check_blas_int64(N, "TRSM N");
+  detail::check_blas_int64(lda, "TRSM lda");
+  detail::check_blas_int64(ldb, "TRSM ldb");
   // solve row major `op ( A ) X = α B` by taking it as `X' op ( A' )  =  α B'`
   // where ' stands for transpose
   cublasSideMode_t cuSide =
@@ -3781,6 +4543,29 @@ void Blas<phi::GPUContext>::TRSM(CBLAS_SIDE side,
   cublasDiagType_t cuDiag =
       (diag == CblasUnit) ? CUBLAS_DIAG_UNIT : CUBLAS_DIAG_NON_UNIT;
 
+  const bool requires_64_bit_blas = M > INT_MAX_VALUE || N > INT_MAX_VALUE ||
+                                    lda > INT_MAX_VALUE || ldb > INT_MAX_VALUE;
+  if (requires_64_bit_blas) {
+    dev_ctx_.CublasCall([&](cublasHandle_t handle) {
+      CUBlas<T>::TRSM_64(handle,
+                         cuSide,
+                         cuUplo,
+                         cuTransA,
+                         cuDiag,
+                         N,
+                         M,
+                         &alpha,
+                         A,
+                         lda,
+                         B,
+                         ldb);
+    });
+    return;
+  }
+  const int m = detail::to_blas_int(M, "TRSM M");
+  const int n = detail::to_blas_int(N, "TRSM N");
+  const int lda_int = detail::to_blas_int(lda, "TRSM lda");
+  const int ldb_int = detail::to_blas_int(ldb, "TRSM ldb");
   dev_ctx_.CublasCall([&](cublasHandle_t handle) {
     CUBlas<T>::TRSM(handle,
                     cuSide,

--- a/paddle/phi/kernels/funcs/blas/blas_impl.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.h
@@ -1228,42 +1228,67 @@ struct CBlas<phi::float16> {
 template <>
 template <typename T>
 T *Blas<CPUContext>::GEMM_ALLOC(const CBLAS_IDENTIFIER id,
-                                const int M,
-                                const int N,
-                                const int K) const {
-  return CBlas<T>::GEMM_ALLOC(id, M, N, K);
+                                int64_t M,
+                                int64_t N,
+                                int64_t K) const {
+  const int m = detail::to_blas_int(M, "GEMM_ALLOC M");
+  const int n = detail::to_blas_int(N, "GEMM_ALLOC N");
+  const int k = detail::to_blas_int(K, "GEMM_ALLOC K");
+  return CBlas<T>::GEMM_ALLOC(id, m, n, k);
 }
 
 template <>
 template <typename T>
 void Blas<CPUContext>::GEMM_PACK(const CBLAS_IDENTIFIER id,
                                  const CBLAS_TRANSPOSE trans,
-                                 int M,
-                                 int N,
-                                 int K,
+                                 int64_t M,
+                                 int64_t N,
+                                 int64_t K,
                                  const T alpha,
                                  const T *src,
-                                 const int ld,
+                                 int64_t ld,
                                  T *dst) const {
-  CBlas<T>::GEMM_PACK(CblasRowMajor, id, trans, M, N, K, alpha, src, ld, dst);
+  const int m = detail::to_blas_int(M, "GEMM_PACK M");
+  const int n = detail::to_blas_int(N, "GEMM_PACK N");
+  const int k = detail::to_blas_int(K, "GEMM_PACK K");
+  const int ld_int = detail::to_blas_int(ld, "GEMM_PACK ld");
+  CBlas<T>::GEMM_PACK(
+      CblasRowMajor, id, trans, m, n, k, alpha, src, ld_int, dst);
 }
 
 template <>
 template <typename T>
 void Blas<CPUContext>::GEMM_COMPUTE(int transA,
                                     int transB,
-                                    int M,
-                                    int N,
-                                    int K,
+                                    int64_t M,
+                                    int64_t N,
+                                    int64_t K,
                                     const T *A,
-                                    const int lda,
+                                    int64_t lda,
                                     const T *B,
-                                    const int ldb,
+                                    int64_t ldb,
                                     T beta,
                                     T *C,
-                                    const int ldc) const {
-  CBlas<T>::GEMM_COMPUTE(
-      CblasRowMajor, transA, transB, M, N, K, A, lda, B, ldb, beta, C, ldc);
+                                    int64_t ldc) const {
+  const int m = detail::to_blas_int(M, "GEMM_COMPUTE M");
+  const int n = detail::to_blas_int(N, "GEMM_COMPUTE N");
+  const int k = detail::to_blas_int(K, "GEMM_COMPUTE K");
+  const int lda_int = detail::to_blas_int(lda, "GEMM_COMPUTE lda");
+  const int ldb_int = detail::to_blas_int(ldb, "GEMM_COMPUTE ldb");
+  const int ldc_int = detail::to_blas_int(ldc, "GEMM_COMPUTE ldc");
+  CBlas<T>::GEMM_COMPUTE(CblasRowMajor,
+                         transA,
+                         transB,
+                         m,
+                         n,
+                         k,
+                         A,
+                         lda_int,
+                         B,
+                         ldb_int,
+                         beta,
+                         C,
+                         ldc_int);
 }
 
 template <>
@@ -1444,13 +1469,9 @@ void Blas<DeviceContext>::MatMul(const DenseTensor &mat_a,
                                       "should be same, please check your "
                                       "code."));
 
-  const int64_t K_64 = !trans_a ? dim_a[1] : dim_a[0];
-  PADDLE_ENFORCE_LE_INT_MAX(dim_out[0], "dim_out[0]");
-  PADDLE_ENFORCE_LE_INT_MAX(dim_out[1], "dim_out[1]");
-  PADDLE_ENFORCE_LE_INT_MAX(K_64, "cblas GEMM K");
-  int M = static_cast<int>(dim_out[0]);
-  int N = static_cast<int>(dim_out[1]);
-  int K = static_cast<int>(K_64);
+  const int64_t M = dim_out[0];
+  const int64_t N = dim_out[1];
+  const int64_t K = !trans_a ? dim_a[1] : dim_a[0];
 
   CBLAS_TRANSPOSE transA = !trans_a ? CblasNoTrans : CblasTrans;
   CBLAS_TRANSPOSE transB = !trans_b ? CblasNoTrans : CblasTrans;
@@ -1518,40 +1539,28 @@ void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   PADDLE_ENFORCE_NOT_NULL(
       C, common::errors::InvalidArgument("Pointer C should not be null."));
 
-  if (M > std::numeric_limits<int>::max() ||
-      N > std::numeric_limits<int>::max() ||
-      K > std::numeric_limits<int>::max() ||
-      batchCount > std::numeric_limits<int>::max()) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "CPU BatchedGEMM only supports M, N, K and batchCount not larger "
-        "than INT_MAX. Expected M <= %d, N <= %d, K <= %d and "
-        "batchCount <= %d, but received M = %ld, N = %ld, K = %ld, "
-        "batchCount = %ld.",
-        std::numeric_limits<int>::max(),
-        std::numeric_limits<int>::max(),
-        std::numeric_limits<int>::max(),
-        std::numeric_limits<int>::max(),
-        M,
-        N,
-        K,
-        batchCount));
-  }
+  detail::to_blas_int(M, "BatchedGEMM M");
+  detail::to_blas_int(N, "BatchedGEMM N");
+  detail::to_blas_int(K, "BatchedGEMM K");
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+  const int64_t strideC = M * N;
 
 #if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
-  int M_int = static_cast<int>(M);
-  int N_int = static_cast<int>(N);
-  int K_int = static_cast<int>(K);
-  int batch_count_int = static_cast<int>(batchCount);
+  int M_int = detail::to_blas_int(M, "BatchedGEMM M");
+  int N_int = detail::to_blas_int(N, "BatchedGEMM N");
+  int K_int = detail::to_blas_int(K, "BatchedGEMM K");
+  int batch_count_int =
+      detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   int lda = (transA == CblasNoTrans) ? K_int : M_int;
   int ldb = (transB == CblasNoTrans) ? N_int : K_int;
   int ldc = N_int;
   auto a_array = std::vector<const T *>(batchCount);
   auto b_array = std::vector<const T *>(batchCount);
   auto c_array = std::vector<T *>(batchCount);
-  for (int k = 0; k < batchCount; ++k) {
+  for (int k = 0; k < batch_count_int; ++k) {
     a_array[k] = &A[k * strideA];
     b_array[k] = &B[k * strideB];
-    c_array[k] = &C[k * M * N];
+    c_array[k] = &C[k * strideC];
   }
   CBlas<T>::GEMM_BATCH(CblasRowMajor,
                        &transA,
@@ -1573,17 +1582,8 @@ void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   for (int64_t k = 0; k < batchCount; ++k) {
     auto *Ak = &A[k * strideA];
     auto *Bk = &B[k * strideB];
-    auto *Ck = &C[k * M * N];
-    this->template GEMM<T>(transA,
-                           transB,
-                           static_cast<int>(M),
-                           static_cast<int>(N),
-                           static_cast<int>(K),
-                           alpha,
-                           Ak,
-                           Bk,
-                           beta,
-                           Ck);
+    auto *Ck = &C[k * strideC];
+    this->template GEMM<T>(transA, transB, M, N, K, alpha, Ak, Bk, beta, Ck);
   }
 #endif
 }
@@ -1609,30 +1609,28 @@ void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
       B, common::errors::InvalidArgument("Pointer B should not be null."));
   PADDLE_ENFORCE_NOT_NULL(
       C, common::errors::InvalidArgument("Pointer C should not be null."));
-  if (M > std::numeric_limits<int>::max() ||
-      N > std::numeric_limits<int>::max() ||
-      K > std::numeric_limits<int>::max() ||
-      batchCount > std::numeric_limits<int>::max()) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "CPU BatchedGEMM does not support M, N, K or batchCount larger than "
-        "INT_MAX."));
-  }
+  detail::to_blas_int(M, "BatchedGEMM M");
+  detail::to_blas_int(N, "BatchedGEMM N");
+  detail::to_blas_int(K, "BatchedGEMM K");
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+  const int64_t strideC = M * N;
 
 #if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
-  int M_int = static_cast<int>(M);
-  int N_int = static_cast<int>(N);
-  int K_int = static_cast<int>(K);
-  int batch_count_int = static_cast<int>(batchCount);
+  int M_int = detail::to_blas_int(M, "BatchedGEMM M");
+  int N_int = detail::to_blas_int(N, "BatchedGEMM N");
+  int K_int = detail::to_blas_int(K, "BatchedGEMM K");
+  int batch_count_int =
+      detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   int lda = (transA == CblasNoTrans) ? K_int : M_int;
   int ldb = (transB == CblasNoTrans) ? N_int : K_int;
   int ldc = N_int;
   auto a_array = std::vector<const T *>(batchCount);
   auto b_array = std::vector<const T *>(batchCount);
   auto c_array = std::vector<T *>(batchCount);
-  for (int k = 0; k < batchCount; ++k) {
+  for (int k = 0; k < batch_count_int; ++k) {
     a_array[k] = &A[k * strideA];
     b_array[k] = &B[k * strideB];
-    c_array[k] = &C[k * M * N];
+    c_array[k] = &C[k * strideC];
   }
 
   CBlas<T>::GEMM_BATCH(CblasRowMajor,
@@ -1655,17 +1653,8 @@ void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   for (int64_t k = 0; k < batchCount; ++k) {
     auto *Ak = &A[k * strideA];
     auto *Bk = &B[k * strideB];
-    auto *Ck = &C[k * M * N];
-    this->template GEMM<T>(transA,
-                           transB,
-                           static_cast<int>(M),
-                           static_cast<int>(N),
-                           static_cast<int>(K),
-                           alpha,
-                           Ak,
-                           Bk,
-                           beta,
-                           Ck);
+    auto *Ck = &C[k * strideC];
+    this->template GEMM<T>(transA, transB, M, N, K, alpha, Ak, Bk, beta, Ck);
   }
 #endif
 }
@@ -1674,25 +1663,29 @@ template <>
 template <typename T>
 void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                    CBLAS_TRANSPOSE transB,
-                                   int M,
-                                   int N,
-                                   int K,
+                                   int64_t M,
+                                   int64_t N,
+                                   int64_t K,
                                    T alpha,
                                    const T **A,
                                    const T **B,
                                    T beta,
                                    T **C,
-                                   int batchCount) const {
+                                   int64_t batchCount) const {
+  int m = detail::to_blas_int(M, "BatchedGEMM M");
+  int n = detail::to_blas_int(N, "BatchedGEMM N");
+  int k = detail::to_blas_int(K, "BatchedGEMM K");
+  int batch_count = detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
 #if defined(PADDLE_WITH_MKLML) || defined(PADDLE_WITH_HML)
-  const int lda = (std::max)((transA == CblasNoTrans) ? K : M, 1);
-  const int ldb = (std::max)((transB == CblasNoTrans) ? N : K, 1);
-  const int ldc = (std::max)(N, 1);
+  const int lda = (std::max)((transA == CblasNoTrans) ? k : m, 1);
+  const int ldb = (std::max)((transB == CblasNoTrans) ? n : k, 1);
+  const int ldc = (std::max)(n, 1);
   CBlas<T>::GEMM_BATCH(CblasRowMajor,
                        &transA,
                        &transB,
-                       &M,
-                       &N,
-                       &K,
+                       &m,
+                       &n,
+                       &k,
                        &alpha,
                        A,
                        &lda,
@@ -1702,11 +1695,11 @@ void Blas<CPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                        C,
                        &ldc,
                        1 /* group_count */,
-                       &batchCount);
+                       &batch_count);
 #else
-  for (int k = 0; k < batchCount; ++k) {
+  for (int i = 0; i < batch_count; ++i) {
     this->template GEMM<T>(
-        transA, transB, M, N, K, alpha, A[k], B[k], beta, C[k]);
+        transA, transB, m, n, k, alpha, A[i], B[i], beta, C[i]);
   }
 #endif
 }
@@ -1717,50 +1710,60 @@ template <>
 template <typename T>
 void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                                            CBLAS_TRANSPOSE transB,
-                                           int W1,
-                                           int H1,
-                                           int W2,
-                                           int H2,
+                                           int64_t W1,
+                                           int64_t H1,
+                                           int64_t W2,
+                                           int64_t H2,
                                            T alpha,
                                            const T *A,
                                            const T *B,
                                            T beta,
                                            T *C,
-                                           int batchCount,
+                                           int64_t batchCount,
                                            int64_t strideA,
                                            int64_t strideB,
                                            int64_t head_number,
                                            bool split_b_vertical) const {
-  int lda = (transA == CblasNoTrans) ? W1 : H1;
-  int ldb = (transB == CblasNoTrans) ? W2 : H2;
-  auto a_array = std::vector<const T *>(batchCount);
-  auto b_array = std::vector<const T *>(batchCount);
-  auto c_array = std::vector<T *>(batchCount);
+  int w1 = detail::to_blas_int(W1, "BatchedGEMMWithHead W1");
+  int h1 = detail::to_blas_int(H1, "BatchedGEMMWithHead H1");
+  int w2 = detail::to_blas_int(W2, "BatchedGEMMWithHead W2");
+  int h2 = detail::to_blas_int(H2, "BatchedGEMMWithHead H2");
+  int batch_count =
+      detail::to_blas_int(batchCount, "BatchedGEMMWithHead batchCount");
+  const int head_num =
+      detail::to_blas_int(head_number, "BatchedGEMMWithHead head_number");
+  int lda = (transA == CblasNoTrans) ? w1 : h1;
+  int ldb = (transB == CblasNoTrans) ? w2 : h2;
+  auto a_array = std::vector<const T *>(batch_count);
+  auto b_array = std::vector<const T *>(batch_count);
+  auto c_array = std::vector<T *>(batch_count);
 
   if (split_b_vertical) {
-    int ldc = W2;
-    int sub_width = W2 / head_number;
+    int ldc = w2;
+    int sub_width = w2 / head_num;
 
-    for (int i = 0; i < head_number; i++) {
-      int sub_matA_offset = (transA == CblasNoTrans)
-                                ? i * (W1 / head_number)
-                                : i * (W1 / head_number) * H1;
-      int sub_matB_offset = (transB == CblasNoTrans)
-                                ? i * (W2 / head_number)
-                                : i * (W2 / head_number) * H2;
-      int sub_matC_offset = i * W2 / head_number;
-      for (int k = 0; k < batchCount; ++k) {
+    for (int i = 0; i < head_num; i++) {
+      const int64_t sub_matA_offset =
+          (transA == CblasNoTrans)
+              ? static_cast<int64_t>(i) * (w1 / head_num)
+              : static_cast<int64_t>(i) * (w1 / head_num) * h1;
+      const int64_t sub_matB_offset =
+          (transB == CblasNoTrans)
+              ? static_cast<int64_t>(i) * (w2 / head_num)
+              : static_cast<int64_t>(i) * (w2 / head_num) * h2;
+      const int64_t sub_matC_offset = static_cast<int64_t>(i) * w2 / head_num;
+      for (int64_t k = 0; k < batch_count; ++k) {
         a_array[k] = &A[k * strideA] + sub_matA_offset;
         b_array[k] = &B[k * strideB] + sub_matB_offset;
-        c_array[k] = &C[k * H1 * W2] + sub_matC_offset;
+        c_array[k] = &C[k * h1 * w2] + sub_matC_offset;
       }
 
       CBlas<T>::GEMM_BATCH(CblasRowMajor,
                            &transA,
                            &transB,
-                           &H1,
+                           &h1,
                            &sub_width,
-                           &H2,
+                           &h2,
                            &alpha,
                            a_array.data(),
                            &lda,
@@ -1770,7 +1773,7 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                            c_array.data(),
                            &ldc,
                            1 /* group_count */,
-                           &batchCount);
+                           &batch_count);
     }
 
   } else {
@@ -1783,28 +1786,31 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
             ", second matrix height %d",
             W1,
             H2));
-    int ldc = W2 * head_number;
-    int sub_width = W1 / head_number;
+    int ldc = detail::to_blas_int(static_cast<int64_t>(w2) * head_num,
+                                  "BatchedGEMMWithHead ldc");
+    int sub_width = w1 / head_num;
 
-    for (int i = 0; i < head_number; i++) {
-      int sub_matA_offset = (transA == CblasNoTrans)
-                                ? i * (W1 / head_number)
-                                : i * (W1 / head_number) * H1;
-      int sub_matB_offset = (transB == CblasNoTrans)
-                                ? i * (W1 / head_number) * W2
-                                : i * (W1 / head_number);
-      int sub_matC_offset = i * W2;
-      for (int k = 0; k < batchCount; ++k) {
+    for (int i = 0; i < head_num; i++) {
+      const int64_t sub_matA_offset =
+          (transA == CblasNoTrans)
+              ? static_cast<int64_t>(i) * (w1 / head_num)
+              : static_cast<int64_t>(i) * (w1 / head_num) * h1;
+      const int64_t sub_matB_offset =
+          (transB == CblasNoTrans)
+              ? static_cast<int64_t>(i) * (w1 / head_num) * w2
+              : static_cast<int64_t>(i) * (w1 / head_num);
+      const int64_t sub_matC_offset = static_cast<int64_t>(i) * w2;
+      for (int64_t k = 0; k < batch_count; ++k) {
         a_array[k] = &A[k * strideA] + sub_matA_offset;
         b_array[k] = &B[k * strideB] + sub_matB_offset;
-        c_array[k] = &C[k * H1 * head_number * W2] + sub_matC_offset;
+        c_array[k] = &C[k * h1 * head_num * w2] + sub_matC_offset;
       }
 
       CBlas<T>::GEMM_BATCH(CblasRowMajor,
                            &transA,
                            &transB,
-                           &H1,
-                           &W2,
+                           &h1,
+                           &w2,
                            &sub_width,
                            &alpha,
                            a_array.data(),
@@ -1815,7 +1821,7 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                            c_array.data(),
                            &ldc,
                            1 /* group_count */,
-                           &batchCount);
+                           &batch_count);
     }
   }
 }
@@ -1827,50 +1833,60 @@ template <>
 template <typename T>
 void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                                            CBLAS_TRANSPOSE transB,
-                                           int W1,
-                                           int H1,
-                                           int W2,
-                                           int H2,
+                                           int64_t W1,
+                                           int64_t H1,
+                                           int64_t W2,
+                                           int64_t H2,
                                            T alpha,
                                            const T *A,
                                            const T *B,
                                            T beta,
                                            T *C,
-                                           int batchCount,
+                                           int64_t batchCount,
                                            int64_t strideA,
                                            int64_t strideB,
                                            int64_t head_number,
                                            bool split_b_vertical) const {
-  int lda = (transA == CblasNoTrans) ? W1 : H1;
-  int ldb = (transB == CblasNoTrans) ? W2 : H2;
-  auto a_array = std::vector<const T *>(batchCount);
-  auto b_array = std::vector<const T *>(batchCount);
-  auto c_array = std::vector<T *>(batchCount);
+  int w1 = detail::to_blas_int(W1, "BatchedGEMMWithHead W1");
+  int h1 = detail::to_blas_int(H1, "BatchedGEMMWithHead H1");
+  int w2 = detail::to_blas_int(W2, "BatchedGEMMWithHead W2");
+  int h2 = detail::to_blas_int(H2, "BatchedGEMMWithHead H2");
+  int batch_count =
+      detail::to_blas_int(batchCount, "BatchedGEMMWithHead batchCount");
+  const int head_num =
+      detail::to_blas_int(head_number, "BatchedGEMMWithHead head_number");
+  int lda = (transA == CblasNoTrans) ? w1 : h1;
+  int ldb = (transB == CblasNoTrans) ? w2 : h2;
+  auto a_array = std::vector<const T *>(batch_count);
+  auto b_array = std::vector<const T *>(batch_count);
+  auto c_array = std::vector<T *>(batch_count);
 
   if (split_b_vertical) {
-    int ldc = W2;
-    int sub_width = W2 / head_number;
+    int ldc = w2;
+    int sub_width = w2 / head_num;
 
-    for (int i = 0; i < head_number; i++) {
-      int sub_matA_offset = (transA == CblasNoTrans)
-                                ? i * (W1 / head_number)
-                                : i * (W1 / head_number) * H1;
-      int sub_matB_offset = (transB == CblasNoTrans)
-                                ? i * (W2 / head_number)
-                                : i * (W2 / head_number) * H2;
-      int sub_matC_offset = i * W2 / head_number;
-      for (int k = 0; k < batchCount; ++k) {
+    for (int i = 0; i < head_num; i++) {
+      const int64_t sub_matA_offset =
+          (transA == CblasNoTrans)
+              ? static_cast<int64_t>(i) * (w1 / head_num)
+              : static_cast<int64_t>(i) * (w1 / head_num) * h1;
+      const int64_t sub_matB_offset =
+          (transB == CblasNoTrans)
+              ? static_cast<int64_t>(i) * (w2 / head_num)
+              : static_cast<int64_t>(i) * (w2 / head_num) * h2;
+      const int64_t sub_matC_offset = static_cast<int64_t>(i) * w2 / head_num;
+      for (int64_t k = 0; k < batch_count; ++k) {
         a_array[k] = &A[k * strideA] + sub_matA_offset;
         b_array[k] = &B[k * strideB] + sub_matB_offset;
-        c_array[k] = &C[k * H1 * W2] + sub_matC_offset;
+        c_array[k] = &C[k * h1 * w2] + sub_matC_offset;
       }
 
       CBlas<T>::GEMM_BATCH(CblasRowMajor,
                            &transA,
                            &transB,
-                           &H1,
+                           &h1,
                            &sub_width,
-                           &H2,
+                           &h2,
                            &alpha,
                            a_array.data(),
                            &lda,
@@ -1880,7 +1896,7 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                            c_array.data(),
                            &ldc,
                            1 /* group_count */,
-                           &batchCount);
+                           &batch_count);
     }
 
   } else {
@@ -1893,28 +1909,31 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
             ", second matrix height %d",
             W1,
             H2));
-    int ldc = W2 * head_number;
-    int sub_width = W1 / head_number;
+    int ldc = detail::to_blas_int(static_cast<int64_t>(w2) * head_num,
+                                  "BatchedGEMMWithHead ldc");
+    int sub_width = w1 / head_num;
 
-    for (int i = 0; i < head_number; i++) {
-      int sub_matA_offset = (transA == CblasNoTrans)
-                                ? i * (W1 / head_number)
-                                : i * (W1 / head_number) * H1;
-      int sub_matB_offset = (transB == CblasNoTrans)
-                                ? i * (W1 / head_number) * W2
-                                : i * (W1 / head_number);
-      int sub_matC_offset = i * W2;
-      for (int k = 0; k < batchCount; ++k) {
+    for (int i = 0; i < head_num; i++) {
+      const int64_t sub_matA_offset =
+          (transA == CblasNoTrans)
+              ? static_cast<int64_t>(i) * (w1 / head_num)
+              : static_cast<int64_t>(i) * (w1 / head_num) * h1;
+      const int64_t sub_matB_offset =
+          (transB == CblasNoTrans)
+              ? static_cast<int64_t>(i) * (w1 / head_num) * w2
+              : static_cast<int64_t>(i) * (w1 / head_num);
+      const int64_t sub_matC_offset = static_cast<int64_t>(i) * w2;
+      for (int64_t k = 0; k < batch_count; ++k) {
         a_array[k] = &A[k * strideA] + sub_matA_offset;
         b_array[k] = &B[k * strideB] + sub_matB_offset;
-        c_array[k] = &C[k * H1 * head_number * W2] + sub_matC_offset;
+        c_array[k] = &C[k * h1 * head_num * w2] + sub_matC_offset;
       }
 
       CBlas<T>::GEMM_BATCH(CblasRowMajor,
                            &transA,
                            &transB,
-                           &H1,
-                           &W2,
+                           &h1,
+                           &w2,
                            &sub_width,
                            &alpha,
                            a_array.data(),
@@ -1925,7 +1944,7 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
                            c_array.data(),
                            &ldc,
                            1 /* group_count */,
-                           &batchCount);
+                           &batch_count);
     }
   }
 }
@@ -1934,7 +1953,7 @@ void Blas<CPUContext>::BatchedGEMMWithHead(CBLAS_TRANSPOSE transA,
 template <typename DeviceContext>
 template <typename T>
 void Blas<DeviceContext>::MatMul(
-    const int M, const int N, const int K, const T *A, const T *B, T *C) const {
+    int64_t M, int64_t N, int64_t K, const T *A, const T *B, T *C) const {
   this->template GEMM<T>(CblasRowMajor,
                          CblasNoTrans,
                          CblasNoTrans,
@@ -1954,7 +1973,7 @@ void Blas<DeviceContext>::MatMul(
 template <>
 template <typename T>
 void Blas<CPUContext>::MatMul(
-    const int M, const int N, const int K, const T *A, const T *B, T *C) const {
+    int64_t M, int64_t N, int64_t K, const T *A, const T *B, T *C) const {
 #ifdef PADDLE_WITH_LIBXSMM
   // Refer to https://github.com/hfp/libxsmm/blob/master/README.md
   // But the threshold is custom constexpr int LIBXSMM_THRESHOLD = 20 * 20 * 20;
@@ -1968,25 +1987,24 @@ void Blas<CPUContext>::MatMul(
   const char transb = 'N';
   const T alpha = static_cast<T>(1);
   const T beta = static_cast<T>(0);
+  const libxsmm_blasint m = detail::to_blas_int(M, "SMM_GEMM M");
+  const libxsmm_blasint n = detail::to_blas_int(N, "SMM_GEMM N");
+  const libxsmm_blasint k = detail::to_blas_int(K, "SMM_GEMM K");
   CBlas<T>::SMM_GEMM(
-      &transa, &transb, &N, &M, &K, &alpha, B, &N, A, &K, &beta, C, &N);
+      &transa, &transb, &n, &m, &k, &alpha, B, &n, A, &k, &beta, C, &n);
   return;
 #endif
 
-  CBlas<T>::GEMM(CblasRowMajor,
-                 CblasNoTrans,
-                 CblasNoTrans,
-                 M,
-                 N,
-                 K,
-                 static_cast<T>(1),
-                 A,
-                 K,
-                 B,
-                 N,
-                 static_cast<T>(0),
-                 C,
-                 N);
+  this->template GEMM<T>(CblasNoTrans,
+                         CblasNoTrans,
+                         M,
+                         N,
+                         K,
+                         static_cast<T>(1),
+                         A,
+                         B,
+                         static_cast<T>(0),
+                         C);
 }
 
 template <typename DeviceContext>
@@ -2094,7 +2112,7 @@ void Blas<DeviceContext>::MatMulWithHead(const DenseTensor &mat_a,
                                          const DenseTensor &mat_b,
                                          const MatDescriptor &dim_b,
                                          T alpha,
-                                         int head_number,
+                                         int64_t head_number,
                                          DenseTensor *mat_out,
                                          T beta,
                                          bool mat_b_split_vertical) const {
@@ -2146,17 +2164,17 @@ void Blas<DeviceContext>::MatMulWithHead(const DenseTensor &mat_a,
   }
 
   if (dim_a.batch_size_ == 0 && dim_b.batch_size_ == 0) {
-    int lda = !dim_a.trans_ ? dim_a.width_ : dim_a.height_;
-    int ldb = !dim_b.trans_ ? dim_b.width_ : dim_b.height_;
-    int sub_matA_offset;
-    int sub_matB_offset;
-    int sub_matC_offset;
-    int sub_mat_M = dim_a.height_;
-    int sub_mat_N;
-    int sub_mat_K;
-    int ldc;
+    int64_t lda = !dim_a.trans_ ? dim_a.width_ : dim_a.height_;
+    int64_t ldb = !dim_b.trans_ ? dim_b.width_ : dim_b.height_;
+    int64_t sub_matA_offset;
+    int64_t sub_matB_offset;
+    int64_t sub_matC_offset;
+    int64_t sub_mat_M = dim_a.height_;
+    int64_t sub_mat_N;
+    int64_t sub_mat_K;
+    int64_t ldc;
 
-    for (int i = 0; i < head_number; i++) {
+    for (int64_t i = 0; i < head_number; i++) {
       sub_matA_offset = dim_a.trans_
                             ? i * (dim_a.width_ / head_number) * dim_a.height_
                             : i * (dim_a.width_ / head_number);
@@ -2257,7 +2275,7 @@ void Blas<DeviceContext>::MatMulWithHead(const DenseTensor &mat_a,
                                          const DenseTensor &mat_b,
                                          const MatDescriptor &dim_b,
                                          T alpha,
-                                         int head_number,
+                                         int64_t head_number,
                                          DenseTensor *mat_out,
                                          T beta,
                                          bool mat_b_split_vertical) const {
@@ -2309,17 +2327,17 @@ void Blas<DeviceContext>::MatMulWithHead(const DenseTensor &mat_a,
   }
 
   if (dim_a.batch_size_ == 0 && dim_b.batch_size_ == 0) {
-    int lda = !dim_a.trans_ ? dim_a.width_ : dim_a.height_;
-    int ldb = !dim_b.trans_ ? dim_b.width_ : dim_b.height_;
-    int sub_matA_offset;
-    int sub_matB_offset;
-    int sub_matC_offset;
-    int sub_mat_M = dim_a.height_;
-    int sub_mat_N;
-    int sub_mat_K;
-    int ldc;
+    int64_t lda = !dim_a.trans_ ? dim_a.width_ : dim_a.height_;
+    int64_t ldb = !dim_b.trans_ ? dim_b.width_ : dim_b.height_;
+    int64_t sub_matA_offset;
+    int64_t sub_matB_offset;
+    int64_t sub_matC_offset;
+    int64_t sub_mat_M = dim_a.height_;
+    int64_t sub_mat_N;
+    int64_t sub_mat_K;
+    int64_t ldc;
 
-    for (int i = 0; i < head_number; i++) {
+    for (int64_t i = 0; i < head_number; i++) {
       sub_matA_offset = dim_a.trans_
                             ? i * (dim_a.width_ / head_number) * dim_a.height_
                             : i * (dim_a.width_ / head_number);

--- a/paddle/phi/kernels/funcs/blas/blas_impl.hip.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.hip.h
@@ -743,10 +743,16 @@ inline void Blas<GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
 
   float h_alpha = static_cast<float>(alpha);
   float h_beta = static_cast<float>(beta);
+  const void *a = static_cast<const void *>(&h_alpha);
+  const void *b = static_cast<const void *>(&h_beta);
 
+  // rocBLAS reads alpha/beta with the width implied by computeType, so the
+  // fp16 path must be handed fp16 scalars. alpha/beta are already fp16 here.
   rocblas_datatype compute_type = rocblas_datatype_f32_r;
   if (FLAGS_gemm_use_half_precision_compute_type == true) {
     compute_type = rocblas_datatype_f16_r;
+    a = static_cast<const void *>(&alpha);
+    b = static_cast<const void *>(&beta);
   }
   VLOG(4) << "gemm_use_half_precision_compute_type: "
           << FLAGS_gemm_use_half_precision_compute_type;
@@ -758,14 +764,14 @@ inline void Blas<GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                 static_cast<int>(N),
                                 static_cast<int>(M),
                                 static_cast<int>(K),
-                                &h_alpha,
+                                a,
                                 B,
                                 rocblas_datatype_f16_r,
                                 static_cast<int>(ldb),
                                 A,
                                 rocblas_datatype_f16_r,
                                 static_cast<int>(lda),
-                                &h_beta,
+                                b,
                                 C,
                                 rocblas_datatype_f16_r,
                                 static_cast<int>(N),
@@ -810,10 +816,18 @@ inline void Blas<GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
 
   float h_alpha = alpha;
   float h_beta = beta;
+  phi::float16 t_alpha = static_cast<phi::float16>(alpha);
+  phi::float16 t_beta = static_cast<phi::float16>(beta);
+  const void *a = static_cast<const void *>(&h_alpha);
+  const void *b = static_cast<const void *>(&h_beta);
 
+  // rocBLAS reads alpha/beta with the width implied by computeType, so the
+  // fp16 path must be handed fp16 scalars, not the float originals.
   rocblas_datatype compute_type = rocblas_datatype_f32_r;
   if (FLAGS_gemm_use_half_precision_compute_type == true) {
     compute_type = rocblas_datatype_f16_r;
+    a = static_cast<const void *>(&t_alpha);
+    b = static_cast<const void *>(&t_beta);
   }
   VLOG(4) << "gemm_use_half_precision_compute_type: "
           << FLAGS_gemm_use_half_precision_compute_type;
@@ -825,14 +839,14 @@ inline void Blas<GPUContext>::GEMM(CBLAS_TRANSPOSE transA,
                                 static_cast<int>(N),
                                 static_cast<int>(M),
                                 static_cast<int>(K),
-                                &h_alpha,
+                                a,
                                 B,
                                 rocblas_datatype_f16_r,
                                 static_cast<int>(ldb),
                                 A,
                                 rocblas_datatype_f16_r,
                                 static_cast<int>(lda),
-                                &h_beta,
+                                b,
                                 C,
                                 rocblas_datatype_f16_r,
                                 static_cast<int>(N),
@@ -1351,17 +1365,16 @@ void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
   rocblas_operation cuTransB = (transB == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
+  detail::to_blas_int(M, "BatchedGEMM M");
+  detail::to_blas_int(N, "BatchedGEMM N");
+  detail::to_blas_int(K, "BatchedGEMM K");
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
     CUBlas<T>::GEMM_STRIDED_BATCH(handle,
@@ -1405,17 +1418,16 @@ void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
   rocblas_operation cuTransB = (transB == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
+  detail::to_blas_int(M, "BatchedGEMM M");
+  detail::to_blas_int(N, "BatchedGEMM N");
+  detail::to_blas_int(K, "BatchedGEMM K");
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
 
   T h_alpha = static_cast<T>(alpha);
@@ -1463,17 +1475,16 @@ inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
   rocblas_operation cuTransB = (transB == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
+  detail::to_blas_int(M, "BatchedGEMM M");
+  detail::to_blas_int(N, "BatchedGEMM N");
+  detail::to_blas_int(K, "BatchedGEMM K");
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::rocblas_hgemm_strided_batched(
@@ -1518,17 +1529,16 @@ inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
   rocblas_operation cuTransB = (transB == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
+  detail::to_blas_int(M, "BatchedGEMM M");
+  detail::to_blas_int(N, "BatchedGEMM N");
+  detail::to_blas_int(K, "BatchedGEMM K");
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
 
   float16 h_alpha = static_cast<float16>(alpha);
@@ -1579,17 +1589,16 @@ inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
   rocblas_operation cuTransB = (transB == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
+  detail::to_blas_int(M, "BatchedGEMM M");
+  detail::to_blas_int(N, "BatchedGEMM N");
+  detail::to_blas_int(K, "BatchedGEMM K");
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::rocblas_sgemm_strided_batched(
@@ -1634,17 +1643,16 @@ inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
   rocblas_operation cuTransB = (transB == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
+  detail::to_blas_int(M, "BatchedGEMM M");
+  detail::to_blas_int(N, "BatchedGEMM N");
+  detail::to_blas_int(K, "BatchedGEMM K");
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
   dev_ctx_.CublasCall([&](rocblas_handle handle) {
     PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::rocblas_dgemm_strided_batched(
@@ -1687,11 +1695,10 @@ inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
+  detail::to_blas_int(M, "BatchedGEMM M");
+  detail::to_blas_int(N, "BatchedGEMM N");
+  detail::to_blas_int(K, "BatchedGEMM K");
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
@@ -1755,12 +1762,11 @@ inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
   int64_t lda = (transA == CblasNoTrans) ? K : M;
   int64_t ldb = (transB == CblasNoTrans) ? N : K;
   int64_t ldc = N;
+  detail::to_blas_int(M, "BatchedGEMM M");
+  detail::to_blas_int(N, "BatchedGEMM N");
+  detail::to_blas_int(K, "BatchedGEMM K");
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
   const int64_t strideC = M * N;
-  if (M > INT_MAX_VALUE || N > INT_MAX_VALUE || K > INT_MAX_VALUE ||
-      batchCount > INT_MAX_VALUE) {
-    PADDLE_THROW(common::errors::Unimplemented(
-        "Hip BatchedGEMM not supported for large tensor size"));
-  }
   rocblas_operation cuTransA = (transA == CblasNoTrans)
                                    ? rocblas_operation_none
                                    : rocblas_operation_transpose;
@@ -1809,18 +1815,19 @@ template <>
 template <typename T>
 void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                    CBLAS_TRANSPOSE transB,
-                                   int M,
-                                   int N,
-                                   int K,
+                                   int64_t M,
+                                   int64_t N,
+                                   int64_t K,
                                    T alpha,
                                    const T **A,
                                    const T **B,
                                    T beta,
                                    T **C,
-                                   int batchCount) const {
-  for (int k = 0; k < batchCount; ++k) {
+                                   int64_t batchCount) const {
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+  for (int64_t i = 0; i < batchCount; ++i) {
     this->template GEMM<T>(
-        transA, transB, M, N, K, alpha, A[k], B[k], beta, C[k]);
+        transA, transB, M, N, K, alpha, A[i], B[i], beta, C[i]);
   }
 }
 
@@ -1828,18 +1835,19 @@ template <>
 template <>
 inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                           CBLAS_TRANSPOSE transB,
-                                          int M,
-                                          int N,
-                                          int K,
+                                          int64_t M,
+                                          int64_t N,
+                                          int64_t K,
                                           phi::float16 alpha,
                                           const phi::float16 **A,
                                           const phi::float16 **B,
                                           phi::float16 beta,
                                           phi::float16 **C,
-                                          int batchCount) const {
-  for (int k = 0; k < batchCount; ++k) {
+                                          int64_t batchCount) const {
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+  for (int64_t i = 0; i < batchCount; ++i) {
     this->template GEMM<phi::float16>(
-        transA, transB, M, N, K, alpha, A[k], B[k], beta, C[k]);
+        transA, transB, M, N, K, alpha, A[i], B[i], beta, C[i]);
   }
 }
 
@@ -1847,18 +1855,19 @@ template <>
 template <>
 inline void Blas<GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
                                           CBLAS_TRANSPOSE transB,
-                                          int M,
-                                          int N,
-                                          int K,
+                                          int64_t M,
+                                          int64_t N,
+                                          int64_t K,
                                           phi::bfloat16 alpha,
                                           const phi::bfloat16 **A,
                                           const phi::bfloat16 **B,
                                           phi::bfloat16 beta,
                                           phi::bfloat16 **C,
-                                          int batchCount) const {
-  for (int k = 0; k < batchCount; ++k) {
+                                          int64_t batchCount) const {
+  detail::to_blas_int(batchCount, "BatchedGEMM batchCount");
+  for (int64_t i = 0; i < batchCount; ++i) {
     this->template GEMM<phi::bfloat16>(
-        transA, transB, M, N, K, alpha, A[k], B[k], beta, C[k]);
+        transA, transB, M, N, K, alpha, A[i], B[i], beta, C[i]);
   }
 }
 

--- a/paddle/phi/kernels/impl/matmul_kernel_impl.h
+++ b/paddle/phi/kernels/impl/matmul_kernel_impl.h
@@ -380,9 +380,6 @@ void MatMulFunctionImplWithBlas(
   out_broadcast_dims[ndim - 2] = M;
   out_broadcast_dims[ndim - 1] = N;
 
-  Out->ResizeAndAllocate(make_ddim(out_broadcast_dims));
-  dev_ctx.template Alloc<T>(Out);
-
   const int batch_dim = ndim - 2;
   // broadcast message
   const bool is_broadcast_dims =
@@ -405,6 +402,12 @@ void MatMulFunctionImplWithBlas(
                       out_broadcast_dims.cbegin() + batch_dim,
                       1LL,
                       std::multiplies<std::int64_t>());
+  // Reject oversized pointer-array batches before allocating output memory.
+  if (is_broadcast_dims && x_batch_size != 1 && y_batch_size != 1) {
+    PADDLE_ENFORCE_LE_INT_MAX(out_batch_size, "broadcast MatMul batch size");
+  }
+  Out->ResizeAndAllocate(make_ddim(out_broadcast_dims));
+  dev_ctx.template Alloc<T>(Out);
   if (out_batch_size == 0) return;
   if (x_batch_size == 1 && y_batch_size == 1) {
     VLOG(3) << "MatMul's case 8";
@@ -421,9 +424,8 @@ void MatMulFunctionImplWithBlas(
   } else if (x_batch_size == 1) {
     if (M == 1 && trans_y) {
       VLOG(3) << "MatMul's case 9";
-      PADDLE_ENFORCE_LE_INT_MAX(y_batch_size * N, "GEMV M");
       blas.GEMV(false,
-                static_cast<int>(y_batch_size * N),
+                y_batch_size * N,
                 K,
                 static_cast<T>(1),
                 y_data,
@@ -482,7 +484,6 @@ void MatMulFunctionImplWithBlas(
   } else if (y_batch_size == 1) {
     if (!trans_x) {
       VLOG(3) << "MatMul's case 11";
-      PADDLE_ENFORCE_LE_INT_MAX(x_batch_size * M, "GEMM M");
       blas.GEMM(CblasNoTrans,
                 trans_y ? CblasTrans : CblasNoTrans,
                 x_batch_size * M,
@@ -526,7 +527,6 @@ void MatMulFunctionImplWithBlas(
                      K * N);
   } else {
     // in the case, can't use stridedgemm
-    PADDLE_ENFORCE_LE_INT_MAX(out_batch_size, "out_batch_size");
     std::vector<const T*> x_ptr(out_batch_size);
     std::vector<const T*> y_ptr(out_batch_size);
     std::vector<T*> out_ptr(out_batch_size);
@@ -554,7 +554,7 @@ void MatMulFunctionImplWithBlas(
                      y_ptr.data(),
                      static_cast<T>(flag),
                      out_ptr.data(),
-                     static_cast<int>(out_batch_size));
+                     out_batch_size);
   }
 }
 
@@ -861,7 +861,6 @@ void MatMulFunctionImplWithCublasLt(
   } else if (x_batch_size == 1) {
     if (M == 1 && trans_y) {
       VLOG(3) << "MatMul with blaslt 9";
-      PADDLE_ENFORCE_LE_INT_MAX(y_batch_size * N, "GEMV M");
       blaslt::Run(dev_ctx,
                   y_data,
                   x_data,
@@ -892,7 +891,6 @@ void MatMulFunctionImplWithCublasLt(
   } else if (y_batch_size == 1) {
     if (!trans_x) {
       VLOG(3) << "MatMul with blaslt 11";
-      PADDLE_ENFORCE_LE_INT_MAX(x_batch_size * M, "GEMM M");
       blaslt::Run(dev_ctx,
                   x_data,
                   y_data,

--- a/test/cpp/phi/kernels/test_math_function.cc
+++ b/test/cpp/phi/kernels/test_math_function.cc
@@ -130,6 +130,40 @@ TEST(math_function, gemm_gemv_int64_dimensions) {
   EXPECT_EQ(gemv_out, expected_gemv);
 }
 
+TEST(math_function, batched_gemm_matmul_int64_dimensions) {
+  auto* dev_ctx =
+      phi::DeviceContextPool::Instance().GetByPlace(phi::CPUPlace());
+  auto blas = GetBlas<float>(*dev_ctx);
+
+  const int64_t m = 2;
+  const int64_t n = 2;
+  const int64_t k = 3;
+  const std::array<float, 6> a = {1, 2, 3, 4, 5, 6};
+  const std::array<float, 6> b = {1, 0, 0, 1, 1, 1};
+  const std::array<float, 4> expected = {4, 5, 10, 11};
+
+  std::array<float, 4> matmul_out{};
+  blas.MatMul(m, n, k, a.data(), b.data(), matmul_out.data());
+  EXPECT_EQ(matmul_out, expected);
+
+  const float* a_array[] = {a.data()};
+  const float* b_array[] = {b.data()};
+  std::array<float, 4> batched_out{};
+  float* out_array[] = {batched_out.data()};
+  blas.BatchedGEMM(CblasNoTrans,
+                   CblasNoTrans,
+                   m,
+                   n,
+                   k,
+                   1.0f,
+                   a_array,
+                   b_array,
+                   0.0f,
+                   out_array,
+                   int64_t{1});
+  EXPECT_EQ(batched_out, expected);
+}
+
 TEST(math_function, gemm_gemv_reject_unsupported_cpu_dimensions) {
   auto* dev_ctx =
       phi::DeviceContextPool::Instance().GetByPlace(phi::CPUPlace());
@@ -166,6 +200,33 @@ TEST(math_function, gemm_gemv_reject_unsupported_cpu_dimensions) {
   EXPECT_THROW(
       blas.GEMV(false, too_large, 1, 1.0f, &value, &value, 0.0f, &value),
       common::enforce::EnforceNotMet);
+}
+
+TEST(math_function, batched_gemm_matmul_reject_invalid_dimensions) {
+  auto* dev_ctx =
+      phi::DeviceContextPool::Instance().GetByPlace(phi::CPUPlace());
+  auto blas = GetBlas<float>(*dev_ctx);
+  const int64_t too_large =
+      static_cast<int64_t>(std::numeric_limits<int>::max()) + 1;
+  const float value = 1.0f;
+  const float* input[] = {&value};
+  float output_value = 0.0f;
+  float* output[] = {&output_value};
+
+  EXPECT_THROW(blas.BatchedGEMM(CblasNoTrans,
+                                CblasNoTrans,
+                                1,
+                                1,
+                                1,
+                                1.0f,
+                                input,
+                                input,
+                                0.0f,
+                                output,
+                                too_large),
+               common::enforce::EnforceNotMet);
+  EXPECT_THROW(blas.MatMul(too_large, 1, 1, &value, &value, &output_value),
+               common::enforce::EnforceNotMet);
 }
 
 TEST(math_function, dot_with_blas_zero_length) {


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

当前 `MatMul` 和 `BatchedGEMM` 的部分接口及实现仍会将 `M/N/K/batchCount` 收窄为 32 位整数，导致大于 `INT_MAX` 的维度无法使用 CUDA 12.3 提供的 64 位 cuBLAS 接口，部分路径还可能基于已截断的维度计算 leading dimension。

本 PR 主要包含以下改动：

- 将 `MatMul` 和 pointer-array `BatchedGEMM` 的维度参数调整为 `int64_t`，保证 MatMul 广播及 BLAS 调用链能够完整传递 64 位维度。
- 为 CUDA BatchedGEMM、StridedBatchedGEMM 和 TRSM 补充 `_64` 动态加载符号及调用封装。当相关维度超过 `INT_MAX` 时，在 Linux CUDA 12.3 及以上环境分发到对应的 64 位 cuBLAS API；其他情况继续使用原有 32 位接口。
- 在不支持 64 位 BLAS API 的 CPU/HIP 路径增加显式范围检查，避免静默整数截断；同时在分配 MatMul 输出内存前校验 pointer-array batch size。
- 修复 CUDA/HIP 开启 `FLAGS_gemm_use_half_precision_compute_type` 时 FP16 `alpha/beta` 的类型不匹配问题，避免 BLAS 按 FP16 读取 float 标量而产生错误结果。
- 将 FP16 accumulation 限制在 compute capability 7.0 及以上，并修正 FP16 64 位分发中的错误模板特化。
- 移除因 `ldc` 不满足 cuBLAS 要求而无法覆盖目标 shape 的 `N == 1` BatchedGEMM 快速路径，以及重复、不可达的维度检查。
- 新增 C++ 单元测试，覆盖 `MatMul/BatchedGEMM` 的 `int64_t` 接口以及 CPU 对不支持维度的异常处理。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否