### PR TITLE
[Operator Mechanism] Fix gradient and bounds handling of strided views

### DIFF
--- a/paddle/fluid/eager/nan_inf_utils.cc
+++ b/paddle/fluid/eager/nan_inf_utils.cc
@@ -128,6 +128,19 @@ void CheckTensorHasNanOrInf(const std::string& api_name, const Tensor& tensor) {
       return;
     }
 
+    // The checker scans the tensor's memory flat, i.e. it reads `ptr[i]` for
+    // every i in [0, numel), which is only valid for a contiguous tensor. On a
+    // strided view the scanned range is unrelated to the elements the view
+    // actually owns, and for a broadcast view (a stride of 0 blows numel up far
+    // beyond the storage) it runs past the end of the allocation and faults.
+    // Skip those tensors; their storage is still checked wherever the
+    // contiguous tensor that produced it is checked.
+    if (!dense_tensor->meta().is_contiguous()) {
+      VLOG(4) << "Tensor[" << tensor_name
+              << "] is not contiguous, skip nan inf check: " << api_name;
+      return;
+    }
+
     auto& place = dense_tensor->place();
     if (phi::is_gpu_place(place)) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)

--- a/paddle/phi/api/include/compat/ATen/ops/as_strided.h
+++ b/paddle/phi/api/include/compat/ATen/ops/as_strided.h
@@ -56,17 +56,23 @@ inline at::Tensor Tensor::as_strided(
   phi::DenseTensorMeta meta(src_tensor->dtype(),
                             common::make_ddim(size_vec),
                             common::make_ddim(stride_vec));
-  // Calculate offset in bytes
+  // Calculate offset in bytes. `storage_offset` counts elements and is
+  // relative to the source tensor, so the conversion has to be checked: an
+  // unchecked multiplication wraps around and turns an out of range request
+  // into a silent alias of the first element.
   int64_t offset = storage_offset.has_value() ? storage_offset.value() : 0;
-  meta.offset = src_tensor->meta().offset +
-                static_cast<size_t>(offset) * phi::SizeOf(src_tensor->dtype());
+  int64_t byte_offset = phi::ElementOffsetToByteOffset(
+      static_cast<int64_t>(src_tensor->meta().offset),
+      offset,
+      static_cast<int64_t>(phi::SizeOf(src_tensor->dtype())));
+  meta.offset = static_cast<size_t>(byte_offset);
   // This entry builds the view by hand instead of going through
   // phi::AsStridedKernel, so it has to run the same storage range check;
   // otherwise a view reaching past the allocation corrupts neighbouring heap
   // memory on every read and write. torch does the same in setStrided ->
   // checkInBoundsForStorage.
   phi::ValidateStridedViewStorage(
-      size_vec, stride_vec, static_cast<int64_t>(meta.offset), *src_tensor);
+      size_vec, stride_vec, byte_offset, *src_tensor);
   new_tensor->set_meta(meta);
   PaddleTensor result;
   result.set_impl(new_tensor);
@@ -95,10 +101,13 @@ inline const at::Tensor& Tensor::as_strided_(
                             common::make_ddim(stride_vec));
   meta.layout = src_tensor->layout();
   int64_t offset = storage_offset.has_value() ? storage_offset.value() : 0;
-  meta.offset = src_tensor->meta().offset +
-                static_cast<size_t>(offset) * phi::SizeOf(src_tensor->dtype());
+  int64_t byte_offset = phi::ElementOffsetToByteOffset(
+      static_cast<int64_t>(src_tensor->meta().offset),
+      offset,
+      static_cast<int64_t>(phi::SizeOf(src_tensor->dtype())));
+  meta.offset = static_cast<size_t>(byte_offset);
   phi::ValidateStridedViewStorage(
-      size_vec, stride_vec, static_cast<int64_t>(meta.offset), *src_tensor);
+      size_vec, stride_vec, byte_offset, *src_tensor);
   src_tensor->set_meta(meta);
   return *this;
 }

--- a/paddle/phi/api/include/compat/ATen/ops/as_strided.h
+++ b/paddle/phi/api/include/compat/ATen/ops/as_strided.h
@@ -21,6 +21,7 @@
 
 #include "paddle/common/ddim.h"
 #include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/kernels/funcs/strided_view_utils.h"
 
 namespace at {
 
@@ -59,6 +60,13 @@ inline at::Tensor Tensor::as_strided(
   int64_t offset = storage_offset.has_value() ? storage_offset.value() : 0;
   meta.offset = src_tensor->meta().offset +
                 static_cast<size_t>(offset) * phi::SizeOf(src_tensor->dtype());
+  // This entry builds the view by hand instead of going through
+  // phi::AsStridedKernel, so it has to run the same storage range check;
+  // otherwise a view reaching past the allocation corrupts neighbouring heap
+  // memory on every read and write. torch does the same in setStrided ->
+  // checkInBoundsForStorage.
+  phi::ValidateStridedViewStorage(
+      size_vec, stride_vec, static_cast<int64_t>(meta.offset), *src_tensor);
   new_tensor->set_meta(meta);
   PaddleTensor result;
   result.set_impl(new_tensor);
@@ -89,6 +97,8 @@ inline const at::Tensor& Tensor::as_strided_(
   int64_t offset = storage_offset.has_value() ? storage_offset.value() : 0;
   meta.offset = src_tensor->meta().offset +
                 static_cast<size_t>(offset) * phi::SizeOf(src_tensor->dtype());
+  phi::ValidateStridedViewStorage(
+      size_vec, stride_vec, static_cast<int64_t>(meta.offset), *src_tensor);
   src_tensor->set_meta(meta);
   return *this;
 }

--- a/paddle/phi/kernels/funcs/strided_grad_utils.h
+++ b/paddle/phi/kernels/funcs/strided_grad_utils.h
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+#include "paddle/common/ddim.h"
+#include "paddle/phi/common/data_type.h"
+#include "paddle/phi/common/scalar.h"
+#include "paddle/phi/core/compat/convert_utils.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/kernel_factory.h"
+#include "paddle/phi/core/visit_type.h"
+#include "paddle/phi/kernels/funcs/strided_utils.h"
+
+namespace phi {
+
+// Returns true when two different logical indices of the view described by
+// (dims, strides) may map to the same memory location. A view whose memory
+// overlaps requires its backward to *accumulate* the incoming gradient instead
+// of scattering it, otherwise the writes destroy each other.
+//
+// The algorithm follows at::detail::_maybe_overlapping_memory: sort the
+// dimensions by stride and check that each dimension starts beyond the span
+// covered by all smaller-stride dimensions. Dimensions of size <= 1 can only
+// ever contribute index 0 and are skipped; a non-positive stride on a
+// dimension of size > 1 (broadcast or reversed view) always overlaps.
+inline bool MaybeOverlappingStrides(const std::vector<int64_t>& dims,
+                                    const std::vector<int64_t>& strides) {
+  if (dims.size() != strides.size()) {
+    return true;
+  }
+  std::vector<size_t> order;
+  order.reserve(dims.size());
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (dims[i] <= 1) {
+      continue;
+    }
+    if (strides[i] <= 0) {
+      return true;
+    }
+    order.push_back(i);
+  }
+  std::sort(order.begin(), order.end(), [&strides](size_t a, size_t b) {
+    return strides[a] < strides[b];
+  });
+  int64_t max_index_in_slice = 0;
+  for (size_t i : order) {
+    if (strides[i] <= max_index_in_slice) {
+      return true;
+    }
+    max_index_in_slice += strides[i] * (dims[i] - 1);
+  }
+  return false;
+}
+
+// Accumulates `out_grad` into the storage of `input_grad` through the view
+// described by (dims, stride, offset), where `offset` is a byte offset into
+// `input_grad`'s allocation, matching AsStridedKernel.
+//
+// Unlike StridedTensorCopy, positions that are hit more than once by the view
+// receive the sum of all contributions. `input_grad` must already be
+// allocated, contiguous and zero filled.
+//
+// Implementation note: the flat storage index of every output element is
+// materialized by taking the very same view over arange(0, storage_numel),
+// which turns the problem into a plain scatter-add handled by `index_put` with
+// accumulate=true. `arange` and `index_put` are dispatched at runtime via
+// PD_VISIT_KERNEL because they are not registered for every (dtype, backend)
+// pair that the STRIDED grad kernels are registered for.
+template <typename T>
+inline void StridedTensorAccumulate(const DenseTensor& out_grad,
+                                    const std::vector<int64_t>& dims,
+                                    const std::vector<int64_t>& stride,
+                                    int64_t offset,
+                                    DenseTensor* input_grad) {
+  const int64_t itemsize = static_cast<int64_t>(SizeOf(input_grad->dtype()));
+  PADDLE_ENFORCE_EQ(offset % itemsize,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The byte offset(%d) of a strided view must be a "
+                        "multiple of its element size(%d).",
+                        offset,
+                        itemsize));
+  const int64_t elem_offset = offset / itemsize;
+  const int64_t storage_numel = input_grad->numel();
+  const int64_t value_numel = out_grad.numel();
+
+  int64_t max_elem_index = elem_offset;
+  int64_t min_elem_index = elem_offset;
+  for (size_t i = 0; i < dims.size(); ++i) {
+    const int64_t span = stride[i] * (dims[i] - 1);
+    if (span > 0) {
+      max_elem_index += span;
+    } else {
+      min_elem_index += span;
+    }
+  }
+  PADDLE_ENFORCE_GE(min_elem_index,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The strided view reaches element %d of the gradient "
+                        "buffer, which is out of range.",
+                        min_elem_index));
+  PADDLE_ENFORCE_LT(max_elem_index,
+                    storage_numel,
+                    common::errors::InvalidArgument(
+                        "The strided view reaches element %d, but the gradient "
+                        "buffer only holds %d elements.",
+                        max_elem_index,
+                        storage_numel));
+
+  auto& pool = DeviceContextPool::Instance();
+  auto* dev_ctx = pool.Get(input_grad->place());
+  const KernelKey index_key(TransToPhiBackend(input_grad->place()),
+                            DataLayout::ALL_LAYOUT,
+                            DataType::INT64);
+
+  // 1. arange(0, storage_numel) over the destination storage.
+  DenseTensor storage_index(DataType::INT64);
+  storage_index.Resize(common::make_ddim(std::vector<int64_t>{storage_numel}));
+  using arange_signature = void (*)(const DeviceContext&,
+                                    const Scalar&,
+                                    const Scalar&,
+                                    const Scalar&,
+                                    DenseTensor*);
+  PD_VISIT_KERNEL("arange",
+                  index_key,
+                  arange_signature,
+                  false,
+                  *dev_ctx,
+                  Scalar(static_cast<int64_t>(0)),
+                  Scalar(storage_numel),
+                  Scalar(static_cast<int64_t>(1)),
+                  &storage_index);
+
+  // 2. Apply the view to it, so that element i of `index` is the storage slot
+  // that element i of `out_grad` belongs to.
+  DenseTensor index_view(storage_index);
+  DenseTensorMeta index_view_meta = storage_index.meta();
+  index_view_meta.dims = DDim(dims.data(), static_cast<int>(dims.size()));
+  index_view_meta.strides =
+      DDim(stride.data(), static_cast<int>(stride.size()));
+  index_view_meta.offset =
+      static_cast<size_t>(elem_offset * static_cast<int64_t>(sizeof(int64_t)));
+  index_view.set_meta(index_view_meta);
+
+  DenseTensor index;
+  index.set_meta(index_view.meta());
+  StridedTensorContiguous<int64_t>(index_view, &index);
+  index.Resize(common::make_ddim(std::vector<int64_t>{value_numel}));
+
+  // 3. Densify the incoming gradient in the matching order.
+  DenseTensor value;
+  value.set_meta(out_grad.meta());
+  StridedTensorContiguous<T>(out_grad, &value);
+  value.Resize(common::make_ddim(std::vector<int64_t>{value_numel}));
+
+  // 4. Scatter-add into the flattened destination storage. Aliasing x and out
+  // is intentional: `input_grad` is already initialized, so `index_put` skips
+  // the x -> out copy and accumulates in place.
+  DenseTensor flat(*input_grad);
+  DenseTensorMeta flat_meta = input_grad->meta();
+  flat_meta.dims = common::make_ddim(std::vector<int64_t>{storage_numel});
+  flat_meta.strides = common::make_ddim(std::vector<int64_t>{1});
+  flat_meta.offset = 0;
+  flat.set_meta(flat_meta);
+
+  std::vector<const DenseTensor*> indices = {&index};
+  using index_put_signature = void (*)(const DeviceContext&,
+                                       const DenseTensor&,
+                                       const std::vector<const DenseTensor*>&,
+                                       const DenseTensor&,
+                                       bool,
+                                       DenseTensor*);
+  PD_VISIT_KERNEL("index_put",
+                  KernelKey(TransToPhiBackend(input_grad->place()),
+                            DataLayout::ALL_LAYOUT,
+                            input_grad->dtype()),
+                  index_put_signature,
+                  false,
+                  *dev_ctx,
+                  flat,
+                  indices,
+                  value,
+                  true,
+                  &flat);
+}
+
+}  // namespace phi

