### PR TITLE
[Build] Require GCC 11 for C++20 baseline

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -6,8 +6,8 @@ include(CheckTypeSize)
 
 function(check_compiler_cxx_baseline_flag)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    if(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 8.2)
-      message(FATAL_ERROR "Unsupported GCC version. GCC >= 8.2 required.")
+    if(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 11)
+      message(FATAL_ERROR "Unsupported GCC version. GCC >= 11 required.")
     endif()
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang|Clang")
     # cmake >= 3.0 compiler id "AppleClang" on Mac OS X, otherwise "Clang"

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -30,19 +30,7 @@ endfunction()
 check_compiler_cxx_baseline_flag()
 
 if(NOT WIN32)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
-                                              VERSION_LESS 11)
-    # TODO(toolchain-cxx20): Keep GCC < 11 builds on C++17 temporarily for
-    # legacy CI images. Remove this fallback after those images are upgraded.
-    message(
-      DEPRECATION
-        "GCC ${CMAKE_CXX_COMPILER_VERSION} is temporarily downgraded to C++17. "
-        "Please upgrade to GCC >= 11 for the C++20 baseline; this fallback will "
-        "be removed after legacy CI images are upgraded.")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-  else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
-  endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
 else()
   # TODO(windows-cxx20): Keep Windows host C++ builds on C++17 until the CI
   # toolchain supports C++20.


### PR DESCRIPTION
### PR Category

Environment Adaptation

### PR Types

Improvements

### Description

非 Windows 主机编译已采用 C++20，但原有编译器基线检查仍允许 GCC 8.2–10，导致不满足当前工具链基线的 GCC 版本继续进入配置流程。

本 PR：
- 将 GCC 最低版本从 8.2 提升到 11，并同步更新错误信息；
- 移除 GCC 11 以下降级到 C++17 的兼容分支，使所有非 Windows 主机编译统一使用 `-std=c++20`；
- 保留 Windows 主机编译的 `CMAKE_CXX_STANDARD 17` 兼容路径。

验证：
- CMake 配置探针：GCC 10.5 被拒绝，GCC 11.0 被接受；
- `prek`；
- `git diff --check`。

### 是否引起精度变化

否
