### PR TITLE
[Performance] Optimize strided transpose and fp8 1x128 quantization

### DIFF
--- a/paddle/phi/kernels/funcs/transpose_function.cuh
+++ b/paddle/phi/kernels/funcs/transpose_function.cuh
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #pragma once
+#include <cstdint>
+
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
@@ -217,6 +219,91 @@ __global__ void TilingSwapDim1And2(const T* __restrict__ input,
           output_ind += output_inc;
         }
       }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bit-exact equivalent of TilingSwapDim1And2 for 2-byte dtypes, differing in
+// three ways:
+//  1) tile coordinates come from a 3D grid, so no runtime integer division is
+//     needed (the scalar version does five per thread);
+//  2) larger tiles, to raise the bytes in flight per thread;
+//  3) global accesses are vectorized. Shared memory is still accessed element
+//     by element, which lets kPad be odd: the column-wise reads on the write
+//     side then stride by an odd number of words and hit no bank conflicts.
+// Out-of-range tiles take the scalar path; the condition depends only on
+// blockIdx, so it is block-uniform and the __syncthreads calls are safe.
+// ---------------------------------------------------------------------------
+template <typename T,
+          int NumThreads,
+          int TileX,
+          int TileY,
+          int VecSize,
+          typename IndexType = int>
+__global__ void TilingSwapDim1And2Vec(const T* __restrict__ input,
+                                      Dim3<IndexType> input_dims,
+                                      T* __restrict__ output) {
+  using VecT = phi::AlignedVector<T, VecSize>;
+  constexpr int kPad = 1;
+  constexpr int RowThreads = TileY / VecSize;  // threads per row, read side
+  constexpr int ReadRows = NumThreads / RowThreads;
+  constexpr int ColThreads = TileX / VecSize;  // threads per row, write side
+  constexpr int WriteRows = NumThreads / ColThreads;
+  static_assert(TileY % VecSize == 0 && TileX % VecSize == 0, "tile/vec");
+  static_assert(NumThreads % RowThreads == 0, "threads/row");
+  static_assert(NumThreads % ColThreads == 0, "threads/col");
+  static_assert(TileX % ReadRows == 0 && TileY % WriteRows == 0, "rows");
+
+  __shared__ T tile_sm[TileX][TileY + kPad];
+
+  const IndexType d1 = input_dims[1];
+  const IndexType d2 = input_dims[2];
+  const IndexType r0 = static_cast<IndexType>(blockIdx.y) * TileX;
+  const IndexType c0 = static_cast<IndexType>(blockIdx.x) * TileY;
+  const IndexType plane = static_cast<IndexType>(blockIdx.z) * d1 * d2;
+  const T* in = input + plane;
+  T* out = output + plane;
+  const int x = threadIdx.x;
+
+  if (r0 + TileX <= d1 && c0 + TileY <= d2) {
+    {
+      const int x_i = x / RowThreads, x_j = x % RowThreads;
+      const T* p = in + (r0 + x_i) * d2 + c0 + x_j * VecSize;
+#pragma unroll
+      for (int i = 0; i < TileX / ReadRows; ++i) {
+        const VecT v = *reinterpret_cast<const VecT*>(p);
+        const int r = x_i + i * ReadRows;
+#pragma unroll
+        for (int k = 0; k < VecSize; ++k) tile_sm[r][x_j * VecSize + k] = v[k];
+        p += static_cast<IndexType>(ReadRows) * d2;
+      }
+    }
+    __syncthreads();
+    {
+      const int y_i = x / ColThreads, y_j = x % ColThreads;
+      T* q = out + (c0 + y_i) * d1 + r0 + y_j * VecSize;
+#pragma unroll
+      for (int i = 0; i < TileY / WriteRows; ++i) {
+        const int c = y_i + i * WriteRows;
+        VecT vb;
+#pragma unroll
+        for (int k = 0; k < VecSize; ++k) vb[k] = tile_sm[y_j * VecSize + k][c];
+        *reinterpret_cast<VecT*>(q) = vb;
+        q += static_cast<IndexType>(WriteRows) * d1;
+      }
+    }
+  } else {
+    for (int idx = x; idx < TileX * TileY; idx += NumThreads) {
+      const int r = idx / TileY, c = idx % TileY;
+      if (r0 + r < d1 && c0 + c < d2)
+        tile_sm[r][c] = in[(r0 + r) * d2 + c0 + c];
+    }
+    __syncthreads();
+    for (int idx = x; idx < TileX * TileY; idx += NumThreads) {
+      const int c = idx / TileX, r = idx % TileX;
+      if (r0 + r < d1 && c0 + c < d2)
+        out[(c0 + c) * d1 + r0 + r] = tile_sm[r][c];
     }
   }
 }
