### PR TITLE
align trunc_normal with torch for gpu

### DIFF
--- a/paddle/fluid/ir_adaptor/translator/op_translator.cc
+++ b/paddle/fluid/ir_adaptor/translator/op_translator.cc
@@ -4270,6 +4270,44 @@ struct GaussianRandomOpTranscriber : public OpTranscriber {
   }
 };
 
+struct TruncatedGaussianRandomOpTranscriber : public OpTranscriber {
+  pir::AttributeMap TranslateOpAttribute(
+      pir::IrContext* ctx,
+      const std::string& normalized_op_name,
+      const OpAttributeInfoList& op_attr_infos,
+      const OpDesc& op_desc) override {
+    auto& attribute_translator = AttributeTranslator::instance();
+    auto& op_normalizer = OpNameNormalizer::instance();
+    pir::AttributeMap attribute_map = {};
+
+    for (const auto& info : op_attr_infos) {
+      auto legacy_attr_name =
+          op_normalizer.GetLegacyAttrName(op_desc.Type(), info.name);
+      VLOG(10) << "[op: " << op_desc.Type()
+               << "][attr] from: " << legacy_attr_name << " to: " << info.name;
+      if (op_desc.HasAttr(legacy_attr_name)) {
+        paddle::framework::Attribute legacy_attr =
+            op_desc.GetAttr(legacy_attr_name);
+        VLOG(10) << "attribute in " << op_desc.Type()
+                 << " name: " << legacy_attr_name << " " << legacy_attr.index();
+        pir::Attribute new_attr =
+            attribute_translator(info.type_name, legacy_attr);
+        if (info.name == "mean" || info.name == "std" || info.name == "a" ||
+            info.name == "b") {
+          new_attr = pir::DoubleAttribute::get(
+              ctx,
+              static_cast<double>(
+                  new_attr.dyn_cast<pir::FloatAttribute>().data()));
+        }
+        attribute_map[info.name] = new_attr;
+      } else {
+        this->HandleNonexistentAttribute(ctx, &attribute_map, info);
+      }
+    }
+    return attribute_map;
+  }
+};
+
 OpTranslator::OpTranslator() {
   pir::IrContext* ctx = pir::IrContext::Instance();
   ctx->GetOrRegisterDialect<paddle::dialect::OperatorDialect>();
@@ -4419,5 +4457,7 @@ OpTranslator::OpTranslator() {
   special_handlers["pad3d"] = Pad3dOpTranscriber();
   special_handlers["pad3d_grad"] = Pad3dOpTranscriber();
   special_handlers["gaussian_random"] = GaussianRandomOpTranscriber();
+  special_handlers["truncated_gaussian_random"] =
+      TruncatedGaussianRandomOpTranscriber();
 }
 }  // namespace paddle::translator

--- a/paddle/fluid/pir/serialize_deserialize/patch/4.yaml
+++ b/paddle/fluid/pir/serialize_deserialize/patch/4.yaml
@@ -162,3 +162,17 @@ op_patches:
       - action : modify_attr
         object : alpha
         type : pir::DoubleAttribute
+  - op_name : pd_op.truncated_gaussian_random
+    actions:
+      - action : modify_attr
+        object : mean
+        type : pir::DoubleAttribute
+      - action : modify_attr
+        object : std
+        type : pir::DoubleAttribute
+      - action : modify_attr
+        object : a
+        type : pir::DoubleAttribute
+      - action : modify_attr
+        object : b
+        type : pir::DoubleAttribute

--- a/paddle/phi/backends/xpu/xpu1_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu1_op_list.cc
@@ -174,7 +174,7 @@ XPUOpMap& get_kl1_ops() {
       {"transpose2", XPUKernelSet({FLOAT32})},
       {"transpose_grad", XPUKernelSet({FLOAT32})},
       {"transpose", XPUKernelSet({FLOAT32})},
-      {"truncated_gaussian_random", XPUKernelSet({FLOAT32})},
+      {"truncated_gaussian_random", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"uniform_random", XPUKernelSet({FLOAT32})},
       {"unsqueeze2_grad",
        XPUKernelSet({FLOAT64, INT64, INT32, BOOL, INT8, UINT8, FLOAT32})},

--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -501,7 +501,7 @@ XPUOpMap& get_kl2_ops() {
        XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16, INT64, INT32, BOOL})},
       {"transpose",
        XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16, INT64, INT32, BOOL})},
-      {"truncated_gaussian_random", XPUKernelSet({FLOAT32})},
+      {"truncated_gaussian_random", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"top_k", XPUKernelSet({FLOAT32, FLOAT16})},
       {"top_k_v2", XPUKernelSet({FLOAT32, FLOAT16})},
       {"top_p_sampling", XPUKernelSet({FLOAT32, FLOAT16})},

--- a/paddle/phi/backends/xpu/xpu3_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu3_op_list.cc
@@ -909,7 +909,7 @@ XPUOpMap& get_kl3_ops() {
                      INT64,
                      INT32,
                      BOOL})},
-      {"truncated_gaussian_random", XPUKernelSet({FLOAT32})},
+      {"truncated_gaussian_random", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},
       {"top_k", XPUKernelSet({FLOAT32, FLOAT16})},
       {"top_k_v2", XPUKernelSet({FLOAT32, FLOAT16})},
       {"top_k_grad", XPUKernelSet({FLOAT32, FLOAT16, BFLOAT16})},

