### PR TITLE
[release/3.4][Operator Mechanism] Fix TopK operator implementation

### DIFF
--- a/paddle/phi/kernels/gpu/top_k_kernel.cu
+++ b/paddle/phi/kernels/gpu/top_k_kernel.cu
@@ -403,6 +403,7 @@ void TopkKernelCuda(const Context& dev_ctx,
   if (k == 1) {
     TopkKernel<T, Context>(
         dev_ctx, x, k_scalar, axis, largest, sorted, out, indices);
+    return;
   }
 
   // Handle k from tensor: output dims may contain -1, resize before Alloc


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
当K=1时，Paddle性能相较于Pytorch性能不足。
case | shape | dtype | k | axis | Paddle (ms) | PyTorch (ms) | Paddle/PyTorch | PyTorch path | check
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
0 | [4, 205923] | float32 | 1 | -1 | 0.1929 | 0.1122 | 1.720x | ATen CUDA | P:ok; T:ok
1 | [2, 4096] | float16 | 2048 | -1 | 0.0319 | 0.0323 | 0.990x | ATen CUDA | P:ok; T:ok
2 | [8, 32768] | float16 | 2048 | -1 | 0.0659 | 0.0802 | 0.822x | ATen CUDA | P:ok; T:ok
3 | [256, 65536] | float16 | 2048 | -1 | 0.1713 | 0.1821 | 0.941x | ATen CUDA | P:ok; T:ok
4 | [8192, 65536] | float32 | 2048 | -1 | 6.2633 | 6.2407 | 1.004x | ATen CUDA | P:ok; T:ok

定位发现现有实现在K=1时，执行了两次计算。

当选择调用TopKernel时，性能为：
item | shape | dtype | k | axis | Paddle ms | PyTorch ms | Paddle/PyTorch | PyTorch path | check
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
0 | [4, 205923] | float32 | 1 | -1 | 0.0890 | 0.1135 | 0.784x | ATen CUDA | P:ok; T:ok
1 | [4, 205923] | float32 | 1 | -1 | 0.0884 | 0.1138 | 0.777x | ATen CUDA | P:ok; T:ok

当删除K=1的特殊路径时，性能为；

item | shape | dtype | k | axis | Paddle ms | PyTorch ms | Paddle/PyTorch | PyTorch path | check
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
0 | [4, 205923] | float32 | 1 | -1 | 0.1111 | 0.1136 | 0.977x | ATen CUDA | P:ok; T:ok
1 | [4, 205923] | float32 | 1 | -1 | 0.1069 | 0.1125 | 0.951x | ATen CUDA | P:ok; T:ok

因此选择性能更好的方案一

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

---

Cherry-pick of #79693 (authored by @feixi139) to `release/3.4`.

devPR:https://github.com/PaddlePaddle/Paddle/pull/79693 <!-- For pass CI -->