@@ -595,6 +682,41 @@ void SendSwapDim1And2InTranspose(const GPUContext& d,
     // suppose 32 X 32 gives best performance, and 8 warp in block.
     constexpr int kTileSize = 32;
     constexpr int kNumThreads = 256;
+
+    // Vectorized path for 2-byte dtypes, taken only when its hard
+    // preconditions hold; otherwise fall through to the scalar tiling below.
+    if constexpr (sizeof(T) == 2) {
+      // gridDim.y / gridDim.z are limited to 65535.
+      const bool grid_ok_64 =
+          (input_dims[1] + 63) / 64 <= 65535 && input_dims[0] <= 65535;
+      // Both transposed extents must be divisible by VecSize (dim2 on the read
+      // side, dim1 on the write side) and both base pointers must be aligned.
+      const bool vec2_ok =
+          input_dims[1] % 2 == 0 && input_dims[2] % 2 == 0 &&
+          reinterpret_cast<uintptr_t>(input) % (2 * sizeof(T)) == 0 &&
+          reinterpret_cast<uintptr_t>(output) % (2 * sizeof(T)) == 0;
+      // Bigger tiles mean fewer blocks, so require enough tiles to fill the
+      // device; small shapes would otherwise leave SMs idle.
+      constexpr int kVecTile = 64;
+      constexpr int kVecThreads = 128;
+      constexpr int kVecSize = 2;
+      IndexType n_tiles64 = input_dims[0];
+      n_tiles64 *= (input_dims[1] + kVecTile - 1) / kVecTile;
+      n_tiles64 *= (input_dims[2] + kVecTile - 1) / kVecTile;
+      if (vec2_ok && grid_ok_64 && n_tiles64 >= d.GetSMCount()) {
+        dim3 g(static_cast<unsigned>((input_dims[2] + kVecTile - 1) / kVecTile),
+               static_cast<unsigned>((input_dims[1] + kVecTile - 1) / kVecTile),
+               static_cast<unsigned>(input_dims[0]));
+        TilingSwapDim1And2Vec<T,
+                              kVecThreads,
+                              kVecTile,
+                              kVecTile,
+                              kVecSize,
+                              IndexType>
+            <<<g, kVecThreads, 0, d.stream()>>>(input, input_dims, output);
+        return;
+      }
+    }
 
     Dim3<IndexType> input_dims_aligned = {
         input_dims[0],
@@ -1386,6 +1508,12 @@ inline void PermuteDispatch(const GPUContext& dev_ctx,
                             T* dst) {
   int rank = dims.size();
   PermuteType type = cls_ptr->GetPermType();
+  // Clamp to the widest case the switches below actually handle. GetVecSize()
+  // can return 8 for 2-byte dtypes, and neither switch has a case for it, so no
+  // kernel would be launched at all and the output would stay uninitialized. A
+  // narrower vector width is only slower, never wrong.
+  int vec_size = cls_ptr->GetVecSize();
+  if (vec_size > 4) vec_size = 4;
 
 #define TRANSPOSE_DISPATCH_VEC_SIZE(size)                             \
   case size: {                                                        \
@@ -1404,14 +1532,14 @@ inline void PermuteDispatch(const GPUContext& dev_ctx,
   switch (type) {
     case kSwapTranspose:
     case kGeneralTranspose:
-      switch (cls_ptr->GetVecSize()) {
+      switch (vec_size) {
         TRANSPOSE_DISPATCH_VEC_SIZE(1);
         TRANSPOSE_DISPATCH_VEC_SIZE(2);
         TRANSPOSE_DISPATCH_VEC_SIZE(4);
       }
       break;
     default:
-      switch (cls_ptr->GetVecSize()) {
+      switch (vec_size) {
         PERMUTE_DISPATCH_VEC_SIZE(1);
         PERMUTE_DISPATCH_VEC_SIZE(2);
         PERMUTE_DISPATCH_VEC_SIZE(4);

--- a/paddle/phi/kernels/funcs/transpose_function.cuh
+++ b/paddle/phi/kernels/funcs/transpose_function.cuh
@@ -662,7 +662,16 @@ void SendSwapDim1And2InTranspose(const GPUContext& d,
                                  T* output) {
   // FP8 fast path
   if constexpr (std::is_same<T, phi::float8_e4m3fn>::value) {
-    if (input_dims[1] >= 128 && input_dims[2] >= 128 &&
+    // The kernel moves 8 bytes at a time through fp8x8_t, whose alignment is 8.
+    // Both extents are multiples of 128, so every row start keeps the alignment
+    // class of the base pointer and checking the two base pointers is enough.
+    // A one-byte dtype makes this a real question: a view into a larger buffer
+    // can start at any byte, and an unaligned vector load faults.
+    constexpr uintptr_t kFp8VecAlign = 8;
+    const bool aligned =
+        reinterpret_cast<uintptr_t>(input) % kFp8VecAlign == 0 &&
+        reinterpret_cast<uintptr_t>(output) % kFp8VecAlign == 0;
+    if (aligned && input_dims[1] >= 128 && input_dims[2] >= 128 &&
         input_dims[1] % 128 == 0 && input_dims[2] % 128 == 0) {
       dispatch_fp8_fast_transpose_kernel<T, IndexType>(
           d, input, input_dims[0], input_dims[1], input_dims[2], output);

--- a/paddle/phi/kernels/gpu/contiguous_kernel.cu
+++ b/paddle/phi/kernels/gpu/contiguous_kernel.cu
@@ -184,15 +184,19 @@ __global__ void ContiguousDefaultFunc(
   }
 }
 
+// This used to reject tensors with a non-zero offset, which is orthogonal to
+// whether the strides are a pure permutation; see the comment on
+// is_only_transposed_tensor in stride/matmul_stride_kernel.cu. Rejecting them
+// fell back from TransposeKernel to ContiguousCaseOneFunc, one element per
+// thread with no coalescing on the read side.
+//
+// Dropping the test requires the set_meta() fix in ContiguousKernel below,
+// which this test was the only thing keeping unreachable.
 bool is_only_transposed(const DDim& shape,
                         const DDim& stride,
-                        uint64_t offset,
                         DDim& src_shape,           // NOLINT
                         DDim& src_stride,          // NOLINT
                         std::vector<int>& axis) {  // NOLINT
-  if (offset != 0) {
-    return false;
-  }
   std::set<int> visited_idx;
   axis.resize(stride.size());
   for (int i = 0; i < stride.size(); i++) {
@@ -505,14 +509,20 @@ void ContiguousKernel(const Context& dev_ctx,
   DDim src_stride = meta.strides;
   DDim src_shape = meta.dims;
   if (is_only_transposed(
-          meta.dims, meta.strides, meta.offset, src_shape, src_stride, axis)) {
-    meta.strides = meta.calc_strides(meta.dims);
-    out->set_meta(meta);
+          meta.dims, meta.strides, src_shape, src_stride, axis)) {
+    // The input offset belongs to tmp_tensor, not to out: out is freshly
+    // allocated and contiguous, so its offset must be zero. Assigning meta to
+    // out directly was only safe while offset was guaranteed to be zero.
+    const uint64_t in_offset = meta.offset;
     DenseTensor tmp_tensor = input;
     DenseTensorMeta tmp_meta = meta;
     tmp_meta.strides = src_stride;
     tmp_meta.dims = src_shape;
+    tmp_meta.offset = in_offset;
     tmp_tensor.set_meta(tmp_meta);
+    meta.strides = meta.calc_strides(meta.dims);
+    meta.offset = 0;
+    out->set_meta(meta);
     TransposeKernel<T, Context>(dev_ctx, tmp_tensor, axis, out);
     return;
   }

--- a/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
@@ -688,35 +688,24 @@ __global__ void __launch_bounds__(512, MINBLK)
     }
   }
 
-  // 2. row-wise amax, packed as bf16x2, then reduced across the lanes of a row
+  // 2. row-wise amax, then reduced across the lanes of a row. The max goes
+  // through device_abs / device_max rather than the packed __habs2 / __hmax2
+  // pair: those are declared only for __CUDA_ARCH__ >= 800 on older toolkits,
+  // and being non-dependent names they are diagnosed even inside a discarded
+  // if-constexpr branch, so a packed bf16 path breaks the pre-sm_80 build of
+  // the float16 instantiation. The kernel is memory bound, so halving the
+  // number of max operations buys nothing anyway.
 #pragma unroll
   for (int i = 0; i < kIters; i++) {
     T warp_max;
-    if constexpr (std::is_same<T, __nv_bfloat16>::value) {
-      __nv_bfloat162 m2;
-      bool first = true;
+    bool first = true;
 #pragma unroll
-      for (int v = 0; v < kNVec; v++) {
-        const __nv_bfloat162 *p =
-            reinterpret_cast<const __nv_bfloat162 *>(&x[i * kNVec + v].data);
+    for (int v = 0; v < kNVec; v++) {
 #pragma unroll
-        for (int k = 0; k < kVec / 2; k++) {
-          __nv_bfloat162 a = __habs2(p[k]);
-          m2 = first ? a : __hmax2(m2, a);
-          first = false;
-        }
-      }
-      warp_max = __hmax(__low2bfloat16(m2), __high2bfloat16(m2));
-    } else {
-      bool first = true;
-#pragma unroll
-      for (int v = 0; v < kNVec; v++) {
-#pragma unroll
-        for (int k = 0; k < kVec; k++) {
-          T a = device_abs(x[i * kNVec + v].data.scalar[k]);
-          warp_max = first ? a : device_max(warp_max, a);
-          first = false;
-        }
+      for (int k = 0; k < kVec; k++) {
+        T a = device_abs(x[i * kNVec + v].data.scalar[k]);
+        warp_max = first ? a : device_max(warp_max, a);
+        first = false;
       }
     }
 #pragma unroll

--- a/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
+++ b/paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu
@@ -15,6 +15,7 @@
 #include "paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.h"
 #include <cuda_fp8.h>
 #include <cstdint>
+#include <type_traits>
 #include <vector>
 #include "paddle/common/flags.h"
 #include "paddle/phi/core/dense_tensor.h"
@@ -601,6 +602,186 @@ __global__ void __launch_bounds__(512)
   }
 }
 
+// Vectorized rewrite of quantize_1x128_kernel, covering only the
+// !input_transpose && !return_transpose_only instantiation.
+//
+// In that instantiation the transpose steps are compiled away, leaving plain
+// streaming quantization with one scale per 128 elements along the last dim,
+// but it still pays for the transpose-oriented layout: 8-byte loads and
+// 4-byte stores per thread, and a full 128x129 fp8 shared buffer of which
+// only 128 bf16 row maxima are used.
+//
+// This version widens the accesses to 128-bit, packs the amax reduction into
+// bf16x2, and shrinks shared memory accordingly. Results are bit-identical:
+// NaN-suppressing max is associative, so reordering the reduction is safe, and
+// the scale computation and its index arithmetic are copied verbatim.
+//
+// Selection is automatic: the template branch is fixed at compile time by
+// if constexpr, and the only runtime condition is base-pointer alignment (see
+// vec128_ok in FP8QuantBlockWiseKernelImpl). Element indices inside the kernel
+// are always multiples of EPT because this branch is only reached for shapes
+// that are multiples of 128, so the tensor base address is the only thing that
+// can break the wider accesses. Unlike the transpose path, no minimum-size
+// condition is needed: tile and grid are unchanged from the scalar version.
+//
+// __launch_bounds__(512, 4) is load-bearing, not decoration. Occupancy here is
+// register-limited and 4 blocks/SM requires staying within 32 registers
+// (65536 / (512 * 4)); without the minimum the compiler settles above that and
+// loses a block, and the exact count drifts with unrelated edits. Most of the
+// speedup comes from the extra resident block rather than from the wider
+// accesses, so do not relax these two numbers.
+template <int EPT>
+struct alignas(EPT) fp8_out_vec_t {
+  __nv_fp8x2_storage_t h[EPT / 2];
+};
+
+template <typename T,
+          typename ScaleT,
+          bool output_scale_transpose,
+          bool use_pow2_scale,
+          bool using_ue8m0_scale,
+          int EPT,
+          int MINBLK = 1>
+__global__ void __launch_bounds__(512, MINBLK)
+    quantize_1x128_kernel_v128(const T *const input,
+                               __nv_fp8_e4m3 *const output,
+                               __nv_fp8_e4m3 *const output_transposed,
+                               ScaleT *const scale,
+                               ScaleT *const scale_transposed,
+                               const size_t rows,
+                               const size_t cols,
+                               const size_t quanted_rows,
+                               const size_t quanted_cols,
+                               const float epsilon) {
+  constexpr int kVec = 8;  // elements per 128-bit access
+  constexpr int kNVec = EPT / kVec;
+  constexpr int kThreads = 512;
+  constexpr int kLanesPerRow = k_block_span / EPT;
+  constexpr int kRowsPerIter = kThreads / kLanesPerRow;
+  constexpr int kIters = k_block_span / kRowsPerIter;
+  static_assert(kNVec >= 1 && k_block_span % EPT == 0, "EPT");
+
+  __shared__ T shm_max[k_block_span];
+  __shared__ float block_scale[k_block_span];
+
+  const size_t col_blocks = rows / k_block_span;  // rows is actually cols
+  const size_t block_x = blockIdx.x % col_blocks;
+  const size_t block_y = blockIdx.x / col_blocks;
+  const size_t block_offset_x = block_x * k_block_span;
+  const size_t block_offset_y = block_y * k_block_span;
+
+  const int tid =
+      static_cast<int>(threadIdx.y) * 32 + static_cast<int>(threadIdx.x);
+  const int sub = tid % kLanesPerRow;          // which segment of the row
+  const int row_in_iter = tid / kLanesPerRow;  // which row of the tile
+
+  // 1. load the tile
+  v128_t<T> x[kIters * kNVec];
+#pragma unroll
+  for (int i = 0; i < kIters; i++) {
+    const size_t base =
+        (block_offset_y + i * kRowsPerIter + row_in_iter) * rows +
+        block_offset_x + static_cast<size_t>(sub) * EPT;
+#pragma unroll
+    for (int v = 0; v < kNVec; v++) {
+      x[i * kNVec + v].load(input + base + v * kVec);
+    }
+  }
+
+  // 2. row-wise amax, packed as bf16x2, then reduced across the lanes of a row
+#pragma unroll
+  for (int i = 0; i < kIters; i++) {
+    T warp_max;
+    if constexpr (std::is_same<T, __nv_bfloat16>::value) {
+      __nv_bfloat162 m2;
+      bool first = true;
+#pragma unroll
+      for (int v = 0; v < kNVec; v++) {
+        const __nv_bfloat162 *p =
+            reinterpret_cast<const __nv_bfloat162 *>(&x[i * kNVec + v].data);
+#pragma unroll
+        for (int k = 0; k < kVec / 2; k++) {
+          __nv_bfloat162 a = __habs2(p[k]);
+          m2 = first ? a : __hmax2(m2, a);
+          first = false;
+        }
+      }
+      warp_max = __hmax(__low2bfloat16(m2), __high2bfloat16(m2));
+    } else {
+      bool first = true;
+#pragma unroll
+      for (int v = 0; v < kNVec; v++) {
+#pragma unroll
+        for (int k = 0; k < kVec; k++) {
+          T a = device_abs(x[i * kNVec + v].data.scalar[k]);
+          warp_max = first ? a : device_max(warp_max, a);
+          first = false;
+        }
+      }
+    }
+#pragma unroll
+    for (int off = kLanesPerRow / 2; off > 0; off /= 2) {
+      T other = __shfl_down_sync(0xFFFFFFFF, warp_max, off);
+      warp_max = device_max(warp_max, other);
+    }
+    if (sub == 0) {
+      shm_max[i * kRowsPerIter + row_in_iter] = warp_max;
+    }
+  }
+  __syncthreads();
+
+  if (threadIdx.y < 4) {
+    T amax = shm_max[threadIdx.y * 32 + threadIdx.x];
+    block_scale[threadIdx.y * 32 + threadIdx.x] =
+        ScaleWrapper < using_ue8m0_scale ||
+        use_pow2_scale > (static_cast<float>(amax), epsilon);
+  }
+  __syncthreads();
+
+  // 3. store the 1x128 scales; index arithmetic copied from the scalar kernel
+  if (threadIdx.y < 4) {
+    size_t col_idx = block_offset_y + static_cast<size_t>(threadIdx.y) * 32 +
+                     static_cast<size_t>(threadIdx.x);
+    size_t row_idx = block_x;
+    float store_scale = 1.0f / block_scale[threadIdx.y * 32 + threadIdx.x];
+
+    size_t stride_rows = using_ue8m0_scale ? quanted_rows * 4 : quanted_rows;
+    size_t idx;
+    if (using_ue8m0_scale) {
+      idx = output_scale_transpose
+                ? (row_idx / 4) * (cols * 4) + col_idx * 4 + (row_idx % 4)
+                : col_idx * stride_rows + row_idx;
+    } else {
+      idx = output_scale_transpose ? row_idx * stride_rows + col_idx
+                                   : col_idx * stride_rows + row_idx;
+    }
+    StoreScale<ScaleT, using_ue8m0_scale>(scale, idx, store_scale);
+  }
+
+  // 4. quantize and store back
+#pragma unroll
+  for (int i = 0; i < kIters; i++) {
+    const int r_local = i * kRowsPerIter + row_in_iter;
+    const float scale_val = block_scale[r_local];
+    const size_t base = (block_offset_y + r_local) * rows + block_offset_x +
+                        static_cast<size_t>(sub) * EPT;
+    fp8_out_vec_t<EPT> o;
+#pragma unroll
+    for (int v = 0; v < kNVec; v++) {
+      const T *s = x[i * kNVec + v].data.scalar;
+#pragma unroll
+      for (int k = 0; k < kVec / 2; k++) {
+        float2 f;
+        f.x = static_cast<float>(s[2 * k]) * scale_val;
+        f.y = static_cast<float>(s[2 * k + 1]) * scale_val;
+        o.h[v * (kVec / 2) + k] =
+            __nv_cvt_float2_to_fp8x2(f, __NV_SATFINITE, __NV_E4M3);
+      }
+    }
+    *reinterpret_cast<fp8_out_vec_t<EPT> *>(output + base) = o;
+  }
+}
+
 template <typename T,
           typename ScaleT,
           bool output_scale_transpose,
@@ -875,6 +1056,33 @@ void FP8QuantBlockWiseKernelImpl(const Context &dev_ctx,
                                                 return_transpose_only,
                                                 using_pow2_scale,
                                                 using_ue8m0_scale>;
+
+    // The vectorized kernel only covers this template branch; every other
+    // combination keeps the scalar kernel assigned above.
+    if constexpr (using_1x128_vec_quant && !input_transpose &&
+                  !return_transpose_only) {
+      // Element indices are always 16-element aligned here, so only the tensor
+      // base addresses can break the 128-bit accesses. Fused parameter buffers
+      // give tensors an arbitrary element offset, which data() folds into the
+      // pointer, so this has to be checked at runtime.
+      constexpr size_t kVecBytes = 16;
+      const bool vec128_ok =
+          reinterpret_cast<uintptr_t>(X.data<T>()) % kVecBytes == 0 &&
+          reinterpret_cast<uintptr_t>(out->data<phi::float8_e4m3fn>()) %
+                  kVecBytes ==
+              0;
+      if (vec128_ok) {
+        // The trailing 4 is the minimum blocks/SM: see the comment on
+        // quantize_1x128_kernel_v128 before changing it or EPT.
+        kernel = quantize_1x128_kernel_v128<NvType,
+                                            ScaleT,
+                                            output_scale_transpose,
+                                            using_pow2_scale,
+                                            using_ue8m0_scale,
+                                            16,
+                                            4>;
+      }
+    }
 
     kernel<<<grid, block, 0, dev_ctx.stream()>>>(
         reinterpret_cast<const NvType *>(X.data<T>()),

--- a/paddle/phi/kernels/stride/matmul_stride_kernel.cu
+++ b/paddle/phi/kernels/stride/matmul_stride_kernel.cu
@@ -50,16 +50,25 @@ DenseTensor Tensor2Contiguous(const Context &dev_ctx,
 /**
  * Check if tensor is only transposed and return the original
  * contiguous shape/stride and transpose axis mapping.
+ *
+ * This used to reject tensors with a non-zero offset. Offset is orthogonal to
+ * the question asked here: only dims/strides are reordered, the caller writes
+ * the original offset back, data() adds it on every access, and
+ * is_contiguous() never looks at it.
+ *
+ * The rejection was also costly, because a non-zero offset is the common case:
+ * fused parameter buffers give every weight but the first a non-zero offset,
+ * so w.t() could not fold into cuBLAS transpose_y and had to materialize a
+ * contiguous copy with a non-coalesced read instead.
+ *
+ * The sibling check in contiguous_kernel.cu lost the same test, but that side
+ * also needed its set_meta() fixed; see the comment there.
  */
 inline bool is_only_transposed_tensor(const DDim &shape,
                                       const DDim &stride,
-                                      const uint64_t &offset,
                                       DDim *src_shape,
                                       DDim *src_stride,
                                       std::vector<int> *axis) {
-  if (offset != 0) {
-    return false;
-  }
   std::set<int> visited_idx;
   axis->resize(stride.size());
   for (int i = 0; i < stride.size(); i++) {
@@ -157,12 +166,9 @@ void MatmulStrideKernel(const Context &dev_ctx,
   DDim y_shape = y_meta.dims;
   std::vector<int> y_axis;
 
-  if (!x.meta().is_contiguous() && is_only_transposed_tensor(x_meta.dims,
-                                                             x_meta.strides,
-                                                             x_meta.offset,
-                                                             &x_shape,
-                                                             &x_stride,
-                                                             &x_axis)) {
+  if (!x.meta().is_contiguous() &&
+      is_only_transposed_tensor(
+          x_meta.dims, x_meta.strides, &x_shape, &x_stride, &x_axis)) {
     auto x_trans_dims = x_axis.size();
     if (x_axis.size() >= 2 && x_axis[x_trans_dims - 1] == x_trans_dims - 2 &&
         x_axis[x_trans_dims - 2] == x_trans_dims - 1) {
@@ -178,12 +184,9 @@ void MatmulStrideKernel(const Context &dev_ctx,
     x_ = Tensor2Contiguous<Context>(dev_ctx, x);
   }
 
-  if (!y.meta().is_contiguous() && is_only_transposed_tensor(y_meta.dims,
-                                                             y_meta.strides,
-                                                             y_meta.offset,
-                                                             &y_shape,
-                                                             &y_stride,
-                                                             &y_axis)) {
+  if (!y.meta().is_contiguous() &&
+      is_only_transposed_tensor(
+          y_meta.dims, y_meta.strides, &y_shape, &y_stride, &y_axis)) {
     auto y_trans_dims = y_axis.size();
     if (y_axis.size() >= 2 && y_axis[y_trans_dims - 1] == y_trans_dims - 2 &&
         y_axis[y_trans_dims - 2] == y_trans_dims - 1) {

--- a/test/legacy_test/test_fp8_quant.py
+++ b/test/legacy_test/test_fp8_quant.py
@@ -305,5 +305,282 @@ class TestFP8QuantizationZeroSizeBF16(unittest.TestCase):
         self.assertEqual(scale.dtype, paddle.float32)
 
 
+def _bits(t):
+    """Raw bytes of a tensor, so the comparison is bit level.
+
+    float8_e4m3fn has no numpy dtype but .numpy() hands back the raw bits as
+    int8, and the float32 scales come back as float32; comparing bytes keeps the
+    two NaN encodings distinguishable and works where == would not.
+    """
+    return np.ascontiguousarray(t.numpy()).tobytes()
+
+
+def _quant(x, **kw):
+    opts = {
+        "epsilon": 0.0,
+        "input_transpose": False,
+        "output_scale_transpose": True,
+        "return_transpose_only": False,
+        "using_pow2_scale": True,
+        "using_ue8m0_scale": False,
+        "quant_method": "1x128",
+        "output_type": "e4m3",
+    }
+    opts.update(kw)
+    return fp8.fp8_quant_blockwise(x, **opts)
+
+
+def _offset_view(values, shape, offset, dtype=paddle.bfloat16):
+    """A view of `shape` starting `offset` elements into a larger buffer.
+
+    The offset moves the base pointer without changing the values, which is the
+    only thing the vectorized quantization path is gated on. Offsets below 4
+    elements are deliberately absent: the scalar kernel already requires an
+    8-byte-aligned base, so those fault on every build and are out of scope.
+    """
+    flat = np.asarray(values, dtype=np.float32).reshape(-1)
+    pad = np.zeros(offset, dtype=np.float32)
+    buf = paddle.to_tensor(np.concatenate([pad, flat]), dtype=dtype)
+    view = buf[offset : offset + flat.size].reshape(shape)
+    return buf, view
+
+
+class TestFP8QuantBasePointerAlignment(unittest.TestCase):
+    """The base pointer must not change the result.
+
+    A 16-byte-aligned base allows 128-bit loads and a narrower one does not, so
+    quantizing the same values at different offsets exercises both the wide and
+    the narrow path and pins them to the same output.
+    """
+
+    def setUp(self):
+        paddle.seed(42)
+        rs = np.random.RandomState(1234)
+        self.shape = [256, 1024]
+        self.values = rs.randn(*self.shape).astype(np.float32)
+        self.offsets = [0, 4, 8, 16, 64, 512, 1024]
+
+    def _run(self, offset, **kw):
+        _, view = _offset_view(self.values, self.shape, offset)
+        self.assertTrue(view.is_contiguous())
+        return [_bits(t) for t in _quant(view, **kw)]
+
+    def test_offsets_agree(self):
+        for p2, ue8 in itertools.product([True, False], repeat=2):
+            with self.subTest(pow2=p2, ue8m0=ue8):
+                ref = None
+                for offset in self.offsets:
+                    got = self._run(
+                        offset, using_pow2_scale=p2, using_ue8m0_scale=ue8
+                    )
+                    if ref is None:
+                        ref = got
+                    self.assertEqual(got, ref, f"offset {offset} differs")
+
+    def test_offsets_agree_scale_layouts(self):
+        for ot in (True, False):
+            with self.subTest(output_scale_transpose=ot):
+                ref = None
+                for offset in self.offsets:
+                    got = self._run(offset, output_scale_transpose=ot)
+                    if ref is None:
+                        ref = got
+                    self.assertEqual(got, ref, f"offset {offset} differs")
+
+    def test_shapes(self):
+        """Several tile counts, since the offset applies per row of blocks."""
+        rs = np.random.RandomState(4321)
+        for shape in ([128, 128], [128, 7168], [1024, 128], [512, 2048]):
+            with self.subTest(shape=shape):
+                self.values = rs.randn(*shape).astype(np.float32)
+                self.shape = shape
+                ref = None
+                for offset in self.offsets:
+                    got = self._run(offset)
+                    if ref is None:
+                        ref = got
+                    self.assertEqual(got, ref, f"offset {offset} differs")
+
+
+class TestFP8QuantVecMatchesScalar(unittest.TestCase):
+    """Cross-check the two 1x128 implementations against each other.
+
+    Asking for the transpose as well forces the scalar implementation, because
+    the wide path only covers the non-transposed instantiation. The
+    non-transposed halves of the two results must be identical: same blocks,
+    same abs-max, same scale.
+    """
+
+    SHAPES = [[128, 128], [256, 1024], [1024, 512], [128, 7168], [2048, 1024]]
+
+    def _pair(self, x, **kw):
+        vec = _quant(x, input_transpose=False, **kw)[:2]
+        scalar = _quant(x, input_transpose=True, **kw)[:2]
+        return [_bits(t) for t in vec], [_bits(t) for t in scalar]
+
+    def test_flag_matrix(self):
+        paddle.seed(42)
+        x = paddle.randn([256, 1024], dtype=paddle.bfloat16)
+        for ot, p2, ue8 in itertools.product([True, False], repeat=3):
+            with self.subTest(scale_transpose=ot, pow2=p2, ue8m0=ue8):
+                vec, scalar = self._pair(
+                    x,
+                    output_scale_transpose=ot,
+                    using_pow2_scale=p2,
+                    using_ue8m0_scale=ue8,
+                )
+                self.assertEqual(vec, scalar)
+
+    def test_shapes(self):
+        paddle.seed(7)
+        for shape in self.SHAPES:
+            with self.subTest(shape=shape):
+                x = paddle.randn(shape, dtype=paddle.bfloat16)
+                vec, scalar = self._pair(x)
+                self.assertEqual(vec, scalar)
+
+    def test_dtypes(self):
+        paddle.seed(11)
+        for dtype in (paddle.bfloat16, paddle.float16):
+            with self.subTest(dtype=dtype):
+                x = paddle.randn([256, 1024], dtype=dtype)
+                vec, scalar = self._pair(x)
+                self.assertEqual(vec, scalar)
+
+    def test_ragged_shapes(self):
+        """Extents that are not multiples of 128 use a different kernel.
+
+        They cannot be cross-checked against the transposing variant, which
+        rejects them outright, so the invariant here is that the offset does not
+        matter. Nothing changed for these shapes; they are present so that a
+        stray template instantiation leaking into the ragged dispatch shows up.
+
+        The transposed scale is padded up to a multiple of four rows and the
+        padding is never written, so only the rows that carry data are compared.
+        """
+        rs = np.random.RandomState(13)
+        for shape in ([4096, 4100], [4095, 4096], [129, 508], [80, 4096]):
+            with self.subTest(shape=shape):
+                values = rs.randn(*shape).astype(np.float32)
+                ref = None
+                for offset in (0, 4, 8, 512):
+                    _, view = _offset_view(values, shape, offset)
+                    q, s = _quant(view)
+                    got = [_bits(q), _bits(s[:, : shape[0]])]
+                    if ref is None:
+                        ref = got
+                    self.assertEqual(got, ref, f"offset {offset} differs")
+
+
+class TestFP8QuantAmaxEdgeCases(unittest.TestCase):
+    """Inputs built so that the order of the abs-max reduction would matter.
+
+    Reordering the reduction is the only thing the wide path does
+    differently, so these are the cases where it could show. Every row is
+    1024 elements, that is eight independent 128-element blocks, and each
+    pattern is laid out per block so that a wrong block boundary changes a
+    scale instead of adding noise.
+    """
+
+    ROWS = 256
+    COLS = 1024
+    BLK = 128
+
+    def _cases(self):
+        rows, cols, blk = self.ROWS, self.COLS, self.BLK
+        rs = np.random.RandomState(9100)
+        cases = {}
+
+        # One huge value per block, at a different position in each block, so no
+        # reduction tree can always meet it first or last.
+        a = rs.randn(rows, cols).astype(np.float32) * 1e-3
+        for j in range(cols // blk):
+            a[:, j * blk + (j * 37) % blk] = 4.0e4 if j % 2 else -4.0e4
+        cases["outlier_position"] = a
+
+        # max is NaN suppressing, so the surviving abs-max has to come from the
+        # other elements whatever the order.
+        a = rs.randn(rows, cols).astype(np.float32)
+        a[np.arange(rows), (np.arange(rows) * 17) % cols] = np.nan
+        cases["nan"] = a
+
+        a = rs.randn(rows, cols).astype(np.float32)
+        a[:, blk * 3 + 5] = np.inf
+        a[:, blk * 5 + 9] = -np.inf
+        cases["inf"] = a
+
+        # Whole blocks of zeros, which is the branch where the scale would be a
+        # division by zero, plus negative zero next to it.
+        a = rs.randn(rows, cols).astype(np.float32)
+        a[:, blk * 2 : blk * 4] = 0.0
+        a[:, blk * 6 : blk * 7] = -0.0
+        cases["zero_blocks"] = a
+
+        # Values straddling the largest e4m3, so saturation happens inside a
+        # block rather than at its edge.
+        cases["saturating"] = rs.randn(rows, cols).astype(np.float32) * 448.0
+        cases["tiny"] = rs.randn(rows, cols).astype(np.float32) * 1e-30
+        cases["huge"] = rs.randn(rows, cols).astype(np.float32) * 1e30
+
+        a = rs.randn(rows, cols).astype(np.float32)
+        a[rs.rand(rows, cols) < 0.9] = 0.0
+        cases["sparse"] = a
+
+        a = np.zeros((rows, cols), np.float32)
+        cases["all_zero"] = a
+        return cases
+
+    def test_vec_matches_scalar(self):
+        for name, values in self._cases().items():
+            x = paddle.to_tensor(values, dtype=paddle.bfloat16)
+            for p2, ue8 in itertools.product([True, False], repeat=2):
+                with self.subTest(case=name, pow2=p2, ue8m0=ue8):
+                    kw = {"using_pow2_scale": p2, "using_ue8m0_scale": ue8}
+                    vec = [_bits(t) for t in _quant(x, **kw)[:2]]
+                    scalar = [
+                        _bits(t)
+                        for t in _quant(x, input_transpose=True, **kw)[:2]
+                    ]
+                    self.assertEqual(vec, scalar)
+
+    def test_offsets_agree(self):
+        for name, values in self._cases().items():
+            with self.subTest(case=name):
+                ref = None
+                for offset in (0, 4, 8, 512):
+                    _, view = _offset_view(
+                        values, [self.ROWS, self.COLS], offset
+                    )
+                    got = [_bits(t) for t in _quant(view)]
+                    if ref is None:
+                        ref = got
+                    self.assertEqual(got, ref, f"offset {offset} differs")
+
+    def test_repeatable(self):
+        for name, values in self._cases().items():
+            with self.subTest(case=name):
+                x = paddle.to_tensor(values, dtype=paddle.bfloat16)
+                first = [_bits(t) for t in _quant(x)]
+                second = [_bits(t) for t in _quant(x)]
+                self.assertEqual(first, second)
+
+    def test_finite_cases_stay_accurate(self):
+        """Bit agreement alone would also hold if both paths were wrong."""
+        for name in ("outlier_position", "saturating", "sparse"):
+            values = self._cases()[name]
+            with self.subTest(case=name):
+                x = paddle.to_tensor(values, dtype=paddle.bfloat16)
+                q, s = _quant(x, output_scale_transpose=False)
+                deq = q.astype("float32") * paddle.repeat_interleave(
+                    s, repeats=self.BLK, axis=1
+                )
+                ref = x.astype("float32")
+                scale = float(paddle.abs(ref).max())
+                rmse = float(
+                    paddle.sqrt(paddle.mean((deq - ref) ** 2)) / max(scale, 1.0)
+                )
+                self.assertLess(rmse, 3e-2)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_stride_offset_kernel.py
+++ b/test/legacy_test/test_stride_offset_kernel.py
@@ -1,0 +1,549 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transpose / contiguous / matmul on strided views with a non-zero offset.
+
+Three groups of cases:
+
+TestTransposeVecTile
+    walks both sides of every selection gate of the vectorized 64x64 tile
+    transpose kernel, so that neither the vectorized nor the scalar tiling can
+    regress unnoticed. Transpose is pure data movement, so the reference is an
+    exact bit comparison rather than a tolerance.
+
+TestContiguousNonZeroOffset
+    materializes views whose offset is non-zero. A freshly allocated output must
+    always start at offset zero, whatever the input offset was; asserting that
+    is what keeps the offset from leaking onto the output.
+
+TestMatmulStrideOffset
+    a transposed view is folded into the cuBLAS transpose flag instead of being
+    materialized. Folding must not depend on the offset, so the result has to be
+    identical, bit for bit, to the same call on a copy that starts at offset
+    zero.
+
+All of it needs FLAGS_use_stride_kernel, because that is what makes slicing and
+transposing return a view instead of a fresh tensor. The transpose cases are run
+with the flag off as well, since that reaches the same kernel through the dense
+dispatch instead of through ContiguousKernel.
+"""
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+def _host_values(n, dtype, seed):
+    """Values for a buffer of n elements, generated on the host.
+
+    The dtype only decides which generator is used; correctness is later checked
+    against the raw bits read back from the device, so no value here has to be
+    exactly representable in the target dtype.
+    """
+    rs = np.random.RandomState(seed)
+    if dtype == "bool":
+        return rs.randint(0, 2, n).astype(np.bool_)
+    if dtype == "int8":
+        return rs.randint(-100, 100, n).astype(np.int8)
+    if dtype in ("int16", "int32", "int64"):
+        return rs.randint(-(2**20), 2**20, n).astype(np.int64)
+    return (rs.randn(n) * 8.0).astype(np.float32)
+
+
+def _buffer(n, dtype, seed):
+    """A contiguous device buffer of n elements and its bits as a host array.
+
+    Taking the reference from the device tensor's own bits, instead of from the
+    host array it was built from, keeps the comparison exact for every dtype:
+    .numpy() on bfloat16 hands back uint16, on float8 int8, so the reference is
+    a permutation of bit patterns and never a rounded value.
+    """
+    t = paddle.to_tensor(_host_values(n, dtype, seed), dtype=dtype)
+    return t, t.numpy()
+
+
+def _bits(t):
+    return t.numpy().tobytes()
+
+
+def _numel(shape):
+    return int(np.prod(shape))
+
+
+@unittest.skipIf(
+    not paddle.is_compiled_with_cuda(), "these kernels are GPU only"
+)
+class StrideFlagTestCase(unittest.TestCase):
+    """Force FLAGS_use_stride_kernel on and put it back afterwards."""
+
+    def setUp(self):
+        paddle.set_device("gpu:0")
+        self._saved = paddle.get_flags(
+            ["FLAGS_use_stride_kernel", "FLAGS_use_stride_compute_kernel"]
+        )
+        paddle.set_flags(
+            {
+                "FLAGS_use_stride_kernel": True,
+                "FLAGS_use_stride_compute_kernel": True,
+            }
+        )
+
+    def tearDown(self):
+        paddle.set_flags(self._saved)
+
+    def check_transpose(self, shape, perm, dtype, seed):
+        """Exact check of transpose(shape, perm) for one dtype."""
+        t, bits = _buffer(_numel(shape), dtype, seed)
+        t = t.reshape(shape)
+        out = paddle.transpose(t, perm).contiguous()
+        self.assertTrue(out.is_contiguous())
+        self.assertEqual(out.shape, [shape[i] for i in perm])
+        ref = np.ascontiguousarray(np.transpose(bits.reshape(shape), perm))
+        np.testing.assert_array_equal(out.numpy(), ref)
+
+    def sweep(self, cases, seed=7000):
+        """Run every case with the stride kernel both on and off.
+
+        Same kernel, two different ways in: with the flag on, transpose only
+        builds a view and the kernel runs from ContiguousKernel; with it off,
+        transpose dispatches the dense kernel directly.
+        """
+        for use_stride in (True, False):
+            paddle.set_flags({"FLAGS_use_stride_kernel": use_stride})
+            for i, (name, shape, perm, dtype) in enumerate(cases):
+                with self.subTest(case=name, stride=use_stride):
+                    self.check_transpose(shape, perm, dtype, seed + i)
+
+
+class TestTransposeVecTile(StrideFlagTestCase):
+    """Both sides of every gate guarding the vectorized tile transpose.
+
+    The gates are: a 2-byte dtype, both transposed extents even, both base
+    pointers 4-byte aligned, gridDim.z within 65535, and enough 64x64 tiles to
+    fill the device. Whether a case ends up vectorized is not observable from
+    the output, so the intent is recorded in the case name only; what is checked
+    is that every case is exact.
+    """
+
+    @property
+    def sm_count(self):
+        return paddle.device.cuda.get_device_properties(0).multi_processor_count
+
+    def test_inside_every_gate(self):
+        # 2048x2048 is 1024 tiles of 64x64, far past the tile-count gate on any
+        # real device, and small enough to stay cheap.
+        self.sweep(
+            [
+                ("2d_bf16", [2048, 2048], [1, 0], "bfloat16"),
+                ("2d_fp16", [2048, 2048], [1, 0], "float16"),
+                ("3d_bf16", [4, 1024, 1024], [0, 2, 1], "bfloat16"),
+                ("wide", [1024, 4096], [1, 0], "bfloat16"),
+                ("tall", [4096, 1024], [1, 0], "bfloat16"),
+                ("tile_multiple", [1280, 640], [1, 0], "bfloat16"),
+            ]
+        )
+
+    def test_ragged_tiles(self):
+        """Extents even but not multiples of 64.
+
+        The edge tiles are partial, which is the one case the vectorized kernel
+        handles element by element instead of with vector loads, so these cover
+        its second half.
+        """
+        self.sweep(
+            [
+                ("both_ragged", [2050, 2050], [1, 0], "bfloat16"),
+                ("cols_ragged", [2048, 2050], [1, 0], "bfloat16"),
+                ("rows_ragged", [2050, 2048], [1, 0], "bfloat16"),
+                ("ragged_3d", [4, 1026, 1026], [0, 2, 1], "bfloat16"),
+            ],
+            seed=7100,
+        )
+
+    def test_odd_extent_rejected(self):
+        """An odd extent makes the 2-element vector loads illegal."""
+        self.sweep(
+            [
+                ("odd_rows", [2049, 2048], [1, 0], "bfloat16"),
+                ("odd_cols", [2048, 2049], [1, 0], "bfloat16"),
+                ("odd_both", [2049, 2049], [1, 0], "bfloat16"),
+                ("odd_3d", [4, 1025, 1025], [0, 2, 1], "bfloat16"),
+            ],
+            seed=7200,
+        )
+
+    def test_too_few_tiles(self):
+        """Below the tile-count gate the scalar 32x32 tiling must be kept."""
+        n = self.sm_count
+        self.sweep(
+            [
+                ("tiles_eq_sm", [n, 64, 64], [0, 2, 1], "bfloat16"),
+                ("tiles_lt_sm", [n - 1, 64, 64], [0, 2, 1], "bfloat16"),
+                ("tiles_few", [1, 128, 128], [0, 2, 1], "bfloat16"),
+                ("tiles_one", [1, 64, 64], [0, 2, 1], "bfloat16"),
+            ],
+            seed=7300,
+        )
+
+    def test_grid_z_overflow(self):
+        """gridDim.z is limited to 65535, and dim0 maps onto it."""
+        self.sweep(
+            [
+                ("z_at_limit", [65535, 16, 16], [0, 2, 1], "bfloat16"),
+                ("z_over_limit", [65600, 16, 16], [0, 2, 1], "bfloat16"),
+            ],
+            seed=7400,
+        )
+
+    def test_small_extents(self):
+        """Extents under 16 do not reach the tiling path at all."""
+        self.sweep(
+            [
+                ("narrow", [1, 8, 4096], [0, 2, 1], "bfloat16"),
+                ("narrow_t", [1, 4096, 8], [0, 2, 1], "bfloat16"),
+                ("tiny", [1, 8, 8], [0, 2, 1], "bfloat16"),
+                ("single", [1, 1, 1], [0, 2, 1], "bfloat16"),
+            ],
+            seed=7500,
+        )
+
+    def test_other_dtypes(self):
+        """Only 2-byte dtypes are vectorized; the rest must be untouched."""
+        self.sweep(
+            [
+                ("fp32", [1024, 1024], [1, 0], "float32"),
+                ("fp64", [512, 512], [1, 0], "float64"),
+                ("int8", [2048, 2048], [1, 0], "int8"),
+                ("int32", [1024, 1024], [1, 0], "int32"),
+                ("int64", [512, 512], [1, 0], "int64"),
+                ("bool", [1024, 1024], [1, 0], "bool"),
+            ],
+            seed=7600,
+        )
+
+    def test_other_permutations(self):
+        """Permutations that are not a trailing-pair swap use other kernels."""
+        self.sweep(
+            [
+                ("perm_210", [64, 64, 64], [2, 1, 0], "bfloat16"),
+                ("perm_102", [64, 32, 128], [1, 0, 2], "bfloat16"),
+                ("perm_120", [32, 64, 128], [1, 2, 0], "bfloat16"),
+                ("perm_0213", [8, 64, 32, 128], [0, 2, 1, 3], "bfloat16"),
+                ("perm_3021", [4, 8, 16, 32], [3, 0, 2, 1], "bfloat16"),
+                ("perm_5d", [2, 3, 4, 5, 6], [4, 3, 2, 1, 0], "bfloat16"),
+                ("perm_identity", [16, 32, 64], [0, 1, 2], "bfloat16"),
+                ("perm_1d", [1024], [0], "bfloat16"),
+                ("perm_0213_fp32", [8, 64, 32, 128], [0, 2, 1, 3], "float32"),
+            ],
+            seed=7700,
+        )
+
+    def test_misaligned_base_pointer(self):
+        """Break the alignment gate through the pointer instead of the shape.
+
+        A bfloat16 view starting at an odd element offset has a 2-byte-aligned
+        base, so 4-byte vector loads would fault and the gate has to reject it.
+        Only reachable with the stride kernel on; otherwise the slice is
+        materialized and the odd offset is lost.
+        """
+        shape = [1024, 1024]
+        n = _numel(shape)
+        buf, bits = _buffer(n + 1, "bfloat16", 7800)
+        view = buf[1:].reshape(shape)
+        self.assertEqual(view.data_ptr() % 4, 2)
+        out = paddle.transpose(view, [1, 0]).contiguous()
+        ref = np.ascontiguousarray(bits[1:].reshape(shape).T)
+        np.testing.assert_array_equal(out.numpy(), ref)
+
+
+class TestContiguousNonZeroOffset(StrideFlagTestCase):
+    """Materializing a view whose offset is not zero.
+
+    Element offset 1024 in bfloat16 is what a fused parameter buffer produces
+    for every parameter but the first, so it is the shape of the case that
+    matters in practice; the small offsets are there because they land in a
+    different alignment class and must therefore take a different path inside
+    the transpose kernel.
+    """
+
+    def _view(self, shape, dtype, off, seed):
+        """A view of `shape` starting `off` elements into a larger buffer."""
+        n = _numel(shape)
+        buf, bits = _buffer(n + off, dtype, seed)
+        view = buf[off : off + n].reshape(shape)
+        self.assertEqual(view.offset, off * buf.element_size())
+        self.assertTrue(view.is_contiguous())
+        return buf, view, bits[off : off + n].reshape(shape)
+
+    def _materialize(self, view, host, perm):
+        """transpose(perm).contiguous() on a view, checked exactly."""
+        strided = paddle.transpose(view, perm)
+        out = strided.contiguous()
+        # The output is a fresh allocation, so it has to start at offset zero
+        # no matter what the input offset was. Inheriting the input offset would
+        # read and write past the end of that allocation.
+        self.assertEqual(out.offset, 0)
+        self.assertTrue(out.is_contiguous())
+        self.assertNotEqual(out.data_ptr(), view.data_ptr())
+        ref = np.ascontiguousarray(np.transpose(host, perm))
+        np.testing.assert_array_equal(out.numpy(), ref)
+        return out
+
+    def test_transposed_2d(self):
+        cases = [
+            # shape, dtype, element offset
+            ([2048, 2048], "bfloat16", 0),
+            ([2048, 2048], "bfloat16", 1),
+            ([2048, 2048], "bfloat16", 4),
+            ([2048, 2048], "bfloat16", 1024),
+            ([1024, 3072], "bfloat16", 1024),
+            ([2050, 2050], "bfloat16", 1024),
+            ([2049, 2048], "bfloat16", 1024),
+            ([65, 4096], "bfloat16", 1024),
+            ([4096, 65], "bfloat16", 1024),
+            ([2048, 2048], "float16", 1024),
+            ([1024, 1024], "float32", 3),
+            ([512, 512], "float64", 7),
+            ([2048, 2048], "int8", 5),
+            ([1024, 1024], "int32", 1024),
+        ]
+        for i, (shape, dtype, off) in enumerate(cases):
+            with self.subTest(shape=shape, dtype=dtype, offset=off):
+                _, view, host = self._view(shape, dtype, off, 8000 + i)
+                self._materialize(view, host, [1, 0])
+
+    def test_permuted_3d(self):
+        """Pure permutations that are not a 2-D transpose, at an offset."""
+        cases = [
+            ([4, 1024, 1024], [0, 2, 1]),
+            ([4, 1026, 1026], [0, 2, 1]),
+            ([64, 64, 64], [2, 1, 0]),
+            ([64, 32, 128], [1, 0, 2]),
+            ([8, 16, 32, 64], [0, 2, 1, 3]),
+            ([8, 16, 32, 64], [3, 2, 1, 0]),
+        ]
+        for i, (shape, perm) in enumerate(cases):
+            with self.subTest(shape=shape, perm=perm):
+                _, view, host = self._view(shape, "bfloat16", 1024, 8100 + i)
+                self._materialize(view, host, perm)
+
+    def test_non_permutation_views(self):
+        """Strided views that are not a permutation, so they cannot be folded.
+
+        These must be rejected and go to the generic strided copy, on top of a
+        non-zero offset; the output still has to be exact and start at zero.
+        """
+        shape = [512, 512]
+        _, view, host = self._view(shape, "bfloat16", 1024, 8200)
+        for name, sub, ref in [
+            ("row_step2", view[::2], host[::2]),
+            ("col_step2", view[:, ::2], host[:, ::2]),
+            ("row_slice_t", view[3:7].t(), host[3:7].T),
+            ("col_slice", view[:, 5:9], host[:, 5:9]),
+            ("both_step", view[1::3, 2::5], host[1::3, 2::5]),
+        ]:
+            with self.subTest(case=name):
+                out = sub.contiguous()
+                self.assertEqual(out.offset, 0)
+                self.assertTrue(out.is_contiguous())
+                np.testing.assert_array_equal(
+                    out.numpy(), np.ascontiguousarray(ref)
+                )
+
+    def test_assign_materializes_the_same_bits(self):
+        """paddle.assign has to materialize the view too, and agree."""
+        _, view, host = self._view([1024, 1024], "bfloat16", 1024, 8300)
+        strided = view.t()
+        by_contiguous = strided.contiguous()
+        by_assign = paddle.assign(strided).contiguous()
+        self.assertEqual(_bits(by_assign), _bits(by_contiguous))
+        np.testing.assert_array_equal(
+            by_contiguous.numpy(), np.ascontiguousarray(host.T)
+        )
+
+    def test_output_does_not_alias_input(self):
+        """The materialized copy must not be affected by later writes."""
+        buf, view, host = self._view([256, 256], "bfloat16", 1024, 8400)
+        out = view.t().contiguous()
+        before = _bits(out)
+        buf[:] = paddle.zeros_like(buf)
+        self.assertEqual(_bits(out), before)
+        np.testing.assert_array_equal(out.numpy(), np.ascontiguousarray(host.T))
+
+    def test_offset_invariance(self):
+        """The same values at different offsets must give the same bits."""
+        shape = [1024, 1024]
+        seen = {}
+        for off in (0, 1, 2, 4, 8, 128, 1024):
+            n = _numel(shape)
+            vals = _host_values(n, "bfloat16", 8500)
+            pad = np.zeros(off, dtype=vals.dtype)
+            buf = paddle.to_tensor(
+                np.concatenate([pad, vals]), dtype="bfloat16"
+            )
+            view = buf[off : off + n].reshape(shape)
+            seen[off] = _bits(view.t().contiguous())
+        ref = seen[0]
+        for off, got in seen.items():
+            self.assertEqual(got, ref, f"offset {off} differs from offset 0")
+
+
+class TestMatmulStrideOffset(StrideFlagTestCase):
+    """Folding a transposed operand into cuBLAS when its offset is not zero.
+
+    The reference is the same call on a copy that starts at offset zero. Both go
+    through the same fold and the same cuBLAS call, so the results must
+    agree bit for bit; a difference means the offset changed the path taken.
+
+    The offset used is a multiple of 1024 elements, the granularity a fused
+    parameter buffer aligns to, so the base pointer keeps its alignment
+    class and cuBLAS cannot pick a different kernel for that reason alone.
+    """
+
+    OFFSET = 1024
+
+    def _pair(self, shape, dtype, seed):
+        """The same values, once as an offset view and once as a tensor."""
+        n = _numel(shape)
+        vals = _host_values(n, dtype, seed)
+        pad = np.zeros(self.OFFSET, dtype=vals.dtype)
+        buf = paddle.to_tensor(np.concatenate([pad, vals]), dtype=dtype)
+        view = buf[self.OFFSET : self.OFFSET + n].reshape(shape)
+        plain = paddle.to_tensor(vals, dtype=dtype).reshape(shape)
+        self.assertNotEqual(view.offset, 0)
+        self.assertEqual(view.data_ptr() % 16, plain.data_ptr() % 16)
+        # Same bits at both offsets, otherwise the comparison below is vacuous.
+        self.assertEqual(_bits(view.contiguous()), _bits(plain))
+        return view, plain
+
+    def _same(self, fn, shape, dtype, seed):
+        """fn applied to the offset view and to the copy must agree exactly."""
+        view, plain = self._pair(shape, dtype, seed)
+        got, ref = fn(view), fn(plain)
+        self.assertEqual(got.shape, ref.shape)
+        self.assertEqual(_bits(got), _bits(ref))
+        return got
+
+    def test_y_operand_folded(self):
+        """matmul(x, w.t()): the transposed view is the second operand."""
+        x = paddle.randn([512, 2048], dtype="float32").astype("bfloat16")
+        u = paddle.randn([256, 1024], dtype="float32").astype("bfloat16")
+        for name, fn in [
+            ("wt", lambda w: paddle.matmul(x, w.t())),
+            ("wt_ty", lambda w: paddle.matmul(u, w.t(), transpose_y=True)),
+            ("w_ty", lambda w: paddle.matmul(x, w, transpose_y=True)),
+            ("w_plain", lambda w: paddle.matmul(u, w)),
+        ]:
+            with self.subTest(case=name):
+                self._same(fn, [1024, 2048], "bfloat16", 8600)
+
+    def test_x_operand_folded(self):
+        """matmul(w.t(), z): the transposed view is the first operand."""
+        z = paddle.randn([1024, 256], dtype="float32").astype("bfloat16")
+        u = paddle.randn([256, 1024], dtype="float32").astype("bfloat16")
+        for name, fn in [
+            ("wt_z", lambda w: paddle.matmul(w.t(), z)),
+            ("wt_ut", lambda w: paddle.matmul(w.t(), u, transpose_y=True)),
+            ("w_tx", lambda w: paddle.matmul(w, z, transpose_x=True)),
+        ]:
+            with self.subTest(case=name):
+                self._same(fn, [1024, 2048], "bfloat16", 8700)
+
+    def test_both_operands_folded(self):
+        """Both operands are offset views of the same buffer."""
+        n = 1024 * 512
+        vals = _host_values(2 * n + self.OFFSET, "bfloat16", 8800)
+        buf = paddle.to_tensor(vals, dtype="bfloat16")
+        a = buf[self.OFFSET : self.OFFSET + n].reshape([512, 1024])
+        b = buf[self.OFFSET + n : self.OFFSET + 2 * n].reshape([512, 1024])
+        got = paddle.matmul(a.t(), b)
+        ref = paddle.matmul(
+            a.contiguous().t(), b.contiguous(), transpose_y=False
+        )
+        self.assertEqual(_bits(got), _bits(ref))
+
+    def test_batched(self):
+        """3-D operands, both a trailing swap and a permutation that is not."""
+        g = paddle.randn([4, 256, 512], dtype="float32").astype("bfloat16")
+        h = paddle.randn([64, 32, 4], dtype="float32").astype("bfloat16")
+        for name, shape, fn in [
+            (
+                "swap_last2",
+                [4, 512, 512],
+                lambda w: paddle.matmul(g, w.transpose([0, 2, 1])),
+            ),
+            (
+                "batched_x",
+                [4, 512, 512],
+                lambda w: paddle.matmul(
+                    w.transpose([0, 2, 1]), g, transpose_y=True
+                ),
+            ),
+            (
+                "perm_102",
+                [4, 64, 512],
+                lambda w: paddle.matmul(h, w.transpose([1, 0, 2])),
+            ),
+        ]:
+            with self.subTest(case=name):
+                self._same(fn, shape, "bfloat16", 8900)
+
+    def test_dtypes(self):
+        """The fold is dtype independent."""
+        for dtype in ("float16", "float32", "float64"):
+            with self.subTest(dtype=dtype):
+                x = paddle.randn([256, 512], dtype="float32").astype(dtype)
+                self._same(
+                    lambda w: paddle.matmul(x, w.t()), [256, 512], dtype, 9000
+                )
+
+    def test_against_float64_reference(self):
+        """Guard against both paths being wrong in the same way.
+
+        Bit-identity only says the offset did not change the answer. This checks
+        the answer itself, in float64 on the host, with a tolerance set by the
+        input dtype rather than by the accumulation order.
+        """
+        shape = [256, 512]
+        view, _ = self._pair(shape, "float32", 9100)
+        x = paddle.randn([128, 512], dtype="float32")
+        got = paddle.matmul(x, view.t()).numpy()
+        ref = (
+            x.numpy().astype(np.float64)
+            @ view.contiguous().numpy().astype(np.float64).T
+        )
+        np.testing.assert_allclose(got, ref, rtol=1e-4, atol=1e-4)
+
+    def test_folded_result_is_used_by_backward(self):
+        """The same fold runs in the gradient matmuls."""
+        w = paddle.randn([1024, 512], dtype="float32")
+        w.stop_gradient = False
+        x = paddle.randn([256, 512], dtype="float32")
+        x.stop_gradient = False
+        out = paddle.matmul(x, w.t())
+        out.backward()
+        self.assertEqual(w.grad.shape, w.shape)
+        self.assertEqual(x.grad.shape, x.shape)
+        np.testing.assert_allclose(
+            x.grad.numpy(),
+            np.ones_like(out.numpy()) @ w.numpy(),
+            rtol=1e-5,
+            atol=1e-4,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/legacy_test/test_stride_offset_kernel.py
+++ b/test/legacy_test/test_stride_offset_kernel.py
@@ -415,6 +415,15 @@ class TestMatmulStrideOffset(StrideFlagTestCase):
 
     OFFSET = 1024
 
+    def setUp(self):
+        super().setUp()
+        # cuBLAS rejects a plain bfloat16 gemm below compute capability 80, so
+        # older cards exercise the fold in float16 instead. Both are two bytes
+        # wide, which keeps the offset alignment argument above valid, and the
+        # fold itself only rewrites meta, so it cannot depend on the dtype.
+        major, minor = paddle.device.cuda.get_device_capability()
+        self.dtype = "bfloat16" if (major, minor) >= (8, 0) else "float16"
+
     def _pair(self, shape, dtype, seed):
         """The same values, once as an offset view and once as a tensor."""
         n = _numel(shape)
@@ -439,8 +448,8 @@ class TestMatmulStrideOffset(StrideFlagTestCase):
 
     def test_y_operand_folded(self):
         """matmul(x, w.t()): the transposed view is the second operand."""
-        x = paddle.randn([512, 2048], dtype="float32").astype("bfloat16")
-        u = paddle.randn([256, 1024], dtype="float32").astype("bfloat16")
+        x = paddle.randn([512, 2048], dtype="float32").astype(self.dtype)
+        u = paddle.randn([256, 1024], dtype="float32").astype(self.dtype)
         for name, fn in [
             ("wt", lambda w: paddle.matmul(x, w.t())),
             ("wt_ty", lambda w: paddle.matmul(u, w.t(), transpose_y=True)),
@@ -448,25 +457,25 @@ class TestMatmulStrideOffset(StrideFlagTestCase):
             ("w_plain", lambda w: paddle.matmul(u, w)),
         ]:
             with self.subTest(case=name):
-                self._same(fn, [1024, 2048], "bfloat16", 8600)
+                self._same(fn, [1024, 2048], self.dtype, 8600)
 
     def test_x_operand_folded(self):
         """matmul(w.t(), z): the transposed view is the first operand."""
-        z = paddle.randn([1024, 256], dtype="float32").astype("bfloat16")
-        u = paddle.randn([256, 1024], dtype="float32").astype("bfloat16")
+        z = paddle.randn([1024, 256], dtype="float32").astype(self.dtype)
+        u = paddle.randn([256, 1024], dtype="float32").astype(self.dtype)
         for name, fn in [
             ("wt_z", lambda w: paddle.matmul(w.t(), z)),
             ("wt_ut", lambda w: paddle.matmul(w.t(), u, transpose_y=True)),
             ("w_tx", lambda w: paddle.matmul(w, z, transpose_x=True)),
         ]:
             with self.subTest(case=name):
-                self._same(fn, [1024, 2048], "bfloat16", 8700)
+                self._same(fn, [1024, 2048], self.dtype, 8700)
 
     def test_both_operands_folded(self):
         """Both operands are offset views of the same buffer."""
         n = 1024 * 512
-        vals = _host_values(2 * n + self.OFFSET, "bfloat16", 8800)
-        buf = paddle.to_tensor(vals, dtype="bfloat16")
+        vals = _host_values(2 * n + self.OFFSET, self.dtype, 8800)
+        buf = paddle.to_tensor(vals, dtype=self.dtype)
         a = buf[self.OFFSET : self.OFFSET + n].reshape([512, 1024])
         b = buf[self.OFFSET + n : self.OFFSET + 2 * n].reshape([512, 1024])
         got = paddle.matmul(a.t(), b)
@@ -477,8 +486,8 @@ class TestMatmulStrideOffset(StrideFlagTestCase):
 
     def test_batched(self):
         """3-D operands, both a trailing swap and a permutation that is not."""
-        g = paddle.randn([4, 256, 512], dtype="float32").astype("bfloat16")
-        h = paddle.randn([64, 32, 4], dtype="float32").astype("bfloat16")
+        g = paddle.randn([4, 256, 512], dtype="float32").astype(self.dtype)
+        h = paddle.randn([64, 32, 4], dtype="float32").astype(self.dtype)
         for name, shape, fn in [
             (
                 "swap_last2",
@@ -499,7 +508,7 @@ class TestMatmulStrideOffset(StrideFlagTestCase):
             ),
         ]:
             with self.subTest(case=name):
-                self._same(fn, shape, "bfloat16", 8900)
+                self._same(fn, shape, self.dtype, 8900)
 
     def test_dtypes(self):
         """The fold is dtype independent."""

--- a/test/legacy_test/test_stride_offset_kernel.py
+++ b/test/legacy_test/test_stride_offset_kernel.py
@@ -363,6 +363,37 @@ class TestContiguousNonZeroOffset(StrideFlagTestCase):
                     out.numpy(), np.ascontiguousarray(ref)
                 )
 
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda()
+        or paddle.device.cuda.get_device_capability() < (8, 9),
+        "float8_e4m3fn needs compute capability 89",
+    )
+    def test_float8_offset_breaks_vector_alignment(self):
+        """A one-byte dtype can start at any byte, unlike the wider ones.
+
+        The float8 tile transpose moves eight bytes at a time, so a view whose
+        offset is not a multiple of eight must not reach it. Its extents are
+        multiples of 128 here, which is what the shape side of that gate asks
+        for, leaving the base pointer as the only thing that can reject it.
+        """
+        shape = [256, 384]
+        n = _numel(shape)
+        for off in (0, 1, 3, 7, 8, 1024):
+            with self.subTest(offset=off):
+                # float8 has no numpy dtype, so the buffer is cast on device
+                # and the reference is read back as the raw bytes.
+                buf = paddle.to_tensor(
+                    _host_values(n + off, "float32", 8400 + off)
+                ).astype("float8_e4m3fn")
+                bits = buf.numpy()
+                view = buf[off : off + n].reshape(shape)
+                self.assertEqual(view.data_ptr() % 8, off % 8)
+                out = paddle.transpose(view, [1, 0]).contiguous()
+                ref = np.ascontiguousarray(
+                    bits[off : off + n].reshape(shape).T
+                )
+                np.testing.assert_array_equal(out.numpy(), ref)
+
     def test_assign_materializes_the_same_bits(self):
         """paddle.assign has to materialize the view too, and agree."""
         _, view, host = self._view([1024, 1024], "bfloat16", 1024, 8300)

--- a/test/legacy_test/test_stride_offset_kernel.py
+++ b/test/legacy_test/test_stride_offset_kernel.py
@@ -389,9 +389,7 @@ class TestContiguousNonZeroOffset(StrideFlagTestCase):
                 view = buf[off : off + n].reshape(shape)
                 self.assertEqual(view.data_ptr() % 8, off % 8)
                 out = paddle.transpose(view, [1, 0]).contiguous()
-                ref = np.ascontiguousarray(
-                    bits[off : off + n].reshape(shape).T
-                )
+                ref = np.ascontiguousarray(bits[off : off + n].reshape(shape).T)
                 np.testing.assert_array_equal(out.numpy(), ref)
 
     def test_assign_materializes_the_same_bits(self):


### PR DESCRIPTION
### PR Category

Performance Optimization

### PR Types

Performance

### Description

sharding stage1 + `split_param` + 融合优化器状态下，融合参数 buffer 里除第一个参数外，`offset` 都不为 0。多条本该命中的快路径都在 `offset != 0` 时被直接挡掉，退化成"一线程一元素、读侧完全不合并"的拷贝。本 PR 逐个打开这些路径，并对两个纯访存 kernel 做向量化。

---

**1. matmul（stride）：去掉 `is_only_transposed_tensor()` 中的 offset 判断**

文件：`paddle/phi/kernels/stride/matmul_stride_kernel.cu`

- **改动**：删掉 `offset != 0` 就返回 false 的那一条。
- **为什么能删**：offset 和"strides 是否只是 dims 的一次置换"这两件事正交。该函数只重排 dims/strides，offset 由调用方原样写回；`data()` 每次访问都会加上 offset，`is_contiguous()` 也从不看 offset。判断的存在纯属过度保守。
- **收益**：融合 buffer 上的 `w.t()` 可以折叠成 cuBLAS 的 transpose flag，省掉一次全量连续化拷贝——这次拷贝读侧完全不合并，是纯访存开销。

**2. contiguous：同一处 offset 判断，外加修正输出的 offset**

文件：`paddle/phi/kernels/gpu/contiguous_kernel.cu`

- **改动**：`is_only_transposed()` 去掉同样的 offset 判断；同时把 `set_meta()` 里 `out` 的 offset 显式置 0。
- **为什么能删**：同上，`is_only_transposed()` 判断的也是"strides 是不是一次置换"。
- **为什么必须同时改 `set_meta()`**：`out` 是新分配的连续张量，它的 offset 必须是 0，不能从输入继承——否则会越过这块分配的尾部读写。原先那条 offset 判断正是让这个隐患一直不可达的唯一原因，所以两处必须一起改。
- **收益**：转置视图上的 `.contiguous()` 不再退到 `ContiguousCaseOneFunc`（一线程一元素、读侧不合并），可以走 `TransposeKernel`。

**3. transpose：为 2 字节 dtype 新增 64×64 向量化 tile 转置**

文件：`paddle/phi/kernels/funcs/transpose_function.cuh`

- **改动**：新增 `TilingSwapDim1And2Vec`，与原 `TilingSwapDim1And2` 逐位等价，差别只有三点：tile 坐标由 3D grid 直接给出，省掉每线程 5 次运行时整除；tile 放大到 64×64，提高在途字节数；global 访存向量化。
- **为什么 pad 取奇数不冲突**：shared memory 仍按元素（而非向量）访问，因此写侧的列向读取跨过奇数个 word，不产生 bank conflict。
- **启用条件（其余情况完全走原有标量 tiling）**：两个转置维均为偶数、输入输出基址均 4 字节对齐、grid 维度不超过 65535、且 64×64 tile 数足以填满设备。

**4. transpose（dispatch）：给 `GetVecSize()` 的返回值加上限截断**

文件：同上

- **改动**：`PermuteDispatch` 中把 vec_size 截断到 4。
- **为什么**：`GetVecSize()` 对 2 字节 dtype 可能返回 8，而下游两个 switch 都没有 8 的分支——一旦命中就不会发射任何 kernel，输出保持未初始化。更窄的向量宽度只会更慢，不会更错。
- **说明**：这是防御性修改，目前未发现默认配置能走到该取值。

**5. fp8_quant_blockwise：新增 128-bit 访存的量化 kernel**

文件：`paddle/phi/kernels/legacy/gpu/fp8_quant_blockwise_kernel.cu`

- **改动**：新增 `quantize_1x128_kernel_v128`，只针对 `!input_transpose && !return_transpose_only` 这一个实例化做 128-bit 访存重写。
- **为什么只覆盖这一个实例化**：它是训练主路径上的热点；带转置的两个实例化访存模式不同，向量化要另做，不在本 PR 范围内。
- **启用条件**：输入与输出基址均 16 字节对齐，否则回退原标量 kernel。

release/3.4 对应 PR：PaddlePaddle/Paddle#79742




### 是否引起精度变化

**否**
