### PR TITLE
[Cherry-Pick][FlexCheckpoint] Add AOA statement generation support

### DIFF
--- a/python/paddle/distributed/flex_checkpoint/aoa/generation.py
+++ b/python/paddle/distributed/flex_checkpoint/aoa/generation.py
@@ -139,12 +139,16 @@ class AOANameScope:
 # Public to the component generators: ``join_name``, ``resolve_single_name``,
 # ``resolve_names``, ``resolve_checkpoint_name_from_anchor``,
 # ``resolve_dtype_cast_rule``, ``format_dtype_cast_attr``,
-# ``format_inv_dtype_cast_attr``, ``should_skip``, ``strip_name_suffix`` and
-# ``validate_checkpoint_name_mapping``; anything underscore-prefixed is internal
-# detail. The only non-trivial logic is root-relative template matching
-# (``_match_template`` / ``_render_template``). A re-rooted subtree passes an
-# ``AOANameScope`` so its checkpoint side is routed through the logical
-# normal-layer root (``_resolve_scoped_names``).
+# ``format_inv_dtype_cast_attr``, ``should_skip`` and ``strip_name_suffix``.
+#
+# ``validate_checkpoint_name_mapping`` is public as well but does not belong to
+# the component recursion: it is an entry-side static check the generation entry
+# runs once per context, before any component reads the mapping.
+#
+# Anything underscore-prefixed is internal detail. The only non-trivial logic is
+# root-relative template matching (``_match_template`` / ``_render_template``).
+# A re-rooted subtree passes an ``AOANameScope`` so its checkpoint side is
+# routed through the logical normal-layer root (``_resolve_scoped_names``).
 # --------------------------------------------------------------------------- #
 
 
@@ -710,7 +714,13 @@ def should_skip(source_name: str, target_name: str, cast: str) -> bool:
 def validate_checkpoint_name_mapping(
     checkpoint_name_mapping: Mapping[str, str],
 ) -> None:
-    """Validates ``checkpoint_name_mapping`` once, run from model ``__init__``.
+    """Validates ``checkpoint_name_mapping`` once, from the generation entry.
+
+    Called by the generation side while it builds an :class:`AOAContext` -- once
+    per context, so a multi-tower model validates each tower's mapping. Running
+    it there turns an invalid mapping into an error at the entry instead of a
+    later ambiguous match or an unrendered placeholder leaking into a
+    checkpoint name.
 
     Enforces three rules:
 

