### PR TITLE
[Operator Mechanism] Align cosine_similarity with torch2.12

### DIFF
--- a/paddle/phi/kernels/xpu/p_norm_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/p_norm_grad_kernel.cc
@@ -168,10 +168,27 @@ void PNormGradKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast_pow");
     dev_ctx.Wait();
 
+    // Add epsilon to the denominator to avoid 0 / 0 for zero-norm inputs.
+    // Keep this consistent with the CPU p_norm_grad implementation.
+    XPUType* safe_y_pow = RAII_GUARD.alloc_l3_or_gm<XPUType>(m * n);
+    PADDLE_ENFORCE_XDNN_NOT_NULL(safe_y_pow);
+    r = xpu::constant(dev_ctx.x_context(),
+                      porder_tensor.data<float>(),
+                      1,
+                      static_cast<float>(epsilon));
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "constant");
+    r = xpu::broadcast_add(dev_ctx.x_context(),
+                           y_pow,
+                           porder_tensor.data<float>(),
+                           safe_y_pow,
+                           y_dim,
+                           p_dim);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast_add");
+
     XPUType* dx_t = x_abs;
 
     r = xpu::broadcast_div(
-        dev_ctx.x_context(), x_pow, y_pow, dx_t, x_dim, y_dim);
+        dev_ctx.x_context(), x_pow, safe_y_pow, dx_t, x_dim, y_dim);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast_div");
 
     XPUType* x_sign = x_pow;

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -2452,18 +2452,42 @@ def cosine_similarity(
     """
     if x1.shape[axis] == 0 or x2.shape[axis] == 0:
         return sum(paddle.multiply(x1, x2), axis=axis)
-    bs = paddle.broadcast_shape([x1.shape[axis]], [x2.shape[axis]])
-    w12 = sum(paddle.multiply(x1, x2), axis=axis)
-    w1 = sum(paddle.multiply(x1, x1), axis=axis)
-    w2 = sum(paddle.multiply(x2, x2), axis=axis)
-    m1, m2 = bs[0] / x1.shape[axis], bs[0] / x2.shape[axis]
-    if m1 != 1:
-        w1 = w1 * m1
-    if m2 != 1:
-        w2 = w2 * m2
-    n12 = sqrt(clip(w1 * w2, min=eps * eps))
-    cos_sim = w12 / n12
-    return cos_sim
+    if paddle.get_flags("FLAGS_use_accuracy_compatible_kernel")[
+        "FLAGS_use_accuracy_compatible_kernel"
+    ]:
+        # Note: aligning with torch 2.12
+        bs = paddle.broadcast_shape([x1.shape[axis]], [x2.shape[axis]])
+        x1_full, x2_full = x1, x2
+        if x1.shape[axis] != bs[0]:
+            shape = [-1] * len(x1.shape)
+            shape[axis] = bs[0]
+            x1_full = paddle.broadcast_to(x1, shape)
+        if x2.shape[axis] != bs[0]:
+            shape = [-1] * len(x2.shape)
+            shape[axis] = bs[0]
+            x2_full = paddle.broadcast_to(x2, shape)
+        n1 = clip(
+            paddle.linalg.vector_norm(x1_full, p=2, axis=axis, keepdim=True),
+            min=eps,
+        )
+        n2 = clip(
+            paddle.linalg.vector_norm(x2_full, p=2, axis=axis, keepdim=True),
+            min=eps,
+        )
+        return sum(paddle.multiply(x1 / n1, x2 / n2), axis=axis)
+    else:
+        bs = paddle.broadcast_shape([x1.shape[axis]], [x2.shape[axis]])
+        w12 = sum(paddle.multiply(x1, x2), axis=axis)
+        w1 = sum(paddle.multiply(x1, x1), axis=axis)
+        w2 = sum(paddle.multiply(x2, x2), axis=axis)
+        m1, m2 = bs[0] / x1.shape[axis], bs[0] / x2.shape[axis]
+        if m1 != 1:
+            w1 = w1 * m1
+        if m2 != 1:
+            w2 = w2 * m2
+        n12 = sqrt(clip(w1 * w2, min=eps * eps))
+        cos_sim = w12 / n12
+        return cos_sim
 
 
 def linear(

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -2453,11 +2453,13 @@ def cosine_similarity(
     """
     # Note: aligning with torch 2.12, including:
     # 1. Casting integral input dtypes to floating dtype and reject non-floating
-    # common dtype since vector_norm has no integer kernel.
-    # The inputs are promoted first and a non-floating common dtype is rejected;
-    # only the integral inputs are cast,
-    # because vector_norm has no integer kernel while a pair of floating inputs
-    # is promoted by the elementwise ops themselves.
+    #   common dtype since vector_norm has no integer kernel.
+    # 2. Each input is divided by its own norm before the dot product to avoid
+    #   overflow.
+    # 3. Broadcast inputs front so axis indexes the common shape
+    # 4. Clamp the norms(||x1|| and ||x2||) against an eps scalar in float32
+    #   when dtype==bf16/fp16 to avoid clamping to zero in such rare cases.
+
     float_dtypes = (
         paddle.float16,
         paddle.bfloat16,
@@ -2477,35 +2479,19 @@ def cosine_similarity(
     if x2.dtype not in float_dtypes:
         x2 = x2.astype(common_dtype)
 
-    # Each input is divided by its own norm before the dot product, so the
-    # denominator is max(|x1|, eps) * max(|x2|, eps) instead of
-    # max(|x1| * |x2|, eps): clamping the product attenuates the result for
-    # small but perfectly valid vectors, and computing |x1| * |x2| overflows
-    # long before either norm alone does. vector_norm matches torch's
-    # linalg_vector_norm bitwise, including the float32 accumulation used for
-    # float16/bfloat16 inputs.
-    #
-    # torch broadcasts both inputs up front, so ``axis`` indexes the common shape and the
-    # reduction runs over the broadcast length of that axis, not the original one.
-    # expand_outplace() in torch.cosine_similarity both infers the broadcast shape and
-    # expands the tensors to it, so paddle.broadcast_shape(x1.shape, x2.shape), which only
-    # counts the shape, is not enough.
+    # torch expand inputs to broadcast shape first then compute norm when need to broadcast.
     # torch.expand only sets the broadcast stride to 0 and keeps the original storage, so it
-    # is 0-copy, and TensorIterator reduces directly over that stride-0 input:
-    # linalg_vector_norm allocates nothing and re-reads the same O(BD) bytes out of cache.
-    # paddle.broadcast_to is a real kernel instead. For example, x1=[B,1,D] and x2=[B,N,D] it
-    # allocates O(BND) space and writes every element, so vector_norm then reads O(BND) from
-    # global memory instead of the O(BD) the data actually occupies. When N is super large,
-    # it will cause huge memory usage and maybe OOM.
-    # Instead of using paddle.broadcast_to, we implement with `unsqueeze` and `||repeat(x,m)||`.
+    # is 0-copy, and TensorIterator runs linalg_vector_norm directly over that stride-0 input,
+    # allocating nothing and re-reading the same O(BD) bytes out of cache.
+    # paddle has no STRIDED p_norm kernel and p_norm only has a single reduction order for
+    # contiguous input, which has accuracy diff with torch when reducing over stride-0 view.
+
+    # So we implement torch's behavior of cosine_similarity with follow steps:
     # 1. unsqueeze x1 and x2 to the same rank as the broadcast shape. When x1.dims != x2.dims
-    # and input axis is larger than smaller dims, unsqueeze op ensures vector_norm is reduced
-    # at the correct dim.
-    # 2. ||repeat(x,m)|| = sqrt(m) * |x|.
-    # This replacement could save memory at vector_norm when x1.dims[axis] != x2.dims[axis]
-    #  and broadcast happens at axis dim.
-    # The literal torch order, expand first and then take the norm, is kept behind
-    # FLAGS_use_accuracy_compatible_kernel at the cost of that extra memory.
+    #   and input axis is larger than smaller dims, unsqueeze op ensures vector_norm is
+    #   reduced at the correct dim.
+    # 2. ||repeat(x,m)|| = sqrt(m) * ||x||.
+
     rank = max(len(x1.shape), len(x2.shape))
     if len(x1.shape) < rank:
         x1 = unsqueeze(x1, axis=list(range(rank - len(x1.shape))))
@@ -2513,29 +2499,25 @@ def cosine_similarity(
         x2 = unsqueeze(x2, axis=list(range(rank - len(x2.shape))))
     bs = paddle.broadcast_shape(x1.shape, x2.shape)
     dim = axis + rank if axis < 0 else axis
-    if paddle.get_flags(["FLAGS_use_accuracy_compatible_kernel"]).get(
-        "FLAGS_use_accuracy_compatible_kernel", False
-    ):
-        # Reproduce torch step by step: expand both inputs to the broadcast
-        # shape and take the norm of the expanded tensors. Unlike torch.expand,
-        # paddle.broadcast_to is not a 0-copy view, so each expanded input costs
-        # an extra O(prod(bs)) allocation that is also read back by vector_norm.
-        # For x1=[B, 1, D] against x2=[B, N, D] that is O(B * N * D) instead of
-        # the O(B * D) the data occupies, and it may OOM when N is large.
-        x1 = paddle.broadcast_to(x1, bs)
-        x2 = paddle.broadcast_to(x2, bs)
-        n1 = paddle.linalg.vector_norm(x1, p=2, axis=dim, keepdim=True)
-        n2 = paddle.linalg.vector_norm(x2, p=2, axis=dim, keepdim=True)
-    else:
-        n1 = paddle.linalg.vector_norm(x1, p=2, axis=dim, keepdim=True)
-        n2 = paddle.linalg.vector_norm(x2, p=2, axis=dim, keepdim=True)
-        # A dynamic (-1) length fails both checks and is left uncorrected.
-        if x1.shape[dim] > 0 and bs[dim] > x1.shape[dim]:
-            n1 = n1 * math.sqrt(bs[dim] / x1.shape[dim])
-        if x2.shape[dim] > 0 and bs[dim] > x2.shape[dim]:
-            n2 = n2 * math.sqrt(bs[dim] / x2.shape[dim])
+    n1 = paddle.linalg.vector_norm(x1, p=2, axis=dim, keepdim=True)
+    n2 = paddle.linalg.vector_norm(x2, p=2, axis=dim, keepdim=True)
+    if x1.shape[dim] > 0 and bs[dim] > x1.shape[dim]:
+        n1 = n1 * math.sqrt(bs[dim] / x1.shape[dim])
+    if x2.shape[dim] > 0 and bs[dim] > x2.shape[dim]:
+        n2 = n2 * math.sqrt(bs[dim] / x2.shape[dim])
+    reduced_dtypes = (paddle.float16, paddle.bfloat16)
+    n1 = (
+        clip(n1.astype(paddle.float32), min=eps).astype(n1.dtype)
+        if n1.dtype in reduced_dtypes
+        else clip(n1, min=eps)
+    )
+    n2 = (
+        clip(n2.astype(paddle.float32), min=eps).astype(n2.dtype)
+        if n2.dtype in reduced_dtypes
+        else clip(n2, min=eps)
+    )
     return sum(
-        paddle.multiply(x1 / clip(n1, min=eps), x2 / clip(n2, min=eps)),
+        paddle.multiply(x1 / n1, x2 / n2),
         axis=dim,
     )
 

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -2504,6 +2504,8 @@ def cosine_similarity(
     # 2. ||repeat(x,m)|| = sqrt(m) * |x|.
     # This replacement could save memory at vector_norm when x1.dims[axis] != x2.dims[axis]
     #  and broadcast happens at axis dim.
+    # The literal torch order, expand first and then take the norm, is kept behind
+    # FLAGS_use_accuracy_compatible_kernel at the cost of that extra memory.
     rank = max(len(x1.shape), len(x2.shape))
     if len(x1.shape) < rank:
         x1 = unsqueeze(x1, axis=list(range(rank - len(x1.shape))))
@@ -2511,13 +2513,27 @@ def cosine_similarity(
         x2 = unsqueeze(x2, axis=list(range(rank - len(x2.shape))))
     bs = paddle.broadcast_shape(x1.shape, x2.shape)
     dim = axis + rank if axis < 0 else axis
-    n1 = paddle.linalg.vector_norm(x1, p=2, axis=dim, keepdim=True)
-    n2 = paddle.linalg.vector_norm(x2, p=2, axis=dim, keepdim=True)
-    # A dynamic (-1) length fails both checks and is left uncorrected.
-    if x1.shape[dim] > 0 and bs[dim] > x1.shape[dim]:
-        n1 = n1 * math.sqrt(bs[dim] / x1.shape[dim])
-    if x2.shape[dim] > 0 and bs[dim] > x2.shape[dim]:
-        n2 = n2 * math.sqrt(bs[dim] / x2.shape[dim])
+    if paddle.get_flags(["FLAGS_use_accuracy_compatible_kernel"]).get(
+        "FLAGS_use_accuracy_compatible_kernel", False
+    ):
+        # Reproduce torch step by step: expand both inputs to the broadcast
+        # shape and take the norm of the expanded tensors. Unlike torch.expand,
+        # paddle.broadcast_to is not a 0-copy view, so each expanded input costs
+        # an extra O(prod(bs)) allocation that is also read back by vector_norm.
+        # For x1=[B, 1, D] against x2=[B, N, D] that is O(B * N * D) instead of
+        # the O(B * D) the data occupies, and it may OOM when N is large.
+        x1 = paddle.broadcast_to(x1, bs)
+        x2 = paddle.broadcast_to(x2, bs)
+        n1 = paddle.linalg.vector_norm(x1, p=2, axis=dim, keepdim=True)
+        n2 = paddle.linalg.vector_norm(x2, p=2, axis=dim, keepdim=True)
+    else:
+        n1 = paddle.linalg.vector_norm(x1, p=2, axis=dim, keepdim=True)
+        n2 = paddle.linalg.vector_norm(x2, p=2, axis=dim, keepdim=True)
+        # A dynamic (-1) length fails both checks and is left uncorrected.
+        if x1.shape[dim] > 0 and bs[dim] > x1.shape[dim]:
+            n1 = n1 * math.sqrt(bs[dim] / x1.shape[dim])
+        if x2.shape[dim] > 0 and bs[dim] > x2.shape[dim]:
+            n2 = n2 * math.sqrt(bs[dim] / x2.shape[dim])
     return sum(
         paddle.multiply(x1 / clip(n1, min=eps), x2 / clip(n2, min=eps)),
         axis=dim,

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -2482,14 +2482,21 @@ def cosine_similarity(
     if x2.dtype not in float_dtypes:
         x2 = x2.astype(common_dtype)
 
-    # p_norm/divide/multiply CPU kernels are not registered for fp16/bf16,
-    # so the dtype are promoted to fp32.
+    # p_norm/divide/multiply CPU kernels are not registered for fp16/bf16.
+    # Use fp32 as the accumulation_dtype when the common dtype is fp16/bf16;
+    # otherwise preserve the precision of the common dtype (in particular,
+    # do not demote a float64 input in a mixed reduced/float64 operation).
     reduced_dtypes = (paddle.float16, paddle.bfloat16)
     # static graph: the device is unknown at construction time, assume CPU
     maybe_cpu = not in_dynamic_mode() or x1.place.is_cpu_place()
     if maybe_cpu and (x1.dtype in reduced_dtypes or x2.dtype in reduced_dtypes):
-        x1 = x1.astype(paddle.float32)
-        x2 = x2.astype(paddle.float32)
+        accumulation_dtype = (
+            paddle.float32 if common_dtype in reduced_dtypes else common_dtype
+        )
+        if x1.dtype in reduced_dtypes:
+            x1 = x1.astype(accumulation_dtype)
+        if x2.dtype in reduced_dtypes:
+            x2 = x2.astype(accumulation_dtype)
 
     # torch expand inputs to broadcast shape first then compute norm when need to broadcast.
     # torch.expand only sets the broadcast stride to 0 and keeps the original storage, so it

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -2501,10 +2501,20 @@ def cosine_similarity(
     dim = axis + rank if axis < 0 else axis
     n1 = paddle.linalg.vector_norm(x1, p=2, axis=dim, keepdim=True)
     n2 = paddle.linalg.vector_norm(x2, p=2, axis=dim, keepdim=True)
-    if x1.shape[dim] > 0 and bs[dim] > x1.shape[dim]:
-        n1 = n1 * math.sqrt(bs[dim] / x1.shape[dim])
-    if x2.shape[dim] > 0 and bs[dim] > x2.shape[dim]:
-        n2 = n2 * math.sqrt(bs[dim] / x2.shape[dim])
+    d1, d2 = x1.shape[dim], x2.shape[dim]
+    if d1 >= 0 and d2 >= 0:
+        if bs[dim] > d1:
+            n1 = n1 * math.sqrt(bs[dim] / d1)
+        if bs[dim] > d2:
+            n2 = n2 * math.sqrt(bs[dim] / d2)
+    else:
+        # For unknown(-1) reduced axis: compute the broadcast repeat factor from
+        # the run-time length, if len==1 -> taking the other side's len.
+        len1 = paddle.shape(x1)[dim].astype(paddle.float32)
+        len2 = paddle.shape(x2)[dim].astype(paddle.float32)
+        common = paddle.where(len1 == 1, len2, len1)
+        n1 = n1 * paddle.sqrt(common / clip(len1, min=1.0)).astype(n1.dtype)
+        n2 = n2 * paddle.sqrt(common / clip(len2, min=1.0)).astype(n2.dtype)
     reduced_dtypes = (paddle.float16, paddle.bfloat16)
     n1 = (
         clip(n1.astype(paddle.float32), min=eps).astype(n1.dtype)

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -2411,8 +2411,9 @@ def cosine_similarity(
 
     Parameters:
         x1 (Tensor): First input. float32/double. float16/bfloat16 are
-            supported on non-CPU devices (e.g. GPU, XPU); on CPU they are not
-            supported and an error is raised.
+            supported on non-CPU devices (e.g. GPU, XPU); on CPU they are
+            computed through a float32 accumulation path and the output keeps
+            the reduced input dtype.
         x2 (Tensor): Second input. Same data type requirement as ``x1``.
         axis (int, optional): Dimension of vectors to compute cosine similarity. Default is 1.
             Alias: ``dim``.
@@ -2481,17 +2482,14 @@ def cosine_similarity(
     if x2.dtype not in float_dtypes:
         x2 = x2.astype(common_dtype)
 
-    # p_norm/divide/multiply CPU kernels are not registered for fp16/bf16.
-    # Non-CPU devices (e.g. GPU/XPU) have these kernels so keep running.
+    # p_norm/divide/multiply CPU kernels are not registered for fp16/bf16,
+    # so the dtype are promoted to fp32.
     reduced_dtypes = (paddle.float16, paddle.bfloat16)
-    if x1.place.is_cpu_place() and (
-        x1.dtype in reduced_dtypes or x2.dtype in reduced_dtypes
-    ):
-        raise NotImplementedError(
-            "cosine_similarity does not support float16/bfloat16 on CPU, "
-            f"got x1.dtype={x1.dtype}, x2.dtype={x2.dtype}. Cast the inputs to "
-            "float32/float64 first."
-        )
+    # static graph: the device is unknown at construction time, assume CPU
+    maybe_cpu = not in_dynamic_mode() or x1.place.is_cpu_place()
+    if maybe_cpu and (x1.dtype in reduced_dtypes or x2.dtype in reduced_dtypes):
+        x1 = x1.astype(paddle.float32)
+        x2 = x2.astype(paddle.float32)
 
     # torch expand inputs to broadcast shape first then compute norm when need to broadcast.
     # torch.expand only sets the broadcast stride to 0 and keeps the original storage, so it
@@ -2539,10 +2537,15 @@ def cosine_similarity(
         if n2.dtype in reduced_dtypes
         else clip(n2, min=eps)
     )
-    return sum(
+    out = sum(
         paddle.multiply(x1 / n1, x2 / n2),
         axis=dim,
     )
+    # when the reduced inputs were promoted to fp32 on CPU, cast the result
+    # back to the common dtype to preserve the output dtype contract
+    if maybe_cpu and out.dtype != common_dtype:
+        return out.astype(common_dtype)
+    return out
 
 
 def linear(

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -41,8 +41,9 @@ from ...base.data_feeder import (
     check_dtype,
     check_type,
     check_variable_and_dtype,
+    promote_types,
 )
-from ...tensor import clip, concat, sqrt, sum
+from ...tensor import clip, concat, sum
 from ...tensor.creation import zeros
 
 # TODO: define the common functions to build a neural network
@@ -2450,44 +2451,77 @@ def cosine_similarity(
             [ 0.97689527,  0.99996042, -0.55138415])
 
     """
-    if x1.shape[axis] == 0 or x2.shape[axis] == 0:
-        return sum(paddle.multiply(x1, x2), axis=axis)
-    if paddle.get_flags("FLAGS_use_accuracy_compatible_kernel")[
-        "FLAGS_use_accuracy_compatible_kernel"
-    ]:
-        # Note: aligning with torch 2.12
-        bs = paddle.broadcast_shape([x1.shape[axis]], [x2.shape[axis]])
-        x1_full, x2_full = x1, x2
-        if x1.shape[axis] != bs[0]:
-            shape = [-1] * len(x1.shape)
-            shape[axis] = bs[0]
-            x1_full = paddle.broadcast_to(x1, shape)
-        if x2.shape[axis] != bs[0]:
-            shape = [-1] * len(x2.shape)
-            shape[axis] = bs[0]
-            x2_full = paddle.broadcast_to(x2, shape)
-        n1 = clip(
-            paddle.linalg.vector_norm(x1_full, p=2, axis=axis, keepdim=True),
-            min=eps,
+    # Note: aligning with torch 2.12, including:
+    # 1. Casting integral input dtypes to floating dtype and reject non-floating
+    # common dtype since vector_norm has no integer kernel.
+    # The inputs are promoted first and a non-floating common dtype is rejected;
+    # only the integral inputs are cast,
+    # because vector_norm has no integer kernel while a pair of floating inputs
+    # is promoted by the elementwise ops themselves.
+    float_dtypes = (
+        paddle.float16,
+        paddle.bfloat16,
+        paddle.float32,
+        paddle.float64,
+    )
+    common_dtype = promote_types(x1.dtype, x2.dtype)
+    if common_dtype not in float_dtypes:
+        raise TypeError(
+            "cosine_similarity expected common dtype to be floating point, "
+            f"yet common dtype is {common_dtype}"
         )
-        n2 = clip(
-            paddle.linalg.vector_norm(x2_full, p=2, axis=axis, keepdim=True),
-            min=eps,
-        )
-        return sum(paddle.multiply(x1 / n1, x2 / n2), axis=axis)
-    else:
-        bs = paddle.broadcast_shape([x1.shape[axis]], [x2.shape[axis]])
-        w12 = sum(paddle.multiply(x1, x2), axis=axis)
-        w1 = sum(paddle.multiply(x1, x1), axis=axis)
-        w2 = sum(paddle.multiply(x2, x2), axis=axis)
-        m1, m2 = bs[0] / x1.shape[axis], bs[0] / x2.shape[axis]
-        if m1 != 1:
-            w1 = w1 * m1
-        if m2 != 1:
-            w2 = w2 * m2
-        n12 = sqrt(clip(w1 * w2, min=eps * eps))
-        cos_sim = w12 / n12
-        return cos_sim
+    if eps < 0:
+        raise ValueError(f"eps must be non-negative, got: {eps}")
+    if x1.dtype not in float_dtypes:
+        x1 = x1.astype(common_dtype)
+    if x2.dtype not in float_dtypes:
+        x2 = x2.astype(common_dtype)
+
+    # Each input is divided by its own norm before the dot product, so the
+    # denominator is max(|x1|, eps) * max(|x2|, eps) instead of
+    # max(|x1| * |x2|, eps): clamping the product attenuates the result for
+    # small but perfectly valid vectors, and computing |x1| * |x2| overflows
+    # long before either norm alone does. vector_norm matches torch's
+    # linalg_vector_norm bitwise, including the float32 accumulation used for
+    # float16/bfloat16 inputs.
+    #
+    # torch broadcasts both inputs up front, so ``axis`` indexes the common shape and the
+    # reduction runs over the broadcast length of that axis, not the original one.
+    # expand_outplace() in torch.cosine_similarity both infers the broadcast shape and
+    # expands the tensors to it, so paddle.broadcast_shape(x1.shape, x2.shape), which only
+    # counts the shape, is not enough.
+    # torch.expand only sets the broadcast stride to 0 and keeps the original storage, so it
+    # is 0-copy, and TensorIterator reduces directly over that stride-0 input:
+    # linalg_vector_norm allocates nothing and re-reads the same O(BD) bytes out of cache.
+    # paddle.broadcast_to is a real kernel instead. For example, x1=[B,1,D] and x2=[B,N,D] it
+    # allocates O(BND) space and writes every element, so vector_norm then reads O(BND) from
+    # global memory instead of the O(BD) the data actually occupies. When N is super large,
+    # it will cause huge memory usage and maybe OOM.
+    # Instead of using paddle.broadcast_to, we implement with `unsqueeze` and `||repeat(x,m)||`.
+    # 1. unsqueeze x1 and x2 to the same rank as the broadcast shape. When x1.dims != x2.dims
+    # and input axis is larger than smaller dims, unsqueeze op ensures vector_norm is reduced
+    # at the correct dim.
+    # 2. ||repeat(x,m)|| = sqrt(m) * |x|.
+    # This replacement could save memory at vector_norm when x1.dims[axis] != x2.dims[axis]
+    #  and broadcast happens at axis dim.
+    rank = max(len(x1.shape), len(x2.shape))
+    if len(x1.shape) < rank:
+        x1 = unsqueeze(x1, axis=list(range(rank - len(x1.shape))))
+    if len(x2.shape) < rank:
+        x2 = unsqueeze(x2, axis=list(range(rank - len(x2.shape))))
+    bs = paddle.broadcast_shape(x1.shape, x2.shape)
+    dim = axis + rank if axis < 0 else axis
+    n1 = paddle.linalg.vector_norm(x1, p=2, axis=dim, keepdim=True)
+    n2 = paddle.linalg.vector_norm(x2, p=2, axis=dim, keepdim=True)
+    # A dynamic (-1) length fails both checks and is left uncorrected.
+    if x1.shape[dim] > 0 and bs[dim] > x1.shape[dim]:
+        n1 = n1 * math.sqrt(bs[dim] / x1.shape[dim])
+    if x2.shape[dim] > 0 and bs[dim] > x2.shape[dim]:
+        n2 = n2 * math.sqrt(bs[dim] / x2.shape[dim])
+    return sum(
+        paddle.multiply(x1 / clip(n1, min=eps), x2 / clip(n2, min=eps)),
+        axis=dim,
+    )
 
 
 def linear(

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -2410,8 +2410,10 @@ def cosine_similarity(
     Compute cosine similarity between x1 and x2 along axis.
 
     Parameters:
-        x1 (Tensor): First input. float32/double.
-        x2 (Tensor): Second input. float32/double.
+        x1 (Tensor): First input. float32/double. float16/bfloat16 are
+            supported on non-CPU devices (e.g. GPU, XPU); on CPU they are not
+            supported and an error is raised.
+        x2 (Tensor): Second input. Same data type requirement as ``x1``.
         axis (int, optional): Dimension of vectors to compute cosine similarity. Default is 1.
             Alias: ``dim``.
         eps(float, optional): Small value to avoid division by zero. Default is 1e-8.
@@ -2479,6 +2481,18 @@ def cosine_similarity(
     if x2.dtype not in float_dtypes:
         x2 = x2.astype(common_dtype)
 
+    # p_norm/divide/multiply CPU kernels are not registered for fp16/bf16.
+    # Non-CPU devices (e.g. GPU/XPU) have these kernels so keep running.
+    reduced_dtypes = (paddle.float16, paddle.bfloat16)
+    if x1.place.is_cpu_place() and (
+        x1.dtype in reduced_dtypes or x2.dtype in reduced_dtypes
+    ):
+        raise NotImplementedError(
+            "cosine_similarity does not support float16/bfloat16 on CPU, "
+            f"got x1.dtype={x1.dtype}, x2.dtype={x2.dtype}. Cast the inputs to "
+            "float32/float64 first."
+        )
+
     # torch expand inputs to broadcast shape first then compute norm when need to broadcast.
     # torch.expand only sets the broadcast stride to 0 and keeps the original storage, so it
     # is 0-copy, and TensorIterator runs linalg_vector_norm directly over that stride-0 input,
@@ -2515,7 +2529,6 @@ def cosine_similarity(
         common = paddle.where(len1 == 1, len2, len1)
         n1 = n1 * paddle.sqrt(common / clip(len1, min=1.0)).astype(n1.dtype)
         n2 = n2 * paddle.sqrt(common / clip(len2, min=1.0)).astype(n2.dtype)
-    reduced_dtypes = (paddle.float16, paddle.bfloat16)
     n1 = (
         clip(n1.astype(paddle.float32), min=eps).astype(n1.dtype)
         if n1.dtype in reduced_dtypes

--- a/test/legacy_test/test_cosine_similarity_api.py
+++ b/test/legacy_test/test_cosine_similarity_api.py
@@ -23,23 +23,22 @@ from paddle import nn, static
 from paddle.base import Executor
 
 
+def _np_cosine_similarity(x1, x2, axis=1, eps=1e-8):
+    """Reference following torch2.12.0: broadcast both inputs first, then divide
+    each of them by its own norm along ``axis`` clamped to ``eps``.
+    """
+    x1, x2 = np.broadcast_arrays(x1, x2)
+    n1 = np.maximum(np.sqrt(np.sum(x1 * x1, axis=axis, keepdims=True)), eps)
+    n2 = np.maximum(np.sqrt(np.sum(x2 * x2, axis=axis, keepdims=True)), eps)
+    return np.sum((x1 / n1) * (x2 / n2), axis=axis)
+
+
 class TestCosineSimilarityAPI(unittest.TestCase):
     def setUp(self):
         self.places = get_places()
 
     def _get_numpy_out(self, x1, x2, axis=1, eps=1e-8):
-        bs = np.broadcast_shapes([x1.shape[axis]], [x2.shape[axis]])
-        w12 = np.sum(x1 * x2, axis=axis)
-        w1 = np.sum(x1 * x1, axis=axis)
-        w2 = np.sum(x2 * x2, axis=axis)
-        m1, m2 = bs[0] / x1.shape[axis], bs[0] / x2.shape[axis]
-        if m1 != 1:
-            w1 = w1 * m1
-        if m2 != 1:
-            w2 = w2 * m2
-        n12 = np.sqrt(np.clip(w1 * w2, eps * eps, None))
-        cos_sim = w12 / n12
-        return cos_sim
+        return _np_cosine_similarity(x1, x2, axis=axis, eps=eps)
 
     def check_static_result(self, place):
         paddle.enable_static()
@@ -177,18 +176,7 @@ class TestCosineSimilarityAPI_ZeroSize(unittest.TestCase):
         self.places = get_places()
 
     def _get_numpy_out(self, x1, x2, axis=1, eps=1e-8):
-        bs = np.broadcast_shapes([x1.shape[axis]], [x2.shape[axis]])
-        w12 = np.sum(x1 * x2, axis=axis)
-        w1 = np.sum(x1 * x1, axis=axis)
-        w2 = np.sum(x2 * x2, axis=axis)
-        m1, m2 = bs[0] / x1.shape[axis], bs[0] / x2.shape[axis]
-        if m1 != 1:
-            w1 = w1 * m1
-        if m2 != 1:
-            w2 = w2 * m2
-        n12 = np.sqrt(np.clip(w1 * w2, eps * eps, None))
-        cos_sim = w12 / n12
-        return cos_sim
+        return _np_cosine_similarity(x1, x2, axis=axis, eps=eps)
 
     def test_dygraph_1(self):
         paddle.disable_static()
@@ -209,6 +197,225 @@ class TestCosineSimilarityAPI_ZeroSize(unittest.TestCase):
         np.testing.assert_allclose(y.numpy(), np_out, rtol=1e-05)
         y.sum().backward()
         np.testing.assert_allclose(tensor_x1.grad.shape, tensor_x1.shape)
+
+
+class TestCosineSimilarityAPI_RankMismatch(unittest.TestCase):
+    """x1 and x2 may have different ranks: they are broadcast first, so
+    ``axis`` indexes the common shape rather than each input's own shape.
+    """
+
+    def test_dygraph(self):
+        paddle.disable_static()
+        np.random.seed(1)
+        for shape1, shape2, axis in [
+            ([2, 3], [1, 2, 3], 1),
+            ([2, 3], [1, 2, 3], 2),
+            ([2, 3], [1, 2, 3], -1),
+            ([2, 3], [1, 2, 3], -2),
+            ([4, 5], [3, 4, 5], 0),
+            ([5], [3, 4, 5], 2),
+            ([1, 7], [2, 3, 7], 1),
+            ([3, 4, 5], [4, 5], 1),
+        ]:
+            np_x1 = np.random.rand(*shape1).astype(np.float32)
+            np_x2 = np.random.rand(*shape2).astype(np.float32)
+            np_out = _np_cosine_similarity(np_x1, np_x2, axis=axis)
+
+            y = F.cosine_similarity(
+                paddle.to_tensor(np_x1), paddle.to_tensor(np_x2), axis=axis
+            )
+            msg = f"x1={shape1} x2={shape2} axis={axis}"
+            self.assertEqual(list(y.shape), list(np_out.shape), msg)
+            np.testing.assert_allclose(
+                y.numpy(), np_out, rtol=1e-05, err_msg=msg
+            )
+
+    def test_static(self):
+        paddle.enable_static()
+        np.random.seed(1)
+        try:
+            for shape1, shape2, axis in [
+                ([2, 3], [1, 2, 3], 1),
+                ([4, 5], [3, 4, 5], 0),
+                ([5], [3, 4, 5], 2),
+                ([3, 4, 5], [4, 5], -1),
+            ]:
+                np_x1 = np.random.rand(*shape1).astype(np.float32)
+                np_x2 = np.random.rand(*shape2).astype(np.float32)
+                np_out = _np_cosine_similarity(np_x1, np_x2, axis=axis)
+                msg = f"x1={shape1} x2={shape2} axis={axis}"
+
+                main_program = static.Program()
+                startup_program = static.Program()
+                with static.program_guard(main_program, startup_program):
+                    x1 = static.data(name="x1", shape=shape1)
+                    x2 = static.data(name="x2", shape=shape2)
+                    result = F.cosine_similarity(x1, x2, axis=axis)
+                    for place in get_places():
+                        fetches = Executor(place).run(
+                            main_program,
+                            feed={"x1": np_x1, "x2": np_x2},
+                            fetch_list=[result],
+                        )
+                        np.testing.assert_allclose(
+                            fetches[0], np_out, rtol=1e-05, err_msg=msg
+                        )
+        finally:
+            paddle.disable_static()
+
+
+class TestCosineSimilarityAPI_LargeBroadcast(unittest.TestCase):
+    """Large inputs that broadcast along ``axis``: the reduction length is the
+    broadcast one, which is what the ||repeat(x, m)|| == sqrt(m) * ||x||
+    correction has to reproduce.
+    """
+
+    def test_dygraph(self):
+        paddle.disable_static()
+        np.random.seed(1)
+        b, n, d = 4, 512, 256
+        for shape1, shape2, axis in [
+            # broadcast on the reduced axis, so both norms need the correction
+            ([b, 1, d], [b, n, d], 1),
+            # broadcast on the reduced axis with mismatched ranks
+            ([1, d], [b, n, d], 1),
+            # broadcast off the reduced axis, no correction
+            ([b, 1, d], [b, n, d], 2),
+            ([d], [b, n, d], 2),
+        ]:
+            np_x1 = np.random.rand(*shape1).astype(np.float32)
+            np_x2 = np.random.rand(*shape2).astype(np.float32)
+            np_out = _np_cosine_similarity(np_x1, np_x2, axis=axis)
+
+            y = F.cosine_similarity(
+                paddle.to_tensor(np_x1), paddle.to_tensor(np_x2), axis=axis
+            )
+            msg = f"x1={shape1} x2={shape2} axis={axis}"
+            self.assertEqual(list(y.shape), list(np_out.shape), msg)
+            np.testing.assert_allclose(
+                y.numpy(), np_out, rtol=1e-05, err_msg=msg
+            )
+
+
+class TestCosineSimilarityAPI_Numerics(unittest.TestCase):
+    def test_small_but_valid_vectors(self):
+        # |x1| * |x2| is below eps while both norms are far above it, so
+        # clamping the product instead of each norm would attenuate the
+        # result to about zero
+        paddle.disable_static()
+        np_x1 = np.array([[1e-6, 0.0, 0.0]], dtype=np.float32)
+        np_x2 = np.array([[2e-6, 0.0, 0.0]], dtype=np.float32)
+        y = F.cosine_similarity(
+            paddle.to_tensor(np_x1), paddle.to_tensor(np_x2), axis=1
+        )
+        np.testing.assert_allclose(
+            y.numpy(), np.ones([1], dtype=np.float32), rtol=1e-06
+        )
+
+    def test_large_vectors_do_not_overflow(self):
+        # |x1|^2 * |x2|^2 overflows float32 here while each norm stays finite
+        paddle.disable_static()
+        np_x1 = np.full([1, 4], 1e10, dtype=np.float32)
+        np_x2 = np.full([1, 4], -1e10, dtype=np.float32)
+        y = F.cosine_similarity(
+            paddle.to_tensor(np_x1), paddle.to_tensor(np_x2), axis=1
+        )
+        np.testing.assert_allclose(
+            y.numpy(), -np.ones([1], dtype=np.float32), rtol=1e-06
+        )
+
+    def test_zero_vector(self):
+        paddle.disable_static()
+        np_x1 = np.zeros([2, 4], dtype=np.float32)
+        np_x2 = np.random.rand(2, 4).astype(np.float32)
+        x1 = paddle.to_tensor(np_x1)
+        x1.stop_gradient = False
+        y = F.cosine_similarity(x1, paddle.to_tensor(np_x2), axis=1)
+        np.testing.assert_allclose(
+            y.numpy(), np.zeros([2], dtype=np.float32), rtol=1e-06
+        )
+        y.sum().backward()
+        self.assertFalse(np.isnan(x1.grad.numpy()).any())
+
+
+class TestCosineSimilarityAPI_BroadcastMemory(unittest.TestCase):
+    """Taking the norm of a broadcast input must not materialize the expanded
+    copy: for x1=[B, 1, D] against x2=[B, N, D] that would be an extra
+    O(B * N * D) allocation. FLAGS_use_accuracy_compatible_kernel opts into that
+    allocation on purpose, so this only holds for the default path.
+    """
+
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda(), "peak memory is queried from CUDA"
+    )
+    @unittest.skipIf(
+        paddle.get_flags(["FLAGS_use_accuracy_compatible_kernel"]).get(
+            "FLAGS_use_accuracy_compatible_kernel", False
+        ),
+        "the accuracy compatible path expands the inputs on purpose",
+    )
+    def test_no_expanded_copy(self):
+        paddle.disable_static()
+        origin_device = paddle.get_device()
+        paddle.set_device('gpu')
+        try:
+            B, N, D = 32, 256, 1024
+            x1 = paddle.randn([B, 1, D])
+            x2 = paddle.randn([B, N, D])
+            full_size = B * N * D * 4
+
+            paddle.device.cuda.empty_cache()
+            paddle.device.cuda.reset_max_memory_allocated()
+            base = paddle.device.cuda.max_memory_allocated()
+            F.cosine_similarity(x1, x2, axis=1).numpy()
+            extra = paddle.device.cuda.max_memory_allocated() - base
+
+            # x2 / n2 and their product are the only full size temporaries
+            self.assertLess(
+                extra,
+                2.5 * full_size,
+                f"{extra} bytes of temporaries for a {full_size} byte input, "
+                "the broadcast input is likely being expanded",
+            )
+        finally:
+            paddle.set_device(origin_device)
+
+
+class TestCosineSimilarityAPI_DtypePromotion(unittest.TestCase):
+    def test_integral_input_is_promoted(self):
+        paddle.disable_static()
+        np_x1 = np.array([[1, 2, 3]], dtype=np.int32)
+        np_x2 = np.array([[3.0, 2.0, 1.0]], dtype=np.float32)
+        y = F.cosine_similarity(
+            paddle.to_tensor(np_x1), paddle.to_tensor(np_x2), axis=1
+        )
+        self.assertEqual(y.dtype, paddle.float32)
+        np_out = _np_cosine_similarity(np_x1.astype(np.float32), np_x2)
+        np.testing.assert_allclose(y.numpy(), np_out, rtol=1e-06)
+
+    def test_mixed_float_dtypes(self):
+        paddle.disable_static()
+        np_x1 = np.random.rand(2, 5).astype(np.float32)
+        np_x2 = np.random.rand(2, 5).astype(np.float64)
+        y = F.cosine_similarity(
+            paddle.to_tensor(np_x1), paddle.to_tensor(np_x2), axis=1
+        )
+        self.assertEqual(y.dtype, paddle.float64)
+        np_out = _np_cosine_similarity(np_x1.astype(np.float64), np_x2)
+        np.testing.assert_allclose(y.numpy(), np_out, rtol=1e-06)
+
+    def test_non_floating_common_dtype(self):
+        paddle.disable_static()
+        for dtype in ('int32', 'int64', 'bool', 'complex64'):
+            x = paddle.ones([1, 3], dtype=dtype)
+            with self.assertRaises(TypeError):
+                F.cosine_similarity(x, x, axis=1)
+
+    def test_negative_eps(self):
+        paddle.disable_static()
+        x = paddle.ones([1, 3])
+        with self.assertRaises(ValueError):
+            F.cosine_similarity(x, x, axis=1, eps=-1e-8)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_cosine_similarity_api.py
+++ b/test/legacy_test/test_cosine_similarity_api.py
@@ -385,15 +385,6 @@ class TestCosineSimilarityAPI_DtypePromotion(unittest.TestCase):
         # CPU has no p_norm/divide/multiply kernels for fp16/bf16, so the
         # inputs are promoted to fp32 for the computation and the result is
         # cast back to the reduced dtype, keeping the output dtype contract.
-        def f32_to_bf16_bits(x):
-            """Round a float32 array to bfloat16, returning its uint16 bit
-            pattern (numpy has no bfloat16 dtype, so bit-exact checks use it).
-            """
-            bits = x.astype(np.float32).view(np.uint32)
-            # round-to-nearest-even on the low 16 bits
-            rounding_bias = 0x7FFF + ((bits >> 16) & 1)
-            return ((bits + rounding_bias) >> 16).astype(np.uint16)
-
         paddle.disable_static()
         origin_device = paddle.get_device()
         paddle.set_device('cpu')
@@ -408,19 +399,52 @@ class TestCosineSimilarityAPI_DtypePromotion(unittest.TestCase):
                 x2 = paddle.to_tensor(np_x2, dtype=dtype)
                 y = F.cosine_similarity(x1, x2, axis=1)
                 self.assertEqual(y.dtype, pd_dtype)
-                qx1 = x1.astype('float32').numpy()
-                qx2 = x2.astype('float32').numpy()
-                np_out = _np_cosine_similarity(qx1, qx2, axis=1)
-                if dtype == 'float16':
-                    np.testing.assert_array_equal(
-                        y.numpy(), np_out.astype(np.float16)
-                    )
-                else:
-                    # numpy has no bfloat16: compare uint16 bit patterns
-                    np.testing.assert_array_equal(
-                        y.view(paddle.uint16).numpy(),
-                        f32_to_bf16_bits(np_out),
-                    )
+                expected = F.cosine_similarity(
+                    x1.astype('float32'),
+                    x2.astype('float32'),
+                    axis=1,
+                ).astype(pd_dtype)
+                np.testing.assert_array_equal(
+                    y.astype('float32').numpy(),
+                    expected.astype('float32').numpy(),
+                )
+        finally:
+            paddle.set_device(origin_device)
+
+    def test_cpu_mixed_reduced_and_float64_dtypes(self):
+        paddle.disable_static()
+        origin_device = paddle.get_device()
+        paddle.set_device('cpu')
+        np_x1 = np.array(
+            [[0.1234, -0.9876, 1.2345]],
+            dtype=np.float16,
+        )
+        np_x2 = np.array(
+            [
+                [
+                    3.141592653589793,
+                    1.4142135623730951,
+                    0.5772156649015329,
+                ]
+            ],
+            dtype=np.float64,
+        )
+        try:
+            x1 = paddle.to_tensor(np_x1, dtype='float16')
+            x2 = paddle.to_tensor(np_x2, dtype='float64')
+
+            y = F.cosine_similarity(x1, x2, axis=1)
+            expected = F.cosine_similarity(
+                x1.astype('float64'),
+                x2,
+                axis=1,
+            )
+
+            self.assertEqual(y.dtype, paddle.float64)
+            np.testing.assert_array_equal(
+                y.numpy(),
+                expected.numpy(),
+            )
         finally:
             paddle.set_device(origin_device)
 
@@ -436,6 +460,36 @@ class TestCosineSimilarityAPI_DtypePromotion(unittest.TestCase):
         x = paddle.ones([1, 3])
         with self.assertRaises(ValueError):
             F.cosine_similarity(x, x, axis=1, eps=-1e-8)
+
+
+class TestCosineSimilarityAPI_BroadcastMemory(unittest.TestCase):
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda(), "peak memory is queried from CUDA"
+    )
+    def test_no_expanded_copy(self):
+        paddle.disable_static()
+        origin_device = paddle.get_device()
+        paddle.set_device('gpu')
+        try:
+            B, N, D = 32, 256, 1024
+            x1 = paddle.randn([B, 1, D])
+            x2 = paddle.randn([B, N, D])
+            full_size = B * N * D * 4
+
+            paddle.device.cuda.empty_cache()
+            paddle.device.cuda.reset_max_memory_allocated()
+            base = paddle.device.cuda.max_memory_allocated()
+            F.cosine_similarity(x1, x2, axis=1).numpy()
+            extra = paddle.device.cuda.max_memory_allocated() - base
+            # x2 / n2 and their product are the only full size temporaries
+            self.assertLess(
+                extra,
+                2.5 * full_size,
+                f"{extra} bytes of temporaries for a {full_size} byte input, "
+                "the broadcast input is likely being expanded",
+            )
+        finally:
+            paddle.set_device(origin_device)
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_cosine_similarity_api.py
+++ b/test/legacy_test/test_cosine_similarity_api.py
@@ -260,7 +260,7 @@ class TestCosineSimilarityAPI_UnknownReduceDim(unittest.TestCase):
                     list(fetches[0].shape), list(np_out.shape), msg
                 )
                 np.testing.assert_allclose(
-                    fetches[0], np_out, rtol=1e-07, err_msg=msg
+                    fetches[0], np_out, rtol=1e-06, atol=1e-07, err_msg=msg
                 )
 
     def test_static(self):
@@ -344,33 +344,18 @@ class TestCosineSimilarityAPI_Numerics(unittest.TestCase):
             y.numpy(), -np.ones([1], dtype=np.float32), rtol=1e-06
         )
 
-    def test_cpu_reduced_dtype_fp32_path(self):
-        # CPU has no p_norm/divide/multiply kernels for fp16/bf16, so the
-        # inputs are promoted to fp32 for the computation and the result is
-        # cast back to the reduced dtype, keeping the output dtype contract.
+    def test_zero_vector(self):
         paddle.disable_static()
-        origin_device = paddle.get_device()
-        paddle.set_device('cpu')
-        np_x1 = np.random.rand(2, 4).astype(np.float32)
+        np_x1 = np.zeros([2, 4], dtype=np.float32)
         np_x2 = np.random.rand(2, 4).astype(np.float32)
-        np_out = _np_cosine_similarity(np_x1, np_x2, axis=1)
-        try:
-            for dtype, pd_dtype in [
-                ('float16', paddle.float16),
-                ('bfloat16', paddle.bfloat16),
-            ]:
-                x1 = paddle.to_tensor(np_x1, dtype=dtype)
-                x2 = paddle.to_tensor(np_x2, dtype=dtype)
-                y = F.cosine_similarity(x1, x2, axis=1)
-                self.assertEqual(y.dtype, pd_dtype)
-                np.testing.assert_allclose(
-                    y.astype('float32').numpy(),
-                    np_out,
-                    rtol=1e-06,
-                    err_msg=f"dtype={dtype}",
-                )
-        finally:
-            paddle.set_device(origin_device)
+        x1 = paddle.to_tensor(np_x1)
+        x1.stop_gradient = False
+        y = F.cosine_similarity(x1, paddle.to_tensor(np_x2), axis=1)
+        np.testing.assert_allclose(
+            y.numpy(), np.zeros([2], dtype=np.float32), rtol=1e-06
+        )
+        y.sum().backward()
+        self.assertFalse(np.isnan(x1.grad.numpy()).any())
 
 
 class TestCosineSimilarityAPI_DtypePromotion(unittest.TestCase):
@@ -395,6 +380,49 @@ class TestCosineSimilarityAPI_DtypePromotion(unittest.TestCase):
         self.assertEqual(y.dtype, paddle.float64)
         np_out = _np_cosine_similarity(np_x1.astype(np.float64), np_x2)
         np.testing.assert_allclose(y.numpy(), np_out, rtol=1e-06)
+
+    def test_cpu_reduced_dtype_fp32_path(self):
+        # CPU has no p_norm/divide/multiply kernels for fp16/bf16, so the
+        # inputs are promoted to fp32 for the computation and the result is
+        # cast back to the reduced dtype, keeping the output dtype contract.
+        def f32_to_bf16_bits(x):
+            """Round a float32 array to bfloat16, returning its uint16 bit
+            pattern (numpy has no bfloat16 dtype, so bit-exact checks use it).
+            """
+            bits = x.astype(np.float32).view(np.uint32)
+            # round-to-nearest-even on the low 16 bits
+            rounding_bias = 0x7FFF + ((bits >> 16) & 1)
+            return ((bits + rounding_bias) >> 16).astype(np.uint16)
+
+        paddle.disable_static()
+        origin_device = paddle.get_device()
+        paddle.set_device('cpu')
+        np_x1 = np.random.rand(2, 4).astype(np.float32)
+        np_x2 = np.random.rand(2, 4).astype(np.float32)
+        try:
+            for dtype, pd_dtype in [
+                ('float16', paddle.float16),
+                ('bfloat16', paddle.bfloat16),
+            ]:
+                x1 = paddle.to_tensor(np_x1, dtype=dtype)
+                x2 = paddle.to_tensor(np_x2, dtype=dtype)
+                y = F.cosine_similarity(x1, x2, axis=1)
+                self.assertEqual(y.dtype, pd_dtype)
+                qx1 = x1.astype('float32').numpy()
+                qx2 = x2.astype('float32').numpy()
+                np_out = _np_cosine_similarity(qx1, qx2, axis=1)
+                if dtype == 'float16':
+                    np.testing.assert_array_equal(
+                        y.numpy(), np_out.astype(np.float16)
+                    )
+                else:
+                    # numpy has no bfloat16: compare uint16 bit patterns
+                    np.testing.assert_array_equal(
+                        y.view(paddle.uint16).numpy(),
+                        f32_to_bf16_bits(np_out),
+                    )
+        finally:
+            paddle.set_device(origin_device)
 
     def test_non_floating_common_dtype(self):
         paddle.disable_static()

--- a/test/legacy_test/test_cosine_similarity_api.py
+++ b/test/legacy_test/test_cosine_similarity_api.py
@@ -230,36 +230,56 @@ class TestCosineSimilarityAPI_RankMismatch(unittest.TestCase):
                 y.numpy(), np_out, rtol=1e-05, err_msg=msg
             )
 
+
+class TestCosineSimilarityAPI_UnknownReduceDim(unittest.TestCase):
+    """A static graph may only know the reduced axis at run time, so the
+    ||repeat(x, m)|| == sqrt(m) * ||x|| factor cannot be folded into a python
+    scalar there: with shape=[2, -1] fed a [2, 1] input broadcast against
+    [2, 5], skipping the factor would report a similarity above 1.
+    """
+
+    def _check(self, shape1, shape2, feed1, feed2, axis):
+        np_x1 = np.random.rand(*feed1).astype(np.float32)
+        np_x2 = np.random.rand(*feed2).astype(np.float32)
+        np_out = _np_cosine_similarity(np_x1, np_x2, axis=axis)
+        msg = f"x1={shape1}{feed1} x2={shape2}{feed2} axis={axis}"
+
+        main_program = static.Program()
+        startup_program = static.Program()
+        with static.program_guard(main_program, startup_program):
+            x1 = static.data(name="x1", shape=shape1, dtype='float32')
+            x2 = static.data(name="x2", shape=shape2, dtype='float32')
+            result = F.cosine_similarity(x1, x2, axis=axis)
+            for place in get_places():
+                fetches = Executor(place).run(
+                    main_program,
+                    feed={"x1": np_x1, "x2": np_x2},
+                    fetch_list=[result],
+                )
+                self.assertEqual(
+                    list(fetches[0].shape), list(np_out.shape), msg
+                )
+                np.testing.assert_allclose(
+                    fetches[0], np_out, rtol=1e-07, err_msg=msg
+                )
+
     def test_static(self):
         paddle.enable_static()
         np.random.seed(1)
         try:
-            for shape1, shape2, axis in [
-                ([2, 3], [1, 2, 3], 1),
-                ([4, 5], [3, 4, 5], 0),
-                ([5], [3, 4, 5], 2),
-                ([3, 4, 5], [4, 5], -1),
+            for shape1, shape2, feed1, feed2, axis in [
+                # the unknown axis is broadcast at run time
+                ([2, -1], [2, 5], (2, 1), (2, 5), 1),
+                # the unknown axis turns out not to be broadcast
+                ([2, -1], [2, 5], (2, 5), (2, 5), 1),
+                # x2 is the short side, so the factor applies to its norm
+                ([2, 5], [2, -1], (2, 5), (2, 1), 1),
+                ([-1, -1], [3, 4], (3, 1), (3, 4), 1),
+                ([2, -1, 4], [2, 6, 4], (2, 1, 4), (2, 6, 4), 1),
+                # a 0-size reduction must not divide by zero
+                ([2, -1], [2, 0], (2, 0), (2, 0), 1),
             ]:
-                np_x1 = np.random.rand(*shape1).astype(np.float32)
-                np_x2 = np.random.rand(*shape2).astype(np.float32)
-                np_out = _np_cosine_similarity(np_x1, np_x2, axis=axis)
-                msg = f"x1={shape1} x2={shape2} axis={axis}"
-
-                main_program = static.Program()
-                startup_program = static.Program()
-                with static.program_guard(main_program, startup_program):
-                    x1 = static.data(name="x1", shape=shape1)
-                    x2 = static.data(name="x2", shape=shape2)
-                    result = F.cosine_similarity(x1, x2, axis=axis)
-                    for place in get_places():
-                        fetches = Executor(place).run(
-                            main_program,
-                            feed={"x1": np_x1, "x2": np_x2},
-                            fetch_list=[result],
-                        )
-                        np.testing.assert_allclose(
-                            fetches[0], np_out, rtol=1e-05, err_msg=msg
-                        )
+                self._check(shape1, shape2, feed1, feed2, axis)
         finally:
             paddle.disable_static()
 
@@ -324,59 +344,31 @@ class TestCosineSimilarityAPI_Numerics(unittest.TestCase):
             y.numpy(), -np.ones([1], dtype=np.float32), rtol=1e-06
         )
 
-    def test_zero_vector(self):
-        paddle.disable_static()
-        np_x1 = np.zeros([2, 4], dtype=np.float32)
-        np_x2 = np.random.rand(2, 4).astype(np.float32)
-        x1 = paddle.to_tensor(np_x1)
-        x1.stop_gradient = False
-        y = F.cosine_similarity(x1, paddle.to_tensor(np_x2), axis=1)
-        np.testing.assert_allclose(
-            y.numpy(), np.zeros([2], dtype=np.float32), rtol=1e-06
-        )
-        y.sum().backward()
-        self.assertFalse(np.isnan(x1.grad.numpy()).any())
-
-
-class TestCosineSimilarityAPI_BroadcastMemory(unittest.TestCase):
-    """Taking the norm of a broadcast input must not materialize the expanded
-    copy: for x1=[B, 1, D] against x2=[B, N, D] that would be an extra
-    O(B * N * D) allocation. FLAGS_use_accuracy_compatible_kernel opts into that
-    allocation on purpose, so this only holds for the default path.
-    """
-
-    @unittest.skipIf(
-        not paddle.is_compiled_with_cuda(), "peak memory is queried from CUDA"
-    )
-    @unittest.skipIf(
-        paddle.get_flags(["FLAGS_use_accuracy_compatible_kernel"]).get(
-            "FLAGS_use_accuracy_compatible_kernel", False
-        ),
-        "the accuracy compatible path expands the inputs on purpose",
-    )
-    def test_no_expanded_copy(self):
+    def test_cpu_reduced_dtype_fp32_path(self):
+        # CPU has no p_norm/divide/multiply kernels for fp16/bf16, so the
+        # inputs are promoted to fp32 for the computation and the result is
+        # cast back to the reduced dtype, keeping the output dtype contract.
         paddle.disable_static()
         origin_device = paddle.get_device()
-        paddle.set_device('gpu')
+        paddle.set_device('cpu')
+        np_x1 = np.random.rand(2, 4).astype(np.float32)
+        np_x2 = np.random.rand(2, 4).astype(np.float32)
+        np_out = _np_cosine_similarity(np_x1, np_x2, axis=1)
         try:
-            B, N, D = 32, 256, 1024
-            x1 = paddle.randn([B, 1, D])
-            x2 = paddle.randn([B, N, D])
-            full_size = B * N * D * 4
-
-            paddle.device.cuda.empty_cache()
-            paddle.device.cuda.reset_max_memory_allocated()
-            base = paddle.device.cuda.max_memory_allocated()
-            F.cosine_similarity(x1, x2, axis=1).numpy()
-            extra = paddle.device.cuda.max_memory_allocated() - base
-
-            # x2 / n2 and their product are the only full size temporaries
-            self.assertLess(
-                extra,
-                2.5 * full_size,
-                f"{extra} bytes of temporaries for a {full_size} byte input, "
-                "the broadcast input is likely being expanded",
-            )
+            for dtype, pd_dtype in [
+                ('float16', paddle.float16),
+                ('bfloat16', paddle.bfloat16),
+            ]:
+                x1 = paddle.to_tensor(np_x1, dtype=dtype)
+                x2 = paddle.to_tensor(np_x2, dtype=dtype)
+                y = F.cosine_similarity(x1, x2, axis=1)
+                self.assertEqual(y.dtype, pd_dtype)
+                np.testing.assert_allclose(
+                    y.astype('float32').numpy(),
+                    np_out,
+                    rtol=1e-06,
+                    err_msg=f"dtype={dtype}",
+                )
         finally:
             paddle.set_device(origin_device)
 

--- a/test/legacy_test/test_triplet_margin_with_distance_loss.py
+++ b/test/legacy_test/test_triplet_margin_with_distance_loss.py
@@ -355,10 +355,13 @@ class TestTripletMarginWithDistanceLossDFE(unittest.TestCase):
         func = distance_function
         shape = (5, 5)
         np.random.seed(1234)
-        input = np.random.uniform(0.1, 0.8, size=shape).astype(np.float64)
-        positive = np.random.uniform(0, 2, size=shape).astype(np.float64)
-        negative = np.random.uniform(0, 2, size=shape).astype(np.float64)
+        np_input = np.random.uniform(0.1, 0.8, size=shape).astype(np.float64)
+        np_positive = np.random.uniform(0, 2, size=shape).astype(np.float64)
+        np_negative = np.random.uniform(0, 2, size=shape).astype(np.float64)
 
+        input = paddle.to_tensor(np_input)
+        positive = paddle.to_tensor(np_positive)
+        negative = paddle.to_tensor(np_negative)
         self.assertRaises(
             ValueError,
             paddle.nn.functional.triplet_margin_with_distance_loss,


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
Operator Mechanism

### PR Types
Others


### Description
<!-- Describe what you’ve done -->
**Align `cosine_similarity` with torch 2.12.0.**
- The current implementation in `python/paddle/nn/functional/common.py` is $\frac{ x_{1} \times x_{2}}{\sqrt{x_{1}^{2} \times x_{2}^{2}}}$, having an issue where the fraction could be overflow.
- Change the Python implementation of the `cosine_similarity` composite op to $\frac{x_1}{||x_1||} \times \frac{x_2}{||x_2||}$.

Note: 
1. When inputs are both `bf16/fp16` in cpu device they will be **converted to high precision dtype(like `fp32/64`)** since **p_nrom/multiply/divide cpu kernel are not registered for `bf16/fp16`**.
2. For inputs those need to **broadcast**, we take alternative algorithm  `||repeat(x,m)|| = sqrt(m) * ||x||` to implement torch's behavior of `cosine_similarity` since **p_norm kernel does not support computing stride-0 view** directly like torch.  
There is a precision difference compared to `torch.vector_norm` handing the input after broadcasting, and paddle also need to  copy stride-0 view inputs to contiguous memory for computing norm.
**If want to completely align broadcasting input, you have to align `p_norm` kernel in handing stride-0 view.**
3. The purpose of `astype`
- Use `astype(common_dtype)` at the begining of `cosine_similarity` to align torch handling `int` dtype. 
- Use `astype(accumulation_dtype)` and`astype(common_dtype)` at the end of `cosine_similarity` to handle `fp16/bf16` at cpu device.
- Use `astype(paddle.float32)` in `clip()` to avoid precision loss when dtype is`fp16/bf16` (align with torch2.12)
4. Fix division-by-zero in `p_norm_grad` XPU kernel for zero-norm inputs, aligning with CPU

### 是否引起精度变化
是
