### PR TITLE
[FlexCheckpoint] Add LoadTransform extension point for quantized checkpoints

### DIFF
--- a/python/paddle/distributed/__init__.py
+++ b/python/paddle/distributed/__init__.py
@@ -126,6 +126,7 @@ from .flex_checkpoint.dcp.load_state_dict import (
     load_merged_state_dict,
     load_state_dict,
 )
+from .flex_checkpoint.dcp.load_transform import LoadTransform
 from .flex_checkpoint.dcp.save_state_dict import save_state_dict
 from .flex_checkpoint.dcp.sharded_weight import (
     ShardedStateDict,
@@ -218,6 +219,7 @@ __all__ = [
     "save_state_dict",
     "load_state_dict",
     "load_merged_state_dict",
+    "LoadTransform",
     "shard_optimizer",
     "shard_scaler",
     "ShardingStage1",

--- a/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
@@ -65,6 +65,8 @@ if TYPE_CHECKING:
     from paddle import Tensor
     from paddle.distributed.collective import Group
 
+    from .load_transform import LoadTransform
+
 PATH_TO_CHECKPOINT_FILES: dict[str, tuple[list, list]] = {}
 
 # When using the communication mode described below, newly created tensors will not be allocated GPU memory.
@@ -72,6 +74,244 @@ PATH_TO_CHECKPOINT_FILES: dict[str, tuple[list, list]] = {}
 _UNINIT_TENSOR_MODES = ["send_recv", "grouped_send_recv"]
 
 _metadata_manager = MetadataManager()
+
+
+def _state_key_name(
+    state_key: str | tuple[str, tuple[int, ...]],
+) -> str:
+    return state_key[0] if isinstance(state_key, tuple) else state_key
+
+
+def _paddle_dtype(dtype_name: str) -> paddle.dtype:
+    normalized = dtype_name.removeprefix('paddle.')
+    dtype = getattr(paddle, normalized, None)
+    if dtype is None:
+        raise ValueError(
+            f"Unsupported transformed output dtype {dtype_name!r}."
+        )
+    return dtype
+
+
+def _target_shard_metadata(
+    target: Tensor | ShardedWeight,
+) -> LocalTensorMetadata:
+    if isinstance(target, ShardedWeight):
+        return LocalTensorMetadata(
+            global_shape=tuple(target.global_shape),
+            local_shape=tuple(target.local_shape),
+            global_offset=tuple(target.global_offset),
+            dtype=str(target.local_tensor.dtype).removeprefix('paddle.'),
+        )
+    shape = tuple(target.shape)
+    return LocalTensorMetadata(
+        global_shape=shape,
+        local_shape=shape,
+        global_offset=(0,) * len(shape),
+        dtype=str(target.dtype).removeprefix('paddle.'),
+    )
+
+
+def _get_transform_read_plan(
+    load_transform: LoadTransform,
+    logical_key: str,
+    target: Tensor | ShardedWeight,
+    force_global: bool = False,
+):
+    read_plan = getattr(load_transform, "read_plan", None)
+    if not callable(read_plan):
+        return None
+    return read_plan(
+        logical_key,
+        _target_shard_metadata(target),
+        force_global=force_global,
+    )
+
+
+def _build_transform_component_load_dict(
+    logical_load_dict: dict[
+        str | tuple[str, tuple[int, ...]], Tensor | ShardedWeight
+    ],
+    physical_metadata: Metadata,
+    load_transform: LoadTransform,
+    offload: bool,
+) -> dict[str | tuple[str, tuple[int, ...]], ShardedWeight]:
+    if load_transform is None:
+        return {}
+    use_tuple_keys = any(isinstance(key, tuple) for key in logical_load_dict)
+    targets_by_logical_key = defaultdict(list)
+    for state_key, target in logical_load_dict.items():
+        targets_by_logical_key[_state_key_name(state_key)].append(target)
+    logical_keys = set(targets_by_logical_key)
+    source_keys_by_logical_key = {
+        logical_key: tuple(load_transform.source_keys(logical_key))
+        for logical_key in logical_keys
+    }
+    required_source_keys = {
+        source_key
+        for logical_key in logical_keys
+        for source_key in source_keys_by_logical_key[logical_key]
+    }
+    source_metadata = physical_metadata.state_dict_metadata
+    plans = {}
+    for logical_key, targets in targets_by_logical_key.items():
+        target_metadata = [_target_shard_metadata(target) for target in targets]
+        force_global = any(
+            metadata != target_metadata[0] for metadata in target_metadata[1:]
+        )
+        plans[logical_key] = _get_transform_read_plan(
+            load_transform,
+            logical_key,
+            targets[0],
+            force_global=force_global,
+        )
+    local_source_slices = {
+        source_key: plan.source_slices[source_key]
+        for logical_key, plan in plans.items()
+        if getattr(plan, "mode", "global") == "local"
+        for source_key in source_keys_by_logical_key[logical_key]
+    }
+
+    component_load_dict = {}
+    for source_key in sorted(required_source_keys):
+        physical_tensor_metadata = source_metadata[source_key][0]
+        global_shape = tuple(physical_tensor_metadata.global_shape)
+        dtype = physical_tensor_metadata.dtype
+        local_shape = global_shape
+        global_offset = (0,) * len(global_shape)
+        candidate = local_source_slices.get(source_key)
+        if candidate is not None:
+            local_shape = tuple(candidate.local_shape)
+            global_offset = tuple(candidate.global_offset)
+        tensor = paddle.empty(local_shape, dtype=dtype)
+        if offload:
+            tensor = tensor.cpu()
+        state_key = (
+            (source_key, global_offset) if use_tuple_keys else source_key
+        )
+        if candidate is None:
+            component_load_dict[state_key] = make_replicated_sharded_weight(
+                source_key, tensor
+            )
+        else:
+            component_load_dict[state_key] = ShardedWeight(
+                key=source_key,
+                local_tensor=tensor,
+                local_shape=local_shape,
+                global_shape=global_shape,
+                global_offset=global_offset,
+            )
+    return component_load_dict
+
+
+def _apply_load_transform(
+    logical_load_dict: dict[
+        str | tuple[str, tuple[int, ...]], Tensor | ShardedWeight
+    ],
+    component_load_dict: dict[str | tuple[str, tuple[int, ...]], ShardedWeight],
+    load_transform: LoadTransform,
+) -> None:
+    if load_transform is None:
+        return
+    transform_metadata = load_transform.logical_metadata()
+    source_keys_by_logical_key = {
+        logical_key: tuple(load_transform.source_keys(logical_key))
+        for logical_key in transform_metadata
+    }
+    targets_by_logical_key = defaultdict(list)
+    for state_key, target in logical_load_dict.items():
+        logical_key = _state_key_name(state_key)
+        if logical_key in transform_metadata:
+            targets_by_logical_key[logical_key].append((state_key, target))
+
+    components_by_key = {
+        _state_key_name(state_key): value
+        for state_key, value in component_load_dict.items()
+    }
+    for logical_key in sorted(targets_by_logical_key):
+        logical_metadata = transform_metadata[logical_key]
+        read_plan = getattr(load_transform, "read_plan_for", lambda _key: None)(
+            logical_key
+        )
+        is_local = getattr(read_plan, "mode", "global") == "local"
+        source_keys = source_keys_by_logical_key[logical_key]
+        source_tensors = {
+            source_key: components_by_key[source_key].local_tensor
+            for source_key in source_keys
+        }
+        output_dtype = _paddle_dtype(logical_metadata.dtype)
+        output = load_transform.apply(logical_key, source_tensors, output_dtype)
+
+        for _state_key, target in targets_by_logical_key[logical_key]:
+            if isinstance(target, ShardedWeight):
+                target_tensor = target.local_tensor
+                local_shape = tuple(target.local_shape)
+                global_offset = tuple(target.global_offset)
+            else:
+                target_tensor = target
+                local_shape = tuple(target.shape)
+                global_offset = (0,) * len(local_shape)
+            if is_local:
+                piece = output
+            else:
+                ends = tuple(
+                    offset + size
+                    for offset, size in zip(global_offset, local_shape)
+                )
+                piece = paddle.slice(
+                    output,
+                    axes=list(range(len(logical_metadata.global_shape))),
+                    starts=list(global_offset),
+                    ends=list(ends),
+                )
+            if piece.place != target_tensor.place:
+                piece = piece.to(target_tensor.place)
+            paddle.assign(piece, target_tensor)
+
+
+def _load_checkpoint_data_file(
+    path: str,
+    safetensors: bool,
+    offload: bool,
+) -> dict[str, Tensor]:
+    if safetensors:
+        # Keep quantized one-byte payloads lossless. Paddle's native FP8
+        # tensor conversion would reinterpret the bytes before dequantization.
+        dtype_aliases = (
+            (paddle, 'float8_e4m3fn', paddle.uint8),
+            (paddle, 'float8_e8m0fnu', paddle.uint8),
+            (np, 'float8_e4m3fn', np.uint8),
+            (np, 'float8_e8m0fnu', np.uint8),
+        )
+        previous_dtypes = {
+            (module, name): getattr(module, name, None)
+            for module, name, _ in dtype_aliases
+        }
+        try:
+            for module, name, dtype in dtype_aliases:
+                setattr(module, name, dtype)
+            if offload:
+                state_dict_numpy = paddle.load(
+                    path, return_numpy=True, safetensors=True
+                )
+                return {
+                    key: paddle.to_tensor(value, place=paddle.CPUPlace())
+                    for key, value in state_dict_numpy.items()
+                }
+            else:
+                return paddle.load(path, safetensors=True)
+        finally:
+            for (module, name), dtype in previous_dtypes.items():
+                if dtype is None:
+                    delattr(module, name)
+                else:
+                    setattr(module, name, dtype)
+    if offload:
+        state_dict_numpy = paddle.load(path, return_numpy=True)
+        return {
+            key: paddle.to_tensor(value, place=paddle.CPUPlace())
+            for key, value in state_dict_numpy.items()
+        }
+    return paddle.load(path)
 
 
 def get_checkpoint_files(
@@ -583,6 +823,7 @@ def _handle_aoa(
     aoa_config,
     safetensors,
     comm_method,
+    load_transform=None,
 ):
     global _metadata_manager
 
@@ -600,6 +841,18 @@ def _handle_aoa(
         _metadata_manager.set_metadata_list([metadata])
     metadata = _metadata_manager.get_metadata_list()[0]
     state_dict_metadata = metadata.state_dict_metadata
+    transform_metadata = (
+        load_transform.logical_metadata() if load_transform is not None else {}
+    )
+    source_keys_by_logical_key = {
+        logical_key: tuple(load_transform.source_keys(logical_key))
+        for logical_key in transform_metadata
+    }
+    transform_component_keys = {
+        source_key
+        for source_keys in source_keys_by_logical_key.values()
+        for source_key in source_keys
+    }
     using_not_init_tensor = (
         True if comm_method in _UNINIT_TENSOR_MODES else False
     )
@@ -616,7 +869,22 @@ def _handle_aoa(
             for meta in local_tensor_metas
         ]
         for param_name, local_tensor_metas in state_dict_metadata.items()
+        if param_name not in transform_component_keys
     }
+    source_state_shard_info.update(
+        {
+            param_name: [
+                ShardedWeightDesc(
+                    key=param_name,
+                    local_shape=tuple(meta.global_shape),
+                    global_shape=tuple(meta.global_shape),
+                    global_offset=(0,) * len(meta.global_shape),
+                    dtype=meta.dtype,
+                )
+            ]
+            for param_name, meta in transform_metadata.items()
+        }
+    )
     aoa_engine = AOAEngine(
         source_state_shard_info=source_state_shard_info,
         destination_state_shard_info=destination_state_shard_info,
@@ -699,6 +967,7 @@ def _handle_aoa(
         worker_groups=worker_groups,
         comm_method=comm_method,
         skip_validation=True,
+        load_transform=load_transform,
     )
 
     for dst_desc, src_desc in dst_to_src_desc_mapping.items():
@@ -776,6 +1045,7 @@ def load_state_dict(
     safetensors: bool = False,
     worker_groups: list[Group] | None = None,
     comm_method: str = "broadcast",
+    load_transform: LoadTransform | None = None,
 ) -> None:
     r"""
     Load the state_dict inplace from a checkpoint path.
@@ -792,6 +1062,7 @@ def load_state_dict(
         safetensors(bool): Whether to use safetensors format. Default is False.
         worker_groups (list[paddle.distributed.collective.Group]): Communication groups used for tensor communications; if multiple are provided, an appropriate group is chosen; if None, the process_group group is used.
         comm_method (str): Communication method for resharding. Choices are "send_recv", "broadcast", "multi_group_broadcast", and "grouped_send_recv". Default is "broadcast".
+        load_transform (LoadTransform, optional): A format-independent callback that assembles one logical tensor from one or more physical checkpoint tensors before AOA postprocessing.
     Example:
         .. code-block:: pycon
 
@@ -838,7 +1109,7 @@ def load_state_dict(
     if use_dist:
         paddle.distributed.barrier(process_group)
 
-    if not safetensors and aoa_config is None:
+    if not safetensors and aoa_config is None and load_transform is None:
         metadata_files, _ = get_checkpoint_files(path, unique_id=unique_id)
         assert len(metadata_files) == 1, "Only support one metadata file now."
         metadata = paddle.load(os.path.join(path, metadata_files[0]))
@@ -873,6 +1144,7 @@ def load_state_dict(
             safetensors=safetensors,
             worker_groups=worker_groups,
             comm_method=comm_method,
+            load_transform=load_transform,
         )
         _metadata_manager.clear()
         gc.collect()
@@ -910,6 +1182,7 @@ def load_state_dict(
             aoa_config,
             safetensors,
             comm_method,
+            load_transform,
         )
     else:
         load_state_dict_impl(
@@ -923,6 +1196,7 @@ def load_state_dict(
             safetensors=safetensors,
             worker_groups=worker_groups,
             comm_method=comm_method,
+            load_transform=load_transform,
         )
     if use_dist:
         _finish_unflatten(flat_shards, padding_info)
@@ -1190,6 +1464,7 @@ def load_state_dict_impl(
     worker_groups: list[Group] | None = None,
     comm_method: str = 'broadcast',
     skip_validation: bool = False,
+    load_transform: LoadTransform | None = None,
 ) -> None:
     with paddle.base.dygraph.guard():
         global _metadata_manager
@@ -1237,10 +1512,50 @@ def load_state_dict_impl(
                 metadata_list.append(paddle.load(os.path.join(path, file)))
             _metadata_manager.set_metadata_list(metadata_list)
 
+        transform_metadata = (
+            load_transform.logical_metadata()
+            if load_transform is not None
+            else {}
+        )
+        if transform_metadata:
+            transformed_load_dict = {
+                key: value
+                for key, value in flat_state_dict.items()
+                if _state_key_name(key) in transform_metadata
+            }
+            passthrough_load_dict = {
+                key: value
+                for key, value in flat_state_dict.items()
+                if _state_key_name(key) not in transform_metadata
+            }
+            component_load_dict = _build_transform_component_load_dict(
+                transformed_load_dict,
+                _metadata_manager.get_metadata_list()[0],
+                load_transform,
+                offload,
+            )
+            collisions = {
+                _state_key_name(key) for key in passthrough_load_dict
+            } & {_state_key_name(key) for key in component_load_dict}
+            if collisions:
+                raise ValueError(
+                    "Physical load transform components conflict with "
+                    "passthrough target tensors: "
+                    f"{sorted(collisions)}."
+                )
+            file_load_dict = {
+                **passthrough_load_dict,
+                **component_load_dict,
+            }
+        else:
+            transformed_load_dict = {}
+            component_load_dict = {}
+            file_load_dict = flat_state_dict
+
         rank_to_files, mw_name_compatibility_mapping = get_rank_to_files(
             _metadata_manager.get_metadata_list(),
             local_data_files,
-            flat_state_dict,
+            file_load_dict,
             process_group,
             use_dist,
             mw_name_compatibility,
@@ -1252,7 +1567,7 @@ def load_state_dict_impl(
 
             state_dict_param_names = {
                 key if isinstance(key, str) else key[0]
-                for key in flat_state_dict.keys()
+                for key in file_load_dict.keys()
             }
             validate_and_report_keys_standard(
                 _metadata_manager.get_metadata_list(),
@@ -1260,7 +1575,7 @@ def load_state_dict_impl(
                 process_group,
                 use_dist,
                 path,
-                state_dict=flat_state_dict,
+                state_dict=file_load_dict,
             )
 
         cur_rank = paddle.distributed.get_rank()
@@ -1286,20 +1601,9 @@ def load_state_dict_impl(
 
         source_state_dict = {}
         for file in local_load_files:
-            if offload:
-                state_dict_numpy = paddle.load(
-                    os.path.join(path, file),
-                    return_numpy=True,
-                    safetensors=safetensors,
-                )
-                source_state_dict[file] = {
-                    key: paddle.to_tensor(value, place=paddle.CPUPlace())
-                    for key, value in state_dict_numpy.items()
-                }
-            else:
-                source_state_dict[file] = paddle.load(
-                    os.path.join(path, file), safetensors=safetensors
-                )
+            source_state_dict[file] = _load_checkpoint_data_file(
+                os.path.join(path, file), safetensors, offload
+            )
 
         metadata = _metadata_manager.get_metadata_list()[0]
         storage_metadata = metadata.storage_metadata
@@ -1353,7 +1657,7 @@ def load_state_dict_impl(
             logger.info("Restored unflattened state dict.")
 
         _load_state_dict(
-            flat_state_dict,
+            file_load_dict,
             source_state_dict,
             _metadata_manager.get_metadata_list(),
             process_group,
@@ -1362,6 +1666,13 @@ def load_state_dict_impl(
             worker_groups,
             comm_method,
         )
+
+        if transformed_load_dict:
+            _apply_load_transform(
+                transformed_load_dict,
+                component_load_dict,
+                load_transform,
+            )
 
         for file_name, file_tensors in source_state_dict.items():
             for key, value in file_tensors.items():
@@ -1379,7 +1690,10 @@ def load_state_dict_impl(
             tmp = state_dict
             for key in keys[:-1]:
                 tmp = tmp[key]
-            tmp[keys[-1]] = flat_state_dict[flat_key]
+            if flat_key in flat_state_dict:
+                tmp[keys[-1]] = flat_state_dict[flat_key]
+            else:
+                tmp[keys[-1]] = file_load_dict[flat_key]
 
 
 def _load_state_dict(

--- a/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/load_state_dict.py
@@ -51,6 +51,7 @@ from .utils import (
     check_resumable_locally,
     check_unique_id,
     create_hf_ckpt_metadata,
+    extract_tensor_metadata,
     flat_range_in_min_slice,
     flatten_state_dict,
     get_max_id,
@@ -92,29 +93,10 @@ def _paddle_dtype(dtype_name: str) -> paddle.dtype:
     return dtype
 
 
-def _target_shard_metadata(
-    target: Tensor | ShardedWeight,
-) -> LocalTensorMetadata:
-    if isinstance(target, ShardedWeight):
-        return LocalTensorMetadata(
-            global_shape=tuple(target.global_shape),
-            local_shape=tuple(target.local_shape),
-            global_offset=tuple(target.global_offset),
-            dtype=str(target.local_tensor.dtype).removeprefix('paddle.'),
-        )
-    shape = tuple(target.shape)
-    return LocalTensorMetadata(
-        global_shape=shape,
-        local_shape=shape,
-        global_offset=(0,) * len(shape),
-        dtype=str(target.dtype).removeprefix('paddle.'),
-    )
-
-
 def _get_transform_read_plan(
     load_transform: LoadTransform,
     logical_key: str,
-    target: Tensor | ShardedWeight,
+    target_metadata: LocalTensorMetadata,
     force_global: bool = False,
 ):
     read_plan = getattr(load_transform, "read_plan", None)
@@ -122,7 +104,7 @@ def _get_transform_read_plan(
         return None
     return read_plan(
         logical_key,
-        _target_shard_metadata(target),
+        target_metadata,
         force_global=force_global,
     )
 
@@ -134,9 +116,12 @@ def _build_transform_component_load_dict(
     physical_metadata: Metadata,
     load_transform: LoadTransform,
     offload: bool,
-) -> dict[str | tuple[str, tuple[int, ...]], ShardedWeight]:
+) -> tuple[
+    dict[str | tuple[str, tuple[int, ...]], ShardedWeight],
+    dict[str, object],
+]:
     if load_transform is None:
-        return {}
+        return {}, {}
     use_tuple_keys = any(isinstance(key, tuple) for key in logical_load_dict)
     targets_by_logical_key = defaultdict(list)
     for state_key, target in logical_load_dict.items():
@@ -154,14 +139,27 @@ def _build_transform_component_load_dict(
     source_metadata = physical_metadata.state_dict_metadata
     plans = {}
     for logical_key, targets in targets_by_logical_key.items():
-        target_metadata = [_target_shard_metadata(target) for target in targets]
-        force_global = any(
-            metadata != target_metadata[0] for metadata in target_metadata[1:]
+        # A distributed target reports its global shape, so the local shape and
+        # global offset have to come from its placements. None metadata means
+        # the target is not initialized on this rank.
+        target_metadata = [
+            extract_tensor_metadata(target)[1] for target in targets
+        ]
+        known_metadata = [
+            metadata for metadata in target_metadata if metadata is not None
+        ]
+        if not known_metadata:
+            plans[logical_key] = None
+            continue
+        # Several differing targets, or a target this rank cannot describe,
+        # cannot share one local read; fall back to reading the whole tensor.
+        force_global = len(known_metadata) != len(target_metadata) or any(
+            metadata != known_metadata[0] for metadata in known_metadata[1:]
         )
         plans[logical_key] = _get_transform_read_plan(
             load_transform,
             logical_key,
-            targets[0],
+            known_metadata[0],
             force_global=force_global,
         )
     local_source_slices = {
@@ -200,7 +198,7 @@ def _build_transform_component_load_dict(
                 global_shape=global_shape,
                 global_offset=global_offset,
             )
-    return component_load_dict
+    return component_load_dict, plans
 
 
 def _apply_load_transform(
@@ -209,6 +207,7 @@ def _apply_load_transform(
     ],
     component_load_dict: dict[str | tuple[str, tuple[int, ...]], ShardedWeight],
     load_transform: LoadTransform,
+    read_plans: dict[str, object],
 ) -> None:
     if load_transform is None:
         return
@@ -229,9 +228,10 @@ def _apply_load_transform(
     }
     for logical_key in sorted(targets_by_logical_key):
         logical_metadata = transform_metadata[logical_key]
-        read_plan = getattr(load_transform, "read_plan_for", lambda _key: None)(
-            logical_key
-        )
+        # Reuse the plan the components were built from: the physical sources
+        # were read according to it, so the transform output is already a local
+        # shard exactly when that plan asked for one.
+        read_plan = read_plans.get(logical_key)
         is_local = getattr(read_plan, "mode", "global") == "local"
         source_keys = source_keys_by_logical_key[logical_key]
         source_tensors = {
@@ -242,14 +242,13 @@ def _apply_load_transform(
         output = load_transform.apply(logical_key, source_tensors, output_dtype)
 
         for _state_key, target in targets_by_logical_key[logical_key]:
-            if isinstance(target, ShardedWeight):
-                target_tensor = target.local_tensor
-                local_shape = tuple(target.local_shape)
-                global_offset = tuple(target.global_offset)
-            else:
-                target_tensor = target
-                local_shape = tuple(target.shape)
-                global_offset = (0,) * len(local_shape)
+            target_tensor, target_metadata = extract_tensor_metadata(target)
+            if target_metadata is None:
+                # Not initialized on this rank: the target lives on a mesh that
+                # does not contain it, so there is nothing to write here.
+                continue
+            local_shape = target_metadata.local_shape
+            global_offset = target_metadata.global_offset
             if is_local:
                 piece = output
             else:
@@ -1528,11 +1527,13 @@ def load_state_dict_impl(
                 for key, value in flat_state_dict.items()
                 if _state_key_name(key) not in transform_metadata
             }
-            component_load_dict = _build_transform_component_load_dict(
-                transformed_load_dict,
-                _metadata_manager.get_metadata_list()[0],
-                load_transform,
-                offload,
+            component_load_dict, transform_read_plans = (
+                _build_transform_component_load_dict(
+                    transformed_load_dict,
+                    _metadata_manager.get_metadata_list()[0],
+                    load_transform,
+                    offload,
+                )
             )
             collisions = {
                 _state_key_name(key) for key in passthrough_load_dict
@@ -1550,6 +1551,7 @@ def load_state_dict_impl(
         else:
             transformed_load_dict = {}
             component_load_dict = {}
+            transform_read_plans = {}
             file_load_dict = flat_state_dict
 
         rank_to_files, mw_name_compatibility_mapping = get_rank_to_files(
@@ -1672,6 +1674,7 @@ def load_state_dict_impl(
                 transformed_load_dict,
                 component_load_dict,
                 load_transform,
+                transform_read_plans,
             )
 
         for file_name, file_tensors in source_state_dict.items():

--- a/python/paddle/distributed/flex_checkpoint/dcp/load_transform.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/load_transform.py
@@ -27,10 +27,20 @@ class LoadTransform(Protocol):
 
     A transform exposes virtual logical tensors to AOA, lists the physical
     checkpoint tensors required to materialize each logical tensor, and runs
-    only after those physical tensors have been fully assembled. Implementers
-    may additionally provide read_plan() and read_plan_for() to request local
-    physical component shards; the three methods below form the required
-    contract.
+    only after those physical tensors have been fully assembled. The three
+    methods below form the required contract.
+
+    An implementer may additionally provide::
+
+        read_plan(logical_key, target_metadata, force_global=False)
+
+    to narrow the physical read to the shard a rank actually needs. When it
+    returns a plan whose ``mode`` is ``"local"``, ``source_tensors`` passed to
+    ``apply()`` hold only that shard and ``apply()`` must return the local
+    shard of the logical tensor; otherwise it receives whole physical tensors
+    and must return the whole logical tensor. ``target_metadata`` describes the
+    local shard of the target on this rank, so ``read_plan()`` must not assume
+    a target's ``shape`` is its local shape.
     """
 
     def logical_metadata(self) -> dict[str, LocalTensorMetadata]: ...

--- a/python/paddle/distributed/flex_checkpoint/dcp/load_transform.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/load_transform.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from paddle import Tensor, dtype
+
+    from .metadata import LocalTensorMetadata
+
+
+class LoadTransform(Protocol):
+    """Format-independent extension point for checkpoint load transforms.
+
+    A transform exposes virtual logical tensors to AOA, lists the physical
+    checkpoint tensors required to materialize each logical tensor, and runs
+    only after those physical tensors have been fully assembled. Implementers
+    may additionally provide read_plan() and read_plan_for() to request local
+    physical component shards; the three methods below form the required
+    contract.
+    """
+
+    def logical_metadata(self) -> dict[str, LocalTensorMetadata]: ...
+
+    def source_keys(self, logical_key: str) -> list[str]: ...
+
+    def apply(
+        self,
+        logical_key: str,
+        source_tensors: dict[str, Tensor],
+        output_dtype: dtype,
+    ) -> Tensor: ...

--- a/python/paddle/distributed/flex_checkpoint/dcp/metadata.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/metadata.py
@@ -22,12 +22,12 @@ class LocalTensorMetadata:
     The location of a local tensor in the global tensor.
     """
 
-    global_offset: tuple[int]
-    local_shape: tuple[int]
+    global_offset: tuple[int, ...]
+    local_shape: tuple[int, ...]
     dtype: str
-    global_shape: tuple[int] | None = None
+    global_shape: tuple[int, ...] | None = None
     is_flattened: bool = False
-    flattened_range: tuple[int] | None = None
+    flattened_range: tuple[int, int] | None = None
 
 
 @dataclass(frozen=True)
@@ -37,15 +37,15 @@ class LocalTensorIndex:
     """
 
     tensor_key: str
-    global_offset: tuple[int]
+    global_offset: tuple[int, ...]
     is_flattened: bool = False
-    flattened_range: tuple[int] | None = None
+    flattened_range: tuple[int, int] | None = None
     replica_id: int | None = None
-    local_shape: tuple[int] | None = None
+    local_shape: tuple[int, ...] | None = None
 
 
 @dataclass
 class Metadata:
-    state_dict_metadata: dict[str, list[LocalTensorMetadata]] = None
-    storage_metadata: dict[LocalTensorIndex, str] = None
-    flat_mapping: dict[str, tuple[str]] = None
+    state_dict_metadata: dict[str, list[LocalTensorMetadata]] | None = None
+    storage_metadata: dict[LocalTensorIndex, str] | None = None
+    flat_mapping: dict[str, tuple[str, ...]] | None = None

--- a/python/paddle/distributed/flex_checkpoint/dcp/utils.py
+++ b/python/paddle/distributed/flex_checkpoint/dcp/utils.py
@@ -44,6 +44,42 @@ if TYPE_CHECKING:
     from paddle.framework import core
 
 
+_SAFETENSORS_DTYPE_MAPPING = {
+    'U16': 'bfloat16',
+    'U8': 'uint8',
+    'I8': 'int8',
+    'I16': 'int16',
+    'BOOL': 'bool',
+    'F16': 'float16',
+    'F32': 'float32',
+    'F64': 'float64',
+    'BF16': 'bfloat16',
+    'I64': 'int64',
+}
+
+# These formats have one byte per element but do not all have an exact Paddle
+# dtype. FlexCheckpoint transports them losslessly as uint8; a caller-provided
+# LoadTransform owns their numerical interpretation.
+_SAFETENSORS_RAW_8BIT_FORMATS = {
+    'F8_E4M3',
+    'F8_E4M3FN',
+    'F8_E8M0',
+}
+
+
+def _safetensors_storage_dtype(storage_format: str) -> str:
+    """Return the Paddle dtype used to transport a safetensors value."""
+    if storage_format in _SAFETENSORS_DTYPE_MAPPING:
+        return _SAFETENSORS_DTYPE_MAPPING[storage_format]
+    if storage_format in _SAFETENSORS_RAW_8BIT_FORMATS:
+        return 'uint8'
+    raise ValueError(
+        f"Safetensors dtype {storage_format!r} is not supported. "
+        "Unknown formats are never treated as raw bytes unless their element "
+        "width and transport semantics are explicitly registered."
+    )
+
+
 def get_coordinator(mesh: np.array | list[list[int]], rank: int):
     mesh = paddle.to_tensor(mesh)
     rand_coordinator = (mesh == rank).nonzero()
@@ -598,20 +634,10 @@ def create_hf_ckpt_metadata(
     ckpt_path: str,
     process_group=None,
 ):
-    dtype_mapping = {
-        'U16': 'bfloat16',
-        'U8': 'uint8',
-        'I8': 'int8',
-        'I16': 'int16',
-        'BOOL': 'bool',
-        'F16': 'float16',
-        'F32': 'float32',
-        'F64': 'float64',
-        'BF16': 'bfloat16',
-        'I64': 'int64',
-    }
-
-    use_dist = paddle.distributed.get_world_size() > 1
+    use_dist = (
+        paddle.distributed.is_initialized()
+        and paddle.distributed.get_world_size() > 1
+    )
     cur_rank = paddle.distributed.get_rank() if use_dist else 0
 
     accessible_files = os.listdir(ckpt_path)
@@ -668,9 +694,8 @@ def create_hf_ckpt_metadata(
             for key in f.keys():
                 t_s = f.get_slice(key)
                 shape = tuple(t_s.get_shape())
-                dtype = t_s.get_dtype()
-                assert dtype in dtype_mapping, f"{dtype} is not supported yet."
-                dtype = dtype_mapping[dtype]
+                storage_format = t_s.get_dtype()
+                dtype = _safetensors_storage_dtype(storage_format)
                 ltm = LocalTensorMetadata(
                     global_offset=(0,) * len(shape),
                     local_shape=shape,
@@ -724,6 +749,8 @@ def create_hf_ckpt_metadata(
 
     if use_dist:
         paddle.distributed.barrier(process_group)
+
+    return metadata
 
 
 def get_target_tensor(target_state_dict, read_item):

--- a/test/flex_checkpoint/CMakeLists.txt
+++ b/test/flex_checkpoint/CMakeLists.txt
@@ -28,7 +28,8 @@ endforeach()
 
 set(GPU_ONLY_DISTRIBUTED_TESTS
     test_sharded_state_dict test_strategy_conversion
-    test_load_state_dict_transpose test_model_full_param)
+    test_load_state_dict_transpose test_model_full_param
+    test_load_transform_dist)
 
 if(TEST test_sharded_state_dict)
   set_tests_properties(test_sharded_state_dict PROPERTIES TIMEOUT 480)
@@ -36,6 +37,10 @@ endif()
 
 if(TEST test_model_full_param)
   set_tests_properties(test_model_full_param PROPERTIES TIMEOUT 480)
+endif()
+
+if(TEST test_load_transform_dist)
+  set_tests_properties(test_load_transform_dist PROPERTIES TIMEOUT 240)
 endif()
 
 if(NOT (WITH_DISTRIBUTE AND WITH_GPU))

--- a/test/flex_checkpoint/CMakeLists.txt
+++ b/test/flex_checkpoint/CMakeLists.txt
@@ -28,7 +28,7 @@ endforeach()
 
 set(GPU_ONLY_DISTRIBUTED_TESTS
     test_sharded_state_dict test_strategy_conversion
-    test_load_state_dict_transpose test_model_full_param
+    test_load_state_dict_transpose test_model_full_param test_load_transform
     test_load_transform_dist)
 
 if(TEST test_sharded_state_dict)

--- a/test/flex_checkpoint/load_transform_dist_logic.py
+++ b/test/flex_checkpoint/load_transform_dist_logic.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from dataclasses import dataclass, field
+
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+from paddle.distributed.flex_checkpoint.dcp.metadata import LocalTensorMetadata
+from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
+    make_replicated_sharded_weight,
+)
+
+_QUANT_KEY = "weight.quant"
+_SCALE_KEY = "weight.scale"
+_GLOBAL_SHAPE = (4, 8)
+_SCALE = 2.0
+
+
+@dataclass(frozen=True)
+class _ReadPlan:
+    mode: str
+    source_slices: dict = field(default_factory=dict)
+
+
+class DequantTransform:
+    """Assembles one logical fp32 weight from a uint8 payload and a scale."""
+
+    def logical_metadata(self):
+        return {
+            "weight": LocalTensorMetadata(
+                global_offset=(0, 0),
+                local_shape=_GLOBAL_SHAPE,
+                dtype="float32",
+                global_shape=_GLOBAL_SHAPE,
+            )
+        }
+
+    def source_keys(self, logical_key):
+        return [_QUANT_KEY, _SCALE_KEY]
+
+    def apply(self, logical_key, source_tensors, output_dtype):
+        payload = source_tensors[_QUANT_KEY].astype(output_dtype)
+        scale = source_tensors[_SCALE_KEY].astype(output_dtype)
+        return payload * scale
+
+
+class ShardedDequantTransform(DequantTransform):
+    """Reads only the rows the local target shard needs.
+
+    ``read_plan()`` is told which shard of the logical tensor this rank holds,
+    so the assertions below fail unless that shard is derived from the target's
+    placements rather than from its (global) ``shape``.
+    """
+
+    def read_plan(self, logical_key, target_metadata, force_global=False):
+        rank = dist.get_rank()
+        rows = _GLOBAL_SHAPE[0] // dist.get_world_size()
+        start = rank * rows
+        assert not force_global, "a single Shard(0) target needs no global read"
+        assert tuple(target_metadata.global_shape) == _GLOBAL_SHAPE
+        assert tuple(target_metadata.local_shape) == (
+            rows,
+            _GLOBAL_SHAPE[1],
+        ), f"rank {rank} was told local shape {target_metadata.local_shape}"
+        assert tuple(target_metadata.global_offset) == (
+            start,
+            0,
+        ), f"rank {rank} was told global offset {target_metadata.global_offset}"
+        return _ReadPlan(
+            mode="local",
+            source_slices={
+                _QUANT_KEY: LocalTensorMetadata(
+                    global_offset=(start, 0),
+                    local_shape=(rows, _GLOBAL_SHAPE[1]),
+                    dtype="uint8",
+                    global_shape=_GLOBAL_SHAPE,
+                ),
+                _SCALE_KEY: LocalTensorMetadata(
+                    global_offset=(0,),
+                    local_shape=(1,),
+                    dtype="float32",
+                    global_shape=(1,),
+                ),
+            },
+        )
+
+
+class TestLoadTransformShardedTarget:
+    """A Shard(0) target must receive only its own rows.
+
+    ``dist.shard_tensor`` reports the global shape, so the local shape and
+    global offset of a transform target have to be derived from its placements
+    rather than from ``shape``, and the result has to be written into
+    ``_local_value()`` instead of the distributed wrapper.
+    """
+
+    def __init__(self):
+        self.ckpt_path = os.getenv("ckpt_path")
+        self.case = os.getenv("transform_case", "global")
+        self.payload = np.arange(
+            _GLOBAL_SHAPE[0] * _GLOBAL_SHAPE[1], dtype=np.uint8
+        ).reshape(_GLOBAL_SHAPE)
+
+    def run_test(self):
+        dist.init_parallel_env()
+        self.save_physical_checkpoint()
+
+        transform = (
+            ShardedDequantTransform()
+            if self.case == "local"
+            else DequantTransform()
+        )
+        mesh = dist.ProcessMesh(list(range(dist.get_world_size())))
+        state_dict = {
+            "weight": dist.shard_tensor(
+                paddle.zeros(list(_GLOBAL_SHAPE), dtype="float32"),
+                mesh,
+                [dist.Shard(0)],
+            )
+        }
+        dist.load_state_dict(
+            state_dict,
+            self.ckpt_path,
+            load_transform=transform,
+        )
+
+        rows = _GLOBAL_SHAPE[0] // dist.get_world_size()
+        start = dist.get_rank() * rows
+        expected = (
+            self.payload.astype(np.float32)[start : start + rows] * _SCALE
+        )
+        local = state_dict["weight"]._local_value().numpy()
+        assert local.shape == expected.shape, (
+            f"rank {dist.get_rank()} got local shape {local.shape}, "
+            f"expected {expected.shape}"
+        )
+        np.testing.assert_allclose(local, expected)
+
+    def save_physical_checkpoint(self):
+        source_state_dict = {
+            _QUANT_KEY: make_replicated_sharded_weight(
+                _QUANT_KEY, paddle.to_tensor(self.payload)
+            ),
+            _SCALE_KEY: make_replicated_sharded_weight(
+                _SCALE_KEY,
+                paddle.to_tensor(np.array([_SCALE], dtype=np.float32)),
+            ),
+        }
+        dist.save_state_dict(source_state_dict, self.ckpt_path)
+
+
+if __name__ == '__main__':
+    TestLoadTransformShardedTarget().run_test()

--- a/test/flex_checkpoint/test_load_transform.py
+++ b/test/flex_checkpoint/test_load_transform.py
@@ -30,7 +30,6 @@ from paddle.distributed.flex_checkpoint.dcp.load_state_dict import (
     _load_checkpoint_data_file,
     _metadata_manager,
     _paddle_dtype,
-    _target_shard_metadata,
 )
 from paddle.distributed.flex_checkpoint.dcp.metadata import (
     LocalTensorMetadata,
@@ -74,6 +73,7 @@ class _LocalTransform:
         self.plan = None
         self.source_key_calls = 0
         self.force_global_calls = 0
+        self.seen_targets = []
 
     def logical_metadata(self):
         return _logical_metadata()
@@ -83,6 +83,7 @@ class _LocalTransform:
         return [_QUANT_KEY, _SCALE_KEY]
 
     def read_plan(self, logical_key, target, force_global=False):
+        self.seen_targets.append(target)
         if force_global:
             self.force_global_calls += 1
             self.plan = _ReadPlan("global", (4, 8), (0, 0), {})
@@ -100,9 +101,6 @@ class _LocalTransform:
                     ),
                 },
             )
-        return self.plan
-
-    def read_plan_for(self, logical_key):
         return self.plan
 
     def apply(self, logical_key, source_tensors, output_dtype):
@@ -205,9 +203,10 @@ def _fp8_checkpoint(directory, scale=2.0):
 
 class TestLoadTransformComponentPlan(unittest.TestCase):
     def _build(self, logical_load_dict, transform, offload=False):
-        return _build_transform_component_load_dict(
+        components, _plans = _build_transform_component_load_dict(
             logical_load_dict, _physical_metadata(), transform, offload
         )
+        return components
 
     def test_returns_nothing_without_transform(self):
         self.assertEqual(self._build({"weight": _target()}, None), {})
@@ -257,21 +256,40 @@ class TestLoadTransformComponentPlan(unittest.TestCase):
         for component in components.values():
             self.assertTrue(component.local_tensor.place.is_cpu_place())
 
-    def test_derives_metadata_from_plain_tensor_target(self):
-        metadata = _target_shard_metadata(paddle.zeros([4, 8], dtype="float32"))
+    def test_passes_plain_tensor_shard_metadata_to_read_plan(self):
+        transform = _LocalTransform()
+        self._build(
+            {"weight": paddle.zeros([4, 8], dtype="float32")}, transform
+        )
 
-        self.assertEqual(metadata.global_shape, (4, 8))
-        self.assertEqual(metadata.local_shape, (4, 8))
-        self.assertEqual(metadata.global_offset, (0, 0))
-        self.assertEqual(metadata.dtype, "float32")
+        (seen,) = transform.seen_targets
+        self.assertEqual(seen.global_shape, (4, 8))
+        self.assertEqual(seen.local_shape, (4, 8))
+        self.assertEqual(seen.global_offset, (0, 0))
+        self.assertEqual(seen.dtype, "float32")
 
-    def test_derives_metadata_from_sharded_weight_target(self):
-        metadata = _target_shard_metadata(_target())
+    def test_passes_sharded_weight_shard_metadata_to_read_plan(self):
+        transform = _LocalTransform()
+        self._build({"weight": _target()}, transform)
 
-        self.assertEqual(metadata.global_shape, (4, 8))
-        self.assertEqual(metadata.local_shape, (2, 8))
-        self.assertEqual(metadata.global_offset, (2, 0))
-        self.assertEqual(metadata.dtype, "float32")
+        (seen,) = transform.seen_targets
+        self.assertEqual(seen.global_shape, (4, 8))
+        self.assertEqual(seen.local_shape, (2, 8))
+        self.assertEqual(seen.global_offset, (2, 0))
+        self.assertEqual(seen.dtype, "float32")
+
+    def test_reads_globally_when_target_is_absent_on_this_rank(self):
+        transform = _LocalTransform()
+        target = paddle.zeros([4, 8], dtype="float32")
+        target._clear_to_zero_allocation()
+
+        components = self._build({"weight": target}, transform)
+
+        # The rank cannot describe a local shard of a target it does not hold,
+        # so read_plan() must not be consulted and the whole tensor is read.
+        self.assertEqual(transform.seen_targets, [])
+        self.assertEqual(components[_QUANT_KEY].local_shape, (4, 8))
+        self.assertEqual(components[_SCALE_KEY].local_shape, (2, 2))
 
 
 class TestApplyLoadTransform(unittest.TestCase):
@@ -282,7 +300,7 @@ class TestApplyLoadTransform(unittest.TestCase):
 
     def test_no_op_without_transform(self):
         target = _target()
-        _apply_load_transform({"weight": target}, {}, None)
+        _apply_load_transform({"weight": target}, {}, None, {})
 
         np.testing.assert_array_equal(
             target.local_tensor.numpy(), np.zeros([2, 8], dtype="float32")
@@ -294,13 +312,21 @@ class TestApplyLoadTransform(unittest.TestCase):
 
         self.assertEqual(transform.source_key_calls, 1)
 
-    def test_assigns_local_transform_output_directly(self):
+    def test_reuses_the_local_plan_the_components_were_built_from(self):
+        """A transform providing only read_plan() must not be re-planned.
+
+        The physical sources are already local shards, so the output is the
+        local shard of the logical tensor and must be assigned as is. Slicing
+        it a second time by the target's global offset silently yields an empty
+        tensor rather than raising.
+        """
         transform = _LocalTransform()
         target = _target()
-        components = self._build({"weight": target}, transform)
+        components, plans = self._build({"weight": target}, transform)
         components[_QUANT_KEY].local_tensor.fill_(1)
 
-        _apply_load_transform({"weight": target}, components, transform)
+        self.assertEqual(plans["weight"].mode, "local")
+        _apply_load_transform({"weight": target}, components, transform, plans)
 
         np.testing.assert_array_equal(
             target.local_tensor.numpy(), np.ones([2, 8], dtype="float32")
@@ -309,13 +335,13 @@ class TestApplyLoadTransform(unittest.TestCase):
     def test_legacy_transform_slices_global_output(self):
         transform = _LegacyTransform()
         target = _target()
-        components = self._build({"weight": target}, transform)
+        components, plans = self._build({"weight": target}, transform)
         values = paddle.arange(32, dtype="float32").reshape([4, 8])
         paddle.assign(
             values.astype("uint8"), components[_QUANT_KEY].local_tensor
         )
 
-        _apply_load_transform({"weight": target}, components, transform)
+        _apply_load_transform({"weight": target}, components, transform, plans)
 
         # The target owns rows [2, 4) of the logical tensor.
         np.testing.assert_array_equal(
@@ -325,23 +351,35 @@ class TestApplyLoadTransform(unittest.TestCase):
     def test_assigns_into_plain_tensor_target(self):
         transform = _LegacyTransform()
         target = paddle.zeros([4, 8], dtype="float32")
-        components = self._build({"weight": target}, transform)
+        components, plans = self._build({"weight": target}, transform)
         values = paddle.arange(32, dtype="float32").reshape([4, 8])
         paddle.assign(
             values.astype("uint8"), components[_QUANT_KEY].local_tensor
         )
 
-        _apply_load_transform({"weight": target}, components, transform)
+        _apply_load_transform({"weight": target}, components, transform, plans)
 
         np.testing.assert_array_equal(target.numpy(), values.numpy())
+
+    def test_skips_target_absent_on_this_rank(self):
+        transform = _LegacyTransform()
+        target = paddle.zeros([4, 8], dtype="float32")
+        target._clear_to_zero_allocation()
+        components, plans = self._build({"weight": target}, transform)
+        components[_QUANT_KEY].local_tensor.fill_(1)
+
+        _apply_load_transform({"weight": target}, components, transform, plans)
+
+        # A target placed on a mesh without this rank stays unallocated.
+        self.assertFalse(target._is_initialized())
 
     def test_copies_transform_output_across_places(self):
         transform = _LegacyTransform()
         target = paddle.zeros([4, 8], dtype="float32").cpu()
-        components = self._build({"weight": target}, transform)
+        components, plans = self._build({"weight": target}, transform)
         components[_QUANT_KEY].local_tensor.fill_(3)
 
-        _apply_load_transform({"weight": target}, components, transform)
+        _apply_load_transform({"weight": target}, components, transform, plans)
 
         # The transform output lives on the default device; the target does
         # not, so it must be moved before the assign.
@@ -353,10 +391,12 @@ class TestApplyLoadTransform(unittest.TestCase):
     def test_rejects_unsupported_logical_dtype(self):
         transform = _BadDtypeTransform()
         target = _target()
-        components = self._build({"weight": target}, transform)
+        components, plans = self._build({"weight": target}, transform)
 
         with self.assertRaisesRegex(ValueError, "not_a_dtype"):
-            _apply_load_transform({"weight": target}, components, transform)
+            _apply_load_transform(
+                {"weight": target}, components, transform, plans
+            )
 
     def test_paddle_dtype_accepts_prefixed_name(self):
         self.assertIs(_paddle_dtype("paddle.float32"), paddle.float32)

--- a/test/flex_checkpoint/test_load_transform.py
+++ b/test/flex_checkpoint/test_load_transform.py
@@ -1,0 +1,619 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import struct
+import tempfile
+import unittest
+from dataclasses import dataclass
+from unittest import mock
+
+import numpy as np
+
+import paddle
+import paddle.distributed as dist
+from paddle.distributed.flex_checkpoint.dcp.load_state_dict import (
+    _apply_load_transform,
+    _build_transform_component_load_dict,
+    _load_checkpoint_data_file,
+    _metadata_manager,
+    _paddle_dtype,
+    _target_shard_metadata,
+)
+from paddle.distributed.flex_checkpoint.dcp.metadata import (
+    LocalTensorMetadata,
+    Metadata,
+)
+from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
+    ShardedWeight,
+    make_replicated_sharded_weight,
+)
+from paddle.distributed.flex_checkpoint.dcp.utils import (
+    _safetensors_storage_dtype,
+)
+
+_QUANT_KEY = "weight.quant"
+_SCALE_KEY = "weight.scale"
+
+
+@dataclass(frozen=True)
+class _ReadPlan:
+    mode: str
+    logical_local_shape: tuple[int, ...]
+    logical_global_offset: tuple[int, ...]
+    source_slices: dict[str, LocalTensorMetadata]
+
+
+def _logical_metadata(dtype="float32"):
+    return {
+        "weight": LocalTensorMetadata(
+            global_offset=(0, 0),
+            local_shape=(4, 8),
+            dtype=dtype,
+            global_shape=(4, 8),
+        )
+    }
+
+
+class _LocalTransform:
+    """Transform that requests per-rank physical shards via read_plan()."""
+
+    def __init__(self):
+        self.plan = None
+        self.source_key_calls = 0
+        self.force_global_calls = 0
+
+    def logical_metadata(self):
+        return _logical_metadata()
+
+    def source_keys(self, logical_key):
+        self.source_key_calls += 1
+        return [_QUANT_KEY, _SCALE_KEY]
+
+    def read_plan(self, logical_key, target, force_global=False):
+        if force_global:
+            self.force_global_calls += 1
+            self.plan = _ReadPlan("global", (4, 8), (0, 0), {})
+        else:
+            self.plan = _ReadPlan(
+                "local",
+                tuple(target.local_shape),
+                tuple(target.global_offset),
+                {
+                    _QUANT_KEY: LocalTensorMetadata(
+                        tuple(target.global_offset), (2, 8), "uint8", (4, 8)
+                    ),
+                    _SCALE_KEY: LocalTensorMetadata(
+                        (1, 0), (1, 2), "uint8", (2, 2)
+                    ),
+                },
+            )
+        return self.plan
+
+    def read_plan_for(self, logical_key):
+        return self.plan
+
+    def apply(self, logical_key, source_tensors, output_dtype):
+        return source_tensors[_QUANT_KEY].astype(output_dtype)
+
+
+class _LegacyTransform:
+    """Transform without read_plan(): every source tensor is read globally."""
+
+    def logical_metadata(self):
+        return _logical_metadata()
+
+    def source_keys(self, logical_key):
+        return [_QUANT_KEY]
+
+    def apply(self, logical_key, source_tensors, output_dtype):
+        return source_tensors[_QUANT_KEY].astype(output_dtype)
+
+
+class _BadDtypeTransform(_LegacyTransform):
+    def logical_metadata(self):
+        return _logical_metadata(dtype="not_a_dtype")
+
+
+class _DequantTransform:
+    """Assembles one logical fp32 tensor from a uint8 payload and a scale."""
+
+    def logical_metadata(self):
+        return _logical_metadata()
+
+    def source_keys(self, logical_key):
+        return [_QUANT_KEY, _SCALE_KEY]
+
+    def apply(self, logical_key, source_tensors, output_dtype):
+        payload = source_tensors[_QUANT_KEY].astype(output_dtype)
+        scale = source_tensors[_SCALE_KEY].astype(output_dtype)
+        return payload * scale
+
+
+def _physical_metadata():
+    return Metadata(
+        state_dict_metadata={
+            _QUANT_KEY: [LocalTensorMetadata((0, 0), (4, 8), "uint8", (4, 8))],
+            _SCALE_KEY: [LocalTensorMetadata((0, 0), (2, 2), "uint8", (2, 2))],
+        },
+        storage_metadata={},
+    )
+
+
+def _target(local_shape=(2, 8), global_offset=(2, 0)):
+    return ShardedWeight(
+        key="weight",
+        local_tensor=paddle.zeros(list(local_shape), dtype="float32"),
+        local_shape=local_shape,
+        global_shape=(4, 8),
+        global_offset=global_offset,
+    )
+
+
+def _write_safetensors(path, entries):
+    """Write a safetensors file directly so exotic dtypes can be produced.
+
+    ``entries`` maps a tensor name to ``(storage_format, shape, raw_bytes)``.
+    Formats such as ``F8_E4M3`` cannot be produced through numpy, so the
+    container is assembled by hand: an 8-byte little-endian header length,
+    a JSON header, then the concatenated payloads.
+    """
+    header = {}
+    payload = b""
+    for name, (storage_format, shape, raw) in entries.items():
+        header[name] = {
+            "dtype": storage_format,
+            "shape": list(shape),
+            "data_offsets": [len(payload), len(payload) + len(raw)],
+        }
+        payload += raw
+    header_bytes = json.dumps(header).encode()
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header_bytes)))
+        f.write(header_bytes)
+        f.write(payload)
+
+
+def _fp8_checkpoint(directory, scale=2.0):
+    """A HuggingFace-style checkpoint whose payload is raw one-byte fp8."""
+    quant_bytes = bytes(range(32))
+    _write_safetensors(
+        os.path.join(directory, "model.safetensors"),
+        {
+            _QUANT_KEY: ("F8_E4M3", (4, 8), quant_bytes),
+            _SCALE_KEY: (
+                "F32",
+                (1,),
+                np.array([scale], dtype=np.float32).tobytes(),
+            ),
+        },
+    )
+    return np.frombuffer(quant_bytes, dtype=np.uint8).reshape(4, 8)
+
+
+class TestLoadTransformComponentPlan(unittest.TestCase):
+    def _build(self, logical_load_dict, transform, offload=False):
+        return _build_transform_component_load_dict(
+            logical_load_dict, _physical_metadata(), transform, offload
+        )
+
+    def test_returns_nothing_without_transform(self):
+        self.assertEqual(self._build({"weight": _target()}, None), {})
+
+    def test_builds_local_physical_components(self):
+        components = self._build({"weight": _target()}, _LocalTransform())
+
+        quant = components[_QUANT_KEY]
+        scale = components[_SCALE_KEY]
+        self.assertEqual(quant.global_shape, (4, 8))
+        self.assertEqual(quant.local_shape, (2, 8))
+        self.assertEqual(quant.global_offset, (2, 0))
+        self.assertEqual(scale.global_shape, (2, 2))
+        self.assertEqual(scale.local_shape, (1, 2))
+        self.assertEqual(scale.global_offset, (1, 0))
+
+    def test_preserves_component_offsets_in_tuple_keys(self):
+        components = self._build(
+            {("weight", (2, 0)): _target()}, _LocalTransform()
+        )
+
+        self.assertIn((_QUANT_KEY, (2, 0)), components)
+        self.assertIn((_SCALE_KEY, (1, 0)), components)
+
+    def test_forces_global_plan_for_mismatched_targets(self):
+        transform = _LocalTransform()
+        components = self._build(
+            {
+                ("weight", (0, 0)): _target(global_offset=(0, 0)),
+                ("weight", (2, 0)): _target(global_offset=(2, 0)),
+            },
+            transform,
+        )
+
+        self.assertEqual(transform.force_global_calls, 1)
+        # A global plan carries no source slices, so every component falls
+        # back to a fully replicated read at offset zero.
+        self.assertIn((_QUANT_KEY, (0, 0)), components)
+        self.assertEqual(components[(_QUANT_KEY, (0, 0))].local_shape, (4, 8))
+        self.assertEqual(components[(_SCALE_KEY, (0, 0))].local_shape, (2, 2))
+
+    def test_offload_places_components_on_cpu(self):
+        components = self._build(
+            {"weight": _target()}, _LocalTransform(), offload=True
+        )
+
+        for component in components.values():
+            self.assertTrue(component.local_tensor.place.is_cpu_place())
+
+    def test_derives_metadata_from_plain_tensor_target(self):
+        metadata = _target_shard_metadata(paddle.zeros([4, 8], dtype="float32"))
+
+        self.assertEqual(metadata.global_shape, (4, 8))
+        self.assertEqual(metadata.local_shape, (4, 8))
+        self.assertEqual(metadata.global_offset, (0, 0))
+        self.assertEqual(metadata.dtype, "float32")
+
+    def test_derives_metadata_from_sharded_weight_target(self):
+        metadata = _target_shard_metadata(_target())
+
+        self.assertEqual(metadata.global_shape, (4, 8))
+        self.assertEqual(metadata.local_shape, (2, 8))
+        self.assertEqual(metadata.global_offset, (2, 0))
+        self.assertEqual(metadata.dtype, "float32")
+
+
+class TestApplyLoadTransform(unittest.TestCase):
+    def _build(self, logical_load_dict, transform):
+        return _build_transform_component_load_dict(
+            logical_load_dict, _physical_metadata(), transform, False
+        )
+
+    def test_no_op_without_transform(self):
+        target = _target()
+        _apply_load_transform({"weight": target}, {}, None)
+
+        np.testing.assert_array_equal(
+            target.local_tensor.numpy(), np.zeros([2, 8], dtype="float32")
+        )
+
+    def test_collects_source_keys_once_per_logical_key(self):
+        transform = _LocalTransform()
+        self._build({"weight": _target()}, transform)
+
+        self.assertEqual(transform.source_key_calls, 1)
+
+    def test_assigns_local_transform_output_directly(self):
+        transform = _LocalTransform()
+        target = _target()
+        components = self._build({"weight": target}, transform)
+        components[_QUANT_KEY].local_tensor.fill_(1)
+
+        _apply_load_transform({"weight": target}, components, transform)
+
+        np.testing.assert_array_equal(
+            target.local_tensor.numpy(), np.ones([2, 8], dtype="float32")
+        )
+
+    def test_legacy_transform_slices_global_output(self):
+        transform = _LegacyTransform()
+        target = _target()
+        components = self._build({"weight": target}, transform)
+        values = paddle.arange(32, dtype="float32").reshape([4, 8])
+        paddle.assign(
+            values.astype("uint8"), components[_QUANT_KEY].local_tensor
+        )
+
+        _apply_load_transform({"weight": target}, components, transform)
+
+        # The target owns rows [2, 4) of the logical tensor.
+        np.testing.assert_array_equal(
+            target.local_tensor.numpy(), values.numpy()[2:]
+        )
+
+    def test_assigns_into_plain_tensor_target(self):
+        transform = _LegacyTransform()
+        target = paddle.zeros([4, 8], dtype="float32")
+        components = self._build({"weight": target}, transform)
+        values = paddle.arange(32, dtype="float32").reshape([4, 8])
+        paddle.assign(
+            values.astype("uint8"), components[_QUANT_KEY].local_tensor
+        )
+
+        _apply_load_transform({"weight": target}, components, transform)
+
+        np.testing.assert_array_equal(target.numpy(), values.numpy())
+
+    def test_copies_transform_output_across_places(self):
+        transform = _LegacyTransform()
+        target = paddle.zeros([4, 8], dtype="float32").cpu()
+        components = self._build({"weight": target}, transform)
+        components[_QUANT_KEY].local_tensor.fill_(3)
+
+        _apply_load_transform({"weight": target}, components, transform)
+
+        # The transform output lives on the default device; the target does
+        # not, so it must be moved before the assign.
+        self.assertTrue(target.place.is_cpu_place())
+        np.testing.assert_array_equal(
+            target.numpy(), np.full([4, 8], 3.0, dtype="float32")
+        )
+
+    def test_rejects_unsupported_logical_dtype(self):
+        transform = _BadDtypeTransform()
+        target = _target()
+        components = self._build({"weight": target}, transform)
+
+        with self.assertRaisesRegex(ValueError, "not_a_dtype"):
+            _apply_load_transform({"weight": target}, components, transform)
+
+    def test_paddle_dtype_accepts_prefixed_name(self):
+        self.assertIs(_paddle_dtype("paddle.float32"), paddle.float32)
+        self.assertIs(_paddle_dtype("uint8"), paddle.uint8)
+
+
+class TestLoadTransformEndToEnd(unittest.TestCase):
+    """Drives the public dist.load_state_dict(..., load_transform=...) API."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ckpt_path = self._tmp.name
+        # A load that raises leaves the module-level metadata cache populated,
+        # which would otherwise leak into the next test in this process.
+        _metadata_manager.clear()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _save_quantized_checkpoint(self, scale=2.0):
+        payload = np.arange(32, dtype=np.uint8).reshape(4, 8)
+        state_dict = {
+            _QUANT_KEY: make_replicated_sharded_weight(
+                _QUANT_KEY, paddle.to_tensor(payload)
+            ),
+            _SCALE_KEY: make_replicated_sharded_weight(
+                _SCALE_KEY,
+                paddle.to_tensor(np.array([scale], dtype=np.float32)),
+            ),
+        }
+        dist.save_state_dict(state_dict, self.ckpt_path)
+        return payload
+
+    def test_load_state_dict_applies_transform(self):
+        payload = self._save_quantized_checkpoint(scale=2.0)
+        target = make_replicated_sharded_weight(
+            "weight", paddle.zeros([4, 8], dtype="float32")
+        )
+
+        dist.load_state_dict(
+            {"weight": target},
+            self.ckpt_path,
+            load_transform=_DequantTransform(),
+        )
+
+        np.testing.assert_allclose(
+            target.local_tensor.numpy(),
+            payload.astype("float32") * 2.0,
+        )
+
+    def test_rejects_component_key_colliding_with_target(self):
+        self._save_quantized_checkpoint()
+        state_dict = {
+            "weight": make_replicated_sharded_weight(
+                "weight", paddle.zeros([4, 8], dtype="float32")
+            ),
+            _QUANT_KEY: make_replicated_sharded_weight(
+                _QUANT_KEY, paddle.zeros([4, 8], dtype="uint8")
+            ),
+        }
+
+        with self.assertRaisesRegex(ValueError, _QUANT_KEY):
+            dist.load_state_dict(
+                state_dict,
+                self.ckpt_path,
+                load_transform=_DequantTransform(),
+            )
+
+    def test_load_state_dict_applies_transform_on_fp8_safetensors(self):
+        payload = _fp8_checkpoint(self.ckpt_path, scale=2.0)
+        target = make_replicated_sharded_weight(
+            "weight", paddle.zeros([4, 8], dtype="float32")
+        )
+
+        dist.load_state_dict(
+            {"weight": target},
+            self.ckpt_path,
+            safetensors=True,
+            load_transform=_DequantTransform(),
+        )
+
+        # FlexCheckpoint must transport the fp8 bytes untouched; the transform
+        # owns their numerical interpretation.
+        np.testing.assert_allclose(
+            target.local_tensor.numpy(),
+            payload.astype("float32") * 2.0,
+        )
+
+    def test_aoa_renames_the_logical_key_of_a_transform(self):
+        payload = self._save_quantized_checkpoint(scale=2.0)
+        target = make_replicated_sharded_weight(
+            "renamed", paddle.zeros([4, 8], dtype="float32")
+        )
+
+        dist.load_state_dict(
+            {"renamed": target},
+            self.ckpt_path,
+            aoa_config={"aoa_statements": ["weight -> renamed"]},
+            load_transform=_DequantTransform(),
+        )
+
+        # AOA sees the logical tensor published by the transform, not the
+        # physical component keys it was assembled from.
+        np.testing.assert_allclose(
+            target.local_tensor.numpy(),
+            payload.astype("float32") * 2.0,
+        )
+
+    def test_aoa_without_transform_loads_physical_keys(self):
+        payload = self._save_quantized_checkpoint()
+        target = make_replicated_sharded_weight(
+            "quant", paddle.zeros([4, 8], dtype="uint8")
+        )
+
+        dist.load_state_dict(
+            {"quant": target},
+            self.ckpt_path,
+            aoa_config={"aoa_statements": [f"{_QUANT_KEY} -> quant"]},
+        )
+
+        np.testing.assert_array_equal(target.local_tensor.numpy(), payload)
+
+    def test_renamed_master_weight_reads_from_component_dict(self):
+        """A passthrough target may be renamed by master-weight compatibility.
+
+        ``get_rank_to_files`` rewrites the key inside the dict it is handed.
+        With a transform that dict is a fresh merge of passthrough and
+        component targets, so the restore loop can no longer find the renamed
+        key in ``flat_state_dict`` and must fall back to it.
+        """
+        payload = np.arange(32, dtype=np.uint8).reshape(4, 8)
+        master = np.arange(6, dtype=np.float32).reshape(2, 3)
+        dist.save_state_dict(
+            {
+                _QUANT_KEY: make_replicated_sharded_weight(
+                    _QUANT_KEY, paddle.to_tensor(payload)
+                ),
+                _SCALE_KEY: make_replicated_sharded_weight(
+                    _SCALE_KEY,
+                    paddle.to_tensor(np.array([2.0], dtype=np.float32)),
+                ),
+                "opt.w_fp32_master_0": make_replicated_sharded_weight(
+                    "opt.w_fp32_master_0", paddle.to_tensor(master)
+                ),
+            },
+            self.ckpt_path,
+        )
+        logical = make_replicated_sharded_weight(
+            "weight", paddle.zeros([4, 8], dtype="float32")
+        )
+        # The checkpoint stores the flattened spelling; the target uses the
+        # nested one.
+        renamed = make_replicated_sharded_weight(
+            "opt.master_weights.w", paddle.zeros([2, 3], dtype="float32")
+        )
+
+        dist.load_state_dict(
+            {"weight": logical, "opt.master_weights.w": renamed},
+            self.ckpt_path,
+            load_transform=_DequantTransform(),
+        )
+
+        np.testing.assert_allclose(
+            logical.local_tensor.numpy(), payload.astype("float32") * 2.0
+        )
+        np.testing.assert_allclose(renamed.local_tensor.numpy(), master)
+
+
+class TestCheckpointDataFileLoading(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.directory = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _fp8_file(self):
+        payload = _fp8_checkpoint(self.directory)
+        return os.path.join(self.directory, "model.safetensors"), payload
+
+    def test_transports_fp8_safetensors_as_lossless_uint8(self):
+        path, payload = self._fp8_file()
+
+        loaded = _load_checkpoint_data_file(path, True, False)
+
+        self.assertEqual(loaded[_QUANT_KEY].dtype, paddle.uint8)
+        np.testing.assert_array_equal(loaded[_QUANT_KEY].numpy(), payload)
+        self.assertEqual(loaded[_SCALE_KEY].dtype, paddle.float32)
+
+    def test_offload_puts_fp8_safetensors_on_cpu(self):
+        path, payload = self._fp8_file()
+
+        loaded = _load_checkpoint_data_file(path, True, True)
+
+        self.assertEqual(loaded[_QUANT_KEY].dtype, paddle.uint8)
+        self.assertTrue(loaded[_QUANT_KEY].place.is_cpu_place())
+        np.testing.assert_array_equal(loaded[_QUANT_KEY].numpy(), payload)
+
+    def test_restores_dtype_aliases_after_loading(self):
+        path, _ = self._fp8_file()
+        original = paddle.float8_e4m3fn
+        had_numpy_alias = hasattr(np, "float8_e4m3fn")
+
+        _load_checkpoint_data_file(path, True, False)
+
+        self.assertIs(paddle.float8_e4m3fn, original)
+        self.assertEqual(hasattr(np, "float8_e4m3fn"), had_numpy_alias)
+
+    def test_restores_dtype_aliases_when_loading_fails(self):
+        path, _ = self._fp8_file()
+        original = paddle.float8_e4m3fn
+        had_numpy_alias = hasattr(np, "float8_e4m3fn")
+
+        def _fail(*args, **kwargs):
+            raise RuntimeError("checkpoint read failed")
+
+        with (
+            mock.patch.object(paddle, "load", _fail),
+            self.assertRaises(RuntimeError),
+        ):
+            _load_checkpoint_data_file(path, True, False)
+
+        self.assertIs(paddle.float8_e4m3fn, original)
+        self.assertEqual(hasattr(np, "float8_e4m3fn"), had_numpy_alias)
+
+    def test_loads_paddle_format_checkpoint(self):
+        path = os.path.join(self.directory, "shard.distcp")
+        expected = np.arange(6, dtype=np.float32).reshape(2, 3)
+        paddle.save({"w": paddle.to_tensor(expected)}, path)
+        runs_on_cpu = paddle.get_device() == "cpu"
+
+        for offload in (False, True):
+            loaded = _load_checkpoint_data_file(path, False, offload)
+            np.testing.assert_array_equal(loaded["w"].numpy(), expected)
+            self.assertEqual(
+                loaded["w"].place.is_cpu_place(),
+                offload or runs_on_cpu,
+            )
+
+
+class TestSafetensorsStorageDtype(unittest.TestCase):
+    def test_maps_registered_formats(self):
+        self.assertEqual(_safetensors_storage_dtype("BF16"), "bfloat16")
+        self.assertEqual(_safetensors_storage_dtype("F32"), "float32")
+        self.assertEqual(_safetensors_storage_dtype("I64"), "int64")
+        self.assertEqual(_safetensors_storage_dtype("BOOL"), "bool")
+
+    def test_maps_raw_one_byte_formats_to_uint8(self):
+        for storage_format in ("F8_E4M3", "F8_E4M3FN", "F8_E8M0"):
+            self.assertEqual(
+                _safetensors_storage_dtype(storage_format), "uint8"
+            )
+
+    def test_rejects_unregistered_format(self):
+        with self.assertRaisesRegex(ValueError, "F4_E2M1"):
+            _safetensors_storage_dtype("F4_E2M1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/flex_checkpoint/test_load_transform_dist.py
+++ b/test/flex_checkpoint/test_load_transform_dist.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+import unittest
+
+import collective.test_communication_api_base as test_base
+
+
+class TestLoadTransformShardedTarget(test_base.CommunicationTestDistBase):
+    def setUp(self):
+        super().setUp(num_of_devices=2)
+
+    def _run_case(self, transform_case):
+        with tempfile.TemporaryDirectory() as ckpt_dir:
+            self.run_test_case(
+                "load_transform_dist_logic.py",
+                user_defined_envs={
+                    "ckpt_path": ckpt_dir,
+                    "transform_case": transform_case,
+                },
+            )
+
+    def test_sharded_target_global_read(self):
+        self._run_case("global")
+
+    def test_sharded_target_local_read_plan(self):
+        self._run_case("local")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category

Auto Parallel

### PR Types

New features

### Description

FlexCheckpoint currently assumes every physical checkpoint tensor maps one-to-one onto a logical model weight. Quantized checkpoints break that assumption: a single logical weight is stored as several physical tensors (packed values plus scales), frequently in element formats that have no exact Paddle dtype.

This PR introduces `paddle.distributed.LoadTransform`, a format-independent protocol that lets the caller own the numerical interpretation while FlexCheckpoint keeps owning I/O, resharding, and AOA.

A transform declares three things:

- `logical_metadata()` — the virtual logical tensors it exposes
- `source_keys(logical_key)` — the physical checkpoint tensors each logical tensor consumes
- `apply(logical_key, source_tensors, output_dtype)` — how to materialize the logical tensor

A transform may additionally provide `read_plan(logical_key, target_metadata, force_global=False)` to narrow the physical read to the shard a rank actually needs; `target_metadata` describes the local shard of the target on that rank. When the returned plan is `"local"`, `apply()` receives local source shards and returns the local shard of the logical tensor; otherwise it receives and returns whole tensors.

The transform runs after the physical components have been fully assembled, so dequantization logic stays out of the reshard and communication layers.

#### Supporting changes

- `load_state_dict` / `load_state_dict_impl` take a `load_transform` argument and split the load dict into passthrough targets and physical components. Collisions between component keys and passthrough targets are rejected explicitly.
- AOA is given the logical tensors instead of the physical components they consume, so renames and other AOA statements apply to the logical key.
- Safetensors one-byte formats (`F8_E4M3`, `F8_E4M3FN`, `F8_E8M0`) are transported losslessly as `uint8`. Previously `assert dtype in dtype_mapping` rejected them; unregistered formats now raise a descriptive `ValueError` rather than being silently reinterpreted.
- `create_hf_ckpt_metadata` returns the metadata it builds, and no longer assumes a distributed environment is initialized (`is_initialized()` guard before `get_world_size()`).
- Variadic tuple type hints in `metadata.py` (`tuple[int]` -> `tuple[int, ...]`).

#### Tests

`test/flex_checkpoint/test_load_transform.py`, 31 single-process cases covering component planning, offload placement, local vs. global read plans, target shard description (plain tensor, `ShardedWeight`, and a target absent on the rank), dtype validation, AOA interaction with logical keys, master-weight renaming, FP8 safetensors transport losslessness, dtype-alias restoration (including on failure), and end-to-end `load_state_dict` with a dequantizing transform.

`test/flex_checkpoint/test_load_transform_dist.py`, a two-card case that loads into a `dist.shard_tensor(..., [dist.Shard(0)])` target, once with a transform that only implements the required three methods and once with a transform that also implements `read_plan()` and asserts it is told its own shard. The second case fails if a target's local shard is derived from its (global) `shape`.

Verified passing on both CPU-only and single-GPU runs, plus the two-card suite on 2 GPUs; existing `test/flex_checkpoint` single-process suites remain green.

#### Backward compatibility

`load_transform` defaults to `None` and every new code path is gated on it, so existing load behaviour is unchanged.

### 是否引起精度变化

否

