### PR TITLE
[ROCm][Fix] Don't hard-fail when CUPTI is absent (ROCm >= 6)

### DIFF
--- a/cmake/cupti.cmake
+++ b/cmake/cupti.cmake
@@ -10,10 +10,14 @@ if(WITH_ROCM)
   elseif(EXISTS "${ROCM_PATH}/cuda/cuda/extras/CUPTI")
     set(ROCM_CUDA_DIR "${ROCM_PATH}/cuda/cuda")
   else()
+    # ROCm >= 6 no longer ships the CUDA compatibility layer under
+    # ${ROCM_PATH}/cuda, so CUPTI cannot exist there. Disable GPU profiling
+    # instead of failing the whole configure step.
     message(
-      FATAL_ERROR
-        "CUPTI not found under ${ROCM_PATH}/cuda/extras/CUPTI or ${ROCM_PATH}/cuda/cuda/extras/CUPTI"
-    )
+      STATUS
+        "CUPTI not found under ${ROCM_PATH}/cuda - GPU profiling disabled")
+    set(CUPTI_FOUND OFF)
+    return()
   endif()
   set(CUPTI_ROOT
       "${ROCM_CUDA_DIR}/extras/CUPTI"


### PR DESCRIPTION
### Problem
Configuring with `-DWITH_ROCM=ON` on any ROCm 6+ installation aborts:

```
CMake Error at cmake/cupti.cmake:
  CUPTI not found under /opt/rocm/cuda/extras/CUPTI or /opt/rocm/cuda/cuda/extras/CUPTI
```

ROCm 6 removed the CUDA compatibility layer that used to live under
`${ROCM_PATH}/cuda`, so this probe can never succeed on a modern ROCm and
the whole configure step fails even though CUPTI is only needed for GPU
profiling.

### Fix
When the probe fails, emit a STATUS message, set `CUPTI_FOUND OFF` and
return — the same graceful degradation a CUDA build gets when CUPTI is
missing. The build proceeds with GPU profiling disabled.

### Verification
Built `develop` with `-DWITH_ROCM=ON -DPADDLE_AMDGPU_TARGETS=gfx1200` on
ROCm 7.2 / Ubuntu 24.04: configure completes, the wheel builds, and a
15M-parameter recognition model trains end-to-end on the GPU.
