### PR TITLE
[API Compatibility No.98] Add torch-compatibility for paddle.linalg.lstsq -part

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -4136,6 +4136,7 @@ def eigvalsh(
         return out_value
 
 
+@ParamAliasDecorator({"x": ["input", "A"], "y": ["b", "B"]})
 def lstsq(
     x: Tensor,
     y: Tensor,
@@ -4149,9 +4150,9 @@ def lstsq(
 
     Args:
         x (Tensor): A tensor with shape ``(*, M, N)`` , the data type of the input Tensor ``x``
-            should be one of float32, float64.
+            should be one of float32, float64. Alias: ``input``, ``A``.
         y (Tensor): A tensor with shape ``(*, M, K)`` , the data type of the input Tensor ``y``
-            should be one of float32, float64.
+            should be one of float32, float64. Alias: ``b``, ``B``.
         rcond(float, optional): The default value is None. A float pointing number used to determine
             the effective rank of ``x``. If ``rcond`` is None, it will be set to max(M, N) times the
             machine precision of x_dtype.

--- a/test/legacy_test/test_api_compatibility_part5.py
+++ b/test/legacy_test/test_api_compatibility_part5.py
@@ -4407,5 +4407,108 @@ class TestQrAPICompatibility(unittest.TestCase):
         paddle.disable_static()
 
 
+# Test lstsq compatibility
+class TestLstsqAPI(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2025)
+        self.np_x = np.array([[1, 3], [3, 2], [5, 6.0]], dtype="float64")
+        self.np_y = np.array(
+            [[3, 4, 6], [5, 3, 4], [1, 2, 1.0]], dtype="float64"
+        )
+
+    def test_dygraph_Compatibility(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        y = paddle.to_tensor(self.np_y)
+
+        # 1. Paddle positional arguments
+        out1 = paddle.linalg.lstsq(x, y, driver="gelsd")
+        # 2. Paddle keyword arguments
+        out2 = paddle.linalg.lstsq(x=x, y=y, driver="gelsd")
+        # 3. PyTorch keyword arguments (A, B)
+        out3 = paddle.linalg.lstsq(A=x, B=y, driver="gelsd")
+        # 4. PyTorch keyword arguments (input, b)
+        out4 = paddle.linalg.lstsq(input=x, b=y, driver="gelsd")
+        # 5. Mixed arguments
+        out5 = paddle.linalg.lstsq(x, y=y, driver="gelsd")
+
+        for out in [out2, out3, out4, out5]:
+            np.testing.assert_allclose(out[0].numpy(), out1[0].numpy())
+            np.testing.assert_allclose(out[1].numpy(), out1[1].numpy())
+            np.testing.assert_array_equal(out[2].numpy(), out1[2].numpy())
+            np.testing.assert_allclose(out[3].numpy(), out1[3].numpy())
+
+        # Verify the solution against numpy
+        expected = np.linalg.lstsq(self.np_x, self.np_y, rcond=-1)
+        np.testing.assert_allclose(out1[0].numpy(), expected[0], rtol=1e-6)
+        np.testing.assert_allclose(out1[1].numpy(), expected[1], rtol=1e-6)
+        self.assertEqual(int(out1[2].numpy()), expected[2])
+        np.testing.assert_allclose(out1[3].numpy(), expected[3], rtol=1e-6)
+
+        paddle.enable_static()
+
+    def test_lstsq_alias_conflict(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.np_x)
+        y = paddle.to_tensor(self.np_y)
+
+        with self.assertRaises(ValueError):
+            paddle.linalg.lstsq(x=x, input=x, y=y, driver="gelsd")
+        with self.assertRaises(ValueError):
+            paddle.linalg.lstsq(x=x, y=y, B=y, driver="gelsd")
+
+        paddle.enable_static()
+
+    def test_static_Compatibility(self):
+        paddle.enable_static()
+        main = paddle.static.Program()
+        startup = paddle.static.Program()
+        with paddle.static.program_guard(main, startup):
+            x = paddle.static.data(name="x", shape=[3, 2], dtype="float64")
+            y = paddle.static.data(name="y", shape=[3, 3], dtype="float64")
+
+            # 1. Paddle positional arguments
+            out1 = paddle.linalg.lstsq(x, y, driver="gelsd")
+            # 2. Paddle keyword arguments
+            out2 = paddle.linalg.lstsq(x=x, y=y, driver="gelsd")
+            # 3. PyTorch keyword arguments (A, B)
+            out3 = paddle.linalg.lstsq(A=x, B=y, driver="gelsd")
+            # 4. PyTorch keyword arguments (input, b)
+            out4 = paddle.linalg.lstsq(input=x, b=y, driver="gelsd")
+
+            exe = paddle.static.Executor()
+            fetches = exe.run(
+                main,
+                feed={
+                    "x": self.np_x,
+                    "y": self.np_y,
+                },
+                fetch_list=[
+                    out1[0],
+                    out1[1],
+                    out1[2],
+                    out1[3],
+                    out2[0],
+                    out2[1],
+                    out2[2],
+                    out2[3],
+                    out3[0],
+                    out3[1],
+                    out3[2],
+                    out3[3],
+                    out4[0],
+                    out4[1],
+                    out4[2],
+                    out4[3],
+                ],
+            )
+            for i in range(4, 16):
+                np.testing.assert_allclose(
+                    fetches[i], fetches[i % 4], rtol=1e-6
+                )
+
+        paddle.disable_static()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### 描述
Related to #76301（启航计划 - PaddlePaddle API兼容性增强）任务 No.98

- **任务编号**: 98
- **PyTorch API**: torch.linalg.lstsq
- **Paddle API**: paddle.linalg.lstsq
- **参考方案**: c++下沉或装饰器 {'input': 'x', 'b': 'y'}

本 PR 为 `paddle.linalg.lstsq` 添加 PyTorch 兼容性：

- 使用 `@ParamAliasDecorator` 为参数添加别名：`x` 支持 `input`、`A`；`y` 支持 `b`、`B`。其中 `input`/`b` 为任务表指定映射（与 torch 实际签名一致），`A`/`B` 遵循 `paddle.linalg.solve`、`paddle.linalg.det` 的 linalg 家族既有双别名约定。
- 更新 docstring 别名说明。
- 新增 `TestLstsqAPI` 兼容性单测（test_api_compatibility_part5.py）：动态图/静态图下的位置参数、Paddle 关键字、PyTorch 别名关键字、混合参数调用、别名冲突检测，以及与 numpy 的数值对拍。

### 是否引起精度变化
否