--- a/python/paddle/distributed/flex_checkpoint/aoa/generation.py
+++ b/python/paddle/distributed/flex_checkpoint/aoa/generation.py
@@ -1,0 +1,794 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generation-side support for modular AOA statement generation.
+
+The AOA engine in this package consumes ``source -> target`` statements; this
+module backs the side that produces them, driven by the
+``Layer.gen_aoa_statements`` / ``gen_inv_aoa_statements`` recursion. It holds the
+two frozen, behavior-free containers threaded through that recursion, plus the
+stateless naming helpers used to read them:
+
+- ``AOAContext``: model config and naming protocols, built once at the
+  whole-model entry and forwarded unchanged to every component override.
+- ``AOANameScope``: path information for a subtree whose checkpoint side is
+  re-rooted (MTP subtrees, the output head).
+
+Carrying data only means a component reading ``ctx`` for the forward and inverse
+directions does not couple the two; forwarding a single ``ctx`` also turns a
+missed constant map into an immediate ``TypeError`` instead of a silent bug.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = []
+
+
+# Placeholder segments captured by root-relative templates. They only ever appear
+# in templates / final AOA macros, never as a ``pp_to_single_mapping`` query key.
+ID_PLACEHOLDERS = frozenset({"$LAYER_ID", "$EXPERT_ID"})
+
+
+class DtypeCastRule(TypedDict):
+    """One model-declared dtype cast: the checkpoint stores the tensor as
+    ``checkpoint_dtype`` while the live model holds ``model_dtype``."""
+
+    checkpoint_dtype: str
+    model_dtype: str
+
+
+_DTYPE_CAST_RULE_KEYS = frozenset(DtypeCastRule.__annotations__)
+
+
+@dataclass(frozen=True)
+class AOAContext:
+    """Frozen, read-only recursion context for AOA statement generation.
+
+    Every field is constant across one whole-model generation pass. The
+    whole-model entry builds one context (per tower for multi-tower models) and
+    forwards it unchanged down the module tree. Per-position path info
+    (``structured_name_prefix`` and the optional ``AOANameScope``) travels
+    alongside ``ctx`` rather than inside it. Maps are ready on construction:
+    empty rules are an empty ``dict``, never ``None``.
+    """
+
+    config: object
+    """Config of the sub-structure being generated: the whole-model config for a
+    single-tower model, the current tower's sub-config for a multi-tower one."""
+
+    checkpoint_name_prefix: str
+    """Checkpoint-side prefix shared by every layer in this generation pass."""
+
+    checkpoint_name_mapping: Mapping[str, str]
+    """Model root-relative template -> checkpoint root-relative mapping."""
+
+    dtype_cast_rules: Mapping[str, DtypeCastRule]
+    """Model root-relative template -> dtype cast rule."""
+
+    pp_to_single_mapping: Mapping[str, str]
+    """Structured name -> single name mapping."""
+
+    model_name_prefix: str
+    """Single-name model root prefix, stripped by the checkpoint resolvers
+    before template matching. Declared by the model, so a multi-tower model can
+    root a tower elsewhere (e.g. ``"model.language_model"``)."""
+
+    excluded_names: frozenset[str] = frozenset()
+    """Structured names the module-tree recursion must not emit.
+
+    Tied / shared tensors registered under several structured names would
+    otherwise produce duplicate or conflicting statements, so the whole-model
+    entry resolves them before recursion, keeps one producer and lists the rest
+    here, re-emitting them itself (fan-out in the checkpoint->model direction,
+    ``-> _`` deletion in the inverse one). Honoring this set is part of the
+    recursion contract: a component override must skip an own-parameter whose
+    ``structured_name_prefix + name`` is in here, exactly as the default
+    ``Layer`` implementation does."""
+
+
+@dataclass(frozen=True)
+class AOANameScope:
+    """Path scope for a subtree whose checkpoint side is re-rooted.
+
+    Built at the whole-model entry for one subtree call, then forwarded as-is
+    during that subtree's recursion. Used wherever the checkpoint layout does
+    not follow the live module path: MTP subtrees (checkpoint keeps them under
+    their own root) and the output head. It is not a new model protocol and
+    holds no leaf mapping.
+    """
+
+    checkpoint_prefix: str
+    """Checkpoint subtree prefix, relative to the shared checkpoint name prefix
+    (unless ``is_checkpoint_prefix_absolute`` is set, in which case it is the
+    full prefix and the shared checkpoint name prefix is not prepended)."""
+
+    logical_model_prefix: str
+    """Logical model prefix used only to match ``checkpoint_name_mapping``."""
+
+    actual_model_prefix: str
+    """Real model single subtree prefix (after PP mapping resolution)."""
+
+    is_checkpoint_prefix_absolute: bool = False
+    """When True, ``checkpoint_prefix`` is already a full checkpoint prefix and
+    ``_scoped_checkpoint_name`` does not prepend ``checkpoint_name_prefix``.
+    Needed whenever the subtree's checkpoint names sit at the checkpoint root
+    rather than under the shared prefix: an MTP boundary that keeps its own
+    params at the root, or the output head, which the ``ForCausalLM`` layout
+    keeps a top-level sibling of the backbone (bare ``lm_head.weight``)."""
+
+
+# --------------------------------------------------------------------------- #
+# Naming & prefix helpers (stateless functions)
+#
+# Public to the component generators: ``join_name``, ``resolve_single_name``,
+# ``resolve_names``, ``resolve_checkpoint_name_from_anchor``,
+# ``resolve_dtype_cast_rule``, ``format_dtype_cast_attr``,
+# ``format_inv_dtype_cast_attr``, ``should_skip``, ``strip_name_suffix`` and
+# ``validate_checkpoint_name_mapping``; anything underscore-prefixed is internal
+# detail. The only non-trivial logic is root-relative template matching
+# (``_match_template`` / ``_render_template``). A re-rooted subtree passes an
+# ``AOANameScope`` so its checkpoint side is routed through the logical
+# normal-layer root (``_resolve_scoped_names``).
+# --------------------------------------------------------------------------- #
+
+
+def join_name(prefix: str, name: str) -> str:
+    """Joins a prefix and a name into a dotted path.
+
+    Args:
+        prefix: Leading path segment; may be empty.
+        name: Trailing path segment; may be empty.
+
+    Returns:
+        ``"{prefix}.{name}"``, or whichever operand is non-empty when the other
+        is empty.
+    """
+    if not prefix:
+        return name
+    if not name:
+        return prefix
+    return f"{prefix}.{name}"
+
+
+def _match_template(template: str, name: str) -> dict[str, str] | None:
+    """Compares a template against a name segment by segment.
+
+    Placeholder segments (``$LAYER_ID`` / ``$EXPERT_ID``) match a decimal-only
+    segment and capture its value; a repeated placeholder must capture the same
+    value.
+
+    Args:
+        template: Dotted template, possibly containing placeholder segments.
+        name: Dotted name to test against ``template``.
+
+    Returns:
+        The capture dict on a match (possibly empty) or ``None`` on a miss.
+        Callers must test ``is not None`` since an empty dict is falsy.
+    """
+    t_parts = template.split(".")
+    n_parts = name.split(".")
+    if len(t_parts) != len(n_parts):
+        return None
+    captures: dict[str, str] = {}
+    for t_part, n_part in zip(t_parts, n_parts):
+        if t_part in ID_PLACEHOLDERS:
+            if (
+                not n_part.isdigit()
+                or captures.setdefault(t_part, n_part) != n_part
+            ):
+                return None
+        elif t_part != n_part:
+            return None
+    return captures
+
+
+def _render_template(template: str, captures: Mapping[str, str]) -> str:
+    """Fills captured placeholders in a value template, segment by segment.
+
+    Args:
+        template: Dotted value template, possibly containing placeholders.
+        captures: Placeholder -> captured value mapping from ``_match_template``.
+
+    Returns:
+        The template with every captured placeholder replaced by its value.
+    """
+    return ".".join(captures.get(p, p) for p in template.split("."))
+
+
+def _strip_name_prefix(name: str, prefix: str) -> str:
+    """Removes a leading prefix from a dotted name.
+
+    Args:
+        name: Dotted name expected to be at or under ``prefix``.
+        prefix: Prefix path to strip.
+
+    Returns:
+        ``name`` with ``prefix`` removed (empty string when equal).
+
+    Raises:
+        ValueError: If ``name`` is not at or under ``prefix``.
+    """
+    if name == prefix:
+        return ""
+    if name.startswith(prefix + "."):
+        return name[len(prefix) + 1 :]
+    raise ValueError(f"{name!r} is not under prefix {prefix!r}")
+
+
+def strip_name_suffix(name: str, suffix: str) -> str:
+    """Removes a trailing suffix from a dotted name.
+
+    Args:
+        name: Dotted name expected to end with ``suffix``.
+        suffix: Suffix path to strip.
+
+    Returns:
+        ``name`` with the trailing ``suffix`` removed (empty string when equal).
+
+    Raises:
+        ValueError: If ``name`` does not end with ``suffix``.
+    """
+    if name == suffix:
+        return ""
+    if name.endswith("." + suffix):
+        return name[: -len(suffix) - 1]
+    raise ValueError(f"{name!r} does not end with suffix {suffix!r}")
+
+
+def _match_checkpoint_relative(
+    model_relative_name: str, checkpoint_name_mapping: Mapping[str, str]
+) -> str:
+    """Maps a root-stripped model relative name to its checkpoint relative name.
+
+    Args:
+        model_relative_name: Model name with the ``model`` root already stripped.
+        checkpoint_name_mapping: Model root-relative template -> checkpoint root-relative
+            template.
+
+    Returns:
+        The rendered checkpoint relative name on exactly one hit, or
+        ``model_relative_name`` unchanged (identity) when no template matches.
+
+    Raises:
+        ValueError: If more than one template matches (ambiguous config).
+    """
+    hits = []
+    for key_template, value_template in checkpoint_name_mapping.items():
+        captures = _match_template(key_template, model_relative_name)
+        if captures is not None:
+            hits.append(_render_template(value_template, captures))
+    if len(hits) > 1:
+        raise ValueError(
+            f"ambiguous checkpoint name mapping for {model_relative_name!r}: {hits}"
+        )
+    return hits[0] if hits else model_relative_name
+
+
+def _resolve_checkpoint_relative(
+    name: str,
+    checkpoint_name_mapping: Mapping[str, str],
+    model_name_prefix: str,
+) -> str:
+    """Strips the model root, then template-maps to a checkpoint relative name.
+
+    Args:
+        name: Single-space model name (starting at the model root prefix).
+        checkpoint_name_mapping: Model root-relative template -> checkpoint root-relative
+            template.
+        model_name_prefix: Model root prefix to strip before template matching.
+
+    Returns:
+        The checkpoint relative name (root-relative, without the checkpoint prefix).
+    """
+    model_relative_name = _strip_name_prefix(name, model_name_prefix)
+    return _match_checkpoint_relative(
+        model_relative_name, checkpoint_name_mapping
+    )
+
+
+def _resolve_checkpoint_name(
+    single_name: str,
+    checkpoint_name_prefix: str,
+    checkpoint_name_mapping: Mapping[str, str],
+    model_name_prefix: str,
+) -> str:
+    """Maps a single name to a full checkpoint name.
+
+    Args:
+        single_name: Single-space model name (starting at the model root prefix).
+        checkpoint_name_prefix: Checkpoint-side prefix to prepend to the mapped relative
+            name.
+        checkpoint_name_mapping: Model root-relative template -> checkpoint root-relative
+            template.
+        model_name_prefix: Model root prefix to strip before template matching.
+
+    Returns:
+        The full checkpoint name (``checkpoint_name_prefix`` joined with the mapped
+        relative name).
+    """
+    return join_name(
+        checkpoint_name_prefix,
+        _resolve_checkpoint_relative(
+            single_name, checkpoint_name_mapping, model_name_prefix
+        ),
+    )
+
+
+def _scoped_checkpoint_name(
+    single_space_name: str,
+    checkpoint_name_prefix: str,
+    checkpoint_name_mapping: Mapping[str, str],
+    aoa_name_scope: AOANameScope,
+    model_name_prefix: str,
+) -> str:
+    """Maps a re-rooted subtree's single-space name to its checkpoint name.
+
+    Extracts the subtree-relative path off the real model subtree root, replaces
+    it under the logical normal-layer root so the same ``checkpoint_name_mapping``
+    leaf rules apply, then re-anchors the mapped leaf name under the checkpoint
+    subtree root. Relies on leaf templates preserving their root prefix in the
+    value (``layers.$LAYER_ID.x -> layers.$LAYER_ID.y``), which is what makes the
+    logical root strippable from the mapped result.
+
+    Args:
+        single_space_name: Single-space model name under the real subtree root.
+        checkpoint_name_prefix: Checkpoint-side prefix to prepend.
+        checkpoint_name_mapping: Model root-relative template -> checkpoint
+            root-relative template.
+        aoa_name_scope: Subtree path scope (real / logical / checkpoint roots).
+        model_name_prefix: Model root prefix to strip before template matching.
+
+    Returns:
+        The full checkpoint name anchored under the checkpoint subtree root.
+
+    Raises:
+        ValueError: If a leaf mapping rewrites the logical root prefix.
+    """
+    actual_relative = _strip_name_prefix(
+        single_space_name, aoa_name_scope.actual_model_prefix
+    )
+    logical_name = join_name(
+        aoa_name_scope.logical_model_prefix, actual_relative
+    )
+    mapped_name = _resolve_checkpoint_relative(
+        logical_name, checkpoint_name_mapping, model_name_prefix
+    )
+    # Strip the logical_model_prefix's model-relative form directly.
+    # checkpoint_name_mapping only contains leaf-level templates and never
+    # rewrites the root prefix (e.g. "layers.$LAYER_ID" stays as-is in
+    # values), so the mapped result always starts with logical_model_relative.
+    logical_model_relative = _strip_name_prefix(
+        aoa_name_scope.logical_model_prefix, model_name_prefix
+    )
+    try:
+        checkpoint_local = _strip_name_prefix(
+            mapped_name, logical_model_relative
+        )
+    except ValueError:
+        raise ValueError(
+            f"checkpoint_name_mapping rewrites the logical root prefix: "
+            f"mapped_name={mapped_name!r} does not start with "
+            f"logical_model_relative={logical_model_relative!r}. "
+            f"Scoped resolution requires that leaf mappings preserve "
+            f"the logical_model_prefix prefix structure in their values "
+            f"(single_space_name={single_space_name!r}, "
+            f"logical_model_prefix={aoa_name_scope.logical_model_prefix!r})."
+        ) from None
+    if aoa_name_scope.is_checkpoint_prefix_absolute:
+        # The scope prefix is already a full checkpoint prefix; the shared
+        # checkpoint prefix is deliberately not prepended (an MTP boundary
+        # whose own params, or an output head, sit at the checkpoint root).
+        return join_name(aoa_name_scope.checkpoint_prefix, checkpoint_local)
+    return join_name(
+        checkpoint_name_prefix,
+        join_name(aoa_name_scope.checkpoint_prefix, checkpoint_local),
+    )
+
+
+def _resolve_scoped_names(
+    local_name: str,
+    checkpoint_name_prefix: str,
+    structured_name_prefix: str,
+    pp_to_single_mapping: Mapping[str, str],
+    checkpoint_name_mapping: Mapping[str, str],
+    aoa_name_scope: AOANameScope,
+    model_name_prefix: str,
+) -> tuple[str, str]:
+    """Re-rooted-subtree variant of ``resolve_names``.
+
+    The real model key still resolves through the live structured prefix and
+    ``pp_to_single_mapping``; only the checkpoint side is routed through the
+    logical normal-layer root.
+
+    Args:
+        local_name: Tensor name local to the current layer.
+        checkpoint_name_prefix: Checkpoint-side prefix.
+        structured_name_prefix: Pre-mapping live module path accumulated from
+            ancestors, ending in ``.`` when non-empty.
+        pp_to_single_mapping: Structured name -> single name mapping.
+        checkpoint_name_mapping: Model root-relative template -> checkpoint
+            root-relative template.
+        aoa_name_scope: Subtree path scope.
+        model_name_prefix: Model root prefix to strip before template matching.
+
+    Returns:
+        A ``(checkpoint_name, single_name)`` pair.
+    """
+    single_name = resolve_single_name(
+        local_name,
+        structured_name_prefix,
+        pp_to_single_mapping,
+        model_name_prefix,
+    )
+    checkpoint_name = _scoped_checkpoint_name(
+        single_name,
+        checkpoint_name_prefix,
+        checkpoint_name_mapping,
+        aoa_name_scope,
+        model_name_prefix,
+    )
+    return checkpoint_name, single_name
+
+
+def resolve_single_name(
+    local_name: str,
+    structured_name_prefix: str,
+    pp_to_single_mapping: Mapping[str, str],
+    model_name_prefix: str,
+) -> str:
+    """Resolves a real model tensor's structured name to its single name.
+
+    Args:
+        local_name: Tensor name local to the current layer.
+        structured_name_prefix: Live module-tree prefix accumulated from
+            ancestors. Like ``Layer.state_dict`` and ``Layer.sharded_state_dict``
+            prefixes, a non-empty value ends in ``.``.
+        pp_to_single_mapping: Structured name -> single name mapping. When non-empty the
+            pre-mapping structured name must hit exactly (no fallback). When empty, only
+            names starting with ``model_name_prefix`` pass through as identity.
+        model_name_prefix: Model root prefix for the identity fallback.
+
+    Returns:
+        The single name for the tensor.
+
+    Raises:
+        KeyError: If ``pp_to_single_mapping`` is non-empty and the structured name misses, or
+            ``pp_to_single_mapping`` is empty and the name doesn't start with model_name_prefix.
+    """
+    structured_name = structured_name_prefix + local_name
+    if pp_to_single_mapping:
+        try:
+            return pp_to_single_mapping[structured_name]
+        except KeyError:
+            raise KeyError(
+                f"structured name {structured_name!r} missing from "
+                f"pp_to_single_mapping (local_name={local_name!r}, "
+                f"structured_name_prefix={structured_name_prefix!r})"
+            ) from None
+    if structured_name == model_name_prefix or structured_name.startswith(
+        model_name_prefix + "."
+    ):
+        return structured_name
+    raise KeyError(
+        f"empty pp_to_single_mapping only allows "
+        f"{model_name_prefix}/{model_name_prefix}.* identity, "
+        f"got {structured_name!r}"
+    )
+
+
+def resolve_names(
+    local_name: str,
+    checkpoint_name_prefix: str,
+    structured_name_prefix: str,
+    pp_to_single_mapping: Mapping[str, str],
+    checkpoint_name_mapping: Mapping[str, str],
+    *,
+    model_name_prefix: str,
+    aoa_name_scope: AOANameScope | None = None,
+) -> tuple[str, str]:
+    """Resolves a real model tensor to its ``(checkpoint_name, single_name)`` pair.
+
+    Args:
+        local_name: Tensor name local to the current layer.
+        checkpoint_name_prefix: Fixed checkpoint-side prefix for the generation
+            pass.
+        structured_name_prefix: Pre-mapping live module path accumulated from
+            ancestors, ending in ``.`` when non-empty.
+        pp_to_single_mapping: Structured name -> single name mapping.
+        checkpoint_name_mapping: Model root-relative template -> checkpoint
+            root-relative template.
+        model_name_prefix: Model root prefix to strip before template matching.
+        aoa_name_scope: Optional re-rooted subtree scope; when set the
+            checkpoint side is routed through the logical normal-layer root.
+
+    Returns:
+        A stable ``(checkpoint_name, single_name)`` pair. Both directions
+        independently resolve this pair and choose their emission order.
+    """
+    if aoa_name_scope is not None:
+        return _resolve_scoped_names(
+            local_name,
+            checkpoint_name_prefix,
+            structured_name_prefix,
+            pp_to_single_mapping,
+            checkpoint_name_mapping,
+            aoa_name_scope,
+            model_name_prefix,
+        )
+
+    # Pre-mapping live structured name -> canonical model name.
+    single_name = resolve_single_name(
+        local_name,
+        structured_name_prefix,
+        pp_to_single_mapping,
+        model_name_prefix,
+    )
+
+    # single name -> checkpoint name
+    checkpoint_name = _resolve_checkpoint_name(
+        single_name,
+        checkpoint_name_prefix,
+        checkpoint_name_mapping,
+        model_name_prefix,
+    )
+
+    return checkpoint_name, single_name
+
+
+def resolve_checkpoint_name_from_anchor(
+    anchor_single_name: str,
+    anchor_local_name: str,
+    checkpoint_local_name: str,
+    checkpoint_name_prefix: str,
+    checkpoint_name_mapping: Mapping[str, str],
+    *,
+    model_name_prefix: str,
+    aoa_name_scope: AOANameScope | None = None,
+) -> str:
+    """Builds a checkpoint-only name (Q/K/V, gate/up, fused alpha) from an anchor.
+
+    Strips ``anchor_local_name`` off the resolved model target to get the
+    enclosing single-name scope, appends the checkpoint-only local name, then
+    maps to the checkpoint side. Checkpoint-only names are never sent through
+    ``pp_to_single_mapping``.
+
+    Args:
+        anchor_single_name: Resolved single name of a real anchor tensor.
+        anchor_local_name: Local name of that anchor, stripped to reach its
+            scope.
+        checkpoint_local_name: Checkpoint-only local name to place inside the
+            anchor's scope.
+        checkpoint_name_prefix: Checkpoint-side prefix.
+        checkpoint_name_mapping: Model root-relative template -> checkpoint
+            root-relative template.
+        model_name_prefix: Model root prefix to strip before template matching.
+        aoa_name_scope: Optional re-rooted subtree scope.
+
+    Returns:
+        The full checkpoint name for the synthetic checkpoint-only tensor.
+    """
+    scope_single = strip_name_suffix(anchor_single_name, anchor_local_name)
+    synthetic_single = join_name(scope_single, checkpoint_local_name)
+    if aoa_name_scope is not None:
+        return _scoped_checkpoint_name(
+            synthetic_single,
+            checkpoint_name_prefix,
+            checkpoint_name_mapping,
+            aoa_name_scope,
+            model_name_prefix,
+        )
+    return _resolve_checkpoint_name(
+        synthetic_single,
+        checkpoint_name_prefix,
+        checkpoint_name_mapping,
+        model_name_prefix,
+    )
+
+
+def resolve_dtype_cast_rule(
+    single_name: str,
+    dtype_rules: Mapping[str, DtypeCastRule],
+    model_name_prefix: str,
+) -> DtypeCastRule | None:
+    """Looks up a dtype cast rule by the single name's root-relative template.
+
+    Args:
+        single_name: Single-space model name (starting at the model root prefix).
+        dtype_rules: Model root-relative template -> dtype cast rule.
+        model_name_prefix: Model root prefix to strip before template matching.
+
+    Returns:
+        The matching rule on a single hit, or ``None`` on a miss (including an
+        empty ``dtype_rules``).
+
+    Raises:
+        ValueError: If more than one template matches, or if the matched rule
+            does not declare both dtype endpoints.
+    """
+    if not dtype_rules:
+        return None
+    model_relative_name = _strip_name_prefix(single_name, model_name_prefix)
+    hits = [
+        (key_template, rule)
+        for key_template, rule in dtype_rules.items()
+        if _match_template(key_template, model_relative_name) is not None
+    ]
+    if len(hits) > 1:
+        raise ValueError(
+            f"ambiguous dtype cast rule for {model_relative_name!r}: matched "
+            f"templates {[key for key, _ in hits]}, rules {[r for _, r in hits]}"
+        )
+    if not hits:
+        return None
+    key_template, rule = hits[0]
+    missing = _DTYPE_CAST_RULE_KEYS - rule.keys()
+    if missing:
+        raise ValueError(
+            f"dtype cast rule {key_template!r} (matched by "
+            f"{model_relative_name!r}) is missing {sorted(missing)}; a rule "
+            f"must declare {sorted(_DTYPE_CAST_RULE_KEYS)}, got {sorted(rule)}"
+        )
+    return rule
+
+
+def format_dtype_cast_attr(rule: DtypeCastRule | None) -> str:
+    """Formats the checkpoint->model dtype-cast attribute suffix.
+
+    Args:
+        rule: A rule from :func:`resolve_dtype_cast_rule`, or ``None`` on a miss.
+
+    Returns:
+        The ``", src_dtype=..., dst_dtype=..."`` suffix to append to a
+        single-input single-output statement, casting ``checkpoint_dtype ->
+        model_dtype``; ``""`` when no cast is needed (no rule, or both
+        endpoints equal).
+    """
+    if rule is None or rule["checkpoint_dtype"] == rule["model_dtype"]:
+        return ""
+    return (
+        f", src_dtype='{rule['checkpoint_dtype']}'"
+        f", dst_dtype='{rule['model_dtype']}'"
+    )
+
+
+def format_inv_dtype_cast_attr(rule: DtypeCastRule | None) -> str:
+    """Formats the inverse (model -> checkpoint) dtype-cast attribute suffix.
+
+    Mirror of :func:`format_dtype_cast_attr` with the endpoints swapped: casts
+    ``model_dtype -> checkpoint_dtype``.
+
+    Args:
+        rule: A rule from :func:`resolve_dtype_cast_rule`, or ``None`` on a miss.
+
+    Returns:
+        The attribute suffix string, or ``""`` when no cast applies.
+    """
+    if rule is None or rule["checkpoint_dtype"] == rule["model_dtype"]:
+        return ""
+    return (
+        f", src_dtype='{rule['model_dtype']}'"
+        f", dst_dtype='{rule['checkpoint_dtype']}'"
+    )
+
+
+def should_skip(source_name: str, target_name: str, cast: str) -> bool:
+    """Reports whether a component may omit the AOA statement for a param.
+
+    ``AOAEngine`` fills any destination key that no statement produced from the
+    same-named source, so a ``foo -> foo`` line with no cast is redundant and
+    generators rely on that passthrough instead. Any real transform (rename,
+    ``^T``, fusion / split, dtype cast) makes the two names differ or sets a
+    non-empty ``cast``, so it is never skipped.
+
+    Args:
+        source_name: The resolved source-side name.
+        target_name: The resolved target-side name.
+        cast: The dtype-cast attribute suffix (``""`` when no cast applies).
+
+    Returns:
+        ``True`` when the statement is redundant and can be omitted.
+    """
+    return source_name == target_name and not cast
+
+
+def validate_checkpoint_name_mapping(
+    checkpoint_name_mapping: Mapping[str, str],
+) -> None:
+    """Validates ``checkpoint_name_mapping`` once, run from model ``__init__``.
+
+    Enforces three rules:
+
+    - a ``$``-bearing segment must be a whole segment and a known placeholder,
+      otherwise it would survive rendering into a bogus checkpoint name;
+    - every placeholder used in a value template is captured by its key template
+      (otherwise the value cannot be rendered);
+    - no two keys map to the same checkpoint target (value template). Tied /
+      shared aliases must be expressed by the whole-model alias handler, never
+      implied by a duplicate value here.
+
+    Args:
+        checkpoint_name_mapping: Model root-relative template -> checkpoint
+            root-relative template mapping to validate.
+
+    Raises:
+        ValueError: On the first violation of any rule.
+    """
+    seen_targets: dict[str, str] = {}
+    for key_template, value_template in checkpoint_name_mapping.items():
+        if not key_template or not value_template:
+            raise ValueError(
+                f"checkpoint name mapping contains an empty-string "
+                f"key or value: {key_template!r} -> {value_template!r}"
+            )
+        for role, template in (
+            ("key", key_template),
+            ("value", value_template),
+        ):
+            for segment in template.split("."):
+                if "$" in segment and segment not in ID_PLACEHOLDERS:
+                    raise ValueError(
+                        f"checkpoint name mapping {key_template!r} -> "
+                        f"{value_template!r} has {role} segment {segment!r} "
+                        f"containing '$'; a placeholder must be a whole dotted "
+                        f"segment and one of {sorted(ID_PLACEHOLDERS)}"
+                    )
+        key_placeholders = {
+            p for p in key_template.split(".") if p in ID_PLACEHOLDERS
+        }
+        value_placeholders = {
+            p for p in value_template.split(".") if p in ID_PLACEHOLDERS
+        }
+        uncaptured = value_placeholders - key_placeholders
+        if uncaptured:
+            raise ValueError(
+                f"checkpoint name mapping {key_template!r} -> {value_template!r} "
+                f"uses placeholder(s) {sorted(uncaptured)} not captured by the "
+                f"key template"
+            )
+        if value_template in seen_targets:
+            raise ValueError(
+                f"duplicate checkpoint target {value_template!r} from keys "
+                f"{seen_targets[value_template]!r} and {key_template!r}; "
+                f"tied/shared aliases must go through the whole-model alias "
+                f"handler, not a duplicate mapping value"
+            )
+        seen_targets[value_template] = key_template
+
+    # Detect simple overlaps: a concrete key (no placeholders) that is also
+    # matchable by another key with placeholders would cause ambiguous hits at
+    # runtime. This is a best-effort static check covering the most common
+    # mistake (a specific layer override coexisting with its general template).
+    concrete_keys = [
+        k
+        for k in checkpoint_name_mapping
+        if not any(seg in ID_PLACEHOLDERS for seg in k.split("."))
+    ]
+    templated_keys = [
+        k
+        for k in checkpoint_name_mapping
+        if any(seg in ID_PLACEHOLDERS for seg in k.split("."))
+    ]
+    for concrete in concrete_keys:
+        for tmpl in templated_keys:
+            if _match_template(tmpl, concrete) is not None:
+                raise ValueError(
+                    f"overlapping checkpoint name mapping: concrete key "
+                    f"{concrete!r} is also matchable by templated key "
+                    f"{tmpl!r}; this would cause ambiguous hits at runtime"
+                )