--- a/paddle/phi/infermeta/nullary.cc
+++ b/paddle/phi/infermeta/nullary.cc
@@ -450,11 +450,11 @@ void SeedInferMeta(int seed, MetaTensor* out) {
 }
 
 void TruncatedGaussianRandomInferMeta(const std::vector<int>& shape,
-                                      float mean,
-                                      float std,
+                                      double mean,
+                                      double std,
                                       int seed,
-                                      float a,
-                                      float b,
+                                      double a,
+                                      double b,
                                       DataType dtype,
                                       MetaTensor* out) {
   auto out_dims = make_ddim(shape);

--- a/paddle/phi/infermeta/nullary.h
+++ b/paddle/phi/infermeta/nullary.h
@@ -123,11 +123,11 @@ PADDLE_API void RecvV2InferMeta(const int ring_id,
 PADDLE_API void SeedInferMeta(int seed, MetaTensor* out);
 
 PADDLE_API void TruncatedGaussianRandomInferMeta(const std::vector<int>& shape,
-                                                 float mean,
-                                                 float std,
+                                                 double mean,
+                                                 double std,
                                                  int seed,
-                                                 float a,
-                                                 float b,
+                                                 double a,
+                                                 double b,
                                                  DataType dtype,
                                                  MetaTensor* out);
 

--- a/paddle/phi/kernels/cpu/truncated_gaussian_random_kernel.cc
+++ b/paddle/phi/kernels/cpu/truncated_gaussian_random_kernel.cc
@@ -28,11 +28,11 @@ namespace phi {
 template <typename T, typename Context>
 void TruncatedGaussianRandomKernel(const Context& dev_ctx,
                                    const std::vector<int>& shape,
-                                   float mean,
-                                   float std,
+                                   double mean,
+                                   double std,
                                    int seed,
-                                   float a,
-                                   float b,
+                                   double a,
+                                   double b,
                                    DataType dtype,
                                    DenseTensor* out) {
   auto tensor = out;
@@ -43,7 +43,10 @@ void TruncatedGaussianRandomKernel(const Context& dev_ctx,
 
   std::uniform_real_distribution<MT> dist(std::numeric_limits<float>::min(),
                                           1.0);
-  TruncatedNormal<MT> truncated_normal(mean, std, a, b);
+  TruncatedNormal<MT> truncated_normal(static_cast<MT>(mean),
+                                       static_cast<MT>(std),
+                                       static_cast<MT>(a),
+                                       static_cast<MT>(b));
   int64_t size = tensor->numel();
 
   std::shared_ptr<std::mt19937_64> engine;
@@ -66,4 +69,5 @@ PD_REGISTER_KERNEL(truncated_gaussian_random,
                    phi::TruncatedGaussianRandomKernel,
                    float,
                    double,
+                   phi::float16,
                    phi::bfloat16) {}

--- a/paddle/phi/kernels/gpu/truncated_gaussian_random_kernel.cu
+++ b/paddle/phi/kernels/gpu/truncated_gaussian_random_kernel.cu
@@ -19,16 +19,24 @@
 #include <thrust/random.h>
 #include <thrust/transform.h>
 
+#include <algorithm>
+#include <cmath>
 #include <limits>
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
+#include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/common/amp_type_traits.h"
+#include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/distribution_helper.h"
 
 namespace phi {
 
+// Legacy generator, only used when the op carries a non-zero `seed` attribute.
+// It keeps the historical inverse-CDF behavior so that graphs pinning an op
+// seed keep reproducing the same values.
 template <typename T, typename MT>
 struct GPUTruncatedNormal {
   MT mean, std, a, b;
@@ -56,58 +64,308 @@ struct GPUTruncatedNormal {
   }
 };
 
+// Marks `flag` when any element of `data` falls outside [lo, hi]. Concurrent
+// threads only ever store the same value, so the race on `flag` is benign.
 template <typename T, typename MT>
-struct TruncatedNormalTransform {
-  MT mean, std, a, b;
-  MT a_normal_cdf;
-  MT b_normal_cdf;
+__global__ void MarkOutOfRangeKernel(
+    const T* data, int64_t numel, MT lo, MT hi, int* flag) {
+  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       i < numel;
+       i += stride) {
+    MT value = static_cast<MT>(data[i]);
+    if (value < lo || value > hi) {
+      *flag = 1;
+    }
+  }
+}
 
-  HOSTDEVICE TruncatedNormalTransform(MT mean, MT std, MT a, MT b)
-      : mean(mean), std(std), a(a), b(b) {
-    a_normal_cdf = (1.0 + erff((a - mean) / std / sqrtf(2.0))) / 2.0;
-    b_normal_cdf = (1.0 + erff((b - mean) / std / sqrtf(2.0))) / 2.0;
+// Fuses torch's `result = where(mask, fresh, result)` with the mask
+// recomputation of the next loop iteration: elements left untouched were
+// already inside [lo, hi], so `flag` ends up as `mask.any()` of the update.
+template <typename T, typename MT>
+__global__ void ReplaceOutOfRangeKernel(
+    T* data, const T* fresh, int64_t numel, MT lo, MT hi, int* flag) {
+  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       i < numel;
+       i += stride) {
+    MT value = static_cast<MT>(data[i]);
+    if (value < lo || value > hi) {
+      T replacement = fresh[i];
+      data[i] = replacement;
+      MT new_value = static_cast<MT>(replacement);
+      if (new_value < lo || new_value > hi) {
+        *flag = 1;
+      }
+    }
+  }
+}
+
+// Port of the `p <= 0.3` branch of torch's `_no_grad_trunc_normal_`: uniform
+// proposals on [a, b] accepted with probability pdf(x)/pdf(mode).
+//
+// The log-pdf is evaluated with the same per-op rounding as the chain
+// `candidates.sub_(mean).div_(std).pow_(2).mul_(-0.5).sub_(log_peak)`, which
+// stores an intermediate of dtype T after every step. That rounding is
+// observable for float16/bfloat16, hence the casts.
+template <typename T, typename MT>
+__global__ void AcceptRejectKernel(T* result,
+                                   const T* proposal,
+                                   const T* accept_rand,
+                                   bool* pending,
+                                   int64_t numel,
+                                   MT mean,
+                                   MT std,
+                                   MT log_peak,
+                                   bool is_first_round,
+                                   int* flag) {
+  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       i < numel;
+       i += stride) {
+    if (!is_first_round && !pending[i]) {
+      continue;
+    }
+    T candidate = is_first_round ? result[i] : proposal[i];
+    if (!is_first_round) {
+      result[i] = candidate;
+    }
+
+    MT value = static_cast<MT>(candidate);
+    value = static_cast<MT>(static_cast<T>(value - mean));
+    value = static_cast<MT>(static_cast<T>(value / std));
+    value = static_cast<MT>(static_cast<T>(value * value));
+    value = static_cast<MT>(static_cast<T>(value * static_cast<MT>(-0.5)));
+    MT log_pdf = static_cast<MT>(static_cast<T>(value - log_peak));
+
+    MT log_u =
+        static_cast<MT>(static_cast<T>(log(static_cast<MT>(accept_rand[i]))));
+
+    bool rejected = log_u > log_pdf;
+    pending[i] = rejected;
+    if (rejected) {
+      *flag = 1;
+    }
+  }
+}
+
+template <typename Context>
+class OutOfRangeFlag {
+ public:
+  explicit OutOfRangeFlag(const Context& dev_ctx) : dev_ctx_(dev_ctx) {
+    flag_.Resize({1});
+    data_ = dev_ctx_.template Alloc<int>(&flag_);
   }
 
-  // Inverts the CDF of the truncated distribution, mapping a uniform sample in
-  // (0, 1] onto [a, b].
-  HOSTDEVICE inline T operator()(MT value) const {
-    auto p = a_normal_cdf + (b_normal_cdf - a_normal_cdf) * value;
-    MT ret = std::sqrt(2.0) * erfinvf(2 * p - 1) * std + mean;
-    return static_cast<T>(std::clamp(ret, a, b));
+  int* data() const { return data_; }
+
+  void Reset() {
+    phi::backends::gpu::GpuMemsetAsync(
+        data_, 0, sizeof(int), dev_ctx_.stream());
   }
+
+  // Mirrors the `mask.any()` device-to-host synchronization that torch's
+  // python-level loop performs once per iteration.
+  bool Read() {
+    int host_flag = 0;
+    memory_utils::Copy(phi::CPUPlace(),
+                       &host_flag,
+                       dev_ctx_.GetPlace(),
+                       data_,
+                       sizeof(int),
+                       dev_ctx_.stream());
+    dev_ctx_.Wait();
+    return host_flag != 0;
+  }
+
+ private:
+  const Context& dev_ctx_;
+  DenseTensor flag_;
+  int* data_ = nullptr;
 };
+
+// Rejection sampling on plain normal draws, matching the `p > 0.3` branch of
+// torch's `_no_grad_trunc_normal_`. Every round redraws a full-size tensor, so
+// the philox offsets consumed here line up with torch's sequence of
+// `normal_()` launches.
+template <typename T, typename Context>
+void RejectionSampleFromNormal(const Context& dev_ctx,
+                               double mean,
+                               double std,
+                               double a,
+                               double b,
+                               DenseTensor* out) {
+  using MT = typename MPTypeTrait<T>::Type;
+  int64_t numel = out->numel();
+
+  funcs::normal_distribution<MT> dist;
+  funcs::normal_transform<MT> trans(static_cast<MT>(mean),
+                                    static_cast<MT>(std));
+  funcs::distribution_and_transform<T>(dev_ctx, out, dist, trans);
+
+  // torch compares against bounds that were first rounded to the output dtype.
+  MT lo = static_cast<MT>(static_cast<T>(a));
+  MT hi = static_cast<MT>(static_cast<T>(b));
+
+  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
+  OutOfRangeFlag<Context> flag(dev_ctx);
+
+  flag.Reset();
+  MarkOutOfRangeKernel<T, MT>
+      <<<config.block_per_grid, config.thread_per_block, 0, dev_ctx.stream()>>>(
+          out->data<T>(), numel, lo, hi, flag.data());
+  if (!flag.Read()) {
+    return;
+  }
+
+  DenseTensor fresh;
+  fresh.Resize(out->dims());
+  dev_ctx.template Alloc<T>(&fresh);
+  while (true) {
+    funcs::distribution_and_transform<T>(dev_ctx, &fresh, dist, trans);
+    flag.Reset();
+    ReplaceOutOfRangeKernel<T, MT><<<config.block_per_grid,
+                                     config.thread_per_block,
+                                     0,
+                                     dev_ctx.stream()>>>(
+        out->data<T>(), fresh.data<T>(), numel, lo, hi, flag.data());
+    if (!flag.Read()) {
+      return;
+    }
+  }
+}
+
+// Rejection sampling on uniform proposals, matching the `p <= 0.3` branch of
+// torch's `_no_grad_trunc_normal_`.
+template <typename T, typename Context>
+void RejectionSampleFromUniform(const Context& dev_ctx,
+                                double mean,
+                                double std,
+                                double a,
+                                double b,
+                                DenseTensor* out) {
+  using MT = typename MPTypeTrait<T>::Type;
+  int64_t numel = out->numel();
+
+  double mode = std::max(a, std::min(mean, b));
+  double log_peak = -0.5 * std::pow((mode - mean) / std, 2);
+
+  funcs::uniform_distribution<MT> dist;
+  // Matches torch's `uniform_kernel`, which folds the bounds to the output
+  // dtype before deriving the range: `range = MT(T(to)) - MT(T(from))`.
+  funcs::uniform_real_transform<MT, T> proposal_trans(
+      static_cast<MT>(static_cast<T>(a)), static_cast<MT>(static_cast<T>(b)));
+  funcs::uniform_real_transform<MT, T> accept_trans(
+      static_cast<MT>(static_cast<T>(0.0)),
+      static_cast<MT>(static_cast<T>(1.0)));
+
+  DenseTensor accept_rand;
+  accept_rand.Resize(out->dims());
+  dev_ctx.template Alloc<T>(&accept_rand);
+
+  DenseTensor pending;
+  pending.Resize(out->dims());
+  bool* pending_data = dev_ctx.template Alloc<bool>(&pending);
+
+  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
+  OutOfRangeFlag<Context> flag(dev_ctx);
+
+  // First round proposes directly into `out`, as torch does.
+  funcs::distribution_and_transform<T>(dev_ctx, out, dist, proposal_trans);
+  funcs::distribution_and_transform<T>(
+      dev_ctx, &accept_rand, dist, accept_trans);
+  flag.Reset();
+  AcceptRejectKernel<T, MT>
+      <<<config.block_per_grid, config.thread_per_block, 0, dev_ctx.stream()>>>(
+          out->data<T>(),
+          nullptr,
+          accept_rand.data<T>(),
+          pending_data,
+          numel,
+          static_cast<MT>(mean),
+          static_cast<MT>(std),
+          static_cast<MT>(log_peak),
+          true,
+          flag.data());
+  if (!flag.Read()) {
+    return;
+  }
+
+  DenseTensor proposal;
+  proposal.Resize(out->dims());
+  dev_ctx.template Alloc<T>(&proposal);
+  while (true) {
+    funcs::distribution_and_transform<T>(
+        dev_ctx, &proposal, dist, proposal_trans);
+    funcs::distribution_and_transform<T>(
+        dev_ctx, &accept_rand, dist, accept_trans);
+    flag.Reset();
+    AcceptRejectKernel<T, MT><<<config.block_per_grid,
+                                config.thread_per_block,
+                                0,
+                                dev_ctx.stream()>>>(out->data<T>(),
+                                                    proposal.data<T>(),
+                                                    accept_rand.data<T>(),
+                                                    pending_data,
+                                                    numel,
+                                                    static_cast<MT>(mean),
+                                                    static_cast<MT>(std),
+                                                    static_cast<MT>(log_peak),
+                                                    false,
+                                                    flag.data());
+    if (!flag.Read()) {
+      return;
+    }
+  }
+}
 
 template <typename T, typename Context>
 void TruncatedGaussianRandomKernel(const Context& dev_ctx,
                                    const std::vector<int>& shape,
-                                   float mean,
-                                   float std,
+                                   double mean,
+                                   double std,
                                    int seed,
-                                   float a,
-                                   float b,
+                                   double a,
+                                   double b,
                                    DataType dtype,
                                    DenseTensor* out) {
   T* data = dev_ctx.template Alloc<T>(out);
 
   using MT = typename MPTypeTrait<T>::Type;
 
-  if (seed == 0) {
-    funcs::uniform_distribution<MT> dist;
-    TruncatedNormalTransform<T, MT> trans(static_cast<MT>(mean),
-                                          static_cast<MT>(std),
-                                          static_cast<MT>(a),
-                                          static_cast<MT>(b));
-    funcs::distribution_and_transform<T>(dev_ctx, out, dist, trans);
-  } else {
-    // use OP seed
+  int64_t size = out->numel();
+  if (size == 0) {
+    return;
+  }
+
+  if (seed != 0) {
+    // use OP seed, keeping the legacy inverse-CDF sampling
     thrust::counting_iterator<int64_t> index_sequence_begin(0);
-    int64_t size = out->numel();
-    thrust::transform(
-        index_sequence_begin,
-        index_sequence_begin + size,
-        thrust::device_ptr<T>(data),
-        GPUTruncatedNormal<T, MT>(
-            mean, std, std::numeric_limits<MT>::min(), seed, a, b));
+    thrust::transform(index_sequence_begin,
+                      index_sequence_begin + size,
+                      thrust::device_ptr<T>(data),
+                      GPUTruncatedNormal<T, MT>(static_cast<MT>(mean),
+                                                static_cast<MT>(std),
+                                                std::numeric_limits<MT>::min(),
+                                                seed,
+                                                static_cast<MT>(a),
+                                                static_cast<MT>(b)));
+    return;
+  }
+
+  // use global Generator seed. Both branches below reproduce torch's
+  // `torch.nn.init.trunc_normal_` bit-for-bit, including which of the two
+  // rejection schemes is picked.
+  auto normal_cdf = [](double x) {
+    return (1.0 + std::erf(x / std::sqrt(2.0))) / 2.0;
+  };
+  double p = normal_cdf((b - mean) / std) - normal_cdf((a - mean) / std);
+
+  if (p > 0.3) {
+    RejectionSampleFromNormal<T, Context>(dev_ctx, mean, std, a, b, out);
+  } else {
+    RejectionSampleFromUniform<T, Context>(dev_ctx, mean, std, a, b, out);
   }
 }
 
@@ -119,4 +377,5 @@ PD_REGISTER_KERNEL(truncated_gaussian_random,
                    phi::TruncatedGaussianRandomKernel,
                    float,
                    double,
+                   phi::float16,
                    phi::bfloat16) {}

--- a/paddle/phi/kernels/gpu/truncated_gaussian_random_kernel.cu
+++ b/paddle/phi/kernels/gpu/truncated_gaussian_random_kernel.cu
@@ -30,9 +30,15 @@
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/aligned_vector.h"
 #include "paddle/phi/kernels/funcs/distribution_helper.h"
 
 namespace phi {
+
+// The scan/replace passes below are bandwidth bound, so they read and write
+// through `AlignedVector`. 4 is enough to reach a 128 bit access for float and
+// keeps the number of template instantiations small.
+constexpr int kTruncatedNormalMaxVecSize = 4;
 
 // Legacy generator, only used when the op carries a non-zero `seed` attribute.
 // It keeps the historical inverse-CDF behavior so that graphs pinning an op
@@ -66,50 +72,107 @@ struct GPUTruncatedNormal {
 
 // Marks `flag` when any element of `data` falls outside [lo, hi]. Concurrent
 // threads only ever store the same value, so the race on `flag` is benign.
-template <typename T, typename MT>
+template <typename T, typename MT, int VecSize>
 __global__ void MarkOutOfRangeKernel(
     const T* data, int64_t numel, MT lo, MT hi, int* flag) {
+  int64_t tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
-  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-       i < numel;
-       i += stride) {
-    MT value = static_cast<MT>(data[i]);
-    if (value < lo || value > hi) {
-      *flag = 1;
+  int64_t vec_numel = numel / VecSize;
+  bool out_of_range = false;
+
+  for (int64_t i = tid; i < vec_numel; i += stride) {
+    phi::AlignedVector<T, VecSize> values;
+    phi::Load<T, VecSize>(data + i * VecSize, &values);
+#pragma unroll
+    for (int j = 0; j < VecSize; ++j) {
+      MT value = static_cast<MT>(values[j]);
+      out_of_range |= (value < lo || value > hi);
     }
+  }
+  for (int64_t i = vec_numel * VecSize + tid; i < numel; i += stride) {
+    MT value = static_cast<MT>(data[i]);
+    out_of_range |= (value < lo || value > hi);
+  }
+
+  if (out_of_range) {
+    *flag = 1;
   }
 }
 
 // Fuses torch's `result = where(mask, fresh, result)` with the mask
 // recomputation of the next loop iteration: elements left untouched were
 // already inside [lo, hi], so `flag` ends up as `mask.any()` of the update.
-template <typename T, typename MT>
+template <typename T, typename MT, int VecSize>
 __global__ void ReplaceOutOfRangeKernel(
     T* data, const T* fresh, int64_t numel, MT lo, MT hi, int* flag) {
+  int64_t tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
-  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-       i < numel;
-       i += stride) {
+  int64_t vec_numel = numel / VecSize;
+  bool still_out_of_range = false;
+
+  for (int64_t i = tid; i < vec_numel; i += stride) {
+    phi::AlignedVector<T, VecSize> values;
+    phi::Load<T, VecSize>(data + i * VecSize, &values);
+
+    bool replace = false;
+#pragma unroll
+    for (int j = 0; j < VecSize; ++j) {
+      MT value = static_cast<MT>(values[j]);
+      replace |= (value < lo || value > hi);
+    }
+    if (!replace) {
+      continue;
+    }
+
+    phi::AlignedVector<T, VecSize> replacements;
+    phi::Load<T, VecSize>(fresh + i * VecSize, &replacements);
+#pragma unroll
+    for (int j = 0; j < VecSize; ++j) {
+      MT value = static_cast<MT>(values[j]);
+      if (value < lo || value > hi) {
+        values[j] = replacements[j];
+        MT new_value = static_cast<MT>(replacements[j]);
+        still_out_of_range |= (new_value < lo || new_value > hi);
+      }
+    }
+    phi::Store<T, VecSize>(values, data + i * VecSize);
+  }
+  for (int64_t i = vec_numel * VecSize + tid; i < numel; i += stride) {
     MT value = static_cast<MT>(data[i]);
     if (value < lo || value > hi) {
       T replacement = fresh[i];
       data[i] = replacement;
       MT new_value = static_cast<MT>(replacement);
-      if (new_value < lo || new_value > hi) {
-        *flag = 1;
-      }
+      still_out_of_range |= (new_value < lo || new_value > hi);
     }
+  }
+
+  if (still_out_of_range) {
+    *flag = 1;
   }
 }
 
-// Port of the `p <= 0.3` branch of torch's `_no_grad_trunc_normal_`: uniform
-// proposals on [a, b] accepted with probability pdf(x)/pdf(mode).
-//
-// The log-pdf is evaluated with the same per-op rounding as the chain
+// Evaluates the log-pdf with the same per-op rounding as torch's chain
 // `candidates.sub_(mean).div_(std).pow_(2).mul_(-0.5).sub_(log_peak)`, which
 // stores an intermediate of dtype T after every step. That rounding is
 // observable for float16/bfloat16, hence the casts.
 template <typename T, typename MT>
+__device__ __forceinline__ bool IsProposalRejected(
+    T candidate, T accept_rand, MT mean, MT std, MT log_peak) {
+  MT value = static_cast<MT>(candidate);
+  value = static_cast<MT>(static_cast<T>(value - mean));
+  value = static_cast<MT>(static_cast<T>(value / std));
+  value = static_cast<MT>(static_cast<T>(value * value));
+  value = static_cast<MT>(static_cast<T>(value * static_cast<MT>(-0.5)));
+  MT log_pdf = static_cast<MT>(static_cast<T>(value - log_peak));
+
+  MT log_u = static_cast<MT>(static_cast<T>(log(static_cast<MT>(accept_rand))));
+  return log_u > log_pdf;
+}
+
+// Port of the `p <= 0.3` branch of torch's `_no_grad_trunc_normal_`: uniform
+// proposals on [a, b] accepted with probability pdf(x)/pdf(mode).
+template <typename T, typename MT, int VecSize>
 __global__ void AcceptRejectKernel(T* result,
                                    const T* proposal,
                                    const T* accept_rand,
@@ -120,10 +183,68 @@ __global__ void AcceptRejectKernel(T* result,
                                    MT log_peak,
                                    bool is_first_round,
                                    int* flag) {
+  int64_t tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
-  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-       i < numel;
-       i += stride) {
+  int64_t vec_numel = numel / VecSize;
+  bool any_rejected = false;
+
+  for (int64_t i = tid; i < vec_numel; i += stride) {
+    int64_t offset = i * VecSize;
+    phi::AlignedVector<bool, VecSize> was_pending;
+    if (is_first_round) {
+#pragma unroll
+      for (int j = 0; j < VecSize; ++j) {
+        was_pending[j] = true;
+      }
+    } else {
+      phi::Load<bool, VecSize>(pending + offset, &was_pending);
+      bool any_pending = false;
+#pragma unroll
+      for (int j = 0; j < VecSize; ++j) {
+        any_pending |= was_pending[j];
+      }
+      if (!any_pending) {
+        continue;
+      }
+    }
+
+    // On the first round `result` already holds the proposal, so it is both the
+    // candidate source and the destination that must be left untouched.
+    phi::AlignedVector<T, VecSize> candidates;
+    phi::Load<T, VecSize>((is_first_round ? result : proposal) + offset,
+                          &candidates);
+    phi::AlignedVector<T, VecSize> accepts;
+    phi::Load<T, VecSize>(accept_rand + offset, &accepts);
+
+    phi::AlignedVector<bool, VecSize> now_pending;
+#pragma unroll
+    for (int j = 0; j < VecSize; ++j) {
+      if (!was_pending[j]) {
+        now_pending[j] = false;
+        continue;
+      }
+      bool rejected = IsProposalRejected<T, MT>(
+          candidates[j], accepts[j], mean, std, log_peak);
+      now_pending[j] = rejected;
+      any_rejected |= rejected;
+    }
+
+    if (!is_first_round) {
+      // torch's `result = where(pending, candidates, result)`.
+      phi::AlignedVector<T, VecSize> values;
+      phi::Load<T, VecSize>(result + offset, &values);
+#pragma unroll
+      for (int j = 0; j < VecSize; ++j) {
+        if (was_pending[j]) {
+          values[j] = candidates[j];
+        }
+      }
+      phi::Store<T, VecSize>(values, result + offset);
+    }
+    phi::Store<bool, VecSize>(now_pending, pending + offset);
+  }
+
+  for (int64_t i = vec_numel * VecSize + tid; i < numel; i += stride) {
     if (!is_first_round && !pending[i]) {
       continue;
     }
@@ -131,22 +252,14 @@ __global__ void AcceptRejectKernel(T* result,
     if (!is_first_round) {
       result[i] = candidate;
     }
-
-    MT value = static_cast<MT>(candidate);
-    value = static_cast<MT>(static_cast<T>(value - mean));
-    value = static_cast<MT>(static_cast<T>(value / std));
-    value = static_cast<MT>(static_cast<T>(value * value));
-    value = static_cast<MT>(static_cast<T>(value * static_cast<MT>(-0.5)));
-    MT log_pdf = static_cast<MT>(static_cast<T>(value - log_peak));
-
-    MT log_u =
-        static_cast<MT>(static_cast<T>(log(static_cast<MT>(accept_rand[i]))));
-
-    bool rejected = log_u > log_pdf;
+    bool rejected = IsProposalRejected<T, MT>(
+        candidate, accept_rand[i], mean, std, log_peak);
     pending[i] = rejected;
-    if (rejected) {
-      *flag = 1;
-    }
+    any_rejected |= rejected;
+  }
+
+  if (any_rejected) {
+    *flag = 1;
   }
 }
 
@@ -185,6 +298,41 @@ class OutOfRangeFlag {
   int* data_ = nullptr;
 };
 
+template <typename T>
+int GetTruncatedNormalVecSize(const T* first, const T* second = nullptr) {
+  int vec_size = phi::GetVectorizedSize<T>(first);
+  if (second != nullptr) {
+    vec_size = std::min(vec_size, phi::GetVectorizedSize<T>(second));
+  }
+  return std::min(vec_size, kTruncatedNormalMaxVecSize);
+}
+
+#define LAUNCH_WITH_VEC_SIZE(kernel, vec_size, ...)                         \
+  do {                                                                      \
+    auto config =                                                           \
+        phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel, vec_size); \
+    switch (vec_size) {                                                     \
+      case 4:                                                               \
+        kernel<T, MT, 4><<<config.block_per_grid,                           \
+                           config.thread_per_block,                         \
+                           0,                                               \
+                           dev_ctx.stream()>>>(__VA_ARGS__);                \
+        break;                                                              \
+      case 2:                                                               \
+        kernel<T, MT, 2><<<config.block_per_grid,                           \
+                           config.thread_per_block,                         \
+                           0,                                               \
+                           dev_ctx.stream()>>>(__VA_ARGS__);                \
+        break;                                                              \
+      default:                                                              \
+        kernel<T, MT, 1><<<config.block_per_grid,                           \
+                           config.thread_per_block,                         \
+                           0,                                               \
+                           dev_ctx.stream()>>>(__VA_ARGS__);                \
+        break;                                                              \
+    }                                                                       \
+  } while (0)
+
 // Rejection sampling on plain normal draws, matching the `p > 0.3` branch of
 // torch's `_no_grad_trunc_normal_`. Every round redraws a full-size tensor, so
 // the philox offsets consumed here line up with torch's sequence of
@@ -208,28 +356,34 @@ void RejectionSampleFromNormal(const Context& dev_ctx,
   MT lo = static_cast<MT>(static_cast<T>(a));
   MT hi = static_cast<MT>(static_cast<T>(b));
 
-  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
   OutOfRangeFlag<Context> flag(dev_ctx);
+  T* out_data = out->data<T>();
 
   flag.Reset();
-  MarkOutOfRangeKernel<T, MT>
-      <<<config.block_per_grid, config.thread_per_block, 0, dev_ctx.stream()>>>(
-          out->data<T>(), numel, lo, hi, flag.data());
+  {
+    int vec_size = GetTruncatedNormalVecSize<T>(out_data);
+    LAUNCH_WITH_VEC_SIZE(
+        MarkOutOfRangeKernel, vec_size, out_data, numel, lo, hi, flag.data());
+  }
   if (!flag.Read()) {
     return;
   }
 
   DenseTensor fresh;
   fresh.Resize(out->dims());
-  dev_ctx.template Alloc<T>(&fresh);
+  T* fresh_data = dev_ctx.template Alloc<T>(&fresh);
+  int vec_size = GetTruncatedNormalVecSize<T>(out_data, fresh_data);
   while (true) {
     funcs::distribution_and_transform<T>(dev_ctx, &fresh, dist, trans);
     flag.Reset();
-    ReplaceOutOfRangeKernel<T, MT><<<config.block_per_grid,
-                                     config.thread_per_block,
-                                     0,
-                                     dev_ctx.stream()>>>(
-        out->data<T>(), fresh.data<T>(), numel, lo, hi, flag.data());
+    LAUNCH_WITH_VEC_SIZE(ReplaceOutOfRangeKernel,
+                         vec_size,
+                         out_data,
+                         fresh_data,
+                         numel,
+                         lo,
+                         hi,
+                         flag.data());
     if (!flag.Read()) {
       return;
     }
@@ -250,6 +404,9 @@ void RejectionSampleFromUniform(const Context& dev_ctx,
 
   double mode = std::max(a, std::min(mean, b));
   double log_peak = -0.5 * std::pow((mode - mean) / std, 2);
+  MT mean_mt = static_cast<MT>(mean);
+  MT std_mt = static_cast<MT>(std);
+  MT log_peak_mt = static_cast<MT>(log_peak);
 
   funcs::uniform_distribution<MT> dist;
   // Matches torch's `uniform_kernel`, which folds the bounds to the output
@@ -262,63 +419,69 @@ void RejectionSampleFromUniform(const Context& dev_ctx,
 
   DenseTensor accept_rand;
   accept_rand.Resize(out->dims());
-  dev_ctx.template Alloc<T>(&accept_rand);
+  T* accept_data = dev_ctx.template Alloc<T>(&accept_rand);
 
   DenseTensor pending;
   pending.Resize(out->dims());
   bool* pending_data = dev_ctx.template Alloc<bool>(&pending);
 
-  auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
   OutOfRangeFlag<Context> flag(dev_ctx);
+  T* out_data = out->data<T>();
 
   // First round proposes directly into `out`, as torch does.
   funcs::distribution_and_transform<T>(dev_ctx, out, dist, proposal_trans);
   funcs::distribution_and_transform<T>(
       dev_ctx, &accept_rand, dist, accept_trans);
   flag.Reset();
-  AcceptRejectKernel<T, MT>
-      <<<config.block_per_grid, config.thread_per_block, 0, dev_ctx.stream()>>>(
-          out->data<T>(),
-          nullptr,
-          accept_rand.data<T>(),
-          pending_data,
-          numel,
-          static_cast<MT>(mean),
-          static_cast<MT>(std),
-          static_cast<MT>(log_peak),
-          true,
-          flag.data());
+  {
+    int vec_size = GetTruncatedNormalVecSize<T>(out_data, accept_data);
+    LAUNCH_WITH_VEC_SIZE(AcceptRejectKernel,
+                         vec_size,
+                         out_data,
+                         static_cast<const T*>(nullptr),
+                         accept_data,
+                         pending_data,
+                         numel,
+                         mean_mt,
+                         std_mt,
+                         log_peak_mt,
+                         true,
+                         flag.data());
+  }
   if (!flag.Read()) {
     return;
   }
 
   DenseTensor proposal;
   proposal.Resize(out->dims());
-  dev_ctx.template Alloc<T>(&proposal);
+  T* proposal_data = dev_ctx.template Alloc<T>(&proposal);
+  int vec_size = std::min(GetTruncatedNormalVecSize<T>(out_data, accept_data),
+                          GetTruncatedNormalVecSize<T>(proposal_data));
   while (true) {
     funcs::distribution_and_transform<T>(
         dev_ctx, &proposal, dist, proposal_trans);
     funcs::distribution_and_transform<T>(
         dev_ctx, &accept_rand, dist, accept_trans);
     flag.Reset();
-    AcceptRejectKernel<T, MT><<<config.block_per_grid,
-                                config.thread_per_block,
-                                0,
-                                dev_ctx.stream()>>>(out->data<T>(),
-                                                    proposal.data<T>(),
-                                                    accept_rand.data<T>(),
-                                                    pending_data,
-                                                    numel,
-                                                    static_cast<MT>(mean),
-                                                    static_cast<MT>(std),
-                                                    static_cast<MT>(log_peak),
-                                                    false,
-                                                    flag.data());
+    LAUNCH_WITH_VEC_SIZE(AcceptRejectKernel,
+                         vec_size,
+                         out_data,
+                         proposal_data,
+                         accept_data,
+                         pending_data,
+                         numel,
+                         mean_mt,
+                         std_mt,
+                         log_peak_mt,
+                         false,
+                         flag.data());
     if (!flag.Read()) {
       return;
     }
   }
 }
+
+#undef LAUNCH_WITH_VEC_SIZE
 
 template <typename T, typename Context>
 void TruncatedGaussianRandomKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/gpu/truncated_gaussian_random_kernel.cu
+++ b/paddle/phi/kernels/gpu/truncated_gaussian_random_kernel.cu
@@ -156,12 +156,17 @@ __global__ void ReplaceOutOfRangeKernel(
 // `candidates.sub_(mean).div_(std).pow_(2).mul_(-0.5).sub_(log_peak)`, which
 // stores an intermediate of dtype T after every step. That rounding is
 // observable for float16/bfloat16, hence the casts.
+//
+// `div_` by a python float takes torch's CPU-scalar fast path, which turns the
+// division into a multiplication by a reciprocal formed in double precision
+// (see `div_true_kernel_cuda` in BinaryDivTrueKernel.cu). That is not the same
+// as dividing, so `inv_std` has to be pre-computed the same way.
 template <typename T, typename MT>
 __device__ __forceinline__ bool IsProposalRejected(
-    T candidate, T accept_rand, MT mean, MT std, MT log_peak) {
+    T candidate, T accept_rand, MT mean, MT inv_std, MT log_peak) {
   MT value = static_cast<MT>(candidate);
   value = static_cast<MT>(static_cast<T>(value - mean));
-  value = static_cast<MT>(static_cast<T>(value / std));
+  value = static_cast<MT>(static_cast<T>(value * inv_std));
   value = static_cast<MT>(static_cast<T>(value * value));
   value = static_cast<MT>(static_cast<T>(value * static_cast<MT>(-0.5)));
   MT log_pdf = static_cast<MT>(static_cast<T>(value - log_peak));
@@ -179,7 +184,7 @@ __global__ void AcceptRejectKernel(T* result,
                                    bool* pending,
                                    int64_t numel,
                                    MT mean,
-                                   MT std,
+                                   MT inv_std,
                                    MT log_peak,
                                    bool is_first_round,
                                    int* flag) {
@@ -224,7 +229,7 @@ __global__ void AcceptRejectKernel(T* result,
         continue;
       }
       bool rejected = IsProposalRejected<T, MT>(
-          candidates[j], accepts[j], mean, std, log_peak);
+          candidates[j], accepts[j], mean, inv_std, log_peak);
       now_pending[j] = rejected;
       any_rejected |= rejected;
     }
@@ -253,7 +258,7 @@ __global__ void AcceptRejectKernel(T* result,
       result[i] = candidate;
     }
     bool rejected = IsProposalRejected<T, MT>(
-        candidate, accept_rand[i], mean, std, log_peak);
+        candidate, accept_rand[i], mean, inv_std, log_peak);
     pending[i] = rejected;
     any_rejected |= rejected;
   }
@@ -405,7 +410,9 @@ void RejectionSampleFromUniform(const Context& dev_ctx,
   double mode = std::max(a, std::min(mean, b));
   double log_peak = -0.5 * std::pow((mode - mean) / std, 2);
   MT mean_mt = static_cast<MT>(mean);
-  MT std_mt = static_cast<MT>(std);
+  // torch's `div_(std)` folds the divisor into a double-precision reciprocal
+  // before multiplying; see the note on IsProposalRejected.
+  MT inv_std_mt = static_cast<MT>(1.0 / std);
   MT log_peak_mt = static_cast<MT>(log_peak);
 
   funcs::uniform_distribution<MT> dist;
@@ -434,7 +441,8 @@ void RejectionSampleFromUniform(const Context& dev_ctx,
       dev_ctx, &accept_rand, dist, accept_trans);
   flag.Reset();
   {
-    int vec_size = GetTruncatedNormalVecSize<T>(out_data, accept_data);
+    int vec_size = std::min(GetTruncatedNormalVecSize<T>(out_data, accept_data),
+                            GetTruncatedNormalVecSize<bool>(pending_data));
     LAUNCH_WITH_VEC_SIZE(AcceptRejectKernel,
                          vec_size,
                          out_data,
@@ -443,7 +451,7 @@ void RejectionSampleFromUniform(const Context& dev_ctx,
                          pending_data,
                          numel,
                          mean_mt,
-                         std_mt,
+                         inv_std_mt,
                          log_peak_mt,
                          true,
                          flag.data());
@@ -455,8 +463,9 @@ void RejectionSampleFromUniform(const Context& dev_ctx,
   DenseTensor proposal;
   proposal.Resize(out->dims());
   T* proposal_data = dev_ctx.template Alloc<T>(&proposal);
-  int vec_size = std::min(GetTruncatedNormalVecSize<T>(out_data, accept_data),
-                          GetTruncatedNormalVecSize<T>(proposal_data));
+  int vec_size = std::min({GetTruncatedNormalVecSize<T>(out_data, accept_data),
+                           GetTruncatedNormalVecSize<T>(proposal_data),
+                           GetTruncatedNormalVecSize<bool>(pending_data)});
   while (true) {
     funcs::distribution_and_transform<T>(
         dev_ctx, &proposal, dist, proposal_trans);
@@ -471,7 +480,7 @@ void RejectionSampleFromUniform(const Context& dev_ctx,
                          pending_data,
                          numel,
                          mean_mt,
-                         std_mt,
+                         inv_std_mt,
                          log_peak_mt,
                          false,
                          flag.data());

--- a/paddle/phi/kernels/truncated_gaussian_random_kernel.h
+++ b/paddle/phi/kernels/truncated_gaussian_random_kernel.h
@@ -22,11 +22,11 @@ namespace phi {
 template <typename T, typename Context>
 void TruncatedGaussianRandomKernel(const Context& dev_ctx,
                                    const std::vector<int>& shape,
-                                   float mean,
-                                   float std,
+                                   double mean,
+                                   double std,
                                    int seed,
-                                   float a,
-                                   float b,
+                                   double a,
+                                   double b,
                                    DataType dtype,
                                    DenseTensor* out);
 

--- a/paddle/phi/kernels/xpu/truncated_gaussian_random_kernel.cc
+++ b/paddle/phi/kernels/xpu/truncated_gaussian_random_kernel.cc
@@ -18,6 +18,7 @@ limitations under the License. */
 #include <random>
 
 #include "paddle/phi/backends/xpu/xpu_context.h"
+#include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/truncated_normal.h"
@@ -36,12 +37,17 @@ void TruncatedGaussianRandomKernel(const Context& dev_ctx,
                                    DenseTensor* out) {
   T* data = dev_ctx.template Alloc<T>(out);
 
-  std::uniform_real_distribution<T> dist(std::numeric_limits<float>::min(),
-                                         1.0);
-  TruncatedNormal<T> truncated_normal(static_cast<T>(mean),
-                                      static_cast<T>(std),
-                                      static_cast<T>(a),
-                                      static_cast<T>(b));
+  // Sampling always happens in float and is rounded to T on store, which keeps
+  // the half precision results identical to the historical behavior of
+  // generating a float32 tensor and appending a cast.
+  using MT = typename MPTypeTrait<T>::Type;
+
+  std::uniform_real_distribution<MT> dist(std::numeric_limits<float>::min(),
+                                          1.0);
+  TruncatedNormal<MT> truncated_normal(static_cast<MT>(mean),
+                                       static_cast<MT>(std),
+                                       static_cast<MT>(a),
+                                       static_cast<MT>(b));
   int64_t size = out->numel();
   std::unique_ptr<T[]> data_cpu(new T[size]);
 
@@ -54,7 +60,7 @@ void TruncatedGaussianRandomKernel(const Context& dev_ctx,
   }
 
   for (int64_t i = 0; i < size; ++i) {
-    data_cpu[i] = truncated_normal(dist(*engine));
+    data_cpu[i] = static_cast<T>(truncated_normal(dist(*engine)));
   }
 
   memory_utils::Copy(dev_ctx.GetPlace(),
@@ -70,4 +76,6 @@ PD_REGISTER_KERNEL(truncated_gaussian_random,
                    XPU,
                    ALL_LAYOUT,
                    phi::TruncatedGaussianRandomKernel,
-                   float) {}
+                   float,
+                   phi::float16,
+                   phi::bfloat16) {}

--- a/paddle/phi/kernels/xpu/truncated_gaussian_random_kernel.cc
+++ b/paddle/phi/kernels/xpu/truncated_gaussian_random_kernel.cc
@@ -27,18 +27,21 @@ namespace phi {
 template <typename T, typename Context>
 void TruncatedGaussianRandomKernel(const Context& dev_ctx,
                                    const std::vector<int>& shape,
-                                   float mean,
-                                   float std,
+                                   double mean,
+                                   double std,
                                    int seed,
-                                   float a,
-                                   float b,
+                                   double a,
+                                   double b,
                                    DataType dtype,
                                    DenseTensor* out) {
   T* data = dev_ctx.template Alloc<T>(out);
 
   std::uniform_real_distribution<T> dist(std::numeric_limits<float>::min(),
                                          1.0);
-  TruncatedNormal<T> truncated_normal(mean, std, a, b);
+  TruncatedNormal<T> truncated_normal(static_cast<T>(mean),
+                                      static_cast<T>(std),
+                                      static_cast<T>(a),
+                                      static_cast<T>(b));
   int64_t size = out->numel();
   std::unique_ptr<T[]> data_cpu(new T[size]);
 

--- a/paddle/phi/ops/yaml/op_version.yaml
+++ b/paddle/phi/ops/yaml/op_version.yaml
@@ -654,6 +654,20 @@
         - add_attr : b
           comment : The maximum cutoff value.
           default: 2.0
+    - checkpoint : Upgrade truncated_gaussian_random, change the type of attributes [mean], [std], [a] and [b] from float to double to avoid float32 truncation that breaks float64 output precision.
+      action :
+        - modify_attr : mean
+          comment : "The type of attr 'mean' is changed from float to double, so that the caller's double-precision value is no longer truncated to float32 before being used by the kernel. The numeric default value is unchanged (0.0)."
+          default : 0.0
+        - modify_attr : std
+          comment : "The type of attr 'std' is changed from float to double, so that the caller's double-precision value is no longer truncated to float32 before being used by the kernel. The numeric default value is unchanged (1.0)."
+          default : 1.0
+        - modify_attr : a
+          comment : "The type of attr 'a' is changed from float to double, so that the caller's double-precision value is no longer truncated to float32 before being used by the kernel. The numeric default value is unchanged (-2.0)."
+          default : -2.0
+        - modify_attr : b
+          comment : "The type of attr 'b' is changed from float to double, so that the caller's double-precision value is no longer truncated to float32 before being used by the kernel. The numeric default value is unchanged (2.0)."
+          default : 2.0
 
 - op : unique_consecutive
   version :

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -5789,7 +5789,7 @@
 
 # python API: paddle.nn.initializer.TruncatedNormal
 - op : truncated_gaussian_random
-  args : (int[] shape, float mean, float std, int seed, float a, float b, DataType dtype=DataType::FLOAT32, Place place={})
+  args : (int[] shape, double mean, double std, int seed, double a, double b, DataType dtype=DataType::FLOAT32, Place place={})
   output : Tensor(out)
   infer_meta :
     func : TruncatedGaussianRandomInferMeta

--- a/python/paddle/nn/initializer/normal.py
+++ b/python/paddle/nn/initializer/normal.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import paddle
 from paddle import _C_ops, pir
 
-from ...base import core, framework, unique_name
+from ...base import core, framework
 from ...base.data_feeder import check_variable_and_dtype
 from ...base.framework import (
     _current_expected_place,
@@ -257,21 +257,10 @@ class TruncatedNormalInitializer(Initializer):
         if self._seed == 0:
             self._seed = block.program.random_seed
 
-        # to be compatible of fp16 initializers
-        if var.dtype in [core.VarDesc.VarType.FP16, core.VarDesc.VarType.BF16]:
-            out_dtype = core.VarDesc.VarType.FP32
-            out_var = block.create_var(
-                name=unique_name.generate(
-                    ".".join(['truncated_gaussian_random', var.name, 'tmp'])
-                ),
-                shape=var.shape,
-                dtype=out_dtype,
-                type=core.VarDesc.VarType.DENSE_TENSOR,
-                persistable=False,
-            )
-        else:
-            out_dtype = var.dtype
-            out_var = var
+        # Sampling happens in `var.dtype` directly: torch draws and applies the
+        # truncation test in the target dtype, so an fp32 detour would round at
+        # a different point and change which samples get rejected.
+        out_dtype = var.dtype
 
         if in_dygraph_mode():
             out_var = _C_ops.truncated_gaussian_random(
@@ -284,18 +273,11 @@ class TruncatedNormalInitializer(Initializer):
                 out_dtype,
                 _current_expected_place(),
             )
-            if var.dtype in [
-                core.VarDesc.VarType.FP16,
-                core.VarDesc.VarType.BF16,
-            ]:
-                var_tmp = _C_ops.cast(out_var, var.dtype)
-                var_tmp._share_underline_tensor_to(var)
-            else:
-                out_var._share_underline_tensor_to(var)
+            out_var._share_underline_tensor_to(var)
             return None
 
         elif in_pir_mode():
-            out_var = _C_ops.truncated_gaussian_random(
+            return _C_ops.truncated_gaussian_random(
                 var.shape,
                 self._mean,
                 self._std_dev,
@@ -305,18 +287,11 @@ class TruncatedNormalInitializer(Initializer):
                 out_dtype,
                 _current_expected_place(),
             )
-            if var.dtype in [
-                core.VarDesc.VarType.FP16,
-                core.VarDesc.VarType.BF16,
-            ]:
-                var_tmp = _C_ops.cast(out_var, var.dtype)
-                var_tmp._share_underline_tensor_to(var)
-            return out_var
 
         else:
             op = block.append_op(
                 type="truncated_gaussian_random",
-                outputs={"Out": out_var},
+                outputs={"Out": var},
                 attrs={
                     "shape": var.shape,
                     "dtype": out_dtype,
@@ -328,17 +303,6 @@ class TruncatedNormalInitializer(Initializer):
                 },
                 stop_gradient=True,
             )
-
-            if var.dtype in [
-                core.VarDesc.VarType.FP16,
-                core.VarDesc.VarType.BF16,
-            ]:
-                block.append_op(
-                    type="cast",
-                    inputs={"X": out_var},
-                    outputs={"Out": var},
-                    attrs={"in_dtype": out_var.dtype, "out_dtype": var.dtype},
-                )
             var.op = op
             return op
 

--- a/test/legacy_test/test_initializer_nn.py
+++ b/test/legacy_test/test_initializer_nn.py
@@ -498,7 +498,7 @@ class TestTruncatedNormal(unittest.TestCase):
                     name="param",
                     initializer=initializer.TruncatedNormal(2.3, 1.9),
                 )
-            num_ops = 2 if dtype in ["float16", "uint16"] else 1
+            num_ops = 1
             self.assertEqual(len(block.ops), num_ops)
             init_op = block.ops[0]
             self.assertEqual(init_op.type, 'truncated_gaussian_random')
@@ -513,15 +513,16 @@ class TestTruncatedNormal(unittest.TestCase):
         """Test truncated normal initializer with float16"""
         paddle.enable_static()
 
+        # Sampling happens directly in float16, so no cast op is appended.
         block = self.test_truncated_normal_initializer("float16")
-        self.assertTrue(check_cast_op(block.ops[1]))
+        self.assertEqual(len(block.ops), 1)
 
     def test_truncated_normal_initializer_bf16(self):
         """Test truncated normal initializer with bfloat16"""
         paddle.enable_static()
 
         block = self.test_truncated_normal_initializer("uint16")  # bfloat16
-        self.assertTrue(check_cast_op(block.ops[1]))
+        self.assertEqual(len(block.ops), 1)
 
     def test_truncated_normal_initializer_fp64(self):
         """Test truncated normal initializer with float64"""


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->Operator Mechanism


### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] --> Improvements


### Description
<!-- Describe what you’ve done -->align truncated norm initializer with torch on gpu 
detail:
1、upgrade parameter precision to double 
2、develop a new trunc_normal gpu kernel uses rejection sampling which is originally applied in python level in torch
3、fix bf16 && fp16 register on xpu according to ci review bot.

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->是
