### PR TITLE
[Environment Adaptation] Upgrade NCCL to 2.31.2

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -752,14 +752,14 @@ def get_paddle_extra_install_requirements():
                 "nvidia-cublas<=13.1.1.3,>=13.1.0.3; platform_system == 'Linux' | "
                 "nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | "
                 "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "
-                "nvidia-nccl-cu13==2.30.7; platform_system == 'Linux' | "
+                "nvidia-nccl-cu13==2.31.2; platform_system == 'Linux' | "
                 "cuda-python==13.0.3; platform_system == 'Linux'"
             ),
             "13.2": (
                 "cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.2.1; platform_system == 'Linux' | "
                 "nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | "
                 "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "
-                "nvidia-nccl-cu13==2.30.7; platform_system == 'Linux' | "
+                "nvidia-nccl-cu13==2.31.2; platform_system == 'Linux' | "
                 "cuda-python==13.2.0; platform_system == 'Linux'"
             ),
         }

--- a/setup.py
+++ b/setup.py
@@ -1263,14 +1263,14 @@ def get_paddle_extra_install_requirements():
                     "nvidia-cublas<=13.1.1.3,>=13.1.0.3; platform_system == 'Linux' | "
                     "nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | "
                     "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "
-                    "nvidia-nccl-cu13==2.30.7; platform_system == 'Linux' | "
+                    "nvidia-nccl-cu13==2.31.2; platform_system == 'Linux' | "
                     "cuda-python==13.0.3; platform_system == 'Linux'"
                 ),
                 "13.2": (
                     "cuda-toolkit[cublas,cudart,cufft,cufile,cupti,curand,cusolver,cusparse,nvjitlink,nvrtc,nvtx]==13.2.1; platform_system == 'Linux' | "
                     "nvidia-cudnn-cu13==9.20.0.48; platform_system == 'Linux' | "
                     "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "
-                    "nvidia-nccl-cu13==2.30.7; platform_system == 'Linux' | "
+                    "nvidia-nccl-cu13==2.31.2; platform_system == 'Linux' | "
                     "cuda-python==13.2.0; platform_system == 'Linux'"
                 ),
             }


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Improvements

### Description
Upgrade the `nvidia-nccl-cu13` dependency from `2.30.7` to `2.31.2` for CUDA 13.0 and CUDA 13.2 in `setup.py` and `python/setup.py.in`.

Validation:
- `python -m py_compile setup.py`
- `git diff --check`

### 是否引起精度变化
否
