### PR TITLE
[Operator Mechanism] Align put_along_axis shape check with torch

### DIFF
--- a/paddle/phi/backends/gpu/gpu_primitives.h
+++ b/paddle/phi/backends/gpu/gpu_primitives.h
@@ -455,12 +455,12 @@ CUDA_ATOMIC_WRAPPER(Mul, float) {
   return __int_as_float(old);
 }
 
-__device__ __forceinline__ uint32_t __loadAligned(const uintptr_t base_addr,
-                                                  uint32_t mask,
-                                                  uint32_t shift) {
-  // get 4B aligned address
-  uint32_t aligned_value = *reinterpret_cast<const uint32_t *>(base_addr);
-  return (aligned_value & mask) >> shift;
+// Reads the whole 4B aligned word holding the sub-word element. Callers keep
+// the neighbouring lanes of that word untouched by rebuilding it as
+// ``(old32 & ~mask) | (new_element << shift)``, so they need the full word
+// here, not just the element.
+__device__ __forceinline__ uint32_t __loadAligned(const uintptr_t base_addr) {
+  return *reinterpret_cast<const uint32_t *>(base_addr);
 }
 
 CUDA_ATOMIC_WRAPPER(Mul, uint8_t) {
@@ -470,7 +470,7 @@ CUDA_ATOMIC_WRAPPER(Mul, uint8_t) {
   uint32_t shift = offset * 8;
   uint32_t mask = 0xFFU << shift;
 
-  uint32_t old32 = __loadAligned(base_addr, mask, shift), assumed32 = 0;
+  uint32_t old32 = __loadAligned(base_addr), assumed32 = 0;
 
   do {
     assumed32 = old32;
@@ -493,14 +493,18 @@ CUDA_ATOMIC_WRAPPER(Mul, int16_t) {
   uint32_t shift = offset * 16;
   uint32_t mask = 0xFFFFU << shift;
 
-  uint32_t old32 = __loadAligned(base_addr, mask, shift), assumed32 = 0;
+  uint32_t old32 = __loadAligned(base_addr), assumed32 = 0;
 
   do {
     assumed32 = old32;
     int16_t current = static_cast<int16_t>((old32 & mask) >> shift);
     int16_t new_val = current * val;
+    // Narrow to uint16_t first: a plain ``static_cast<uint32_t>`` of a negative
+    // int16_t sign extends, and the ``|`` below would then overwrite the
+    // neighbouring halfword of the word with 0xFFFF.
     uint32_t new32 =
-        (old32 & ~mask) | (static_cast<uint32_t>(new_val) << shift);
+        (old32 & ~mask) |
+        (static_cast<uint32_t>(static_cast<uint16_t>(new_val)) << shift);
 
     old32 =
         atomicCAS(reinterpret_cast<uint32_t *>(base_addr), assumed32, new32);
@@ -1001,7 +1005,7 @@ CUDA_ATOMIC_WRAPPER(Min, phi::dtype::bfloat16) {
     }                                                                         \
     uint8_t current = 0;                                                      \
     uint8_t new_val = 0;                                                      \
-    uint32_t assumed32 = 0, old32 = __loadAligned(base_addr, mask, shift);    \
+    uint32_t assumed32 = 0, old32 = __loadAligned(base_addr);                 \
     do {                                                                      \
       assumed32 = old32;                                                      \
       current = static_cast<uint8_t>((old32 & mask) >> shift);                \

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -2581,19 +2581,33 @@ void PutAlongAxisInferMeta(const MetaTensor& x,
   const auto& index_dims = index.dims();
   const auto& value_dims = value.dims();
 
+  // 0-D tensors are handled as 1-D tensors holding a single element, the same
+  // way ``ensure_nonempty_dim`` / ``ensure_nonempty_size`` do in torch.
+  auto nonempty_rank = [](const DDim& dims) {
+    return std::max<int>(static_cast<int>(dims.size()), 1);
+  };
+  auto nonempty_size = [](const DDim& dims, int d) -> int64_t {
+    return dims.size() == 0 ? 1 : dims[d];
+  };
+
+  // torch normalizes ``dim`` and checks its range in ``scatter_meta_impl``
+  // before the empty-index short circuit of ``scatter_shape_check``, so an
+  // illegal axis is reported even when nothing would be scattered.
+  const int rank = nonempty_rank(x_dims);
+  const int dim = axis < 0 ? axis + rank : axis;
+  PADDLE_ENFORCE_EQ(
+      dim >= 0 && dim < rank,
+      true,
+      common::errors::OutOfRange(
+          "Dimension out of range, expected axis to be in [%d, %d), but got "
+          "%d.",
+          -rank,
+          rank,
+          axis));
+
   // Mirrors ``scatter_shape_check`` in torch: an empty ``index`` performs no
   // scatter at all, so no shape constraint applies to it.
   if (common::product(index_dims) != 0) {
-    // 0-D tensors are handled as 1-D tensors holding a single element, the same
-    // way ``ensure_nonempty_dim`` / ``ensure_nonempty_size`` do in torch.
-    auto nonempty_rank = [](const DDim& dims) {
-      return std::max<int>(static_cast<int>(dims.size()), 1);
-    };
-    auto nonempty_size = [](const DDim& dims, int d) -> int64_t {
-      return dims.size() == 0 ? 1 : dims[d];
-    };
-
-    const int rank = nonempty_rank(x_dims);
     PADDLE_ENFORCE_EQ(
         nonempty_rank(index_dims),
         rank,
@@ -2610,17 +2624,6 @@ void PutAlongAxisInferMeta(const MetaTensor& x,
             "tensor, but got index %s and value %s.",
             index_dims,
             value_dims));
-
-    const int dim = axis < 0 ? axis + rank : axis;
-    PADDLE_ENFORCE_EQ(
-        dim >= 0 && dim < rank,
-        true,
-        common::errors::OutOfRange(
-            "Dimension out of range, expected axis to be in [%d, %d), but got "
-            "%d.",
-            -rank,
-            rank,
-            axis));
 
     for (int d = 0; d < rank; ++d) {
       const int64_t index_d = nonempty_size(index_dims, d);

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/phi/infermeta/ternary.h"
 
+#include <algorithm>
 #include <array>
 
 #include "glog/logging.h"
@@ -2576,7 +2577,95 @@ void PutAlongAxisInferMeta(const MetaTensor& x,
                            int axis,
                            const std::string& reduce,
                            MetaTensor* out) {
-  out->set_dims(x.dims());
+  const auto& x_dims = x.dims();
+  const auto& index_dims = index.dims();
+  const auto& value_dims = value.dims();
+
+  // Mirrors ``scatter_shape_check`` in torch: an empty ``index`` performs no
+  // scatter at all, so no shape constraint applies to it.
+  if (common::product(index_dims) != 0) {
+    // 0-D tensors are handled as 1-D tensors holding a single element, the same
+    // way ``ensure_nonempty_dim`` / ``ensure_nonempty_size`` do in torch.
+    auto nonempty_rank = [](const DDim& dims) {
+      return std::max<int>(static_cast<int>(dims.size()), 1);
+    };
+    auto nonempty_size = [](const DDim& dims, int d) -> int64_t {
+      return dims.size() == 0 ? 1 : dims[d];
+    };
+
+    const int rank = nonempty_rank(x_dims);
+    PADDLE_ENFORCE_EQ(
+        nonempty_rank(index_dims),
+        rank,
+        common::errors::InvalidArgument(
+            "Index tensor must have the same number of dimensions as self "
+            "tensor, but got index %s and self %s.",
+            index_dims,
+            x_dims));
+    PADDLE_ENFORCE_EQ(
+        nonempty_rank(value_dims),
+        rank,
+        common::errors::InvalidArgument(
+            "Index tensor must have the same number of dimensions as value "
+            "tensor, but got index %s and value %s.",
+            index_dims,
+            value_dims));
+
+    const int dim = axis < 0 ? axis + rank : axis;
+    PADDLE_ENFORCE_EQ(
+        dim >= 0 && dim < rank,
+        true,
+        common::errors::OutOfRange(
+            "Dimension out of range, expected axis to be in [%d, %d), but got "
+            "%d.",
+            -rank,
+            rank,
+            axis));
+
+    for (int d = 0; d < rank; ++d) {
+      const int64_t index_d = nonempty_size(index_dims, d);
+      if (index_d < 0) {
+        // dynamic shape, nothing can be decided here.
+        continue;
+      }
+      // ``index`` addresses ``x`` with its own coordinates on every dimension
+      // but ``dim``, so being larger than ``x`` there would make the scatter
+      // kernel write out of bounds.
+      const int64_t x_d = nonempty_size(x_dims, d);
+      if (d != dim && x_d >= 0) {
+        PADDLE_ENFORCE_LE(
+            index_d,
+            x_d,
+            common::errors::InvalidArgument(
+                "Size does not match at dimension %d expected index %s to be "
+                "no larger than self %s apart from dimension %d and to be no "
+                "larger than value %s.",
+                d,
+                index_dims,
+                x_dims,
+                dim,
+                value_dims));
+      }
+      // Unlike ``x``, every coordinate of ``index`` also reads ``value``, so
+      // ``dim`` is constrained here as well.
+      const int64_t value_d = nonempty_size(value_dims, d);
+      if (value_d >= 0) {
+        PADDLE_ENFORCE_LE(
+            index_d,
+            value_d,
+            common::errors::InvalidArgument(
+                "Size does not match at dimension %d expected index %s to be "
+                "no larger than self %s apart from dimension %d and to be no "
+                "larger than value %s.",
+                d,
+                index_dims,
+                x_dims,
+                dim,
+                value_dims));
+      }
+    }
+  }
+  out->set_dims(x_dims);
   out->set_dtype(x.dtype());
 }
 

--- a/paddle/phi/kernels/cpu/put_along_axis_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/put_along_axis_grad_kernel.cc
@@ -26,16 +26,26 @@ namespace phi {
 
 template <typename T, typename Context>
 void PutAlongAxisGradKernel(const Context& dev_ctx,
-                            const DenseTensor& x,
-                            const DenseTensor& index,
-                            const DenseTensor& value,
-                            const DenseTensor& out,
-                            const DenseTensor& out_grad,
+                            const DenseTensor& arr,
+                            const DenseTensor& indices,
+                            const DenseTensor& values,
+                            const DenseTensor& output,
+                            const DenseTensor& output_grad,
                             int axis,
                             const std::string& reduce,
                             bool include_self,
                             DenseTensor* x_grad,
                             DenseTensor* value_grad) {
+  // Shallow views sharing the caller's buffers, so the promotion below rewrites
+  // local metadata only. The two early returns are left to run on the shapes
+  // exactly as the caller wrote them: a 0-size operand must still be answered
+  // with a 0-size gradient.
+  DenseTensor x = arr;
+  DenseTensor index = indices;
+  DenseTensor value = values;
+  DenseTensor out = output;
+  DenseTensor out_grad = output_grad;
+
   if (x.numel() == 0) {
     if (x_grad) {
       dev_ctx.template Alloc<T>(x_grad);
@@ -56,8 +66,20 @@ void PutAlongAxisGradKernel(const Context& dev_ctx,
     }
     return;
   }
+  // Brings the operands into the representation the scatter functor can
+  // address: a 0-D operand becomes rank 1 and ``axis`` is normalized, the same
+  // way the forward kernel does. A 0-D tensor has ``numel() == 1``, so it gets
+  // here, and the functor would then read ``dims()`` and ``strides()`` slots
+  // that ``calc_strides`` never wrote and size ``CoordinateManager`` from
+  // ``index.dims().size() == 0``.
+  funcs::PreparePutAlongAxisGradOperands(
+      &x, &index, &value, &out, &out_grad, &axis);
+
   const auto& index_type = index.dtype();
   if (x_grad) {
+    // ``Copy`` gives ``x_grad`` the promoted shape of ``out_grad``, so the
+    // functor writes through a rank-1 buffer. The shape the caller expects is
+    // the one of ``arr``, restored once the scatter is done.
     Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
     if (include_self == false || reduce == "assign") {
       if (index_type == DataType::INT32) {
@@ -119,9 +141,12 @@ void PutAlongAxisGradKernel(const Context& dev_ctx,
             out_grad, axis, index, *x_grad, include_self, dev_ctx);
       }
     }
+    x_grad->Resize(arr.dims());
   }
 
   if (value_grad) {
+    // The gradient of ``value`` carries the shape of the index: the functor is
+    // given the promoted one, the caller gets back the one it wrote.
     value_grad->Resize(index.dims());
     dev_ctx.template Alloc<T>(value_grad);
     auto* grad_data = value_grad->data<T>();
@@ -187,6 +212,7 @@ void PutAlongAxisGradKernel(const Context& dev_ctx,
             dev_ctx);
       }
     }
+    value_grad->Resize(indices.dims());
   }
 }
 

--- a/paddle/phi/kernels/cpu/put_along_axis_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/put_along_axis_grad_kernel.cc
@@ -20,6 +20,7 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/funcs/for_range.h"
 #include "paddle/phi/kernels/funcs/gather_scatter_functor.h"
 
 namespace phi {
@@ -81,6 +82,20 @@ void PutAlongAxisGradKernel(const Context& dev_ctx,
     // functor writes through a rank-1 buffer. The shape the caller expects is
     // the one of ``arr``, restored once the scatter is done.
     Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
+    // torch derives the whole input gradient of a scatter-mul from a single
+    // expression over the tensor, and on every position no index reaches that
+    // expression collapses to a redundant ``(g * m) / m``. Replaying it here is
+    // what keeps the two frameworks bit for bit identical there; the positions
+    // an index does reach are overwritten below, from the untouched
+    // ``out_grad``.
+    if constexpr (funcs::MulInputGradNeedsRoundTrip<T>()) {
+      if (reduce == "mul" || reduce == "multiply") {
+        funcs::ForRange<Context> for_range(
+            dev_ctx, static_cast<size_t>(x_grad->numel()));
+        for_range(funcs::MulInputGradRoundTripFunctor<T>{x.data<T>(),
+                                                         x_grad->data<T>()});
+      }
+    }
     if (include_self == false || reduce == "assign") {
       if (index_type == DataType::INT32) {
         funcs::cpu_scatter_input_grad_kernel<T, int32_t>(

--- a/paddle/phi/kernels/cpu/put_along_axis_kernel.cc
+++ b/paddle/phi/kernels/cpu/put_along_axis_kernel.cc
@@ -26,14 +26,27 @@ namespace phi {
 template <typename T, typename Context>
 void PutAlongAxisKernel(const Context& dev_ctx,
                         const DenseTensor& x,
-                        const DenseTensor& index,
-                        const DenseTensor& value,
+                        const DenseTensor& indices,
+                        const DenseTensor& values,
                         int axis,
                         const std::string& reduce,
                         bool include_self,
                         DenseTensor* out) {
   Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+
+  // Brings the operands into the representation the scatter functor can
+  // address: a 0-D operand becomes rank 1 and ``axis`` is normalized.
+  // ``index`` and ``value`` are shallow views sharing the caller's buffer.
+  // ``out`` is promoted in place because the scatter writes through it, so its
+  // shape is saved here and restored once the scatter is done -- reading it
+  // back from ``x`` would not do, since ``x`` and ``out`` are the same tensor
+  // when the op runs inplace.
+  const DDim out_dims = out->dims();
+  DenseTensor index = indices;
+  DenseTensor value = values;
   const auto& index_type = index.dtype();
+  funcs::PreparePutAlongAxisOperands(out, &index, &value, &axis);
+
   if (reduce == "add") {
     if (index_type == DataType::INT32) {
       funcs::cpu_scatter_add_kernel<T, int32_t>(
@@ -92,6 +105,7 @@ void PutAlongAxisKernel(const Context& dev_ctx,
         reduce));
     return;
   }
+  out->Resize(out_dims);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cc
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cc
@@ -485,7 +485,7 @@ void cpu_scatter_input_grad_kernel(DenseTensor self UNUSED,
 }
 
 template <typename tensor_t, typename index_t>
-void cpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self UNUSED,
+void cpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
                                                int dim,
                                                const DenseTensor& index,
                                                const DenseTensor& out,
@@ -500,6 +500,7 @@ void cpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self UNUSED,
   auto* out_data = out.data<tensor_t>();
   auto* x_data = x.data<tensor_t>();
   auto* value_data = value.data<tensor_t>();
+  const auto* self_data = self.data<tensor_t>();
 
   const int ndim = index.dims().size();
   const int64_t index_size = index.numel();
@@ -541,17 +542,21 @@ void cpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self UNUSED,
     int64_t replace_index_grad = cm.offset1;
     if (is_mul && num_elements[replace_index_grad] == 0) {
       const tensor_t x = x_data[replace_index_grad];
+      // The base gradient is read from ``out_grad`` and not from ``grad_data``:
+      // ``MulInputGradRoundTripFunctor`` has already rewritten the latter with
+      // torch's redundant ``(g * m) / m`` for the sake of the positions no
+      // index reaches, and this position is not one of them.
+      const tensor_t g = self_data[replace_index_grad];
       const int zeros = zero_count[replace_index_grad] +
                         (x == static_cast<tensor_t>(0) ? 1 : 0);
       if (zeros == 0) {
-        tensor_t val = grad_data[replace_index_grad];
+        tensor_t val = g;
         val *= out_data[replace_index_grad];
         val /= x;
         grad_data[replace_index_grad] = static_cast<tensor_t>(val);
       } else if (zeros == 1 && x == static_cast<tensor_t>(0)) {
         grad_data[replace_index_grad] =
-            static_cast<tensor_t>(grad_data[replace_index_grad] *
-                                  masked_value_prod[replace_index_grad]);
+            static_cast<tensor_t>(g * masked_value_prod[replace_index_grad]);
       } else {
         // ``x`` is not the only zero factor, so the product stays zero whatever
         // ``x`` becomes.

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cc
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cc
@@ -274,9 +274,9 @@ struct cpu_gather_scatter_functor {
         method_name == "gather" || method_name == "assign";
 
     if (self_size == 0 || src_size == 0 || index_size == 0) {
+      // Nothing to read or write. Shape validation lives in the InferMeta of
+      // the calling op, not here.
       VLOG(3) << "zero size input found";
-      common::errors::InvalidArgument(
-          "self_size, src_size, index_size cannot be 0");
       return;
     }
     int64_t self_select_dim_size = self_dims[dim];

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cc
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cc
@@ -245,6 +245,26 @@ class ReversedCoordinateManager {
   }
 };
 
+// The subscript read from ``index`` is runtime data: no shape check can bound
+// it, so every caller of ``CalculateOffset`` has to reject an out of range one
+// and fold a negative one into ``[0, dim_size)`` first. Neither coordinate
+// manager does it, and a raw negative subscript becomes a negative offset, that
+// is, an access before the start of the tensor. ``dim_size`` is the length
+// along ``dim`` of the tensor the subscript addresses -- never that of
+// ``index`` itself, which may differ.
+static int64_t NormalizeScatterIndex(int64_t index, int64_t dim_size) {
+  PADDLE_ENFORCE_EQ((index >= -dim_size) && (index < dim_size),
+                    true,
+                    common::errors::OutOfRange(
+                        "Variable value (index) of scatter grad cpu kernel, "
+                        "expected >= %ld and < %ld, but got %ld."
+                        "Please check the input value.",
+                        -dim_size,
+                        dim_size,
+                        index));
+  return index < 0 ? index + dim_size : index;
+}
+
 template <typename tensor_t,
           typename index_t = int64_t,
           bool is_scatter_like = true>
@@ -474,10 +494,12 @@ void cpu_scatter_input_grad_kernel(DenseTensor self UNUSED,
 
   const int ndim = index.dims().size();
   const int64_t index_size = index.numel();
+  // The subscript addresses the gradient of ``x``.
+  const int64_t self_select_dim_size = grad.dims()[dim];
   CoordinateManager<false> cm(index.dims(), grad.strides(), ndim, dim, nullptr);
 
   for (int64_t i = 0; i < index_size; i++) {
-    int64_t index = index_data[i];
+    int64_t index = NormalizeScatterIndex(index_data[i], self_select_dim_size);
     cm.CalculateOffset(index);
     int64_t replace_index = cm.offset1;
     grad_data[replace_index] = 0;
@@ -505,6 +527,8 @@ void cpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
   const int ndim = index.dims().size();
   const int64_t index_size = index.numel();
   const int64_t grad_size = grad.numel();
+  // The subscript addresses the gradient of ``x``.
+  const int64_t self_select_dim_size = grad.dims()[dim];
   // only amin/amax needs the offset2, but we compute together anyway.
   CoordinateManager<true> cm(
       index.dims(), grad.strides(), ndim, dim, &value.strides());
@@ -525,7 +549,8 @@ void cpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
     CoordinateManager<true> pre_cm(
         index.dims(), grad.strides(), ndim, dim, &value.strides());
     for (int64_t i = 0; i < index_size; i++) {
-      int64_t index = index_data[i];
+      int64_t index =
+          NormalizeScatterIndex(index_data[i], self_select_dim_size);
       pre_cm.CalculateOffset(index);
       const tensor_t value_i = value_data[pre_cm.offset2];
       if (value_i == static_cast<tensor_t>(0)) {
@@ -537,7 +562,7 @@ void cpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
     }
   }
   for (int64_t i = 0; i < index_size; i++) {
-    int64_t index = index_data[i];
+    int64_t index = NormalizeScatterIndex(index_data[i], self_select_dim_size);
     cm.CalculateOffset(index);
     int64_t replace_index_grad = cm.offset1;
     if (is_mul && num_elements[replace_index_grad] == 0) {
@@ -597,10 +622,12 @@ void cpu_scatter_mean_input_grad_kernel(DenseTensor self UNUSED,
 
   const int ndim = index.dims().size();
   const int64_t index_size = index.numel();
+  // The subscript addresses the gradient of ``x``.
+  const int64_t self_select_dim_size = grad.dims()[dim];
   CoordinateManager<false> cm(index.dims(), grad.strides(), ndim, dim, nullptr);
   std::vector<int> num_elements(grad_size, 0);
   for (int64_t i = 0; i < index_size; i++) {
-    int64_t index = index_data[i];
+    int64_t index = NormalizeScatterIndex(index_data[i], self_select_dim_size);
     cm.CalculateOffset(index);
     int64_t replace_index = cm.offset1;
     num_elements[replace_index] += 1;
@@ -624,11 +651,14 @@ void cpu_scatter_value_grad_kernel(DenseTensor self,
   std::vector<bool> is_self_grad_used(self.numel(), false);
 
   const int ndim = index.dims().size();
+  // Here the subscript addresses ``out_grad``, the operand shaped like ``x``;
+  // ``grad`` is the gradient of ``value`` and carries the shape of ``index``.
+  const int64_t self_select_dim_size = self.dims()[dim];
   ReversedCoordinateManager<true> cm(
       index.dims(), self.strides(), ndim, dim, &grad.strides());
 
   for (int64_t i = index.numel() - 1; i >= 0; i--) {
-    int64_t index = index_data[i];
+    int64_t index = NormalizeScatterIndex(index_data[i], self_select_dim_size);
     cm.CalculateOffset(index);
     int64_t replace_index_self = cm.offset1;
     int64_t replace_index_grad = cm.offset2;
@@ -660,6 +690,9 @@ void cpu_scatter_add_mean_value_grad_kernel(DenseTensor self,
 
   std::vector<int> num_elements;
   const int ndim = index.dims().size();
+  // Here the subscript addresses ``out_grad``, the operand shaped like ``x``;
+  // ``grad`` is the gradient of ``value`` and carries the shape of ``index``.
+  const int64_t self_select_dim_size = self.dims()[dim];
 
   // Note: make sure that `reduce` in {'mean', 'add'}.
   const bool is_mean = reduce == "mean";
@@ -669,7 +702,8 @@ void cpu_scatter_add_mean_value_grad_kernel(DenseTensor self,
         index.dims(), self.strides(), ndim, dim, nullptr);
 
     for (int64_t i = index.numel() - 1; i >= 0; i--) {
-      int64_t index = index_data[i];
+      int64_t index =
+          NormalizeScatterIndex(index_data[i], self_select_dim_size);
       cm.CalculateOffset(index);
       int64_t replace_index_self = cm.offset1;
       num_elements[replace_index_self] += 1;
@@ -679,7 +713,7 @@ void cpu_scatter_add_mean_value_grad_kernel(DenseTensor self,
   ReversedCoordinateManager<true> cm(
       index.dims(), self.strides(), ndim, dim, &grad.strides());
   for (int64_t i = index.numel() - 1; i >= 0; i--) {
-    int64_t index = index_data[i];
+    int64_t index = NormalizeScatterIndex(index_data[i], self_select_dim_size);
     cm.CalculateOffset(index);
     int64_t replace_index_self = cm.offset1;
     int64_t replace_index_grad = cm.offset2;
@@ -717,6 +751,9 @@ void cpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
 
   const int ndim = index.dims().size();
   const int64_t index_size = index.numel();
+  // Here the subscript addresses ``out_grad``, the operand shaped like ``x``;
+  // ``grad`` is the gradient of ``value`` and carries the shape of ``index``.
+  const int64_t self_select_dim_size = self.dims()[dim];
   // The derivative of a product is the product of the *other* factors. Once one
   // factor is zero ``out`` no longer carries the others, so the zero factors
   // are counted and the non-zero ones multiplied on the side.
@@ -728,7 +765,8 @@ void cpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
     CoordinateManager<true> pre_cm(
         index.dims(), self.strides(), ndim, dim, &grad.strides());
     for (int64_t i = 0; i < index_size; i++) {
-      int64_t index = index_data[i];
+      int64_t index =
+          NormalizeScatterIndex(index_data[i], self_select_dim_size);
       pre_cm.CalculateOffset(index);
       const tensor_t value_i = value_data[pre_cm.offset2];
       if (value_i == static_cast<tensor_t>(0)) {
@@ -743,7 +781,8 @@ void cpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
     CoordinateManager<true> cm(
         index.dims(), self.strides(), ndim, dim, &grad.strides());
     for (int64_t i = 0; i < index_size; i++) {
-      int64_t index = index_data[i];
+      int64_t index =
+          NormalizeScatterIndex(index_data[i], self_select_dim_size);
       cm.CalculateOffset(index);
       int64_t replace_index_self = cm.offset1;
       int64_t replace_index_grad = cm.offset2;
@@ -777,7 +816,8 @@ void cpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
     CoordinateManager<true> cm(
         index.dims(), self.strides(), ndim, dim, &grad.strides());
     for (int64_t i = 0; i < index_size; i++) {
-      int64_t index = index_data[i];
+      int64_t index =
+          NormalizeScatterIndex(index_data[i], self_select_dim_size);
       cm.CalculateOffset(index);
       int64_t replace_index_self = cm.offset1;
       int64_t replace_index_grad = cm.offset2;

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cc
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cc
@@ -511,17 +511,50 @@ void cpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self UNUSED,
   // make sure that reduce in {'mul', 'multiply', 'amin', 'amax'}
   const bool is_mul = reduce == "multiply" || reduce == "mul";
   std::vector<int> num_elements(grad.numel(), 0);
+  // The derivative of a product is the product of the *other* factors. Once one
+  // factor is zero ``out`` no longer carries the others, so the zero factors
+  // are counted and the non-zero ones multiplied on the side.
+  std::vector<int> zero_count;
+  std::vector<tensor_t> masked_value_prod;
+  if (is_mul) {
+    zero_count.assign(grad_size, 0);
+    masked_value_prod.assign(grad_size, static_cast<tensor_t>(1));
+    // ``cm`` is stateful and must not be stepped more than index.numel()
+    // times, so the pre-pass needs its own walker.
+    CoordinateManager<true> pre_cm(
+        index.dims(), grad.strides(), ndim, dim, &value.strides());
+    for (int64_t i = 0; i < index_size; i++) {
+      int64_t index = index_data[i];
+      pre_cm.CalculateOffset(index);
+      const tensor_t value_i = value_data[pre_cm.offset2];
+      if (value_i == static_cast<tensor_t>(0)) {
+        zero_count[pre_cm.offset1] += 1;
+      } else {
+        masked_value_prod[pre_cm.offset1] =
+            masked_value_prod[pre_cm.offset1] * value_i;
+      }
+    }
+  }
   for (int64_t i = 0; i < index_size; i++) {
     int64_t index = index_data[i];
     cm.CalculateOffset(index);
     int64_t replace_index_grad = cm.offset1;
     if (is_mul && num_elements[replace_index_grad] == 0) {
-      if (x_data[replace_index_grad] != static_cast<tensor_t>(0)) {
+      const tensor_t x = x_data[replace_index_grad];
+      const int zeros = zero_count[replace_index_grad] +
+                        (x == static_cast<tensor_t>(0) ? 1 : 0);
+      if (zeros == 0) {
         tensor_t val = grad_data[replace_index_grad];
         val *= out_data[replace_index_grad];
-        val /= x_data[replace_index_grad];
+        val /= x;
         grad_data[replace_index_grad] = static_cast<tensor_t>(val);
+      } else if (zeros == 1 && x == static_cast<tensor_t>(0)) {
+        grad_data[replace_index_grad] =
+            static_cast<tensor_t>(grad_data[replace_index_grad] *
+                                  masked_value_prod[replace_index_grad]);
       } else {
+        // ``x`` is not the only zero factor, so the product stays zero whatever
+        // ``x`` becomes.
         grad_data[replace_index_grad] = static_cast<tensor_t>(0);
       }
       num_elements[replace_index_grad] += 1;
@@ -679,6 +712,28 @@ void cpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
 
   const int ndim = index.dims().size();
   const int64_t index_size = index.numel();
+  // The derivative of a product is the product of the *other* factors. Once one
+  // factor is zero ``out`` no longer carries the others, so the zero factors
+  // are counted and the non-zero ones multiplied on the side.
+  std::vector<int> zero_count;
+  std::vector<tensor_t> masked_value_prod;
+  if (!is_min_max) {
+    zero_count.assign(self.numel(), 0);
+    masked_value_prod.assign(self.numel(), static_cast<tensor_t>(1));
+    CoordinateManager<true> pre_cm(
+        index.dims(), self.strides(), ndim, dim, &grad.strides());
+    for (int64_t i = 0; i < index_size; i++) {
+      int64_t index = index_data[i];
+      pre_cm.CalculateOffset(index);
+      const tensor_t value_i = value_data[pre_cm.offset2];
+      if (value_i == static_cast<tensor_t>(0)) {
+        zero_count[pre_cm.offset1] += 1;
+      } else {
+        masked_value_prod[pre_cm.offset1] =
+            masked_value_prod[pre_cm.offset1] * value_i;
+      }
+    }
+  }
   {  // `cm` should be destroyed once the computation is done, no reuse
     CoordinateManager<true> cm(
         index.dims(), self.strides(), ndim, dim, &grad.strides());
@@ -691,11 +746,22 @@ void cpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
           out_data[replace_index_self] == value_data[replace_index_grad]) {
         num_elements[replace_index_self] += 1;
       } else if (!is_min_max) {
-        if (value_data[replace_index_grad] != static_cast<tensor_t>(0)) {
+        const tensor_t value_i = value_data[replace_index_grad];
+        const bool x_is_zero = include_self && x_data[replace_index_self] ==
+                                                   static_cast<tensor_t>(0);
+        const int zeros = zero_count[replace_index_self] + (x_is_zero ? 1 : 0);
+        if (zeros == 0) {
+          grad_data[replace_index_grad] = self_data[replace_index_self] *
+                                          out_data[replace_index_self] /
+                                          value_i;
+        } else if (zeros == 1 && value_i == static_cast<tensor_t>(0)) {
+          tensor_t others = masked_value_prod[replace_index_self];
+          if (include_self) others = others * x_data[replace_index_self];
           grad_data[replace_index_grad] =
-              self_data[replace_index_self] *
-              (out_data[replace_index_self] / value_data[replace_index_grad]);
+              self_data[replace_index_self] * others;
         } else {
+          // ``value`` is not the only zero factor, so the product stays zero
+          // whatever ``value`` becomes.
           grad_data[replace_index_grad] = static_cast<tensor_t>(0);
         }
       }

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -194,6 +194,11 @@ __device__ __forceinline__ void ComputeOffset(
       static_cast<int64_t>(select_dim_size),                                  \
       static_cast<int64_t>(index));
 
+// Both macros below normalize a negative subscript the same way the forward
+// kernels do, so they require ``self_select_dim_size`` -- the length along
+// ``dim`` of the tensor the subscript addresses -- to be in scope. That is the
+// gradient of ``x`` for the input-grad kernels and ``out_grad`` for the
+// value-grad ones; never ``index``, whose own length along ``dim`` may differ.
 #define COMPUTE_OFFSET_SINGLE_OUTPUT(                                     \
     var_name, smem_offset, id_var_name, copy_size)                        \
   extern __shared__ int64_t smem_shape_strides[];                         \
@@ -205,6 +210,8 @@ __device__ __forceinline__ void ComputeOffset(
   if (id_var_name >= numel) return;                                       \
   int64_t var_name = 0;                                                   \
   index_t index = index_data[id_var_name];                                \
+  ENFORCE_SCATTER_INDEX_IN_BOUND(index, self_select_dim_size);            \
+  if (index < 0) index += static_cast<index_t>(self_select_dim_size);     \
   const int64_t* stride_info = smem_shape_strides + smem_offset * ndim;   \
   ComputeOffset<false>(smem_shape_strides,                                \
                        stride_info,                                       \
@@ -226,6 +233,8 @@ __device__ __forceinline__ void ComputeOffset(
   __syncthreads();                                                        \
   if (id_var_name >= numel) return;                                       \
   index_t index = index_data[id_var_name];                                \
+  ENFORCE_SCATTER_INDEX_IN_BOUND(index, self_select_dim_size);            \
+  if (index < 0) index += static_cast<index_t>(self_select_dim_size);     \
   const int64_t* grad_strides = smem_shape_strides + offset1 * ndim;      \
   const int64_t* self_strides = smem_shape_strides + offset2 * ndim;      \
   int64_t var_name1 = 0, var_name2 = 0;                                   \
@@ -747,6 +756,7 @@ __global__ void ScatterInputGradGPUKernel(
     const int64_t* __restrict__ shape_strides,
     int dim,
     int ndim,
+    int64_t self_select_dim_size,
     int64_t numel) {
   // no more than 18 int64_t, different from forward kernels
   // the backward kernel does not require src, so src_strides are not needed
@@ -763,6 +773,10 @@ __global__ void ScatterInputGradGPUKernel(
 
   int64_t replace_index = 0;
   index_t index = index_data[tid];
+  // This kernel does not go through COMPUTE_OFFSET_SINGLE_OUTPUT, so it has to
+  // bound-check and normalize the subscript on its own.
+  ENFORCE_SCATTER_INDEX_IN_BOUND(index, self_select_dim_size);
+  if (index < 0) index += static_cast<index_t>(self_select_dim_size);
   const int64_t* grad_strides = smem_shape_strides + ndim;
 
   ComputeOffset<false>(smem_shape_strides,
@@ -793,6 +807,10 @@ void gpu_scatter_input_grad_kernel(DenseTensor self,
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
   int64_t select_dim_size = index_dims[dim];
+  // ``select_dim_size`` above is the length of ``index`` along ``dim`` and only
+  // sizes the launch. Normalizing a negative subscript needs the length of the
+  // tensor it addresses instead, which here is the gradient of ``x``.
+  const int64_t self_select_dim_size = grad.dims()[dim];
   for (int64_t i = 0; i < dim; ++i) {
     inner_dim_size *= index_dims[i];
   }
@@ -833,8 +851,13 @@ void gpu_scatter_input_grad_kernel(DenseTensor self,
   const size_t shared_mem_bytes = sizeof(int64_t) * shape_stride_dev.numel();
 
   ScatterInputGradGPUKernel<tensor_t, index_t>
-      <<<grid, block, shared_mem_bytes, stream>>>(
-          grad_data, index_data, shape_strides, dim, ndim, index_size);
+      <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
+                                                  index_data,
+                                                  shape_strides,
+                                                  dim,
+                                                  ndim,
+                                                  self_select_dim_size,
+                                                  index_size);
 }
 
 namespace {
@@ -873,6 +896,7 @@ __global__ void ScatterGradPrePassKernel(
     const int64_t* __restrict__ shape_strides,
     int dim,
     int ndim,
+    int64_t self_select_dim_size,
     int64_t numel,
     int64_t grad_numel,
     int* __restrict__ aux_buffer,
@@ -930,6 +954,7 @@ __global__ void ScatterMulInputGradGPUKernel(
     const int64_t* __restrict__ shape_strides,
     int dim,
     int ndim,
+    int64_t self_select_dim_size,
     int64_t numel,
     int64_t grad_numel,
     int* __restrict__ aux_buffer,
@@ -967,6 +992,7 @@ __global__ void ScatterMinMaxInputGradGPUKernel(
     const int64_t* __restrict__ shape_strides,
     int dim,
     int ndim,
+    int64_t self_select_dim_size,
     int64_t numel,
     int* __restrict__ aux_buffer) {
   COMPUTE_OFFSET_SINGLE_OUTPUT(replace_index, 1, tid, 2)
@@ -1001,6 +1027,9 @@ void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
   int64_t select_dim_size = index_dims[dim];
+  // The subscript addresses the gradient of ``x``, so that is the length a
+  // negative one has to be normalized against.
+  const int64_t self_select_dim_size = grad.dims()[dim];
   for (int64_t i = 0; i < dim; ++i) {
     inner_dim_size *= index_dims[i];
   }
@@ -1071,6 +1100,7 @@ void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
                                                     shape_strides,
                                                     dim,
                                                     ndim,
+                                                    self_select_dim_size,
                                                     index.numel(),
                                                     grad.numel(),
                                                     aux_buffer,
@@ -1085,6 +1115,7 @@ void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
                                                     shape_strides,
                                                     dim,
                                                     ndim,
+                                                    self_select_dim_size,
                                                     index.numel(),
                                                     grad.numel(),
                                                     aux_buffer,
@@ -1103,6 +1134,7 @@ void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
                                                     shape_strides,
                                                     dim,
                                                     ndim,
+                                                    self_select_dim_size,
                                                     index.numel(),
                                                     grad.numel(),
                                                     aux_buffer);
@@ -1115,6 +1147,7 @@ void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
                                                     shape_strides,
                                                     dim,
                                                     ndim,
+                                                    self_select_dim_size,
                                                     index.numel(),
                                                     aux_buffer);
   }
@@ -1127,6 +1160,7 @@ __global__ void ScatterMeanInputGradGPUKernel(
     const int64_t* __restrict__ shape_strides,
     int dim,
     int ndim,
+    int64_t self_select_dim_size,
     int64_t numel,
     int64_t grad_numel,
     int* __restrict__ aux_buffer) {
@@ -1153,6 +1187,9 @@ void gpu_scatter_mean_input_grad_kernel(DenseTensor self,
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
   int64_t select_dim_size = index_dims[dim];
+  // The subscript addresses the gradient of ``x``, so that is the length a
+  // negative one has to be normalized against.
+  const int64_t self_select_dim_size = grad.dims()[dim];
   for (int64_t i = 0; i < dim; ++i) {
     inner_dim_size *= index_dims[i];
   }
@@ -1214,6 +1251,7 @@ void gpu_scatter_mean_input_grad_kernel(DenseTensor self,
                                                   shape_strides,
                                                   dim,
                                                   ndim,
+                                                  self_select_dim_size,
                                                   index.numel(),
                                                   grad_size,
                                                   aux_buffer);
@@ -1223,6 +1261,7 @@ void gpu_scatter_mean_input_grad_kernel(DenseTensor self,
                                                   shape_strides,
                                                   dim,
                                                   ndim,
+                                                  self_select_dim_size,
                                                   index.numel(),
                                                   grad_size,
                                                   aux_buffer);
@@ -1236,6 +1275,7 @@ __global__ void ScatterValueGradGPUKernel(
     const int64_t* __restrict__ shape_strides,
     int dim,
     int ndim,
+    int64_t self_select_dim_size,
     int64_t numel,
     int* __restrict__ aux_buffer) {
   COMPUTE_OFFSET_DOUBLE_OUTPUT(
@@ -1261,6 +1301,9 @@ void gpu_scatter_value_grad_kernel(DenseTensor self,
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
   int64_t select_dim_size = index_dims[dim];
+  // Here the subscript addresses ``out_grad``, the operand shaped like ``x``;
+  // ``grad`` is the gradient of ``value`` and carries the shape of ``index``.
+  const int64_t self_select_dim_size = self.dims()[dim];
   for (int64_t i = 0; i < dim; ++i) {
     inner_dim_size *= index_dims[i];
   }
@@ -1315,6 +1358,7 @@ void gpu_scatter_value_grad_kernel(DenseTensor self,
                                                   shape_strides,
                                                   dim,
                                                   ndim,
+                                                  self_select_dim_size,
                                                   index.numel(),
                                                   grad.numel(),
                                                   aux_buffer);
@@ -1325,6 +1369,7 @@ void gpu_scatter_value_grad_kernel(DenseTensor self,
                                                   shape_strides,
                                                   dim,
                                                   ndim,
+                                                  self_select_dim_size,
                                                   index.numel(),
                                                   aux_buffer);
 }
@@ -1337,6 +1382,7 @@ __global__ void ScatterMeanValueGradGPUKernel(
     const int64_t* __restrict__ shape_strides,
     int dim,
     int ndim,
+    int64_t self_select_dim_size,
     int64_t numel,
     int* __restrict__ aux_buffer) {
   COMPUTE_OFFSET_DOUBLE_OUTPUT(
@@ -1354,6 +1400,7 @@ __global__ void ScatterAddValueGradGPUKernel(
     const int64_t* __restrict__ shape_strides,
     int dim,
     int ndim,
+    int64_t self_select_dim_size,
     int64_t numel) {
   COMPUTE_OFFSET_DOUBLE_OUTPUT(
       replace_index_grad, replace_index_self, tid, 1, 2)
@@ -1381,6 +1428,9 @@ void gpu_scatter_add_mean_value_grad_kernel(DenseTensor self,
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
   int64_t select_dim_size = index_dims[dim];
+  // Here the subscript addresses ``out_grad``, the operand shaped like ``x``;
+  // ``grad`` is the gradient of ``value`` and carries the shape of ``index``.
+  const int64_t self_select_dim_size = self.dims()[dim];
   for (int64_t i = 0; i < dim; ++i) {
     inner_dim_size *= index_dims[i];
   }
@@ -1437,6 +1487,7 @@ void gpu_scatter_add_mean_value_grad_kernel(DenseTensor self,
                                                     shape_strides,
                                                     dim,
                                                     ndim,
+                                                    self_select_dim_size,
                                                     index.numel(),
                                                     grad.numel(),
                                                     aux_buffer);
@@ -1447,6 +1498,7 @@ void gpu_scatter_add_mean_value_grad_kernel(DenseTensor self,
                                                     shape_strides,
                                                     dim,
                                                     ndim,
+                                                    self_select_dim_size,
                                                     index.numel(),
                                                     aux_buffer);
   } else if (reduce == "add") {
@@ -1457,6 +1509,7 @@ void gpu_scatter_add_mean_value_grad_kernel(DenseTensor self,
                                                     shape_strides,
                                                     dim,
                                                     ndim,
+                                                    self_select_dim_size,
                                                     index.numel());
   }
 }
@@ -1472,6 +1525,7 @@ __global__ void ScatterMulValueGradGPUKernel(
     const int64_t* __restrict__ shape_strides,
     int dim,
     int ndim,
+    int64_t self_select_dim_size,
     int64_t numel,
     bool include_self,
     const int* __restrict__ aux_buffer,
@@ -1508,6 +1562,7 @@ __global__ void ScatterMinMaxValueGradGPUKernel(
     const int64_t* __restrict__ shape_strides,
     int dim,
     int ndim,
+    int64_t self_select_dim_size,
     int64_t numel,
     bool include_self,
     int* __restrict__ aux_buffer) {
@@ -1542,6 +1597,9 @@ void gpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
   int64_t inner_dim_size = 1;
   int64_t outer_dim_size = 1;
   int64_t select_dim_size = index_dims[dim];
+  // Here the subscript addresses ``out_grad``, the operand shaped like ``x``;
+  // ``grad`` is the gradient of ``value`` and carries the shape of ``index``.
+  const int64_t self_select_dim_size = self.dims()[dim];
   for (int64_t i = 0; i < dim; ++i) {
     inner_dim_size *= index_dims[i];
   }
@@ -1607,6 +1665,7 @@ void gpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
                                                     shape_strides,
                                                     dim,
                                                     ndim,
+                                                    self_select_dim_size,
                                                     index.numel(),
                                                     grad.numel(),
                                                     aux_buffer,
@@ -1622,6 +1681,7 @@ void gpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
                                                     shape_strides,
                                                     dim,
                                                     ndim,
+                                                    self_select_dim_size,
                                                     index.numel(),
                                                     include_self,
                                                     aux_buffer,
@@ -1644,6 +1704,7 @@ void gpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
                                                     shape_strides,
                                                     dim,
                                                     ndim,
+                                                    self_select_dim_size,
                                                     index.numel(),
                                                     grad.numel(),
                                                     aux_buffer,
@@ -1657,6 +1718,7 @@ void gpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
                                                     shape_strides,
                                                     dim,
                                                     ndim,
+                                                    self_select_dim_size,
                                                     index.numel(),
                                                     include_self,
                                                     aux_buffer);

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -926,6 +926,7 @@ __global__ void ScatterMulInputGradGPUKernel(
     const index_t* __restrict__ index_data,
     const tensor_t* __restrict__ out_data,
     const tensor_t* __restrict__ x_data,
+    const tensor_t* __restrict__ self_data,
     const int64_t* __restrict__ shape_strides,
     int dim,
     int ndim,
@@ -936,16 +937,19 @@ __global__ void ScatterMulInputGradGPUKernel(
   COMPUTE_OFFSET_SINGLE_OUTPUT(replace_index, 1, tid, 2)
   if (tid != aux_buffer[replace_index]) return;
   const tensor_t x = x_data[replace_index];
+  // The base gradient is read from ``out_grad`` and not from ``grad_data``:
+  // ``MulInputGradRoundTripFunctor`` has already rewritten the latter with
+  // torch's redundant ``(g * m) / m`` for the sake of the positions no index
+  // reaches, and this position is not one of them.
+  const tensor_t g = self_data[replace_index];
   // ``out / x`` loses every factor once one of them is zero, so the derivative
   // has to be rebuilt from the product of the remaining factors instead.
   const int zero_count = aux_buffer[grad_numel + replace_index] +
                          (x == static_cast<tensor_t>(0) ? 1 : 0);
   if (zero_count == 0) {
-    grad_data[replace_index] =
-        grad_data[replace_index] * out_data[replace_index] / x;
+    grad_data[replace_index] = g * out_data[replace_index] / x;
   } else if (zero_count == 1 && x == static_cast<tensor_t>(0)) {
-    grad_data[replace_index] =
-        grad_data[replace_index] * masked_value_prod[replace_index];
+    grad_data[replace_index] = g * masked_value_prod[replace_index];
   } else {
     // ``x`` is not the only zero factor, so the product stays zero whatever
     // ``x`` becomes.
@@ -1077,6 +1081,7 @@ void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
                                                     index_data,
                                                     out_data,
                                                     x_data,
+                                                    self_data,
                                                     shape_strides,
                                                     dim,
                                                     ndim,

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -183,16 +183,21 @@ __device__ __forceinline__ void ComputeOffset(
 // it, so every kernel that turns it into an offset has to reject it here.
 // Without this the offset arithmetic below silently addresses memory outside
 // the tensor.
-#define ENFORCE_SCATTER_INDEX_IN_BOUND(index, select_dim_size)                \
-  PADDLE_ENFORCE(                                                             \
-      (index) >= -(select_dim_size) && (index) < (select_dim_size),           \
-      "The index is out of bounds, "                                          \
-      "please check whether the index and "                                   \
-      "input's shape meet the requirements. It should "                       \
-      "be greater or equal to [%ld] and less than [%ld], but received [%ld]", \
-      static_cast<int64_t>(-(select_dim_size)),                               \
-      static_cast<int64_t>(select_dim_size),                                  \
-      static_cast<int64_t>(index));
+// The three arguments are 64 bit, so the conversion has to be ``%lld`` and the
+// cast has to name that type: ``long`` is 32 bit on Windows, where a ``%ld``
+// makes the formatter take four of the eight bytes and then read every later
+// argument from the wrong offset.
+#define ENFORCE_SCATTER_INDEX_IN_BOUND(index, select_dim_size)            \
+  PADDLE_ENFORCE(                                                         \
+      (index) >= -(select_dim_size) && (index) < (select_dim_size),       \
+      "The index is out of bounds, "                                      \
+      "please check whether the index and "                               \
+      "input's shape meet the requirements. It should "                   \
+      "be greater or equal to [%lld] and less than [%lld], but received " \
+      "[%lld]",                                                           \
+      static_cast<long long>(-(select_dim_size)), /* NOLINT */            \
+      static_cast<long long>(select_dim_size),    /* NOLINT */            \
+      static_cast<long long>(index));             /* NOLINT */
 
 // Both macros below normalize a negative subscript the same way the forward
 // kernels do, so they require ``self_select_dim_size`` -- the length along

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -382,6 +382,7 @@ __global__ void ScatterAssignScalarValue(
   __syncthreads();
   if (tid >= numel) return;
   index_t index = index_data[tid];
+  ENFORCE_SCATTER_INDEX_IN_BOUND(index, self_select_dim_size);
   if (index < 0) index += static_cast<index_t>(self_select_dim_size);
 
   // some kernels might store input_strides differently! Be careful when dealing
@@ -1027,8 +1028,9 @@ void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
     int64_t* host_data = shape_stride_host.data<int64_t>();
     for (int64_t i = 0; i < ndim; i++) {
       host_data[i] = index_dims[i];
-      // notice that the ordering is different from forward, since
-      // value.strides() is not used for mul
+      // notice that the ordering is different from forward: the grad strides
+      // come first here, since that is the only block the mul grad kernel
+      // itself reads. value.strides() is only needed by the pre-pass.
       host_data[i + ndim] = grad.strides()[i];
       host_data[i + (ndim << 1)] = value.strides()[i];
     }

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.cu
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.cu
@@ -179,6 +179,21 @@ __device__ __forceinline__ void ComputeOffset(
   if constexpr (compute_self) *input_offset = _input_offset;
 }
 
+// The subscript read from ``index`` is runtime data: no shape check can bound
+// it, so every kernel that turns it into an offset has to reject it here.
+// Without this the offset arithmetic below silently addresses memory outside
+// the tensor.
+#define ENFORCE_SCATTER_INDEX_IN_BOUND(index, select_dim_size)                \
+  PADDLE_ENFORCE(                                                             \
+      (index) >= -(select_dim_size) && (index) < (select_dim_size),           \
+      "The index is out of bounds, "                                          \
+      "please check whether the index and "                                   \
+      "input's shape meet the requirements. It should "                       \
+      "be greater or equal to [%ld] and less than [%ld], but received [%ld]", \
+      static_cast<int64_t>(-(select_dim_size)),                               \
+      static_cast<int64_t>(select_dim_size),                                  \
+      static_cast<int64_t>(index));
+
 #define COMPUTE_OFFSET_SINGLE_OUTPUT(                                     \
     var_name, smem_offset, id_var_name, copy_size)                        \
   extern __shared__ int64_t smem_shape_strides[];                         \
@@ -278,29 +293,13 @@ __global__ void GatherScatterGPUKernel(
     input_strides = smem_shape_strides +
                     ndim * 2;  // gather pass actually does not need this
     // scatter
-    PADDLE_ENFORCE(
-        index >= -self_select_dim_size && index < self_select_dim_size,
-        "The index is out of bounds, "
-        "please check whether the index and "
-        "input's shape meet the requirements. It should "
-        "be greater or equal to [%d] and less than [%d], but received [%ld]",
-        -self_select_dim_size,
-        self_select_dim_size,
-        (int64_t)index);
+    ENFORCE_SCATTER_INDEX_IN_BOUND(index, self_select_dim_size);
     if (index < 0) {
       index += self_select_dim_size;
     }
   } else {
     // gather
-    PADDLE_ENFORCE(
-        index >= -src_select_dim_size && index < src_select_dim_size,
-        "The index is out of bounds, "
-        "please check whether the index and "
-        "input's shape meet the requirements. It should "
-        "be greater or equal to [%d] and less than [%d], but received [%d]",
-        -src_select_dim_size,
-        src_select_dim_size,
-        (int32_t)index);
+    ENFORCE_SCATTER_INDEX_IN_BOUND(index, src_select_dim_size);
     if (index < 0) {
       index += src_select_dim_size;
     }
@@ -429,6 +428,7 @@ __global__ void PickWinnersScatterKernel(
   // out of bound
   if (tid >= numel) return;
   index_t index = index_data[tid];
+  ENFORCE_SCATTER_INDEX_IN_BOUND(index, self_select_dim_size);
   if (index < 0) index += static_cast<index_t>(self_select_dim_size);
 
   const int64_t* input_strides = smem_shape_strides + 2 * ndim;
@@ -471,6 +471,7 @@ __global__ void ScatterWriteByWinnersKernel(
   // out of bound
   if (tid >= numel) return;
   index_t index = index_data[tid];
+  ENFORCE_SCATTER_INDEX_IN_BOUND(index, self_select_dim_size);
   if (index < 0) index += static_cast<index_t>(self_select_dim_size);
 
   const int64_t* src_strides = smem_shape_strides + ndim;
@@ -843,7 +844,22 @@ enum GradDispatchTag {
   ValueGrad,
   MeanValueGrad,
   MinMaxValueGrad,
+  MulValueGrad,
 };
+
+// Splits the factors a scatter-mul position receives into "how many of them are
+// zero" and "the product of the ones that are not". The backward of a product
+// is the product of the *other* factors, and once a factor is zero ``out`` has
+// dropped that information, so it has to be collected on the side.
+template <typename tensor_t>
+__device__ __forceinline__ void AccumulateZeroCountAndMaskedProd(
+    const tensor_t value, int* zero_count, tensor_t* masked_prod) {
+  if (value == static_cast<tensor_t>(0)) {
+    phi::CudaAtomicAdd(zero_count, 1);
+  } else {
+    phi::CudaAtomicMul(masked_prod, value);
+  }
+}
 }  // anonymous namespace
 
 template <typename tensor_t, typename index_t, GradDispatchTag dispatch>
@@ -859,10 +875,22 @@ __global__ void ScatterGradPrePassKernel(
     int64_t numel,
     int64_t grad_numel,
     int* __restrict__ aux_buffer,
-    bool include_self = true) {
+    bool include_self = true,
+    tensor_t* __restrict__ masked_value_prod = nullptr) {
   if constexpr (dispatch == GradDispatchTag::MulInputGrad) {
-    COMPUTE_OFFSET_SINGLE_OUTPUT(replace_index, 1, tid, 2)
+    // ``value``'s offset comes from the third stride block, the same layout
+    // ``MinMaxInputGrad`` below relies on.
+    COMPUTE_OFFSET_DOUBLE_OUTPUT(replace_index_value, replace_index, tid, 2, 1)
     atomicMax(aux_buffer + replace_index, static_cast<int>(tid));
+    AccumulateZeroCountAndMaskedProd(value_data[replace_index_value],
+                                     aux_buffer + grad_numel + replace_index,
+                                     masked_value_prod + replace_index);
+  } else if constexpr (dispatch == GradDispatchTag::MulValueGrad) {
+    COMPUTE_OFFSET_DOUBLE_OUTPUT(
+        replace_index_grad, replace_index_self, tid, 1, 2)
+    AccumulateZeroCountAndMaskedProd(value_data[replace_index_grad],
+                                     aux_buffer + replace_index_self,
+                                     masked_value_prod + replace_index_self);
   } else if constexpr (dispatch == GradDispatchTag::MinMaxInputGrad) {
     // This is a special case, src is stored in shape_strides + 2 * dim but used
     // as the 2nd param for compute offset
@@ -901,16 +929,26 @@ __global__ void ScatterMulInputGradGPUKernel(
     int dim,
     int ndim,
     int64_t numel,
-    int* __restrict__ aux_buffer) {
+    int64_t grad_numel,
+    int* __restrict__ aux_buffer,
+    const tensor_t* __restrict__ masked_value_prod) {
   COMPUTE_OFFSET_SINGLE_OUTPUT(replace_index, 1, tid, 2)
-  if (tid == aux_buffer[replace_index]) {
-    if (x_data[replace_index] != static_cast<tensor_t>(0)) {
-      grad_data[replace_index] = grad_data[replace_index] *
-                                 out_data[replace_index] /
-                                 x_data[replace_index];
-    } else {
-      grad_data[replace_index] = static_cast<tensor_t>(0);
-    }
+  if (tid != aux_buffer[replace_index]) return;
+  const tensor_t x = x_data[replace_index];
+  // ``out / x`` loses every factor once one of them is zero, so the derivative
+  // has to be rebuilt from the product of the remaining factors instead.
+  const int zero_count = aux_buffer[grad_numel + replace_index] +
+                         (x == static_cast<tensor_t>(0) ? 1 : 0);
+  if (zero_count == 0) {
+    grad_data[replace_index] =
+        grad_data[replace_index] * out_data[replace_index] / x;
+  } else if (zero_count == 1 && x == static_cast<tensor_t>(0)) {
+    grad_data[replace_index] =
+        grad_data[replace_index] * masked_value_prod[replace_index];
+  } else {
+    // ``x`` is not the only zero factor, so the product stays zero whatever
+    // ``x`` becomes.
+    grad_data[replace_index] = static_cast<tensor_t>(0);
   }
 }
 
@@ -944,7 +982,7 @@ void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
                                                const DenseTensor& value,
                                                DenseTensor grad,
                                                const std::string& reduce,
-                                               bool include_self UNUSED,
+                                               bool include_self,
                                                const DeviceContext& dev_ctx) {
   auto* grad_data = grad.data<tensor_t>();
   auto* index_data = index.data<index_t>();
@@ -970,8 +1008,10 @@ void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
   const uint32_t grid = GetCudaLaunchGrid(
       n, block, "gpu_scatter_mul_min_max_input_grad_kernel launch grid");
   auto stream = reinterpret_cast<const GPUContext&>(dev_ctx).stream();
+  const bool is_mul = reduce == "mul" || reduce == "multiply";
   DenseTensor aux_tensor;
-  aux_tensor.Resize({grad.numel()});
+  // mul needs a second plane behind the winner tid to count the zero factors.
+  aux_tensor.Resize({is_mul ? grad.numel() * 2 : grad.numel()});
   dev_ctx.Alloc<int>(&aux_tensor);
   int* aux_buffer = aux_tensor.data<int>();
 
@@ -1003,10 +1043,18 @@ void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
   const int64_t* shape_strides = shape_stride_dev.data<int64_t>();
   size_t shared_mem_bytes = sizeof(int64_t) * ndim;
 
-  if (reduce == "mul" || reduce == "multiply") {
+  if (is_mul) {
     PADDLE_ENFORCE_LE_INT_MAX(index.numel(), "gather_scatter input grad tid");
     funcs::set_constant(dev_ctx, &aux_tensor, 0);
-    shared_mem_bytes *= 2;  // 1 stride, 1 shape
+    shared_mem_bytes *= 3;  // two strides, 1 shape
+
+    // Product of the non-zero factors ``value`` contributes to each position,
+    // needed to reconstruct the derivative when a factor is zero.
+    DenseTensor masked_prod_tensor;
+    masked_prod_tensor.Resize({grad.numel()});
+    dev_ctx.Alloc<tensor_t>(&masked_prod_tensor);
+    funcs::set_constant(dev_ctx, &masked_prod_tensor, 1);
+    tensor_t* masked_value_prod = masked_prod_tensor.data<tensor_t>();
 
     ScatterGradPrePassKernel<tensor_t, index_t, MulInputGrad>
         <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
@@ -1019,7 +1067,9 @@ void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
                                                     ndim,
                                                     index.numel(),
                                                     grad.numel(),
-                                                    aux_buffer);
+                                                    aux_buffer,
+                                                    include_self,
+                                                    masked_value_prod);
     ScatterMulInputGradGPUKernel<tensor_t, index_t>
         <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
                                                     index_data,
@@ -1029,7 +1079,9 @@ void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
                                                     dim,
                                                     ndim,
                                                     index.numel(),
-                                                    aux_buffer);
+                                                    grad.numel(),
+                                                    aux_buffer,
+                                                    masked_value_prod);
   } else if (reduce == "amin" || reduce == "amax") {
     funcs::set_constant(dev_ctx, &aux_tensor, 1);
     shared_mem_bytes *= 3;  // two strides, 1 shape
@@ -1409,17 +1461,32 @@ __global__ void ScatterMulValueGradGPUKernel(
     const tensor_t* __restrict__ self_data,
     const tensor_t* __restrict__ value_data,
     const tensor_t* __restrict__ out_data,
+    const tensor_t* __restrict__ x_data,
     const int64_t* __restrict__ shape_strides,
     int dim,
     int ndim,
-    int64_t numel) {
+    int64_t numel,
+    bool include_self,
+    const int* __restrict__ aux_buffer,
+    const tensor_t* __restrict__ masked_value_prod) {
   COMPUTE_OFFSET_DOUBLE_OUTPUT(
       replace_index_grad, replace_index_self, tid, 1, 2)
-  if (value_data[replace_index_grad] != static_cast<tensor_t>(0)) {
+  const tensor_t value = value_data[replace_index_grad];
+  const bool x_is_zero =
+      include_self && x_data[replace_index_self] == static_cast<tensor_t>(0);
+  // ``out / value`` loses every factor once one of them is zero, so the
+  // derivative has to be rebuilt from the product of the remaining factors.
+  const int zero_count = aux_buffer[replace_index_self] + (x_is_zero ? 1 : 0);
+  if (zero_count == 0) {
     grad_data[replace_index_grad] =
-        self_data[replace_index_self] *
-        (out_data[replace_index_self] / value_data[replace_index_grad]);
+        self_data[replace_index_self] * out_data[replace_index_self] / value;
+  } else if (zero_count == 1 && value == static_cast<tensor_t>(0)) {
+    tensor_t others = masked_value_prod[replace_index_self];
+    if (include_self) others = others * x_data[replace_index_self];
+    grad_data[replace_index_grad] = self_data[replace_index_self] * others;
   } else {
+    // ``value`` is not the only zero factor, so the product stays zero
+    // whatever ``value`` becomes.
     grad_data[replace_index_grad] = static_cast<tensor_t>(0);
   }
 }
@@ -1508,16 +1575,50 @@ void gpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
   size_t shared_mem_bytes = sizeof(int64_t) * ndim * 3;
 
   if (reduce == "mul" || reduce == "multiply") {
+    PADDLE_ENFORCE_LE_INT_MAX(index.numel(),
+                              "gather_scatter mul value grad tid");
+    // Zero factor count and product of the non-zero ``value`` factors each
+    // position receives, needed to rebuild the derivative around a zero.
+    DenseTensor aux_tensor;
+    aux_tensor.Resize({self.numel()});
+    dev_ctx.Alloc<int>(&aux_tensor);
+    funcs::set_constant(dev_ctx, &aux_tensor, 0);
+    int* aux_buffer = aux_tensor.data<int>();
+
+    DenseTensor masked_prod_tensor;
+    masked_prod_tensor.Resize({self.numel()});
+    dev_ctx.Alloc<tensor_t>(&masked_prod_tensor);
+    funcs::set_constant(dev_ctx, &masked_prod_tensor, 1);
+    tensor_t* masked_value_prod = masked_prod_tensor.data<tensor_t>();
+
+    ScatterGradPrePassKernel<tensor_t, index_t, MulValueGrad>
+        <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
+                                                    index_data,
+                                                    out_data,
+                                                    value_data,
+                                                    x_data,
+                                                    shape_strides,
+                                                    dim,
+                                                    ndim,
+                                                    index.numel(),
+                                                    grad.numel(),
+                                                    aux_buffer,
+                                                    include_self,
+                                                    masked_value_prod);
     ScatterMulValueGradGPUKernel<tensor_t, index_t>
         <<<grid, block, shared_mem_bytes, stream>>>(grad_data,
                                                     index_data,
                                                     self_data,
                                                     value_data,
                                                     out_data,
+                                                    x_data,
                                                     shape_strides,
                                                     dim,
                                                     ndim,
-                                                    index.numel());
+                                                    index.numel(),
+                                                    include_self,
+                                                    aux_buffer,
+                                                    masked_value_prod);
   } else if (reduce == "amin" || reduce == "amax") {
     DenseTensor aux_tensor;
     aux_tensor.Resize({self.numel()});

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.h
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.h
@@ -13,7 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include <algorithm>
+#include <type_traits>
 
+#include "paddle/common/hostdevice.h"
+#include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/device_context.h"
 #include "paddle/phi/core/enforce.h"
@@ -263,7 +267,7 @@ void gpu_scatter_input_grad_kernel(DenseTensor self,
                                    const DeviceContext& dev_ctx);
 
 template <typename tensor_t, typename index_t>
-void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self UNUSED,
+void gpu_scatter_mul_min_max_input_grad_kernel(DenseTensor self,
                                                int dim,
                                                const DenseTensor& index,
                                                const DenseTensor& out,
@@ -313,6 +317,50 @@ void gpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
                                                const std::string& reduce,
                                                bool include_self,
                                                const DeviceContext& dev_ctx);
+
+// Only the floating-point instantiations need the round trip below. An integer
+// ``(g * m) / m`` is either exactly ``g`` or an overflow, and torch never takes
+// a gradient through an integer tensor to begin with.
+template <typename tensor_t>
+constexpr bool MulInputGradNeedsRoundTrip() {
+  return std::is_floating_point<tensor_t>::value ||
+         std::is_same<tensor_t, phi::dtype::float16>::value ||
+         std::is_same<tensor_t, phi::dtype::bfloat16>::value;
+}
+
+// Reproduces the rounding torch leaves on the positions of ``x_grad`` that no
+// index reaches, for ``reduce`` in {mul, multiply}.
+//
+// ``FunctionsManual.cpp::scatter_reduce_backward`` computes the input gradient
+// over the *whole* tensor at once:
+//
+//   masked_self = self.masked_fill(self == 0, 1)
+//   grad_self   = grad * masked_self.scatter_reduce(dim, index, src, "prod")
+//               / masked_self
+//
+// Where no index lands, the inner scatter leaves ``masked_self`` untouched and
+// the expression collapses to ``(grad * m) / m``. That is ``grad`` in exact
+// arithmetic, but it rounds twice, so it can land 1 ulp away from ``grad``.
+// Paddle used to hand ``out_grad`` straight through there -- the exact
+// derivative, yet not the value torch reports. Applying the same round trip
+// here is what makes the two frameworks agree bit for bit; the positions an
+// index does reach are overwritten afterwards, and take their base gradient
+// from the untouched ``out_grad`` rather than from this buffer.
+//
+// The zero mask is part of the contract: where ``x`` is zero torch divides by
+// one, which is exact and must not be turned into a division by zero.
+template <typename tensor_t>
+struct MulInputGradRoundTripFunctor {
+  const tensor_t* x_data;
+  tensor_t* grad_data;
+
+  HOSTDEVICE void operator()(size_t i) const {
+    const tensor_t m = x_data[i] == static_cast<tensor_t>(0)
+                           ? static_cast<tensor_t>(1)
+                           : x_data[i];
+    grad_data[i] = static_cast<tensor_t>(grad_data[i] * m) / m;
+  }
+};
 
 // A 0-D operand becomes a 1-D operand holding a single element, the way
 // ``ensure_nonempty_*`` does in torch. ``Resize`` rewrites the metadata of the

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.h
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.h
@@ -314,6 +314,16 @@ void gpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
                                                bool include_self,
                                                const DeviceContext& dev_ctx);
 
+// A 0-D operand becomes a 1-D operand holding a single element, the way
+// ``ensure_nonempty_*`` does in torch. ``Resize`` rewrites the metadata of the
+// tensor passed here and nothing else, so a shallow view can be promoted
+// without touching the caller's tensor or the underlying buffer.
+inline void PromoteZeroDimOperand(DenseTensor* tensor) {
+  if (tensor->dims().size() == 0) {
+    tensor->Resize(DDim({1}));
+  }
+}
+
 // Brings the operands of ``put_along_axis`` into the representation that the
 // gather/scatter functor below can actually address, and raises the diagnosis
 // that only the kernel is able to give.
@@ -349,16 +359,9 @@ inline void PreparePutAlongAxisOperands(DenseTensor* self,
   if (*axis < 0) {
     *axis += rank;
   }
-  const DDim single_element({1});
-  if (self->dims().size() == 0) {
-    self->Resize(single_element);
-  }
-  if (index->dims().size() == 0) {
-    index->Resize(single_element);
-  }
-  if (value->dims().size() == 0) {
-    value->Resize(single_element);
-  }
+  PromoteZeroDimOperand(self);
+  PromoteZeroDimOperand(index);
+  PromoteZeroDimOperand(value);
 
   // A 0-size scatter dimension leaves no valid index value at all, so every
   // element of a non-empty ``index`` is out of bounds. torch reports this from
@@ -381,6 +384,36 @@ inline void PreparePutAlongAxisOperands(DenseTensor* self,
           "to [0] and less than [0], which leaves no valid index value at all "
           "because dimension [%d] of the input has size 0.",
           *axis));
+}
+
+// Companion of ``PreparePutAlongAxisOperands`` for the backward pass.
+//
+// ``PutAlongAxisGradKernel`` reaches the same functor and forwards the shapes
+// and strides of every operand it is given: ``index`` sizes
+// ``CoordinateManager``, ``out_grad`` is the ``self`` of the value-grad
+// functors, and ``value`` is restrided by the mul/min/max input-grad functor.
+// A 0-D tensor has ``numel() == 1``, so it gets past both 0-size early returns
+// of the grad kernel and would reach the functor with rank 0.
+//
+// The 0-size diagnosis raised by the forward helper is not repeated here: by
+// the time this runs, both 0-size cases have already returned. ``axis`` is
+// normalized for the same reason as in the forward kernel -- the grad kernel
+// receives the attribute exactly as the caller wrote it.
+inline void PreparePutAlongAxisGradOperands(DenseTensor* x,
+                                            DenseTensor* index,
+                                            DenseTensor* value,
+                                            DenseTensor* out,
+                                            DenseTensor* out_grad,
+                                            int* axis) {
+  const int rank = std::max<int>(static_cast<int>(x->dims().size()), 1);
+  if (*axis < 0) {
+    *axis += rank;
+  }
+  PromoteZeroDimOperand(x);
+  PromoteZeroDimOperand(index);
+  PromoteZeroDimOperand(value);
+  PromoteZeroDimOperand(out);
+  PromoteZeroDimOperand(out_grad);
 }
 
 }  // namespace funcs

--- a/paddle/phi/kernels/funcs/gather_scatter_functor.h
+++ b/paddle/phi/kernels/funcs/gather_scatter_functor.h
@@ -12,8 +12,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+#include <algorithm>
+
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/device_context.h"
+#include "paddle/phi/core/enforce.h"
 
 #pragma once
 
@@ -310,6 +313,75 @@ void gpu_scatter_mul_min_max_value_grad_kernel(DenseTensor self,
                                                const std::string& reduce,
                                                bool include_self,
                                                const DeviceContext& dev_ctx);
+
+// Brings the operands of ``put_along_axis`` into the representation that the
+// gather/scatter functor below can actually address, and raises the diagnosis
+// that only the kernel is able to give.
+//
+// torch represents a 0-D tensor as a 1-D tensor holding a single element
+// (``ensure_nonempty_dim`` / ``ensure_nonempty_size`` /
+// ``ensure_nonempty_vec``) and restrides self, index and src into that
+// representation before entering its scatter kernel, so its shape check and its
+// kernel agree on one set of ranks.
+// ``PutAlongAxisInferMeta`` follows the same rule. The functor, however,
+// indexes
+// ``dims()`` and ``strides()`` directly and sizes ``CoordinateManager`` from
+// ``index.dims().size()``: a rank-0 operand would read a slot that
+// ``calc_strides`` never wrote, and a rank-0 ``index`` would give ``ndim ==
+// 0``, leaving ``CoordinateManager::indices`` empty while it is still indexed.
+// So the promotion has to happen here as well.
+//
+// ``Resize`` rewrites the metadata of the tensors passed here and nothing else,
+// so a shallow view can be promoted without touching the caller's tensor or the
+// underlying buffer. ``self`` is the one operand a kernel may have to promote
+// in place, since the scatter writes through it: the ``put_along_axis`` kernels
+// pass their output and restore its shape once the scatter is done, so the
+// promotion never reaches the caller.
+//
+// ``axis`` is normalized at the same time. It reaches the kernel exactly as the
+// caller wrote it, so it can still be negative when the op is entered through
+// ``_C_ops`` rather than the python wrapper.
+inline void PreparePutAlongAxisOperands(DenseTensor* self,
+                                        DenseTensor* index,
+                                        DenseTensor* value,
+                                        int* axis) {
+  const int rank = std::max<int>(static_cast<int>(self->dims().size()), 1);
+  if (*axis < 0) {
+    *axis += rank;
+  }
+  const DDim single_element({1});
+  if (self->dims().size() == 0) {
+    self->Resize(single_element);
+  }
+  if (index->dims().size() == 0) {
+    index->Resize(single_element);
+  }
+  if (value->dims().size() == 0) {
+    value->Resize(single_element);
+  }
+
+  // A 0-size scatter dimension leaves no valid index value at all, so every
+  // element of a non-empty ``index`` is out of bounds. torch reports this from
+  // the scatter kernel as an index out-of-bounds error rather than from its
+  // shape check, so the diagnosis is raised here instead of in the InferMeta.
+  //
+  // The shared gather/scatter functor cannot do it: it early-returns on any
+  // 0-size operand, and that early return is relied upon by the grad kernels of
+  // ``take_along_axis``, ``cummax``/``cummin`` and friends, which legitimately
+  // scatter a non-empty index into a 0-size buffer.
+  if (index->numel() == 0) {
+    return;
+  }
+  PADDLE_ENFORCE_NE(
+      self->dims()[*axis],
+      0,
+      common::errors::OutOfRange(
+          "The index is out of bounds, please check whether the index and "
+          "input's shape meet the requirements. It should be greater or equal "
+          "to [0] and less than [0], which leaves no valid index value at all "
+          "because dimension [%d] of the input has size 0.",
+          *axis));
+}
 
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/put_along_axis_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/put_along_axis_grad_kernel.cu
@@ -27,16 +27,26 @@ namespace phi {
 
 template <typename T, typename Context>
 void PutAlongAxisGradKernel(const Context& dev_ctx,
-                            const DenseTensor& x,
-                            const DenseTensor& index,
-                            const DenseTensor& value,
-                            const DenseTensor& out,
-                            const DenseTensor& out_grad,
+                            const DenseTensor& arr,
+                            const DenseTensor& indices,
+                            const DenseTensor& values,
+                            const DenseTensor& output,
+                            const DenseTensor& output_grad,
                             int axis,
                             const std::string& reduce,
                             bool include_self,
                             DenseTensor* x_grad,
                             DenseTensor* value_grad) {
+  // Shallow views sharing the caller's buffers, so the promotion below rewrites
+  // local metadata only. The two early returns are left to run on the shapes
+  // exactly as the caller wrote them: a 0-size operand must still be answered
+  // with a 0-size gradient.
+  DenseTensor x = arr;
+  DenseTensor index = indices;
+  DenseTensor value = values;
+  DenseTensor out = output;
+  DenseTensor out_grad = output_grad;
+
   if (x.numel() == 0) {
     if (x_grad) {
       dev_ctx.template Alloc<T>(x_grad);
@@ -57,8 +67,20 @@ void PutAlongAxisGradKernel(const Context& dev_ctx,
     }
     return;
   }
+  // Brings the operands into the representation the scatter functor can
+  // address: a 0-D operand becomes rank 1 and ``axis`` is normalized, the same
+  // way the forward kernel does. A 0-D tensor has ``numel() == 1``, so it gets
+  // here, and the functor would then read ``dims()`` and ``strides()`` slots
+  // that ``calc_strides`` never wrote and size ``CoordinateManager`` from
+  // ``index.dims().size() == 0``.
+  funcs::PreparePutAlongAxisGradOperands(
+      &x, &index, &value, &out, &out_grad, &axis);
+
   const auto& index_type = index.dtype();
   if (x_grad) {
+    // ``Copy`` gives ``x_grad`` the promoted shape of ``out_grad``, so the
+    // functor writes through a rank-1 buffer. The shape the caller expects is
+    // the one of ``arr``, restored once the scatter is done.
     Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
     if (!include_self || reduce == "assign") {
       if (index_type == DataType::INT32) {
@@ -104,8 +126,11 @@ void PutAlongAxisGradKernel(const Context& dev_ctx,
             out_grad, axis, index, *x_grad, include_self, dev_ctx);
       }
     }
+    x_grad->Resize(arr.dims());
   }
   if (value_grad) {
+    // The gradient of ``value`` carries the shape of the index: the functor is
+    // given the promoted one, the caller gets back the one it wrote.
     value_grad->Resize(index.dims());
     dev_ctx.template Alloc<T>(value_grad);
 #ifdef PADDLE_WITH_HIP
@@ -176,6 +201,7 @@ void PutAlongAxisGradKernel(const Context& dev_ctx,
             dev_ctx);
       }
     }
+    value_grad->Resize(indices.dims());
   }
 }
 

--- a/paddle/phi/kernels/gpu/put_along_axis_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/put_along_axis_grad_kernel.cu
@@ -20,6 +20,7 @@
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/core/utils/data_type.h"
 #include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/funcs/for_range.h"
 #include "paddle/phi/kernels/funcs/gather_scatter_functor.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 
@@ -82,6 +83,20 @@ void PutAlongAxisGradKernel(const Context& dev_ctx,
     // functor writes through a rank-1 buffer. The shape the caller expects is
     // the one of ``arr``, restored once the scatter is done.
     Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
+    // torch derives the whole input gradient of a scatter-mul from a single
+    // expression over the tensor, and on every position no index reaches that
+    // expression collapses to a redundant ``(g * m) / m``. Replaying it here is
+    // what keeps the two frameworks bit for bit identical there; the positions
+    // an index does reach are overwritten below, from the untouched
+    // ``out_grad``.
+    if constexpr (funcs::MulInputGradNeedsRoundTrip<T>()) {
+      if (reduce == "mul" || reduce == "multiply") {
+        funcs::ForRange<Context> for_range(
+            dev_ctx, static_cast<size_t>(x_grad->numel()));
+        for_range(funcs::MulInputGradRoundTripFunctor<T>{x.data<T>(),
+                                                         x_grad->data<T>()});
+      }
+    }
     if (!include_self || reduce == "assign") {
       if (index_type == DataType::INT32) {
         funcs::gpu_scatter_input_grad_kernel<T, int32_t>(

--- a/paddle/phi/kernels/gpu/put_along_axis_kernel.cu
+++ b/paddle/phi/kernels/gpu/put_along_axis_kernel.cu
@@ -26,15 +26,28 @@ namespace phi {
 template <typename T, typename Context>
 void PutAlongAxisKernel(const Context& dev_ctx,
                         const DenseTensor& x,
-                        const DenseTensor& index,
-                        const DenseTensor& value,
+                        const DenseTensor& indices,
+                        const DenseTensor& values,
                         int axis,
                         const std::string& reduce,
                         bool include_self,
                         DenseTensor* out) {
+  // Brings the operands into the representation the scatter functor can
+  // address: a 0-D operand becomes rank 1 and ``axis`` is normalized.
+  // ``index`` and ``value`` are shallow views sharing the caller's buffer.
+  // ``out`` is promoted in place because the scatter writes through it, so its
+  // shape is saved here and restored once the scatter is done -- reading it
+  // back from ``x`` would not do, since ``x`` and ``out`` are the same tensor
+  // when the op runs inplace.
+  DenseTensor index = indices;
+  DenseTensor value = values;
   const auto& index_type = index.dtype();
 
   Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+
+  const DDim out_dims = out->dims();
+  funcs::PreparePutAlongAxisOperands(out, &index, &value, &axis);
+
   if (reduce == "add") {
     if (index_type == DataType::INT32) {
       funcs::gpu_scatter_add_kernel<T, int32_t>(
@@ -92,6 +105,7 @@ void PutAlongAxisKernel(const Context& dev_ctx,
         reduce));
     return;
   }
+  out->Resize(out_dims);
 }
 }  // namespace phi
 

--- a/paddle/phi/kernels/xpu/put_along_axis_kernel.cc
+++ b/paddle/phi/kernels/xpu/put_along_axis_kernel.cc
@@ -18,6 +18,7 @@
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/funcs/gather_scatter_functor.h"
 
 namespace phi {
 
@@ -47,16 +48,26 @@ int64_t get_reduction_mode(const std::string& reduce) {
 
 template <typename T, typename Context>
 void PutAlongAxisKernel(const Context& dev_ctx,
-                        const DenseTensor& x,
-                        const DenseTensor& index,
-                        const DenseTensor& value,
+                        const DenseTensor& arr,
+                        const DenseTensor& indices,
+                        const DenseTensor& values,
                         int axis,
                         const std::string& reduce,
                         bool include_self,
                         DenseTensor* out) {
+  // Shallow views of the operands, brought into the same representation the
+  // InferMeta reasons about: a 0-D operand becomes rank 1 and ``axis`` is
+  // normalized. XDNN is given the promoted shapes, so a 0-D operand does not
+  // reach it as an empty shape vector.
+  DenseTensor x = arr;
+  DenseTensor index = indices;
+  DenseTensor value = values;
+
   out->Resize(x.dims());
+  funcs::PreparePutAlongAxisOperands(&x, &index, &value, &axis);
+
   if (x.numel() == 0 || index.numel() == 0) {
-    Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+    Copy(dev_ctx, arr, dev_ctx.GetPlace(), false, out);
     return;
   }
   dev_ctx.template Alloc<T>(out);

--- a/paddle/phi/ops/yaml/ops.yaml
+++ b/paddle/phi/ops/yaml/ops.yaml
@@ -4426,8 +4426,8 @@
   args : (Tensor arr, Tensor indices, Tensor values, int axis, str reduce = "assign", bool include_self = true)
   output : Tensor(out)
   infer_meta :
-    func : UnchangedInferMeta
-    param : [arr]
+    func : PutAlongAxisInferMeta
+    param : [arr, indices, values, axis, reduce]
     spmd_rule : PutAlongAxisInferSpmd
   kernel :
     func : put_along_axis

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -7408,6 +7408,39 @@ def infer_broadcast_shape(
     return broadcast_shape
 
 
+def check_put_along_axis_index_shape(
+    arr: Tensor, indices: Tensor, axis: int
+) -> None:
+    """Validate that ``indices`` can address ``arr`` in put_along_axis.
+
+    ``indices`` is only allowed to exceed ``arr`` along ``axis``. The remaining
+    dimensions of ``indices`` are used as coordinates into ``arr``, so a larger
+    size there would make the scatter kernel write out of bounds.
+
+    An empty ``arr.shape[axis]`` is deliberately *not* rejected here: it leaves
+    no valid index value, which the kernel reports as an index out-of-bounds
+    error, the same way ``torch.scatter_`` does.
+
+    ``broadcast=False`` and ``torch.scatter_`` already reject the case above;
+    this brings the ``broadcast=True`` path in line with them.
+    """
+    if 0 in indices.shape:
+        # No scatter to perform, nothing can go out of bounds.
+        return
+    for i in range(len(arr.shape)):
+        if i == axis:
+            continue
+        if arr.shape[i] < 0 or indices.shape[i] < 0:
+            # dynamic shape, cannot be checked at compile time.
+            continue
+        if arr.shape[i] < indices.shape[i]:
+            raise RuntimeError(
+                f"Size does not match at dimension {i} expected index "
+                f"{indices.shape} to be no larger than self {arr.shape} "
+                f"apart from dimension {axis}"
+            )
+
+
 def scatter_add(
     input: Tensor,
     dim: int,
@@ -7807,6 +7840,7 @@ def put_along_axis(
             indices = paddle.broadcast_to(indices, broadcast_shape)
             values = paddle.broadcast_to(values, broadcast_shape)
         else:
+            check_put_along_axis_index_shape(arr, indices, axis)
             broadcast_shape = infer_broadcast_shape(arr, indices, axis)
             values = (
                 paddle.to_tensor(values)
@@ -7915,6 +7949,7 @@ def put_along_axis_(
         )
         return arr
     if broadcast:
+        check_put_along_axis_index_shape(arr, indices, axis)
         broadcast_shape = infer_broadcast_shape(arr, indices, axis)
         values = (
             paddle.to_tensor(values)

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -7431,15 +7431,16 @@ def check_put_along_axis_index_shape(
 
     ``broadcast=False`` and ``torch.scatter_`` already reject the case above;
     this brings the ``broadcast=True`` path in line with them.
+
+    Both callers reach here only with a non-empty ``indices`` and with both
+    shapes fully known, so neither case is handled again: they return early on
+    an empty ``indices``, and a dynamic shape either cannot occur (the inplace
+    API runs its body in dygraph only) or is routed to
+    ``infer_dynamic_broadcast_shape``, which leaves the same diagnosis to
+    ``PutAlongAxisInferMeta`` when the executor re-runs it with runtime shapes.
     """
-    if 0 in indices.shape:
-        # No scatter to perform, nothing can go out of bounds.
-        return
     for i in range(len(arr.shape)):
         if i == axis:
-            continue
-        if arr.shape[i] < 0 or indices.shape[i] < 0:
-            # dynamic shape, cannot be checked at compile time.
             continue
         if arr.shape[i] < indices.shape[i]:
             raise RuntimeError(

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -4495,32 +4495,45 @@ def _put_along_axis_inplace_wrapper(
         raise ValueError(
             "`index` and `input` must have the same number of dimensions!"
         )
-    axis = non_negative_axis(input, dim)
+    is_0d = len(input.shape) == 0
+    axis = (
+        normalize_put_along_axis_0d_axis(dim)
+        if is_0d
+        else non_negative_axis(input, dim)
+    )
 
-    if isinstance(src, (paddle.Tensor, paddle.pir.Value)):
-        if len(index.shape) != len(src.shape):
-            raise ValueError(
-                "`index` and `src` must have the same number of dimensions!"
-            )
-        for i in range(len(input.shape)):
-            if (i != axis and input.shape[i] < index.shape[i]) or index.shape[
-                i
-            ] > src.shape[i]:
-                raise RuntimeError(
-                    f"Size does not match at dimension {i} expected index {index.shape} to be smaller than self {input.shape} apart from dimension {axis} and to be smaller size than src {src.shape}"
-                )
+    if is_0d:
+        # 0-D operands have no dimension to compare and no
+        # ``input.shape[axis]`` to bound the index against: the kernel promotes
+        # them to rank 1 itself and bound checks the single index there. ``src``
+        # still has to become a tensor, since that is all the kernel accepts.
+        if not isinstance(src, (paddle.Tensor, paddle.pir.Value)):
+            src = paddle.to_tensor(src).astype(input.dtype)
     else:
-        src = paddle.to_tensor(src).astype(input.dtype)
-        elements = 1
-        for num in src.shape:
-            elements *= num
-        if elements == 1:  # paddle.pir.Value has no attribute 'size'
-            src = paddle.broadcast_to(src, index.shape)
-    axis_max_size = input.shape[axis]
-    if not (index < axis_max_size).all():
-        raise RuntimeError(
-            f"one of element of index is out of bounds for dimension {axis} with size {axis_max_size}"
-        )
+        if isinstance(src, (paddle.Tensor, paddle.pir.Value)):
+            if len(index.shape) != len(src.shape):
+                raise ValueError(
+                    "`index` and `src` must have the same number of dimensions!"
+                )
+            for i in range(len(input.shape)):
+                if (
+                    i != axis and input.shape[i] < index.shape[i]
+                ) or index.shape[i] > src.shape[i]:
+                    raise RuntimeError(
+                        f"Size does not match at dimension {i} expected index {index.shape} to be smaller than self {input.shape} apart from dimension {axis} and to be smaller size than src {src.shape}"
+                    )
+        else:
+            src = paddle.to_tensor(src).astype(input.dtype)
+            elements = 1
+            for num in src.shape:
+                elements *= num
+            if elements == 1:  # paddle.pir.Value has no attribute 'size'
+                src = paddle.broadcast_to(src, index.shape)
+        axis_max_size = input.shape[axis]
+        if not (index < axis_max_size).all():
+            raise RuntimeError(
+                f"one of element of index is out of bounds for dimension {axis} with size {axis_max_size}"
+            )
 
     if convert_dtype(index.dtype) not in ['int32', 'int64']:
         raise TypeError(
@@ -7450,6 +7463,23 @@ def check_put_along_axis_index_shape(
             )
 
 
+def normalize_put_along_axis_0d_axis(axis: int) -> int:
+    """Normalize ``axis`` when the put_along_axis operands are 0-D.
+
+    A 0-D tensor is treated as holding a single element on one dimension, the
+    way ``PutAlongAxisInferMeta`` and ``torch.scatter_`` do, so ``axis`` ranges
+    over ``[-1, 1)``. ``non_negative_axis`` cannot express that: it derives the
+    range from ``len(arr.shape)``, which is 0 here, leaving no legal value at
+    all.
+    """
+    if axis not in (0, -1):
+        raise IndexError(
+            f"Dimension out of range, expected axis to be in [-1, 1), but got "
+            f"{axis}."
+        )
+    return 0
+
+
 def scatter_add(
     input: Tensor,
     dim: int,
@@ -7819,7 +7849,12 @@ def put_along_axis(
         raise ValueError(
             "`indices` and `arr` must have the same number of dimensions!"
         )
-    axis = non_negative_axis(arr, axis)
+    is_0d = len(arr.shape) == 0
+    axis = (
+        normalize_put_along_axis_0d_axis(axis)
+        if is_0d
+        else non_negative_axis(arr, axis)
+    )
     # When indices is empty (numel == 0) there are no scatter operations to
     # perform.  Return a copy of arr immediately to avoid passing a 0-size
     # index tensor through the broadcast path, which would attempt an invalid
@@ -7832,7 +7867,14 @@ def put_along_axis(
             arr, indices, reduce, include_self
         )
         return paddle.assign(arr)
-    if broadcast:
+    if is_0d:
+        # There is nothing to broadcast and no ``arr.shape[axis]`` to compare
+        # against: the kernel promotes the 0-D operands to rank 1 itself and
+        # bound checks the single index there. ``values`` still has to become a
+        # tensor, since that is all the kernel accepts.
+        if not isinstance(values, (paddle.Tensor, paddle.pir.Value, Variable)):
+            values = paddle.to_tensor(values).astype(arr.dtype)
+    elif broadcast:
         if has_dynamic_shape(arr.shape) or has_dynamic_shape(indices.shape):
             arr_shape = paddle.shape(arr)
             indices_shape = paddle.shape(indices)
@@ -7951,13 +7993,25 @@ def put_along_axis_(
         raise ValueError(
             "`indices` and `arr` must have the same number of dimensions!"
         )
-    axis = non_negative_axis(arr, axis)
+    is_0d = len(arr.shape) == 0
+    axis = (
+        normalize_put_along_axis_0d_axis(axis)
+        if is_0d
+        else non_negative_axis(arr, axis)
+    )
     if 0 in indices.shape:
         _check_put_along_axis_early_return_params(
             arr, indices, reduce, include_self
         )
         return arr
-    if broadcast:
+    if is_0d:
+        # There is nothing to broadcast and no ``arr.shape[axis]`` to compare
+        # against: the kernel promotes the 0-D operands to rank 1 itself and
+        # bound checks the single index there. ``values`` still has to become a
+        # tensor, since that is all the kernel accepts.
+        if not isinstance(values, (paddle.Tensor, paddle.pir.Value)):
+            values = paddle.to_tensor(values).astype(arr.dtype)
+    elif broadcast:
         check_put_along_axis_index_shape(arr, indices, axis)
         broadcast_shape = infer_broadcast_shape(arr, indices, axis)
         values = (

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -7371,25 +7371,33 @@ def infer_dynamic_broadcast_shape(
     Returns:
         Tensor: The shape tensor for later broadcasting
     """
+    # Outside ``axis`` the target is the larger of the two sizes, not ``arr``'s
+    # alone. Taking ``arr``'s size unconditionally silently overrides an
+    # ``indices`` dimension that exceeds it: for ``arr`` of shape [0, 10, 10, 10]
+    # and ``indices`` of shape [1, 1, 1, 1] the target used to be [0, 10, 1, 10],
+    # which expands a non-empty index into an empty one and turns the scatter
+    # into a silent no-op, where torch reports that the index is larger than self
+    # apart from ``axis``. Keeping the larger size leaves the violation visible
+    # to ``PutAlongAxisInferMeta``, which runs again with the runtime shapes.
     if axis == 0:
         new_shapes = [
             indices_shape[
                 :1
             ],  # use indices_shape[0] will error in concat after, because its shape is [], and shape of arr_shape[1:] is [1]
-            arr_shape[1:],
+            paddle.maximum(arr_shape[1:], indices_shape[1:]),
         ]
     elif axis == arr_shape_dim - 1:
         new_shapes = [
-            arr_shape[:axis],
+            paddle.maximum(arr_shape[:axis], indices_shape[:axis]),
             indices_shape[
                 axis:
             ],  # use indices_shape[axis] will error in concat after, because its shape is [], and shape of arr_shape[axis:] is [1]
         ]
     else:
         new_shapes = [
-            arr_shape[:axis],
+            paddle.maximum(arr_shape[:axis], indices_shape[:axis]),
             indices_shape[axis : axis + 1],
-            arr_shape[axis + 1 :],
+            paddle.maximum(arr_shape[axis + 1 :], indices_shape[axis + 1 :]),
         ]
     return paddle.concat(new_shapes)
 

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -2041,30 +2041,31 @@ class TestPutAlongAxisIndexLargerThanInput(unittest.TestCase):
         np.testing.assert_allclose(out.numpy(), expected)
 
 
-@unittest.skipIf(
-    not (core.is_compiled_with_cuda() or is_custom_device()),
-    "core is not compiled with CUDA",
-)
 class TestPutAlongAxisIncludeSelfFalseInvalidIndex(unittest.TestCase):
     """``include_self=False`` initializes scatter targets before reducing.
 
-    That initialization kernel has to reject index values before computing the
-    target offset, otherwise an invalid index can write out of bounds before
-    the main scatter kernel reports the error.
+    That initialization has to reject index values before computing the target
+    offset, otherwise an invalid index writes out of bounds before the reduce
+    step ever looks at it.
+
+    Only the CPU place is exercised. On GPU the same check is a device-side
+    ``PADDLE_ENFORCE``, which prints and then traps; the trap destroys the CUDA
+    context, so the failure surfaces as ``CUDA error(719)`` instead of the
+    diagnostic, and every later CUDA call in the process fails as well. torch
+    reports an out-of-range scatter index the same way, and for the same
+    reason, so there is nothing in-process to assert there.
     """
 
     def setUp(self):
         paddle.disable_static()
 
     def test_reduce_mul_checks_index_before_initialization(self):
-        place = get_device_place()
-        x = paddle.zeros([2, 3], dtype='float32', device=place)
+        place = paddle.CPUPlace()
+        x = paddle.zeros([2, 3], dtype='float32').cpu()
         index = paddle.to_tensor([[10, 0, 0]], dtype='int64', place=place)
-        value = paddle.ones([1, 3], dtype='float32', device=place)
+        value = paddle.ones([1, 3], dtype='float32').cpu()
 
-        with self.assertRaisesRegex(
-            (RuntimeError, IndexError), "out of bounds"
-        ):
+        with self.assertRaisesRegex(IndexError, "expected >= -2 and < 2"):
             out = paddle._C_ops.put_along_axis(x, index, value, 0, 'mul', False)
             out.numpy()
 

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -1821,7 +1821,8 @@ class TestPutAlongAxisMulIntegerDivByZero(unittest.TestCase):
     x or value contains zero, because the grad formula divides by x or value
     without a zero guard.
 
-    Fixed in gather_scatter_functor.cc/.cu by returning grad=0 when divisor is 0.
+    Fixed in gather_scatter_functor.cc/.cu: a zero factor is handled by the
+    zero-count path and never reaches the division.
 
     For integer dtypes (uint8/int32/int64), Paddle does not support autograd
     (no sum_grad kernel registered for these types), so we verify only that the
@@ -2040,6 +2041,34 @@ class TestPutAlongAxisIndexLargerThanInput(unittest.TestCase):
         np.testing.assert_allclose(out.numpy(), expected)
 
 
+@unittest.skipIf(
+    not (core.is_compiled_with_cuda() or is_custom_device()),
+    "core is not compiled with CUDA",
+)
+class TestPutAlongAxisIncludeSelfFalseInvalidIndex(unittest.TestCase):
+    """``include_self=False`` initializes scatter targets before reducing.
+
+    That initialization kernel has to reject index values before computing the
+    target offset, otherwise an invalid index can write out of bounds before
+    the main scatter kernel reports the error.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+
+    def test_reduce_mul_checks_index_before_initialization(self):
+        place = get_device_place()
+        x = paddle.zeros([2, 3], dtype='float32', place=place)
+        index = paddle.to_tensor([[10, 0, 0]], dtype='int64', place=place)
+        value = paddle.ones([1, 3], dtype='float32', place=place)
+
+        with self.assertRaisesRegex(
+            (RuntimeError, IndexError), "out of bounds"
+        ):
+            out = paddle._C_ops.put_along_axis(x, index, value, 0, 'mul', False)
+            out.numpy()
+
+
 class TestPutAlongAxisInferMetaShapeCheck(unittest.TestCase):
     """``PutAlongAxisInferMeta`` mirrors ``scatter_shape_check`` in torch.
 
@@ -2196,7 +2225,7 @@ class TestPutAlongAxisZeroDimOperands(unittest.TestCase):
             np.testing.assert_allclose(out.numpy(), np.array(14.0))
 
     def test_negative_axis(self):
-        """``axis`` reaches the kernel exactly as written, so it normalizes it."""
+        """``axis`` reaches the kernel as written, which normalizes it."""
         expected = np.zeros([3, 4], dtype='float32')
         expected[0, 0] = 1.0
         expected[1, 1] = 2.0
@@ -2277,23 +2306,21 @@ class TestPutAlongAxisZeroDimOperandsGrad(unittest.TestCase):
 
 
 class TestPutAlongAxisMulFloat32DivByZeroGrad(unittest.TestCase):
-    """
-    Bug A (float32 backward path): verify that the div-by-zero guard in
-    gather_scatter_functor.cc is exercised when x or value contains 0.
+    """``reduce='mul'`` never divides by zero, whichever factor vanishes.
 
-    - cpu_scatter_mul_min_max_input_grad_kernel: x==0 → grad=0 (line 524)
-      and x!=0 → normal division (line 520-522).
-    - cpu_scatter_mul_min_max_value_grad_kernel: value==0 → grad=0 (line 698)
-      and value!=0 → normal division (line 694-696).
-
-    Both tests must not crash and must return finite gradients.
+    The backward of a product is the product of the *other* factors, computed
+    as ``out / factor`` while every factor is non-zero. A zero factor takes the
+    zero-count path instead of the division, so the gradients stay finite.
+    ``TestPutAlongAxisMulZeroFactorGrad`` pins down their values; these two
+    only guard the multi-dimensional, non-contiguous-index shape against
+    crashes and infinities.
     """
 
     def setUp(self):
         paddle.disable_static()
 
     def test_x_grad_with_zero_in_x(self):
-        """x contains 0: covers x==0 branch (grad=0) and x!=0 branch."""
+        """x contains 0, so both the zero and the division path run."""
         cpu = paddle.CPUPlace()
         x = paddle.to_tensor(
             [[[1.0, 0.0, 3.0], [0.0, 5.0, 6.0]]],
@@ -2319,7 +2346,7 @@ class TestPutAlongAxisMulFloat32DivByZeroGrad(unittest.TestCase):
         self.assertTrue(paddle.isfinite(x.grad).all())
 
     def test_value_grad_with_zero_in_value(self):
-        """value contains 0: covers value==0 branch (grad=0) and value!=0 branch."""
+        """value contains 0, so both the zero and the division path run."""
         cpu = paddle.CPUPlace()
         x = paddle.to_tensor(
             [[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]],
@@ -2343,6 +2370,181 @@ class TestPutAlongAxisMulFloat32DivByZeroGrad(unittest.TestCase):
         loss.backward()
         self.assertIsNotNone(value.grad)
         self.assertTrue(paddle.isfinite(value.grad).all())
+
+
+class TestPutAlongAxisZeroDimPublicAPI(unittest.TestCase):
+    """The public API reaches the 0-D kernels instead of rejecting them.
+
+    ``non_negative_axis`` derives the legal ``axis`` range from
+    ``len(arr.shape)``, which is 0 here, so it used to leave no legal value at
+    all and the 0-D support of the kernel was reachable through ``_C_ops``
+    only. ``torch`` treats a 0-D tensor as holding a single element on one
+    dimension and accepts ``axis`` in ``[-1, 0]``.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+        self.places = zero_dim_operand_places()
+
+    def _operands(self, place):
+        return (
+            paddle.to_tensor(5.0, place=place),
+            paddle.to_tensor(0, dtype='int64', place=place),
+            paddle.to_tensor(3.0, place=place),
+        )
+
+    def test_put_along_axis(self):
+        for place in self.places:
+            for axis in (0, -1):
+                arr, index, value = self._operands(place)
+                out = paddle.put_along_axis(arr, index, value, axis, 'add')
+                self.assertEqual(list(out.shape), [])
+                np.testing.assert_allclose(out.numpy(), np.array(8.0))
+
+    def test_put_along_axis_no_broadcast(self):
+        """The ``broadcast=False`` path has no ``arr.shape[axis]`` to read."""
+        for place in self.places:
+            arr, index, value = self._operands(place)
+            out = paddle.put_along_axis(
+                arr, index, value, 0, 'add', broadcast=False
+            )
+            np.testing.assert_allclose(out.numpy(), np.array(8.0))
+
+    def test_put_along_axis_scalar_value(self):
+        """``values`` is turned into a tensor on the 0-D path as well."""
+        for place in self.places:
+            arr, index, _ = self._operands(place)
+            out = paddle.put_along_axis(arr, index, 3.0, 0, 'add')
+            np.testing.assert_allclose(out.numpy(), np.array(8.0))
+
+    def test_put_along_axis_inplace(self):
+        for place in self.places:
+            arr, index, value = self._operands(place)
+            paddle.put_along_axis_(arr, index, value, 0, 'add')
+            np.testing.assert_allclose(arr.numpy(), np.array(8.0))
+
+    def test_scatter_inplace(self):
+        """``Tensor.scatter_`` normalizes ``dim`` in its own wrapper."""
+        for place in self.places:
+            arr, index, value = self._operands(place)
+            arr.scatter_(0, index, value, reduce='add')
+            np.testing.assert_allclose(arr.numpy(), np.array(8.0))
+
+    def test_grad(self):
+        for place in self.places:
+            arr, index, value = self._operands(place)
+            arr.stop_gradient = False
+            value.stop_gradient = False
+            out = paddle.put_along_axis(arr, index, value, 0, 'add')
+            out.backward()
+            self.assertEqual(list(arr.grad.shape), [])
+            np.testing.assert_allclose(arr.grad.numpy(), np.array(1.0))
+            np.testing.assert_allclose(value.grad.numpy(), np.array(1.0))
+
+    def test_axis_out_of_range(self):
+        """``[-1, 1)`` is the only legal range, as ``torch`` reports too."""
+        arr, index, value = self._operands(paddle.CPUPlace())
+        for axis in (1, -2):
+            with self.assertRaises(IndexError):
+                paddle.put_along_axis(arr, index, value, axis)
+            with self.assertRaises(IndexError):
+                paddle.put_along_axis_(arr, index, value, axis)
+            with self.assertRaises(IndexError):
+                arr.scatter_(axis, index, value)
+
+
+class TestPutAlongAxisMulZeroFactorGrad(unittest.TestCase):
+    """The gradient of a product is the product of the *other* factors.
+
+    ``reduce='mul'`` used to compute it as ``out / factor``, which is only the
+    product of the others while none of them is zero: as soon as one factor is
+    zero ``out`` is zero too and no longer carries the rest. The old kernel
+    answered 0 for every factor in that case, but the derivative with respect to
+    the single zero factor is the (generally non-zero) product of the others.
+    Only two or more zeros make every gradient vanish.
+
+    Every expectation below is what ``torch.Tensor.scatter_reduce(...,
+    'prod')`` returns for the same inputs.
+    """
+
+    # (note, arr, index, value, x_grad, value_grad), include_self=True
+    CASES = [
+        ("no zeros", [2, 3], [0, 0], [5, 11], [55, 1], [22, 10]),
+        ("only x is zero", [0, 3], [0], [7], [7, 1], [0]),
+        ("only value is zero", [2, 3], [0, 0], [0, 11], [0, 1], [22, 0]),
+        ("x and value zero", [0, 3], [0], [0], [0, 1], [0]),
+        ("x and one value zero", [0, 3], [0, 0], [0, 11], [0, 1], [0, 0]),
+        ("two values zero", [2, 3], [0, 0], [0, 0], [0, 1], [0, 0]),
+    ]
+    # ``include_self=False`` drops ``x`` from the product, so a zero ``x`` must
+    # not be counted as a zero factor there.
+    CASES_NO_SELF = [
+        ("value is zero", [5, 3], [0], [0], [0, 1], [1]),
+        ("one value is zero", [5, 3], [0, 0], [0, 11], [0, 1], [11, 0]),
+    ]
+
+    def setUp(self):
+        paddle.disable_static()
+        self.places = zero_dim_operand_places()
+
+    def test_grad(self):
+        for place in self.places:
+            for inc, cases in ((True, self.CASES), (False, self.CASES_NO_SELF)):
+                for note, arr, index, value, x_grad, v_grad in cases:
+                    self._check(
+                        place, inc, note, arr, index, value, x_grad, v_grad
+                    )
+
+    def _check(self, place, inc, note, arr, index, value, x_grad, v_grad):
+        a = paddle.to_tensor(arr, dtype='float32', place=place)
+        a.stop_gradient = False
+        v = paddle.to_tensor(value, dtype='float32', place=place)
+        v.stop_gradient = False
+        out = paddle.put_along_axis(
+            a,
+            paddle.to_tensor(index, dtype='int64', place=place),
+            v,
+            0,
+            'mul',
+            include_self=inc,
+        )
+        out.backward(paddle.ones_like(out))
+        where = f"'{note}' with include_self={inc} on {place}"
+        np.testing.assert_allclose(
+            a.grad.numpy(),
+            np.array(x_grad, dtype='float32'),
+            err_msg=f"x_grad of {where}",
+        )
+        np.testing.assert_allclose(
+            v.grad.numpy(),
+            np.array(v_grad, dtype='float32'),
+            err_msg=f"value_grad of {where}",
+        )
+
+
+class TestPutAlongAxisMulInt16NegativeValue(unittest.TestCase):
+    """``mul`` on int16 must not corrupt the neighbouring element.
+
+    The GPU reduce is a sub-word ``atomicCAS`` that rebuilds the whole 4-byte
+    word around the element. Widening a negative ``int16_t`` result with a plain
+    ``static_cast<uint32_t>`` sign extends it, and OR-ing that in overwrites the
+    other half of the word with 0xFFFF. Only an even element offset is affected,
+    so element 0 is the one scattered into here and element 1 is the witness.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+        self.places = zero_dim_operand_places()
+
+    def test_negative_product_keeps_neighbour(self):
+        for place in self.places:
+            x = paddle.to_tensor([3, 7], dtype='int16', place=place)
+            index = paddle.to_tensor([0], dtype='int64', place=place)
+            value = paddle.to_tensor([-2], dtype='int16', place=place)
+            out = paddle.put_along_axis(x, index, value, 0, 'mul')
+            np.testing.assert_array_equal(
+                out.numpy(), np.array([-6, 7], dtype='int16')
+            )
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -2547,6 +2547,106 @@ class TestPutAlongAxisMulInt16NegativeValue(unittest.TestCase):
             )
 
 
+class TestPutAlongAxisNegativeIndexGrad(unittest.TestCase):
+    """A negative subscript has to mean the same thing in the backward pass.
+
+    ``if (index < 0) index += size`` used to live in the forward gather/scatter
+    kernels only. The backward ones handed the raw subscript to the offset
+    arithmetic, so a negative one became a negative offset -- an access before
+    the start of the tensor. Both gradients came out wrong on CPU and on GPU,
+    and the GPU reduce kernels could fault outright.
+
+    The normalization needs the length along the axis of the tensor the
+    subscript addresses, which is never ``index`` itself: the ``index shorter
+    than arr`` case below is the one that tells the two apart.
+    """
+
+    REDUCES = ['assign', 'add', 'mean', 'mul', 'amin', 'amax']
+
+    # (note, arr, index, value). ``index`` holds negative subscripts only; the
+    # reference run replaces each of them with ``i + arr.shape[axis]``.
+    CASES = [
+        ("single element", [1.0, 2.0, 3.0], [-1], [10.0]),
+        ("every position", [1.0, 2.0, 3.0], [-1, -2, -3], [10.0, 20.0, 30.0]),
+        (
+            "index shorter than arr",
+            [1.0, 2.0, 3.0, 4.0],
+            [-1, -4],
+            [10.0, 20.0],
+        ),
+        ("duplicate subscripts", [1.0, 2.0, 3.0], [-2, -2], [10.0, 20.0]),
+    ]
+
+    def setUp(self):
+        paddle.disable_static()
+        self.places = zero_dim_operand_places()
+
+    def _run(self, place, include_self, reduce, arr, index, value):
+        a = paddle.to_tensor(arr, dtype='float32', place=place)
+        a.stop_gradient = False
+        v = paddle.to_tensor(value, dtype='float32', place=place)
+        v.stop_gradient = False
+        out = paddle.put_along_axis(
+            a,
+            paddle.to_tensor(index, dtype='int64', place=place),
+            v,
+            0,
+            reduce,
+            include_self=include_self,
+        )
+        out.backward(paddle.ones_like(out))
+        return out.numpy(), a.grad.numpy(), v.grad.numpy()
+
+    def test_matches_the_positive_subscript(self):
+        # The positive path is the reference: same offsets, so the two runs have
+        # to agree exactly, not just to a tolerance.
+        for place in self.places:
+            for include_self in (True, False):
+                for reduce in self.REDUCES:
+                    for note, arr, index, value in self.CASES:
+                        got = self._run(
+                            place, include_self, reduce, arr, index, value
+                        )
+                        want = self._run(
+                            place,
+                            include_self,
+                            reduce,
+                            arr,
+                            [i + len(arr) for i in index],
+                            value,
+                        )
+                        where = (
+                            f"'{note}' reduce={reduce} "
+                            f"include_self={include_self} on {place}"
+                        )
+                        for name, g, w in zip(
+                            ('out', 'x_grad', 'value_grad'), got, want
+                        ):
+                            np.testing.assert_array_equal(
+                                g, w, err_msg=f"{name} of {where}"
+                            )
+
+    def test_assign_grad_values(self):
+        # Anchors the comparison above: ``index=[-1]`` on a 3 element input has
+        # to zero the last position of ``x_grad`` and nothing else.
+        for place in self.places:
+            out, x_grad, v_grad = self._run(
+                place, True, 'assign', [1.0, 2.0, 3.0], [-1], [10.0]
+            )
+            where = f"on {place}"
+            np.testing.assert_array_equal(
+                out, np.array([1.0, 2.0, 10.0], dtype='float32'), err_msg=where
+            )
+            np.testing.assert_array_equal(
+                x_grad,
+                np.array([1.0, 1.0, 0.0], dtype='float32'),
+                err_msg=where,
+            )
+            np.testing.assert_array_equal(
+                v_grad, np.array([1.0], dtype='float32'), err_msg=where
+            )
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -1572,12 +1572,14 @@ class TestPutAlongAxisDynamicShape_ZeroSize(TestPutAlongAxisDynamicShape):
     """``arr`` is 0-size while ``put_along_axis_net`` scatters a [1, 1, 1, 1]
     index, which exceeds ``arr`` on dimension 0.
 
-    Dygraph rejects it. The to_static path cannot: ``arr`` is traced with a
-    fully dynamic ``(-1, -1, -1, -1)`` spec, so the shapes are unknown when the
-    check would run, and at execution time ``indices`` gets broadcast against
-    the runtime shape of ``arr``, which collapses it to 0-size. An empty index
-    scatters nothing, so returning ``arr`` unchanged is correct there -- the
-    same thing ``torch.scatter_`` does for an empty index.
+    Both paths reject it, from different places. Dygraph knows the shapes and
+    reports it in ``check_put_along_axis_index_shape``. The to_static path
+    traces ``arr`` with a fully dynamic ``(-1, -1, -1, -1)`` spec, so nothing
+    can be decided at compile time; the broadcast target keeps the larger of
+    the two sizes apart from ``axis``, which leaves the violation for
+    ``PutAlongAxisInferMeta`` to report when the executor runs it again with
+    the runtime shapes. Before, ``arr``'s 0 won, the index was collapsed to
+    0-size and the scatter became a silent no-op.
     """
 
     def setUp(self):
@@ -1598,10 +1600,57 @@ class TestPutAlongAxisDynamicShape_ZeroSize(TestPutAlongAxisDynamicShape):
 
     def test_dynamic_static(self):
         with dygraph_guard():
-            with self.assertRaises(RuntimeError):
-                self.train(to_static=False)
-            res, _ = self.train(to_static=True)
-            self.assertEqual(list(res.shape), [0, 10, 10, 10])
+            for to_static in (False, True):
+                with self.assertRaisesRegex(
+                    (RuntimeError, ValueError), "no larger than self"
+                ):
+                    self.train(to_static=to_static)
+
+
+class TestPutAlongAxisDynamicShapeIndexLargerThanInput(
+    TestPutAlongAxisDynamicShape
+):
+    """``indices`` exceeds ``arr`` on a dimension other than ``axis`` while
+    ``arr`` is traced with a dynamic shape.
+
+    The broadcast target keeps ``indices``' larger size instead of overriding
+    it with ``arr``'s, so the violation stays visible to
+    ``PutAlongAxisInferMeta`` and is reported the way torch does. Before, the
+    index was silently shrunk to fit ``arr``.
+    """
+
+    def setUp(self):
+        np.random.seed(2024)
+
+        def net(arr, axis=-1):
+            indices = paddle.to_tensor(
+                [[[[2]]]] * 5, dtype='int32', stop_gradient=False
+            )
+            return paddle.put_along_axis(
+                arr, indices=indices, values=-4.0, axis=axis, reduce='add'
+            )
+
+        self.net = net
+        self.enable_cinn = False
+        self.tol = 1e-6
+        self.dtype = "float32"
+        self.axis = -2
+        self.input_specs = [
+            InputSpec(
+                shape=(-1, -1, -1, -1),
+                dtype=self.dtype,
+                stop_gradient=False,
+            )
+        ]
+        self.arr = np.random.random([3, 10, 10, 10]).astype(self.dtype)
+
+    def test_dynamic_static(self):
+        with dygraph_guard():
+            for to_static in (False, True):
+                with self.assertRaisesRegex(
+                    (RuntimeError, ValueError), "no larger than self"
+                ):
+                    self.train(to_static=to_static)
 
 
 class TestPutAlongAxisZeroSizeIndex(unittest.TestCase):

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -23,7 +23,7 @@ from op_test import (
     get_places,
     is_custom_device,
 )
-from utils import dygraph_guard
+from utils import dygraph_guard, static_guard
 
 import paddle
 from paddle.framework import core
@@ -1078,70 +1078,72 @@ class TestPutAlongAxisAPICase4(unittest.TestCase):
         for place in self.place:
             run(place)
 
-    def test_error(self):
+    def _check_error(self, index_too_large_error):
+        """The body of ``test_error``, run once per mode.
+
+        ``index_too_large_error`` is what tells the two modes apart: in dygraph
+        the wrapper rejects the index itself and raises ``RuntimeError``, while
+        in static and PIR that check is skipped -- it is guarded by
+        ``in_dynamic_mode()`` -- and ``PutAlongAxisInferMeta`` reports the
+        violation as ``InvalidArgument``, which surfaces in python as
+        ``ValueError``.
+        """
         tensorx = paddle.to_tensor([[1, 2, 3], [4, 5, 6]]).astype("float32")
         indices = paddle.to_tensor([1]).astype("int32")
         values = paddle.to_tensor([2])
         # len(arr.shape) != len(indices.shape)
-        try:
-            res = paddle.put_along_axis(
+        with self.assertRaises(ValueError):
+            paddle.put_along_axis(
                 tensorx, indices, 1.0, 0, 'assign', True, False
             )
-        except Exception as error:
-            self.assertIsInstance(error, ValueError)
         indices = paddle.to_tensor([[1]]).astype("int32")
         # len(values.shape) != len(indices.shape)
-        try:
-            res = paddle.put_along_axis(
+        with self.assertRaises(ValueError):
+            paddle.put_along_axis(
                 tensorx, indices, values, 0, 'assign', True, False
             )
-        except Exception as error:
-            self.assertIsInstance(error, ValueError)
         # len(values.shape) != len(indices.shape)
-        try:
+        with self.assertRaises(ValueError):
             tensorx.put_along_axis_(indices, values, 0, 'assign', True, False)
-        except Exception as error:
-            self.assertIsInstance(error, ValueError)
         indices = paddle.to_tensor(
             [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]
         ).astype("int32")
-        # ``indices`` too large. Which layer reports it depends on the mode this
-        # test runs in, and the preceding tests leave static mode enabled: there
-        # the wrapper's check is skipped -- it is guarded by
-        # ``in_dynamic_mode()`` -- and the diagnosis comes from
-        # ``PutAlongAxisInferMeta`` instead, as InvalidArgument, which surfaces
-        # in python as ``ValueError``. In dygraph the wrapper raises
-        # ``RuntimeError`` before the op is reached. Static mode used to raise
-        # nothing at all here, so both blocks below asserted nothing.
-        expected_error = (
-            RuntimeError if paddle.in_dynamic_mode() else ValueError
-        )
-        try:
-            res = paddle.put_along_axis(
-                tensorx, indices, 1.0, 0, 'assign', True, False
-            )
-        except Exception as error:
-            self.assertIsInstance(error, expected_error)
         # indices too large
-        try:
-            tensorx.put_along_axis_(indices, 1.0, 0, 'assign', True, False)
-        except Exception as error:
-            self.assertIsInstance(error, expected_error)
-        indices = paddle.to_tensor([[10]]).astype("int32")
-        # The element of indices is out of range. This is a value check, which
-        # only the wrapper performs and only in dygraph, so static mode still
-        # raises nothing here.
-        try:
-            res = paddle.put_along_axis(
+        with self.assertRaises(index_too_large_error):
+            paddle.put_along_axis(
                 tensorx, indices, 1.0, 0, 'assign', True, False
             )
-        except Exception as error:
-            self.assertIsInstance(error, RuntimeError)
-        # the element of indices out of range
-        try:
+        # indices too large
+        with self.assertRaises(index_too_large_error):
             tensorx.put_along_axis_(indices, 1.0, 0, 'assign', True, False)
-        except Exception as error:
-            self.assertIsInstance(error, RuntimeError)
+        if not paddle.in_dynamic_mode():
+            # What is left is a check on the index *values*, which only the
+            # wrapper performs and only in dygraph. Outside it there is nothing
+            # to assert: the shapes below are legal, so InferMeta accepts them
+            # and an out-of-range element would only be seen by the kernel, at
+            # a point this test never reaches.
+            return
+        indices = paddle.to_tensor([[10]]).astype("int32")
+        # the element of indices out of range
+        with self.assertRaises(RuntimeError):
+            paddle.put_along_axis(
+                tensorx, indices, 1.0, 0, 'assign', True, False
+            )
+        # the element of indices out of range
+        with self.assertRaises(RuntimeError):
+            tensorx.put_along_axis_(indices, 1.0, 0, 'assign', True, False)
+
+    def test_error(self):
+        # Pin the mode rather than inherit whichever one the previously run
+        # test left enabled: which layer rejects an illegal input depends on
+        # it, so an inherited mode would decide what this test asserts.
+        with dygraph_guard():
+            self._check_error(RuntimeError)
+        with (
+            static_guard(),
+            paddle.static.program_guard(paddle.static.Program()),
+        ):
+            self._check_error(ValueError)
 
     def test_index_type_error(self):
         tensorx = paddle.to_tensor([[1, 2, 3], [4, 5, 6]]).astype("float32")
@@ -2123,6 +2125,21 @@ class TestPutAlongAxisInferMetaShapeCheck(unittest.TestCase):
         self.assertEqual(list(out.shape), [])
 
 
+def zero_dim_operand_places():
+    """The places the 0-D promotion cases have to run on.
+
+    ``get_places`` leaves CPU out unless ``FLAGS_CI_both_cpu_and_gpu`` is set,
+    so on a GPU build these cases would only ever enter the ``.cu`` kernel. The
+    promotion they are about lives in ``gather_scatter_functor.h``, shared by
+    every backend, and only the CPU kernel is a host translation unit, so CPU
+    has to be in the list for the coverage build to record those lines as run.
+    """
+    places = get_places()
+    if not any(isinstance(place, paddle.CPUPlace) for place in places):
+        places.insert(0, paddle.CPUPlace())
+    return places
+
+
 class TestPutAlongAxisZeroDimOperands(unittest.TestCase):
     """A 0-D operand counts as a 1-D operand holding a single element.
 
@@ -2137,54 +2154,63 @@ class TestPutAlongAxisZeroDimOperands(unittest.TestCase):
 
     def setUp(self):
         paddle.disable_static()
+        self.places = zero_dim_operand_places()
 
     def test_all_zero_dim(self):
-        out = paddle._C_ops.put_along_axis(
-            paddle.to_tensor(5.0),
-            paddle.to_tensor(0, dtype='int64'),
-            paddle.to_tensor(9.0),
-            0,
-            'assign',
-            True,
-        )
-        self.assertEqual(list(out.shape), [])
-        np.testing.assert_allclose(out.numpy(), np.array(9.0))
+        for place in self.places:
+            out = paddle._C_ops.put_along_axis(
+                paddle.to_tensor(5.0, place=place),
+                paddle.to_tensor(0, dtype='int64', place=place),
+                paddle.to_tensor(9.0, place=place),
+                0,
+                'assign',
+                True,
+            )
+            self.assertEqual(list(out.shape), [])
+            np.testing.assert_allclose(out.numpy(), np.array(9.0))
 
     def test_zero_dim_input_with_rank_one_index(self):
-        out = paddle._C_ops.put_along_axis(
-            paddle.to_tensor(5.0),
-            paddle.to_tensor([0], dtype='int64'),
-            paddle.to_tensor([9.0]),
-            0,
-            'assign',
-            True,
-        )
-        self.assertEqual(list(out.shape), [])
-        np.testing.assert_allclose(out.numpy(), np.array(9.0))
+        for place in self.places:
+            out = paddle._C_ops.put_along_axis(
+                paddle.to_tensor(5.0, place=place),
+                paddle.to_tensor([0], dtype='int64', place=place),
+                paddle.to_tensor([9.0], place=place),
+                0,
+                'assign',
+                True,
+            )
+            self.assertEqual(list(out.shape), [])
+            np.testing.assert_allclose(out.numpy(), np.array(9.0))
 
     def test_zero_dim_operands_reduce_add(self):
-        out = paddle._C_ops.put_along_axis(
-            paddle.to_tensor(5.0),
-            paddle.to_tensor(0, dtype='int64'),
-            paddle.to_tensor(9.0),
-            0,
-            'add',
-            True,
-        )
-        self.assertEqual(list(out.shape), [])
-        np.testing.assert_allclose(out.numpy(), np.array(14.0))
+        for place in self.places:
+            out = paddle._C_ops.put_along_axis(
+                paddle.to_tensor(5.0, place=place),
+                paddle.to_tensor(0, dtype='int64', place=place),
+                paddle.to_tensor(9.0, place=place),
+                0,
+                'add',
+                True,
+            )
+            self.assertEqual(list(out.shape), [])
+            np.testing.assert_allclose(out.numpy(), np.array(14.0))
 
     def test_negative_axis(self):
         """``axis`` reaches the kernel exactly as written, so it normalizes it."""
-        x = paddle.zeros([3, 4], dtype='float32')
-        index = paddle.to_tensor([[0], [1], [2]], dtype='int64')
-        value = paddle.to_tensor([[1.0], [2.0], [3.0]])
-        out = paddle._C_ops.put_along_axis(x, index, value, -1, 'assign', True)
         expected = np.zeros([3, 4], dtype='float32')
         expected[0, 0] = 1.0
         expected[1, 1] = 2.0
         expected[2, 2] = 3.0
-        np.testing.assert_allclose(out.numpy(), expected)
+        for place in self.places:
+            x = paddle.to_tensor(np.zeros([3, 4], dtype='float32'), place=place)
+            index = paddle.to_tensor(
+                [[0], [1], [2]], dtype='int64', place=place
+            )
+            value = paddle.to_tensor([[1.0], [2.0], [3.0]], place=place)
+            out = paddle._C_ops.put_along_axis(
+                x, index, value, -1, 'assign', True
+            )
+            np.testing.assert_allclose(out.numpy(), expected)
 
 
 class TestPutAlongAxisZeroDimOperandsGrad(unittest.TestCase):
@@ -2198,14 +2224,15 @@ class TestPutAlongAxisZeroDimOperandsGrad(unittest.TestCase):
 
     def setUp(self):
         paddle.disable_static()
+        self.places = zero_dim_operand_places()
 
-    def _run(self, reduce):
-        x = paddle.to_tensor(5.0)
+    def _run(self, reduce, place, axis=0):
+        x = paddle.to_tensor(5.0, place=place)
         x.stop_gradient = False
-        value = paddle.to_tensor(9.0)
+        value = paddle.to_tensor(9.0, place=place)
         value.stop_gradient = False
-        index = paddle.to_tensor(0, dtype='int64')
-        out = paddle._C_ops.put_along_axis(x, index, value, 0, reduce, True)
+        index = paddle.to_tensor(0, dtype='int64', place=place)
+        out = paddle._C_ops.put_along_axis(x, index, value, axis, reduce, True)
         out.backward()
         self.assertEqual(list(x.grad.shape), [])
         self.assertEqual(list(value.grad.shape), [])
@@ -2213,24 +2240,40 @@ class TestPutAlongAxisZeroDimOperandsGrad(unittest.TestCase):
 
     def test_assign_grad(self):
         """``scatter_input_grad_kernel`` + ``scatter_value_grad_kernel``."""
-        x_grad, value_grad = self._run('assign')
-        np.testing.assert_allclose(x_grad, np.array(0.0))
-        np.testing.assert_allclose(value_grad, np.array(1.0))
+        for place in self.places:
+            x_grad, value_grad = self._run('assign', place)
+            np.testing.assert_allclose(x_grad, np.array(0.0))
+            np.testing.assert_allclose(value_grad, np.array(1.0))
 
     def test_add_grad(self):
         """``scatter_mean_input_grad_kernel`` is skipped for ``add``, so this
         covers ``scatter_add_mean_value_grad_kernel``."""
-        x_grad, value_grad = self._run('add')
-        np.testing.assert_allclose(x_grad, np.array(1.0))
-        np.testing.assert_allclose(value_grad, np.array(1.0))
+        for place in self.places:
+            x_grad, value_grad = self._run('add', place)
+            np.testing.assert_allclose(x_grad, np.array(1.0))
+            np.testing.assert_allclose(value_grad, np.array(1.0))
 
     def test_mul_grad(self):
         """``scatter_mul_min_max_{input,value}_grad_kernel``, the pair that
         also restrides ``value``."""
-        x_grad, value_grad = self._run('mul')
-        # out == x * value, so the gradient of each operand is the other one.
-        np.testing.assert_allclose(x_grad, np.array(9.0))
-        np.testing.assert_allclose(value_grad, np.array(5.0))
+        for place in self.places:
+            x_grad, value_grad = self._run('mul', place)
+            # out == x * value, so the gradient of each operand is the other
+            # one.
+            np.testing.assert_allclose(x_grad, np.array(9.0))
+            np.testing.assert_allclose(value_grad, np.array(5.0))
+
+    def test_negative_axis_grad(self):
+        """``axis`` is normalized in the grad kernel too, not only the forward
+        one: it arrives as the caller wrote it there as well.
+
+        ``-1`` is the only negative axis a 0-D ``x`` admits, and it has to
+        select the same element as ``0``.
+        """
+        for place in self.places:
+            x_grad, value_grad = self._run('add', place, axis=-1)
+            np.testing.assert_allclose(x_grad, np.array(1.0))
+            np.testing.assert_allclose(value_grad, np.array(1.0))
 
 
 class TestPutAlongAxisMulFloat32DivByZeroGrad(unittest.TestCase):

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -2048,6 +2048,19 @@ class TestPutAlongAxisInferMetaShapeCheck(unittest.TestCase):
         out = self._call([3, 4], [3, 6], [3, 6], 1)
         self.assertEqual(list(out.shape), [3, 4])
 
+    def test_empty_index_still_checks_axis(self):
+        """torch normalizes and range-checks ``dim`` in ``scatter_meta_impl``
+        before the empty-index short circuit of ``scatter_shape_check``, so an
+        illegal axis is reported even when nothing would be scattered."""
+        with self.assertRaisesRegex(IndexError, "Dimension out of range"):
+            self._call([3, 4], [0, 2], [3, 2], 2)
+
+    def test_zero_dim_input_allows_axis_minus_one(self):
+        """``maybe_wrap_dim(dim, 0)`` treats a 0-D self as rank 1, so both -1
+        and 0 are legal."""
+        out = self._call(None, None, None, -1)
+        self.assertEqual(list(out.shape), [])
+
 
 class TestPutAlongAxisZeroDimOperands(unittest.TestCase):
     """A 0-D operand counts as a 1-D operand holding a single element.
@@ -2111,6 +2124,52 @@ class TestPutAlongAxisZeroDimOperands(unittest.TestCase):
         expected[1, 1] = 2.0
         expected[2, 2] = 3.0
         np.testing.assert_allclose(out.numpy(), expected)
+
+
+class TestPutAlongAxisZeroDimOperandsGrad(unittest.TestCase):
+    """The backward pass promotes 0-D operands as well.
+
+    A 0-D tensor has ``numel() == 1``, so it gets past both 0-size early
+    returns of ``PutAlongAxisGradKernel`` and reaches the same scatter functor,
+    which indexes ``dims()`` and ``strides()`` directly. Reachable only through
+    ``_C_ops``, like the forward cases above.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+
+    def _run(self, reduce):
+        x = paddle.to_tensor(5.0)
+        x.stop_gradient = False
+        value = paddle.to_tensor(9.0)
+        value.stop_gradient = False
+        index = paddle.to_tensor(0, dtype='int64')
+        out = paddle._C_ops.put_along_axis(x, index, value, 0, reduce, True)
+        out.backward()
+        self.assertEqual(list(x.grad.shape), [])
+        self.assertEqual(list(value.grad.shape), [])
+        return x.grad.numpy(), value.grad.numpy()
+
+    def test_assign_grad(self):
+        """``scatter_input_grad_kernel`` + ``scatter_value_grad_kernel``."""
+        x_grad, value_grad = self._run('assign')
+        np.testing.assert_allclose(x_grad, np.array(0.0))
+        np.testing.assert_allclose(value_grad, np.array(1.0))
+
+    def test_add_grad(self):
+        """``scatter_mean_input_grad_kernel`` is skipped for ``add``, so this
+        covers ``scatter_add_mean_value_grad_kernel``."""
+        x_grad, value_grad = self._run('add')
+        np.testing.assert_allclose(x_grad, np.array(1.0))
+        np.testing.assert_allclose(value_grad, np.array(1.0))
+
+    def test_mul_grad(self):
+        """``scatter_mul_min_max_{input,value}_grad_kernel``, the pair that
+        also restrides ``value``."""
+        x_grad, value_grad = self._run('mul')
+        # out == x * value, so the gradient of each operand is the other one.
+        np.testing.assert_allclose(x_grad, np.array(9.0))
+        np.testing.assert_allclose(value_grad, np.array(5.0))
 
 
 class TestPutAlongAxisMulFloat32DivByZeroGrad(unittest.TestCase):

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -2058,9 +2058,9 @@ class TestPutAlongAxisIncludeSelfFalseInvalidIndex(unittest.TestCase):
 
     def test_reduce_mul_checks_index_before_initialization(self):
         place = get_device_place()
-        x = paddle.zeros([2, 3], dtype='float32', place=place)
+        x = paddle.zeros([2, 3], dtype='float32', device=place)
         index = paddle.to_tensor([[10, 0, 0]], dtype='int64', place=place)
-        value = paddle.ones([1, 3], dtype='float32', place=place)
+        value = paddle.ones([1, 3], dtype='float32', device=place)
 
         with self.assertRaisesRegex(
             (RuntimeError, IndexError), "out of bounds"

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -1105,20 +1105,32 @@ class TestPutAlongAxisAPICase4(unittest.TestCase):
         indices = paddle.to_tensor(
             [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]]
         ).astype("int32")
-        # indices too large
+        # ``indices`` too large. Which layer reports it depends on the mode this
+        # test runs in, and the preceding tests leave static mode enabled: there
+        # the wrapper's check is skipped -- it is guarded by
+        # ``in_dynamic_mode()`` -- and the diagnosis comes from
+        # ``PutAlongAxisInferMeta`` instead, as InvalidArgument, which surfaces
+        # in python as ``ValueError``. In dygraph the wrapper raises
+        # ``RuntimeError`` before the op is reached. Static mode used to raise
+        # nothing at all here, so both blocks below asserted nothing.
+        expected_error = (
+            RuntimeError if paddle.in_dynamic_mode() else ValueError
+        )
         try:
             res = paddle.put_along_axis(
                 tensorx, indices, 1.0, 0, 'assign', True, False
             )
         except Exception as error:
-            self.assertIsInstance(error, RuntimeError)
+            self.assertIsInstance(error, expected_error)
         # indices too large
         try:
             tensorx.put_along_axis_(indices, 1.0, 0, 'assign', True, False)
         except Exception as error:
-            self.assertIsInstance(error, RuntimeError)
+            self.assertIsInstance(error, expected_error)
         indices = paddle.to_tensor([[10]]).astype("int32")
-        # the element of indices out of range
+        # The element of indices is out of range. This is a value check, which
+        # only the wrapper performs and only in dygraph, so static mode still
+        # raises nothing here.
         try:
             res = paddle.put_along_axis(
                 tensorx, indices, 1.0, 0, 'assign', True, False

--- a/test/legacy_test/test_put_along_axis_op.py
+++ b/test/legacy_test/test_put_along_axis_op.py
@@ -1569,6 +1569,17 @@ class TestPutAlongAxisDynamicShape3(TestPutAlongAxisDynamicShape):
 
 
 class TestPutAlongAxisDynamicShape_ZeroSize(TestPutAlongAxisDynamicShape):
+    """``arr`` is 0-size while ``put_along_axis_net`` scatters a [1, 1, 1, 1]
+    index, which exceeds ``arr`` on dimension 0.
+
+    Dygraph rejects it. The to_static path cannot: ``arr`` is traced with a
+    fully dynamic ``(-1, -1, -1, -1)`` spec, so the shapes are unknown when the
+    check would run, and at execution time ``indices`` gets broadcast against
+    the runtime shape of ``arr``, which collapses it to 0-size. An empty index
+    scatters nothing, so returning ``arr`` unchanged is correct there -- the
+    same thing ``torch.scatter_`` does for an empty index.
+    """
+
     def setUp(self):
         np.random.seed(2024)
         self.net = put_along_axis_net
@@ -1584,6 +1595,13 @@ class TestPutAlongAxisDynamicShape_ZeroSize(TestPutAlongAxisDynamicShape):
             )
         ]
         self.arr = np.random.random([0, 10, 10, 10]).astype(self.dtype)
+
+    def test_dynamic_static(self):
+        with dygraph_guard():
+            with self.assertRaises(RuntimeError):
+                self.train(to_static=False)
+            res, _ = self.train(to_static=True)
+            self.assertEqual(list(res.shape), [0, 10, 10, 10])
 
 
 class TestPutAlongAxisZeroSizeIndex(unittest.TestCase):
@@ -1782,7 +1800,11 @@ class TestPutAlongAxisZeroSizeInputGrad(unittest.TestCase):
     the CPU grad kernel lacked a numel==0 early-return guard.
 
     Fixed in put_along_axis_grad_kernel.cc by adding the same guard
-    that the GPU grad kernel already had.
+    that the GPU grad kernel already had. The guard is kept as defense in
+    depth, but such shapes are now rejected up front: a 0-size input with a
+    non-empty index is always out of bounds, either because index exceeds
+    input on a non-axis dimension or because the scatter dimension has no
+    valid index value. See ``TestPutAlongAxisZeroSizeInputInvalidIndex``.
     """
 
     def setUp(self):
@@ -1839,34 +1861,256 @@ class TestPutAlongAxisZeroSizeInputGrad(unittest.TestCase):
             [4, 4, 0], [1, 1, 0], [1, 1, 0], axis=0, reduce='assign'
         )
 
-    def test_mid_dim_zero_nonempty_index(self):
-        """x.numel()==0 but indices.numel()!=0, so C++ grad kernel is called."""
-        self._run_zero_size_input(
-            [2, 0, 3], [2, 1, 3], [2, 1, 3], axis=1, reduce='assign'
+
+class TestPutAlongAxisZeroSizeInputInvalidIndex(unittest.TestCase):
+    """
+    A 0-size input combined with a non-empty index can never be valid, and
+    ``broadcast=True`` used to silently ignore it while ``broadcast=False``
+    and ``torch.scatter_`` both raise. Both flavours now agree.
+
+    Two distinct reasons to reject:
+
+    - the 0-size dimension is not ``axis``, so index exceeds input there and
+      the scatter would write out of bounds. Rejected up front from the shape
+      alone, mirroring the wording of the ``broadcast=False`` branch;
+    - the 0-size dimension *is* ``axis``, so no index value can be in range.
+      This one is reported by the kernel as an index out-of-bounds error, the
+      way ``torch.scatter_`` does, which surfaces as ``IndexError``. The
+      ``broadcast=False`` branch checks the index values in python first and
+      raises ``RuntimeError``, so both types are accepted.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+
+    def _places(self):
+        places = [paddle.CPUPlace()]
+        if core.is_compiled_with_cuda() or is_custom_device():
+            places.append(get_device_place())
+        if paddle.device.is_compiled_with_xpu():
+            places.append(paddle.XPUPlace(0))
+        return places
+
+    def _run(self, x_shape, idx_shape, val_shape, axis, place, broadcast):
+        x = paddle.to_tensor(
+            np.random.rand(*x_shape).astype('float32'), place=place
+        )
+        index = paddle.to_tensor(
+            np.zeros(idx_shape, dtype='int64'), place=place
+        )
+        value = paddle.to_tensor(
+            np.random.rand(*val_shape).astype('float32'), place=place
+        )
+        paddle.put_along_axis(
+            x,
+            index,
+            value,
+            axis=axis,
+            reduce='assign',
+            include_self=True,
+            broadcast=broadcast,
         )
 
-    def test_first_dim_zero_nonempty_index(self):
-        self._run_zero_size_input(
-            [0, 20], [1024, 6], [1024, 6], axis=1, reduce='assign'
+    def test_non_axis_dim_zero(self):
+        for place in self._places():
+            for broadcast in (True, False):
+                with self.assertRaisesRegex(
+                    RuntimeError, "apart from dimension"
+                ):
+                    self._run(
+                        [0, 20], [1024, 6], [1024, 6], 1, place, broadcast
+                    )
+
+    def test_axis_dim_zero(self):
+        for place in self._places():
+            for broadcast in (True, False):
+                with self.assertRaisesRegex(
+                    (RuntimeError, IndexError), "out of bounds"
+                ):
+                    self._run(
+                        [2, 0, 3], [2, 1, 3], [2, 1, 3], 1, place, broadcast
+                    )
+
+    def test_inplace_rejects_too(self):
+        x = paddle.zeros([0, 20], dtype='float32')
+        index = paddle.zeros([1024, 6], dtype='int64')
+        value = paddle.zeros([1024, 6], dtype='float32')
+        with self.assertRaisesRegex(RuntimeError, "apart from dimension"):
+            x.put_along_axis_(index, value, axis=1)
+
+
+class TestPutAlongAxisIndexLargerThanInput(unittest.TestCase):
+    """
+    ``indices`` may only exceed ``arr`` along ``axis``. On any other dimension
+    its coordinates address ``arr`` directly, so a larger size made the scatter
+    kernel write past the end of ``arr`` -- a segfault with a large enough
+    index, silently ignored when ``arr`` was 0-size. ``infer_broadcast_shape``
+    returns None for both situations, and the ``broadcast=True`` path used to
+    read that as "just skip broadcasting" without validating anything.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+
+    def test_index_rows_exceed_input_rows(self):
+        for broadcast in (True, False):
+            arr = paddle.zeros([3, 4], dtype='float32')
+            index = paddle.zeros([4096, 2], dtype='int64')
+            value = paddle.ones([4096, 2], dtype='float32')
+            with self.assertRaisesRegex(RuntimeError, "apart from dimension"):
+                paddle.put_along_axis(
+                    arr, index, value, axis=1, broadcast=broadcast
+                )
+
+    def test_index_longer_along_axis_is_allowed(self):
+        """Exceeding ``arr`` on ``axis`` itself stays legal."""
+        arr = paddle.zeros([3, 4], dtype='float32')
+        index = paddle.to_tensor(
+            [[0, 1, 2, 3, 0, 1], [0, 0, 0, 0, 0, 0], [3, 3, 3, 3, 3, 3]],
+            dtype='int64',
         )
-        if core.is_compiled_with_cuda() or is_custom_device():
-            self._run_zero_size_input(
-                [0, 20],
-                [1024, 6],
-                [1024, 6],
-                axis=1,
-                reduce='assign',
-                place=get_device_place(),
-            )
-        if paddle.device.is_compiled_with_xpu():
-            self._run_zero_size_input(
-                [0, 20],
-                [1024, 6],
-                [1024, 6],
-                axis=1,
-                reduce='assign',
-                place=paddle.XPUPlace(0),
-            )
+        value = paddle.arange(18).astype('float32').reshape([3, 6])
+        out = paddle.put_along_axis(arr, index, value, axis=1)
+        expected = np.array(
+            [[4.0, 5.0, 2.0, 3.0], [11.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 17.0]]
+        )
+        np.testing.assert_allclose(out.numpy(), expected)
+
+
+class TestPutAlongAxisInferMetaShapeCheck(unittest.TestCase):
+    """``PutAlongAxisInferMeta`` mirrors ``scatter_shape_check`` in torch.
+
+    The python wrapper rejects a rank mismatch and normalizes ``values`` by
+    broadcasting, so these constraints are only observable when the op is
+    called directly. Going through ``_C_ops`` covers the static graph, PIR and
+    custom-pass entries at the same time, since they all share the InferMeta.
+
+    Shape violations are reported as ``InvalidArgument``, which surfaces as
+    ``ValueError`` in python.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+
+    def _call(self, x_shape, idx_shape, val_shape, axis):
+        def make(shape, dtype):
+            if shape is None:  # 0-D tensor
+                return paddle.zeros([], dtype=dtype)
+            return paddle.zeros(shape, dtype=dtype)
+
+        return paddle._C_ops.put_along_axis(
+            make(x_shape, 'float32'),
+            make(idx_shape, 'int64'),
+            make(val_shape, 'float32'),
+            axis,
+            'assign',
+            True,
+        )
+
+    def test_index_rank_mismatch(self):
+        with self.assertRaisesRegex(
+            ValueError, "same number of dimensions as self"
+        ):
+            self._call([3, 4], [3], [3], 1)
+
+    def test_value_rank_mismatch(self):
+        with self.assertRaisesRegex(
+            ValueError, "same number of dimensions as value"
+        ):
+            self._call([3, 4], [3, 2], [3], 1)
+
+    def test_zero_dim_input_rank_mismatch(self):
+        """A 0-D tensor counts as a 1-D tensor holding a single element."""
+        with self.assertRaisesRegex(
+            ValueError, "same number of dimensions as self"
+        ):
+            self._call(None, [2, 3], [2, 3], 0)
+
+    def test_index_larger_than_value(self):
+        """Unlike ``x``, ``value`` is constrained on ``axis`` as well."""
+        with self.assertRaisesRegex(ValueError, "no larger than value"):
+            self._call([3, 4], [3, 2], [3, 1], 1)
+
+    def test_index_larger_than_input_off_axis(self):
+        with self.assertRaisesRegex(ValueError, "apart from dimension"):
+            self._call([3, 4], [4096, 2], [4096, 2], 1)
+
+    def test_axis_out_of_range(self):
+        with self.assertRaisesRegex(IndexError, "Dimension out of range"):
+            self._call([3, 4], [3, 2], [3, 2], 2)
+
+    def test_empty_index_skips_every_check(self):
+        """An empty index scatters nothing, so no shape constraint applies."""
+        out = self._call([8192, 32], [0, 10], [8192, 10], 1)
+        self.assertEqual(list(out.shape), [8192, 32])
+
+    def test_index_longer_along_axis_is_allowed(self):
+        out = self._call([3, 4], [3, 6], [3, 6], 1)
+        self.assertEqual(list(out.shape), [3, 4])
+
+
+class TestPutAlongAxisZeroDimOperands(unittest.TestCase):
+    """A 0-D operand counts as a 1-D operand holding a single element.
+
+    ``PutAlongAxisInferMeta`` accepts these shapes, so the kernel has to be
+    able to run them: it promotes the 0-D operands to rank 1 before entering
+    the scatter functor, which indexes ``dims()`` and ``strides()`` directly
+    and cannot address a rank-0 tensor.
+
+    The python wrapper rejects both combinations before they get this far, so
+    they are only reachable through ``_C_ops``.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+
+    def test_all_zero_dim(self):
+        out = paddle._C_ops.put_along_axis(
+            paddle.to_tensor(5.0),
+            paddle.to_tensor(0, dtype='int64'),
+            paddle.to_tensor(9.0),
+            0,
+            'assign',
+            True,
+        )
+        self.assertEqual(list(out.shape), [])
+        np.testing.assert_allclose(out.numpy(), np.array(9.0))
+
+    def test_zero_dim_input_with_rank_one_index(self):
+        out = paddle._C_ops.put_along_axis(
+            paddle.to_tensor(5.0),
+            paddle.to_tensor([0], dtype='int64'),
+            paddle.to_tensor([9.0]),
+            0,
+            'assign',
+            True,
+        )
+        self.assertEqual(list(out.shape), [])
+        np.testing.assert_allclose(out.numpy(), np.array(9.0))
+
+    def test_zero_dim_operands_reduce_add(self):
+        out = paddle._C_ops.put_along_axis(
+            paddle.to_tensor(5.0),
+            paddle.to_tensor(0, dtype='int64'),
+            paddle.to_tensor(9.0),
+            0,
+            'add',
+            True,
+        )
+        self.assertEqual(list(out.shape), [])
+        np.testing.assert_allclose(out.numpy(), np.array(14.0))
+
+    def test_negative_axis(self):
+        """``axis`` reaches the kernel exactly as written, so it normalizes it."""
+        x = paddle.zeros([3, 4], dtype='float32')
+        index = paddle.to_tensor([[0], [1], [2]], dtype='int64')
+        value = paddle.to_tensor([[1.0], [2.0], [3.0]])
+        out = paddle._C_ops.put_along_axis(x, index, value, -1, 'assign', True)
+        expected = np.zeros([3, 4], dtype='float32')
+        expected[0, 0] = 1.0
+        expected[1, 1] = 2.0
+        expected[2, 2] = 3.0
+        np.testing.assert_allclose(out.numpy(), expected)
 
 
 class TestPutAlongAxisMulFloat32DivByZeroGrad(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

本 PR 围绕 `put_along_axis` 补齐输入校验和边界处理，并修复 `reduce="mul"` 反向及 GPU 低位宽 atomic 的正确性问题。主要包含四类修改：

1. 输入 shape、动态 broadcast 与 index 边界校验；
2. axis 校验与 0-D Tensor 支持；
3. `reduce="mul"` 的梯度计算修复；
4. GPU 子字宽 atomic 操作修复。

#### 1. 输入 shape、动态 broadcast 与 index 边界校验

##### 问题

`ops.yaml` 中 `put_along_axis` 原先使用 `UnchangedInferMeta`，只把 `arr` 的形状照搬给输出，没有对 `indices` 和 `values` 做 shape 校验：

```yaml
- op : put_along_axis
  args : (Tensor arr, Tensor indices, Tensor values, int axis, ...)
  infer_meta :
    func : UnchangedInferMeta
    param : [arr]
```

仓库中虽然已经存在 `PutAlongAxisInferMeta`（`paddle/phi/infermeta/ternary.cc`），但之前没有被 `ops.yaml` 引用。Python wrapper 也只覆盖部分动态图路径，从 `_C_ops`、静态图或 PIR 进入的调用可能绕过检查。

以下输入原先可能不报错，而是进入 scatter kernel 后发生越界访问：

**1. `index` / `value` 的 rank 与 `arr` 不一致**

```python
paddle._C_ops.put_along_axis(
    paddle.zeros([3, 4]), paddle.zeros([2], dtype='int64'),
    paddle.ones([2]), 0, 'assign', True)
```

**2. `index` 在非 `axis` 维大于 `arr`**

```python
paddle._C_ops.put_along_axis(
    paddle.zeros([2, 3]), paddle.zeros([3, 4], dtype='int64'),
    paddle.ones([3, 4]), 0, 'assign', True)
```

`index` 的非-axis 维被用作 `arr` 的坐标，因此不能大于 `arr` 对应维度，否则 kernel 计算出的目标 offset 可能越界。

**3. `index` 大于 `value`**

```python
paddle._C_ops.put_along_axis(
    paddle.zeros([4, 4]), paddle.zeros([4, 4], dtype='int64'),
    paddle.ones([4, 2]), 0, 'assign', True)
```

`index` 的每一个维度都会参与读取 `value`，因此 `index` 不能大于 `value` 的对应维度，否则可能发生越界读。

**4. `arr` 在 axis 上长度为 0，index 非空**

```python
arr = paddle.zeros([4, 0], dtype='float32')
idx = paddle.zeros([4, 6], dtype='int64')
val = paddle.ones([4, 6], dtype='float32')
paddle.put_along_axis(arr, idx, val, 1)
```

axis 对应的输入长度为 0 时不存在任何合法 index。之前部分路径会静默返回 `arr`，但 torch 会报告 index 越界。

动态 shape 下还存在另一类问题。原来的 `infer_dynamic_broadcast_shape` 在非-axis 维无条件使用 `arr` 的尺寸，可能把非法 `index` 维度覆盖掉，或者把非空 `index` 推导成空 tensor，最终导致错误的 broadcast 或静默 no-op：

```python
# arr 的运行时 shape 为 [3, 10, 10, 10]
# index 的 shape 为 [5, 1, 1, 1]
# index 在非-axis 维大于 arr
```

此外，index 是运行时数据，仅靠 InferMeta 无法检查具体的 index 数值。CUDA kernel 原先只有主 scatter 路径中的部分位置进行了检查，其他把 index 转成 offset 的 kernel 仍可能直接访问非法地址。尤其是 `include_self=False` 时，`ScatterAssignScalarValue` 会先于主 scatter kernel 执行；如果只在后者检查，非法 index 可能已经导致越界写入。

##### 改动

- 在 `paddle/phi/ops/yaml/ops.yaml` 中将 `infer_meta.func` 从 `UnchangedInferMeta` 改为 `PutAlongAxisInferMeta`，并传入 `arr`、`indices`、`values`、`axis` 和 `reduce`；
- 在 `paddle/phi/infermeta/ternary.cc` 中按 torch `scatter_shape_check` 补充校验：
  - `index` 和 `value` 的 rank 必须与 `arr` 一致；
  - 除 axis 外，`index` 每一维不得大于 `arr`；
  - `index` 每一维不得大于 `value`；
  - 空 `index` 不执行 scatter，因此不施加普通 shape 约束；
  - 动态维度为 `-1` 时跳过编译期无法判断的检查；
- 在 Python wrapper 中新增 `check_put_along_axis_index_shape`，在 broadcast 前检查 `index` 的非-axis 维度，避免 `broadcast_to` 先抛出与真实原因无关的错误；
- 修改 `infer_dynamic_broadcast_shape`，动态场景下在非-axis 维使用 `max(arr_shape, indices_shape)`，保留非法 shape，交由运行期 InferMeta 给出正确诊断；
- 在 `gather_scatter_functor.cu` 中抽取 `ENFORCE_SCATTER_INDEX_IN_BOUND`，统一检查：
  - 通用 gather/scatter kernel；
  - winner 选择和写回 kernel；
  - `include_self=False` 使用的 `ScatterAssignScalarValue` 初始化 kernel。

合法 index 的范围仍然是：

```text
-select_dim_size <= index < select_dim_size
```

负 index 在检查通过后会被归一化，不改变原有负 index 语义。

#### 2. axis 校验与 0-D Tensor 支持

##### 问题

原来的 axis 检查直接根据 `arr.shape` 的 rank 判断。对于 0-D Tensor，rank 为 0，因此 `axis=0` 和 `axis=-1` 都无法通过检查。即使底层逻辑可以把 0-D Tensor 看作只含一个元素的 Tensor，Python API 也无法正常到达 kernel。

此外，axis 校验位于空 index 的 early return 之后时，以下非法调用会被静默接受：

```python
paddle._C_ops.put_along_axis(
    paddle.zeros([2, 3]), paddle.zeros([2, 0], dtype='int64'),
    paddle.ones([2, 0]), 7, 'assign', True)
```

torch 会先检查 axis，再判断 index 是否为空，因此仍然会报告 axis 越界。

0-D 操作数直接进入原 functor 时还会导致 `dims()` / `strides()` 按 rank 0 被访问，`CoordinateManager` 可能读取未初始化的 stride 槽位，造成错误的 offset 或越界访问。反向路径同样存在该问题。

##### 改动

- Python API、inplace API 和 `Tensor.scatter_` 对 0-D Tensor 使用 `[-1, 1)` 的 axis 范围；
- 在 InferMeta 中将 axis 合法性检查提前到空 index short circuit 之前；
- 新增 `normalize_put_along_axis_0d_axis`，将 0-D Tensor 的 `axis=0/-1` 归一化为内部 axis `0`；
- 在 `gather_scatter_functor.h` 中新增 `PromoteZeroDimOperand`，在 forward 和 backward 中将 0-D 操作数临时提升为 `[1]` 的浅层 metadata view；
- 新增 `PreparePutAlongAxisOperands` 和 `PreparePutAlongAxisGradOperands`，统一处理 forward/backward 的 axis 归一化及 0-D operand promotion；
- promotion 只修改浅层 Tensor 的 metadata，不修改调用方 Tensor 的实际 shape 和底层 buffer，输出仍保持 0-D shape。

因此以下调用可以正常工作：

```python
arr = paddle.to_tensor(5.0)
index = paddle.to_tensor(0, dtype='int64')
value = paddle.to_tensor(3.0)

out = paddle.put_along_axis(arr, index, value, axis=0, reduce='add')
# out 为 0-D Tensor，值为 8
```

`axis=-1` 也具有相同语义，`axis=1` 和 `axis=-2` 则会明确报告越界。

#### 3. `reduce="mul"` 的梯度计算修复

##### 问题

`reduce="mul"` 的输出是同一目标位置上多个因子的乘积。原来的反向计算使用：

```text
grad = dout * out / factor
```

当所有因子都非零时，该公式成立。但只要存在一个零因子，`out` 就变成 0，已经无法从 `out` 中恢复其他因子的乘积。此时直接除以零还可能产生 NaN/Inf；即使通过 zero guard 返回 0，对于“唯一零因子”的情况也仍然是错误的，因为该因子的梯度应当等于其他因子的乘积。

例如，乘积为：

```text
2 * 0 * 11 = 0
```

对中间的 0 求导，结果应为 `2 * 11 = 22`，而不是 0。只有当乘积中存在两个或更多零因子时，所有相关因子的梯度才为 0。

##### 改动

CPU 路径在 `cpu_scatter_mul_min_max_input_grad_kernel` 和 `cpu_scatter_mul_min_max_value_grad_kernel` 中增加 pre-pass：

- `zero_count`：统计每个 scatter 目标位置上的零因子个数；
- `masked_value_prod`：计算该位置所有非零 `value` 因子的乘积；
- 使用独立的 `CoordinateManager` 执行 pre-pass，避免复用有状态的 walker 导致 offset 被重复推进。

GPU 路径新增 `MulValueGrad` dispatch，并扩展 `ScatterGradPrePassKernel`：

- 在 pre-pass 中使用 `AccumulateZeroCountAndMaskedProd` 统计零因子和非零因子乘积；
- `ScatterMulInputGradGPUKernel` 根据零因子数量决定使用除法路径、补乘路径还是直接置零；
- `ScatterMulValueGradGPUKernel` 使用同样的规则计算 value 梯度；
- 正确区分 `include_self=True` 和 `include_self=False`：前者将 `x` 作为乘积因子，后者不计入 `x`；
- 对重复 index 的同一目标位置统一进行因子统计。

输入梯度还需要对齐 Torch 在未命中位置上的浮点舍入行为。Torch 对整个输入计算：

```text
masked_self = self.masked_fill(self == 0, 1)
grad_self = dout * masked_self.scatter_reduce(dim, index, value, "prod")
            / masked_self
```

当某个位置没有 index 命中时，上式退化为 `(dout * m) / m`。数学上它等于 `dout`，但浮点乘除会产生两次舍入，结果可能与直接复制 `dout` 相差 1 ulp。CPU/GPU 反向入口现在通过 `MulInputGradRoundTripFunctor` 在 `reduce` 为 `mul`/`multiply` 时重放这段 round-trip；随后被 index 命中的位置使用未改写的 `out_grad` 重新计算，避免 round-trip 结果参与命中位置的梯度。该逻辑只对浮点、`float16` 和 `bfloat16` 生效，整数实例保持原路径。

`reduce="mul"` 的计算规则为：

```text
零因子数为 0：使用 dout * out / factor
零因子数为 1 且当前 factor 为 0：使用 dout * 其他因子的乘积
零因子数大于 1：梯度为 0
未命中位置（浮点输入梯度）：使用 (dout * m) / m，其中 m = x（x 为 0 时 m = 1）
```

该修复同时覆盖 CPU/GPU 的输入梯度和值梯度路径，并保留整数类型的除零保护。

#### 4. GPU 子字宽 atomic 操作修复

##### 问题

GPU 对 `uint8_t`、`int16_t` 等子字宽类型没有直接对应的完整 atomic 操作，因此相关 scatter reduce kernel 使用 32-bit `atomicCAS` 模拟 read-modify-write。

原实现存在两个问题：

- `__loadAligned` 只返回目标子元素，而不是包含它的完整 4-byte aligned word。后续重建 32-bit word 时，无法可靠保留同一 word 中的相邻元素；
- 负数 `int16_t` 直接转换为 `uint32_t` 时会发生符号扩展。将结果左移并通过按位或写回时，可能把相邻 halfword 覆盖为 `0xFFFF`。

例如：

```python
x = paddle.to_tensor([3, 7], dtype='int16', place=place)
index = paddle.to_tensor([0], dtype='int64', place=place)
value = paddle.to_tensor([-2], dtype='int16', place=place)
out = paddle.put_along_axis(x, index, value, 0, reduce='mul')
```

正确结果为：

```text
[-6, 7]
```

旧实现可能在更新第 0 个元素时同时破坏第 1 个元素。这是 GPU 子字宽 atomic 的底层 read-modify-write 问题，不是 `put_along_axis` shape 或梯度公式问题。

##### 改动

在 `paddle/phi/backends/gpu/gpu_primitives.h` 中：

- 修改 `__loadAligned`，返回完整的 32-bit aligned word；
- 使用 mask 只更新目标 byte/halfword，保留相邻元素；
- 对 `int16_t` 结果先转换为 `uint16_t`，再扩展为 `uint32_t`，避免负数符号扩展污染相邻 halfword；
- 同步调整依赖该 helper 的低位宽 atomic 实现。

这样可以保证子字宽 atomic 更新目标元素时，不会修改同一 32-bit word 中的其他元素。

#### 修改后的行为

| 类别 | 之前 | 之后 |
| --- | --- | --- |
| shape 不匹配 | 可能无报错并进入 kernel 越界访问 | InferMeta/Python wrapper 提前报出明确错误 |
| 动态 shape 非法 broadcast | 可能报无关的 `expand_v2` 错误或静默 no-op | 保留实际 shape，并由 InferMeta 报告真实原因 |
| GPU 非法 index | 部分 kernel 未检查，可能越界读写 | 每个计算 offset 的相关 kernel 都检查 index |
| 非法 axis | 可能表现为错误的 kernel index 报错，空 index 时甚至静默返回 | 按 axis 维度范围明确报错 |
| 0-D Tensor | forward/backward 可能访问错误 stride 或被错误拒绝 | `axis=0/-1` 正常执行，输出保持 0-D |
| `reduce="mul"` 且存在零因子 | 梯度错误或除零产生 NaN/Inf | 按零因子数量计算正确梯度 |
| GPU `int16` 负数 atomic | 可能污染相邻元素 | 只更新目标子元素，保留相邻数据 |

合法输入的计算结果不变；修改主要影响原本应该报错的非法输入和原本计算错误的特殊梯度/atomic 场景。
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是