### PR TITLE
[Cherry-Pick][Performance] Partition Muon 2D params per dtype to restore comm fusion

### DIFF
--- a/ci/h-test.sh
+++ b/ci/h-test.sh
@@ -166,7 +166,8 @@ concurrency_list="^test_fp8_deep_gemm$|\
 ^test_compat_scaled_dot_product_attention$|\
 ^test_flash_attention$|\
 ^test_batched_gemm$|\
-^test_parallel_dygraph_muon$"
+^test_parallel_dygraph_muon$|\
+^test_muon_sharding_mixed_dtype_partition$"
 
 cd ${work_dir}/build
 tmp_dir=$(mktemp -d)

--- a/python/paddle/distributed/fleet/meta_optimizers/muon_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/muon_sharding_optimizer.py
@@ -665,9 +665,11 @@ class MuonShardingOptimizer:
         for p in params:
             params_by_dtype[p.dtype].append(p)
 
-        # Sorted so that every rank walks the dtypes in the same order and
-        # derives an identical mapping, otherwise the reduce dst and the
-        # broadcast src would disagree across ranks.
+        # Sorted so the result is fully determined by the input list rather than
+        # by the order the dtypes happen to appear in it. Owner assignment does
+        # not depend on this -- every dtype packs from rank 0 independently --
+        # but the order of each rank's param list does, and that order is what
+        # ``_local_2d`` is built from.
         for dtype in sorted(params_by_dtype, key=str):
             parameters = params_by_dtype[dtype]
             parameters.sort(

--- a/python/paddle/distributed/fleet/meta_optimizers/muon_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/muon_sharding_optimizer.py
@@ -643,42 +643,64 @@ class MuonShardingOptimizer:
         return [b for b in buffers if cls._buffer_color(b) in shared_colors]
 
     def _partition_2d_parameters(self, params, world_size, label=""):
-        """Partition 2D parameters among ranks using greedy bin-packing.
+        """Partition 2D parameters among ranks, bin-packing each dtype apart.
 
-        Only assign parameters to the first n ranks such that total size > comm_buffer_size_MB.
-        Remaining ranks get no parameters.
+        A FusedCommBuffer never mixes dtypes, since ``AssignGroupBySize`` keys
+        its groups on dtype. Bin-packing all dtypes together therefore sizes
+        ``active_ranks`` from the total of the whole color group, and a dtype
+        that only holds a small share of the parameters gets spread over far
+        more ranks than its own volume needs. Each of those ranks then builds a
+        tiny buffer of that dtype instead of one fused buffer. Running the same
+        greedy packing once per dtype keeps every dtype on as few ranks as it
+        actually needs.
+
+        Within a dtype, only the first n ranks are assigned parameters such that
+        total size > comm_buffer_size_MB. Remaining ranks get no parameters.
         """
         mapping = {}
         for rank in range(world_size):
             mapping[rank] = []
 
-        parameters = list(params)
-        parameters.sort(
-            key=lambda p: functools_reduce(lambda x, y: x * y, p.shape),
-            reverse=True,
-        )
+        params_by_dtype = defaultdict(list)
+        for p in params:
+            params_by_dtype[p.dtype].append(p)
 
-        total_numel = sum(
-            functools_reduce(lambda x, y: x * y, p.shape, 1) for p in parameters
-        )
-        total_size_bytes = total_numel * 4
-        total_size_mb = total_size_bytes / (1024**2)
+        # Sorted so that every rank walks the dtypes in the same order and
+        # derives an identical mapping, otherwise the reduce dst and the
+        # broadcast src would disagree across ranks.
+        for dtype in sorted(params_by_dtype, key=str):
+            parameters = params_by_dtype[dtype]
+            parameters.sort(
+                key=lambda p: functools_reduce(lambda x, y: x * y, p.shape),
+                reverse=True,
+            )
 
-        buffer_size_mb = (
-            self.comm_buffer_size_MB if self.comm_buffer_size_MB > 0 else 256
-        )
-        min_active_ranks = 1
-        if total_size_mb > 0:
-            min_active_ranks = max(1, int(total_size_mb / buffer_size_mb) + 1)
+            total_numel = sum(
+                functools_reduce(lambda x, y: x * y, p.shape, 1)
+                for p in parameters
+            )
+            total_size_bytes = total_numel * 4
+            total_size_mb = total_size_bytes / (1024**2)
 
-        active_ranks = min(min_active_ranks, world_size)
-        sizes = [0] * active_ranks
+            buffer_size_mb = (
+                self.comm_buffer_size_MB
+                if self.comm_buffer_size_MB > 0
+                else 256
+            )
+            min_active_ranks = 1
+            if total_size_mb > 0:
+                min_active_ranks = max(
+                    1, int(total_size_mb / buffer_size_mb) + 1
+                )
 
-        for param in parameters:
-            rank = sizes.index(min(sizes))
-            mapping[rank].append(param)
-            numel = functools_reduce(lambda x, y: x * y, param.shape, 1)
-            sizes[rank] += numel
+            active_ranks = min(min_active_ranks, world_size)
+            sizes = [0] * active_ranks
+
+            for param in parameters:
+                rank = sizes.index(min(sizes))
+                mapping[rank].append(param)
+                numel = functools_reduce(lambda x, y: x * y, param.shape, 1)
+                sizes[rank] += numel
 
         return mapping
 

--- a/test/collective/fleet/CMakeLists.txt
+++ b/test/collective/fleet/CMakeLists.txt
@@ -980,6 +980,23 @@ endif()
 if(WITH_NCCL)
   if((WITH_GPU) AND LOCAL_ALL_PLAT)
     bash_test_modules(
+      test_muon_sharding_mixed_dtype_partition
+      START_BASH
+      ../../legacy_test/dist_test.sh
+      TIMEOUT
+      "400"
+      LABELS
+      "RUN_TYPE=DIST"
+      ENVS
+      "PADDLE_DIST_UT_PORT=22352;http_proxy=;https_proxy=;PYTHONPATH=../..:${PADDLE_BINARY_DIR}/python"
+    )
+    set_tests_properties(test_muon_sharding_mixed_dtype_partition
+                         PROPERTIES TIMEOUT "400")
+  endif()
+endif()
+if(WITH_NCCL)
+  if((WITH_GPU) AND LOCAL_ALL_PLAT)
+    bash_test_modules(
       test_parallel_dygraph_muon
       START_BASH
       ../../legacy_test/dist_test.sh

--- a/test/collective/fleet/hybrid_parallel_sharding_muon_mixed_dtype_model.py
+++ b/test/collective/fleet/hybrid_parallel_sharding_muon_mixed_dtype_model.py
@@ -1,0 +1,333 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Real single-machine 2-card Muon test for per-dtype 2D owner partitioning in
+# MuonShardingOptimizer._partition_2d_parameters.
+#
+# A FusedCommBuffer never mixes dtypes, because AssignGroupBySize keys its
+# groups on dtype. The partitioner therefore bin-packs each dtype separately:
+# packing the whole color group at once sizes active_ranks from the group total,
+# which scatters a dtype that holds only a small share of the parameters over
+# far more ranks than its own volume needs, leaving one tiny buffer per rank.
+#
+# The model below puts bf16 and fp32 2D params in the same (default) color
+# group and picks a bucket size that makes the two strategies disagree, then
+# asserts:
+#   1. every rank derives the same owner mapping (if they disagreed, the reduce
+#      dst and the broadcast src would not match and the job would hang),
+#   2. bf16 spreads over both ranks while fp32 concentrates on rank 0,
+#   3. the fp32 params end up in a single FusedCommBuffer,
+#   4. after real optimizer steps all ranks hold bit-identical parameters.
+#
+# Assertions 1-3 are guarded by an explicit regime check, so the case cannot
+# silently degenerate into the trivial "everything on rank 0" partition that a
+# small model with the default 256 MB bucket would produce.
+
+import os
+import random
+import unittest
+from collections import defaultdict
+
+import numpy as np
+
+import paddle
+from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_optimizers.muon_sharding_optimizer import (
+    MuonShardingOptimizer,
+)
+from paddle.distributed.fleet.utils import mix_precision_utils
+from paddle.optimizer.muon import MuonParamInfo, _default_should_use_muon
+
+os.environ["MUON_DEBUG"] = "0"
+
+SHARDING_DEGREE = 2
+
+# comm_buffer_size_MB is an int32 in distributed_strategy.proto, so 1 MB is the
+# smallest usable bucket. The shapes are chosen relative to it, using the same
+# `numel * 4` volume estimate the partitioner applies to every dtype:
+#   bf16: 4 x [512, 512] -> 4 x 1.0  MB = 4.0 MB -> min(int(4.0/1)+1, 2) = 2 ranks
+#   fp32: 2 x [256, 256] -> 2 x 0.25 MB = 0.5 MB -> min(int(0.5/1)+1, 2) = 1 rank
+# Packing all six together instead -- what the code did before per-dtype
+# partitioning -- gives active_ranks = 2 for the whole group, and the greedy
+# fill then lands one fp32 param on each rank, i.e. two one-param fp32 buffers.
+COMM_BUFFER_SIZE_MB = 1
+BF16_DIM = 512
+N_BF16_LAYERS = 4
+FP32_DIM = 256
+N_FP32_LAYERS = 2
+
+BATCH_SIZE = 16  # divisible by SHARDING_DEGREE
+STEPS = 3
+
+EXPECTED_BF16_OWNERS = {0, 1}
+EXPECTED_FP32_OWNERS = {0}
+
+
+def _linear(dim, np_weight):
+    return paddle.nn.Linear(
+        dim,
+        dim,
+        bias_attr=False,
+        weight_attr=paddle.framework.ParamAttr(
+            initializer=paddle.nn.initializer.Assign(np_weight)
+        ),
+    )
+
+
+class MixedDtypeNet(paddle.nn.Layer):
+    """Two branches whose 2D weights deliberately end up in different dtypes.
+
+    ``bf16_layers`` is cast by ``amp.decorate(level='O2')``; ``fp32_layers`` is
+    passed through ``excluded_layers`` and keeps float32 weights. Both live in
+    the same (default) color group, which is the configuration that made the old
+    whole-group bin-packing scatter the minority dtype.
+
+    Each branch casts its own input explicitly rather than relying on
+    ``auto_cast``, so the parameter dtypes the partitioner sees are unambiguous.
+    """
+
+    def __init__(self, bf16_weights, fp32_weights):
+        super().__init__()
+        self.bf16_layers = paddle.nn.LayerList(
+            [_linear(BF16_DIM, w) for w in bf16_weights]
+        )
+        self.fp32_layers = paddle.nn.LayerList(
+            [_linear(FP32_DIM, w) for w in fp32_weights]
+        )
+
+    def forward(self, x):
+        h = x.astype("bfloat16")
+        for fc in self.bf16_layers:
+            h = fc(h)
+        g = x[:, :FP32_DIM]
+        for fc in self.fp32_layers:
+            g = fc(g)
+        return h.astype("float32").mean() + g.mean()
+
+
+def _init_weights():
+    """Initial weights, identical on every rank."""
+    return (
+        [
+            np.random.random_sample((BF16_DIM, BF16_DIM)).astype("float32")
+            for _ in range(N_BF16_LAYERS)
+        ],
+        [
+            np.random.random_sample((FP32_DIM, FP32_DIM)).astype("float32")
+            for _ in range(N_FP32_LAYERS)
+        ],
+    )
+
+
+def _build_model(weights):
+    model = MixedDtypeNet(*weights)
+    model = mix_precision_utils.MixPrecisionLayer(model, dtype="bfloat16")
+    paddle.amp.decorate(
+        models=model,
+        level="O2",
+        dtype="bfloat16",
+        excluded_layers=[model._layers.fp32_layers],
+    )
+    return model
+
+
+def _build_optimizer(model):
+    muon_param_info_map = {}
+    for name, param in model.named_parameters():
+        muon_param_info_map[param.name] = MuonParamInfo(
+            use_muon=_default_should_use_muon(name, param.shape, []),
+            split_concat_func=None,
+        )
+    return paddle.optimizer.Muon(
+        parameters=model.parameters(),
+        learning_rate=0.001,
+        weight_decay=0.00001,
+        muon_param_info_map=muon_param_info_map,
+        ns_steps=5,
+        ns_coeff_type="simple",
+        multi_precision=True,
+    )
+
+
+def _short_dtype(dtype):
+    return str(dtype).split(".")[-1]
+
+
+class TestMuonMixedDtypePartition(unittest.TestCase):
+    def setUp(self):
+        random.seed(2024)
+        np.random.seed(2024)
+        paddle.seed(2024)
+
+        strategy = fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "sharding_degree": SHARDING_DEGREE,
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 1,
+        }
+        strategy.use_muon_sharding = True
+        sharding_configs = strategy.hybrid_configs["sharding_configs"]
+        sharding_configs.accumulate_steps = 1
+        sharding_configs.comm_buffer_size_MB = COMM_BUFFER_SIZE_MB
+
+        fleet.init(is_collective=True, strategy=strategy)
+
+        # Identical full dataset on every rank; each rank slices its own shard.
+        self.data = [
+            np.random.random_sample((BATCH_SIZE, BF16_DIM)).astype("float32")
+            for _ in range(STEPS)
+        ]
+
+    @staticmethod
+    def _owner_map(inner_opt):
+        """{color -> {param name -> owner rank}}, as every rank computed it."""
+        return {
+            str(color): dict(name2rank)
+            for color, name2rank in inner_opt._param2rank_2d_by_color.items()
+        }
+
+    @staticmethod
+    def _dtype_map(inner_opt):
+        return {
+            p.name: _short_dtype(p.dtype)
+            for params in inner_opt._params_2d_by_color.values()
+            for p in params
+        }
+
+    def _owners_by_dtype(self, owner_map, dtype_map):
+        owners = defaultdict(set)
+        for name2rank in owner_map.values():
+            for name, rank in name2rank.items():
+                owners[dtype_map[name]].add(rank)
+        return owners
+
+    def _train(self, model, optimizer):
+        hcg = fleet.get_hybrid_communicate_group()
+        sharding_rank = hcg.get_sharding_parallel_rank()
+        local_bs = BATCH_SIZE // SHARDING_DEGREE
+        for idx in range(STEPS):
+            start = sharding_rank * local_bs
+            batch = paddle.to_tensor(self.data[idx][start : start + local_bs])
+            loss = model(batch)
+            loss.backward()
+            optimizer.step()
+            optimizer.clear_grad()
+
+    def test_mixed_dtype_partition(self):
+        model = _build_model(_init_weights())
+        optimizer = _build_optimizer(model)
+        optimizer = mix_precision_utils.MixPrecisionOptimizer(optimizer)
+
+        model = fleet.distributed_model(model)
+        optimizer = fleet.distributed_optimizer(optimizer)
+
+        inner_opt = optimizer._inner_opt
+        self.assertIsInstance(inner_opt, MuonShardingOptimizer)
+
+        owner_map = self._owner_map(inner_opt)
+        dtype_map = self._dtype_map(inner_opt)
+        owners = self._owners_by_dtype(owner_map, dtype_map)
+
+        # Regime guard: without this the assertions below could hold vacuously,
+        # which is what happens with the default 256 MB bucket and a small model
+        # (active_ranks collapses to 1 and every param lands on rank 0).
+        self.assertEqual(
+            set(owners),
+            {"bfloat16", "float32"},
+            msg=(
+                "the two dtypes were not both present among 2D params; "
+                f"got {dict(owners)} -- amp.decorate/excluded_layers did not "
+                "produce the intended mixed-dtype color group"
+            ),
+        )
+
+        # bf16 volume needs both ranks, fp32 volume needs only one. Under the
+        # previous whole-group packing fp32 would be spread over both ranks.
+        self.assertEqual(
+            owners["bfloat16"],
+            EXPECTED_BF16_OWNERS,
+            msg=(
+                "bf16 params should span both ranks, so the partition is not "
+                f"in the degenerate single-rank regime; got {owners['bfloat16']}"
+            ),
+        )
+        self.assertEqual(
+            owners["float32"],
+            EXPECTED_FP32_OWNERS,
+            msg=(
+                "fp32 params should concentrate on a single rank sized by their "
+                f"own volume; got {owners['float32']}"
+            ),
+        )
+
+        # Every rank builds this mapping independently. If they disagreed, the
+        # dst of the gradient reduce and the src of the parameter broadcast
+        # would not line up and the job would hang instead of failing.
+        gathered_maps = []
+        paddle.distributed.all_gather_object(gathered_maps, owner_map)
+        for rank, other in enumerate(gathered_maps):
+            self.assertEqual(
+                other,
+                gathered_maps[0],
+                msg=(
+                    f"rank {rank} derived a different 2D owner mapping than "
+                    "rank 0; ranks must agree or collectives will mismatch"
+                ),
+            )
+
+        # The point of per-dtype packing: the minority dtype fuses into one
+        # buffer instead of one small buffer per rank it was scattered over.
+        buffers_per_dtype = defaultdict(int)
+        for buf in inner_opt.comm_buffer_2d:
+            buffers_per_dtype[_short_dtype(buf._params[0].dtype)] += 1
+        self.assertEqual(
+            buffers_per_dtype["float32"],
+            1,
+            msg=(
+                "expected the fp32 2D params to fuse into a single comm "
+                f"buffer; got {dict(buffers_per_dtype)}"
+            ),
+        )
+
+        self._train(model, optimizer)
+
+        # 2D params are updated by their owner and broadcast back, so after the
+        # steps above every rank must hold bit-identical values.
+        for name, param in model.named_parameters():
+            gathered = []
+            paddle.distributed.all_gather(gathered, param.cast("float32"))
+            reference = gathered[0].numpy()
+            for rank, other in enumerate(gathered):
+                np.testing.assert_array_equal(
+                    other.numpy(),
+                    reference,
+                    err_msg=(
+                        f"param {name!r} differs between rank {rank} and rank "
+                        "0 after the optimizer steps; owner update and "
+                        "broadcast are inconsistent"
+                    ),
+                )
+
+        if paddle.distributed.get_rank() == 0:
+            print(
+                "[PASS] per-dtype 2D partition: "
+                f"bf16 owners={sorted(owners['bfloat16'])}, "
+                f"fp32 owners={sorted(owners['float32'])}, "
+                f"buffers per dtype={dict(buffers_per_dtype)}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/hybrid_parallel_sharding_muon_mixed_dtype_model.py
+++ b/test/collective/fleet/hybrid_parallel_sharding_muon_mixed_dtype_model.py
@@ -130,14 +130,25 @@ class MixedDtypeNet(paddle.nn.Layer):
 
 
 def _init_weights():
-    """Initial weights, identical on every rank."""
+    """Initial weights, identical on every rank.
+
+    Scaled by 1/sqrt(dim) so each layer roughly preserves the activation scale.
+    Unscaled U[0, 1) weights grow the activations by ~dim/2 per layer, which
+    reaches inf by the third of four 512-wide layers in float16 -- and the
+    resulting nan parameters would compare equal on every rank, so the
+    cross-rank check at the end would pass without meaning anything.
+    """
     return (
         [
-            np.random.random_sample((LOW_DIM, LOW_DIM)).astype("float32")
+            (np.random.randn(LOW_DIM, LOW_DIM) / np.sqrt(LOW_DIM)).astype(
+                "float32"
+            )
             for _ in range(N_LOW_LAYERS)
         ],
         [
-            np.random.random_sample((FP32_DIM, FP32_DIM)).astype("float32")
+            (np.random.randn(FP32_DIM, FP32_DIM) / np.sqrt(FP32_DIM)).astype(
+                "float32"
+            )
             for _ in range(N_FP32_LAYERS)
         ],
     )
@@ -250,6 +261,14 @@ class TestMuonMixedDtypePartition(unittest.TestCase):
             start = sharding_rank * local_bs
             batch = paddle.to_tensor(self.data[idx][start : start + local_bs])
             loss = model(batch)
+            # The forward must stay in range, especially in float16: an
+            # overflowed loss produces nan parameters, and nan compares equal to
+            # nan on every rank, which would make the cross-rank check below
+            # pass without testing anything.
+            self.assertTrue(
+                np.isfinite(float(loss)),
+                msg=f"step {idx} loss is {float(loss)}, not finite",
+            )
             loss.backward()
             optimizer.step()
             optimizer.clear_grad()
@@ -341,6 +360,14 @@ class TestMuonMixedDtypePartition(unittest.TestCase):
             gathered = []
             paddle.distributed.all_gather(gathered, param.cast("float32"))
             reference = gathered[0].numpy()
+            self.assertTrue(
+                np.isfinite(reference).all(),
+                msg=(
+                    f"param {name!r} is not finite after the optimizer steps; "
+                    "nan/inf compares equal across ranks and would make the "
+                    "comparison below vacuous"
+                ),
+            )
             for rank, other in enumerate(gathered):
                 np.testing.assert_array_equal(
                     other.numpy(),

--- a/test/collective/fleet/hybrid_parallel_sharding_muon_mixed_dtype_model.py
+++ b/test/collective/fleet/hybrid_parallel_sharding_muon_mixed_dtype_model.py
@@ -21,18 +21,26 @@
 # which scatters a dtype that holds only a small share of the parameters over
 # far more ranks than its own volume needs, leaving one tiny buffer per rank.
 #
-# The model below puts bf16 and fp32 2D params in the same (default) color
-# group and picks a bucket size that makes the two strategies disagree, then
-# asserts:
+# The model below puts a low-precision dtype and fp32 2D params in the same
+# (default) color group and picks a bucket size that makes the two strategies
+# disagree, then asserts:
 #   1. every rank derives the same owner mapping (if they disagreed, the reduce
 #      dst and the broadcast src would not match and the job would hang),
-#   2. bf16 spreads over both ranks while fp32 concentrates on rank 0,
+#   2. the low-precision params spread over both ranks while fp32 concentrates
+#      on rank 0,
 #   3. the fp32 params end up in a single FusedCommBuffer,
 #   4. after real optimizer steps all ranks hold bit-identical parameters.
 #
 # Assertions 1-3 are guarded by an explicit regime check, so the case cannot
 # silently degenerate into the trivial "everything on rank 0" partition that a
 # small model with the default 256 MB bucket would produce.
+#
+# The low-precision dtype is whichever of bf16/fp16 the device actually has.
+# ``amp.decorate`` returns without casting anything when it does not (auto_cast
+# gates bf16 on Compute Capability >= 8 and fp16 on >= 7) and says nothing about
+# it, so the candidates are applied and the parameter dtype read back rather
+# than predicted. This matters: CI runs these distributed cases on V100
+# (CC 7.0), where bf16 is unavailable and fp16 is.
 
 import os
 import random
@@ -55,22 +63,26 @@ SHARDING_DEGREE = 2
 
 # comm_buffer_size_MB is an int32 in distributed_strategy.proto, so 1 MB is the
 # smallest usable bucket. The shapes are chosen relative to it, using the same
-# `numel * 4` volume estimate the partitioner applies to every dtype:
-#   bf16: 4 x [512, 512] -> 4 x 1.0  MB = 4.0 MB -> min(int(4.0/1)+1, 2) = 2 ranks
+# `numel * 4` volume estimate the partitioner applies to every dtype, so they
+# hold whether the low-precision branch ends up bf16 or fp16:
+#   low : 4 x [512, 512] -> 4 x 1.0  MB = 4.0 MB -> min(int(4.0/1)+1, 2) = 2 ranks
 #   fp32: 2 x [256, 256] -> 2 x 0.25 MB = 0.5 MB -> min(int(0.5/1)+1, 2) = 1 rank
 # Packing all six together instead -- what the code did before per-dtype
 # partitioning -- gives active_ranks = 2 for the whole group, and the greedy
 # fill then lands one fp32 param on each rank, i.e. two one-param fp32 buffers.
 COMM_BUFFER_SIZE_MB = 1
-BF16_DIM = 512
-N_BF16_LAYERS = 4
+LOW_DIM = 512
+N_LOW_LAYERS = 4
 FP32_DIM = 256
 N_FP32_LAYERS = 2
 
 BATCH_SIZE = 16  # divisible by SHARDING_DEGREE
 STEPS = 3
 
-EXPECTED_BF16_OWNERS = {0, 1}
+# Most capable first; the first one the device accepts is used.
+LOW_DTYPE_CANDIDATES = ("bfloat16", "float16")
+
+EXPECTED_LOW_OWNERS = {0, 1}
 EXPECTED_FP32_OWNERS = {0}
 
 
@@ -88,27 +100,28 @@ def _linear(dim, np_weight):
 class MixedDtypeNet(paddle.nn.Layer):
     """Two branches whose 2D weights deliberately end up in different dtypes.
 
-    ``bf16_layers`` is cast by ``amp.decorate(level='O2')``; ``fp32_layers`` is
+    ``low_layers`` is cast by ``amp.decorate(level='O2')``; ``fp32_layers`` is
     passed through ``excluded_layers`` and keeps float32 weights. Both live in
     the same (default) color group, which is the configuration that made the old
     whole-group bin-packing scatter the minority dtype.
 
-    Each branch casts its own input explicitly rather than relying on
-    ``auto_cast``, so the parameter dtypes the partitioner sees are unambiguous.
+    Each branch casts its own input to whatever dtype its weights actually have,
+    rather than relying on ``auto_cast``, so the parameter dtypes the
+    partitioner sees are unambiguous and the forward works on either dtype.
     """
 
-    def __init__(self, bf16_weights, fp32_weights):
+    def __init__(self, low_weights, fp32_weights):
         super().__init__()
-        self.bf16_layers = paddle.nn.LayerList(
-            [_linear(BF16_DIM, w) for w in bf16_weights]
+        self.low_layers = paddle.nn.LayerList(
+            [_linear(LOW_DIM, w) for w in low_weights]
         )
         self.fp32_layers = paddle.nn.LayerList(
             [_linear(FP32_DIM, w) for w in fp32_weights]
         )
 
     def forward(self, x):
-        h = x.astype("bfloat16")
-        for fc in self.bf16_layers:
+        h = x.astype(self.low_layers[0].weight.dtype)
+        for fc in self.low_layers:
             h = fc(h)
         g = x[:, :FP32_DIM]
         for fc in self.fp32_layers:
@@ -120,8 +133,8 @@ def _init_weights():
     """Initial weights, identical on every rank."""
     return (
         [
-            np.random.random_sample((BF16_DIM, BF16_DIM)).astype("float32")
-            for _ in range(N_BF16_LAYERS)
+            np.random.random_sample((LOW_DIM, LOW_DIM)).astype("float32")
+            for _ in range(N_LOW_LAYERS)
         ],
         [
             np.random.random_sample((FP32_DIM, FP32_DIM)).astype("float32")
@@ -130,16 +143,32 @@ def _init_weights():
     )
 
 
+def _short_dtype(dtype):
+    return str(dtype).split(".")[-1]
+
+
 def _build_model(weights):
+    """Build the net and cast its low-precision branch.
+
+    Returns the model and the dtype that was actually applied, which is read
+    back off a parameter because ``amp.decorate`` is a silent no-op on a device
+    that cannot do the requested dtype.
+    """
     model = MixedDtypeNet(*weights)
-    model = mix_precision_utils.MixPrecisionLayer(model, dtype="bfloat16")
-    paddle.amp.decorate(
-        models=model,
-        level="O2",
-        dtype="bfloat16",
-        excluded_layers=[model._layers.fp32_layers],
+    model = mix_precision_utils.MixPrecisionLayer(
+        model, dtype=LOW_DTYPE_CANDIDATES[0]
     )
-    return model
+    probe = model._layers.low_layers[0].weight
+    for dtype in LOW_DTYPE_CANDIDATES:
+        paddle.amp.decorate(
+            models=model,
+            level="O2",
+            dtype=dtype,
+            excluded_layers=[model._layers.fp32_layers],
+        )
+        if _short_dtype(probe.dtype) == dtype:
+            return model, dtype
+    return model, _short_dtype(probe.dtype)
 
 
 def _build_optimizer(model):
@@ -186,7 +215,7 @@ class TestMuonMixedDtypePartition(unittest.TestCase):
 
         # Identical full dataset on every rank; each rank slices its own shard.
         self.data = [
-            np.random.random_sample((BATCH_SIZE, BF16_DIM)).astype("float32")
+            np.random.random_sample((BATCH_SIZE, LOW_DIM)).astype("float32")
             for _ in range(STEPS)
         ]
 
@@ -226,7 +255,7 @@ class TestMuonMixedDtypePartition(unittest.TestCase):
             optimizer.clear_grad()
 
     def test_mixed_dtype_partition(self):
-        model = _build_model(_init_weights())
+        model, low_dtype = _build_model(_init_weights())
         optimizer = _build_optimizer(model)
         optimizer = mix_precision_utils.MixPrecisionOptimizer(optimizer)
 
@@ -242,25 +271,28 @@ class TestMuonMixedDtypePartition(unittest.TestCase):
 
         # Regime guard: without this the assertions below could hold vacuously,
         # which is what happens with the default 256 MB bucket and a small model
-        # (active_ranks collapses to 1 and every param lands on rank 0).
+        # (active_ranks collapses to 1 and every param lands on rank 0), or when
+        # amp.decorate silently declines to cast on an unsupported device.
         self.assertEqual(
             set(owners),
-            {"bfloat16", "float32"},
+            {low_dtype, "float32"},
             msg=(
                 "the two dtypes were not both present among 2D params; "
-                f"got {dict(owners)} -- amp.decorate/excluded_layers did not "
-                "produce the intended mixed-dtype color group"
+                f"got {dict(owners)} with low_dtype={low_dtype!r} -- neither "
+                f"{' nor '.join(LOW_DTYPE_CANDIDATES)} could be applied to the "
+                "low-precision branch on this device"
             ),
         )
 
-        # bf16 volume needs both ranks, fp32 volume needs only one. Under the
-        # previous whole-group packing fp32 would be spread over both ranks.
+        # The low-precision volume needs both ranks, the fp32 volume needs only
+        # one. Under the previous whole-group packing fp32 spanned both ranks.
         self.assertEqual(
-            owners["bfloat16"],
-            EXPECTED_BF16_OWNERS,
+            owners[low_dtype],
+            EXPECTED_LOW_OWNERS,
             msg=(
-                "bf16 params should span both ranks, so the partition is not "
-                f"in the degenerate single-rank regime; got {owners['bfloat16']}"
+                f"{low_dtype} params should span both ranks, so the partition "
+                "is not in the degenerate single-rank regime; got "
+                f"{owners[low_dtype]}"
             ),
         )
         self.assertEqual(
@@ -323,7 +355,7 @@ class TestMuonMixedDtypePartition(unittest.TestCase):
         if paddle.distributed.get_rank() == 0:
             print(
                 "[PASS] per-dtype 2D partition: "
-                f"bf16 owners={sorted(owners['bfloat16'])}, "
+                f"{low_dtype} owners={sorted(owners[low_dtype])}, "
                 f"fp32 owners={sorted(owners['float32'])}, "
                 f"buffers per dtype={dict(buffers_per_dtype)}"
             )

--- a/test/collective/fleet/hybrid_parallel_sharding_muon_mixed_dtype_model.py
+++ b/test/collective/fleet/hybrid_parallel_sharding_muon_mixed_dtype_model.py
@@ -200,10 +200,6 @@ def _build_optimizer(model):
     )
 
 
-def _short_dtype(dtype):
-    return str(dtype).split(".")[-1]
-
-
 class TestMuonMixedDtypePartition(unittest.TestCase):
     def setUp(self):
         random.seed(2024)

--- a/test/collective/fleet/test_muon_sharding_mixed_dtype_partition.py
+++ b/test/collective/fleet/test_muon_sharding_mixed_dtype_partition.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from legacy_test.test_parallel_dygraph_dataparallel import (
+    TestMultipleAccelerators,
+)
+
+
+class TestMuonShardingMixedDtypePartition(TestMultipleAccelerators):
+    def test_muon_sharding_mixed_dtype_partition(self):
+        """Per-dtype 2D owner partitioning under mixed BF16/FP32 params.
+
+        Test logic is in hybrid_parallel_sharding_muon_mixed_dtype_model.py:
+        it checks that all ranks derive the same owner mapping, that each dtype
+        only occupies as many ranks as its own volume needs, that the minority
+        dtype fuses into a single comm buffer, and that parameters stay
+        identical across ranks after real optimizer steps.
+        """
+        self.run_mnist_2accelerators(
+            'hybrid_parallel_sharding_muon_mixed_dtype_model.py'
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/collective/fleet/testslist.csv
+++ b/test/collective/fleet/testslist.csv
@@ -78,6 +78,7 @@ test_pp_dw_recompute_overlap,,GPU,800,DIST,../../legacy_test/dist_test.sh,4,,htt
 test_layer_spec,,,,,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_schedule_node,,,,,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_muon_sharding_no_hook_overlap,,GPU,400,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,WITH_NCCL
+test_muon_sharding_mixed_dtype_partition,,GPU,400,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,WITH_NCCL
 test_parallel_dygraph_muon,,GPU,400,DIST,../../legacy_test/dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,WITH_NCCL
 test_pipeline_parallel_micro_step_hooks,,,,,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=../..,
 test_pipeline_parallel_p2p_issued_hook,LINUX,GPU,500,HYBRID,test_runner.py,,,http_proxy=;https_proxy=;PYTHONPATH=../..,

--- a/test/legacy_test/test_muon_2d_partition.py
+++ b/test/legacy_test/test_muon_2d_partition.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-process tests for MuonShardingOptimizer._partition_2d_parameters.
+
+The method maps every 2D (Muon) parameter to an owner rank. It reads nothing
+but ``self.comm_buffer_size_MB`` and each parameter's ``shape``/``dtype``, so it
+can be exercised directly against stub parameters -- no communication groups, no
+accelerators, no launcher. The multi-process behaviour it feeds into is covered
+by test/collective/fleet/test_muon_sharding_mixed_dtype_partition.py.
+"""
+
+import unittest
+from functools import reduce
+
+from paddle.distributed.fleet.meta_optimizers.muon_sharding_optimizer import (
+    MuonShardingOptimizer,
+)
+
+WORLD_SIZES = (1, 2, 4, 8, 16, 32)
+BUFFER_SIZES_MB = (0, 1, 64, 128, 256, 512)
+
+
+class _StubParam:
+    def __init__(self, name, shape, dtype):
+        self.name = name
+        self.shape = shape
+        self.dtype = dtype
+
+
+class _StubPartitioner:
+    """Carries only the state ``_partition_2d_parameters`` actually reads."""
+
+    _partition_2d_parameters = MuonShardingOptimizer._partition_2d_parameters
+
+    def __init__(self, comm_buffer_size_MB):
+        self.comm_buffer_size_MB = comm_buffer_size_MB
+
+
+def _numel(param):
+    return reduce(lambda x, y: x * y, param.shape, 1)
+
+
+def _partition(params, world_size, comm_buffer_size_MB):
+    return _StubPartitioner(comm_buffer_size_MB)._partition_2d_parameters(
+        list(params), world_size
+    )
+
+
+def _active_ranks(volume_numel, world_size, comm_buffer_size_MB):
+    """The rank count the greedy fill is allowed to spread over."""
+    total_size_mb = volume_numel * 4 / (1024**2)
+    buffer_size_mb = comm_buffer_size_MB if comm_buffer_size_MB > 0 else 256
+    min_active_ranks = 1
+    if total_size_mb > 0:
+        min_active_ranks = max(1, int(total_size_mb / buffer_size_mb) + 1)
+    return min(min_active_ranks, world_size)
+
+
+def _partition_whole_group(params, world_size, comm_buffer_size_MB):
+    """The pre-change strategy: one bin-packing pass over all dtypes at once."""
+    mapping = {rank: [] for rank in range(world_size)}
+    parameters = sorted(params, key=_numel, reverse=True)
+    sizes = [0] * _active_ranks(
+        sum(_numel(p) for p in parameters), world_size, comm_buffer_size_MB
+    )
+    for param in parameters:
+        rank = sizes.index(min(sizes))
+        mapping[rank].append(param)
+        sizes[rank] += _numel(param)
+    return mapping
+
+
+def _owner_of(mapping):
+    return {p.name: rank for rank, plist in mapping.items() for p in plist}
+
+
+def _ranks_holding(mapping, dtype):
+    return {
+        rank
+        for rank, plist in mapping.items()
+        if any(p.dtype == dtype for p in plist)
+    }
+
+
+def _bf16(count, dim=512):
+    return [
+        _StubParam(f"bf16_{i}", [dim, dim], "bfloat16") for i in range(count)
+    ]
+
+
+def _fp32(count, dim=256):
+    return [
+        _StubParam(f"fp32_{i}", [dim, dim], "float32") for i in range(count)
+    ]
+
+
+PARAM_SETS = {
+    "empty": [],
+    "single": _bf16(1),
+    "bf16_only": _bf16(10),
+    "fp32_only": _fp32(8),
+    "mixed": _bf16(10) + _fp32(8),
+    "three_dtypes": _bf16(6)
+    + _fp32(4)
+    + [_StubParam(f"fp16_{i}", [128, 128], "float16") for i in range(3)],
+    "ragged": [
+        _StubParam(f"bf16_r{i}", [64 * (i + 1), 512], "bfloat16")
+        for i in range(7)
+    ]
+    + [
+        _StubParam(f"fp32_r{i}", [32 * (i + 1), 256], "float32")
+        for i in range(5)
+    ],
+}
+
+
+class TestPartition2DParameters(unittest.TestCase):
+    def test_every_param_owned_exactly_once(self):
+        for label, params in PARAM_SETS.items():
+            for world_size in WORLD_SIZES:
+                for buffer_mb in BUFFER_SIZES_MB:
+                    with self.subTest(
+                        params=label, world_size=world_size, buffer=buffer_mb
+                    ):
+                        mapping = _partition(params, world_size, buffer_mb)
+                        self.assertEqual(
+                            set(mapping),
+                            set(range(world_size)),
+                            "every rank must be present as a key, even if empty",
+                        )
+                        owners = _owner_of(mapping)
+                        self.assertEqual(
+                            sorted(owners),
+                            sorted(p.name for p in params),
+                            "params must be neither dropped nor duplicated",
+                        )
+
+    def test_single_dtype_matches_whole_group_packing(self):
+        """A single-dtype list must reproduce the pre-change mapping exactly."""
+        for label in ("empty", "single", "bf16_only", "fp32_only"):
+            params = PARAM_SETS[label]
+            for world_size in WORLD_SIZES:
+                for buffer_mb in BUFFER_SIZES_MB:
+                    with self.subTest(
+                        params=label, world_size=world_size, buffer=buffer_mb
+                    ):
+                        self.assertEqual(
+                            _owner_of(
+                                _partition(params, world_size, buffer_mb)
+                            ),
+                            _owner_of(
+                                _partition_whole_group(
+                                    params, world_size, buffer_mb
+                                )
+                            ),
+                        )
+
+    def test_rank_count_follows_own_dtype_volume(self):
+        """Each dtype spreads only as wide as its own volume requires."""
+        for label, params in PARAM_SETS.items():
+            dtypes = {p.dtype for p in params}
+            for world_size in WORLD_SIZES:
+                for buffer_mb in BUFFER_SIZES_MB:
+                    mapping = _partition(params, world_size, buffer_mb)
+                    for dtype in dtypes:
+                        own = [p for p in params if p.dtype == dtype]
+                        expected = min(
+                            _active_ranks(
+                                sum(_numel(p) for p in own),
+                                world_size,
+                                buffer_mb,
+                            ),
+                            len(own),
+                        )
+                        with self.subTest(
+                            params=label,
+                            world_size=world_size,
+                            buffer=buffer_mb,
+                            dtype=dtype,
+                        ):
+                            self.assertEqual(
+                                len(_ranks_holding(mapping, dtype)),
+                                expected,
+                            )
+
+    def test_minority_dtype_is_not_scattered(self):
+        """The regression this partitioning exists for.
+
+        A few fp32 params among many bf16 ones. When the bf16 volume alone needs
+        every rank, packing the whole group at once fills all ranks with bf16 and
+        then keeps going with the fp32 params, scattering them; each rank they
+        land on gets its own small fp32 comm buffer, because AssignGroupBySize
+        keys its groups on dtype. Per-dtype packing sizes the fp32 spread from
+        the fp32 volume alone.
+        """
+
+        def buffer_count(mapping):
+            # One FusedCommBuffer per (owner rank, dtype).
+            return sum(len({p.dtype for p in pl}) for pl in mapping.values())
+
+        # world_size, bf16 param count, fp32 param count, bucket MB
+        configs = ((2, 4, 2, 1), (4, 8, 2, 1), (8, 16, 3, 1))
+        for world_size, n_bf16, n_fp32, buffer_mb in configs:
+            params = _bf16(n_bf16) + _fp32(n_fp32)
+            with self.subTest(world_size=world_size, buffer=buffer_mb):
+                new = _partition(params, world_size, buffer_mb)
+                old = _partition_whole_group(params, world_size, buffer_mb)
+                self.assertLess(
+                    len(_ranks_holding(new, "float32")),
+                    len(_ranks_holding(old, "float32")),
+                    "per-dtype packing should concentrate the minority dtype",
+                )
+                self.assertLess(buffer_count(new), buffer_count(old))
+
+    def test_dtype_iteration_order_does_not_change_owners(self):
+        """Owner assignment must not depend on dtype discovery order.
+
+        Each dtype is packed from rank 0 with a fresh size vector, so the order
+        the dtypes are visited in cannot move a param to another rank. Feeding
+        the same params with the dtypes grouped in the opposite order (relative
+        order within each dtype preserved) must give the same owners.
+        """
+        bf16, fp32 = _bf16(5), _fp32(3)
+        for world_size in (2, 4, 8):
+            for buffer_mb in (1, 64, 256):
+                with self.subTest(world_size=world_size, buffer=buffer_mb):
+                    self.assertEqual(
+                        _owner_of(
+                            _partition(bf16 + fp32, world_size, buffer_mb)
+                        ),
+                        _owner_of(
+                            _partition(fp32 + bf16, world_size, buffer_mb)
+                        ),
+                    )
+
+    def test_input_list_is_not_reordered(self):
+        """The caller's list must survive the call unchanged."""
+        params = PARAM_SETS["mixed"]
+        before = [p.name for p in params]
+        _partition(params, 8, 1)
+        self.assertEqual([p.name for p in params], before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

Performance

### Description

devPR:https://github.com/PaddlePaddle/Paddle/pull/79740

本 PR 是 develop 分支 #79740 的 cherry-pick，请在 #79740 合入后再合本 PR，代码内容与 develop PR 完全一致（`git cherry-pick -x`）。

`MuonShardingOptimizer._partition_2d_parameters` assigns an owner rank to
every 2D (Muon) parameter by greedy bin-packing. It packs all parameters of a
color group together and derives `active_ranks` from the group's total volume,
without looking at dtype.

The buffers built from that mapping cannot mix dtypes: `_build_2d_comm_buffers`
buckets by owner rank and then calls `assign_group_by_size`, whose underlying
`AssignGroupBySize` (`paddle/fluid/distributed/collective/reducer.cc`) keys
`next_group` on dtype, because a `FusedCommBuffer` is a single flat buffer of
one dtype.

So when a dtype holds only a small share of the parameters — e.g. a handful of
fp32 parameters among bf16 ones — `active_ranks` is sized for the whole group
and the greedy packing scatters those few parameters across many ranks. Each of
those ranks then builds its own buffer holding one or two parameters of that
dtype. Fusion for the minority dtype effectively disappears and the reduce
degenerates into many small-payload calls; the fewer and more scattered the
minority-dtype parameters, the worse it gets.

This PR runs the same greedy packing once per dtype, so each dtype occupies only
as many ranks as its own volume requires and its parameters concentrate into one
(or few) properly sized buffers.

Notes on what is deliberately left unchanged:

- The bin-packing itself, the `total_numel * 4` byte estimate and the
  `int(total_size_mb / buffer_size_mb) + 1` rounding are kept exactly as before,
  so no unrelated behaviour is folded into this change. A single-dtype parameter
  list therefore reproduces the previous mapping exactly.
- dtypes are iterated in `sorted(..., key=str)` order so the result is fully
  determined by the input list rather than by the order the dtypes happen to
  appear in it. It does not affect owner assignment -- every dtype is packed
  from rank 0 with a fresh size vector, so dtype order cannot move a param to
  another rank -- but it does pin the order of each rank's param list, which is
  what `_local_2d` is built from. (An earlier revision of this description
  claimed the sort was what keeps the reduce `dst` and the broadcast `src`
  aligned across ranks; that was wrong.)
- Every dtype still starts filling from rank 0, so low-numbered ranks can hold
  several dtypes. Staggering the start rank per dtype would balance this better,
  but is left out to keep the change minimal.

### Tests

Added in a follow-up commit, after review feedback that the mixed-dtype path had
no regression coverage.

`test/collective/fleet/test_muon_sharding_mixed_dtype_partition.py` (2 cards)
puts bf16 and fp32 2D params in the same color group -- bf16 via
`amp.decorate(level='O2')`, fp32 kept out through `excluded_layers` -- with
`comm_buffer_size_MB=1` and shapes sized so the two strategies disagree. It
asserts that every rank derives the same owner mapping, that bf16 spans both
ranks while fp32 concentrates on one, that the fp32 params fuse into a single
comm buffer, and that parameters stay bit-identical across ranks after real
optimizer steps. A regime guard fails the test if the partition degenerates to
the trivial single-rank case, which is what the pre-existing Muon cases silently
do (small model plus the default 256 MB bucket).

`test/legacy_test/test_muon_2d_partition.py` (single process, no accelerator)
drives the method against stub params over a world_size x bucket-size x
param-shape matrix: single-dtype input reproduces the previous whole-group
mapping exactly, params are neither dropped nor duplicated, each dtype spreads
only as wide as its own volume requires, owner assignment does not depend on
dtype discovery order, and the caller's list is not reordered.

`test/collective/fleet/CMakeLists.txt` is hand-edited rather than regenerated:
`gen_ut_cmakelists.py` currently aborts on this directory because 9 of the 84
rows in `testslist.csv` name test files that no longer exist. The added block
mirrors the neighbouring Muon entry and takes the next free dist UT port.

### 是否引起精度变化

是（仅在同一 color 组内混合 dtype 时）。

改动改变了参数到 owner rank 的映射，因此每个 2D 参数梯度 `reduce` 的 root
发生变化，NCCL 内部的归约拓扑随 root 改变，浮点累加次序不同，结果不保证逐 bit
一致。梯度走 `main_grad`（fp32）时为末位量级差异。

数学语义不变：每个 2D 参数仍然只由唯一 owner 执行 Newton-Schulz 再广播，换
owner 不改变计算内容；参数之间的梯度独立 reduce，没有累加关系，调用顺序重排
不影响数值。

单一 dtype 的情形映射与改动前完全相同，无任何精度变化。
