### PR TITLE
[Operator Mechanism] Add comment for sufficient big tensor IndexT guards

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise_grad_base.h
+++ b/paddle/phi/kernels/funcs/elementwise_grad_base.h
@@ -1043,6 +1043,8 @@ static void ElemwiseGradBroadcast1CUDA(gpuStream_t stream,
     grid_size_64 = std::min(grid_size_64, max_grid_dim);
     PADDLE_ENFORCE_LE_UINT32_MAX(grid_size_64, "elementwise grad launch dim");
     uint32_t grid_size = static_cast<uint32_t>(grid_size_64);
+    // Sufficient while IndexType is uint32_t. If it becomes int32_t, need to
+    // re-check the upper bounds of `i` and `j` in the kernel.
     if (h * w > std::numeric_limits<int>::max()) {
       ElemwiseGradBroadcast1CUDAKernel<int64_t>
           <<<grid_size, block_size, 0, stream>>>(
@@ -1062,6 +1064,8 @@ static void ElemwiseGradBroadcast1CUDA(gpuStream_t stream,
     grid_size_64 = std::min(grid_size_64, max_grid_dim);
     PADDLE_ENFORCE_LE_UINT32_MAX(grid_size_64, "elementwise grad launch dim");
     uint32_t grid_size = static_cast<uint32_t>(grid_size_64);
+    // Sufficient while IndexType is uint32_t. If it becomes int32_t, re-check
+    // the upper bounds of `m` and `n` in the kernel.
     if (h * w > std::numeric_limits<int>::max()) {
       FastElemwiseGradBroadcast1CUDAKernel<int64_t>
           <<<grid_size, block_size, 0, stream>>>(
@@ -1098,6 +1102,8 @@ static void ElemwiseGradBroadcast2CUDA(gpuStream_t stream,
   PADDLE_ENFORCE_LE_UINT32_MAX(grid_size_64, "elementwise grad launch dim");
   uint32_t grid_size = static_cast<uint32_t>(grid_size_64);
 
+  // This guard is sufficient while IndexType is uint32_t. If IndexType becomes
+  // int32_t, re-check the upper bounds of `ttid` and `j` in kernel.
   if (pre * n * post > std::numeric_limits<int>::max()) {
     ElemwiseGradBroadcast2CUDAKernel<
         int64_t><<<grid_size, block_size, 0, stream>>>(
@@ -1293,6 +1299,8 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
     if (h > split_h) kh = split_h;
     if (w > split_w) kw = split_w;
 
+    // Sufficient guard while IndexType is uint32_t. If it becomes int32_t,
+    // need to re-check bounds of index `i` and `j` in kernel.
     bool use_int64_index = (w * h) > (std::numeric_limits<int32_t>::max());
 
     if (is_y) {
@@ -1465,6 +1473,8 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
             << " broadcast_pos.size() " << broadcast_pos.size()
             << " out_dims_array[0] " << out_dims_array[0];
 
+    // Sufficient while IndexType is uint32_t. If it becomes int32_t, need to
+    // re-check the upper bounds of loop tail in the kernel.
     bool use_int64_index = h * w > std::numeric_limits<int32_t>::max();
 
     if (w < 16 || h < 16) {
@@ -1581,6 +1591,8 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
     grid_size_64 = std::min(grid_size_64, max_grid_dim);
     PADDLE_ENFORCE_LE_UINT32_MAX(grid_size_64, "elementwise grad launch dim");
     uint32_t grid_size = static_cast<uint32_t>(grid_size_64);
+    // Sufficient while IndexType is uint32_t. If it becomes int32_t, re-check
+    // the upper bound of the `i` in the kernel.
     if (pre * mid * post > std::numeric_limits<int32_t>::max()) {
       FastCommonGradBroadcastAllCUDAKernel<int64_t>
           <<<grid_size, block_size, 0, stream>>>(x_data,
@@ -1651,6 +1663,10 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
       // we need to calc y offset with blockid, so do x_pre/y_pre to get
       // left size.
       if (k_pre != pre) k_pre = pre / k_pre;
+      // Guard is sufficient while IndexType is uint32_t. If it became int32_t
+      // need to re-check the upper bounds of the `i` in the kernel.
+      // `post * k_pre` in the kernel relies on k_pre <= pre from the line
+      // above.
       if (pre * mid * post > std::numeric_limits<int32_t>::max() ||
           k_pre * k_mid * k_post > std::numeric_limits<int32_t>::max()) {
         FastCommonGradBroadcastOneCUDAKernel<int64_t>
@@ -1704,6 +1720,10 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
       uint32_t grid_size = static_cast<uint32_t>(grid_size_64);
       if (k_pre != pre) k_pre = pre / k_pre;
 
+      // Guard is sufficient while IndexType is uint32_t. If it became int32_t
+      // need to re-check the upper bounds of the `i` loop.
+      // `post * k_pre` in the kernel relies on k_pre <= pre from the line
+      // above.
       if (pre * mid * post > std::numeric_limits<int32_t>::max() ||
           k_pre * k_mid * k_post > std::numeric_limits<int32_t>::max()) {
         FastCommonGradBroadcastOneCUDAKernel<int64_t>
@@ -1908,6 +1928,8 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
                        stable_x_dims_order,
                        bytes,
                        dev_ctx.stream());
+    // Sufficient while IndexType is uint32_t. If it becomes int32_t, re-check
+    // the upper bound of the `j` loop tail in the kernel.
     if (out_size > std::numeric_limits<int32_t>::max()) {
       CommonGradBroadcastCUDAKernel<int64_t, T, DX_OP, Tout>
           <<<x_blocks, x_block_size, 0, dev_ctx.stream()>>>(x_strides_array_gpu,
@@ -1974,6 +1996,8 @@ void CommonGradBroadcastCUDA(const DenseTensor &x,
                        stable_y_dims_order,
                        bytes,
                        dev_ctx.stream());
+    // Sufficient while IndexType is uint32_t. If it becomes int32_t, re-check
+    // the upper bound of the `j` loop tail in the kernel.
     if (out_size > std::numeric_limits<int32_t>::max()) {
       CommonGradBroadcastCUDAKernel<int64_t, T, DY_OP, Tout>
           <<<y_blocks, y_block_size, 0, dev_ctx.stream()>>>(x_strides_array_gpu,

--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -1162,6 +1162,9 @@ void ReduceKernel(const KPDevice& dev_ctx,
     auto grid_num = config.grid;
     auto block_num = config.block;
 #endif
+    // Every index inside ReduceHigherDimKernel is bounded by numel
+    // and all the loop bounds are <= numel,
+    //  so `numel <= INT32_MAX` is sufficient.
     if (numel > std::numeric_limits<int32_t>::max()) {
       ReduceHigherDimKernel<Tx, Ty, MT, ReduceOp<MT>, TransformOp, int64_t>
           <<<grid_num, block_num, 0, stream>>>(
@@ -1210,6 +1213,7 @@ void ReduceKernel(const KPDevice& dev_ctx,
       auto grid_size = grid;
       auto block_size = block;
 #endif
+      // numel still bounds all the indices when reducing tmp_data.
       if (numel > std::numeric_limits<int32_t>::max()) {
         ReduceHigherDimKernel<MT,
                               Ty,
@@ -1258,6 +1262,8 @@ void ReduceKernel(const KPDevice& dev_ctx,
   // when reduce_dim.size() == 1 and reduce_dim[0] == x_dim.size() - 1, or
   // when reduce_dim.size() != 1 and reduce_dim.size() != x_dim.size(), this
   // function will be used
+  // All the indices in ReduceAnyKernel are bounded by numel,
+  // so `numel <= INT32_MAX` is safe for int32 indices.
   if (numel > std::numeric_limits<int32_t>::max()) {
     LaunchReduceKernel<Tx, Ty, MT, ReduceOp<MT>, TransformOp, int64_t>(
         x_data,

--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -1162,10 +1162,13 @@ void ReduceKernel(const KPDevice& dev_ctx,
     auto grid_num = config.grid;
     auto block_num = config.block;
 #endif
-    // Every index inside ReduceHigherDimKernel is bounded by numel
-    // and all the loop bounds are <= numel,
-    //  so `numel <= INT32_MAX` is sufficient.
-    if (numel > std::numeric_limits<int32_t>::max()) {
+    // Data indices are bounded by numel, but the grid-stride loop over the left
+    // dim runs one more `idx += stride` before exiting, so the peak index value
+    // is `size + stride`. Guard against overflow explicitly here.
+    int64_t index_peak = (config.left_num - config.left_num % config.block.x) +
+                         static_cast<int64_t>(config.grid.x) * config.block.x;
+    if (numel > std::numeric_limits<int32_t>::max() ||
+        index_peak > std::numeric_limits<int32_t>::max()) {
       ReduceHigherDimKernel<Tx, Ty, MT, ReduceOp<MT>, TransformOp, int64_t>
           <<<grid_num, block_num, 0, stream>>>(
               x_data,
@@ -1213,8 +1216,10 @@ void ReduceKernel(const KPDevice& dev_ctx,
       auto grid_size = grid;
       auto block_size = block;
 #endif
-      // numel still bounds all the indices when reducing tmp_data.
-      if (numel > std::numeric_limits<int32_t>::max()) {
+      // The second pass walks tmp_data (numel of left_num * grid.y * grid.z <=
+      // numel) with the same left-dim stride, so `index_peak` still applies.
+      if (numel > std::numeric_limits<int32_t>::max() ||
+          index_peak > std::numeric_limits<int32_t>::max()) {
         ReduceHigherDimKernel<MT,
                               Ty,
                               MT,

--- a/paddle/phi/kernels/funcs/transpose_function.cuh
+++ b/paddle/phi/kernels/funcs/transpose_function.cuh
@@ -1446,6 +1446,8 @@ inline void PermuteAndTranspose(
                                        phi::gpuMemcpyDeviceToDevice,
                                        dev_ctx.stream());
   } else {
+    // The guard is sufficient. The upper bound of index in grid-stride loop
+    // is `count - 1 + stride` and `stride = ceil(count / threads) * threads`
     if (count < std::numeric_limits<uint32_t>::max() / 2) {
       PermuteDispatch<T, uint32_t>(dev_ctx,
                                    static_cast<uint32_t>(count),

--- a/paddle/phi/kernels/funcs/transpose_function.cuh
+++ b/paddle/phi/kernels/funcs/transpose_function.cuh
@@ -1446,16 +1446,11 @@ inline void PermuteAndTranspose(
                                        phi::gpuMemcpyDeviceToDevice,
                                        dev_ctx.stream());
   } else {
-    // The guard is sufficient. Both kernels only dereference indices < count:
-    // the vectorized loop iterates `idx` over `[0, main_cnt_)` with
-    // `main_cnt_ = count / VecSize` (raw element bound is
-    // `idx * VecSize + VecSize - 1 <= count - 1`), and the tail is covered
-    // by `idx = tid + offset` for `tid < tail_cnt`,
-    // `offset = count - tail_cnt` (bound is `tail_cnt - 1 + offset =
-    // count - 1`). The grid is derived from `main_cnt_` by
-    // GetGpuLaunchConfig1D and capped at the device grid limit, so the
-    // grid-stride step `blockDim.x * gridDim.x` only controls loop
-    // progress and never extends the written index beyond `count - 1`.
+    // The guard of `count` is sufficient for both dispatch paths.
+    // TransposeLauncher uses tiled row/column/channel bounds in
+    // TransposeDataReader/Writer.
+    // PermuteLauncher bounds `idx` by `main_cnt_ = count / VecSize` for the
+    // vectorized part and by `tid + (count - tail_cnt)` for the tail.
     if (count < std::numeric_limits<uint32_t>::max() / 2) {
       PermuteDispatch<T, uint32_t>(dev_ctx,
                                    static_cast<uint32_t>(count),

--- a/paddle/phi/kernels/funcs/transpose_function.cuh
+++ b/paddle/phi/kernels/funcs/transpose_function.cuh
@@ -1446,8 +1446,16 @@ inline void PermuteAndTranspose(
                                        phi::gpuMemcpyDeviceToDevice,
                                        dev_ctx.stream());
   } else {
-    // The guard is sufficient. The upper bound of index in grid-stride loop
-    // is `count - 1 + stride` and `stride = ceil(count / threads) * threads`
+    // The guard is sufficient. Both kernels only dereference indices < count:
+    // the vectorized loop iterates `idx` over `[0, main_cnt_)` with
+    // `main_cnt_ = count / VecSize` (raw element bound is
+    // `idx * VecSize + VecSize - 1 <= count - 1`), and the tail is covered
+    // by `idx = tid + offset` for `tid < tail_cnt`,
+    // `offset = count - tail_cnt` (bound is `tail_cnt - 1 + offset =
+    // count - 1`). The grid is derived from `main_cnt_` by
+    // GetGpuLaunchConfig1D and capped at the device grid limit, so the
+    // grid-stride step `blockDim.x * gridDim.x` only controls loop
+    // progress and never extends the written index beyond `count - 1`.
     if (count < std::numeric_limits<uint32_t>::max() / 2) {
       PermuteDispatch<T, uint32_t>(dev_ctx,
                                    static_cast<uint32_t>(count),

--- a/paddle/phi/kernels/gpu/elementwise_grad.h
+++ b/paddle/phi/kernels/gpu/elementwise_grad.h
@@ -189,13 +189,8 @@ void ElementwiseMixedPrecisionAddGrad(const GPUContext &dev_ctx,
   dim3 grid_dim(grid_size, 1, 1);
   dim3 block_dim(block_size, 1, 1);
 
-  // The largest intermediate is the tail start of the highest-numbered
-  // thread, `loop * vec_size + tid`, whose upper bound is
-  // `main_size + (grid_size * block_size - 1)`; the strided increments
-  // `i += stride` are bounded by `(size - 1) + grid_size * block_size`. Both
-  // are covered by `size + grid_size * block_size <= INT_MAX`.
-  //
-  // Avoid `loop * vec_size + tid` overflow when `size % vec_size` != 0.
+  // Guard is enough: `loop * vec_size + tid` and `i += stride` in
+  // kernel are both bounded by `size + grid_size * block_size`.
   const int64_t index_span = static_cast<int64_t>(grid_size) * block_size;
   if (size + index_span <= std::numeric_limits<int>::max()) {
     MixedPrecisionElemwiseAddGradCUDAKernel<T_dy, int>

--- a/paddle/phi/kernels/gpu/where_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/where_grad_kernel.cu
@@ -57,6 +57,7 @@ void WhereGradKernel(const Context& dev_ctx,
 
   auto stream = dev_ctx.stream();
   auto config = backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
+  // `stride` is int64_t and guard is enough
   if (numel <= std::numeric_limits<int>::max()) {
     WhereGradCUDAKernel<T, int>
         <<<config.block_per_grid.x, config.thread_per_block.x, 0, stream>>>(

--- a/paddle/phi/kernels/impl/isclose_kernel_impl.h
+++ b/paddle/phi/kernels/impl/isclose_kernel_impl.h
@@ -290,6 +290,8 @@ struct IscloseFunctor<GPUContext, T> {
 #else
     cudaMemset(out_data, true, num * sizeof(bool));
 #endif
+    // The index at the kernel's loop peaks at `num - 1 + grid * block`,
+    // this guard is enough
     if (num + grid * block + 1 > std::numeric_limits<unsigned int>::max()) {
       IscloseCUDAKernel<T, int64_t><<<grid, block, 0, dev_ctx.stream()>>>(
           in_data, other_data, rtol, atol, equal_nan, num, out_data);

--- a/paddle/phi/kernels/impl/isfinite_kernel_impl.h
+++ b/paddle/phi/kernels/impl/isfinite_kernel_impl.h
@@ -493,6 +493,8 @@ struct IsfiniteFunctor<GPUContext, T> {
     int64_t block = 1024;
     int64_t grid = (block - 1 + num) / block;
     grid = (grid > block) ? block : grid;
+    // The index at the kernel's loop peaks at `num - 1 + grid * block`,
+    // this guard is enough
     if (num + block * grid + 1 > std::numeric_limits<unsigned int>::max()) {
       IsfiniteCUDAKernel<T, int64_t>
           <<<grid, block, 0, dev_ctx.stream()>>>(in_data, num, out_data);
@@ -514,6 +516,8 @@ struct IsnanFunctor<GPUContext, T> {
     int64_t block = 1024;
     int64_t grid = (block - 1 + num) / block;
     grid = (grid > block) ? block : grid;
+    // The index at the kernel's loop peaks at `num - 1 + grid * block`,
+    // this guard is enough
     if (num + block * grid + 1 > std::numeric_limits<unsigned int>::max()) {
       IsnanCUDAKernel<T, int64_t>
           <<<grid, block, 0, dev_ctx.stream()>>>(in_data, num, out_data);
@@ -535,6 +539,8 @@ struct IsinfFunctor<GPUContext, T> {
     int64_t block = 1024;
     int64_t grid = (block - 1 + num) / block;
     grid = (grid > block) ? block : grid;
+    // The index at the kernel's loop peaks at `num - 1 + grid * block`,
+    // this guard is enough
     if (num + block * grid + 1 > std::numeric_limits<unsigned int>::max()) {
       IsinfCUDAKernel<T, int64_t>
           <<<grid, block, 0, dev_ctx.stream()>>>(in_data, num, out_data);

--- a/paddle/phi/kernels/impl/weight_quantize_kernel_gpu_impl.h
+++ b/paddle/phi/kernels/impl/weight_quantize_kernel_gpu_impl.h
@@ -206,6 +206,9 @@ void weight_permute_gpu(const GPUContext& dev_ctx,
                         const int32_t arch,
                         const std::string& algo) {
   int64_t numel = shape[0] * shape[1];
+  // `numel <= INT32_MAX` bounds every index in the int32 branch.
+  // CUDA_KERNEL_LOOP_TYPE also keeps its loop counter in int64, so the strided
+  // iteration cannot wrap even when numel == INT32_MAX.
   if (numel <= std::numeric_limits<int>::max()) {
     weight_permute_gpu_impl<GPUContext, int>(
         dev_ctx, input_data, output_data, shape, arch, algo);


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism

### PR Types
Others

### Description
1. 为 GPU kernel 中 int32 / int64 索引类型分发处的 guard 补充注释，说明guard 究竟由哪个索引表达式的上界决定、是否充分，便于后续big tensor 相关改造时快速判断 guard 是否仍然成立。
涉及文件：
- `paddle/phi/kernels/funcs/elementwise_grad_base.h`
- `paddle/phi/kernels/funcs/reduce_function.h`
- `paddle/phi/kernels/funcs/transpose_function.cuh`
- `paddle/phi/kernels/gpu/elementwise_grad.h`：
- `paddle/phi/kernels/gpu/where_grad_kernel.cu`
- `paddle/phi/kernels/impl/isclose_kernel_impl.h`、`isfinite_kernel_impl.h`：
- `paddle/phi/kernels/impl/weight_quantize_kernel_gpu_impl.h`

2. 将ReduceHigherDimKernel中对index的隐式约束提到guard处声明


### 是否引起精度变化
否