--- a/paddle/phi/kernels/funcs/strided_grad_utils.h
+++ b/paddle/phi/kernels/funcs/strided_grad_utils.h
@@ -382,10 +382,11 @@ inline void StridedTensorAccumulateThroughStorage(
 
   auto& pool = DeviceContextPool::Instance();
   auto* dev_ctx = pool.Get(input_grad->place());
-  DenseTensor storage;
-  storage.set_meta(
-      DenseTensorMeta(input_grad->dtype(),
-                      common::make_ddim(std::vector<int64_t>{storage_numel})));
+  // Resize rather than set_meta: the rvalue set_meta overload requires the
+  // destination meta to be invalid, and a default constructed DenseTensor
+  // already reports a valid one (float32, NCHW, rank -1 dims).
+  DenseTensor storage(input_grad->dtype());
+  storage.Resize(common::make_ddim(std::vector<int64_t>{storage_numel}));
   dev_ctx->Alloc(&storage, storage.dtype());
   StridedTensorFill<T>(storage, 0, &storage);
 

--- a/paddle/phi/kernels/funcs/strided_grad_utils.h
+++ b/paddle/phi/kernels/funcs/strided_grad_utils.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstring>
 #include <vector>
 
 #include "paddle/common/ddim.h"
@@ -119,7 +120,10 @@ inline void HostAccumulateStridedView(const T* values,
 // Unlike StridedTensorCopy, positions that the view hits more than once
 // receive the sum of all contributions. `input_grad` must already be
 // allocated, contiguous, zero filled, and start at element 0 of its
-// allocation.
+// allocation. Zero filling is a hard requirement and not just a convention:
+// the host path below relies on it to skip reading the destination back from
+// the device, so a non-zero buffer would be accumulated into on GPU but
+// overwritten everywhere else.
 template <typename T>
 inline void StridedTensorAccumulate(const DenseTensor& out_grad,
                                     const std::vector<int64_t>& dims,
@@ -271,18 +275,24 @@ inline void StridedTensorAccumulate(const DenseTensor& out_grad,
     return;
   }
 
-  // Any other backend: stage both operands on the host, accumulate there and
-  // copy the result back. Slow, but a correct scatter-add is worth more than a
-  // fast wrong one, and the device kernels needed to do better do not exist.
+  // Any other backend: accumulate on the host and copy the result back. Slow,
+  // but a correct scatter-add is worth more than a fast wrong one, and the
+  // device kernels needed to do better do not exist.
+  //
+  // Only the incoming gradient is staged with a device to host copy. The
+  // destination is required to be zero filled on entry, so reading it back
+  // would only reproduce zeros; allocating the host side zeroed instead saves
+  // a full copy of the gradient buffer.
   DenseTensor host_value;
   host_value.set_layout(value.layout());
   phi::Copy(*dev_ctx, value, CPUPlace(), /*blocking=*/true, &host_value);
   DenseTensor host_storage;
-  host_storage.set_layout(input_grad->layout());
-  phi::Copy(
-      *dev_ctx, *input_grad, CPUPlace(), /*blocking=*/true, &host_storage);
+  host_storage.set_meta(input_grad->meta());
+  T* host_ptr =
+      static_cast<T*>(dev_ctx->HostAlloc(&host_storage, host_storage.dtype()));
+  std::memset(host_ptr, 0, static_cast<size_t>(storage_numel) * sizeof(T));
   HostAccumulateStridedView<T>(
-      host_value.data<T>(), dims, stride, elem_base, host_storage.data<T>());
+      host_value.data<T>(), dims, stride, elem_base, host_ptr);
   phi::Copy(*dev_ctx,
             host_storage,
             input_grad->place(),

--- a/paddle/phi/kernels/funcs/strided_grad_utils.h
+++ b/paddle/phi/kernels/funcs/strided_grad_utils.h
@@ -18,13 +18,16 @@
 #include <vector>
 
 #include "paddle/common/ddim.h"
+#include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/compat/convert_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_factory.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/core/visit_type.h"
 #include "paddle/phi/kernels/funcs/strided_utils.h"
+#include "paddle/phi/kernels/funcs/strided_view_utils.h"
 
 namespace phi {
 
@@ -62,31 +65,73 @@ inline bool MaybeOverlappingStrides(const std::vector<int64_t>& dims,
     if (strides[i] <= max_index_in_slice) {
       return true;
     }
-    max_index_in_slice += strides[i] * (dims[i] - 1);
+    int64_t span = 0;
+    // A span that overflows int64 cannot describe a view that fits in any
+    // allocation. Report it as overlapping and let the range check reject it.
+    if (!SafeMulInt64(strides[i], dims[i] - 1, &span) ||
+        !SafeAddInt64(max_index_in_slice, span, &max_index_in_slice)) {
+      return true;
+    }
   }
   return false;
 }
 
+// Serial scatter-add of `values` (dense, in view order) into `storage` through
+// the view described by (dims, stride) starting at element `elem_base`.
+//
+// Both pointers must be host accessible. Correctness before speed: an
+// overlapping view hits the same slot several times, so this loop cannot be
+// parallelized without atomics.
+template <typename T>
+inline void HostAccumulateStridedView(const T* values,
+                                      const std::vector<int64_t>& dims,
+                                      const std::vector<int64_t>& stride,
+                                      int64_t elem_base,
+                                      T* storage) {
+  const int rank = static_cast<int>(dims.size());
+  int64_t numel = 1;
+  for (int i = 0; i < rank; ++i) {
+    numel *= dims[i];
+  }
+  if (numel == 0) {
+    return;
+  }
+  std::vector<int64_t> counter(static_cast<size_t>(rank), 0);
+  int64_t dest = elem_base;
+  for (int64_t i = 0; i < numel; ++i) {
+    storage[dest] = static_cast<T>(storage[dest] + values[i]);
+    // Odometer over the logical indices, keeping `dest` in sync.
+    for (int d = rank - 1; d >= 0; --d) {
+      dest += stride[d];
+      if (++counter[d] < dims[d]) {
+        break;
+      }
+      counter[d] = 0;
+      dest -= stride[d] * dims[d];
+    }
+  }
+}
+
 // Accumulates `out_grad` into the storage of `input_grad` through the view
 // described by (dims, stride, offset), where `offset` is a byte offset into
-// `input_grad`'s allocation, matching AsStridedKernel.
+// `input_grad`'s own allocation.
 //
-// Unlike StridedTensorCopy, positions that are hit more than once by the view
+// Unlike StridedTensorCopy, positions that the view hits more than once
 // receive the sum of all contributions. `input_grad` must already be
-// allocated, contiguous and zero filled.
-//
-// Implementation note: the flat storage index of every output element is
-// materialized by taking the very same view over arange(0, storage_numel),
-// which turns the problem into a plain scatter-add handled by `index_put` with
-// accumulate=true. `arange` and `index_put` are dispatched at runtime via
-// PD_VISIT_KERNEL because they are not registered for every (dtype, backend)
-// pair that the STRIDED grad kernels are registered for.
+// allocated, contiguous, zero filled, and start at element 0 of its
+// allocation.
 template <typename T>
 inline void StridedTensorAccumulate(const DenseTensor& out_grad,
                                     const std::vector<int64_t>& dims,
                                     const std::vector<int64_t>& stride,
                                     int64_t offset,
                                     DenseTensor* input_grad) {
+  PADDLE_ENFORCE_EQ(input_grad->offset(),
+                    0u,
+                    common::errors::InvalidArgument(
+                        "The gradient buffer must start at the beginning of "
+                        "its own allocation, but its offset is %d.",
+                        input_grad->offset()));
   const int64_t itemsize = static_cast<int64_t>(SizeOf(input_grad->dtype()));
   PADDLE_ENFORCE_EQ(offset % itemsize,
                     0,
@@ -95,109 +140,154 @@ inline void StridedTensorAccumulate(const DenseTensor& out_grad,
                         "multiple of its element size(%d).",
                         offset,
                         itemsize));
-  const int64_t elem_offset = offset / itemsize;
+  const int64_t elem_base = offset / itemsize;
   const int64_t storage_numel = input_grad->numel();
   const int64_t value_numel = out_grad.numel();
-
-  int64_t max_elem_index = elem_offset;
-  int64_t min_elem_index = elem_offset;
-  for (size_t i = 0; i < dims.size(); ++i) {
-    const int64_t span = stride[i] * (dims[i] - 1);
-    if (span > 0) {
-      max_elem_index += span;
-    } else {
-      min_elem_index += span;
-    }
+  // Overflow checked. The bound is numel() and not the size of the allocation
+  // because the index buffer built below covers exactly that many elements.
+  const StridedViewRange range =
+      ComputeStridedViewRange(dims, stride, elem_base);
+  if (range.empty || value_numel == 0) {
+    return;
   }
-  PADDLE_ENFORCE_GE(min_elem_index,
+  PADDLE_ENFORCE_GE(range.min_index,
                     0,
                     common::errors::InvalidArgument(
                         "The strided view reaches element %d of the gradient "
                         "buffer, which is out of range.",
-                        min_elem_index));
-  PADDLE_ENFORCE_LT(max_elem_index,
+                        range.min_index));
+  PADDLE_ENFORCE_LT(range.max_index,
                     storage_numel,
                     common::errors::InvalidArgument(
                         "The strided view reaches element %d, but the gradient "
                         "buffer only holds %d elements.",
-                        max_elem_index,
+                        range.max_index,
                         storage_numel));
 
   auto& pool = DeviceContextPool::Instance();
   auto* dev_ctx = pool.Get(input_grad->place());
-  const KernelKey index_key(TransToPhiBackend(input_grad->place()),
-                            DataLayout::ALL_LAYOUT,
-                            DataType::INT64);
+  const Backend backend = TransToPhiBackend(input_grad->place());
+  auto& factory = KernelFactory::Instance();
+  // Only the GPU index_put accumulates atomically (CudaAtomicAdd). The CPU
+  // kernel uses a plain `+=` inside an OpenMP loop, which loses updates on
+  // exactly the duplicated indices that an overlapping view produces by
+  // construction; XPU registers no `arange` at all and covers only a handful of
+  // dtypes in index_put. Every backend but GPU, and every dtype that GPU's
+  // index_put does not implement, therefore takes the serial host path below.
+  // HasKernel throws when the kernel *name* is unknown, which cannot happen
+  // here: both names are registered unconditionally for CPU.
+  const bool use_device_scatter_add =
+      input_grad->place().GetType() == AllocationType::GPU &&
+      factory.HasKernel(
+          "arange",
+          KernelKey(backend, DataLayout::ALL_LAYOUT, DataType::INT64)) &&
+      factory.HasKernel(
+          "index_put",
+          KernelKey(backend, DataLayout::ALL_LAYOUT, input_grad->dtype()));
 
-  // 1. arange(0, storage_numel) over the destination storage.
-  DenseTensor storage_index(DataType::INT64);
-  storage_index.Resize(common::make_ddim(std::vector<int64_t>{storage_numel}));
-  using arange_signature = void (*)(const DeviceContext&,
-                                    const Scalar&,
-                                    const Scalar&,
-                                    const Scalar&,
-                                    DenseTensor*);
-  PD_VISIT_KERNEL("arange",
-                  index_key,
-                  arange_signature,
-                  false,
-                  *dev_ctx,
-                  Scalar(static_cast<int64_t>(0)),
-                  Scalar(storage_numel),
-                  Scalar(static_cast<int64_t>(1)),
-                  &storage_index);
+  if (use_device_scatter_add) {
+    // 1. arange(0, storage_numel) over the destination storage.
+    DenseTensor storage_index(DataType::INT64);
+    storage_index.Resize(
+        common::make_ddim(std::vector<int64_t>{storage_numel}));
+    using arange_signature = void (*)(const DeviceContext&,
+                                      const Scalar&,
+                                      const Scalar&,
+                                      const Scalar&,
+                                      DenseTensor*);
+    PD_VISIT_KERNEL("arange",
+                    KernelKey(backend, DataLayout::ALL_LAYOUT, DataType::INT64),
+                    arange_signature,
+                    false,
+                    *dev_ctx,
+                    Scalar(static_cast<int64_t>(0)),
+                    Scalar(storage_numel),
+                    Scalar(static_cast<int64_t>(1)),
+                    &storage_index);
 
-  // 2. Apply the view to it, so that element i of `index` is the storage slot
-  // that element i of `out_grad` belongs to.
-  DenseTensor index_view(storage_index);
-  DenseTensorMeta index_view_meta = storage_index.meta();
-  index_view_meta.dims = DDim(dims.data(), static_cast<int>(dims.size()));
-  index_view_meta.strides =
-      DDim(stride.data(), static_cast<int>(stride.size()));
-  index_view_meta.offset =
-      static_cast<size_t>(elem_offset * static_cast<int64_t>(sizeof(int64_t)));
-  index_view.set_meta(index_view_meta);
+    // 2. Apply the view to it, so that element i of `index` is the storage slot
+    // that element i of `out_grad` belongs to.
+    DenseTensor index_view(storage_index);
+    DenseTensorMeta index_view_meta = storage_index.meta();
+    index_view_meta.dims = DDim(dims.data(), static_cast<int>(dims.size()));
+    index_view_meta.strides =
+        DDim(stride.data(), static_cast<int>(stride.size()));
+    index_view_meta.offset =
+        static_cast<size_t>(elem_base * static_cast<int64_t>(sizeof(int64_t)));
+    index_view.set_meta(index_view_meta);
 
-  DenseTensor index;
-  index.set_meta(index_view.meta());
-  StridedTensorContiguous<int64_t>(index_view, &index);
-  index.Resize(common::make_ddim(std::vector<int64_t>{value_numel}));
+    DenseTensor index;
+    index.set_meta(index_view.meta());
+    StridedTensorContiguous<int64_t>(index_view, &index);
+    index.Resize(common::make_ddim(std::vector<int64_t>{value_numel}));
 
-  // 3. Densify the incoming gradient in the matching order.
+    // 3. Densify the incoming gradient in the matching order.
+    DenseTensor value;
+    value.set_meta(out_grad.meta());
+    StridedTensorContiguous<T>(out_grad, &value);
+    value.Resize(common::make_ddim(std::vector<int64_t>{value_numel}));
+
+    // 4. Scatter-add into the flattened destination storage. Aliasing x and out
+    // is intentional: `input_grad` is already initialized, so `index_put` skips
+    // the x -> out copy and accumulates in place.
+    DenseTensor flat(*input_grad);
+    DenseTensorMeta flat_meta = input_grad->meta();
+    flat_meta.dims = common::make_ddim(std::vector<int64_t>{storage_numel});
+    flat_meta.strides = common::make_ddim(std::vector<int64_t>{1});
+    flat_meta.offset = 0;
+    flat.set_meta(flat_meta);
+
+    std::vector<const DenseTensor*> indices = {&index};
+    using index_put_signature = void (*)(const DeviceContext&,
+                                         const DenseTensor&,
+                                         const std::vector<const DenseTensor*>&,
+                                         const DenseTensor&,
+                                         bool,
+                                         DenseTensor*);
+    PD_VISIT_KERNEL(
+        "index_put",
+        KernelKey(backend, DataLayout::ALL_LAYOUT, input_grad->dtype()),
+        index_put_signature,
+        false,
+        *dev_ctx,
+        flat,
+        indices,
+        value,
+        true,
+        &flat);
+    return;
+  }
+
+  // Serial host fallback. Densify the incoming gradient first so that the
+  // accumulate loop only has to walk the destination side.
   DenseTensor value;
   value.set_meta(out_grad.meta());
   StridedTensorContiguous<T>(out_grad, &value);
   value.Resize(common::make_ddim(std::vector<int64_t>{value_numel}));
 
-  // 4. Scatter-add into the flattened destination storage. Aliasing x and out
-  // is intentional: `input_grad` is already initialized, so `index_put` skips
-  // the x -> out copy and accumulates in place.
-  DenseTensor flat(*input_grad);
-  DenseTensorMeta flat_meta = input_grad->meta();
-  flat_meta.dims = common::make_ddim(std::vector<int64_t>{storage_numel});
-  flat_meta.strides = common::make_ddim(std::vector<int64_t>{1});
-  flat_meta.offset = 0;
-  flat.set_meta(flat_meta);
+  if (input_grad->place().GetType() == AllocationType::CPU) {
+    HostAccumulateStridedView<T>(
+        value.data<T>(), dims, stride, elem_base, input_grad->data<T>());
+    return;
+  }
 
-  std::vector<const DenseTensor*> indices = {&index};
-  using index_put_signature = void (*)(const DeviceContext&,
-                                       const DenseTensor&,
-                                       const std::vector<const DenseTensor*>&,
-                                       const DenseTensor&,
-                                       bool,
-                                       DenseTensor*);
-  PD_VISIT_KERNEL("index_put",
-                  KernelKey(TransToPhiBackend(input_grad->place()),
-                            DataLayout::ALL_LAYOUT,
-                            input_grad->dtype()),
-                  index_put_signature,
-                  false,
-                  *dev_ctx,
-                  flat,
-                  indices,
-                  value,
-                  true,
-                  &flat);
+  // Any other backend: stage both operands on the host, accumulate there and
+  // copy the result back. Slow, but a correct scatter-add is worth more than a
+  // fast wrong one, and the device kernels needed to do better do not exist.
+  DenseTensor host_value;
+  host_value.set_layout(value.layout());
+  phi::Copy(*dev_ctx, value, CPUPlace(), /*blocking=*/true, &host_value);
+  DenseTensor host_storage;
+  host_storage.set_layout(input_grad->layout());
+  phi::Copy(
+      *dev_ctx, *input_grad, CPUPlace(), /*blocking=*/true, &host_storage);
+  HostAccumulateStridedView<T>(
+      host_value.data<T>(), dims, stride, elem_base, host_storage.data<T>());
+  phi::Copy(*dev_ctx,
+            host_storage,
+            input_grad->place(),
+            /*blocking=*/true,
+            input_grad);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/strided_grad_utils.h
+++ b/paddle/phi/kernels/funcs/strided_grad_utils.h
@@ -290,4 +290,116 @@ inline void StridedTensorAccumulate(const DenseTensor& out_grad,
             input_grad);
 }
 
+// Backward of a strided view whose `input` is itself a non-contiguous view, or
+// whose window starts before `input` does.
+//
+// (dims, stride, offset) describe the view in the coordinate system of the
+// allocation shared with `input`, while `input_grad` is a dense row-major
+// buffer over `input`'s own logical indices. Those two coordinate systems only
+// differ by a constant when `input` is contiguous; in general the storage index
+// of an element is not its row-major index, so the gradient has to be routed
+// through a temporary buffer laid out in storage coordinates: scatter-add
+// `out_grad` into it through the out geometry, then gather it back through
+// `input`'s own geometry. This mirrors at::as_strided_backward.
+//
+// `input_grad` must already be allocated with `input`'s dims; its previous
+// contents are overwritten. Only the meta of `input` is read, never its data,
+// because the forward declares `no_need_buffer : input`.
+template <typename T>
+inline void StridedTensorAccumulateThroughStorage(
+    const DenseTensor& out_grad,
+    const std::vector<int64_t>& dims,
+    const std::vector<int64_t>& stride,
+    int64_t offset,
+    const DenseTensor& input,
+    DenseTensor* input_grad) {
+  const int64_t itemsize = static_cast<int64_t>(SizeOf(input_grad->dtype()));
+  PADDLE_ENFORCE_EQ(offset % itemsize,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The byte offset(%d) of a strided view must be a "
+                        "multiple of its element size(%d).",
+                        offset,
+                        itemsize));
+  const std::vector<int64_t> input_dims =
+      common::vectorize<int64_t>(input.dims());
+  const std::vector<int64_t> input_stride =
+      common::vectorize<int64_t>(input.strides());
+  // The gradient with respect to a view that aliases itself is only defined
+  // once a convention is fixed for splitting a slot between the logical
+  // positions that share it (torch divides by an occurrence count). Refuse
+  // instead of silently picking one.
+  PADDLE_ENFORCE_EQ(
+      MaybeOverlappingStrides(input_dims, input_stride),
+      false,
+      common::errors::Unimplemented(
+          "as_strided_grad does not support an input whose own memory "
+          "overlaps (shape %s, stride %s): the gradient of such a view is "
+          "ambiguous. Make the input contiguous first.",
+          input.dims(),
+          input.strides()));
+
+  const int64_t out_base = offset / itemsize;
+  const int64_t input_base = static_cast<int64_t>(input.offset()) / itemsize;
+  const StridedViewRange out_range =
+      ComputeStridedViewRange(dims, stride, out_base);
+  const StridedViewRange input_range =
+      ComputeStridedViewRange(input_dims, input_stride, input_base);
+  if (out_range.empty || input_range.empty || out_grad.numel() == 0) {
+    return;
+  }
+  const int64_t shared_base =
+      std::min(out_range.min_index, input_range.min_index);
+  PADDLE_ENFORCE_GE(shared_base,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The strided view reaches element %d of the shared "
+                        "allocation, which is before its beginning.",
+                        shared_base));
+  int64_t storage_numel = 0;
+  const int64_t shared_last =
+      std::max(out_range.max_index, input_range.max_index);
+  PADDLE_ENFORCE_EQ(
+      SafeAddInt64(shared_last - shared_base, 1, &storage_numel),
+      true,
+      common::errors::InvalidArgument(
+          "The element range spanned by the view described by shape %s, "
+          "stride %s and byte offset %d together with its input overflows "
+          "int64.",
+          common::make_ddim(dims),
+          common::make_ddim(stride),
+          offset));
+
+  auto& pool = DeviceContextPool::Instance();
+  auto* dev_ctx = pool.Get(input_grad->place());
+  DenseTensor storage;
+  storage.set_meta(
+      DenseTensorMeta(input_grad->dtype(),
+                      common::make_ddim(std::vector<int64_t>{storage_numel})));
+  dev_ctx->Alloc(&storage, storage.dtype());
+  StridedTensorFill<T>(storage, 0, &storage);
+
+  const int64_t out_byte_base = (out_base - shared_base) * itemsize;
+  if (MaybeOverlappingStrides(dims, stride)) {
+    StridedTensorAccumulate<T>(out_grad, dims, stride, out_byte_base, &storage);
+  } else {
+    // Distinct slots, so a plain scatter is enough and avoids the serial
+    // accumulate. Mirrors the copy_ branch of at::as_strided_backward.
+    DenseTensor window(storage);
+    StridedTensorCopy<T>(out_grad, dims, stride, out_byte_base, &window);
+  }
+
+  // Read the accumulated storage back through `input`'s geometry. Contiguous
+  // materialization is exactly the gather that turns storage indices into
+  // row-major ones, and it reuses the buffer `input_grad` already owns.
+  DenseTensor gathered(storage);
+  DenseTensorMeta gathered_meta = storage.meta();
+  gathered_meta.dims = input.dims();
+  gathered_meta.strides = input.strides();
+  gathered_meta.offset =
+      static_cast<size_t>((input_base - shared_base) * itemsize);
+  gathered.set_meta(gathered_meta);
+  StridedTensorContiguous<T>(gathered, input_grad);
+}
+
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/strided_view_utils.h
+++ b/paddle/phi/kernels/funcs/strided_view_utils.h
@@ -70,6 +70,42 @@ inline bool SafeAddInt64(int64_t a, int64_t b, int64_t* out) {
   return true;
 }
 
+// Turns a torch style storage offset, expressed in *elements* and relative to
+// the offset of the tensor being viewed, into the absolute *byte* offset that
+// DenseTensorMeta::offset and phi::AsStridedKernel expect. Do not call this on
+// an offset that is already a byte offset.
+//
+// The conversion needs its own helper because phi::SizeOf returns size_t, so
+// the obvious `static_cast<size_t>(offset) * SizeOf(dtype)` is unsigned
+// arithmetic that wraps around silently: a storage offset of 1 << 62 on a four
+// byte dtype becomes 0, and the range check below would then happily validate
+// a completely different view and let the out of range request through.
+inline int64_t ElementOffsetToByteOffset(int64_t base_byte_offset,
+                                         int64_t element_offset,
+                                         int64_t itemsize) {
+  PADDLE_ENFORCE_GE(element_offset,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The storage offset of a view must be non-negative, "
+                        "but got %d.",
+                        element_offset));
+  int64_t byte_offset = 0;
+  bool ok = SafeMulInt64(element_offset, itemsize, &byte_offset);
+  if (ok) {
+    ok = SafeAddInt64(base_byte_offset, byte_offset, &byte_offset);
+  }
+  PADDLE_ENFORCE_EQ(ok,
+                    true,
+                    common::errors::InvalidArgument(
+                        "The byte offset of the view overflows int64: element "
+                        "offset %d of a %d byte dtype, relative to byte offset "
+                        "%d.",
+                        element_offset,
+                        itemsize,
+                        base_byte_offset));
+  return byte_offset;
+}
+
 // Element indices, relative to the start of the allocation, that a strided
 // view touches. `empty` marks a view with a zero sized dimension, which reads
 // and writes nothing at all.

--- a/paddle/phi/kernels/funcs/strided_view_utils.h
+++ b/paddle/phi/kernels/funcs/strided_view_utils.h
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "paddle/common/ddim.h"
+#include "paddle/common/enforce.h"
+#include "paddle/phi/common/data_type.h"
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+
+// int64_t arithmetic that reports overflow instead of wrapping around.
+//
+// The element range of a strided view is computed from a caller supplied
+// (shape, stride, offset) triple, so the products and sums below can exceed
+// int64_t for adversarial input. Without these guards the range check wraps
+// around and happily accepts a view that reaches far outside of the
+// allocation, which is worse than having no check at all. __int128 and
+// __builtin_*_overflow are avoided on purpose: this header is reachable from
+// the public compat headers, which are also compiled by MSVC.
+inline bool SafeMulInt64(int64_t a, int64_t b, int64_t* out) {
+  constexpr int64_t kMax = (std::numeric_limits<int64_t>::max)();
+  constexpr int64_t kMin = (std::numeric_limits<int64_t>::lowest)();
+  if (a == 0 || b == 0) {
+    *out = 0;
+    return true;
+  }
+  // Handled separately so that the divisions below never evaluate kMin / -1.
+  if (a == -1) {
+    if (b == kMin) return false;
+    *out = -b;
+    return true;
+  }
+  if (b == -1) {
+    if (a == kMin) return false;
+    *out = -a;
+    return true;
+  }
+  if (a > 0) {
+    if (b > 0 ? a > kMax / b : b < kMin / a) return false;
+  } else {
+    if (b > 0 ? a < kMin / b : a < kMax / b) return false;
+  }
+  *out = a * b;
+  return true;
+}
+
+inline bool SafeAddInt64(int64_t a, int64_t b, int64_t* out) {
+  constexpr int64_t kMax = (std::numeric_limits<int64_t>::max)();
+  constexpr int64_t kMin = (std::numeric_limits<int64_t>::lowest)();
+  if (b > 0 && a > kMax - b) return false;
+  if (b < 0 && a < kMin - b) return false;
+  *out = a + b;
+  return true;
+}
+
+// Element indices, relative to the start of the allocation, that a strided
+// view touches. `empty` marks a view with a zero sized dimension, which reads
+// and writes nothing at all.
+struct StridedViewRange {
+  int64_t min_index{0};
+  int64_t max_index{0};
+  bool empty{false};
+};
+
+inline StridedViewRange ComputeStridedViewRange(
+    const std::vector<int64_t>& dims,
+    const std::vector<int64_t>& strides,
+    int64_t base_index) {
+  StridedViewRange range;
+  range.min_index = base_index;
+  range.max_index = base_index;
+  for (size_t i = 0; i < dims.size(); ++i) {
+    PADDLE_ENFORCE_GE(dims[i],
+                      0,
+                      common::errors::InvalidArgument(
+                          "The shape of a strided view must be non-negative, "
+                          "but got %s.",
+                          common::make_ddim(dims)));
+    if (dims[i] == 0) {
+      range.empty = true;
+      return range;
+    }
+    int64_t span = 0;
+    bool ok = SafeMulInt64(strides[i], dims[i] - 1, &span);
+    if (ok) {
+      ok = span > 0 ? SafeAddInt64(range.max_index, span, &range.max_index)
+                    : SafeAddInt64(range.min_index, span, &range.min_index);
+    }
+    PADDLE_ENFORCE_EQ(
+        ok,
+        true,
+        common::errors::InvalidArgument(
+            "The element range of the view described by shape %s, stride %s "
+            "and element offset %d overflows int64.",
+            common::make_ddim(dims),
+            common::make_ddim(strides),
+            base_index));
+  }
+  return range;
+}
+
+// Rejects views that would reach outside of `input`'s allocation. Without this
+// check a bad (shape, stride, offset) triple silently produces a tensor whose
+// reads and writes corrupt neighbouring heap memory.
+//
+// `offset` is a byte offset into the allocation, matching AsStridedKernel and
+// DenseTensorMeta::offset.
+inline void ValidateStridedViewStorage(const std::vector<int64_t>& dims,
+                                       const std::vector<int64_t>& strides,
+                                       int64_t offset,
+                                       const DenseTensor& input) {
+  if (input.numel() == 0 || input.Holder() == nullptr) {
+    return;
+  }
+  PADDLE_ENFORCE_EQ(dims.size(),
+                    strides.size(),
+                    common::errors::InvalidArgument(
+                        "The size of dims and strides should be equal."));
+  const int64_t itemsize = static_cast<int64_t>(SizeOf(input.dtype()));
+  PADDLE_ENFORCE_EQ(offset % itemsize,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The offset(%d) is a byte offset and must be a "
+                        "multiple of the element size(%d) of the input.",
+                        offset,
+                        itemsize));
+  const StridedViewRange range =
+      ComputeStridedViewRange(dims, strides, offset / itemsize);
+  if (range.empty) {
+    return;
+  }
+  const int64_t storage_numel =
+      static_cast<int64_t>(input.Holder()->size()) / itemsize;
+  PADDLE_ENFORCE_GE(range.min_index,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The view described by shape %s, stride %s and offset "
+                        "%d reaches element %d, which is before the beginning "
+                        "of the input storage.",
+                        common::make_ddim(dims),
+                        common::make_ddim(strides),
+                        offset,
+                        range.min_index));
+  PADDLE_ENFORCE_LT(range.max_index,
+                    storage_numel,
+                    common::errors::InvalidArgument(
+                        "The view described by shape %s, stride %s and offset "
+                        "%d reaches element %d, but the input storage only "
+                        "holds %d elements.",
+                        common::make_ddim(dims),
+                        common::make_ddim(strides),
+                        offset,
+                        range.max_index,
+                        storage_numel));
+}
+
+}  // namespace phi

