### PR TITLE
[FSDP] optim FSDP save load

### DIFF
--- a/python/paddle/distributed/fsdp/fully_shard_fusion.py
+++ b/python/paddle/distributed/fsdp/fully_shard_fusion.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from enum import Enum
@@ -26,6 +27,7 @@ from paddle.distributed.fleet.utils.tensor_fusion_helper import (
     alignment,
     get_current_device_type,
 )
+from paddle.distributed.flex_checkpoint.dcp.sharded_weight import ShardedWeight
 from paddle.distributed.fsdp._fsdp_context import (
     register_fsdp_context,
 )
@@ -54,6 +56,7 @@ class BufferGroup:
     fsdp_unit_id: int = None
     is_expert_param: bool = False
     is_tie: bool = False
+    no_decay: bool = False
     fsdp_group: object = None
     params_buffer: 'TensorFusionBuffer' = None
     grads_buffer: 'TensorFusionBuffer' = None
@@ -91,6 +94,9 @@ class TensorFusionBuffer:
             self.param_offsets[param.name] = self.total_buffer_size
             self.total_buffer_size += self.get_padded_size(param)
 
+        self.shard_start = 0
+        self.shard_end = self.total_buffer_size
+
         if is_params:
             # Create fused params_buffer
             # TODO(lizhenxing): Build full params_buffer on CPU and only move shards to GPU to minimize mem peaks
@@ -127,6 +133,8 @@ class TensorFusionBuffer:
                 ) // self.fsdp_degree
                 start = curr_rank * piece_len
                 end = min(start + piece_len, total_nums)
+                self.shard_start = start
+                self.shard_end = end
                 self.data_buffer = paddle.slice(
                     self.data_buffer, [0], [start], [end]
                 ).clone()
@@ -141,6 +149,14 @@ class TensorFusionBuffer:
                 shape=[self.total_buffer_size // self.fsdp_degree],
                 dtype=self.main_grad_dtype,
             )
+
+            if self.is_sharded:
+                shard_size = self.total_buffer_size // self.fsdp_degree
+                self.shard_start = (
+                    paddle.distributed.get_rank(fsdp_group) * shard_size
+                )
+                self.shard_end = self.shard_start + shard_size
+
             # Register get_main_grad method for each param, returns view_slice of grad_buffer
             for param in params:
                 if param.trainable:
@@ -187,6 +203,20 @@ class TensorFusionBuffer:
             * self.fsdp_degree
         )
         return ((size + align_size - 1) // align_size) * align_size
+
+    def param_shard(self, param):
+        """Intersect a param's slot in the fused buffer with this rank's shard, or None."""
+        offset = self.param_offsets[param.name]
+        numel = int(np.prod(param.shape))
+        begin = max(offset, self.shard_start)
+        end = min(offset + numel, self.shard_end)
+        if end <= begin:
+            return None
+        return (
+            begin - self.shard_start,
+            end - self.shard_start,
+            slice(begin - offset, end - offset),
+        )
 
     def get_tmp_buffer(self):
         if not self.is_sharded:
@@ -294,11 +324,13 @@ class FSDPBufferManager:
                 is_expert,
                 fsdp_group,
                 param.name == self.tie_param_name,
+                # A buffer must not mix params with and without weight decay.
+                bool(getattr(param, "no_weight_decay", False)),
             )
             keyed_params.setdefault(key, []).append(param)
 
         def sort_key(item):
-            _, trainable, unit_id, is_expert_param, _, is_tie = item[0]
+            _, trainable, unit_id, is_expert_param, _, is_tie, _ = item[0]
             return (
                 0 if is_tie else (1 if not trainable else 2),
                 unit_id if unit_id is not None else float('inf'),
@@ -314,6 +346,7 @@ class FSDPBufferManager:
                 is_expert_param=is_expert_param,
                 fsdp_group=fsdp_group,
                 is_tie=is_tie,
+                no_decay=no_decay,
             )
             for (
                 dtype,
@@ -322,6 +355,7 @@ class FSDPBufferManager:
                 is_expert_param,
                 fsdp_group,
                 is_tie,
+                no_decay,
             ), params in sorted(keyed_params.items(), key=sort_key)
         ]
 
