### PR TITLE
[Bug Fix] Align `Conv1D/2D/3D` default init with PyTorch (`Uniform(±1/√fan_in)`) to fix activation explosion in deep/weight-shared stacks

### DIFF
--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -334,7 +334,8 @@ class Conv1D(_ConvNd):
             of conv1d. If it is set to None or one attribute of ParamAttr, conv1d
             will create ParamAttr as param_attr. If the Initializer of the param_attr
             is not set, the parameter is initialized with :math:`Uniform(-bound, bound)`,
-            and the :math:`bound` is :math:`(\frac{1}{filter\_elem\_num})^{0.5}`. Default: None.
+            and the :math:`bound` is :math:`(\frac{1}{fan\_in})^{0.5}`, where :math:`fan\_in`
+            is :math:`(\frac{in\_channels}{groups}) \times \prod(kernel\_size)`. Default: None.
         bias_attr (ParamAttr or bool, optional): The attribute for the bias of conv1d.
             If it is set to False, no bias will be added to the output units.
             If it is set to None or one attribute of ParamAttr, conv1d
@@ -775,7 +776,8 @@ class Conv2D(_ConvNd):
             of conv2d. If it is set to None or one attribute of ParamAttr, conv2d
             will create ParamAttr as param_attr. If it is set to None, the parameter
             is initialized with :math:`Uniform(-bound, bound)`, and the :math:`bound` is
-            :math:`(\frac{1}{filter\_elem\_num})^{0.5}`. The default value is None.
+            :math:`(\frac{1}{fan\_in})^{0.5}`, where :math:`fan\_in` is
+            :math:`(\frac{in\_channels}{groups}) \times \prod(kernel\_size)`. The default value is None.
         bias_attr(ParamAttr|bool, optional): The parameter attribute for the bias of conv2d.
             If it is set to False, no bias will be added to the output units.
             If it is set to None or one attribute of ParamAttr, conv2d
@@ -1218,7 +1220,8 @@ class Conv3D(_ConvNd):
             of conv3d. If it is set to None or one attribute of ParamAttr, conv3d
             will create ParamAttr as param_attr. If it is set to None, the parameter
             is initialized with :math:`Uniform(-bound, bound)`, and the :math:`bound` is