--- a/paddle/phi/kernels/funcs/strided_view_utils.h
+++ b/paddle/phi/kernels/funcs/strided_view_utils.h
@@ -119,6 +119,15 @@ inline StridedViewRange ComputeStridedViewRange(
     const std::vector<int64_t>& dims,
     const std::vector<int64_t>& strides,
     int64_t base_index) {
+  // Every loop below indexes strides[i] for i < dims.size(). Callers that may
+  // be handed a mismatched pair have to filter it out beforehand.
+  PADDLE_ENFORCE_EQ(dims.size(),
+                    strides.size(),
+                    common::errors::InvalidArgument(
+                        "The size of dims(%d) and strides(%d) of a strided "
+                        "view should be equal.",
+                        dims.size(),
+                        strides.size()));
   StridedViewRange range;
   range.min_index = base_index;
   range.max_index = base_index;
@@ -165,10 +174,15 @@ inline void ValidateStridedViewStorage(const std::vector<int64_t>& dims,
   if (input.numel() == 0 || input.Holder() == nullptr) {
     return;
   }
-  PADDLE_ENFORCE_EQ(dims.size(),
-                    strides.size(),
-                    common::errors::InvalidArgument(
-                        "The size of dims and strides should be equal."));
+  // Outside of the zero-size case AsStridedKernel has never required dims and
+  // strides to have the same length, and callers rely on that: the
+  // TestDygraphInplaceSet case of test_inplace.py asks for a rank 2 shape with
+  // a rank 1 stride. Such a view is malformed and its element range is not
+  // even well defined, but rejecting it here would be a behaviour change
+  // unrelated to the out-of-range views this check is about, so leave it alone.
+  if (dims.size() != strides.size()) {
+    return;
+  }
   const int64_t itemsize = static_cast<int64_t>(SizeOf(input.dtype()));
   PADDLE_ENFORCE_EQ(offset % itemsize,
                     0,

--- a/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
@@ -19,6 +19,7 @@
 #include "paddle/phi/kernels/as_strided_kernel.h"
 #include "paddle/phi/kernels/funcs/strided_grad_utils.h"
 #include "paddle/phi/kernels/funcs/strided_utils.h"
+#include "paddle/phi/kernels/funcs/strided_view_utils.h"
 
 COMMON_DECLARE_bool(use_stride_kernel);
 
@@ -48,20 +49,29 @@ void AsStridedGradKernel(const Context& dev_ctx,
   }
   // `offset` is a byte offset into the allocation shared with the forward
   // `input`, but `input_grad` is a dense row-major buffer over `input`'s own
-  // logical indices. The two coordinate systems differ by a constant only when
-  // `input` is contiguous, in which case subtracting `input.offset()` is enough
-  // -- otherwise a storage index is not a row-major index and the gradient has
-  // to be routed through a buffer laid out in storage coordinates. The same
-  // detour handles a view that starts before `input` does, whose leading
-  // contributions belong to no element of `input_grad` at all.
-  const int64_t grad_offset = offset - static_cast<int64_t>(input.offset());
-  if (!input.meta().is_contiguous() || grad_offset < 0) {
+  // logical indices. Subtracting `input.offset()` lines the two up only when
+  // `input` is contiguous *and* the whole window of the view lands inside
+  // `input`. Otherwise a storage index is not a row-major index; and since the
+  // forward validates a view against the shared allocation rather than against
+  // the extent of `input`, a window may legally reach outside `input` on either
+  // side, where its contributions belong to no element of `input_grad` and have
+  // to be dropped instead of written past its end. Everything but the fast case
+  // is routed through a buffer laid out in storage coordinates.
+  const int64_t itemsize = static_cast<int64_t>(SizeOf(input_grad->dtype()));
+  const int64_t input_base = static_cast<int64_t>(input.offset()) / itemsize;
+  const StridedViewRange out_range =
+      ComputeStridedViewRange(dims, stride, offset / itemsize);
+  const bool inside_input = !out_range.empty &&
+                            out_range.min_index >= input_base &&
+                            out_range.max_index < input_base + input.numel();
+  if (!input.meta().is_contiguous() || !inside_input) {
     PD_VISIT_ALL_TYPES(out_grad.dtype(), "AsStridedGradKernel", ([&] {
                          phi::StridedTensorAccumulateThroughStorage<data_t>(
                              out_grad, dims, stride, offset, input, input_grad);
                        }));
     return;
   }
+  const int64_t grad_offset = offset - static_cast<int64_t>(input.offset());
   if (MaybeOverlappingStrides(dims, stride)) {
     // Several elements of out_grad map to the same storage slot, so the
     // gradient has to be accumulated instead of copied.

--- a/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
@@ -46,18 +46,35 @@ void AsStridedGradKernel(const Context& dev_ctx,
   if (out_grad.numel() == 0) {
     return;
   }
+  // `offset` is a byte offset into the allocation of the forward *input*, but
+  // `input_grad` is a freshly allocated buffer that starts at element 0 of its
+  // own allocation. When `input` is itself a view (a nested as_strided), its
+  // own offset is already part of `offset` and has to be subtracted, otherwise
+  // the gradient is written at the wrong place or past the end of the buffer.
+  const int64_t grad_offset = offset - static_cast<int64_t>(input.offset());
+  PADDLE_ENFORCE_GE(
+      grad_offset,
+      0,
+      common::errors::InvalidArgument(
+          "The offset(%d) of as_strided is an absolute byte offset into the "
+          "shared allocation, so it must not be smaller than the offset(%d) "
+          "of the tensor being viewed: the gradient of a view that starts "
+          "before its input has nowhere to go.",
+          offset,
+          input.offset()));
   if (MaybeOverlappingStrides(dims, stride)) {
     // Several elements of out_grad map to the same storage slot, so the
     // gradient has to be accumulated instead of copied.
     PD_VISIT_ALL_TYPES(out_grad.dtype(), "AsStridedGradKernel", ([&] {
                          phi::StridedTensorAccumulate<data_t>(
-                             out_grad, dims, stride, offset, input_grad);
+                             out_grad, dims, stride, grad_offset, input_grad);
                        }));
     return;
   }
   DenseTensor tmp;
   tmp.set_meta(out_grad.meta());
-  AsStridedKernel<Context>(dev_ctx, *input_grad, dims, stride, offset, &tmp);
+  AsStridedKernel<Context>(
+      dev_ctx, *input_grad, dims, stride, grad_offset, &tmp);
   PD_VISIT_ALL_TYPES(out_grad.dtype(), "AsStridedGradKernel", ([&] {
                        phi::StridedTensorCopy<data_t>(
                            out_grad,

--- a/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
@@ -57,14 +57,25 @@ void AsStridedGradKernel(const Context& dev_ctx,
   // side, where its contributions belong to no element of `input_grad` and have
   // to be dropped instead of written past its end. Everything but the fast case
   // is routed through a buffer laid out in storage coordinates.
-  const int64_t itemsize = static_cast<int64_t>(SizeOf(input_grad->dtype()));
-  const int64_t input_base = static_cast<int64_t>(input.offset()) / itemsize;
-  const StridedViewRange out_range =
-      ComputeStridedViewRange(dims, stride, offset / itemsize);
-  const bool inside_input = !out_range.empty &&
-                            out_range.min_index >= input_base &&
-                            out_range.max_index < input_base + input.numel();
-  if (!input.meta().is_contiguous() || !inside_input) {
+  //
+  // A view whose stride is shorter than its shape is malformed, but the forward
+  // accepts it for a non-empty input, so it has to keep working here as well.
+  // Its element range is not well defined and every helper below indexes
+  // stride[i] for i < dims.size(), so such a view stays on the original copy
+  // path.
+  const bool ranked_alike = dims.size() == stride.size();
+  bool through_storage = false;
+  if (ranked_alike) {
+    const int64_t itemsize = static_cast<int64_t>(SizeOf(input_grad->dtype()));
+    const int64_t input_base = static_cast<int64_t>(input.offset()) / itemsize;
+    const StridedViewRange out_range =
+        ComputeStridedViewRange(dims, stride, offset / itemsize);
+    const bool inside_input = !out_range.empty &&
+                              out_range.min_index >= input_base &&
+                              out_range.max_index < input_base + input.numel();
+    through_storage = !input.meta().is_contiguous() || !inside_input;
+  }
+  if (through_storage) {
     PD_VISIT_ALL_TYPES(out_grad.dtype(), "AsStridedGradKernel", ([&] {
                          phi::StridedTensorAccumulateThroughStorage<data_t>(
                              out_grad, dims, stride, offset, input, input_grad);
@@ -72,7 +83,7 @@ void AsStridedGradKernel(const Context& dev_ctx,
     return;
   }
   const int64_t grad_offset = offset - static_cast<int64_t>(input.offset());
-  if (MaybeOverlappingStrides(dims, stride)) {
+  if (ranked_alike && MaybeOverlappingStrides(dims, stride)) {
     // Several elements of out_grad map to the same storage slot, so the
     // gradient has to be accumulated instead of copied.
     PD_VISIT_ALL_TYPES(out_grad.dtype(), "AsStridedGradKernel", ([&] {

--- a/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
@@ -46,22 +46,22 @@ void AsStridedGradKernel(const Context& dev_ctx,
   if (out_grad.numel() == 0) {
     return;
   }
-  // `offset` is a byte offset into the allocation of the forward *input*, but
-  // `input_grad` is a freshly allocated buffer that starts at element 0 of its
-  // own allocation. When `input` is itself a view (a nested as_strided), its
-  // own offset is already part of `offset` and has to be subtracted, otherwise
-  // the gradient is written at the wrong place or past the end of the buffer.
+  // `offset` is a byte offset into the allocation shared with the forward
+  // `input`, but `input_grad` is a dense row-major buffer over `input`'s own
+  // logical indices. The two coordinate systems differ by a constant only when
+  // `input` is contiguous, in which case subtracting `input.offset()` is enough
+  // -- otherwise a storage index is not a row-major index and the gradient has
+  // to be routed through a buffer laid out in storage coordinates. The same
+  // detour handles a view that starts before `input` does, whose leading
+  // contributions belong to no element of `input_grad` at all.
   const int64_t grad_offset = offset - static_cast<int64_t>(input.offset());
-  PADDLE_ENFORCE_GE(
-      grad_offset,
-      0,
-      common::errors::InvalidArgument(
-          "The offset(%d) of as_strided is an absolute byte offset into the "
-          "shared allocation, so it must not be smaller than the offset(%d) "
-          "of the tensor being viewed: the gradient of a view that starts "
-          "before its input has nowhere to go.",
-          offset,
-          input.offset()));
+  if (!input.meta().is_contiguous() || grad_offset < 0) {
+    PD_VISIT_ALL_TYPES(out_grad.dtype(), "AsStridedGradKernel", ([&] {
+                         phi::StridedTensorAccumulateThroughStorage<data_t>(
+                             out_grad, dims, stride, offset, input, input_grad);
+                       }));
+    return;
+  }
   if (MaybeOverlappingStrides(dims, stride)) {
     // Several elements of out_grad map to the same storage slot, so the
     // gradient has to be accumulated instead of copied.

--- a/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
@@ -17,6 +17,7 @@
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/as_strided_kernel.h"
+#include "paddle/phi/kernels/funcs/strided_grad_utils.h"
 #include "paddle/phi/kernels/funcs/strided_utils.h"
 
 COMMON_DECLARE_bool(use_stride_kernel);
@@ -43,6 +44,15 @@ void AsStridedGradKernel(const Context& dev_ctx,
                            *input_grad, 0, input_grad);
                      }));
   if (out_grad.numel() == 0) {
+    return;
+  }
+  if (MaybeOverlappingStrides(dims, stride)) {
+    // Several elements of out_grad map to the same storage slot, so the
+    // gradient has to be accumulated instead of copied.
+    PD_VISIT_ALL_TYPES(out_grad.dtype(), "AsStridedGradKernel", ([&] {
+                         phi::StridedTensorAccumulate<data_t>(
+                             out_grad, dims, stride, offset, input_grad);
+                       }));
     return;
   }
   DenseTensor tmp;

--- a/paddle/phi/kernels/stride/as_strided_kernel.cc
+++ b/paddle/phi/kernels/stride/as_strided_kernel.cc
@@ -17,6 +17,7 @@
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/strided_view_utils.h"
 
 COMMON_DECLARE_bool(use_stride_kernel);
 
@@ -42,68 +43,6 @@ void ValidateZeroSizeTensorShape(const std::vector<int64_t>& dims,
       "zero-size."));
 }
 
-// Rejects views that would reach outside of the input's allocation. Without
-// this check a bad (shape, stride, offset) triple silently produces a tensor
-// whose reads and writes corrupt neighbouring heap memory.
-void ValidateStorageRange(const std::vector<int64_t>& dims,
-                          const std::vector<int64_t>& strides,
-                          int64_t offset,
-                          const DenseTensor& input) {
-  if (input.numel() == 0 || input.Holder() == nullptr) {
-    return;
-  }
-  PADDLE_ENFORCE_EQ(dims.size(),
-                    strides.size(),
-                    common::errors::InvalidArgument(
-                        "The size of dims and strides should be equal."));
-  const int64_t itemsize = static_cast<int64_t>(SizeOf(input.dtype()));
-  PADDLE_ENFORCE_EQ(offset % itemsize,
-                    0,
-                    common::errors::InvalidArgument(
-                        "The offset(%d) is a byte offset and must be a "
-                        "multiple of the element size(%d) of the input.",
-                        offset,
-                        itemsize));
-  // Element index range covered by the view, relative to `offset`.
-  int64_t min_index = 0;
-  int64_t max_index = 0;
-  for (size_t i = 0; i < dims.size(); ++i) {
-    if (dims[i] == 0) {
-      return;  // An empty view never touches the storage.
-    }
-    const int64_t span = strides[i] * (dims[i] - 1);
-    if (span > 0) {
-      max_index += span;
-    } else {
-      min_index += span;
-    }
-  }
-  const int64_t base = offset / itemsize;
-  const int64_t storage_numel =
-      static_cast<int64_t>(input.Holder()->size()) / itemsize;
-  PADDLE_ENFORCE_GE(base + min_index,
-                    0,
-                    common::errors::InvalidArgument(
-                        "The view described by shape %s, stride %s and offset "
-                        "%d reaches element %d, which is before the beginning "
-                        "of the input storage.",
-                        common::make_ddim(dims),
-                        common::make_ddim(strides),
-                        offset,
-                        base + min_index));
-  PADDLE_ENFORCE_LT(base + max_index,
-                    storage_numel,
-                    common::errors::InvalidArgument(
-                        "The view described by shape %s, stride %s and offset "
-                        "%d reaches element %d, but the input storage only "
-                        "holds %d elements.",
-                        common::make_ddim(dims),
-                        common::make_ddim(strides),
-                        offset,
-                        base + max_index,
-                        storage_numel));
-}
-
 template <typename Context>
 void AsStridedKernel(const Context& dev_ctx,
                      const DenseTensor& input,
@@ -126,7 +65,7 @@ void AsStridedKernel(const Context& dev_ctx,
       0,
       common::errors::InvalidArgument(
           "The offset must be non-negative, but got %d.", offset));
-  ValidateStorageRange(dims, stride, offset, input);
+  ValidateStridedViewStorage(dims, stride, offset, input);
   out->set_meta(meta);
   out->ResetHolder(input.Holder());
   out->ShareInplaceVersionCounterWith(input);

--- a/paddle/phi/kernels/stride/as_strided_kernel.cc
+++ b/paddle/phi/kernels/stride/as_strided_kernel.cc
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/as_strided_kernel.h"
+#include "paddle/common/ddim.h"
 #include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
+#include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 COMMON_DECLARE_bool(use_stride_kernel);
@@ -40,6 +42,68 @@ void ValidateZeroSizeTensorShape(const std::vector<int64_t>& dims,
       "zero-size."));
 }
 
+// Rejects views that would reach outside of the input's allocation. Without
+// this check a bad (shape, stride, offset) triple silently produces a tensor
+// whose reads and writes corrupt neighbouring heap memory.
+void ValidateStorageRange(const std::vector<int64_t>& dims,
+                          const std::vector<int64_t>& strides,
+                          int64_t offset,
+                          const DenseTensor& input) {
+  if (input.numel() == 0 || input.Holder() == nullptr) {
+    return;
+  }
+  PADDLE_ENFORCE_EQ(dims.size(),
+                    strides.size(),
+                    common::errors::InvalidArgument(
+                        "The size of dims and strides should be equal."));
+  const int64_t itemsize = static_cast<int64_t>(SizeOf(input.dtype()));
+  PADDLE_ENFORCE_EQ(offset % itemsize,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The offset(%d) is a byte offset and must be a "
+                        "multiple of the element size(%d) of the input.",
+                        offset,
+                        itemsize));
+  // Element index range covered by the view, relative to `offset`.
+  int64_t min_index = 0;
+  int64_t max_index = 0;
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (dims[i] == 0) {
+      return;  // An empty view never touches the storage.
+    }
+    const int64_t span = strides[i] * (dims[i] - 1);
+    if (span > 0) {
+      max_index += span;
+    } else {
+      min_index += span;
+    }
+  }
+  const int64_t base = offset / itemsize;
+  const int64_t storage_numel =
+      static_cast<int64_t>(input.Holder()->size()) / itemsize;
+  PADDLE_ENFORCE_GE(base + min_index,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The view described by shape %s, stride %s and offset "
+                        "%d reaches element %d, which is before the beginning "
+                        "of the input storage.",
+                        common::make_ddim(dims),
+                        common::make_ddim(strides),
+                        offset,
+                        base + min_index));
+  PADDLE_ENFORCE_LT(base + max_index,
+                    storage_numel,
+                    common::errors::InvalidArgument(
+                        "The view described by shape %s, stride %s and offset "
+                        "%d reaches element %d, but the input storage only "
+                        "holds %d elements.",
+                        common::make_ddim(dims),
+                        common::make_ddim(strides),
+                        offset,
+                        base + max_index,
+                        storage_numel));
+}
+
 template <typename Context>
 void AsStridedKernel(const Context& dev_ctx,
                      const DenseTensor& input,
@@ -62,6 +126,7 @@ void AsStridedKernel(const Context& dev_ctx,
       0,
       common::errors::InvalidArgument(
           "The offset must be non-negative, but got %d.", offset));
+  ValidateStorageRange(dims, stride, offset, input);
   out->set_meta(meta);
   out->ResetHolder(input.Holder());
   out->ShareInplaceVersionCounterWith(input);

--- a/paddle/phi/kernels/stride/tensor_unfold_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/tensor_unfold_grad_kernel.cc
@@ -15,6 +15,7 @@
 #include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/strided_grad_utils.h"
 #include "paddle/phi/kernels/funcs/strided_utils.h"
 #include "paddle/phi/kernels/tensor_unfold_kernel.h"
 
@@ -43,12 +44,6 @@ void TensorUnfoldGradKernel(const Context& dev_ctx,
     return;
   }
   input_grad->set_strides(DenseTensorMeta::calc_strides(input_grad->dims()));
-  if (out_grad.numel() < input.numel()) {
-    PD_VISIT_ALL_TYPES(input_grad->dtype(), "TensorUnfoldGradKernel", ([&] {
-                         phi::StridedTensorFill<data_t>(
-                             *input_grad, 0, input_grad);
-                       }));
-  }
   DenseTensor tmp;
   tmp.set_layout(out_grad.layout());
   tmp.set_lod(out_grad.lod());
@@ -56,14 +51,35 @@ void TensorUnfoldGradKernel(const Context& dev_ctx,
   tmp.Resize(out_grad.dims());
 
   TensorUnfoldKernel<Context>(dev_ctx, *input_grad, axis, size, step, &tmp);
-  PD_VISIT_ALL_TYPES(out_grad.dtype(), "TensorUnfoldGradKernel", ([&] {
-                       phi::StridedTensorCopy<data_t>(
-                           out_grad,
-                           vectorize<int64_t>(tmp.dims()),
-                           vectorize<int64_t>(tmp.strides()),
-                           tmp.offset(),
-                           &tmp);
-                     }));
+  std::vector<int64_t> view_dims = vectorize<int64_t>(tmp.dims());
+  std::vector<int64_t> view_stride = vectorize<int64_t>(tmp.strides());
+  // step < size makes the unfolded windows overlap, so several elements of
+  // out_grad map to the same input element and must be summed.
+  const bool overlapping =
+      out_grad.numel() > 0 && MaybeOverlappingStrides(view_dims, view_stride);
+
+  if (overlapping || out_grad.numel() < input.numel()) {
+    PD_VISIT_ALL_TYPES(input_grad->dtype(), "TensorUnfoldGradKernel", ([&] {
+                         phi::StridedTensorFill<data_t>(
+                             *input_grad, 0, input_grad);
+                       }));
+  }
+  if (overlapping) {
+    PD_VISIT_ALL_TYPES(out_grad.dtype(), "TensorUnfoldGradKernel", ([&] {
+                         phi::StridedTensorAccumulate<data_t>(
+                             out_grad,
+                             view_dims,
+                             view_stride,
+                             static_cast<int64_t>(tmp.offset()),
+                             input_grad);
+                       }));
+    return;
+  }
+  PD_VISIT_ALL_TYPES(
+      out_grad.dtype(), "TensorUnfoldGradKernel", ([&] {
+        phi::StridedTensorCopy<data_t>(
+            out_grad, view_dims, view_stride, tmp.offset(), &tmp);
+      }));
 }
 
 }  // namespace phi

--- a/test/cpp/compat/ATen_as_strided_test.cc
+++ b/test/cpp/compat/ATen_as_strided_test.cc
@@ -166,3 +166,30 @@ TEST_F(TensorAsStridedTest, AsStridedContiguous) {
   at::Tensor non_contig = t.as_strided({3, 2}, {1, 3});
   ASSERT_FALSE(non_contig.is_contiguous());
 }
+
+TEST_F(TensorAsStridedTest, AsStridedRejectsOutOfRangeView) {
+  // The view reaches element 4095 of a 12 element allocation. Without the
+  // range check every read and write through it corrupts unrelated memory.
+  at::Tensor t = at::arange(12, at::kFloat);
+  ASSERT_ANY_THROW(t.as_strided({64, 64}, {64, 1}));
+}
+
+TEST_F(TensorAsStridedTest, AsStridedRejectsOverflowingStorageOffset) {
+  // storage_offset counts elements, so it has to be multiplied by the element
+  // size. 2^62 * 4 wraps around to 0 in size_t arithmetic, which would turn an
+  // out of range request into a silent alias of the first element.
+  at::Tensor t = at::arange(12, at::kFloat);
+  ASSERT_ANY_THROW(t.as_strided({2}, {1}, int64_t{1} << 62));
+}
+
+TEST_F(TensorAsStridedTest, AsStridedRejectsNegativeStorageOffset) {
+  at::Tensor t = at::arange(12, at::kFloat);
+  ASSERT_ANY_THROW(t.as_strided({2}, {1}, -1));
+}
+
+TEST_F(TensorAsStridedTest, AsStridedInplaceRejectsBadStorageOffset) {
+  at::Tensor t = at::arange(12, at::kFloat);
+  ASSERT_ANY_THROW(t.as_strided_({2}, {1}, int64_t{1} << 62));
+  at::Tensor u = at::arange(12, at::kFloat);
+  ASSERT_ANY_THROW(u.as_strided_({64, 64}, {64, 1}));
+}

--- a/test/legacy_test/test_as_strided.py
+++ b/test/legacy_test/test_as_strided.py
@@ -225,6 +225,20 @@ class TestAsStridedStorageRange(unittest.TestCase):
                     offset=1,
                 )
 
+    def test_overflowing_span_is_rejected(self):
+        # 4 * 2**62 wraps around to 0 in int64, so unchecked arithmetic would
+        # accept this view and let it read and write far outside the allocation.
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.zeros([16], dtype='float32')
+                self.assertRaises(
+                    ValueError,
+                    paddle.as_strided,
+                    x=x,
+                    shape=(5,),
+                    stride=(1 << 62,),
+                )
+
     def test_in_range_view_is_allowed(self):
         for place in self.places:
             with base.dygraph.guard(place):
@@ -232,6 +246,51 @@ class TestAsStridedStorageRange(unittest.TestCase):
                 x = paddle.to_tensor(x_np)
                 y = paddle.as_strided(x, shape=(4, 4), stride=(4, 1), offset=0)
                 np.testing.assert_allclose(y.numpy(), x_np.reshape(4, 4))
+
+
+class TestAsStridedNestedViewBackward(unittest.TestCase):
+    """`offset` is an absolute byte offset into the shared allocation, while the
+    gradient buffer of a view starts at its own element 0. Taking a view of a
+    view therefore has to relocate the offset before writing the gradient."""
+
+    def setUp(self):
+        self.places = get_places()
+
+    def _check(self, shape, stride, dtype='float32'):
+        itemsize = np.dtype(dtype).itemsize
+        base_numel = 8
+        outer_numel = 6
+        outer_offset = 2
+        expected = np.zeros([base_numel], dtype=dtype)
+        for idx in np.ndindex(*shape):
+            expected[outer_offset + int(np.dot(idx, stride))] += 1
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(
+                    np.random.random([base_numel]).astype(dtype)
+                )
+                x.stop_gradient = False
+                outer = paddle.as_strided(
+                    x,
+                    shape=(outer_numel,),
+                    stride=(1,),
+                    offset=outer_offset * itemsize,
+                )
+                inner = paddle.as_strided(
+                    outer,
+                    shape=shape,
+                    stride=stride,
+                    offset=outer_offset * itemsize,
+                )
+                inner.backward(paddle.ones_like(inner))
+                np.testing.assert_allclose(x.grad.numpy(), expected)
+
+    def test_nested_non_overlapping(self):
+        self._check((2,), (2,))
+        self._check((3,), (2,))
+
+    def test_nested_overlapping(self):
+        self._check((3, 3), (1, 1))
 
 
 if __name__ == '__main__':

--- a/test/legacy_test/test_as_strided.py
+++ b/test/legacy_test/test_as_strided.py
@@ -293,10 +293,11 @@ class TestAsStridedNestedViewBackward(unittest.TestCase):
         self._check((3, 3), (1, 1))
 
 
-class TestAsStridedNonContiguousInputBackward(unittest.TestCase):
+class TestAsStridedStorageCoordinateBackward(unittest.TestCase):
     """`dims` / `stride` / `offset` address the shared allocation, while the
     gradient buffer is dense and row-major over the input's own logical
-    indices. When the input is not contiguous the two orders differ, so the
+    indices. The two orders coincide only when the input is contiguous and the
+    whole window of the view lands inside it, so in every other case the
     gradient has to be routed back through the input's own strides."""
 
     def setUp(self):
@@ -366,6 +367,20 @@ class TestAsStridedNonContiguousInputBackward(unittest.TestCase):
         # they belong to no element of its gradient.
         self._check(8, (4,), (1,), 2, (4,), (1,), offset_elems=0)
         self._check(8, (2, 2), (1, 2), 2, (3,), (1,), offset_elems=1)
+
+    def test_view_ending_after_input(self):
+        # A view may legally reach past the end of its input, because the
+        # forward validates it against the shared allocation and not against
+        # the extent of the input. Only storage slot 5 belongs to the input
+        # here, so its gradient is [0, 0, 0, 1].
+        self._check(8, (4,), (1,), 2, (3,), (1,), offset_elems=5)
+
+    def test_view_disjoint_from_input(self):
+        # No slot is shared, so nothing reaches the input's gradient at all.
+        self._check(8, (4,), (1,), 2, (2,), (1,), offset_elems=6)
+
+    def test_view_ending_after_input_overlapping(self):
+        self._check(8, (4,), (1,), 2, (2, 2), (1, 1), offset_elems=4)
 
     def test_overlapping_input_is_rejected(self):
         # The gradient of a view that aliases itself needs a convention for

--- a/test/legacy_test/test_as_strided.py
+++ b/test/legacy_test/test_as_strided.py
@@ -293,5 +293,92 @@ class TestAsStridedNestedViewBackward(unittest.TestCase):
         self._check((3, 3), (1, 1))
 
 
+class TestAsStridedNonContiguousInputBackward(unittest.TestCase):
+    """`dims` / `stride` / `offset` address the shared allocation, while the
+    gradient buffer is dense and row-major over the input's own logical
+    indices. When the input is not contiguous the two orders differ, so the
+    gradient has to be routed back through the input's own strides."""
+
+    def setUp(self):
+        self.places = get_places()
+
+    def _check(
+        self,
+        base_numel,
+        input_shape,
+        input_stride,
+        input_offset,
+        shape,
+        stride,
+        offset_elems=0,
+        dtype='float64',
+    ):
+        itemsize = np.dtype(dtype).itemsize
+        # Gradient per slot of the shared allocation.
+        storage_grad = np.zeros([base_numel], dtype=dtype)
+        for idx in np.ndindex(*shape):
+            storage_grad[offset_elems + int(np.dot(idx, stride))] += 1
+        # Read back through the input geometry: this is what distinguishes a
+        # storage index from a row-major one.
+        expected_input = np.zeros(input_shape, dtype=dtype)
+        expected_base = np.zeros([base_numel], dtype=dtype)
+        for idx in np.ndindex(*input_shape):
+            slot = input_offset + int(np.dot(idx, input_stride))
+            expected_input[idx] = storage_grad[slot]
+            expected_base[slot] += storage_grad[slot]
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(
+                    np.random.random([base_numel]).astype(dtype)
+                )
+                x.stop_gradient = False
+                inp = paddle.as_strided(
+                    x,
+                    shape=input_shape,
+                    stride=input_stride,
+                    offset=input_offset * itemsize,
+                )
+                inp.retain_grads()
+                y = paddle.as_strided(
+                    inp,
+                    shape=shape,
+                    stride=stride,
+                    offset=offset_elems * itemsize,
+                )
+                y.backward(paddle.ones_like(y))
+                np.testing.assert_allclose(inp.grad.numpy(), expected_input)
+                np.testing.assert_allclose(x.grad.numpy(), expected_base)
+
+    def test_transposed_input_overlapping_view(self):
+        # 2x2 transpose viewed with a repeated stride: storage slot 1 collects
+        # two contributions and belongs to input[1, 0], not to input[0, 1].
+        self._check(4, (2, 2), (1, 2), 0, (2, 2), (1, 1))
+
+    def test_transposed_input_non_overlapping_view(self):
+        self._check(6, (2, 3), (1, 2), 0, (3,), (2,))
+        self._check(6, (2, 3), (1, 2), 0, (2, 2), (1, 2))
+
+    def test_transposed_input_float32(self):
+        self._check(4, (2, 2), (1, 2), 0, (2, 2), (1, 1), dtype='float32')
+
+    def test_view_starting_before_input(self):
+        # The leading contributions land outside the input and are dropped;
+        # they belong to no element of its gradient.
+        self._check(8, (4,), (1,), 2, (4,), (1,), offset_elems=0)
+        self._check(8, (2, 2), (1, 2), 2, (3,), (1,), offset_elems=1)
+
+    def test_overlapping_input_is_rejected(self):
+        # The gradient of a view that aliases itself needs a convention for
+        # splitting a shared slot, so it is refused rather than guessed.
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(np.random.random([4]).astype('float32'))
+                x.stop_gradient = False
+                inp = paddle.as_strided(x, shape=(2, 2), stride=(1, 1))
+                y = paddle.as_strided(inp, shape=(2,), stride=(1,))
+                with self.assertRaises(NotImplementedError):
+                    y.backward(paddle.ones_like(y))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_as_strided.py
+++ b/test/legacy_test/test_as_strided.py
@@ -180,6 +180,37 @@ class TestAsStridedOverlapBackward(unittest.TestCase):
         self._check(6, (2, 3), (3, 1), dtype='float32')
 
 
+@unittest.skipIf(
+    not base.core.is_compiled_with_xpu(), "core is not compiled with XPU"
+)
+class TestAsStridedOverlapBackwardXPU(unittest.TestCase):
+    """get_places() reports CPU, CUDA and CustomPlace but never XPU, so without
+    this class the serial host fallback of the overlapping backward -- the only
+    path an XPU takes, since the device scatter-add needs GPU atomics -- would
+    never run. It stages both operands on the host through phi::Copy, so it
+    also covers the XPU <-> CPU copies that path depends on."""
+
+    def test_repeated_stride(self):
+        with base.dygraph.guard(base.XPUPlace(0)):
+            x = paddle.to_tensor(np.random.random([5]).astype('float32'))
+            x.stop_gradient = False
+            y = paddle.as_strided(x, shape=(3, 3), stride=(1, 1))
+            y.backward(paddle.ones_like(y))
+            np.testing.assert_allclose(
+                x.grad.numpy(), np.array([1, 2, 3, 2, 1], dtype='float32')
+            )
+
+    def test_zero_stride(self):
+        with base.dygraph.guard(base.XPUPlace(0)):
+            x = paddle.to_tensor(np.random.random([1]).astype('float32'))
+            x.stop_gradient = False
+            y = paddle.as_strided(x, shape=(4, 4), stride=(0, 0))
+            y.backward(paddle.ones_like(y))
+            np.testing.assert_allclose(
+                x.grad.numpy(), np.array([16], dtype='float32')
+            )
+
+
 class TestAsStridedStorageRange(unittest.TestCase):
     """A view must stay inside the allocation of its input, otherwise reads and
     writes through it corrupt unrelated memory."""

--- a/test/legacy_test/test_as_strided.py
+++ b/test/legacy_test/test_as_strided.py
@@ -278,6 +278,18 @@ class TestAsStridedStorageRange(unittest.TestCase):
                 y = paddle.as_strided(x, shape=(4, 4), stride=(4, 1), offset=0)
                 np.testing.assert_allclose(y.numpy(), x_np.reshape(4, 4))
 
+    def test_stride_shorter_than_shape_is_allowed(self):
+        # Outside of the zero-size case the forward has never required shape and
+        # stride to have the same length, and callers rely on it: the
+        # TestDygraphInplaceSet case of test_inplace.py asks for a rank 2 shape
+        # with a rank 1 stride. The view is malformed, so nothing is read back
+        # from it here; the point is only that the range check keeps accepting
+        # it.
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.zeros([15, 3], dtype='float32')
+                paddle.as_strided(x, shape=[15, 3], stride=[2])
+
 
 class TestAsStridedNestedViewBackward(unittest.TestCase):
     """`offset` is an absolute byte offset into the shared allocation, while the

--- a/test/legacy_test/test_as_strided.py
+++ b/test/legacy_test/test_as_strided.py
@@ -134,5 +134,105 @@ class TestAsStridedAlias(unittest.TestCase):
                 np.testing.assert_array_equal(out_ref.numpy(), out_both.numpy())
 
 
+class TestAsStridedOverlapBackward(unittest.TestCase):
+    """When a view maps several logical positions onto the same element, the
+    backward has to sum all the incoming contributions instead of letting the
+    writes overwrite each other."""
+
+    def setUp(self):
+        self.places = get_places()
+
+    def _check(self, numel, shape, stride, offset_elems=0, dtype='float64'):
+        itemsize = np.dtype(dtype).itemsize
+        expected = np.zeros([numel], dtype=dtype)
+        for idx in np.ndindex(*shape):
+            expected[offset_elems + int(np.dot(idx, stride))] += 1
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(np.random.random([numel]).astype(dtype))
+                x.stop_gradient = False
+                y = paddle.as_strided(
+                    x,
+                    shape=shape,
+                    stride=stride,
+                    offset=offset_elems * itemsize,
+                )
+                y.backward(paddle.ones_like(y))
+                np.testing.assert_allclose(x.grad.numpy(), expected)
+
+    def test_repeated_stride(self):
+        self._check(5, (3, 3), (1, 1))
+        self._check(64, (32, 32), (1, 1))
+
+    def test_zero_stride(self):
+        self._check(1, (4, 4), (0, 0))
+        self._check(3, (3, 4), (1, 0))
+
+    def test_offset(self):
+        self._check(8, (3, 3), (1, 1), offset_elems=2)
+
+    def test_float32(self):
+        self._check(5, (3, 3), (1, 1), dtype='float32')
+
+    def test_non_overlapping(self):
+        self._check(6, (2, 3), (3, 1))
+        self._check(6, (3, 2), (1, 3))
+        self._check(6, (2, 3), (3, 1), dtype='float32')
+
+
+class TestAsStridedStorageRange(unittest.TestCase):
+    """A view must stay inside the allocation of its input, otherwise reads and
+    writes through it corrupt unrelated memory."""
+
+    def setUp(self):
+        self.places = get_places()
+
+    def test_shape_out_of_range(self):
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.zeros([16], dtype='float32')
+                self.assertRaises(
+                    ValueError,
+                    paddle.as_strided,
+                    x=x,
+                    shape=(64, 64),
+                    stride=(64, 1),
+                )
+
+    def test_offset_out_of_range(self):
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.zeros([16], dtype='float32')
+                self.assertRaises(
+                    ValueError,
+                    paddle.as_strided,
+                    x=x,
+                    shape=(16,),
+                    stride=(1,),
+                    offset=4096 * 4,
+                )
+
+    def test_misaligned_offset(self):
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.zeros([16], dtype='float32')
+                self.assertRaises(
+                    ValueError,
+                    paddle.as_strided,
+                    x=x,
+                    shape=(2,),
+                    stride=(1,),
+                    offset=1,
+                )
+
+    def test_in_range_view_is_allowed(self):
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x_np = np.random.random([16]).astype('float32')
+                x = paddle.to_tensor(x_np)
+                y = paddle.as_strided(x, shape=(4, 4), stride=(4, 1), offset=0)
+                np.testing.assert_allclose(y.numpy(), x_np.reshape(4, 4))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_tensor_unfold.py
+++ b/test/legacy_test/test_tensor_unfold.py
@@ -160,5 +160,41 @@ class TestUnfoldAPI_Compatibility(unittest.TestCase):
         np.testing.assert_array_equal(out1.numpy(), out4.numpy())
 
 
+class TestTensorUnfoldOverlapBackward(unittest.TestCase):
+    """With step < size the unfolded windows overlap, so every input element
+    must receive the sum of the gradients of all windows containing it."""
+
+    def setUp(self):
+        self.places = get_places()
+
+    def _check(self, shape, axis, size, step, dtype='float64'):
+        x_np = np.random.random(shape).astype(dtype)
+        expected = np.zeros(shape, dtype=dtype)
+        num_window = (shape[axis] - size) // step + 1
+        index = [slice(None)] * len(shape)
+        for w in range(num_window):
+            index[axis] = slice(w * step, w * step + size)
+            expected[tuple(index)] += 1
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(x_np)
+                x.stop_gradient = False
+                y = paddle.unfold(x, axis, size, step)
+                y.backward(paddle.ones_like(y))
+                np.testing.assert_allclose(x.grad.numpy(), expected)
+
+    def test_overlapping_windows(self):
+        self._check([5], 0, 3, 1)
+        self._check([16], 0, 4, 1)
+        self._check([8, 4], 0, 4, 2)
+
+    def test_overlapping_windows_float32(self):
+        self._check([5], 0, 3, 1, dtype='float32')
+
+    def test_non_overlapping_windows(self):
+        self._check([12], 0, 4, 4)
+        self._check([12], -1, 2, 5)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

修复内存重叠的视图（`as_strided` / `unfold`）反向时梯度被覆盖写而非累加的问题，补上 `as_strided` 缺失的存储越界校验，并修掉 nan/inf 检查器在非连续张量上的越界扫描。

#### 问题 1：重叠视图的反向丢梯度

一个视图的多个逻辑下标可以映射到同一块内存 —— `as_strided(x, shape=(3,3), stride=(1,1))` 的反对角线元素全都指向同一个 `x[i]`，`unfold` 在 `step < size` 时相邻窗口互相重叠。这类视图的反向必须把所有流入的梯度**求和**，而 `as_strided_grad` / `tensor_unfold_grad` 走的是 `StridedTensorCopy`，即沿着同一个视图**逐个写入**。写入顺序上后来的覆盖先来的，于是每个内存位置只保留了最后一个贡献，其余全部丢失。

以 `x` 形状 `[5]`、`as_strided(x, shape=(3,3), stride=(1,1))` 为例，正确的 `x.grad` 是 `[1,2,3,2,1]`（每个元素被多少个逻辑位置引用），实际得到 `[1,1,1,1,1]`。torch 在 `as_strided_backward` 里对重叠视图专门走累加路径，行为与此不一致。

这个问题在既有单测里没被发现，原因有两个：既有的重叠用例（`test_tensor_unfold.py` 的 `unfold(x, 0, 5, 1)`）只断言 `b.grad` 而不是 `x.grad`，而 `b` 在视图之后，反向根本没走到出错的那一步；PaddleAPITest 侧默认 `atol=rtol=0.01`，小规模重叠 case 的绝对误差落在容差内。

#### 问题 2：越界视图静默破坏堆内存

`AsStridedKernel` 只校验 `offset >= 0`，不校验 `(shape, stride, offset)` 三元组触达的内存区间是否落在输入的 allocation 内。`as_strided(paddle.zeros([16]), shape=(64,64), stride=(64,1))` 会成功返回一个宣称有 4096 个元素的张量，对它的任何读写都在破坏相邻的堆内存。

#### 问题 3：nan/inf 检查器在非连续张量上越界

`egr::CheckTensorHasNanOrInf` 是 stride-unaware 的：它把 `DenseTensor` 直接交给 `FindNanInfAndBlockMaxMin`，该 kernel 只收到 `tensor.data<T>()` 和 `tensor.numel()`，内部按 `value_ptr[i]`（`i` 遍历 `[0, numel)`）扁平扫描，隐含假设张量连续。

在广播视图上这个假设崩塌：storage 只有 1 个 bfloat16 元素、视图 shape `[23936, 4096]` / stride `[0, 0]` 时，`numel` 是 98,041,856，检查器会顺着指针读约 187 MiB，其中只有开头 2 字节合法。GPU 上即 illegal memory access。由于 kernel launch 异步且 CUDA 错误是 sticky 的，error 700 在下一次 CUDA API 调用时才返回并 abort，日志里只剩一个 `PADDLE_CRASH`，看不到真正的肇事者 —— 这也是最初误判为 `as_strided_grad` 崩溃的原因。

注意这三个问题彼此独立：问题 3 发生在前向（`as_strided_ad_func`），`as_strided_grad` 尚未被调用。

#### 改动

1. **重叠判定**（新增 `paddle/phi/kernels/funcs/strided_grad_utils.h` 的 `MaybeOverlappingStrides`）：算法对齐 `at::detail::_maybe_overlapping_memory` —— 按 stride 升序排列各维，检查每一维的 stride 是否越过所有更小 stride 维覆盖的跨度之和；size ≤ 1 的维只能贡献下标 0，跳过；size > 1 而 stride ≤ 0（广播或反向视图）直接判定重叠。

2. **累加实现**（同文件的 `StridedTensorAccumulate<T>`）：不新增任何 CUDA / XPU kernel。对 `arange(0, storage_numel)` 套用**同一个**视图并 `contiguous` 化，得到每个输出元素对应的扁平 storage 下标，问题就退化成 `index_put(accumulate=true)` 的 scatter-add，作用在 `input_grad` 的一维扁平视图上。`x` 与 `out` 故意 aliasing：`input_grad` 已初始化，`index_put` 会跳过 `x -> out` 的拷贝而原地累加。

   `arange` 与 `index_put` 通过 `PD_VISIT_KERNEL` **运行时**派发。这一点是必须的：STRIDED grad kernel 用 `PD_REGISTER_KERNEL_FOR_ALL_BACKEND_DTYPE` 注册，`PD_VISIT_ALL_TYPES` 展开 15 个 dtype，而 `index_put` 在 CPU/GPU 上只注册了 12 个、XPU 上只有 5 个，编译期模板实例化会因缺少符号而链接失败。

3. **接入两个 grad kernel**：
   - `as_strided_grad_kernel.cc`：在 `out_grad.numel() == 0` 早返回之后插入重叠分支；非重叠仍走原来的 `StridedTensorCopy` 快路径。已有的无条件零填充正好满足累加路径「目标必须已分配、连续、清零」的前置条件。
   - `tensor_unfold_grad_kernel.cc`：调整顺序，先由 `TensorUnfoldKernel` 构造 `tmp` 以取得视图的 dims / strides / offset，再据此判定重叠。零填充条件从 `out_grad.numel() < input.numel()` 扩宽为 `overlapping || out_grad.numel() < input.numel()` —— 否则累加会叠加在残留的脏数据上。

4. **存储范围校验**（`as_strided_kernel.cc` 新增 `ValidateStorageRange`）：用 `span = stride[i] * (dims[i] - 1)` 累出视图触达的元素区间上下界，与 `input.Holder()->size() / itemsize` 比对；同时校验 `offset` 按元素大小对齐。任一维为 0 时视图不触碰存储，直接放行。调用点在已有的 `PADDLE_ENFORCE_GE(offset, 0, ...)` 之后、`out->set_meta(meta)` 之前。

   `StridedTensorAccumulate` 内部也做了一份等价的边界检查，因为它会用视图去索引 `arange` 缓冲区，越界会读到缓冲区之外。

5. **跳过非连续张量的 nan/inf 检查**（`nan_inf_utils.cc`）：在 `dense_tensor` 解析完之后、取 `place` 之前插入 `is_contiguous()` 判断并 return。位置选在这里使得 DenseTensor / SelectedRows / DistTensor 三条路径与 CPU / GPU 两个分支都被覆盖，只需一次判断。用 `dense_tensor->meta().is_contiguous()` 而非 `tensor.is_contiguous()`，是为了对 SelectedRows / DistTensor 检查真正会被扫描的那个 `value()`，与 `eager/utils.cc:1348`、`reducer.cc:852` 的既有写法一致。

   跳过而非修正扫描方式，是因为非连续张量的存储必然由某个连续张量产生，那个张量在它自己的产出点已经被检查过；在视图上重复检查不增加信息量，却要么需要让 kernel 感知 stride，要么需要先 `contiguous()` 复制一份（广播视图上是 187 MiB 的无谓开销）。

#### 行为变化

| 输入 | 之前 | 之后 |
| --- | --- | --- |
| `as_strided` 重叠视图的反向 | 覆盖写，仅保留最后一个贡献 | 累加，与 torch 一致 |
| `unfold` 且 `step < size` 的反向 | 同上 | 同上 |
| `as_strided` 视图越出输入 allocation | 静默返回，读写破坏相邻堆内存 | `ValueError` |
| `as_strided` 的 `offset` 未按元素大小对齐 | 静默返回，错位读写 | `ValueError` |
| 开启 `FLAGS_check_nan_inf` 时对非连续张量做检查 | 扁平扫描，广播视图上越界 → CUDA 700 / `PADDLE_CRASH` | 跳过该张量 |

非重叠视图的反向走的还是原来的 `StridedTensorCopy`，结果与性能均不变。已手工核对既有单测的形状全部落在非重叠分支：`as_strided (3,)/(1,)`、`(3,4)/(32,1)`；`unfold([5,5],0,5,1)` → `tmp (1,5,5)/(5,1,5)`；`unfold([12],0,4,4)` → `(3,4)/(4,1)`；`as_strided(*, (0,4), (32,1))` 在 `numel()==0` 处早返回。

#### 已知限制

- `ValidateStorageRange` 以 `Holder()->size()` 为界，而 GPU 的 auto-growth allocator 会把分配向上取整，因此它只能拦住明显的越界，小幅越界仍可能漏过。测试用例故意取夸张尺寸（`[16]` 上开 `(64,64)`）就是为了绕开这一点。
- 同一处校验可能把某些原本静默越界的调用路径（例如对「本身已是更大 buffer 的视图」的张量再 `as_strided`）从静默破坏改成抛 `ValueError`，有让 CI 变红的风险。这类路径本就是缺陷，但如果 reviewer 倾向于分开处理，第二个 commit 可以单独摘出。
- `StridedTensorAccumulate` 在 XPU 上让 `index_put` 的 `x` 与 `out` aliasing。CPU / GPU 的实现中 `x` 是 UNUSED，aliasing 显然安全；XPU 实现同时读 `x.data<T>()` 并写 `out_data`，安全性无法从代码静态断言，且本地无 XPU 可验证。若 reviewer 认为有风险，可在该路径上改用独立的暂存缓冲区。
- 累加通过 scatter-add 完成，浮点加法顺序不确定，重叠度高的视图上可能出现 1–2 ulp 级别的抖动。这是 atomic 累加的固有性质，与 `index_put(accumulate=True)` 自身的行为一致。

#### 测试

`test/legacy_test/test_as_strided.py` 新增：

- `TestAsStridedOverlapBackward`：期望梯度由 `np.ndindex` 逐个下标累计得出，覆盖重复 stride（`5 → (3,3)/(1,1)` 期望 `[1,2,3,2,1]`；`64 → (32,32)/(1,1)`）、零 stride（`1 → (4,4)/(0,0)`；`3 → (3,4)/(1,0)`）、带 offset、float32，并附非重叠对照（`6 → (2,3)/(3,1)`、`(3,2)/(1,3)`）以确认快路径未被改坏。
- `TestAsStridedStorageRange`：shape 越界、offset 越界、offset 未对齐三种情形均应抛 `ValueError`，外加一条合法视图放行的正向断言。

`test/legacy_test/test_tensor_unfold.py` 新增：

- `TestTensorUnfoldOverlapBackward`：期望梯度按窗口逐个累加得出，覆盖 `[5],0,3,1`、`[16],0,4,1`、`[8,4],0,4,2` 三组重叠配置及 float32，并附非重叠对照 `[12],0,4,4`、`[12],-1,2,5`。

PaddleAPITest 侧另有 31 条语料 `tester/api_config/11_fix_op/as_strided_unfold_overlap_grad.txt`，修复前 GPU 7 pass / 24 fail、CPU 6 pass / 25 fail。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是