@@ -685,6 +719,281 @@ class FullyShardFusion:
         )
         self.register_tensor_fusion_hooks(self.model)
         register_fsdp_context(self)
+        # fused buffer name -> {structured param name: slice info in the local shard}
+        self._shard_descs = {}
+        # Redirect the model's own API; the original stays as our description base.
+        self._model_sharded_state_dict = self.model.sharded_state_dict
+        self.model.sharded_state_dict = self.sharded_state_dict
+
+    def _base_sharded_state_dict(self, structured_name_prefix):
+        """Model descriptions of every param; fused params get a scratch view since their storage is cleared."""
+        cleared = []
+        scratch = {}
+        for group in self.buffer_manager.buffer_groups:
+            for param in group.params:
+                if param._is_initialized():
+                    continue
+                numel = int(np.prod(param.shape))
+                cleared.append((param, param.shape, numel))
+                scratch[param.dtype] = max(scratch.get(param.dtype, 0), numel)
+
+        scratch = {
+            dtype: paddle.empty([numel], dtype=dtype)
+            for dtype, numel in scratch.items()
+        }
+        for param, shape, numel in cleared:
+            view = paddle._C_ops.view_slice(scratch[param.dtype], 0, numel)
+            view.get_tensor()._set_dims(shape)
+            param.get_tensor()._share_data_with(view.get_tensor())
+        try:
+            return self._model_sharded_state_dict(structured_name_prefix)
+        finally:
+            for param, shape, _ in cleared:
+                stop_gradient = param.stop_gradient
+                param._clear_data()
+                param.stop_gradient = stop_gradient
+                param.get_tensor()._set_dims(shape)
+
+    def _create_sharded_weight(self, key, tensor, slice_info):
+        """Wrap the ``slice_info`` piece of ``tensor`` as a flattened ShardedWeight."""
+        (
+            begin,
+            end,
+            flattened_range,
+            local_shape,
+            global_shape,
+            global_offset,
+        ) = slice_info
+        return ShardedWeight(
+            key=key,
+            local_tensor=tensor._slice(begin, end),
+            local_shape=local_shape,
+            global_shape=global_shape,
+            global_offset=global_offset,
+            is_flattened=True,
+            flattened_range=flattened_range,
+        )
+
+    def sharded_state_dict(self, structured_name_prefix=""):
+        """Describe every fused param as a flattened piece of this rank's shard, no all_gather."""
+        base = self._base_sharded_state_dict(structured_name_prefix)
+
+        static_to_struct = {}
+        for key, sharded_weight in sorted(base.items()):
+            static_to_struct.setdefault(
+                sharded_weight.local_tensor.name, []
+            ).append(key)
+
+        result = dict(base)
+        self._shard_descs = {}
+        hcg = self.buffer_manager.hcg
+        for group in self.buffer_manager.buffer_groups:
+            params_buffer = group.params_buffer
+            param_slice_info = {}
+            # (nranks, rank) of the expert parallel group, (1, 0) without EP.
+            ep_nranks, ep_rank = 1, 0
+            if group.is_expert_param and hasattr(
+                hcg, "get_expert_parallel_world_size"
+            ):
+                nranks = hcg.get_expert_parallel_world_size()
+                if nranks > 1:
+                    ep_nranks, ep_rank = nranks, hcg.get_expert_parallel_rank()
+            for param in group.params:
+                struct_names = static_to_struct.get(param.name)
+                if not struct_names:
+                    continue
+                # Tied weights share one shard; only the first key carries optimizer state.
+                ref = base[struct_names[0]]
+                local_shape = tuple(ref.local_shape)
+                global_shape = tuple(ref.global_shape)
+                global_offset = tuple(ref.global_offset)
+                if ep_nranks > 1 and global_shape == local_shape:
+                    # Expert described as replicated: fold EP into axis 0 to keep keys distinct.
+                    global_shape = (
+                        local_shape[0] * ep_nranks,
+                        *local_shape[1:],
+                    )
+                    global_offset = (
+                        ep_rank * local_shape[0],
+                        *(0 for _ in local_shape[1:]),
+                    )
+                shard = params_buffer.param_shard(param)
+                if shard is None:
+                    # Nothing of this param lives on this rank.
+                    for struct_name in struct_names:
+                        result.pop(struct_name, None)
+                    continue
+                begin, end, flattened_range = shard
+                slice_info = (
+                    begin,
+                    end,
+                    flattened_range,
+                    local_shape,
+                    global_shape,
+                    global_offset,
+                )
+                param_slice_info[struct_names[0]] = slice_info
+                for struct_name in struct_names:
+                    result[struct_name] = self._create_sharded_weight(
+                        struct_name, params_buffer.data_buffer, slice_info
+                    )
+            self._shard_descs[params_buffer.data_buffer.name] = param_slice_info
+        return result
+
+    def bind_decay_param_fun(self, optimizer):
+        """Answer ``apply_decay_param_fun`` for the fused buffers.
+
+        The callback matches model param names, so every ``fuse_params_*`` name
+        would answer False and weight decay would be dropped silently.
+        """
+        fun = getattr(optimizer, "_apply_decay_param_fun", None)
+        if fun is None or getattr(optimizer, "_fsdp_decay_fun_bound", False):
+            return
+        buffer_decay = {}
+        for group in self.buffer_manager.buffer_groups:
+            buffer_name = group.params_buffer.data_buffer.name
+            decayed, exempt = [], []
+            for param in group.params:
+                (decayed if fun(param.name) else exempt).append(param.name)
+            if decayed and exempt:
+                # A fused update can only honor one decay answer per buffer.
+                raise ValueError(
+                    f"FSDP: fused buffer {buffer_name} mixes params with and "
+                    "without weight decay; mark the exempt ones with "
+                    "`param.no_weight_decay = True` before fully_shard(). "
+                    f"Decayed: {decayed}; exempt: {exempt}."
+                )
+            buffer_decay[buffer_name] = bool(decayed) and not group.no_decay
+
+        def fsdp_apply_decay_param_fun(name):
+            if name in buffer_decay:
+                return buffer_decay[name]
+            return fun(name)
+
+        optimizer._apply_decay_param_fun = fsdp_apply_decay_param_fun
+        optimizer._fsdp_decay_fun_bound = True
+
+    def owns_optimizer_params(self, optimizer):
+        """Whether ``optimizer`` steps on the fused buffers of this context."""
+        # It still holds the model params; the fused buffers are substituted inside ``step``.
+        managed = self.buffer_manager.param_to_buffer_id
+        for param in optimizer._parameter_list:
+            if getattr(param, "name", None) in managed:
+                return True
+        return False
+
+    def init_optimizer_state(self, optimizer):
+        """Create optimizer accumulators on the fused buffers before load."""
+        parameter_list = [
+            group.params_buffer.data_buffer
+            for group in self.buffer_manager.buffer_groups
+            if not group.params_buffer.data_buffer.stop_gradient
+        ]
+        optimizer._create_accumulators(
+            paddle.base.framework.default_main_program().global_block(),
+            parameter_list,
+        )
+
+    def optimizer_sharded_state_dict(self, optimizer):
+        """Split the state keyed by ``fuse_params_<gid>`` into per-param flattened shards."""
+        if not self._shard_descs:
+            self.sharded_state_dict()
+
+        inner = optimizer
+        while hasattr(inner, "_inner_opt"):
+            inner = inner._inner_opt
+        # Keep the raw value: Adadelta's acc names start with '_' themselves.
+        tags = sorted(
+            {
+                getattr(cls, attr)
+                for cls in type(inner).__mro__
+                for attr in vars(cls)
+                if attr.endswith("_str")
+                and "_acc" in attr
+                and isinstance(getattr(cls, attr), str)
+            },
+            key=len,
+            reverse=True,
+        )
+        _master_weight_suffix = re.compile(r"^(.*)_fp32_master_\d+$")
+        # ``_add_accumulator`` prefixes the accumulator with the optimizer name.
+        opt_name = getattr(inner, "_name", None)
+
+        def _split_optimizer_state_name(vname):
+            """``fuse_params_0_fp32_master_0_moment1_3`` -> ``("fuse_params_0", "moment1_0")``."""
+            for tag in tags:
+                marker = "_" + tag + "_"
+                idx = vname.rfind(marker)
+                if idx < 0:
+                    continue
+                if not vname[idx + len(marker) :].isdigit():
+                    continue
+                base = vname[:idx]
+                if opt_name and base.endswith("_" + opt_name):
+                    base = base[: -len(opt_name) - 1]
+                matched = _master_weight_suffix.match(base)
+                if matched:
+                    base = matched.group(1)
+                return base, f"{tag.lstrip('_')}_0"
+            return None, None
+
+        def _replicated_scalar(key, tensor):
+            return ShardedWeight(
+                key=key,
+                local_tensor=tensor,
+                local_shape=tuple(tensor.shape),
+                global_shape=tuple(tensor.shape),
+                global_offset=tuple(0 for _ in tensor.shape),
+            )
+
+        state_dict = dict(optimizer.state_dict())
+        master_weights = state_dict.pop("master_weights", None)
+
+        sharded_state = {}
+        for vname, tensor in state_dict.items():
+            owner = next(
+                (
+                    name
+                    for name in self._shard_descs
+                    if vname.startswith(name + "_")
+                ),
+                None,
+            )
+            if owner is None:
+                continue
+            base_name, tag = _split_optimizer_state_name(vname)
+            if base_name != owner:
+                raise NotImplementedError(
+                    f"FSDP cannot save optimizer state '{vname}' of "
+                    f"{type(inner).__name__} on fused buffer '{owner}': the "
+                    "accumulator is not declared through a '_*_acc*_str' "
+                    "attribute, and skipping it would silently reset the state "
+                    "on load."
+                )
+            param_slice_info = self._shard_descs[owner]
+            if int(tensor.numel()) == 1:
+                for struct_name in param_slice_info:
+                    key = f"{struct_name}.{tag}"
+                    sharded_state[key] = _replicated_scalar(key, tensor)
+            else:
+                for struct_name, slice_info in param_slice_info.items():
+                    key = f"{struct_name}.{tag}"
+                    sharded_state[key] = self._create_sharded_weight(
+                        key, tensor, slice_info
+                    )
+
+        if master_weights:
+            for base_name, tensor in master_weights.items():
+                param_slice_info = self._shard_descs.get(base_name)
+                if param_slice_info is None:
+                    continue
+                for struct_name, slice_info in param_slice_info.items():
+                    key = f"{struct_name}.w_0"
+                    sharded_state[key] = self._create_sharded_weight(
+                        key, tensor, slice_info
+                    )
+
+        return sharded_state
 
     def comm_sync_and_reset_status(self):
         self.comm_manager.finish_grads_sync()

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -1718,6 +1718,8 @@ class Optimizer:
                             "FSDP does not support optimizer parameter groups."
                         )
                     fsdp_context.comm_sync_and_reset_status()
