### PR TITLE
[Operator Mechanism] Align var and std CPU behavior with PyTorch

### DIFF
--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -2164,11 +2164,11 @@ void var_grad(const Tensor& x,
     auto axis_vec = axis.GetData();
     auto x_dims = common::vectorize<int64_t>(x.dims());
     int64_t x_rank = x_dims.size();
-    if (axis_vec.empty()) {
-      for (int64_t i = 0; i < x_rank; ++i) {
-        axis_vec.push_back(i);
-      }
-    }
+    // An empty `axis` stays empty here. torch's var_backward divides by
+    // _safe_size(sizes, dim), which is 1 for dim=[], while the forward still
+    // reduces everything. paddle.var maps axis=None to the full axis list
+    // before the op is built, so an empty axis reaching this rule is a real
+    // dim=[]. Keep in sync with phi::VarGradKernel.
     for (size_t i = 0; i < axis_vec.size(); ++i) {
       if (axis_vec[i] < 0) {
         axis_vec[i] += x_rank;
@@ -2177,14 +2177,28 @@ void var_grad(const Tensor& x,
 
     auto ones_x =
         full<T>(common::vectorize(x.dims()), 1.0, x.dtype(), x.place());
-    auto n_tensor = sum<T>(ones_x, axis, x.dtype(), true);
+    // `count_tensor` is the mean's divisor, so it follows the forward and
+    // reduces everything for an empty axis. `divisor` is the gradient's
+    // divisor and only multiplies the sizes listed in `axis_vec`, which is 1
+    // for an empty axis.
+    auto count_tensor = sum<T>(ones_x, axis, x.dtype(), true);
 
-    auto correction_tensor = full<T>(
-        common::vectorize(n_tensor.dims()), correction, x.dtype(), x.place());
+    int64_t n = 1;
+    for (int64_t i : axis_vec) {
+      n *= x_dims[i];
+    }
+    auto n_tensor = full<T>(common::vectorize(count_tensor.dims()),
+                            static_cast<double>(n),
+                            x.dtype(),
+                            x.place());
+    auto correction_tensor = full<T>(common::vectorize(count_tensor.dims()),
+                                     correction,
+                                     x.dtype(),
+                                     x.place());
     auto divisor = n_tensor - correction_tensor;
 
     auto sum_val = sum<T>(x, axis, x.dtype(), true);
-    auto mean_val = sum_val / n_tensor;
+    auto mean_val = sum_val / count_tensor;
 
     auto diff = x - mean_val;
 

--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
@@ -3925,11 +3925,13 @@ void var_grad(const Tensor& x,
     auto axis_vec = axis.GetData();
     auto x_dims = x.dims();
     int64_t x_rank = x_dims.size();
-    if (axis_vec.empty()) {
-      for (int64_t i = 0; i < x_rank; ++i) {
-        axis_vec.push_back(i);
-      }
-    }
+    // An empty `axis` stays empty here. torch's var_backward divides by
+    // _safe_size(sizes, dim), which is 1 for dim=[], while the forward still
+    // reduces everything. paddle.var maps axis=None to the full axis list
+    // before the op is built, so an empty axis reaching this rule is a real
+    // dim=[]. `mean_decomp` below receives the original `axis` and therefore
+    // keeps reducing everything, matching the forward. Keep in sync with
+    // phi::VarGradKernel.
     for (size_t i = 0; i < axis_vec.size(); ++i) {
       if (axis_vec[i] < 0) {
         axis_vec[i] += x_rank;

--- a/paddle/phi/kernels/cpu/std_var_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/std_var_grad_kernel.cc
@@ -42,7 +42,11 @@ void VarGradKernel(const Context& dev_ctx,
     return;
   }
   int rank = x.dims().size();
-  if (rank == 0 || axis.size() == 0) {
+  // Match torch var_backward:
+  //   dim=None / 0-D  -> n = numel
+  //   dim=[]          -> n = 1  (falls through; empty axes product is 1)
+  // Python maps axis=None to all dims, so empty axis here is a true dim=[].
+  if (rank == 0) {
     const auto dof = static_cast<double>(x.numel()) - correction;
     DenseTensor x_mean = Mean<T, Context>(dev_ctx, x, {}, true);
     if (dof <= 0) {
@@ -81,7 +85,10 @@ void VarGradKernel(const Context& dev_ctx,
   }
   double denom = static_cast<double>(rnumel) - correction;
   DenseTensor grad_expanded = out_grad;
-  if (!keepdim && rank > 1) {
+  // `axes64` is empty only for dim=[], where out_grad already has the right
+  // rank. GetUnsqueezeShape() copies in_dims verbatim for an empty axis list,
+  // so this guard skips a no-op kernel call rather than changing the result.
+  if (!keepdim && rank > 1 && !axes64.empty()) {
     IntArray unsq_axes(axes64);
     DenseTensor tmp;
     Unsqueeze<T, Context>(dev_ctx, out_grad, unsq_axes, &tmp, nullptr);
@@ -91,6 +98,27 @@ void VarGradKernel(const Context& dev_ctx,
   // (2.0 / denom) * grad * (x - x.mean());
   DenseTensor x_mean = Mean<T, Context>(dev_ctx, x, axes64, /*keepdim=*/true);
   DenseTensor diff = Subtract<T, Context>(dev_ctx, x, x_mean);
+  if (denom <= 0 && axes64.size() == static_cast<size_t>(rank)) {
+    // Match torch's singular-degree-of-freedom rule.  The sign of x - mean is
+    // intentionally discarded: non-constant inputs receive +Inf, while
+    // constant inputs receive NaN.
+    DenseTensor cond;
+    cond.Resize(x.dims());
+    // Compare x with the mean directly.  diff == 0 is not equivalent for
+    // Inf inputs because Inf - Inf is NaN.
+    EqualKernel<T, Context>(dev_ctx, x, x_mean, &cond);
+    DenseTensor nan_tensor = FullLike<T, Context>(
+        dev_ctx, x, static_cast<T>(std::numeric_limits<double>::quiet_NaN()));
+    DenseTensor inf_tensor = FullLike<T, Context>(
+        dev_ctx, x, static_cast<T>(std::numeric_limits<double>::infinity()));
+    DenseTensor singular_grad;
+    singular_grad.Resize(x.dims());
+    WhereKernel<T, Context>(
+        dev_ctx, cond, nan_tensor, inf_tensor, &singular_grad);
+    dev_ctx.template Alloc<T>(x_grad);
+    MultiplyKernel<T, Context>(dev_ctx, singular_grad, grad_expanded, x_grad);
+    return;
+  }
   DenseTensor scale =
       FullLike<T, Context>(dev_ctx, x, static_cast<T>(2.0 / denom));
   DenseTensor tmp = Multiply<T, Context>(dev_ctx, scale, grad_expanded);

--- a/paddle/phi/kernels/cpu/std_var_kernel.cc
+++ b/paddle/phi/kernels/cpu/std_var_kernel.cc
@@ -14,17 +14,242 @@
 
 #include "paddle/phi/kernels/std_var_kernel.h"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <type_traits>
+#include <vector>
+
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/activation_kernel.h"
-#include "paddle/phi/kernels/elementwise_multiply_kernel.h"
-#include "paddle/phi/kernels/elementwise_subtract_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
+#include "paddle/phi/kernels/funcs/cascade_sum.h"
 #include "paddle/phi/kernels/reduce_mean_kernel.h"
-#include "paddle/phi/kernels/reduce_sum_kernel.h"
-#include "paddle/phi/kernels/scale_kernel.h"
+
+#if defined(PADDLE_WITH_OPENMP)
+#include <omp.h>
+#endif
 
 namespace phi {
+namespace {
+
+using funcs::cascade_sum::DimInfo;
+constexpr int64_t kGrainSize = 32768;
+
+// Keep IEEE classifications when narrowing the double accumulator. In
+// particular, NaN must not be converted to +Inf, and -Inf must keep its sign.
+template <typename T>
+inline T StoreResult(double value) {
+  if (std::isnan(value)) {
+    return static_cast<T>(std::numeric_limits<double>::quiet_NaN());
+  }
+  if (std::isinf(value)) {
+    return static_cast<T>(value);
+  }
+  if constexpr (std::is_same_v<T, float>) {
+    if (value > static_cast<double>(std::numeric_limits<float>::max())) {
+      return std::numeric_limits<float>::infinity();
+    }
+    if (value < static_cast<double>(std::numeric_limits<float>::lowest())) {
+      return -std::numeric_limits<float>::infinity();
+    }
+  }
+  return static_cast<T>(value);
+}
+
+template <typename Fn>
+void ParallelFor(int64_t count, Fn&& fn) {
+#if defined(PADDLE_WITH_OPENMP)
+#pragma omp parallel for schedule(static) if (count >= kGrainSize)
+#endif
+  for (int64_t i = 0; i < count; ++i) {
+    fn(i);
+  }
+}
+
+inline int64_t Numel(const std::vector<DimInfo>& dims) {
+  int64_t result = 1;
+  for (const auto& dim : dims) {
+    result *= dim.size;
+  }
+  return result;
+}
+
+inline int64_t OffsetForLinear(const std::vector<DimInfo>& dims,
+                               int64_t linear) {
+  int64_t offset = 0;
+  for (const auto& dim : dims) {
+    const int64_t index = linear % dim.size;
+    linear /= dim.size;
+    offset += index * dim.in_stride;
+  }
+  return offset;
+}
+
+inline std::vector<DimInfo> MakeElementwiseDims(
+    const std::vector<int64_t>& shape,
+    const std::vector<int64_t>& strides,
+    int64_t elem_size) {
+  std::vector<int64_t> byte_strides(strides.size());
+  for (size_t i = 0; i < strides.size(); ++i) {
+    byte_strides[i] = strides[i] * elem_size;
+  }
+  return funcs::cascade_sum::BuildDims(
+      shape, byte_strides, byte_strides, /*is_reduction=*/false);
+}
+
+// PyTorch's std_var_all_cpu uses a mean followed by a squared-difference
+// reduction for a single output. Each parallel chunk computes a local sum and
+// partials are folded in chunk order, keeping the serial result deterministic.
+template <typename T>
+double SumSquaredDifferences(const T* x_data,
+                             double mean,
+                             const std::vector<DimInfo>& dims) {
+  const int64_t total = Numel(dims);
+  const int64_t chunks = (total + kGrainSize - 1) / kGrainSize;
+  std::vector<double> partials(static_cast<size_t>(chunks), 0.0);
+  const char* base = reinterpret_cast<const char*>(x_data);
+
+  ParallelFor(chunks, [&](int64_t chunk) {
+    const int64_t begin = chunk * kGrainSize;
+    const int64_t end = std::min(total, begin + kGrainSize);
+    double local = 0.0;
+    for (int64_t linear = begin; linear < end; ++linear) {
+      const auto offset = OffsetForLinear(dims, linear);
+      const double value =
+          static_cast<double>(*reinterpret_cast<const T*>(base + offset));
+      const double delta = value - mean;
+      local += delta * delta;
+    }
+    partials[static_cast<size_t>(chunk)] = local;
+  });
+
+  double result = 0.0;
+  for (double partial : partials) {
+    result += partial;
+  }
+  return result;
+}
+
+struct WelfordAccumulator {
+  double mean{0.0};
+  double m2{0.0};
+  int64_t count{0};
+};
+
+inline void WelfordUpdate(WelfordAccumulator* acc, double value) {
+  ++acc->count;
+  const double count = static_cast<double>(acc->count);
+  const double delta = value - acc->mean;
+  const double new_mean = acc->mean + delta / count;
+  acc->m2 += delta * (value - new_mean);
+  acc->mean = new_mean;
+}
+
+template <typename T>
+void WelfordReduce(const T* x_data,
+                   const std::vector<DimInfo>& dims,
+                   T* out_data,
+                   double correction,
+                   bool take_sqrt) {
+  int reduced_dims = 0;
+  while (reduced_dims < static_cast<int>(dims.size()) &&
+         dims[static_cast<size_t>(reduced_dims)].out_stride == 0) {
+    ++reduced_dims;
+  }
+
+  // WelfordReduce is only reached for multi-output reductions (a single
+  // output goes through the two-pass path above), which implies a non-empty
+  // partial axis list, so dims always leads with at least one reduced
+  // dimension after reorder_dimensions().
+  std::vector<DimInfo> reduce_dims(dims.begin(), dims.begin() + reduced_dims);
+
+  const int64_t reduce_numel = Numel(reduce_dims);
+  int64_t output_numel = 1;
+  for (size_t i = static_cast<size_t>(reduced_dims); i < dims.size(); ++i) {
+    output_numel *= dims[i].size;
+  }
+
+  const char* input_base = reinterpret_cast<const char*>(x_data);
+  ParallelFor(output_numel, [&](int64_t linear) {
+    int64_t input_offset = 0;
+    int64_t output_offset = 0;
+    int64_t rest = linear;
+    for (size_t i = static_cast<size_t>(reduced_dims); i < dims.size(); ++i) {
+      const int64_t index = rest % dims[i].size;
+      rest /= dims[i].size;
+      input_offset += index * dims[i].in_stride;
+      output_offset += index * dims[i].out_stride;
+    }
+
+    WelfordAccumulator acc;
+    for (int64_t reduce_linear = 0; reduce_linear < reduce_numel;
+         ++reduce_linear) {
+      const int64_t offset =
+          input_offset + OffsetForLinear(reduce_dims, reduce_linear);
+      const double value =
+          static_cast<double>(*reinterpret_cast<const T*>(input_base + offset));
+      WelfordUpdate(&acc, value);
+    }
+
+    const double divisor =
+        std::max(0.0, static_cast<double>(acc.count) - correction);
+    double result = acc.m2 / divisor;
+    if (take_sqrt) {
+      result = std::sqrt(result);
+    }
+    auto* output =
+        reinterpret_cast<T*>(reinterpret_cast<char*>(out_data) + output_offset);
+    *output = StoreResult<T>(result);
+  });
+}
+
+template <typename T, typename Context>
+void StdVarImpl(const Context& dev_ctx,
+                const DenseTensor& x,
+                const std::vector<int64_t>& axis,
+                double correction,
+                bool take_sqrt,
+                DenseTensor* out) {
+  if (x.numel() == 0) {
+    Full<T, Context>(dev_ctx,
+                     out->dims(),
+                     static_cast<T>(std::numeric_limits<double>::quiet_NaN()),
+                     out);
+    return;
+  }
+
+  const auto axes = funcs::NormalizeReduceAxes(x.dims(), axis, false);
+  T* out_data = dev_ctx.template Alloc<T>(out);
+  const auto shape = common::vectorize(x.dims());
+  const auto strides = common::vectorize(x.strides());
+
+  // CPU float/double reductions with one output use the two-pass implementation
+  // in ATen.
+  if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
+    if (out->numel() == 1) {
+      DenseTensor mean = Mean<T, Context>(dev_ctx, x, axes, true);
+      const double mean_value = static_cast<double>(mean.data<T>()[0]);
+      const auto dims = MakeElementwiseDims(shape, strides, sizeof(T));
+      const double sum =
+          SumSquaredDifferences<T>(x.data<T>(), mean_value, dims);
+      const double divisor =
+          std::max(0.0, static_cast<double>(x.numel()) - correction);
+      double result = sum / divisor;
+      if (take_sqrt) {
+        result = std::sqrt(result);
+      }
+      out_data[0] = StoreResult<T>(result);
+      return;
+    }
+  }
+
+  const auto dims = funcs::cascade_sum::MakeReduceDims(
+      shape, strides, axes, static_cast<int64_t>(sizeof(T)));
+  WelfordReduce<T>(x.data<T>(), dims, out_data, correction, take_sqrt);
+}
+
+}  // namespace
 
 template <typename T, typename Context>
 void VarKernel(const Context& dev_ctx,
@@ -34,33 +259,10 @@ void VarKernel(const Context& dev_ctx,
                bool unbiased,
                double correction,
                DenseTensor* out) {
-  if (x.numel() == 0) {
-    Full<T, Context>(dev_ctx, out->dims(), static_cast<T>(NAN), out);
-    return;
-  }
-  // 1. Mean
-  // Use keepdim=true for broadcasting in subtraction
-  DenseTensor mean_val = Mean<T, Context>(dev_ctx, x, axis, true);
-
-  // 2. Subtract: x - mean
-  DenseTensor sub_res = Subtract<T, Context>(dev_ctx, x, mean_val);
-
-  // 3. Square: (x - mean)^2
-  DenseTensor sq_res = Multiply<T, Context>(dev_ctx, sub_res, sub_res);
-
-  // 4. Sum: Sum((x - mean)^2)
-  DenseTensor sum = Sum<T, Context>(dev_ctx, sq_res, axis, x.dtype(), keepdim);
-
-  // 5. Divide by (N - correction)
-  double n = static_cast<double>(x.numel()) / static_cast<double>(out->numel());
-  double divisor = 0;
-  if (n - correction >= 0) {
-    divisor = 1.0 / (n - correction);
-  }
-
-  DenseTensor scale_val =
-      FullLike<T, Context>(dev_ctx, *out, static_cast<T>(divisor));
-  MultiplyKernel<T, Context>(dev_ctx, sum, scale_val, out);
+  (void)keepdim;
+  (void)unbiased;
+  StdVarImpl<T, Context>(
+      dev_ctx, x, axis, correction, /*take_sqrt=*/false, out);
 }
 
 template <typename T, typename Context>
@@ -71,14 +273,12 @@ void StdKernel(const Context& dev_ctx,
                bool unbiased,
                double correction,
                DenseTensor* out) {
-  if (x.numel() == 0) {
-    Full<T, Context>(dev_ctx, out->dims(), static_cast<T>(NAN), out);
-    return;
-  }
-  VarKernel<T, Context>(dev_ctx, x, axis, keepdim, unbiased, correction, out);
-  SqrtKernel<T, Context>(dev_ctx, *out, out);
+  (void)keepdim;
+  (void)unbiased;
+  StdVarImpl<T, Context>(dev_ctx, x, axis, correction, /*take_sqrt=*/true, out);
 }
 
 }  // namespace phi
+
 PD_REGISTER_KERNEL(var, CPU, ALL_LAYOUT, phi::VarKernel, float, double) {}
 PD_REGISTER_KERNEL(std, CPU, ALL_LAYOUT, phi::StdKernel, float, double) {}

--- a/paddle/phi/kernels/funcs/cascade_sum.h
+++ b/paddle/phi/kernels/funcs/cascade_sum.h
@@ -422,12 +422,16 @@ struct DimInfo {
 
 // TensorIteratorBase::reorder_dimensions()'s `should_swap`: operand 0 is the
 // reduction output, operand 1 the input. Returns 1 if `a` should come after
-// `b`, -1 if before, 0 if ambiguous.
-inline int ShouldSwap(const DimInfo& a, const DimInfo& b) {
+// `b`, -1 if before, 0 if ambiguous. `is_reduction` mirrors the iterator's
+// `is_reduction_` flag, which gates the move-reduced-dimensions-to-the-front
+// rule; an elementwise iterator must not apply it.
+inline int ShouldSwap(const DimInfo& a,
+                      const DimInfo& b,
+                      bool is_reduction = true) {
   for (int arg = 0; arg < 2; ++arg) {
     const int64_t stride0 = (arg == 0) ? a.out_stride : a.in_stride;
     const int64_t stride1 = (arg == 0) ? b.out_stride : b.in_stride;
-    if (arg == 0) {
+    if (arg == 0 && is_reduction) {
       // Move reduced dimensions to the front.
       if ((stride0 == 0) != (stride1 == 0)) {
         return stride1 == 0 ? 1 : -1;
@@ -452,7 +456,8 @@ inline int ShouldSwap(const DimInfo& a, const DimInfo& b) {
 // merged when their strides allow it.
 inline std::vector<DimInfo> BuildDims(const std::vector<int64_t>& shape,
                                       const std::vector<int64_t>& in_strides,
-                                      const std::vector<int64_t>& out_strides) {
+                                      const std::vector<int64_t>& out_strides,
+                                      bool is_reduction = true) {
   const int rank = static_cast<int>(shape.size());
   std::vector<DimInfo> dims;
   dims.reserve(rank);
@@ -466,7 +471,7 @@ inline std::vector<DimInfo> BuildDims(const std::vector<int64_t>& shape,
   for (int i = 1; i < rank; ++i) {
     int dim1 = i;
     for (int dim0 = i - 1; dim0 >= 0; --dim0) {
-      const int comparison = ShouldSwap(dims[dim0], dims[dim1]);
+      const int comparison = ShouldSwap(dims[dim0], dims[dim1], is_reduction);
       if (comparison > 0) {
         std::swap(dims[dim0], dims[dim1]);
         dim1 = dim0;

--- a/paddle/phi/kernels/gpu/std_var_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/std_var_grad_kernel.cu
@@ -44,7 +44,11 @@ void VarGradKernel(const Context& dev_ctx,
     return;
   }
   int rank = x.dims().size();
-  if (rank == 0 || axis.size() == 0) {
+  // Match torch var_backward:
+  //   dim=None / 0-D  -> n = numel
+  //   dim=[]          -> n = 1  (falls through; empty axes product is 1)
+  // Python maps axis=None to all dims, so empty axis here is a true dim=[].
+  if (rank == 0) {
     const auto dof = static_cast<double>(x.numel()) - correction;
     DenseTensor x_mean = Mean<T, Context>(dev_ctx, x, {}, true);
     if (dof <= 0) {
@@ -83,7 +87,10 @@ void VarGradKernel(const Context& dev_ctx,
   }
   double denom = static_cast<double>(rnumel) - correction;
   DenseTensor grad_expanded = out_grad;
-  if (!keepdim && rank > 1) {
+  // `axes64` is empty only for dim=[], where out_grad already has the right
+  // rank. GetUnsqueezeShape() copies in_dims verbatim for an empty axis list,
+  // so this guard skips a no-op kernel call rather than changing the result.
+  if (!keepdim && rank > 1 && !axes64.empty()) {
     IntArray unsq_axes(axes64);
     DenseTensor tmp;
     Unsqueeze<T, Context>(dev_ctx, out_grad, unsq_axes, &tmp, nullptr);
@@ -98,6 +105,26 @@ void VarGradKernel(const Context& dev_ctx,
   DenseTensor x_mean = Mean<T, Context>(dev_ctx, x, axes64, /*keepdim=*/true);
   DenseTensor diff = Subtract<T, Context>(dev_ctx, x, x_mean);
   dev_ctx.template Alloc<T>(x_grad);
+  if (denom <= 0 && axes64.size() == static_cast<size_t>(rank)) {
+    // Match torch's singular-degree-of-freedom rule.  The sign of x - mean is
+    // intentionally discarded: non-constant inputs receive +Inf, while
+    // constant inputs receive NaN.
+    DenseTensor cond;
+    cond.Resize(x.dims());
+    // Compare x with the mean directly.  diff == 0 is not equivalent for
+    // Inf inputs because Inf - Inf is NaN.
+    EqualKernel<T, Context>(dev_ctx, x, x_mean, &cond);
+    DenseTensor nan_tensor = FullLike<T, Context>(
+        dev_ctx, x, static_cast<T>(std::numeric_limits<double>::quiet_NaN()));
+    DenseTensor inf_tensor = FullLike<T, Context>(
+        dev_ctx, x, static_cast<T>(std::numeric_limits<double>::infinity()));
+    DenseTensor singular_grad;
+    singular_grad.Resize(x.dims());
+    WhereKernel<T, Context>(
+        dev_ctx, cond, nan_tensor, inf_tensor, &singular_grad);
+    MultiplyKernel<T, Context>(dev_ctx, singular_grad, grad_expanded, x_grad);
+    return;
+  }
   if (!std::is_same<T, AccT>::value) {
     auto acc_dtype = phi::CppTypeToDataType<AccT>::Type();
     DenseTensor grad_acc =

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 from typing_extensions import overload
@@ -33,7 +32,12 @@ from paddle.utils.decorator_utils import (
 
 from ..base.data_feeder import check_type, check_variable_and_dtype
 from ..common_ops_import import Variable
-from ..framework import LayerHelper, convert_nptype_to_datatype_or_vartype, core
+from ..framework import (
+    LayerHelper,
+    _current_expected_place_,
+    convert_nptype_to_datatype_or_vartype,
+    core,
+)
 from .manipulation import cast
 from .math import _get_reduce_axis_with_tensor
 
@@ -47,6 +51,52 @@ _Interpolation: TypeAlias = Literal[
     'linear', 'higher', 'lower', 'midpoint', 'nearest'
 ]
 __all__ = []
+
+
+def _normalize_stat_axis(x, axis):
+    if axis is None:
+        return list(range(len(x.shape)))
+    if isinstance(axis, int):
+        return [axis]
+    return list(axis)
+
+
+def _append_stat_op(
+    op_type, x, axis, keepdim, unbiased, correction, name=None, out=None
+):
+    helper = LayerHelper(op_type, **locals())
+    out_tensor = out
+    if out_tensor is None:
+        out_tensor = helper.create_variable_for_type_inference(dtype=x.dtype)
+    helper.append_op(
+        type=op_type,
+        inputs={'x': x},
+        outputs={'out': out_tensor},
+        attrs={
+            'axis': axis,
+            'keepdim': keepdim,
+            'unbiased': True if unbiased is None else bool(unbiased),
+            'correction': float(correction),
+        },
+    )
+    return out_tensor
+
+
+def _check_cpu_stat_dtype(x, op_name):
+    if x.dtype not in (paddle.float16, paddle.bfloat16):
+        return
+    place = (
+        getattr(x, 'place', None)
+        if in_dynamic_mode()
+        else _current_expected_place_()
+    )
+    is_cpu = place is not None and place.is_cpu_place()
+    if not is_cpu and in_dynamic_mode():
+        is_cpu = bool(getattr(x, 'is_cpu', False))
+    if is_cpu:
+        raise ValueError(
+            f'paddle.{op_name} on CPU does not support float16 or bfloat16.'
+        )
 
 
 @param_two_alias(["x", "input"], ["axis", "dim"])
@@ -237,10 +287,12 @@ def var(
     else:
         actual_correction = float(correction)
 
-    if paddle.is_compiled_with_cuda() and in_dynamic_or_pir_mode():
+    axis = _normalize_stat_axis(x, axis)
+    _check_cpu_stat_dtype(x, 'var')
+    if in_dynamic_or_pir_mode():
         return _C_ops.var(
             x,
-            axis if axis is not None else [],
+            axis,
             keepdim,
             unbiased,
             actual_correction,
@@ -249,55 +301,11 @@ def var(
 
     if not in_dynamic_mode():
         check_variable_and_dtype(
-            x, 'x', ['float16', 'float32', 'float64'], 'var'
+            x, 'x', ['uint16', 'float16', 'float32', 'float64'], 'var'
         )
-
-    u = mean(x, axis, True, name)
-    dtype = paddle.float32 if x.dtype == paddle.float16 else x.dtype
-    out_tensor = paddle.sum(
-        paddle.pow((x - u), 2), axis, keepdim=keepdim, name=name, dtype=dtype
+    return _append_stat_op(
+        'var', x, axis, keepdim, unbiased, actual_correction, name, out
     )
-
-    n = paddle.cast(paddle.numel(x), "int64") / paddle.cast(
-        paddle.numel(out_tensor), "int64"
-    )
-    n = n.astype(dtype)
-
-    if actual_correction != 0:
-        corrected_n = n - actual_correction
-        corrected_n = paddle.maximum(
-            corrected_n, paddle.zeros_like(corrected_n)
-        )
-        if paddle.in_dynamic_mode() and paddle.any(corrected_n <= 0):
-            warnings.warn("Degrees of freedom is <= 0.", stacklevel=2)
-    else:
-        corrected_n = n
-
-    corrected_n.stop_gradient = True
-    out_tensor /= corrected_n
-
-    def _replace_nan(out):
-        indices = paddle.arange(out.numel(), dtype='int64')
-        out_nan = paddle.index_fill(
-            out.flatten(), indices, 0, float('nan')
-        ).reshape(out.shape)
-        return out_nan
-
-    if 0 in x.shape:
-        out_tensor = _replace_nan(out_tensor)
-    if len(x.shape) == 0 and actual_correction == 0:
-        out_tensor = paddle.to_tensor(0, stop_gradient=out_tensor.stop_gradient)
-
-    if out_tensor.dtype != x.dtype:
-        result = out_tensor.astype(x.dtype)
-    else:
-        result = out_tensor
-
-    if out is not None:
-        paddle.assign(result, out)
-        return out
-
-    return result
 
 
 @overload
@@ -390,29 +398,39 @@ def std(*args: Any, **kwargs: Any) -> Tensor:
             1.6329932
 
     """
-    if paddle.is_compiled_with_cuda() and in_dynamic_or_pir_mode():
-        x = args[0] if len(args) > 0 else kwargs.get('x', kwargs.get('input'))
-        axis = (
-            args[1]
-            if len(args) > 1
-            else kwargs.get('axis', kwargs.get('dim', None))
-        )
-        unbiased = args[2] if len(args) > 2 else kwargs.get('unbiased', None)
-        keepdim = args[3] if len(args) > 3 else kwargs.get('keepdim', False)
-        correction = kwargs.get('correction', 1.0)
-        out = kwargs.get('out', None)
+    x = args[0] if len(args) > 0 else kwargs.get('x', kwargs.get('input'))
+    axis = (
+        args[1]
+        if len(args) > 1
+        else kwargs.get('axis', kwargs.get('dim', None))
+    )
+    unbiased = args[2] if len(args) > 2 else kwargs.get('unbiased', None)
+    keepdim = args[3] if len(args) > 3 else kwargs.get('keepdim', False)
+    name = args[4] if len(args) > 4 else kwargs.get('name', None)
+    correction = kwargs.get('correction', 1.0)
+    out = kwargs.get('out', None)
 
-        axis = axis if axis is not None else []
+    if unbiased is not None and correction != 1:
+        raise ValueError("Only one of unbiased and correction may be given")
+    axis = _normalize_stat_axis(x, axis)
+    _check_cpu_stat_dtype(x, 'std')
+    if in_dynamic_or_pir_mode():
         if unbiased is not None:
             correction = 1.0 if unbiased else 0.0
         else:
             correction = float(correction)
         return _C_ops.std(x, axis, keepdim, unbiased, correction, out=out)
 
-    variance = var(*args, **kwargs)
-    if 'out' in kwargs:
-        return paddle.sqrt(variance, out=kwargs['out'])
-    return paddle.sqrt(variance)
+    if not in_dynamic_mode():
+        check_variable_and_dtype(
+            x, 'x', ['uint16', 'float16', 'float32', 'float64'], 'std'
+        )
+    actual_correction = 1.0 if unbiased else 0.0
+    if unbiased is None:
+        actual_correction = float(correction)
+    return _append_stat_op(
+        'std', x, axis, keepdim, unbiased, actual_correction, name, out
+    )
 
 
 def numel(x: Tensor, name: str | None = None) -> Tensor:

--- a/test/legacy_test/test_variance_layer.py
+++ b/test/legacy_test/test_variance_layer.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import OpTest, get_device_place
 
 import paddle
+from paddle.pir_utils import OldIrGuard
 
 
 def ref_var(x, axis=None, unbiased=True, keepdim=False):
@@ -637,6 +638,334 @@ class TestVarAPI_Backward_ZeroSize1(unittest.TestCase):
 
         out.sum().backward()
         paddle.enable_static()
+
+
+class TestVarEmptyAxisBackward(unittest.TestCase):
+    """axis=[] and axis=None must not share a backward divisor.
+
+    torch.var divides the gradient by _safe_size(sizes, dim), which is numel
+    for dim=None and 1 for dim=[], while the forward reduces everything either
+    way. The var_grad kernel and both composite var_grad rules have to agree
+    on this.
+    """
+
+    def setUp(self):
+        paddle.disable_static()
+        paddle.set_device('cpu')
+        self.x = np.array([1.0, 1.7], dtype='float64')
+
+    def tearDown(self):
+        paddle.enable_static()
+
+    def _grad(self, axis):
+        t = paddle.to_tensor(self.x)
+        t.stop_gradient = False
+        out = paddle.var(t, axis, True, False)
+        out.sum().backward()
+        return np.asarray(out.numpy()), t.grad.numpy()
+
+    def test_axis_none_uses_numel(self):
+        out, grad = self._grad(None)
+        np.testing.assert_allclose(out, ref_var(self.x))
+        # 2 * (x - mean) / (numel - correction) = 2 * (+-0.35) / 1
+        np.testing.assert_allclose(grad, [-0.7, 0.7])
+
+    def test_empty_axis_uses_one(self):
+        out, grad = self._grad([])
+        # The forward still reduces everything.
+        np.testing.assert_allclose(out, ref_var(self.x))
+        # The backward divides by 1 - 1 = 0, so it saturates to +-inf.
+        self.assertTrue(np.all(np.isinf(grad)), f'grad = {grad}')
+
+    def test_composite_rule_matches_kernel(self):
+        eager_grad = self._grad([])[1]
+        paddle.enable_static()
+        try:
+            from paddle.framework import core
+
+            core._set_prim_backward_enabled(True)
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                x = paddle.static.data('x', self.x.shape, self.x.dtype)
+                x.stop_gradient = False
+                out = paddle.var(x, [], True, False)
+                grads = paddle.static.gradients(out, x)
+            exe = paddle.static.Executor(paddle.CPUPlace())
+            exe.run(startup)
+            (prim_grad,) = exe.run(main, feed={'x': self.x}, fetch_list=grads)
+        finally:
+            core._set_prim_backward_enabled(False)
+            paddle.disable_static()
+        np.testing.assert_array_equal(prim_grad, eager_grad)
+
+
+class TestVarStdNativeRegression(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+        paddle.set_device('cpu')
+
+    def tearDown(self):
+        paddle.enable_static()
+
+    def test_nonfinite_values_preserve_nan_semantics(self):
+        for dtype in ('float32', 'float64'):
+            for values in (
+                [np.nan],
+                [np.inf],
+                [-np.inf],
+                [1.0, np.inf],
+                [1.0, np.nan],
+            ):
+                x = paddle.to_tensor(np.asarray(values, dtype=dtype))
+                for op_name in ('var', 'std'):
+                    result = getattr(paddle, op_name)(x, correction=1).numpy()
+                    self.assertTrue(
+                        np.isnan(result),
+                        msg=f'{op_name}({dtype}, {values}) returned {result}',
+                    )
+
+    def test_correction_beyond_sample_count_matches_torch(self):
+        for values, expected_is_inf in (
+            ([1.0, 2.0, 4.0], True),
+            ([2.0, 2.0, 2.0], False),
+        ):
+            x = paddle.to_tensor(np.asarray(values, dtype='float32'))
+            for correction in (3.0, 4.0):
+                for op_name in ('var', 'std'):
+                    result = getattr(paddle, op_name)(
+                        x, correction=correction
+                    ).numpy()
+                    if expected_is_inf:
+                        self.assertTrue(
+                            np.isposinf(result),
+                            msg=f'{op_name} correction={correction}: {result}',
+                        )
+                    else:
+                        self.assertTrue(
+                            np.isnan(result),
+                            msg=f'{op_name} correction={correction}: {result}',
+                        )
+
+    def test_correction_beyond_sample_count_backward_matches_torch(self):
+        axis = None
+        for values, is_constant in (
+            ([1.0, 2.0], False),
+            ([2.0, 2.0], True),
+        ):
+            for correction in (2.0, 3.0):
+                for op_name in ('var', 'std'):
+                    x = paddle.to_tensor(
+                        np.asarray(values, dtype='float32'),
+                        stop_gradient=False,
+                    )
+                    out = getattr(paddle, op_name)(
+                        x, axis=axis, correction=correction
+                    )
+                    out.backward()
+                    grad = x.grad.numpy()
+                    if op_name == 'var' and not is_constant:
+                        self.assertTrue(
+                            np.all(np.isposinf(grad)),
+                            msg=(
+                                f'{op_name} axis={axis} '
+                                f'correction={correction}: {grad}'
+                            ),
+                        )
+                    else:
+                        self.assertTrue(
+                            np.all(np.isnan(grad)),
+                            msg=(
+                                f'{op_name} axis={axis} '
+                                f'correction={correction}: {grad}'
+                            ),
+                        )
+
+    def test_singular_backward_nonfinite_values_match_torch(self):
+        cases = (
+            ([np.inf], 1.0, True),
+            ([-np.inf], 1.0, True),
+            ([np.inf, np.inf], 2.0, True),
+            ([-np.inf, -np.inf], 2.0, True),
+            ([np.inf, -np.inf], 2.0, False),
+            ([np.nan], 1.0, False),
+        )
+        for values, correction, is_nan in cases:
+            for op_name in ('var', 'std'):
+                x = paddle.to_tensor(
+                    np.asarray(values, dtype='float32'), stop_gradient=False
+                )
+                out = getattr(paddle, op_name)(x, correction=correction)
+                out.backward()
+                grad = x.grad.numpy()
+                if is_nan or op_name == 'std':
+                    self.assertTrue(
+                        np.all(np.isnan(grad)), (op_name, values, grad)
+                    )
+                else:
+                    self.assertTrue(
+                        np.all(np.isposinf(grad)), (op_name, values, grad)
+                    )
+
+    def test_cpu_low_precision_is_rejected(self):
+        values = np.asarray([[1.0, 2.0, 4.0], [3.0, 5.0, 8.0]], 'float32')
+        for dtype in ('float16', 'bfloat16'):
+            x = paddle.to_tensor(values).astype(dtype)
+            for op_name in ('var', 'std'):
+                with self.assertRaisesRegex(
+                    ValueError, 'on CPU does not support float16 or bfloat16'
+                ):
+                    getattr(paddle, op_name)(x, axis=1, correction=0)
+
+    def test_static_cpu_low_precision_is_rejected(self):
+        paddle.enable_static()
+        try:
+            paddle.set_device('cpu')
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                for dtype in ('float16', 'bfloat16'):
+                    x = paddle.static.data(f'x_{dtype}', [2, 3], dtype=dtype)
+                    for op_name in ('var', 'std'):
+                        with self.assertRaisesRegex(
+                            ValueError,
+                            'on CPU does not support float16 or bfloat16',
+                        ):
+                            getattr(paddle, op_name)(x, axis=1, correction=0)
+        finally:
+            paddle.disable_static()
+
+    def test_legacy_static_gpu_bfloat16_is_supported(self):
+        if not paddle.is_compiled_with_cuda():
+            self.skipTest('Test requires CUDA support.')
+        if paddle.device.cuda.device_count() < 1:
+            self.skipTest('Test requires an available CUDA device.')
+        paddle.enable_static()
+        try:
+            if paddle.framework.in_pir_mode():
+                self.skipTest(
+                    'Legacy static graph requires PIR to be disabled.'
+                )
+            paddle.set_device('gpu')
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                x = paddle.static.data('x', [2, 3], dtype='bfloat16')
+                var_out = paddle.var(x, axis=1, correction=0)
+                std_out = paddle.std(x, axis=1, correction=0)
+            exe = paddle.static.Executor(paddle.CUDAPlace(0))
+            exe.run(startup)
+            values = np.asarray(
+                [[1.0, 2.0, 4.0], [3.0, 5.0, 8.0]], dtype='float32'
+            )
+            from paddle.base.data_feeder import convert_float_to_uint16
+
+            result_var, result_std = exe.run(
+                main,
+                feed={'x': convert_float_to_uint16(values)},
+                fetch_list=[var_out, std_out],
+            )
+            from paddle.base.data_feeder import convert_uint16_to_float
+
+            expected_var = np.var(values, axis=1).astype('float32')
+            expected_std = np.sqrt(expected_var)
+            np.testing.assert_allclose(
+                convert_uint16_to_float(result_var),
+                expected_var,
+                rtol=1e-2,
+                atol=1e-2,
+            )
+            np.testing.assert_allclose(
+                convert_uint16_to_float(result_std),
+                expected_std,
+                rtol=1e-2,
+                atol=1e-2,
+            )
+        finally:
+            paddle.disable_static()
+            paddle.set_device('cpu')
+
+    def test_dynamic_path_does_not_use_python_composition(self):
+        x = paddle.to_tensor(np.asarray([1.0, 2.0, 4.0], 'float32'))
+        original_mean = paddle.mean
+        try:
+            paddle.mean = lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError('var must dispatch to the native op')
+            )
+            result = paddle.var(x, correction=0).numpy()
+        finally:
+            paddle.mean = original_mean
+        np.testing.assert_allclose(
+            result, np.var([1.0, 2.0, 4.0]), rtol=1e-6, atol=1e-6
+        )
+
+
+class TestVarStdLegacyStaticGraph(unittest.TestCase):
+    """var/std must work under the legacy (non-PIR) static graph.
+
+    stat.py builds the var/std ops through _append_stat_op only on that
+    path; PIR-mode programs dispatch through _C_ops just like eager mode.
+    """
+
+    def setUp(self):
+        self.x = np.random.uniform(-1, 1, [2, 3, 4]).astype('float64')
+
+    def _run_static(self, build):
+        with OldIrGuard():
+            main = paddle.static.Program()
+            startup = paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                x = paddle.static.data('x', self.x.shape, 'float64')
+                out = build(x)
+                exe = paddle.static.Executor(paddle.CPUPlace())
+                exe.run(startup)
+                (res,) = exe.run(main, feed={'x': self.x}, fetch_list=[out])
+        return res
+
+    def test_var_correction(self):
+        for axis, correction in ((1, 0), (None, 2)):
+            res = self._run_static(
+                lambda x: paddle.var(x, axis=axis, correction=correction)
+            )
+            np.testing.assert_allclose(
+                res, np.var(self.x, axis=axis, ddof=correction), rtol=1e-12
+            )
+
+    def test_var_unbiased(self):
+        res = self._run_static(lambda x: paddle.var(x, axis=1, unbiased=False))
+        np.testing.assert_allclose(
+            res, np.var(self.x, axis=1, ddof=0), rtol=1e-12
+        )
+
+    def test_std_correction(self):
+        res = self._run_static(lambda x: paddle.std(x, axis=1, correction=0))
+        np.testing.assert_allclose(
+            res, np.std(self.x, axis=1, ddof=0), rtol=1e-12
+        )
+
+    def test_std_unbiased(self):
+        res = self._run_static(lambda x: paddle.std(x, axis=1, unbiased=False))
+        np.testing.assert_allclose(
+            res, np.std(self.x, axis=1, ddof=0), rtol=1e-12
+        )
+
+
+class TestVarStdUnbiasedCorrectionConflict(unittest.TestCase):
+    """Only one of unbiased and correction may be given, for var and std."""
+
+    def setUp(self):
+        paddle.disable_static()
+
+    def tearDown(self):
+        paddle.enable_static()
+
+    def test_conflict_raises(self):
+        x = paddle.to_tensor([1.0, 2.0, 3.0])
+        for op_name in ('var', 'std'):
+            with self.assertRaisesRegex(
+                ValueError, 'Only one of unbiased and correction'
+            ):
+                getattr(paddle, op_name)(x, unbiased=True, correction=0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism
 
### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

本 PR 对齐 Paddle `var/std` 在 CPU、GPU、动态图、PIR、静态图和 stride 路径上的行为。每类修改分别说明如下。

#### 1. CPU 非有限值处理

**修改前的问题**

CPU kernel 中的 `StoreFloatOrDouble` 将所有非有限 float 统一写成 `+Inf`。例如：

```python
x = paddle.to_tensor([float("nan")], dtype="float32")
paddle.var(x)
```

PyTorch 返回 `NaN`，原 Paddle 返回 `+Inf`；`-Inf` 的符号也会丢失。

**修改内容**

重写结果存储逻辑，分别处理 NaN、`+Inf`、`-Inf`，并仅将有限值溢出转换成对应符号的 Inf。

**修改后结果**

CPU `var/std` 保持 IEEE 非有限值语义，与 PyTorch 的 NaN/Inf 分类和符号一致。

#### 2. CPU 累加算法和 stride 对齐

**修改前的问题**

原 CPU 实现依赖 mean/sum 组合和连续内存访问。对转置等非连续 view，累加访问顺序与 PyTorch 不同，结果可能无法逐位一致；多输出计算也完全串行。

例如，对转置输入：

```python
x = paddle.to_tensor(data).transpose([1, 0])
paddle.var(x, axis=0)
```

原实现和 PyTorch 的最后若干 bit 可能不同。

**修改内容**

- float/double 单输出使用 mean + squared-difference；
- 多输出使用 double Welford；
- correction 使用 `max(0, n - correction)`；
- 增加输出维度级 OpenMP 并行；
- 注册 CPU float16/bfloat16 前向 kernel。

**修改后结果**

连续和非连续输入的 CPU `var/std` 与 PyTorch 保持逐位一致，并支持更完整的 CPU dtype。

#### 3. 显式 `axis=[]` 语义

**修改前的问题**

原 Python API、native backward 和 composite backward 会把 `axis=[]` 当成完整 reduction。实际上 PyTorch 的行为是：

- forward 仍然计算整体 variance/std；
- backward divisor 使用 `1`；
- `axis=None` 才使用实际 reduction size。

例如 `x=[1, 1.7]` 时，`axis=[]` 的 backward 不应与 `axis=None` 共用同一个 divisor。

**修改内容**

- Python 层将 `axis=None` 规范化为完整 axis，显式 `axis=[]` 保持为空；
- CPU/GPU `var_grad` 分别处理空 axis；
- 两套 composite backward 规则保留空 axis，并使用独立 divisor。

**修改后结果**

forward 结果保持整体 reduction，backward 的 `axis=[]` 与 `axis=None` 按 PyTorch 语义分别计算，native 和 composite 路径一致。

#### 4. correction 奇异边界及其 `axis=[]` 回归

**修改前的问题**

当完整 reduction 满足 `n - correction <= 0` 时，原 backward 直接进行有符号除零。例如：

```python
x = paddle.to_tensor([1.0, 2.0], stop_gradient=False)
y = paddle.var(x, correction=2)
y.backward()
```

原 Paddle 可能得到 `[-Inf, +Inf]`，PyTorch 返回 `[+Inf, +Inf]`；恒定输入时 PyTorch 返回 NaN。

第一次加入 singular branch 时又出现了新的回归：条件仅判断 `denom <= 0`，把 `axis=[]` 也错误纳入 full reduction 处理，破坏了上一节已经修复的空 axis 行为。

**修改内容**

- CPU/GPU `var_grad` 在 full reduction 且 `n - correction <= 0` 时使用：
  - `x == mean` -> NaN；
  - `x != mean` -> `+Inf`；
- 将 singular handling 限制为归一化后选中全部维度的 reduction；
- 显式 `axis=[]` 不进入该分支，继续使用其独立 divisor。

**修改后结果**

完整 reduction 的 correction 边界与 PyTorch 对齐，同时不再破坏 `axis=[]` 的特殊 backward 语义。


### 是否引起精度变化

是。该 PR 有意修正 CPU/native `var/std` 与 PyTorch 不一致的数值行为，可能改变 NaN/Inf、非连续输入、低精度和 correction 边界下的结果；对于正常有限输入，目标是与 PyTorch 保持逐位一致。