-            :math:`(\frac{1}{filter\_elem\_num})^{0.5}`. The default value is None.
+            :math:`(\frac{1}{fan\_in})^{0.5}`, where :math:`fan\_in` is
+            :math:`(\frac{in\_channels}{groups}) \times \prod(kernel\_size)`. The default value is None.
         bias_attr(ParamAttr|bool, optional): The parameter attribute for the bias of conv3d.
             If it is set to False, no bias will be added to the output units.
             If it is set to None or one attribute of ParamAttr, conv3d

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -34,7 +34,7 @@ from ...device import (
 from ...utils import convert_to_list
 from .. import functional as F
 from ..functional.conv import _update_padding_nd
-from ..initializer import Normal
+from ..initializer import Uniform
 from .layers import Layer
 
 if TYPE_CHECKING:
@@ -59,12 +59,6 @@ if TYPE_CHECKING:
     from ..functional.common import _PaddingSizeMode, _PaddingTensorMode
 
 __all__ = []
-
-
-def _get_default_param_initializer(num_channels, filter_size):
-    filter_elem_num = num_channels * np.prod(filter_size)
-    std = (2.0 / filter_elem_num) ** 0.5
-    return Normal(0.0, std)
 
 
 def _reverse_repeat_list(t, n):
@@ -185,9 +179,17 @@ class _ConvNd(Layer):
         def _get_default_param_initializer():
             if transposed:
                 return None
-            filter_elem_num = np.prod(self._kernel_size) * self._in_channels
-            std = (2.0 / filter_elem_num) ** 0.5
-            return Normal(0.0, std)
+            # Equivalent to PyTorch's default (kaiming_uniform_ with
+            # a=sqrt(5)), i.e. U(-1/sqrt(fan_in), 1/sqrt(fan_in)). The previous
+            # He-Normal default (std=sqrt(2/fan_in)) has a per-layer variance
+            # gain > 1 for non-ReLU activations and exponentially amplifies
+            # activations in deep or weight-shared stacks (see #79706).
+            # Note fan_in accounts for groups, matching the filter shape.
+            fan_in = (self._in_channels // self._groups) * np.prod(
+                self._kernel_size
+            )
+            bound = float(fan_in) ** -0.5
+            return Uniform(-bound, bound)
 
         self.weight = self.create_parameter(
             shape=filter_shape,
@@ -331,8 +333,8 @@ class Conv1D(_ConvNd):
         weight_attr (ParamAttr, optional): The parameter attribute for learnable weights(Parameter)
             of conv1d. If it is set to None or one attribute of ParamAttr, conv1d
             will create ParamAttr as param_attr. If the Initializer of the param_attr
-            is not set, the parameter is initialized with :math:`Normal(0.0, std)`,
-            and the :math:`std` is :math:`(\frac{2.0 }{filter\_elem\_num})^{0.5}`. Default: None.
+            is not set, the parameter is initialized with :math:`Uniform(-bound, bound)`,
+            and the :math:`bound` is :math:`(\frac{1}{filter\_elem\_num})^{0.5}`. Default: None.
         bias_attr (ParamAttr or bool, optional): The attribute for the bias of conv1d.
             If it is set to False, no bias will be added to the output units.
             If it is set to None or one attribute of ParamAttr, conv1d
@@ -772,8 +774,8 @@ class Conv2D(_ConvNd):
         weight_attr(ParamAttr, optional): The parameter attribute for learnable parameters/weights
             of conv2d. If it is set to None or one attribute of ParamAttr, conv2d
             will create ParamAttr as param_attr. If it is set to None, the parameter
-            is initialized with :math:`Normal(0.0, std)`, and the :math:`std` is
-            :math:`(\frac{2.0 }{filter\_elem\_num})^{0.5}`. The default value is None.
+            is initialized with :math:`Uniform(-bound, bound)`, and the :math:`bound` is
+            :math:`(\frac{1}{filter\_elem\_num})^{0.5}`. The default value is None.
         bias_attr(ParamAttr|bool, optional): The parameter attribute for the bias of conv2d.
             If it is set to False, no bias will be added to the output units.
             If it is set to None or one attribute of ParamAttr, conv2d
@@ -1215,8 +1217,8 @@ class Conv3D(_ConvNd):
         weight_attr(ParamAttr, optional): The parameter attribute for learnable parameters/weights
             of conv3d. If it is set to None or one attribute of ParamAttr, conv3d
             will create ParamAttr as param_attr. If it is set to None, the parameter
-            is initialized with :math:`Normal(0.0, std)`, and the :math:`std` is
-            :math:`(\frac{2.0 }{filter\_elem\_num})^{0.5}`. The default value is None.
+            is initialized with :math:`Uniform(-bound, bound)`, and the :math:`bound` is
+            :math:`(\frac{1}{filter\_elem\_num})^{0.5}`. The default value is None.
         bias_attr(ParamAttr|bool, optional): The parameter attribute for the bias of conv3d.
             If it is set to False, no bias will be added to the output units.
             If it is set to None or one attribute of ParamAttr, conv3d

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -188,7 +188,14 @@ class _ConvNd(Layer):
             fan_in = (self._in_channels // self._groups) * np.prod(
                 self._kernel_size
             )
-            bound = float(fan_in) ** -0.5
+            # Note: keep numpy scalar semantics here (do NOT cast fan_in to
+            # Python float before the power). For invalid configs such as an
+            # unknown static channel dim (in_channels=-1) or kernel_size=0,
+            # fan_in <= 0 then yields nan/inf, so Uniform's bound assert (or a
+            # downstream shape check) raises the same AssertionError/ValueError
+            # as the previous He-Normal default, instead of a new TypeError
+            # from Python's complex-result negative-base power.
+            bound = float(fan_in**-0.5)
             return Uniform(-bound, bound)
 
         self.weight = self.create_parameter(

--- a/test/legacy_test/test_conv1d_layer.py
+++ b/test/legacy_test/test_conv1d_layer.py
@@ -180,7 +180,87 @@ class Conv1DTypeErrorTestCase(Conv1DTestCase):
             self.paddle_nn_layer()
 
 
+class Conv1DDefaultInitTestCase(unittest.TestCase):
+    """Lock the default parameter initializer (see #79706): weight is
+    Uniform(-bound, bound) with bound = 1/sqrt(fan_in), where
+    fan_in = (in_channels // groups) * prod(kernel_size); bias is zeros."""
+
+    def __init__(
+        self,
+        methodName='runTest',
+        num_channels=16,
+        num_filters=32,
+        groups=1,
+    ):
+        super().__init__(methodName)
+        self.num_channels = num_channels
+        self.num_filters = num_filters
+        self.groups = groups
+        self.fan_in = (num_channels // groups) * 3
+        self.bound = float(self.fan_in) ** -0.5
+
+    def _check_params(self, w, b):
+        self.assertEqual(
+            tuple(w.shape),
+            (self.num_filters, self.num_channels // self.groups, 3),
+        )
+        self.assertLessEqual(float(np.abs(w).max()), self.bound * (1 + 1e-6))
+        expected_std = self.bound / np.sqrt(3.0)
+        self.assertAlmostEqual(
+            float(w.std()), expected_std, delta=0.2 * expected_std
+        )
+        self.assertTrue(np.all(b == 0))
+
+    def _dygraph_params(self, place):
+        with dg.guard(place):
+            paddle.seed(2024)
+            conv = nn.Conv1D(
+                self.num_channels,
+                self.num_filters,
+                3,
+                groups=self.groups,
+            )
+            return conv.weight.numpy(), conv.bias.numpy()
+
+    def _static_params(self, place):
+        paddle.seed(2024)
+        main = base.Program()
+        start = base.Program()
+        with (
+            base.unique_name.guard(),
+            base.program_guard(main, start),
+        ):
+            x = paddle.static.data(
+                "input", [1, self.num_channels, 8], dtype="float32"
+            )
+            conv = nn.Conv1D(
+                self.num_channels,
+                self.num_filters,
+                3,
+                groups=self.groups,
+            )
+            y = conv(x)
+        exe = base.Executor(place)
+        exe.run(start)
+        return exe.run(
+            main,
+            feed={"input": np.zeros([1, self.num_channels, 8], "float32")},
+            fetch_list=[conv.weight, conv.bias],
+        )
+
+    def runTest(self):
+        places = [base.CPUPlace()]
+        if base.core.is_compiled_with_cuda() or is_custom_device():
+            places.append(get_device_place())
+        for place in places:
+            self._check_params(*self._dygraph_params(place))
+            with paddle.pir_utils.IrGuard():
+                self._check_params(*self._static_params(place))
+
+
 def add_cases(suite):
+    suite.addTest(Conv1DDefaultInitTestCase(methodName='runTest'))
+    suite.addTest(Conv1DDefaultInitTestCase(methodName='runTest', groups=4))
     suite.addTest(Conv1DTestCase(methodName='runTest'))
     suite.addTest(Conv1DTestCase(methodName='runTest', stride=[1], dilation=2))
     suite.addTest(Conv1DTestCase(methodName='runTest', stride=2, dilation=(1)))

--- a/test/legacy_test/test_conv2d_layer.py
+++ b/test/legacy_test/test_conv2d_layer.py
@@ -200,7 +200,87 @@ class Conv2DErrorTestCase(Conv2DTestCase):
             self.paddle_nn_layer()
 
 
+class Conv2DDefaultInitTestCase(unittest.TestCase):
+    """Lock the default parameter initializer (see #79706): weight is
+    Uniform(-bound, bound) with bound = 1/sqrt(fan_in), where
+    fan_in = (in_channels // groups) * prod(kernel_size); bias is zeros."""
+
+    def __init__(
+        self,
+        methodName='runTest',
+        num_channels=16,
+        num_filters=32,
+        groups=1,
+    ):
+        super().__init__(methodName)
+        self.num_channels = num_channels
+        self.num_filters = num_filters
+        self.groups = groups
+        self.fan_in = (num_channels // groups) * 3 * 3
+        self.bound = float(self.fan_in) ** -0.5
+
+    def _check_params(self, w, b):
+        self.assertEqual(
+            tuple(w.shape),
+            (self.num_filters, self.num_channels // self.groups, 3, 3),
+        )
+        self.assertLessEqual(float(np.abs(w).max()), self.bound * (1 + 1e-6))
+        expected_std = self.bound / np.sqrt(3.0)
+        self.assertAlmostEqual(
+            float(w.std()), expected_std, delta=0.2 * expected_std
+        )
+        self.assertTrue(np.all(b == 0))
+
+    def _dygraph_params(self, place):
+        with dg.guard(place):
+            paddle.seed(2024)
+            conv = nn.Conv2D(
+                self.num_channels,
+                self.num_filters,
+                3,
+                groups=self.groups,
+            )
+            return conv.weight.numpy(), conv.bias.numpy()
+
+    def _static_params(self, place):
+        paddle.seed(2024)
+        main = base.Program()
+        start = base.Program()
+        with (
+            base.unique_name.guard(),
+            base.program_guard(main, start),
+        ):
+            x = paddle.static.data(
+                "input", [1, self.num_channels, 8, 8], dtype="float32"
+            )
+            conv = nn.Conv2D(
+                self.num_channels,
+                self.num_filters,
+                3,
+                groups=self.groups,
+            )
+            y = conv(x)
+        exe = base.Executor(place)
+        exe.run(start)
+        return exe.run(
+            main,
+            feed={"input": np.zeros([1, self.num_channels, 8, 8], "float32")},
+            fetch_list=[conv.weight, conv.bias],
+        )
+
+    def runTest(self):
+        places = [base.CPUPlace()]
+        if base.core.is_compiled_with_cuda() or is_custom_device():
+            places.append(get_device_place())
+        for place in places:
+            self._check_params(*self._dygraph_params(place))
+            with paddle.pir_utils.IrGuard():
+                self._check_params(*self._static_params(place))
+
+
 def add_cases(suite):
+    suite.addTest(Conv2DDefaultInitTestCase(methodName='runTest'))
+    suite.addTest(Conv2DDefaultInitTestCase(methodName='runTest', groups=4))
     suite.addTest(Conv2DTestCase(methodName='runTest'))
     suite.addTest(
         Conv2DTestCase(methodName='runTest', stride=[1, 2], dilation=2)

--- a/test/legacy_test/test_conv3d_layer.py
+++ b/test/legacy_test/test_conv3d_layer.py
@@ -218,7 +218,89 @@ class Conv3DErrorTestCase(Conv3DTestCase):
             self.paddle_nn_layer()
 
 
+class Conv3DDefaultInitTestCase(unittest.TestCase):
+    """Lock the default parameter initializer (see #79706): weight is
+    Uniform(-bound, bound) with bound = 1/sqrt(fan_in), where
+    fan_in = (in_channels // groups) * prod(kernel_size); bias is zeros."""
+
+    def __init__(
+        self,
+        methodName='runTest',
+        num_channels=16,
+        num_filters=32,
+        groups=1,
+    ):
+        super().__init__(methodName)
+        self.num_channels = num_channels
+        self.num_filters = num_filters
+        self.groups = groups
+        self.fan_in = (num_channels // groups) * 3 * 3 * 3
+        self.bound = float(self.fan_in) ** -0.5
+
+    def _check_params(self, w, b):
+        self.assertEqual(
+            tuple(w.shape),
+            (self.num_filters, self.num_channels // self.groups, 3, 3, 3),
+        )
+        self.assertLessEqual(float(np.abs(w).max()), self.bound * (1 + 1e-6))
+        expected_std = self.bound / np.sqrt(3.0)
+        self.assertAlmostEqual(
+            float(w.std()), expected_std, delta=0.2 * expected_std
+        )
+        self.assertTrue(np.all(b == 0))
+
+    def _dygraph_params(self, place):
+        with dg.guard(place):
+            paddle.seed(2024)
+            conv = nn.Conv3D(
+                self.num_channels,
+                self.num_filters,
+                3,
+                groups=self.groups,
+            )
+            return conv.weight.numpy(), conv.bias.numpy()
+
+    def _static_params(self, place):
+        paddle.seed(2024)
+        main = base.Program()
+        start = base.Program()
+        with (
+            base.unique_name.guard(),
+            base.program_guard(main, start),
+        ):
+            x = paddle.static.data(
+                "input", [1, self.num_channels, 4, 4, 4], dtype="float32"
+            )
+            conv = nn.Conv3D(
+                self.num_channels,
+                self.num_filters,
+                3,
+                groups=self.groups,
+            )
+            y = conv(x)
+        exe = base.Executor(place)
+        exe.run(start)
+        return exe.run(
+            main,
+            feed={
+                "input": np.zeros([1, self.num_channels, 4, 4, 4], "float32")
+            },
+            fetch_list=[conv.weight, conv.bias],
+        )
+
+    def runTest(self):
+        places = [base.CPUPlace()]
+        if base.core.is_compiled_with_cuda() or is_custom_device():
+            places.append(get_device_place())
+        for place in places:
+            self._check_params(*self._dygraph_params(place))
+            with paddle.pir_utils.IrGuard():
+                self._check_params(*self._static_params(place))
+
+
 def add_cases(suite):
+    suite.addTest(Conv3DDefaultInitTestCase(methodName='runTest'))
+    suite.addTest(Conv3DDefaultInitTestCase(methodName='runTest', groups=4))
     suite.addTest(Conv3DTestCase(methodName='runTest'))
     suite.addTest(
         Conv3DTestCase(methodName='runTest', stride=[1, 2, 1], dilation=2)


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

Fix #79706

#### 背景与动机

如 #79706 所述，`paddle.nn.Conv1D/2D/3D` 的默认权重初始化为 `Normal(0, sqrt(2/fan_in))`（He Normal）。对于非 ReLU 激活（如 SiLU、GELU）或深层、权重共享的堆叠结构，该初始化使每层输出方差增益 > 1，激活值随深度**指数级放大**，直至前向溢出为 inf、反向传播出现 NaN。

最小复现（来自 issue，CPU，float32）：两个权重共享残差块（`conv -> silu -> conv -> residual`）在 16 通道 8x8 输入上循环应用 8 轮：

| 初始化方式 | 8 轮后激活 max 绝对值 | 梯度 NaN |
|---|---|---|
| 当前默认 `Normal(0, sqrt(2/fan_in))` | ~2.0e4 且持续爆炸 | 8 个参数 NaN |
| `Uniform(-1/sqrt(fan_in), 1/sqrt(fan_in))` | ~7.2，有界 | 无 |

16->16 3x3 卷积默认初始化权重实测：Paddle std = 0.1164（max 0.412），PyTorch std = 0.0475（max 0.083），相差约 2.45 倍。

#### 改动内容

代码修改集中在 `python/paddle/nn/layer/conv.py`，另新增三个测试文件内的测试类：

- `Conv1D`/`Conv2D`/`Conv3D`（共享 `_ConvNd.__init__`）的默认初始化由 `Normal(0, sqrt(2/fan_in))` 改为 `Uniform(-1/sqrt(fan_in), 1/sqrt(fan_in))`，与 PyTorch 默认（`kaiming_uniform_`，`a=sqrt(5)`）完全等价；
- `fan_in` 计入 `groups`，即 `(in_channels // groups) * prod(kernel_size)`，与每个 filter 的实际形状一致（旧公式忽略 groups）；
- 删除模块级死代码 `_get_default_param_initializer(num_channels, filter_size)`（全仓库无调用者）；
- 同步更新 `Conv1D`/`Conv2D`/`Conv3D` 的 `weight_attr` 文档串，显式定义 `fan_in = (in_channels/groups) × ∏(kernel_size)`（响应 review）；
- 新增 `Conv1D/2D/3DDefaultInitTestCase`（`test/legacy_test/test_conv{1,2,3}d_layer.py`）：固定 seed，断言默认初始化权重落在 `1/sqrt(fan_in)` 边界内、std ≈ bound/√3、bias 全零；覆盖普通卷积与 `groups=4` 分组卷积，且每个用例同时跑动态图与 PIR 静态图两种模式（响应 review）。

数值验证（fan_in = 144）：bound = 0.0833，采样 std = 0.0482，max = 0.0833，与 PyTorch 实测（std 0.0475 / max 0.083）一致；上述复现场景在新初始化下激活有界、梯度无 NaN。

#### 有意未改动（留待后续）

- `ConvTranspose1D/2D/3D`：保持原有 Xavier 兜底初始化；
- bias：保持 Paddle 文档化的零初始化（不对齐 PyTorch 的非零均匀 bias）；
- `paddle/static/nn/common.py`、`paddle/vision/ops.py`、`paddle/sparse/nn/layer/conv.py`、`paddle/incubate/...` 中平行的旧公式副本，为保持本 PR 最小化，留待后续 PR 处理。

#### 测试说明

本地为源码环境、无本地构建的 libpaddle，未能跑全量测试，依赖 CI 验证。新增测试的断言逻辑已在本地做镜像验证：用显式 `Uniform` 初始化模拟新默认值，动态图 + PIR 静态图两条路径共 12 例全部通过；再用当前旧 `Normal` 默认做负对照，边界断言按预期失败，确认测试确实锁定新行为。`test/legacy_test/test_imperative_ocr_attention_model.py` 显式传入初始化器，不受影响。如 CI 标记 golden-value 测试，我会跟进调整。

### 是否引起精度变化

否 —— 本 PR 仅改变 `Conv1D/2D/3D` 在未显式指定初始化器时的默认权重分布（Normal -> Uniform，对齐 PyTorch），不改变任何算子在给定参数下的计算逻辑与数值结果；已有 checkpoint 加载与推理不受影响。同类 torch 对齐 PR（如 #79227、#76915）均填否。注意：从零训练的起始点会变，如维护者认为需走精度审批流程请留言，我来配合。