+                    if hasattr(fsdp_context, "bind_decay_param_fun"):
+                        fsdp_context.bind_decay_param_fun(self)
                     new_params_grads = []
                     for group in fsdp_context.buffer_manager.buffer_groups:
                         if not group.params_buffer.data_buffer.stop_gradient:

--- a/test/flex_checkpoint/sharded_state_dict_logic.py
+++ b/test/flex_checkpoint/sharded_state_dict_logic.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import math
 import os
 
+import numpy as np
+
 import paddle
+import paddle.distributed as dist
 from paddle import nn
 from paddle.distributed import ShardedWeight, fleet
 from paddle.distributed.fleet.layers.mpu import (
@@ -33,10 +37,13 @@ from paddle.distributed.fleet.meta_parallel.sharding.group_sharded_optimizer_sta
 from paddle.distributed.fleet.meta_parallel.sharding.group_sharded_stage3 import (
     GroupShardedStage3,
 )
+from paddle.distributed.fleet.utils import mix_precision_utils
 from paddle.distributed.fleet.utils.sequence_parallel_utils import (
     ColumnSequenceParallelLinear,
     RowSequenceParallelLinear,
 )
+from paddle.distributed.fsdp._fsdp_context import get_fsdp_context
+from paddle.distributed.fsdp.fully_shard import fully_shard
 
 
 class SimpleMLP(
@@ -61,6 +68,30 @@ class SimpleMLP(
         return x
 
 
+class TiedHead(nn.Layer):
+    def __init__(self, weight):
+        super().__init__()
+        self.weight = weight
+
+    def forward(self, x):
+        return paddle.matmul(x, self.weight, transpose_y=True)
+
+
+class FSDPMLP(nn.Layer):
+    def __init__(self, hidden_size=100, has_bias=False):
+        super().__init__()
+        self.embedding = nn.Embedding(24, hidden_size)
+        self.linear1 = nn.Linear(hidden_size, hidden_size, bias_attr=has_bias)
+        self.linear2 = nn.Linear(hidden_size, hidden_size, bias_attr=has_bias)
+        self.llm_head = TiedHead(self.embedding.weight)
+
+    def forward(self, x):
+        x = self.embedding(x)
+        x = self.linear1(x)
+        x = self.linear2(x)
+        return self.llm_head(x)
+
+
 class TestParallelLayersLogic:
     def __init__(self):
         self.optimizer_var_suffix = [".moment1_0", ".moment2_0", ".w_0"]
@@ -74,6 +105,7 @@ class TestParallelLayersLogic:
         self.master_weight = (
             os.getenv("master_weight", "False").lower() == "true"
         )
+        self.amp_level = os.getenv("amp_level", "O1")
         self.batch_size = 2
         self.hidden_size = 32
         self.vocab_size = 24
@@ -523,8 +555,176 @@ class TestParallelLayersLogic:
                         assert tuple(
                             opt_sharded_state_dict[opt__var_name].global_offset
                         ) == tuple(value.global_offset)
+        elif self.layer_type == "FullyShard":
+            inner = FSDPMLP(has_bias=self.has_bias)
+            self.amp_dtype = "float16" if self.amp_level == "O2" else "bfloat16"
+            if self.amp_level == "O2":
+                inner = paddle.amp.decorate(
+                    models=inner, level="O2", dtype=self.amp_dtype
+                )
+            model = mix_precision_utils.MixPrecisionLayer(
+                fully_shard(inner), dtype=self.amp_dtype
+            )
+            opt_cls = getattr(
+                paddle.optimizer, os.getenv("optimizer_type", "AdamW")
+            )
+            opt_kwargs = {
+                "learning_rate": paddle.optimizer.lr.StepDecay(
+                    0.01, step_size=1
+                ),
+                "parameters": [p for p in model.parameters() if p.trainable],
+            }
+            if "multi_precision" in inspect.signature(opt_cls).parameters:
+                opt_kwargs["multi_precision"] = self.master_weight
+            # A named optimizer prefixes its accumulator names with `name`.
+            if os.getenv("optimizer_name"):
+                opt_kwargs["name"] = os.getenv("optimizer_name")
+            opt = mix_precision_utils.MixPrecisionOptimizer(
+                opt_cls(**opt_kwargs)
+            )
+            fsdp_context = get_fsdp_context()
+            assert fsdp_context.owns_optimizer_params(opt)
+            assert not fsdp_context.owns_optimizer_params(
+                paddle.optimizer.AdamW(
+                    parameters=[paddle.create_parameter([2], "float32")]
+                )
+            )
+            self._check_mixed_decay_rejected(fsdp_context)
+            fsdp_context.init_optimizer_state(opt)
+            model.train()
+            self.run_fully_shard_test(model, opt, fsdp_context)
         else:
             raise ValueError(f"Unknown layer_type: {self.layer_type}")
+
+    def _check_mixed_decay_rejected(self, fsdp_context):
+        """A buffer mixing decayed and exempt params must be rejected, not decayed as a whole."""
+
+        class FakeOptimizer:
+            def __init__(self, fun):
+                self._apply_decay_param_fun = fun
+
+        group = next(
+            (
+                g
+                for g in fsdp_context.buffer_manager.buffer_groups
+                if len(g.params) > 1
+            ),
+            None,
+        )
+        assert group is not None, "no fused buffer holds more than one param"
+        buffer_name = group.params_buffer.data_buffer.name
+        decayed_name = group.params[0].name
+
+        mixed = FakeOptimizer(lambda name: name == decayed_name)
+        try:
+            fsdp_context.bind_decay_param_fun(mixed)
+        except ValueError as err:
+            assert buffer_name in str(err), str(err)
+        else:
+            raise AssertionError(
+                "mixed weight decay inside one fused buffer was not rejected"
+            )
+
+        uniform = FakeOptimizer(lambda name: True)
+        fsdp_context.bind_decay_param_fun(uniform)
+        assert uniform._apply_decay_param_fun(buffer_name) == (
+            not group.no_decay
+        )
+        assert uniform._apply_decay_param_fun("not_a_fused_buffer")
+
+    def run_fully_shard_test(self, model, opt, fsdp_context):
+        assert fsdp_context.optimizer_sharded_state_dict(opt)
+
+        def state_dict():
+            state = dict(model.sharded_state_dict())
+            state.update(fsdp_context.optimizer_sharded_state_dict(opt))
+            return state
+
+        def snapshot(state):
+            return {
+                key: sharded.local_tensor.astype("float32").numpy()
+                for key, sharded in state.items()
+            }
+
+        def train_step(step):
+            rng = np.random.RandomState(1000 + step)
+            x = paddle.to_tensor(
+                rng.randint(
+                    0,
+                    self.vocab_size,
+                    size=[self.batch_size, self.seq_len, self.hidden_size],
+                ).astype("int64")
+            )
+            with paddle.amp.auto_cast(level="O1", dtype=self.amp_dtype):
+                loss = model(x).astype("float32").sum()
+            loss.backward()
+            opt.step()
+            opt.clear_grad()
+
+        train_step(0)
+        train_step(1)
+        model_state = model.sharded_state_dict()
+        state = state_dict()
+        checked = 0
+        for key, value in model_state.items():
+            for opt_key, opt_var in state.items():
+                if not opt_key.startswith(key + "."):
+                    continue
+                if int(opt_var.local_tensor.numel()) == 1:
+                    continue
+                checked += 1
+                assert opt_var.flattened_range == value.flattened_range
+                assert tuple(opt_var.local_shape) == tuple(value.local_shape)
+                assert tuple(opt_var.global_shape) == tuple(value.global_shape)
+                assert tuple(opt_var.global_offset) == tuple(
+                    value.global_offset
+                )
+        assert checked, "no optimizer state matched a model key"
+
+        if self.amp_level == "O2":
+            assert any(key.endswith(".w_0") for key in state), (
+                "no fp32 master weight reached the sharded optimizer state"
+            )
+
+        saved = snapshot(state)
+        trained = [
+            key
+            for key in sorted(set(state) - set(model_state))
+            if saved[key].size > 1
+        ]
+        assert trained, "no sharded optimizer accumulator reached the save side"
+        for key in trained:
+            assert np.abs(saved[key]).max() > 0, (
+                f"optimizer accumulator '{key}' is all zeros after training"
+            )
+
+        ckpt_path = os.getenv("ckpt_path")
+        dist.save_state_dict(state, ckpt_path)
+        # Wait for every rank's shard file before listing.
+        dist.barrier()
+        if dist.get_rank() == 0:
+            shards = [
+                name
+                for name in os.listdir(ckpt_path)
+                if name.endswith(".distcp")
+            ]
+            assert len(shards) == self.world_size, sorted(shards)
+            assert os.path.exists(os.path.join(ckpt_path, "0.metadata"))
+
+        train_step(2)
+        resumed = snapshot(state_dict())
+        for sharded in state.values():
+            sharded.local_tensor.zero_()
+        dist.load_state_dict(state, ckpt_path)
+        for key, value in snapshot(state).items():
+            np.testing.assert_allclose(
+                value, saved[key], rtol=0, atol=0, err_msg=key
+            )
+        train_step(2)
+        for key, value in snapshot(state_dict()).items():
+            np.testing.assert_allclose(
+                value, resumed[key], rtol=1e-5, atol=1e-6, err_msg=key
+            )
 
 
 if __name__ == '__main__':

--- a/test/flex_checkpoint/test_sharded_state_dict.py
+++ b/test/flex_checkpoint/test_sharded_state_dict.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tempfile
 import unittest
 
 import collective.test_communication_api_base as test_base
@@ -150,6 +151,47 @@ TEST_CONFIGS = {
             "has_bias": "True",
             "master_weight": "True",
         },
+        {
+            "test_type": "optimizer",
+            "layer_type": "FullyShard",
+            "world_size": 2,
+            "tp": 1,
+            "sharding_degree": 2,
+            "has_bias": "True",
+            "master_weight": "True",
+        },
+        {
+            "test_type": "optimizer",
+            "layer_type": "FullyShard",
+            "optimizer_type": "Adamax",
+            "world_size": 2,
+            "tp": 1,
+            "sharding_degree": 2,
+            "has_bias": "True",
+            "master_weight": "True",
+        },
+        {
+            "test_type": "optimizer",
+            "layer_type": "FullyShard",
+            "optimizer_type": "Adadelta",
+            "world_size": 2,
+            "tp": 1,
+            "sharding_degree": 2,
+            "has_bias": "True",
+            "master_weight": "True",
+        },
+        {
+            "test_type": "optimizer",
+            "layer_type": "FullyShard",
+            "optimizer_type": "AdamW",
+            "optimizer_name": "opt",
+            "amp_level": "O2",
+            "world_size": 2,
+            "tp": 1,
+            "sharding_degree": 2,
+            "has_bias": "True",
+            "master_weight": "True",
+        },
     ],
     "4_card_tests": [
         {
@@ -199,10 +241,12 @@ class TestParallelLayersWith2Devices(test_base.CommunicationTestDistBase):
     def test_metadata(self):
         for config in TEST_CONFIGS["2_card_tests"]:
             envs = {k: str(v) for k, v in config.items()}
-            self.run_test_case(
-                "sharded_state_dict_logic.py",
-                user_defined_envs=envs,
-            )
+            with tempfile.TemporaryDirectory() as ckpt_dir:
+                envs["ckpt_path"] = ckpt_dir
+                self.run_test_case(
+                    "sharded_state_dict_logic.py",
+                    user_defined_envs=envs,
+                )
 
 
 class TestParallelLayersWith4Devices(test_base.CommunicationTestDistBase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
save/load 方案：
FSDP 将参数拼接为融合 buffer 并按 rank 切分，单卡不持有完整参数。save 时各 rank 直接落盘本地分片，不再 all_gather 参数，记录该分片所属参数及其区间，由 flex_checkpoint 在 load 时重组。
以上为 FC 格式；HF 格式需完整参数，显式 raise 并走离线转换（暂无转换脚本）。
验证：
在 Qwen3-30B-A3B N1C8 上已验证接续对齐。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否