--- a/python/paddle/nn/layer/layers.py
+++ b/python/paddle/nn/layer/layers.py
@@ -51,6 +51,13 @@ from paddle.base.framework import (
     paddle_type_to_proto_type,
 )
 from paddle.base.layer_helper_base import LayerHelperBase
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    format_dtype_cast_attr,
+    format_inv_dtype_cast_attr,
+    resolve_dtype_cast_rule,
+    resolve_names,
+    should_skip,
+)
 from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
     ShardedStateDict,
     build_sharded_state_dict,
@@ -66,6 +73,10 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping, Sequence
 
     from paddle._typing import DTypeLike, ParamAttrLike, PlaceLike, ShapeLike
+    from paddle.distributed.flex_checkpoint.aoa.generation import (
+        AOAContext,
+        AOANameScope,
+    )
     from paddle.nn.initializer import Initializer
 
 
@@ -2703,6 +2714,130 @@ class Layer:
                 sharded_state_dict.update(sub_sharded)
 
         return sharded_state_dict
+
+    def gen_aoa_statements(
+        self,
+        ctx: AOAContext,
+        *,
+        structured_name_prefix: str = "",
+        aoa_name_scope: AOANameScope | None = None,
+    ) -> list[str]:
+        """Recursively generates checkpoint -> model AOA statements.
+
+        Emits a ``source -> target`` statement per own Parameter / persistable
+        buffer (same source as ``sharded_state_dict``), then recurses into
+        sub-layers, omitting redundant statements (``should_skip``) and names
+        in ``ctx.excluded_names``. Components with a special checkpoint layout
+        override this method; the rest fall back here.
+
+        Args:
+            ctx: Read-only ``AOAContext`` holding the constant name and dtype
+                maps for the whole generation pass.
+            structured_name_prefix: Live module path prefix, ending in ``.``
+                when non-empty, as in ``sharded_state_dict``.
+            aoa_name_scope: Optional checkpoint-side scope for a re-rooted
+                subtree (MTP subtrees, output head), passed down unchanged.
+
+        Returns:
+            Statements for this layer and all its sub-layers.
+        """
+        statements: list[str] = []
+        # Same source as ``sharded_state_dict`` so the generated model-side
+        # names stay in sync with the checkpoint keys it produces.
+        own_state_dict = self.state_dict(
+            structured_name_prefix="", include_sublayers=False
+        )
+        for name in own_state_dict:
+            if structured_name_prefix + name in ctx.excluded_names:
+                continue
+            source_name, target_name = resolve_names(
+                name,
+                ctx.checkpoint_name_prefix,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            cast = format_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    target_name,
+                    ctx.dtype_cast_rules,
+                    ctx.model_name_prefix,
+                )
+            )
+            if should_skip(source_name, target_name, cast):
+                continue
+            statements.append(f"{source_name} -> {target_name}{cast}")
+        for layer_name, sublayer in self._sub_layers.items():
+            if sublayer is not None:
+                statements += sublayer.gen_aoa_statements(
+                    ctx,
+                    structured_name_prefix=f"{structured_name_prefix}{layer_name}.",
+                    aoa_name_scope=aoa_name_scope,
+                )
+        return statements
+
+    def gen_inv_aoa_statements(
+        self,
+        ctx: AOAContext,
+        *,
+        structured_name_prefix: str = "",
+        aoa_name_scope: AOANameScope | None = None,
+    ) -> list[str]:
+        """Recursively generates model -> checkpoint AOA statements.
+
+        Independently resolves the same checkpoint/model name pair as
+        ``gen_aoa_statements`` and emits it in the opposite order, with the
+        same ``should_skip`` and ``ctx.excluded_names`` omissions.
+
+        Args:
+            ctx: Read-only ``AOAContext`` holding the constant name and dtype
+                maps for the whole generation pass.
+            structured_name_prefix: Live module path prefix, ending in ``.``
+                when non-empty, as in ``sharded_state_dict``.
+            aoa_name_scope: Optional checkpoint-side scope for a re-rooted
+                subtree (MTP subtrees, output head), passed down unchanged.
+
+        Returns:
+            Statements for this layer and all its sub-layers.
+        """
+        statements: list[str] = []
+        # Same source as ``sharded_state_dict`` so the generated model-side
+        # names stay in sync with the checkpoint keys it produces.
+        own_state_dict = self.state_dict(
+            structured_name_prefix="", include_sublayers=False
+        )
+        for name in own_state_dict:
+            if structured_name_prefix + name in ctx.excluded_names:
+                continue
+            target_name, source_name = resolve_names(
+                name,
+                ctx.checkpoint_name_prefix,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            cast = format_inv_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    source_name,
+                    ctx.dtype_cast_rules,
+                    ctx.model_name_prefix,
+                )
+            )
+            if should_skip(source_name, target_name, cast):
+                continue
+            statements.append(f"{source_name} -> {target_name}{cast}")
+        for layer_name, sublayer in self._sub_layers.items():
+            if sublayer is not None:
+                statements += sublayer.gen_inv_aoa_statements(
+                    ctx,
+                    structured_name_prefix=f"{structured_name_prefix}{layer_name}.",
+                    aoa_name_scope=aoa_name_scope,
+                )
+        return statements
 
     def full(
         self,

--- a/test/flex_checkpoint/test_aoa_generation.py
+++ b/test/flex_checkpoint/test_aoa_generation.py
@@ -1,0 +1,513 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: direct unit tests for the stateless helpers in
+# ``paddle.distributed.flex_checkpoint.aoa.generation``. The recursion that
+# consumes them lives on ``Layer`` and is pinned by
+# ``test_gen_aoa_statements.py``, which only ever drives their happy paths.
+# This file covers the name-space algebra (root stripping, placeholder
+# templates, subtree re-rooting), the dtype-cast rule lookup and its two
+# formatters, and every documented failure mode: those raises are what stops a
+# mis-declared model config from silently producing wrong checkpoint keys
+# instead of failing at conversion time.
+
+import unittest
+from dataclasses import FrozenInstanceError
+
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    AOAContext,
+    AOANameScope,
+    format_dtype_cast_attr,
+    format_inv_dtype_cast_attr,
+    join_name,
+    resolve_checkpoint_name_from_anchor,
+    resolve_dtype_cast_rule,
+    resolve_names,
+    resolve_single_name,
+    should_skip,
+    strip_name_suffix,
+    validate_checkpoint_name_mapping,
+)
+
+_MODEL = "model"
+
+_RULE = {"checkpoint_dtype": "float32", "model_dtype": "bfloat16"}
+
+# The MTP layout: the checkpoint keeps the subtree under its own root, while
+# the leaf mapping rules are written against a normal layer ("layers.1").
+_MTP_SCOPE = AOANameScope(
+    checkpoint_prefix="mtp.0",
+    logical_model_prefix="model.layers.1",
+    actual_model_prefix="model.mtp.0",
+)
+
+
+def _resolve(
+    local_name,
+    structured_name_prefix,
+    *,
+    checkpoint_name_prefix="hf",
+    pp_mapping=None,
+    name_mapping=None,
+    model_name_prefix=_MODEL,
+    aoa_name_scope=None,
+):
+    return resolve_names(
+        local_name,
+        checkpoint_name_prefix,
+        structured_name_prefix,
+        pp_mapping or {},
+        name_mapping or {},
+        model_name_prefix=model_name_prefix,
+        aoa_name_scope=aoa_name_scope,
+    )
+
+
+def _ctx():
+    return AOAContext(
+        config=None,
+        checkpoint_name_prefix="hf",
+        checkpoint_name_mapping={},
+        dtype_cast_rules={},
+        pp_to_single_mapping={},
+        model_name_prefix=_MODEL,
+    )
+
+
+class TestJoinName(unittest.TestCase):
+    def test_both_operands_present(self):
+        self.assertEqual(
+            join_name("model.layers.0", "weight"), "model.layers.0.weight"
+        )
+
+    def test_empty_operand_is_dropped(self):
+        # An empty checkpoint prefix (a checkpoint rooted at the top level)
+        # must not leave a leading dot behind.
+        self.assertEqual(join_name("", "stem.weight"), "stem.weight")
+        self.assertEqual(join_name("hf", ""), "hf")
+        self.assertEqual(join_name("", ""), "")
+
+
+class TestStripNameSuffix(unittest.TestCase):
+    def test_strips_a_dotted_tail(self):
+        self.assertEqual(
+            strip_name_suffix("model.layers.0.q_proj.weight", "q_proj.weight"),
+            "model.layers.0",
+        )
+
+    def test_whole_name_becomes_empty(self):
+        self.assertEqual(strip_name_suffix("weight", "weight"), "")
+
+    def test_substring_is_not_a_suffix(self):
+        # "roj.weight" ends the name as a string but not on a segment
+        # boundary, so it is a miss rather than a silent bad split.
+        with self.assertRaisesRegex(ValueError, "does not end with suffix"):
+            strip_name_suffix("model.q_proj.weight", "roj.weight")
+
+
+class TestResolveSingleName(unittest.TestCase):
+    _PP = {"pipe.block.weight": "model.layers.0.weight"}
+
+    def test_non_empty_mapping_hits_the_pre_mapping_name(self):
+        self.assertEqual(
+            resolve_single_name("weight", "pipe.block.", self._PP, _MODEL),
+            "model.layers.0.weight",
+        )
+
+    def test_non_empty_mapping_miss_raises(self):
+        # Deliberately no identity fallback: under PP a miss means the mapping
+        # and the live tree disagree, and falling back would mis-key silently.
+        with self.assertRaisesRegex(
+            KeyError, "missing from pp_to_single_mapping"
+        ):
+            resolve_single_name("bias", "pipe.block.", self._PP, _MODEL)
+
+    def test_empty_mapping_allows_root_identity(self):
+        self.assertEqual(
+            resolve_single_name("weight", "model.stem.", {}, _MODEL),
+            "model.stem.weight",
+        )
+        self.assertEqual(resolve_single_name("model", "", {}, _MODEL), "model")
+
+    def test_empty_mapping_rejects_a_foreign_root(self):
+        with self.assertRaisesRegex(
+            KeyError, "empty pp_to_single_mapping only allows"
+        ):
+            resolve_single_name("weight", "layers.0.", {}, _MODEL)
+
+    def test_root_must_match_on_a_segment_boundary(self):
+        # "modelx" has "model" as a string prefix but is a different root.
+        with self.assertRaisesRegex(
+            KeyError, "empty pp_to_single_mapping only allows"
+        ):
+            resolve_single_name("weight", "modelx.", {}, _MODEL)
+
+
+class TestResolveNames(unittest.TestCase):
+    def test_identity_pair_positional_signature(self):
+        # Called positionally on purpose: the argument order is part of the
+        # contract every component generator is written against.
+        self.assertEqual(
+            resolve_names(
+                "weight", "hf", "model.stem.", {}, {}, model_name_prefix=_MODEL
+            ),
+            ("hf.stem.weight", "model.stem.weight"),
+        )
+
+    def test_empty_checkpoint_prefix_keeps_names_at_the_root(self):
+        self.assertEqual(
+            _resolve("weight", "model.stem.", checkpoint_name_prefix=""),
+            ("stem.weight", "model.stem.weight"),
+        )
+
+    def test_tower_root_is_stripped_before_template_matching(self):
+        # A multi-tower model roots a tower below the model root; the
+        # checkpoint side is relative to that tower root, not to "model".
+        self.assertEqual(
+            _resolve(
+                "weight",
+                "model.language_model.stem.",
+                model_name_prefix="model.language_model",
+            ),
+            ("hf.stem.weight", "model.language_model.stem.weight"),
+        )
+
+    def test_placeholders_are_captured_and_rendered(self):
+        mapping = {
+            "layers.$LAYER_ID.experts.$EXPERT_ID.weight": (
+                "blocks.$LAYER_ID.e.$EXPERT_ID.w"
+            )
+        }
+        self.assertEqual(
+            _resolve(
+                "weight", "model.layers.2.experts.5.", name_mapping=mapping
+            )[0],
+            "hf.blocks.2.e.5.w",
+        )
+
+    def test_placeholder_only_matches_a_decimal_segment(self):
+        mapping = {"layers.$LAYER_ID.weight": "blocks.$LAYER_ID.w"}
+        # A non-numeric segment misses, so the name passes through unchanged
+        # rather than rendering "blocks.shared.w" from an uncaptured template.
+        self.assertEqual(
+            _resolve("weight", "model.layers.shared.", name_mapping=mapping)[0],
+            "hf.layers.shared.weight",
+        )
+
+    def test_repeated_placeholder_must_capture_one_value(self):
+        mapping = {"layers.$LAYER_ID.mtp.$LAYER_ID.weight": "x.$LAYER_ID.w"}
+        self.assertEqual(
+            _resolve("weight", "model.layers.0.mtp.0.", name_mapping=mapping)[
+                0
+            ],
+            "hf.x.0.w",
+        )
+        self.assertEqual(
+            _resolve("weight", "model.layers.0.mtp.1.", name_mapping=mapping)[
+                0
+            ],
+            "hf.layers.0.mtp.1.weight",
+        )
+
+    def test_segment_count_mismatch_is_a_miss(self):
+        mapping = {"layers.$LAYER_ID.weight": "blocks.$LAYER_ID.w"}
+        self.assertEqual(
+            _resolve("weight", "model.layers.0.attn.", name_mapping=mapping)[0],
+            "hf.layers.0.attn.weight",
+        )
+
+    def test_ambiguous_mapping_raises_at_resolution_time(self):
+        mapping = {
+            "layers.$LAYER_ID.weight": "a.$LAYER_ID.w",
+            "layers.0.weight": "b.w",
+        }
+        with self.assertRaisesRegex(
+            ValueError, "ambiguous checkpoint name mapping"
+        ):
+            _resolve("weight", "model.layers.0.", name_mapping=mapping)
+
+
+class TestResolveNamesScoped(unittest.TestCase):
+    def test_subtree_is_rerooted_under_the_checkpoint_prefix(self):
+        self.assertEqual(
+            _resolve("weight", "model.mtp.0.", aoa_name_scope=_MTP_SCOPE),
+            ("hf.mtp.0.weight", "model.mtp.0.weight"),
+        )
+
+    def test_leaf_mapping_applies_through_the_logical_root(self):
+        # The rule is written for a normal layer; scoped resolution routes the
+        # subtree name through the logical root so the same rule still hits.
+        mapping = {"layers.$LAYER_ID.weight": "layers.$LAYER_ID.linear.weight"}
+        self.assertEqual(
+            _resolve(
+                "weight",
+                "model.mtp.0.",
+                name_mapping=mapping,
+                aoa_name_scope=_MTP_SCOPE,
+            )[0],
+            "hf.mtp.0.linear.weight",
+        )
+
+    def test_absolute_prefix_skips_the_shared_checkpoint_prefix(self):
+        # The ForCausalLM layout keeps the head at the checkpoint root, a
+        # sibling of the backbone rather than under it.
+        head = AOANameScope(
+            checkpoint_prefix="lm_head",
+            logical_model_prefix="model.output_layer",
+            actual_model_prefix="model.output_layer",
+            is_checkpoint_prefix_absolute=True,
+        )
+        self.assertEqual(
+            _resolve("weight", "model.output_layer.", aoa_name_scope=head)[0],
+            "lm_head.weight",
+        )
+
+    def test_relative_prefix_is_the_default(self):
+        head = AOANameScope(
+            checkpoint_prefix="lm_head",
+            logical_model_prefix="model.output_layer",
+            actual_model_prefix="model.output_layer",
+        )
+        self.assertFalse(head.is_checkpoint_prefix_absolute)
+        self.assertEqual(
+            _resolve("weight", "model.output_layer.", aoa_name_scope=head)[0],
+            "hf.lm_head.weight",
+        )
+
+    def test_name_outside_the_subtree_raises(self):
+        scope = AOANameScope(
+            checkpoint_prefix="mtp.0",
+            logical_model_prefix="model.layers.1",
+            actual_model_prefix="model.mtp.9",
+        )
+        with self.assertRaisesRegex(ValueError, "is not under prefix"):
+            _resolve("weight", "model.mtp.0.", aoa_name_scope=scope)
+
+    def test_mapping_that_rewrites_the_logical_root_raises(self):
+        # Scoped resolution strips the logical root back off the mapped name
+        # before re-anchoring it, so a value template that drops that root
+        # cannot be re-anchored and must not be guessed at.
+        mapping = {"layers.$LAYER_ID.weight": "embeddings.weight"}
+        with self.assertRaisesRegex(
+            ValueError, "rewrites the logical root prefix"
+        ):
+            _resolve(
+                "weight",
+                "model.mtp.0.",
+                name_mapping=mapping,
+                aoa_name_scope=_MTP_SCOPE,
+            )
+
+
+class TestResolveCheckpointNameFromAnchor(unittest.TestCase):
+    def _anchor(self, anchor_local="q_proj.weight", **kwargs):
+        return resolve_checkpoint_name_from_anchor(
+            kwargs.pop("anchor_single", "model.layers.0.q_proj.weight"),
+            anchor_local,
+            "qkv_proj.weight",
+            "hf",
+            kwargs.pop("name_mapping", None) or {},
+            model_name_prefix=_MODEL,
+            **kwargs,
+        )
+
+    def test_synthetic_name_lands_in_the_anchor_scope(self):
+        # qkv_proj exists only in the checkpoint, so it is never sent through
+        # pp_to_single_mapping; its scope comes from a real sibling.
+        self.assertEqual(self._anchor(), "hf.layers.0.qkv_proj.weight")
+
+    def test_mapping_applies_to_the_synthetic_name(self):
+        mapping = {
+            "layers.$LAYER_ID.qkv_proj.weight": "layers.$LAYER_ID.attn.qkv.w"
+        }
+        self.assertEqual(
+            self._anchor(name_mapping=mapping), "hf.layers.0.attn.qkv.w"
+        )
+
+    def test_wrong_anchor_local_name_raises(self):
+        # The anchor's local name must really end the resolved single name,
+        # otherwise the derived scope would be silently wrong.
+        with self.assertRaisesRegex(ValueError, "does not end with suffix"):
+            self._anchor(anchor_local="k_proj.weight")
+
+    def test_scoped_anchor_is_rerooted_like_a_real_param(self):
+        self.assertEqual(
+            self._anchor(
+                anchor_single="model.mtp.0.q_proj.weight",
+                aoa_name_scope=_MTP_SCOPE,
+            ),
+            "hf.mtp.0.qkv_proj.weight",
+        )
+
+
+class TestResolveDtypeCastRule(unittest.TestCase):
+    _TEMPLATE = {"layers.$LAYER_ID.weight": _RULE}
+
+    def test_empty_rules_short_circuit_before_root_stripping(self):
+        # The early return keeps the overwhelmingly common no-rule case free of
+        # any name work at all -- so a foreign root is not even looked at.
+        self.assertIsNone(resolve_dtype_cast_rule("elsewhere", {}, _MODEL))
+
+    def test_template_matches_through_the_model_root(self):
+        self.assertEqual(
+            resolve_dtype_cast_rule(
+                "model.layers.7.weight", self._TEMPLATE, _MODEL
+            ),
+            _RULE,
+        )
+
+    def test_miss_returns_none(self):
+        self.assertIsNone(
+            resolve_dtype_cast_rule(
+                "model.layers.7.bias", self._TEMPLATE, _MODEL
+            )
+        )
+
+    def test_name_outside_the_model_root_raises(self):
+        with self.assertRaisesRegex(ValueError, "is not under prefix"):
+            resolve_dtype_cast_rule("other.stem.weight", self._TEMPLATE, _MODEL)
+
+    def test_ambiguous_templates_raise(self):
+        rules = {
+            "layers.$LAYER_ID.weight": _RULE,
+            "layers.0.weight": {
+                "checkpoint_dtype": "float32",
+                "model_dtype": "float16",
+            },
+        }
+        with self.assertRaisesRegex(
+            ValueError, "ambiguous dtype cast rule for 'layers.0.weight'"
+        ):
+            resolve_dtype_cast_rule("model.layers.0.weight", rules, _MODEL)
+
+    def test_half_declared_rule_raises(self):
+        # Refusing at lookup names the offending template; letting it through
+        # would surface as a KeyError inside a formatter instead.
+        rules = {"stem.weight": {"checkpoint_dtype": "float32"}}
+        with self.assertRaisesRegex(
+            ValueError, r"is missing \['model_dtype'\]"
+        ):
+            resolve_dtype_cast_rule("model.stem.weight", rules, _MODEL)
+
+
+class TestFormatDtypeCastAttr(unittest.TestCase):
+    def test_no_rule_is_no_suffix(self):
+        self.assertEqual(format_dtype_cast_attr(None), "")
+        self.assertEqual(format_inv_dtype_cast_attr(None), "")
+
+    def test_equal_endpoints_are_a_noop(self):
+        rule = {"checkpoint_dtype": "bfloat16", "model_dtype": "bfloat16"}
+        self.assertEqual(format_dtype_cast_attr(rule), "")
+        self.assertEqual(format_inv_dtype_cast_attr(rule), "")
+
+    def test_endpoints_are_mirrored_between_directions(self):
+        # One rule drives both directions and the endpoint order is the only
+        # difference between the two functions, so pin both literals together:
+        # swapping them silently casts the wrong way.
+        self.assertEqual(
+            format_dtype_cast_attr(_RULE),
+            ", src_dtype='float32', dst_dtype='bfloat16'",
+        )
+        self.assertEqual(
+            format_inv_dtype_cast_attr(_RULE),
+            ", src_dtype='bfloat16', dst_dtype='float32'",
+        )
+
+
+class TestShouldSkip(unittest.TestCase):
+    def test_untransformed_identity_is_skipped(self):
+        # AOAEngine fills an unproduced destination from the same-named source,
+        # so emitting this line would be redundant.
+        self.assertTrue(should_skip("model.weight", "model.weight", ""))
+
+    def test_a_cast_keeps_an_identity_alive(self):
+        self.assertFalse(should_skip("model.weight", "model.weight", ", cast"))
+
+    def test_differing_names_are_never_skipped(self):
+        self.assertFalse(should_skip("hf.weight", "model.weight", ""))
+
+
+class TestValidateCheckpointNameMapping(unittest.TestCase):
+    def test_empty_mapping_is_valid(self):
+        validate_checkpoint_name_mapping({})
+
+    def test_wellformed_mapping_is_valid(self):
+        validate_checkpoint_name_mapping(
+            {
+                "layers.$LAYER_ID.weight": "layers.$LAYER_ID.linear.weight",
+                "layers.$LAYER_ID.experts.$EXPERT_ID.w": (
+                    "layers.$LAYER_ID.e.$EXPERT_ID.w"
+                ),
+            }
+        )
+
+    def test_empty_key_or_value_raises(self):
+        for mapping in ({"": "a.w"}, {"a.w": ""}):
+            with self.assertRaisesRegex(ValueError, "empty-string"):
+                validate_checkpoint_name_mapping(mapping)
+
+    def test_placeholder_must_be_a_whole_known_segment(self):
+        # Either form would survive rendering into a bogus checkpoint name.
+        for mapping in (
+            {"layers.l$LAYER_ID.weight": "x.w"},
+            {"layers.$LAYERID.weight": "x.w"},
+        ):
+            with self.assertRaisesRegex(ValueError, "has key segment"):
+                validate_checkpoint_name_mapping(mapping)
+
+    def test_unknown_placeholder_in_a_value_raises(self):
+        with self.assertRaisesRegex(ValueError, "has value segment"):
+            validate_checkpoint_name_mapping({"a.w": "x.$FOO.w"})
+
+    def test_value_placeholder_must_be_captured_by_the_key(self):
+        with self.assertRaisesRegex(ValueError, "not captured by the key"):
+            validate_checkpoint_name_mapping(
+                {"layers.0.w": "blocks.$LAYER_ID.w"}
+            )
+
+    def test_duplicate_target_raises(self):
+        # Two model names landing on one checkpoint key is a tie, which only
+        # the whole-model alias handler may express.
+        with self.assertRaisesRegex(ValueError, "duplicate checkpoint target"):
+            validate_checkpoint_name_mapping({"a.w": "z.w", "b.w": "z.w"})
+
+    def test_concrete_key_shadowed_by_a_template_raises(self):
+        # Same config that TestResolveNames pins as a runtime ambiguity; the
+        # config-time check catches it first and names both keys.
+        with self.assertRaisesRegex(
+            ValueError, "overlapping checkpoint name mapping"
+        ):
+            validate_checkpoint_name_mapping(
+                {
+                    "layers.$LAYER_ID.weight": "a.$LAYER_ID.w",
+                    "layers.0.weight": "b.w",
+                }
+            )
+
+
+class TestContainerDefaults(unittest.TestCase):
+    def test_excluded_names_defaults_to_empty(self):
+        self.assertEqual(_ctx().excluded_names, frozenset())
+
+    def test_context_is_frozen(self):
+        with self.assertRaises(FrozenInstanceError):
+            _ctx().checkpoint_name_prefix = "mut"
+
+    def test_name_scope_is_frozen(self):
+        with self.assertRaises(FrozenInstanceError):
+            _MTP_SCOPE.checkpoint_prefix = "mut"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/flex_checkpoint/test_gen_aoa_statements.py
+++ b/test/flex_checkpoint/test_gen_aoa_statements.py
@@ -1,0 +1,500 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: ``Layer.gen_aoa_statements`` / ``Layer.gen_inv_aoa_statements`` -- the
+# recursion that walks the live module tree and emits AOA statements. What is
+# pinned here is what those two methods decide: which params and buffers take
+# part, in what order, how ``ctx`` / the structured-name prefix / an
+# ``AOANameScope`` thread down through nesting, when a sublayer's own override
+# takes over, and which dtype-cast endpoint order each direction uses. The
+# stateless name and dtype helpers they call live in
+# ``flex_checkpoint/aoa/generation.py`` and are pinned directly by
+# ``test_aoa_generation.py``.
+
+import unittest
+
+import paddle
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    AOAContext,
+    AOANameScope,
+)
+
+
+class _Leaf(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.weight = self.create_parameter(shape=[1])
+
+
+class _LeafWithBuffer(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.weight = self.create_parameter(shape=[1])
+        self.register_buffer(
+            "running_stat", paddle.zeros([1]), persistable=True
+        )
+        self.register_buffer("tmp_cache", paddle.zeros([1]), persistable=False)
+
+
+class _OverridingLeaf(paddle.nn.Layer):
+    """Sublayer that fully overrides statement generation (virtual dispatch)."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = self.create_parameter(shape=[1])
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        return [f"__custom_fwd__::{structured_name_prefix}"]
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        return [f"__custom_inv__::{structured_name_prefix}"]
+
+
+class _NestedModel(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.model = paddle.nn.Layer()
+        self.model.stem = _Leaf()
+        self.model.block = paddle.nn.Layer()
+        self.model.block.proj = _Leaf()
+
+
+class _RecordingMapping(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.queries = []
+
+    def __getitem__(self, key):
+        self.queries.append(key)
+        return super().__getitem__(key)
+
+
+def _context(
+    *,
+    checkpoint_name_prefix="checkpoint",
+    pp_mapping=None,
+    name_mapping=None,
+    dtype_rules=None,
+    model_name_prefix="model",
+):
+    return AOAContext(
+        config=None,
+        checkpoint_name_prefix=checkpoint_name_prefix,
+        pp_to_single_mapping=pp_mapping or {},
+        checkpoint_name_mapping=name_mapping or {},
+        dtype_cast_rules=dtype_rules or {},
+        model_name_prefix=model_name_prefix,
+    )
+
+
+class TestGenAOAStatements(unittest.TestCase):
+    def test_same_name_identity_is_omitted_by_base_layer(self):
+        model = _NestedModel()
+        ctx = _context(checkpoint_name_prefix="model")
+
+        self.assertEqual(model.gen_aoa_statements(ctx), [])
+
+    def test_nested_recursion_matches_sharded_state_dict_keys(self):
+        model = _NestedModel()
+        ctx = _context(checkpoint_name_prefix="hf")
+
+        sharded_keys = set(model.sharded_state_dict())
+        forward = model.gen_aoa_statements(ctx)
+        model_keys = {statement.split(" -> ")[1] for statement in forward}
+
+        self.assertEqual(model_keys, sharded_keys)
+        self.assertEqual(
+            forward,
+            [
+                "hf.stem.weight -> model.stem.weight",
+                "hf.block.proj.weight -> model.block.proj.weight",
+            ],
+        )
+        self.assertTrue(all(".." not in statement for statement in forward))
+
+    def test_forward_and_inverse_resolve_the_same_name_pair(self):
+        model = _NestedModel()
+        ctx = _context(checkpoint_name_prefix="archive.root")
+
+        forward = model.gen_aoa_statements(ctx)
+        inverse = model.gen_inv_aoa_statements(ctx)
+
+        self.assertEqual(
+            inverse,
+            [
+                "model.stem.weight -> archive.root.stem.weight",
+                "model.block.proj.weight -> archive.root.block.proj.weight",
+            ],
+        )
+        self.assertEqual(
+            inverse,
+            [" -> ".join(reversed(item.split(" -> "))) for item in forward],
+        )
+
+    def test_dtype_cast_endpoints_swap_between_directions(self):
+        # Both directions look the rule up by the *model*-side name, so one key
+        # template drives both and only the endpoint order differs. Getting the
+        # order wrong silently casts the wrong way, so pin the literal suffix.
+        model = _NestedModel()
+        ctx = _context(
+            checkpoint_name_prefix="hf",
+            dtype_rules={
+                "stem.weight": {
+                    "checkpoint_dtype": "float32",
+                    "model_dtype": "bfloat16",
+                }
+            },
+        )
+
+        self.assertEqual(
+            model.gen_aoa_statements(ctx),
+            [
+                "hf.stem.weight -> model.stem.weight"
+                ", src_dtype='float32', dst_dtype='bfloat16'",
+                # Unmatched param: the rule must not leak onto it.
+                "hf.block.proj.weight -> model.block.proj.weight",
+            ],
+        )
+        self.assertEqual(
+            model.gen_inv_aoa_statements(ctx),
+            [
+                "model.stem.weight -> hf.stem.weight"
+                ", src_dtype='bfloat16', dst_dtype='float32'",
+                "model.block.proj.weight -> hf.block.proj.weight",
+            ],
+        )
+
+    def test_dtype_cast_defeats_the_same_name_skip(self):
+        # A cast is a real transform, so it must keep an otherwise identity
+        # statement alive -- the ``cast`` half of ``should_skip``, reached
+        # through the recursion rather than called directly. ``block.proj``
+        # carries no rule and is still omitted.
+        model = _NestedModel()
+        ctx = _context(
+            checkpoint_name_prefix="model",
+            dtype_rules={
+                "stem.weight": {
+                    "checkpoint_dtype": "float32",
+                    "model_dtype": "bfloat16",
+                }
+            },
+        )
+
+        self.assertEqual(
+            model.gen_aoa_statements(ctx),
+            [
+                "model.stem.weight -> model.stem.weight"
+                ", src_dtype='float32', dst_dtype='bfloat16'"
+            ],
+        )
+        self.assertEqual(
+            model.gen_inv_aoa_statements(ctx),
+            [
+                "model.stem.weight -> model.stem.weight"
+                ", src_dtype='bfloat16', dst_dtype='float32'"
+            ],
+        )
+
+    def test_equal_dtype_endpoints_emit_no_cast(self):
+        # A rule whose endpoints agree is a no-op, not a transform: the suffix
+        # is empty in both directions, so the identity skip applies again.
+        model = _NestedModel()
+        ctx = _context(
+            checkpoint_name_prefix="model",
+            dtype_rules={
+                "stem.weight": {
+                    "checkpoint_dtype": "bfloat16",
+                    "model_dtype": "bfloat16",
+                }
+            },
+        )
+
+        self.assertEqual(model.gen_aoa_statements(ctx), [])
+        self.assertEqual(model.gen_inv_aoa_statements(ctx), [])
+
+    def test_ambiguous_dtype_cast_rule_raises(self):
+        # A literal template and a placeholder template can both match the same
+        # name. Picking either silently would make the emitted cast depend on
+        # dict order, so the lookup refuses instead.
+        model = paddle.nn.Layer()
+        model.layers = paddle.nn.LayerList([_Leaf()])
+        ctx = _context(
+            checkpoint_name_prefix="hf",
+            dtype_rules={
+                "layers.$LAYER_ID.weight": {
+                    "checkpoint_dtype": "float32",
+                    "model_dtype": "bfloat16",
+                },
+                "layers.0.weight": {
+                    "checkpoint_dtype": "float32",
+                    "model_dtype": "float16",
+                },
+            },
+        )
+
+        for gen in (model.gen_aoa_statements, model.gen_inv_aoa_statements):
+            with self.assertRaisesRegex(
+                ValueError, "ambiguous dtype cast rule for 'layers.0.weight'"
+            ):
+                gen(ctx, structured_name_prefix="model.")
+
+    def test_dtype_cast_rule_missing_an_endpoint_raises(self):
+        # A half-declared rule cannot be formatted in either direction; failing
+        # at lookup names the offending template instead of raising a KeyError
+        # deep inside the formatter.
+        model = _NestedModel()
+        ctx = _context(
+            checkpoint_name_prefix="hf",
+            dtype_rules={"stem.weight": {"checkpoint_dtype": "float32"}},
+        )
+
+        for gen in (model.gen_aoa_statements, model.gen_inv_aoa_statements):
+            with self.assertRaisesRegex(
+                ValueError,
+                r"rule 'stem.weight' \(matched by 'stem.weight'\) is missing "
+                r"\['model_dtype'\]",
+            ):
+                gen(ctx)
+
+    def test_pp_mapping_uses_pre_mapping_structured_name(self):
+        model = paddle.nn.Layer()
+        model.block = _Leaf()
+        pp_mapping = _RecordingMapping(
+            {"pipe.block.weight": "model.layers.0.weight"}
+        )
+        ctx = _context(checkpoint_name_prefix="hf", pp_mapping=pp_mapping)
+
+        statements = model.gen_aoa_statements(
+            ctx, structured_name_prefix="pipe."
+        )
+
+        self.assertEqual(pp_mapping.queries, ["pipe.block.weight"])
+        self.assertEqual(
+            statements, ["hf.layers.0.weight -> model.layers.0.weight"]
+        )
+
+    def test_persistable_buffer_is_emitted_but_transient_is_skipped(self):
+        model = paddle.nn.Layer()
+        model.leaf = _LeafWithBuffer()
+        ctx = _context(checkpoint_name_prefix="hf")
+
+        forward = model.gen_aoa_statements(ctx, structured_name_prefix="model.")
+        targets = [statement.split(" -> ")[1] for statement in forward]
+
+        # Persistable buffer participates like a parameter; non-persistable is
+        # absent, mirroring ``sharded_state_dict`` / ``state_dict`` semantics.
+        self.assertIn("model.leaf.weight", targets)
+        self.assertIn("model.leaf.running_stat", targets)
+        self.assertNotIn("model.leaf.tmp_cache", targets)
+        self.assertEqual(
+            set(forward),
+            set(model.gen_aoa_statements(ctx, structured_name_prefix="model.")),
+        )
+
+    def test_recursion_dispatches_to_overridden_sublayer(self):
+        model = paddle.nn.Layer()
+        model.plain = _Leaf()
+        model.special = _OverridingLeaf()
+        ctx = _context(checkpoint_name_prefix="hf")
+
+        forward = model.gen_aoa_statements(ctx, structured_name_prefix="model.")
+        inverse = model.gen_inv_aoa_statements(
+            ctx, structured_name_prefix="model."
+        )
+
+        # Plain leaf follows the default recursion; the overriding sublayer is
+        # dispatched virtually and contributes only its custom sentinel, with
+        # the structured-name prefix threaded through unchanged.
+        self.assertIn("hf.plain.weight -> model.plain.weight", forward)
+        self.assertIn("__custom_fwd__::model.special.", forward)
+        self.assertIn("__custom_inv__::model.special.", inverse)
+        self.assertTrue(
+            all("special.weight" not in statement for statement in forward)
+        )
+
+    def test_ctx_maps_thread_through_recursion(self):
+        # Every leaf must resolve against the *same* ctx maps; a RecordingMapping
+        # confirms the nested structured names are the exact keys queried.
+        model = paddle.nn.Layer()
+        model.a = _Leaf()
+        model.b = paddle.nn.Layer()
+        model.b.c = _Leaf()
+        pp_mapping = _RecordingMapping(
+            {
+                "a.weight": "model.a.weight",
+                "b.c.weight": "model.b.c.weight",
+            }
+        )
+        ctx = _context(checkpoint_name_prefix="hf", pp_mapping=pp_mapping)
+
+        forward = model.gen_aoa_statements(ctx)
+
+        self.assertEqual(sorted(pp_mapping.queries), ["a.weight", "b.c.weight"])
+        self.assertEqual(
+            forward,
+            [
+                "hf.a.weight -> model.a.weight",
+                "hf.b.c.weight -> model.b.c.weight",
+            ],
+        )
+
+    def test_aoa_name_scope_reroots_mtp_subtree_during_recursion(self):
+        # An MTP subtree whose logical root differs from its actual module
+        # root. The scope re-roots the checkpoint-relative path so the emitted
+        # checkpoint name follows the logical (mtp) layout, independent of the
+        # live module path used on the model side.
+        name_mapping = {
+            "weight": "weight",
+        }
+        model = paddle.nn.Layer()
+        model.mtp = paddle.nn.Layer()
+        model.mtp.block = _Leaf()
+        scope = AOANameScope(
+            checkpoint_prefix="mtp.0",
+            logical_model_prefix="model.layers.1",
+            actual_model_prefix="model.mtp.block",
+        )
+        ctx = _context(checkpoint_name_prefix="hf", name_mapping=name_mapping)
+
+        forward = model.mtp.block.gen_aoa_statements(
+            ctx,
+            structured_name_prefix="model.mtp.block.",
+            aoa_name_scope=scope,
+        )
+
+        self.assertEqual(len(forward), 1)
+        source, target = forward[0].split(" -> ")
+        # Checkpoint side is re-rooted under the logical mtp path; model side
+        # keeps the live module path.
+        self.assertTrue(source.startswith("hf.mtp.0"))
+        self.assertTrue(target.startswith("model.mtp.block"))
+
+    def test_aoa_name_scope_with_non_identity_mapping_threaded_from_root(self):
+        # Stronger scope test: start from a root model, use a non-identity
+        # checkpoint_name_mapping (leaf rename), and verify aoa_name_scope is
+        # correctly threaded through multi-level recursion.
+        name_mapping = {
+            "layers.$LAYER_ID.mlp.down_proj.weight": (
+                "layers.$LAYER_ID.ffn.w2.weight"
+            ),
+        }
+        model = paddle.nn.Layer()
+        model.mtp = paddle.nn.Layer()
+        model.mtp.mlp = paddle.nn.Layer()
+        model.mtp.mlp.down_proj = _Leaf()
+        scope = AOANameScope(
+            checkpoint_prefix="mtp.0",
+            logical_model_prefix="model.layers.1",
+            actual_model_prefix="model.mtp",
+        )
+        pp_mapping = {
+            "model.mtp.mlp.down_proj.weight": (
+                "model.mtp.mlp.down_proj.weight"
+            ),
+        }
+        ctx = _context(
+            checkpoint_name_prefix="hf",
+            pp_mapping=pp_mapping,
+            name_mapping=name_mapping,
+        )
+
+        # Start from root's child (mtp), threading aoa_name_scope down.
+        forward = model.mtp.gen_aoa_statements(
+            ctx,
+            structured_name_prefix="model.mtp.",
+            aoa_name_scope=scope,
+        )
+
+        self.assertEqual(len(forward), 1)
+        # Should map through layers.1.mlp.down_proj.weight -> layers.1.ffn.w2.weight,
+        # then strip layers.1 and re-anchor under mtp.0.
+        self.assertEqual(
+            forward[0],
+            "hf.mtp.0.ffn.w2.weight -> model.mtp.mlp.down_proj.weight",
+        )
+
+        # Inverse should produce the reversed pair.
+        inverse = model.mtp.gen_inv_aoa_statements(
+            ctx,
+            structured_name_prefix="model.mtp.",
+            aoa_name_scope=scope,
+        )
+        self.assertEqual(
+            inverse[0],
+            "model.mtp.mlp.down_proj.weight -> hf.mtp.0.ffn.w2.weight",
+        )
+
+    def test_custom_model_name_prefix_resolves_correctly(self):
+        # Simulates a multi-tower model (e.g. Qwen3-VL) where the model root
+        # is "model.language_model" instead of the default "model".
+        model = paddle.nn.Layer()
+        model.language_model = paddle.nn.Layer()
+        model.language_model.layers = paddle.nn.Layer()
+        model.language_model.layers.proj = _Leaf()
+        pp_mapping = {
+            "model.language_model.layers.proj.weight": (
+                "model.language_model.layers.proj.weight"
+            ),
+        }
+        # A leaf mapping that renames "proj.weight" -> "linear.weight"
+        name_mapping = {
+            "layers.proj.weight": "layers.linear.weight",
+        }
+        ctx = _context(
+            checkpoint_name_prefix="hf",
+            pp_mapping=pp_mapping,
+            name_mapping=name_mapping,
+            model_name_prefix="model.language_model",
+        )
+
+        forward = model.gen_aoa_statements(ctx, structured_name_prefix="model.")
+        self.assertEqual(len(forward), 1)
+        # single_name = "model.language_model.layers.proj.weight"
+        # strip "model.language_model" -> "layers.proj.weight"
+        # match mapping -> "layers.linear.weight"
+        # checkpoint = "hf.layers.linear.weight"
+        self.assertEqual(
+            forward[0],
+            "hf.layers.linear.weight"
+            " -> model.language_model.layers.proj.weight",
+        )
+
+    def test_custom_model_name_prefix_identity_fallback(self):
+        # Without pp_mapping, the identity fallback must accept
+        # structured names starting with "model.language_model".
+        model = paddle.nn.Layer()
+        model.language_model = paddle.nn.Layer()
+        model.language_model.fc = _Leaf()
+        ctx = _context(
+            checkpoint_name_prefix="hf",
+            model_name_prefix="model.language_model",
+        )
+
+        forward = model.gen_aoa_statements(ctx, structured_name_prefix="model.")
+        self.assertEqual(len(forward), 1)
+        # Identity: strip "model.language_model" -> "fc.weight"
+        # No mapping -> "fc.weight" (identity)
+        # checkpoint = "hf.fc.weight"
+        self.assertEqual(
+            forward[0],
+            "hf.fc.weight -> model.language_model.fc.weight",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
New features

### Description
在 Paddle 侧落地「模块化 AOA」的基础能力——把语句生成下沉到 Layer，由模块树递归产出，具体模型只需在拥有特殊 checkpoint 布局的组件上覆写。
devPR:https://github.com/PaddlePaddle/Paddle/pull/79723

### 是否引起精度变化
否