### PR TITLE
[Operator Mechanism] Consolidate strided view validation and gradient fixes

### DIFF
--- a/paddle/fluid/eager/nan_inf_utils.cc
+++ b/paddle/fluid/eager/nan_inf_utils.cc
@@ -128,6 +128,19 @@ void CheckTensorHasNanOrInf(const std::string& api_name, const Tensor& tensor) {
       return;
     }
 
+    // The checker scans the tensor's memory flat, i.e. it reads `ptr[i]` for
+    // every i in [0, numel), which is only valid for a contiguous tensor. On a
+    // strided view the scanned range is unrelated to the elements the view
+    // actually owns, and for a broadcast view (a stride of 0 blows numel up far
+    // beyond the storage) it runs past the end of the allocation and faults.
+    // Skip those tensors; their storage is still checked wherever the
+    // contiguous tensor that produced it is checked.
+    if (!dense_tensor->meta().is_contiguous()) {
+      VLOG(4) << "Tensor[" << tensor_name
+              << "] is not contiguous, skip nan inf check: " << api_name;
+      return;
+    }
+
     auto& place = dense_tensor->place();
     if (phi::is_gpu_place(place)) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)

--- a/paddle/phi/api/include/compat/ATen/ops/as_strided.h
+++ b/paddle/phi/api/include/compat/ATen/ops/as_strided.h
@@ -21,6 +21,7 @@
 
 #include "paddle/common/ddim.h"
 #include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/kernels/funcs/strided_utils.h"
 
 namespace at {
 
@@ -55,10 +56,23 @@ inline at::Tensor Tensor::as_strided(
   phi::DenseTensorMeta meta(src_tensor->dtype(),
                             common::make_ddim(size_vec),
                             common::make_ddim(stride_vec));
-  // Calculate offset in bytes
+  phi::ValidateZeroSizeTensorShape(size_vec, stride_vec, *src_tensor);
+  // Calculate offset in bytes. `storage_offset` counts elements and is
+  // relative to the source tensor, so the conversion has to be checked: an
+  // unchecked multiplication wraps around and turns an out of range request
+  // into a silent alias of the first element.
   int64_t offset = storage_offset.has_value() ? storage_offset.value() : 0;
-  meta.offset = src_tensor->meta().offset +
-                static_cast<size_t>(offset) * phi::SizeOf(src_tensor->dtype());
+  int64_t byte_offset = phi::ElementOffsetToByteOffset(
+      static_cast<int64_t>(src_tensor->meta().offset),
+      offset,
+      static_cast<int64_t>(phi::SizeOf(src_tensor->dtype())));
+  meta.offset = static_cast<size_t>(byte_offset);
+  // This entry builds the view by hand instead of going through
+  // phi::AsStridedKernel, so it has to run the same storage range check;
+  // otherwise a view reaching past the allocation corrupts neighbouring heap
+  // memory on every read and write.
+  phi::ValidateStridedViewStorage(
+      size_vec, stride_vec, byte_offset, *src_tensor);
   new_tensor->set_meta(meta);
   PaddleTensor result;
   result.set_impl(new_tensor);
@@ -86,9 +100,15 @@ inline const at::Tensor& Tensor::as_strided_(
                             common::make_ddim(size_vec),
                             common::make_ddim(stride_vec));
   meta.layout = src_tensor->layout();
+  phi::ValidateZeroSizeTensorShape(size_vec, stride_vec, *src_tensor);
   int64_t offset = storage_offset.has_value() ? storage_offset.value() : 0;
-  meta.offset = src_tensor->meta().offset +
-                static_cast<size_t>(offset) * phi::SizeOf(src_tensor->dtype());
+  int64_t byte_offset = phi::ElementOffsetToByteOffset(
+      static_cast<int64_t>(src_tensor->meta().offset),
+      offset,
+      static_cast<int64_t>(phi::SizeOf(src_tensor->dtype())));
+  meta.offset = static_cast<size_t>(byte_offset);
+  phi::ValidateStridedViewStorage(
+      size_vec, stride_vec, byte_offset, *src_tensor);
   src_tensor->set_meta(meta);
   return *this;
 }

--- a/paddle/phi/kernels/funcs/strided_utils.h
+++ b/paddle/phi/kernels/funcs/strided_utils.h
@@ -13,9 +13,18 @@
 // limitations under the License.
 
 #pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+
 #include "paddle/phi/backends/context_pool.h"
+#include "paddle/phi/common/data_type.h"
+#include "paddle/phi/common/scalar.h"
+#include "paddle/phi/core/compat/convert_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_factory.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/core/visit_type.h"
 #include "paddle/phi/kernels/contiguous_kernel.h"
 #include "paddle/phi/kernels/fill_kernel.h"
@@ -151,5 +160,599 @@ inline void StridedTensorContiguous(const DenseTensor& input,
     PADDLE_THROW(common::errors::Unimplemented(
         "Place type is not supported when `contiguous` kernel is called."));
   }
+}
+
+// int64_t arithmetic that reports overflow instead of wrapping around.
+//
+// The element range of a strided view is computed from a caller supplied
+// (shape, stride, offset) triple, so the products and sums below can exceed
+// int64_t for adversarial input. Without these guards the range check wraps
+// around and happily accepts a view that reaches far outside of the
+// allocation, which is worse than having no check at all. __int128 and
+// __builtin_*_overflow are avoided on purpose: this header is reachable from
+// the public compat headers, which are also compiled by MSVC.
+inline bool CheckedMulInt64(int64_t a, int64_t b, int64_t* out) {
+  constexpr int64_t kMax = (std::numeric_limits<int64_t>::max)();
+  constexpr int64_t kMin = (std::numeric_limits<int64_t>::lowest)();
+  if (a == 0 || b == 0) {
+    *out = 0;
+    return true;
+  }
+  // Handled separately so that the divisions below never evaluate kMin / -1.
+  if (a == -1) {
+    if (b == kMin) return false;
+    *out = -b;
+    return true;
+  }
+  if (b == -1) {
+    if (a == kMin) return false;
+    *out = -a;
+    return true;
+  }
+  if (a > 0) {
+    if (b > 0 ? a > kMax / b : b < kMin / a) return false;
+  } else {
+    if (b > 0 ? a < kMin / b : a < kMax / b) return false;
+  }
+  *out = a * b;
+  return true;
+}
+
+inline bool CheckedAddInt64(int64_t a, int64_t b, int64_t* out) {
+  constexpr int64_t kMax = (std::numeric_limits<int64_t>::max)();
+  constexpr int64_t kMin = (std::numeric_limits<int64_t>::lowest)();
+  if (b > 0 && a > kMax - b) return false;
+  if (b < 0 && a < kMin - b) return false;
+  *out = a + b;
+  return true;
+}
+
+// Turns a torch style storage offset, expressed in *elements* and relative to
+// the offset of the tensor being viewed, into the absolute *byte* offset that
+// DenseTensorMeta::offset and phi::AsStridedKernel expect. Do not call this on
+// an offset that is already a byte offset.
+//
+// The conversion needs its own helper because phi::SizeOf returns size_t, so
+// the obvious `static_cast<size_t>(offset) * SizeOf(dtype)` is unsigned
+// arithmetic that wraps around silently: a storage offset of 1 << 62 on a four
+// byte dtype becomes 0, and the range check below would then happily validate
+// a completely different view and let the out of range request through.
+inline int64_t ElementOffsetToByteOffset(int64_t base_byte_offset,
+                                         int64_t element_offset,
+                                         int64_t itemsize) {
+  PADDLE_ENFORCE_GE(element_offset,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The storage offset of a view must be non-negative, "
+                        "but got %d.",
+                        element_offset));
+  int64_t byte_offset = 0;
+  bool no_overflow = CheckedMulInt64(element_offset, itemsize, &byte_offset);
+  if (no_overflow) {
+    no_overflow = CheckedAddInt64(base_byte_offset, byte_offset, &byte_offset);
+  }
+  PADDLE_ENFORCE_EQ(no_overflow,
+                    true,
+                    common::errors::InvalidArgument(
+                        "The byte offset of the view overflows int64: element "
+                        "offset %d of a %d byte dtype, relative to byte offset "
+                        "%d.",
+                        element_offset,
+                        itemsize,
+                        base_byte_offset));
+  return byte_offset;
+}
+
+// Element indices, relative to the start of the allocation, that a strided
+// view touches. `empty` marks a view with a zero sized dimension, which reads
+// and writes nothing at all.
+struct StridedViewRange {
+  int64_t min_index{0};
+  int64_t max_index{0};
+  bool empty{false};
+};
+
+inline StridedViewRange ComputeStridedViewRange(
+    const std::vector<int64_t>& dims,
+    const std::vector<int64_t>& strides,
+    int64_t base_index) {
+  // Every loop below indexes strides[i] for i < dims.size(); reject a
+  // mismatched shape/stride pair before entering the loop.
+  PADDLE_ENFORCE_EQ(dims.size(),
+                    strides.size(),
+                    common::errors::InvalidArgument(
+                        "The size of dims(%d) and strides(%d) of a strided "
+                        "view should be equal.",
+                        dims.size(),
+                        strides.size()));
+  StridedViewRange range;
+  range.min_index = base_index;
+  range.max_index = base_index;
+  for (size_t i = 0; i < dims.size(); ++i) {
+    PADDLE_ENFORCE_GE(dims[i],
+                      0,
+                      common::errors::InvalidArgument(
+                          "The shape of a strided view must be non-negative, "
+                          "but got %s.",
+                          common::make_ddim(dims)));
+    if (dims[i] == 0) {
+      range.empty = true;
+      return range;
+    }
+    int64_t dim_span = 0;
+    bool no_overflow = CheckedMulInt64(strides[i], dims[i] - 1, &dim_span);
+    if (no_overflow) {
+      no_overflow =
+          dim_span > 0
+              ? CheckedAddInt64(range.max_index, dim_span, &range.max_index)
+              : CheckedAddInt64(range.min_index, dim_span, &range.min_index);
+    }
+    PADDLE_ENFORCE_EQ(
+        no_overflow,
+        true,
+        common::errors::InvalidArgument(
+            "The element range of the view described by shape %s, stride %s "
+            "and element offset %d overflows int64.",
+            common::make_ddim(dims),
+            common::make_ddim(strides),
+            base_index));
+  }
+  return range;
+}
+
+inline void ValidateZeroSizeTensorShape(const std::vector<int64_t>& dims,
+                                        const std::vector<int64_t>& strides,
+                                        const DenseTensor& input) {
+  if (input.numel() != 0) {
+    return;
+  }
+  PADDLE_ENFORCE_EQ(dims.size(),
+                    strides.size(),
+                    common::errors::InvalidArgument(
+                        "The size of dims and strides should be equal."));
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (dims[i] == 0) {
+      return;
+    }
+  }
+  PADDLE_THROW(common::errors::InvalidArgument(
+      "When input is zero-size tensor, the shape attribute must also be "
+      "zero-size."));
+}
+
+// Rejects views that would reach outside of `input`'s allocation. Without this
+// check a bad (shape, stride, offset) triple silently produces a tensor whose
+// reads and writes corrupt neighbouring heap memory.
+//
+// `offset` is a byte offset into the allocation, matching AsStridedKernel and
+// DenseTensorMeta::offset.
+inline void ValidateStridedViewStorage(const std::vector<int64_t>& dims,
+                                       const std::vector<int64_t>& strides,
+                                       int64_t offset,
+                                       const DenseTensor& input) {
+  PADDLE_ENFORCE_EQ(
+      dims.size(),
+      strides.size(),
+      common::errors::InvalidArgument(
+          "The size of dims(%d) and strides(%d) of a strided view should be "
+          "equal.",
+          dims.size(),
+          strides.size()));
+  if (input.numel() == 0 || input.Holder() == nullptr) {
+    return;
+  }
+  const int64_t itemsize = static_cast<int64_t>(SizeOf(input.dtype()));
+  PADDLE_ENFORCE_EQ(offset % itemsize,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The offset(%d) is a byte offset and must be a "
+                        "multiple of the element size(%d) of the input.",
+                        offset,
+                        itemsize));
+  const StridedViewRange range =
+      ComputeStridedViewRange(dims, strides, offset / itemsize);
+  if (range.empty) {
+    return;
+  }
+  const int64_t storage_numel =
+      static_cast<int64_t>(input.Holder()->size()) / itemsize;
+  PADDLE_ENFORCE_GE(range.min_index,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The view described by shape %s, stride %s and offset "
+                        "%d reaches element %d, which is before the beginning "
+                        "of the input storage.",
+                        common::make_ddim(dims),
+                        common::make_ddim(strides),
+                        offset,
+                        range.min_index));
+  PADDLE_ENFORCE_LT(range.max_index,
+                    storage_numel,
+                    common::errors::InvalidArgument(
+                        "The view described by shape %s, stride %s and offset "
+                        "%d reaches element %d, but the input storage only "
+                        "holds %d elements.",
+                        common::make_ddim(dims),
+                        common::make_ddim(strides),
+                        offset,
+                        range.max_index,
+                        storage_numel));
+}
+
+// Returns true when two different logical indices of the view described by
+// (dims, strides) may map to the same memory location. A view whose memory
+// overlaps requires its backward to *accumulate* the incoming gradient instead
+// of scattering it, otherwise the writes destroy each other.
+//
+// Sort dimensions by absolute stride and check that each dimension starts
+// beyond the span covered by all smaller-stride dimensions. Dimensions of
+// size <= 1 can only ever contribute index 0 and are skipped. A zero stride
+// on a dimension of size > 1 is a broadcast and always overlaps; negative
+// strides are valid reversed views and are checked by their absolute span.
+inline bool MaybeOverlappingStrides(const std::vector<int64_t>& dims,
+                                    const std::vector<int64_t>& strides) {
+  if (dims.size() != strides.size()) {
+    return true;
+  }
+  std::vector<size_t> order;
+  order.reserve(dims.size());
+  for (size_t i = 0; i < dims.size(); ++i) {
+    if (dims[i] <= 1) {
+      continue;
+    }
+    if (strides[i] == 0) {
+      return true;
+    }
+    if (strides[i] == (std::numeric_limits<int64_t>::lowest)()) {
+      return true;
+    }
+    order.push_back(i);
+  }
+  std::sort(order.begin(), order.end(), [&strides](size_t a, size_t b) {
+    const int64_t stride_a = strides[a] < 0 ? -strides[a] : strides[a];
+    const int64_t stride_b = strides[b] < 0 ? -strides[b] : strides[b];
+    return stride_a < stride_b;
+  });
+  int64_t max_index_in_slice = 0;
+  for (size_t i : order) {
+    const int64_t abs_stride = strides[i] < 0 ? -strides[i] : strides[i];
+    if (abs_stride <= max_index_in_slice) {
+      return true;
+    }
+    int64_t dim_span = 0;
+    // A span that overflows int64 cannot describe a view that fits in any
+    // allocation. Report it as overlapping and let the range check reject it.
+    if (!CheckedMulInt64(abs_stride, dims[i] - 1, &dim_span) ||
+        !CheckedAddInt64(max_index_in_slice, dim_span, &max_index_in_slice)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Serial scatter-add of `values` (dense, in view order) into `storage` through
+// the view described by (dims, stride) starting at element `elem_base`.
+//
+// Both pointers must be host accessible. Correctness before speed: an
+// overlapping view hits the same slot several times, so this loop cannot be
+// parallelized without atomics.
+template <typename T>
+inline void HostAccumulateStridedView(const T* values,
+                                      const std::vector<int64_t>& dims,
+                                      const std::vector<int64_t>& stride,
+                                      int64_t elem_base,
+                                      T* storage) {
+  const int rank = static_cast<int>(dims.size());
+  int64_t numel = 1;
+  for (int i = 0; i < rank; ++i) {
+    numel *= dims[i];
+  }
+  if (numel == 0) {
+    return;
+  }
+  std::vector<int64_t> counter(static_cast<size_t>(rank), 0);
+  int64_t dest = elem_base;
+  for (int64_t i = 0; i < numel; ++i) {
+    storage[dest] = static_cast<T>(storage[dest] + values[i]);
+    // Odometer over the logical indices, keeping `dest` in sync.
+    for (int d = rank - 1; d >= 0; --d) {
+      dest += stride[d];
+      if (++counter[d] < dims[d]) {
+        break;
+      }
+      counter[d] = 0;
+      dest -= stride[d] * dims[d];
+    }
+  }
+}
+
+// Accumulates `out_grad` into the storage of `input_grad` through the view
+// described by (dims, stride, offset), where `offset` is a byte offset into
+// `input_grad`'s own allocation.
+//
+// Unlike StridedTensorCopy, positions that the view hits more than once
+// receive the sum of all contributions. `input_grad` must already be
+// allocated, contiguous, zero filled, and start at element 0 of its
+// allocation. Zero filling is a hard requirement and not just a convention:
+// the host path below relies on it to skip reading the destination back from
+// the device, so a non-zero buffer would be accumulated into on GPU but
+// overwritten everywhere else.
+template <typename T>
+inline void StridedTensorAccumulate(const DenseTensor& out_grad,
+                                    const std::vector<int64_t>& dims,
+                                    const std::vector<int64_t>& stride,
+                                    int64_t offset,
+                                    DenseTensor* input_grad) {
+  PADDLE_ENFORCE_EQ(input_grad->meta().offset,
+                    0u,
+                    common::errors::InvalidArgument(
+                        "The gradient buffer must start at the beginning of "
+                        "its own allocation, but its offset is %d.",
+                        input_grad->meta().offset));
+  const int64_t itemsize = static_cast<int64_t>(SizeOf(input_grad->dtype()));
+  PADDLE_ENFORCE_EQ(offset % itemsize,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The byte offset(%d) of a strided view must be a "
+                        "multiple of its element size(%d).",
+                        offset,
+                        itemsize));
+  const int64_t elem_base = offset / itemsize;
+  const int64_t storage_numel = input_grad->numel();
+  const int64_t value_numel = out_grad.numel();
+  // Overflow checked. The bound is numel() and not the size of the allocation
+  // because the index buffer built below covers exactly that many elements.
+  const StridedViewRange range =
+      ComputeStridedViewRange(dims, stride, elem_base);
+  if (range.empty || value_numel == 0) {
+    return;
+  }
+  PADDLE_ENFORCE_GE(range.min_index,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The strided view reaches element %d of the gradient "
+                        "buffer, which is out of range.",
+                        range.min_index));
+  PADDLE_ENFORCE_LT(range.max_index,
+                    storage_numel,
+                    common::errors::InvalidArgument(
+                        "The strided view reaches element %d, but the gradient "
+                        "buffer only holds %d elements.",
+                        range.max_index,
+                        storage_numel));
+
+  auto& pool = DeviceContextPool::Instance();
+  auto* dev_ctx = pool.Get(input_grad->place());
+  const Backend backend = TransToPhiBackend(input_grad->place());
+  auto& factory = KernelFactory::Instance();
+  // Only the GPU index_put accumulates atomically (CudaAtomicAdd). The CPU
+  // kernel uses a plain `+=` inside an OpenMP loop, which loses updates on
+  // exactly the duplicated indices that an overlapping view produces by
+  // construction; XPU registers no `arange` at all and covers only a handful of
+  // dtypes in index_put. Every backend but GPU, and every dtype that GPU's
+  // index_put does not implement, therefore takes the serial host path below.
+  // HasKernel throws when the kernel *name* is unknown, which cannot happen
+  // here: both names are registered unconditionally for CPU.
+  const bool use_device_scatter_add =
+      input_grad->place().GetType() == AllocationType::GPU &&
+      factory.HasKernel(
+          "arange",
+          KernelKey(backend, DataLayout::ALL_LAYOUT, DataType::INT64)) &&
+      factory.HasKernel(
+          "index_put",
+          KernelKey(backend, DataLayout::ALL_LAYOUT, input_grad->dtype()));
+
+  if (use_device_scatter_add) {
+    // 1. arange(0, storage_numel) over the destination storage.
+    DenseTensor storage_index(DataType::INT64);
+    storage_index.Resize(
+        common::make_ddim(std::vector<int64_t>{storage_numel}));
+    using arange_signature = void (*)(const DeviceContext&,
+                                      const Scalar&,
+                                      const Scalar&,
+                                      const Scalar&,
+                                      DenseTensor*);
+    PD_VISIT_KERNEL("arange",
+                    KernelKey(backend, DataLayout::ALL_LAYOUT, DataType::INT64),
+                    arange_signature,
+                    false,
+                    *dev_ctx,
+                    Scalar(static_cast<int64_t>(0)),
+                    Scalar(storage_numel),
+                    Scalar(static_cast<int64_t>(1)),
+                    &storage_index);
+
+    // 2. Apply the view to it, so that element i of `index` is the storage slot
+    // that element i of `out_grad` belongs to.
+    DenseTensor index_view(storage_index);
+    DenseTensorMeta index_view_meta = storage_index.meta();
+    index_view_meta.dims = DDim(dims.data(), static_cast<int>(dims.size()));
+    index_view_meta.strides =
+        DDim(stride.data(), static_cast<int>(stride.size()));
+    index_view_meta.offset =
+        static_cast<size_t>(elem_base * static_cast<int64_t>(sizeof(int64_t)));
+    index_view.set_meta(index_view_meta);
+
+    DenseTensor index;
+    index.set_meta(index_view.meta());
+    StridedTensorContiguous<int64_t>(index_view, &index);
+    index.Resize(common::make_ddim(std::vector<int64_t>{value_numel}));
+
+    // 3. Densify the incoming gradient in the matching order.
+    DenseTensor dense_grad;
+    dense_grad.set_meta(out_grad.meta());
+    StridedTensorContiguous<T>(out_grad, &dense_grad);
+    dense_grad.Resize(common::make_ddim(std::vector<int64_t>{value_numel}));
+
+    // 4. Scatter-add into the flattened destination storage. Aliasing x and out
+    // is intentional: `input_grad` is already initialized, so `index_put` skips
+    // the x -> out copy and accumulates in place.
+    DenseTensor flat(*input_grad);
+    DenseTensorMeta flat_meta = input_grad->meta();
+    flat_meta.dims = common::make_ddim(std::vector<int64_t>{storage_numel});
+    flat_meta.strides = common::make_ddim(std::vector<int64_t>{1});
+    flat_meta.offset = 0;
+    flat.set_meta(flat_meta);
+
+    std::vector<const DenseTensor*> indices = {&index};
+    using index_put_signature = void (*)(const DeviceContext&,
+                                         const DenseTensor&,
+                                         const std::vector<const DenseTensor*>&,
+                                         const DenseTensor&,
+                                         bool,
+                                         DenseTensor*);
+    PD_VISIT_KERNEL(
+        "index_put",
+        KernelKey(backend, DataLayout::ALL_LAYOUT, input_grad->dtype()),
+        index_put_signature,
+        false,
+        *dev_ctx,
+        flat,
+        indices,
+        dense_grad,
+        true,
+        &flat);
+    return;
+  }
+
+  // Serial host fallback. Densify the incoming gradient first so that the
+  // accumulate loop only has to walk the destination side.
+  DenseTensor dense_grad;
+  dense_grad.set_meta(out_grad.meta());
+  StridedTensorContiguous<T>(out_grad, &dense_grad);
+  dense_grad.Resize(common::make_ddim(std::vector<int64_t>{value_numel}));
+
+  if (input_grad->place().GetType() == AllocationType::CPU) {
+    HostAccumulateStridedView<T>(
+        dense_grad.data<T>(), dims, stride, elem_base, input_grad->data<T>());
+    return;
+  }
+
+  // Any other backend: accumulate on the host and copy the result back. Slow,
+  // but a correct scatter-add is worth more than a fast wrong one, and the
+  // device kernels needed to do better do not exist.
+  //
+  // Only the incoming gradient is staged with a device to host copy. The
+  // destination is required to be zero filled on entry, so reading it back
+  // would only reproduce zeros; allocating the host side zeroed instead saves
+  // a full copy of the gradient buffer.
+  DenseTensor host_grad;
+  const DenseTensorMeta host_grad_meta(dense_grad.dtype(),
+                                       dense_grad.dims(),
+                                       dense_grad.layout(),
+                                       dense_grad.meta().offset);
+  host_grad.set_meta(host_grad_meta);
+  phi::Copy(*dev_ctx, dense_grad, CPUPlace(), /*blocking=*/true, &host_grad);
+  DenseTensor host_storage;
+  host_storage.set_meta(input_grad->meta());
+  T* host_ptr =
+      static_cast<T*>(dev_ctx->HostAlloc(&host_storage, host_storage.dtype()));
+  std::memset(host_ptr, 0, static_cast<size_t>(storage_numel) * sizeof(T));
+  HostAccumulateStridedView<T>(
+      host_grad.data<T>(), dims, stride, elem_base, host_ptr);
+  phi::Copy(*dev_ctx,
+            host_storage,
+            input_grad->place(),
+            /*blocking=*/true,
+            input_grad);
+}
+
+// Backward of a strided view whose `input` is itself a non-contiguous view, or
+// whose window starts before `input` does.
+//
+// (dims, stride, offset) describe the view in the coordinate system of the
+// allocation shared with `input`, while `input_grad` is a dense row-major
+// buffer over `input`'s own logical indices. Those two coordinate systems only
+// differ by a constant when `input` is contiguous; in general the storage index
+// of an element is not its row-major index, so the gradient has to be routed
+// through a temporary buffer laid out in storage coordinates: scatter-add
+// `out_grad` into it through the out geometry, then gather it back through
+// `input`'s own geometry. This mirrors at::as_strided_backward.
+//
+// `input_grad` must already be allocated with `input`'s dims; its previous
+// contents are overwritten. Only the meta of `input` is read, never its data,
+// because the forward declares `no_need_buffer : input`.
+template <typename T>
+inline void StridedTensorAccumulateThroughStorage(
+    const DenseTensor& out_grad,
+    const std::vector<int64_t>& dims,
+    const std::vector<int64_t>& stride,
+    int64_t offset,
+    const DenseTensor& input,
+    DenseTensor* input_grad) {
+  const int64_t itemsize = static_cast<int64_t>(SizeOf(input_grad->dtype()));
+  PADDLE_ENFORCE_EQ(offset % itemsize,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The byte offset(%d) of a strided view must be a "
+                        "multiple of its element size(%d).",
+                        offset,
+                        itemsize));
+  const std::vector<int64_t> input_dims =
+      common::vectorize<int64_t>(input.dims());
+  const std::vector<int64_t> input_stride =
+      common::vectorize<int64_t>(input.strides());
+  const int64_t out_base = offset / itemsize;
+  const int64_t input_base =
+      static_cast<int64_t>(input.meta().offset) / itemsize;
+  const StridedViewRange out_range =
+      ComputeStridedViewRange(dims, stride, out_base);
+  const StridedViewRange input_range =
+      ComputeStridedViewRange(input_dims, input_stride, input_base);
+  if (out_range.empty || input_range.empty || out_grad.numel() == 0) {
+    return;
+  }
+  const int64_t shared_base =
+      std::min(out_range.min_index, input_range.min_index);
+  PADDLE_ENFORCE_GE(shared_base,
+                    0,
+                    common::errors::InvalidArgument(
+                        "The strided view reaches element %d of the shared "
+                        "allocation, which is before its beginning.",
+                        shared_base));
+  int64_t storage_numel = 0;
+  const int64_t shared_last =
+      std::max(out_range.max_index, input_range.max_index);
+  PADDLE_ENFORCE_EQ(
+      CheckedAddInt64(shared_last - shared_base, 1, &storage_numel),
+      true,
+      common::errors::InvalidArgument(
+          "The element range spanned by the view described by shape %s, "
+          "stride %s and byte offset %d together with its input overflows "
+          "int64.",
+          common::make_ddim(dims),
+          common::make_ddim(stride),
+          offset));
+
+  auto& pool = DeviceContextPool::Instance();
+  auto* dev_ctx = pool.Get(input_grad->place());
+  // Resize rather than set_meta: the rvalue set_meta overload requires the
+  // destination meta to be invalid, and a default constructed DenseTensor
+  // already reports a valid one (float32, NCHW, rank -1 dims).
+  DenseTensor storage(input_grad->dtype());
+  storage.Resize(common::make_ddim(std::vector<int64_t>{storage_numel}));
+  dev_ctx->Alloc(&storage, storage.dtype());
+  StridedTensorFill<T>(storage, 0, &storage);
+
+  const int64_t out_byte_base = (out_base - shared_base) * itemsize;
+  if (MaybeOverlappingStrides(dims, stride)) {
+    StridedTensorAccumulate<T>(out_grad, dims, stride, out_byte_base, &storage);
+  } else {
+    // Distinct slots, so a plain scatter is enough and avoids the serial
+    // accumulate. Mirrors the copy_ branch of at::as_strided_backward.
+    StridedTensorCopy<T>(out_grad, dims, stride, out_byte_base, &storage);
+  }
+
+  // Read the accumulated storage back through `input`'s geometry. Contiguous
+  // materialization is exactly the gather that turns storage indices into
+  // row-major ones, and it reuses the buffer `input_grad` already owns.
+  DenseTensor gathered(storage);
+  DenseTensorMeta gathered_meta = storage.meta();
+  gathered_meta.dims = input.dims();
+  gathered_meta.strides = input.strides();
+  gathered_meta.offset =
+      static_cast<size_t>((input_base - shared_base) * itemsize);
+  gathered.set_meta(gathered_meta);
+  StridedTensorContiguous<T>(gathered, input_grad);
 }
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/strided_utils.h
+++ b/paddle/phi/kernels/funcs/strided_utils.h
@@ -544,9 +544,14 @@ inline void StridedTensorAccumulate(const DenseTensor& out_grad,
 
   if (use_device_scatter_add) {
     // 1. arange(0, storage_numel) over the destination storage.
-    DenseTensor storage_index(DataType::INT64);
-    storage_index.Resize(
-        common::make_ddim(std::vector<int64_t>{storage_numel}));
+    // DenseTensor(DataType) lives in dense_tensor.inl and is hidden from
+    // PADDLE_WITH_CUSTOM_KERNEL TUs, including ATen_resize_custom_kernel_test
+    // which includes this header through as_strided.h. set_meta(const&) is
+    // always visible and overwrites the default-constructed float32 meta.
+    DenseTensor storage_index;
+    storage_index.set_meta(DenseTensorMeta(
+        DataType::INT64,
+        common::make_ddim(std::vector<int64_t>{storage_numel})));
     using arange_signature = void (*)(const DeviceContext&,
                                       const Scalar&,
                                       const Scalar&,
@@ -726,11 +731,14 @@ inline void StridedTensorAccumulateThroughStorage(
 
   auto& pool = DeviceContextPool::Instance();
   auto* dev_ctx = pool.Get(input_grad->place());
-  // Resize rather than set_meta: the rvalue set_meta overload requires the
-  // destination meta to be invalid, and a default constructed DenseTensor
-  // already reports a valid one (float32, NCHW, rank -1 dims).
-  DenseTensor storage(input_grad->dtype());
-  storage.Resize(common::make_ddim(std::vector<int64_t>{storage_numel}));
+  // The rvalue set_meta overload requires an invalid destination meta, and a
+  // default constructed DenseTensor already reports a valid one (float32,
+  // NCHW, rank -1 dims). The const-ref overload overwrites dtype/dims instead.
+  // DenseTensor(DataType) is also unavailable under PADDLE_WITH_CUSTOM_KERNEL.
+  DenseTensor storage;
+  storage.set_meta(
+      DenseTensorMeta(input_grad->dtype(),
+                      common::make_ddim(std::vector<int64_t>{storage_numel})));
   dev_ctx->Alloc(&storage, storage.dtype());
   StridedTensorFill<T>(storage, 0, &storage);
 

--- a/paddle/phi/kernels/funcs/strided_utils.h
+++ b/paddle/phi/kernels/funcs/strided_utils.h
@@ -549,9 +549,10 @@ inline void StridedTensorAccumulate(const DenseTensor& out_grad,
     // which includes this header through as_strided.h. set_meta(const&) is
     // always visible and overwrites the default-constructed float32 meta.
     DenseTensor storage_index;
-    storage_index.set_meta(DenseTensorMeta(
+    DenseTensorMeta storage_index_meta(
         DataType::INT64,
-        common::make_ddim(std::vector<int64_t>{storage_numel})));
+        common::make_ddim(std::vector<int64_t>{storage_numel}));
+    storage_index.set_meta(storage_index_meta);
     using arange_signature = void (*)(const DeviceContext&,
                                       const Scalar&,
                                       const Scalar&,
@@ -736,9 +737,10 @@ inline void StridedTensorAccumulateThroughStorage(
   // NCHW, rank -1 dims). The const-ref overload overwrites dtype/dims instead.
   // DenseTensor(DataType) is also unavailable under PADDLE_WITH_CUSTOM_KERNEL.
   DenseTensor storage;
-  storage.set_meta(
-      DenseTensorMeta(input_grad->dtype(),
-                      common::make_ddim(std::vector<int64_t>{storage_numel})));
+  DenseTensorMeta storage_meta(
+      input_grad->dtype(),
+      common::make_ddim(std::vector<int64_t>{storage_numel}));
+  storage.set_meta(storage_meta);
   dev_ctx->Alloc(&storage, storage.dtype());
   StridedTensorFill<T>(storage, 0, &storage);
 

--- a/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/as_strided_grad_kernel.cc
@@ -45,9 +45,58 @@ void AsStridedGradKernel(const Context& dev_ctx,
   if (out_grad.numel() == 0) {
     return;
   }
+  // `offset` is a byte offset into the allocation shared with the forward
+  // `input`, but `input_grad` is a dense row-major buffer over `input`'s own
+  // logical indices. Subtracting `input.offset()` lines the two up only when
+  // `input` is contiguous *and* the whole window of the view lands inside
+  // `input`. Otherwise a storage index is not a row-major index; and since the
+  // forward validates a view against the shared allocation rather than against
+  // the extent of `input`, a window may legally reach outside `input` on either
+  // side, where its contributions belong to no element of `input_grad` and have
+  // to be dropped instead of written past its end. Everything but the fast case
+  // is routed through a buffer laid out in storage coordinates.
+  //
+  const std::vector<int64_t> input_dims =
+      common::vectorize<int64_t>(input.dims());
+  const std::vector<int64_t> input_stride =
+      common::vectorize<int64_t>(input.strides());
+  PADDLE_ENFORCE_EQ(
+      MaybeOverlappingStrides(input_dims, input_stride),
+      false,
+      common::errors::Unimplemented(
+          "as_strided_grad does not support an input whose own memory "
+          "overlaps (shape %s, stride %s). Make the input contiguous first.",
+          input.dims(),
+          input.strides()));
+  const int64_t itemsize = static_cast<int64_t>(SizeOf(input_grad->dtype()));
+  const int64_t input_base = static_cast<int64_t>(input.offset()) / itemsize;
+  const StridedViewRange out_range =
+      ComputeStridedViewRange(dims, stride, offset / itemsize);
+  const bool inside_input = !out_range.empty &&
+                            out_range.min_index >= input_base &&
+                            out_range.max_index < input_base + input.numel();
+  const bool through_storage = !input.meta().is_contiguous() || !inside_input;
+  if (through_storage) {
+    PD_VISIT_ALL_TYPES(out_grad.dtype(), "AsStridedGradKernel", ([&] {
+                         phi::StridedTensorAccumulateThroughStorage<data_t>(
+                             out_grad, dims, stride, offset, input, input_grad);
+                       }));
+    return;
+  }
+  const int64_t grad_offset = offset - static_cast<int64_t>(input.offset());
+  if (MaybeOverlappingStrides(dims, stride)) {
+    // Several elements of out_grad map to the same storage slot, so the
+    // gradient has to be accumulated instead of copied.
+    PD_VISIT_ALL_TYPES(out_grad.dtype(), "AsStridedGradKernel", ([&] {
+                         phi::StridedTensorAccumulate<data_t>(
+                             out_grad, dims, stride, grad_offset, input_grad);
+                       }));
+    return;
+  }
   DenseTensor tmp;
   tmp.set_meta(out_grad.meta());
-  AsStridedKernel<Context>(dev_ctx, *input_grad, dims, stride, offset, &tmp);
+  AsStridedKernel<Context>(
+      dev_ctx, *input_grad, dims, stride, grad_offset, &tmp);
   PD_VISIT_ALL_TYPES(out_grad.dtype(), "AsStridedGradKernel", ([&] {
                        phi::StridedTensorCopy<data_t>(
                            out_grad,

--- a/paddle/phi/kernels/stride/as_strided_kernel.cc
+++ b/paddle/phi/kernels/stride/as_strided_kernel.cc
@@ -12,34 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/phi/kernels/as_strided_kernel.h"
+#include "paddle/common/ddim.h"
 #include "paddle/common/flags.h"
 #include "paddle/phi/backends/all_context.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/strided_utils.h"
 
 COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace phi {
-void ValidateZeroSizeTensorShape(const std::vector<int64_t>& dims,
-                                 const std::vector<int64_t>& strides,
-                                 const DenseTensor& input) {
-  if (input.numel() != 0) {
-    return;
-  }
-  PADDLE_ENFORCE_EQ(dims.size(),
-                    strides.size(),
-                    common::errors::InvalidArgument(
-                        "The size of dims and strides should be equal."));
-  for (size_t i = 0; i < dims.size(); i++) {
-    if (dims[i] == 0) {
-      return;
-    }
-  }
-
-  PADDLE_THROW(common::errors::InvalidArgument(
-      "When input is zero-size tensor, the shape attribute must also be "
-      "zero-size."));
-}
-
 template <typename Context>
 void AsStridedKernel(const Context& dev_ctx,
                      const DenseTensor& input,
@@ -62,6 +43,7 @@ void AsStridedKernel(const Context& dev_ctx,
       0,
       common::errors::InvalidArgument(
           "The offset must be non-negative, but got %d.", offset));
+  ValidateStridedViewStorage(dims, stride, offset, input);
   out->set_meta(meta);
   out->ResetHolder(input.Holder());
   out->ShareInplaceVersionCounterWith(input);

--- a/paddle/phi/kernels/stride/tensor_unfold_grad_kernel.cc
+++ b/paddle/phi/kernels/stride/tensor_unfold_grad_kernel.cc
@@ -43,12 +43,6 @@ void TensorUnfoldGradKernel(const Context& dev_ctx,
     return;
   }
   input_grad->set_strides(DenseTensorMeta::calc_strides(input_grad->dims()));
-  if (out_grad.numel() < input.numel()) {
-    PD_VISIT_ALL_TYPES(input_grad->dtype(), "TensorUnfoldGradKernel", ([&] {
-                         phi::StridedTensorFill<data_t>(
-                             *input_grad, 0, input_grad);
-                       }));
-  }
   DenseTensor tmp;
   tmp.set_layout(out_grad.layout());
   tmp.set_lod(out_grad.lod());
@@ -56,14 +50,35 @@ void TensorUnfoldGradKernel(const Context& dev_ctx,
   tmp.Resize(out_grad.dims());
 
   TensorUnfoldKernel<Context>(dev_ctx, *input_grad, axis, size, step, &tmp);
-  PD_VISIT_ALL_TYPES(out_grad.dtype(), "TensorUnfoldGradKernel", ([&] {
-                       phi::StridedTensorCopy<data_t>(
-                           out_grad,
-                           vectorize<int64_t>(tmp.dims()),
-                           vectorize<int64_t>(tmp.strides()),
-                           tmp.offset(),
-                           &tmp);
-                     }));
+  std::vector<int64_t> view_dims = vectorize<int64_t>(tmp.dims());
+  std::vector<int64_t> view_stride = vectorize<int64_t>(tmp.strides());
+  // step < size makes the unfolded windows overlap, so several elements of
+  // out_grad map to the same input element and must be summed.
+  const bool overlapping =
+      out_grad.numel() > 0 && MaybeOverlappingStrides(view_dims, view_stride);
+
+  if (overlapping || out_grad.numel() < input.numel()) {
+    PD_VISIT_ALL_TYPES(input_grad->dtype(), "TensorUnfoldGradKernel", ([&] {
+                         phi::StridedTensorFill<data_t>(
+                             *input_grad, 0, input_grad);
+                       }));
+  }
+  if (overlapping) {
+    PD_VISIT_ALL_TYPES(out_grad.dtype(), "TensorUnfoldGradKernel", ([&] {
+                         phi::StridedTensorAccumulate<data_t>(
+                             out_grad,
+                             view_dims,
+                             view_stride,
+                             static_cast<int64_t>(tmp.offset()),
+                             input_grad);
+                       }));
+    return;
+  }
+  PD_VISIT_ALL_TYPES(
+      out_grad.dtype(), "TensorUnfoldGradKernel", ([&] {
+        phi::StridedTensorCopy<data_t>(
+            out_grad, view_dims, view_stride, tmp.offset(), &tmp);
+      }));
 }
 
 }  // namespace phi

--- a/test/cpp/compat/ATen_as_strided_test.cc
+++ b/test/cpp/compat/ATen_as_strided_test.cc
@@ -166,3 +166,36 @@ TEST_F(TensorAsStridedTest, AsStridedContiguous) {
   at::Tensor non_contig = t.as_strided({3, 2}, {1, 3});
   ASSERT_FALSE(non_contig.is_contiguous());
 }
+
+TEST_F(TensorAsStridedTest, AsStridedRejectsOutOfRangeView) {
+  // The view reaches element 4095 of a 12 element allocation. Without the
+  // range check every read and write through it corrupts unrelated memory.
+  at::Tensor t = at::arange(12, at::kFloat);
+  ASSERT_ANY_THROW(t.as_strided({64, 64}, {64, 1}));
+}
+
+TEST_F(TensorAsStridedTest, AsStridedRejectsNonEmptyViewOnEmptyStorage) {
+  at::Tensor t = at::empty({0}, at::kFloat);
+  ASSERT_ANY_THROW(t.as_strided({1}, {1}));
+  ASSERT_NO_THROW(t.as_strided({0}, {1}));
+}
+
+TEST_F(TensorAsStridedTest, AsStridedRejectsOverflowingStorageOffset) {
+  // storage_offset counts elements, so it has to be multiplied by the element
+  // size. 2^62 * 4 wraps around to 0 in size_t arithmetic, which would turn an
+  // out of range request into a silent alias of the first element.
+  at::Tensor t = at::arange(12, at::kFloat);
+  ASSERT_ANY_THROW(t.as_strided({2}, {1}, int64_t{1} << 62));
+}
+
+TEST_F(TensorAsStridedTest, AsStridedRejectsNegativeStorageOffset) {
+  at::Tensor t = at::arange(12, at::kFloat);
+  ASSERT_ANY_THROW(t.as_strided({2}, {1}, -1));
+}
+
+TEST_F(TensorAsStridedTest, AsStridedInplaceRejectsBadStorageOffset) {
+  at::Tensor t = at::arange(12, at::kFloat);
+  ASSERT_ANY_THROW(t.as_strided_({2}, {1}, int64_t{1} << 62));
+  at::Tensor u = at::arange(12, at::kFloat);
+  ASSERT_ANY_THROW(u.as_strided_({64, 64}, {64, 1}));
+}

--- a/test/cpp/eager/task_tests/nan_inf_utils_test.cc
+++ b/test/cpp/eager/task_tests/nan_inf_utils_test.cc
@@ -26,12 +26,14 @@
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/phi/api/include/api.h"
 #include "paddle/phi/api/include/strings_api.h"
+#include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
 
 PD_DECLARE_KERNEL(full, CPU, ALL_LAYOUT);
 PD_DECLARE_KERNEL(strings_empty, CPU, ALL_LAYOUT);
 
 COMMON_DECLARE_string(check_nan_inf_blacklist);
+COMMON_DECLARE_bool(use_stride_kernel);
 
 namespace egr {
 
@@ -137,12 +139,35 @@ TEST(NanInfUtils, SkipFloat8Tensor) {
 
 TEST(NanInfUtils, SkipNonContiguousTensor) {
   FLAGS_check_nan_inf_blacklist = "";
+  // is_contiguous() throws when FLAGS_use_stride_kernel is off and the tensor
+  // is actually strided. XPU CI sets that flag to 0, so the skip path has to
+  // enable it for the duration of this test. Restore on every exit, including
+  // assertion failure: a leaked true would hide later stride-kernel bugs.
+  struct RestoreStrideFlag {
+    bool orig;
+    explicit RestoreStrideFlag(bool value) : orig(FLAGS_use_stride_kernel) {
+      FLAGS_use_stride_kernel = value;
+    }
+    ~RestoreStrideFlag() { FLAGS_use_stride_kernel = orig; }
+  } restore_stride_flag(true);
 
   auto tensor = paddle::experimental::full(
       {2, 3}, std::numeric_limits<double>::quiet_NaN(), phi::DataType::FLOAT64);
   CHECK_NAN_INF(tensor);
 
-  auto non_contiguous = paddle::experimental::transpose(tensor, {1, 0});
+  // Do not go through transpose: with FLAGS_use_stride_kernel=0, and on XPU
+  // which does not register float64 transpose, it materializes a contiguous
+  // copy and this assertion fails before the skip path is exercised.
+  auto* src = static_cast<phi::DenseTensor*>(tensor.impl().get());
+  auto view = std::make_shared<phi::DenseTensor>();
+  view->ShareDataWith(*src);
+  phi::DenseTensorMeta meta(
+      src->dtype(), common::make_ddim({3, 2}), common::make_ddim({1, 3}));
+  meta.offset = src->meta().offset;
+  view->set_meta(meta);
+
+  paddle::Tensor non_contiguous;
+  non_contiguous.set_impl(view);
   ASSERT_FALSE(static_cast<const phi::DenseTensor*>(non_contiguous.impl().get())
                    ->meta()
                    .is_contiguous());

--- a/test/cpp/eager/task_tests/nan_inf_utils_test.cc
+++ b/test/cpp/eager/task_tests/nan_inf_utils_test.cc
@@ -135,6 +135,20 @@ TEST(NanInfUtils, SkipFloat8Tensor) {
   CHECK_NO_NAN_INF(fp8_e5m2);
 }
 
+TEST(NanInfUtils, SkipNonContiguousTensor) {
+  FLAGS_check_nan_inf_blacklist = "";
+
+  auto tensor = paddle::experimental::full(
+      {2, 3}, std::numeric_limits<double>::quiet_NaN(), phi::DataType::FLOAT64);
+  CHECK_NAN_INF(tensor);
+
+  auto non_contiguous = paddle::experimental::transpose(tensor, {1, 0});
+  ASSERT_FALSE(static_cast<const phi::DenseTensor*>(non_contiguous.impl().get())
+                   ->meta()
+                   .is_contiguous());
+  CHECK_NO_NAN_INF(non_contiguous);
+}
+
 TEST(NanInfUtils, Functions) {
   // test all methods
   auto tensor = paddle::experimental::full(

--- a/test/cpp/phi/kernels/strided_memcpy_test.cc
+++ b/test/cpp/phi/kernels/strided_memcpy_test.cc
@@ -18,8 +18,68 @@ limitations under the License. */
 #include "gtest/gtest.h"
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/common/memory_utils.h"
+#include "paddle/phi/kernels/funcs/strided_utils.h"
 namespace phi {
 namespace tests {
+
+TEST(StridedUtils, CheckedMulInt64Boundaries) {
+  int64_t result = 0;
+  EXPECT_FALSE(
+      CheckedMulInt64(std::numeric_limits<int64_t>::lowest(), -1, &result));
+  EXPECT_FALSE(
+      CheckedMulInt64(-1, std::numeric_limits<int64_t>::lowest(), &result));
+  EXPECT_TRUE(
+      CheckedMulInt64(std::numeric_limits<int64_t>::lowest(), 1, &result));
+  EXPECT_EQ(result, std::numeric_limits<int64_t>::lowest());
+  EXPECT_FALSE(
+      CheckedMulInt64(std::numeric_limits<int64_t>::lowest(), 2, &result));
+  EXPECT_FALSE(
+      CheckedMulInt64(std::numeric_limits<int64_t>::lowest(), -2, &result));
+  EXPECT_FALSE(
+      CheckedMulInt64(std::numeric_limits<int64_t>::max(), 2, &result));
+  EXPECT_TRUE(CheckedMulInt64(-7, -9, &result));
+  EXPECT_EQ(result, 63);
+}
+
+TEST(StridedUtils, HostAccumulateStridedView) {
+  const std::vector<float> values = {1, 2, 3, 4, 5, 6};
+
+  std::vector<float> non_overlapping(6, 0);
+  HostAccumulateStridedView(
+      values.data(), {2, 3}, {3, 1}, 0, non_overlapping.data());
+  EXPECT_EQ(non_overlapping, values);
+
+  std::vector<float> overlapping(4, 0);
+  HostAccumulateStridedView(
+      values.data(), {2, 3}, {1, 1}, 0, overlapping.data());
+  EXPECT_EQ(overlapping, (std::vector<float>{1, 6, 8, 6}));
+
+  std::vector<float> reversed(4, 0);
+  HostAccumulateStridedView(values.data(), {4}, {-1}, 3, reversed.data());
+  EXPECT_EQ(reversed, (std::vector<float>{4, 3, 2, 1}));
+
+  std::vector<float> empty_storage = {7, 8};
+  HostAccumulateStridedView(
+      values.data(), {0, 3}, {1, 1}, 0, empty_storage.data());
+  EXPECT_EQ(empty_storage, (std::vector<float>{7, 8}));
+}
+
+// Empty dims make ComputeStridedViewRange return early, which is the same
+// guard StridedTensorAccumulateThroughStorage uses. Do not instantiate that
+// helper here: it pulls in FillKernel/ContiguousKernel templates that are
+// not exported from phi.dll, so Windows cannot link strided_memcpy_test.exe.
+TEST(StridedUtils, ComputeStridedViewRangeEmptyShape) {
+  auto empty_1d = ComputeStridedViewRange({0}, {1}, 0);
+  EXPECT_TRUE(empty_1d.empty);
+
+  auto empty_middle = ComputeStridedViewRange({2, 0, 3}, {3, 1, 1}, 0);
+  EXPECT_TRUE(empty_middle.empty);
+
+  auto nonempty = ComputeStridedViewRange({2, 3}, {3, 1}, 0);
+  EXPECT_FALSE(nonempty.empty);
+  EXPECT_EQ(nonempty.min_index, 0);
+  EXPECT_EQ(nonempty.max_index, 5);
+}
 
 TEST(StridedMemcpy, CPUCrop) {
   // clang-format off

--- a/test/legacy_test/test_as_strided.py
+++ b/test/legacy_test/test_as_strided.py
@@ -134,5 +134,376 @@ class TestAsStridedAlias(unittest.TestCase):
                 np.testing.assert_array_equal(out_ref.numpy(), out_both.numpy())
 
 
+class TestAsStridedOverlapBackward(unittest.TestCase):
+    """When a view maps several logical positions onto the same element, the
+    backward has to sum all the incoming contributions instead of letting the
+    writes overwrite each other."""
+
+    def setUp(self):
+        self.places = get_places()
+
+    def _check(self, numel, shape, stride, offset_elems=0, dtype='float64'):
+        itemsize = np.dtype(dtype).itemsize
+        expected = np.zeros([numel], dtype=dtype)
+        for idx in np.ndindex(*shape):
+            expected[offset_elems + int(np.dot(idx, stride))] += 1
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(np.random.random([numel]).astype(dtype))
+                x.stop_gradient = False
+                y = paddle.as_strided(
+                    x,
+                    shape=shape,
+                    stride=stride,
+                    offset=offset_elems * itemsize,
+                )
+                y.backward(paddle.ones_like(y))
+                np.testing.assert_allclose(x.grad.numpy(), expected)
+
+    def test_repeated_stride(self):
+        self._check(5, (3, 3), (1, 1))
+        self._check(64, (32, 32), (1, 1))
+
+    def test_repeated_stride_non_contiguous_out_grad(self):
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(np.random.random([4]).astype('float32'))
+                x.stop_gradient = False
+                y = paddle.as_strided(x, shape=(2, 3), stride=(1, 1))
+                grad_storage = paddle.to_tensor(
+                    np.arange(12, dtype='float32').reshape([3, 4])
+                )
+                out_grad = paddle.as_strided(
+                    grad_storage, shape=(2, 3), stride=(4, 1)
+                )
+                self.assertFalse(out_grad.is_contiguous())
+                y.backward(out_grad)
+                np.testing.assert_allclose(
+                    x.grad.numpy(), np.array([0, 5, 7, 6], dtype='float32')
+                )
+
+    def test_zero_stride(self):
+        self._check(1, (4, 4), (0, 0))
+        self._check(3, (3, 4), (1, 0))
+
+    def test_zero_stride_non_contiguous_out_grad(self):
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(np.random.random([3]).astype('float32'))
+                x.stop_gradient = False
+                y = paddle.as_strided(x, shape=(3, 4), stride=(1, 0))
+                grad_storage = paddle.to_tensor(
+                    np.arange(12, dtype='float32').reshape([4, 3])
+                )
+                out_grad = paddle.as_strided(
+                    grad_storage, shape=(3, 4), stride=(1, 3)
+                )
+                self.assertFalse(out_grad.is_contiguous())
+                y.backward(out_grad)
+                np.testing.assert_allclose(
+                    x.grad.numpy(), np.array([18, 22, 26], dtype='float32')
+                )
+
+    def test_offset(self):
+        self._check(8, (3, 3), (1, 1), offset_elems=2)
+
+    def test_float32(self):
+        self._check(5, (3, 3), (1, 1), dtype='float32')
+
+    def test_non_overlapping(self):
+        self._check(6, (2, 3), (3, 1))
+        self._check(6, (3, 2), (1, 3))
+        self._check(6, (2, 3), (3, 1), dtype='float32')
+
+
+@unittest.skipIf(
+    not base.core.is_compiled_with_xpu(), "core is not compiled with XPU"
+)
+class TestAsStridedOverlapBackwardXPU(unittest.TestCase):
+    """get_places() reports CPU, CUDA and CustomPlace but never XPU, so without
+    this class the serial host fallback of the overlapping backward -- the only
+    path an XPU takes, since the device scatter-add needs GPU atomics -- would
+    never run. It stages both operands on the host through phi::Copy, so it
+    also covers the XPU <-> CPU copies that path depends on."""
+
+    def test_repeated_stride(self):
+        with base.dygraph.guard(base.XPUPlace(0)):
+            x = paddle.to_tensor(np.random.random([5]).astype('float32'))
+            x.stop_gradient = False
+            y = paddle.as_strided(x, shape=(3, 3), stride=(1, 1))
+            y.backward(paddle.ones_like(y))
+            np.testing.assert_allclose(
+                x.grad.numpy(), np.array([1, 2, 3, 2, 1], dtype='float32')
+            )
+
+    def test_zero_stride(self):
+        with base.dygraph.guard(base.XPUPlace(0)):
+            x = paddle.to_tensor(np.random.random([1]).astype('float32'))
+            x.stop_gradient = False
+            y = paddle.as_strided(x, shape=(4, 4), stride=(0, 0))
+            y.backward(paddle.ones_like(y))
+            np.testing.assert_allclose(
+                x.grad.numpy(), np.array([16], dtype='float32')
+            )
+
+    def test_non_contiguous_out_grad(self):
+        with base.dygraph.guard(base.XPUPlace(0)):
+            x = paddle.to_tensor(np.random.random([4]).astype('float32'))
+            x.stop_gradient = False
+            y = paddle.as_strided(x, shape=(2, 3), stride=(1, 1))
+            grad_storage = paddle.to_tensor(
+                np.arange(12, dtype='float32').reshape([3, 4])
+            )
+            out_grad = paddle.as_strided(
+                grad_storage, shape=(2, 3), stride=(4, 1)
+            )
+            self.assertFalse(out_grad.is_contiguous())
+            y.backward(out_grad)
+            np.testing.assert_allclose(
+                x.grad.numpy(), np.array([0, 5, 7, 6], dtype='float32')
+            )
+
+
+class TestAsStridedStorageRange(unittest.TestCase):
+    """A view must stay inside the allocation of its input, otherwise reads and
+    writes through it corrupt unrelated memory."""
+
+    def setUp(self):
+        self.places = get_places()
+
+    def test_shape_out_of_range(self):
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.zeros([16], dtype='float32')
+                self.assertRaises(
+                    ValueError,
+                    paddle.as_strided,
+                    x=x,
+                    shape=(64, 64),
+                    stride=(64, 1),
+                )
+
+    def test_offset_out_of_range(self):
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.zeros([16], dtype='float32')
+                self.assertRaises(
+                    ValueError,
+                    paddle.as_strided,
+                    x=x,
+                    shape=(16,),
+                    stride=(1,),
+                    offset=4096 * 4,
+                )
+
+    def test_misaligned_offset(self):
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.zeros([16], dtype='float32')
+                self.assertRaises(
+                    ValueError,
+                    paddle.as_strided,
+                    x=x,
+                    shape=(2,),
+                    stride=(1,),
+                    offset=1,
+                )
+
+    def test_overflowing_span_is_rejected(self):
+        # 4 * 2**62 wraps around to 0 in int64, so unchecked arithmetic would
+        # accept this view and let it read and write far outside the allocation.
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.zeros([16], dtype='float32')
+                self.assertRaises(
+                    ValueError,
+                    paddle.as_strided,
+                    x=x,
+                    shape=(5,),
+                    stride=(1 << 62,),
+                )
+
+    def test_in_range_view_is_allowed(self):
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x_np = np.random.random([16]).astype('float32')
+                x = paddle.to_tensor(x_np)
+                y = paddle.as_strided(x, shape=(4, 4), stride=(4, 1), offset=0)
+                np.testing.assert_allclose(y.numpy(), x_np.reshape(4, 4))
+
+    def test_stride_shorter_than_shape_is_rejected(self):
+        # A strided view needs one stride for every shape dimension. Accepting
+        # a shorter stride vector lets later kernels read past the attribute.
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.zeros([15, 3], dtype='float32')
+                with self.assertRaises(ValueError):
+                    paddle.as_strided(x, shape=[15, 3], stride=[2])
+
+
+class TestAsStridedNestedViewBackward(unittest.TestCase):
+    """`offset` is an absolute byte offset into the shared allocation, while the
+    gradient buffer of a view starts at its own element 0. Taking a view of a
+    view therefore has to relocate the offset before writing the gradient."""
+
+    def setUp(self):
+        self.places = get_places()
+
+    def _check(self, shape, stride, dtype='float32'):
+        itemsize = np.dtype(dtype).itemsize
+        base_numel = 8
+        outer_numel = 6
+        outer_offset = 2
+        expected = np.zeros([base_numel], dtype=dtype)
+        for idx in np.ndindex(*shape):
+            expected[outer_offset + int(np.dot(idx, stride))] += 1
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(
+                    np.random.random([base_numel]).astype(dtype)
+                )
+                x.stop_gradient = False
+                outer = paddle.as_strided(
+                    x,
+                    shape=(outer_numel,),
+                    stride=(1,),
+                    offset=outer_offset * itemsize,
+                )
+                inner = paddle.as_strided(
+                    outer,
+                    shape=shape,
+                    stride=stride,
+                    offset=outer_offset * itemsize,
+                )
+                inner.backward(paddle.ones_like(inner))
+                np.testing.assert_allclose(x.grad.numpy(), expected)
+
+    def test_nested_non_overlapping(self):
+        self._check((2,), (2,))
+        self._check((3,), (2,))
+
+    def test_nested_overlapping(self):
+        self._check((3, 3), (1, 1))
+
+    def test_nested_negative_stride(self):
+        dtype = 'float32'
+        itemsize = np.dtype(dtype).itemsize
+        expected = np.ones([4], dtype=dtype)
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(np.random.random([4]).astype(dtype))
+                x.stop_gradient = False
+                inp = paddle.as_strided(
+                    x, shape=(4,), stride=(-1,), offset=3 * itemsize
+                )
+                y = paddle.as_strided(
+                    inp, shape=(4,), stride=(-1,), offset=3 * itemsize
+                )
+                y.backward(paddle.ones_like(y))
+                np.testing.assert_allclose(x.grad.numpy(), expected)
+
+
+class TestAsStridedStorageCoordinateBackward(unittest.TestCase):
+    """`dims` / `stride` / `offset` address the shared allocation, while the
+    gradient buffer is dense and row-major over the input's own logical
+    indices. The two orders coincide only when the input is contiguous and the
+    whole window of the view lands inside it, so in every other case the
+    gradient has to be routed back through the input's own strides."""
+
+    def setUp(self):
+        self.places = get_places()
+
+    def _check(
+        self,
+        base_numel,
+        input_shape,
+        input_stride,
+        input_offset,
+        shape,
+        stride,
+        offset_elems=0,
+        dtype='float64',
+    ):
+        itemsize = np.dtype(dtype).itemsize
+        # Gradient per slot of the shared allocation.
+        storage_grad = np.zeros([base_numel], dtype=dtype)
+        for idx in np.ndindex(*shape):
+            storage_grad[offset_elems + int(np.dot(idx, stride))] += 1
+        # Read back through the input geometry: this is what distinguishes a
+        # storage index from a row-major one.
+        expected_input = np.zeros(input_shape, dtype=dtype)
+        expected_base = np.zeros([base_numel], dtype=dtype)
+        for idx in np.ndindex(*input_shape):
+            slot = input_offset + int(np.dot(idx, input_stride))
+            expected_input[idx] = storage_grad[slot]
+            expected_base[slot] += storage_grad[slot]
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(
+                    np.random.random([base_numel]).astype(dtype)
+                )
+                x.stop_gradient = False
+                inp = paddle.as_strided(
+                    x,
+                    shape=input_shape,
+                    stride=input_stride,
+                    offset=input_offset * itemsize,
+                )
+                inp.retain_grads()
+                y = paddle.as_strided(
+                    inp,
+                    shape=shape,
+                    stride=stride,
+                    offset=offset_elems * itemsize,
+                )
+                y.backward(paddle.ones_like(y))
+                np.testing.assert_allclose(inp.grad.numpy(), expected_input)
+                np.testing.assert_allclose(x.grad.numpy(), expected_base)
+
+    def test_transposed_input_overlapping_view(self):
+        # 2x2 transpose viewed with a repeated stride: storage slot 1 collects
+        # two contributions and belongs to input[1, 0], not to input[0, 1].
+        self._check(4, (2, 2), (1, 2), 0, (2, 2), (1, 1))
+
+    def test_transposed_input_non_overlapping_view(self):
+        self._check(6, (2, 3), (1, 2), 0, (3,), (2,))
+        self._check(6, (2, 3), (1, 2), 0, (2, 2), (1, 2))
+
+    def test_transposed_input_float32(self):
+        self._check(4, (2, 2), (1, 2), 0, (2, 2), (1, 1), dtype='float32')
+
+    def test_view_starting_before_input(self):
+        # The leading contributions land outside the input and are dropped;
+        # they belong to no element of its gradient.
+        self._check(8, (4,), (1,), 2, (4,), (1,), offset_elems=0)
+        self._check(8, (2, 2), (1, 2), 2, (3,), (1,), offset_elems=1)
+
+    def test_view_ending_after_input(self):
+        # A view may legally reach past the end of its input, because the
+        # forward validates it against the shared allocation and not against
+        # the extent of the input. Only storage slot 5 belongs to the input
+        # here, so its gradient is [0, 0, 0, 1].
+        self._check(8, (4,), (1,), 2, (3,), (1,), offset_elems=5)
+
+    def test_view_disjoint_from_input(self):
+        # No slot is shared, so nothing reaches the input's gradient at all.
+        self._check(8, (4,), (1,), 2, (2,), (1,), offset_elems=6)
+
+    def test_view_ending_after_input_overlapping(self):
+        self._check(8, (4,), (1,), 2, (2, 2), (1, 1), offset_elems=4)
+
+    def test_overlapping_input_is_rejected(self):
+        # The gradient of a view that aliases itself needs a convention for
+        # splitting a shared slot, so it is refused rather than guessed.
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(np.random.random([4]).astype('float32'))
+                x.stop_gradient = False
+                inp = paddle.as_strided(x, shape=(2, 2), stride=(1, 1))
+                y = paddle.as_strided(inp, shape=(2,), stride=(1,))
+                with self.assertRaises(NotImplementedError):
+                    y.backward(paddle.ones_like(y))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/legacy_test/test_inplace.py
+++ b/test/legacy_test/test_inplace.py
@@ -2284,10 +2284,10 @@ class TestDygraphInplaceSet(unittest.TestCase):
         x = paddle.to_tensor(self.x_np).astype(self.dtype)
         new_x = paddle.to_tensor(self.new_x_np).astype(self.dtype)
         no_inplace_x4 = self.non_inplace_api_processing(
-            x, new_x=new_x, stride=self.new_stride
+            x, new_x=new_x, stride=new_x.strides
         )
         inplace_x4 = self.inplace_api_processing(
-            x, new_x=new_x, stride=self.new_stride
+            x, new_x=new_x, stride=new_x.strides
         )
         np.testing.assert_array_equal(no_inplace_x4.numpy(), inplace_x4.numpy())
 
@@ -2324,10 +2324,10 @@ class TestDygraphInplaceSet(unittest.TestCase):
         x = paddle.to_tensor(self.x_np).astype(self.dtype)
         new_x = paddle.to_tensor(self.new_x_np).astype(self.dtype)
         no_inplace_x8 = self.non_inplace_api_processing(
-            x, new_x=new_x, stride=self.new_stride, offset=self.new_offset
+            x, new_x=new_x, stride=new_x.strides, offset=self.new_offset
         )
         inplace_x8 = self.inplace_api_processing(
-            x, new_x=new_x, stride=self.new_stride, offset=self.new_offset
+            x, new_x=new_x, stride=new_x.strides, offset=self.new_offset
         )
         np.testing.assert_array_equal(no_inplace_x8.numpy(), inplace_x8.numpy())
 

--- a/test/legacy_test/test_tensor_unfold.py
+++ b/test/legacy_test/test_tensor_unfold.py
@@ -160,5 +160,41 @@ class TestUnfoldAPI_Compatibility(unittest.TestCase):
         np.testing.assert_array_equal(out1.numpy(), out4.numpy())
 
 
+class TestTensorUnfoldOverlapBackward(unittest.TestCase):
+    """With step < size the unfolded windows overlap, so every input element
+    must receive the sum of the gradients of all windows containing it."""
+
+    def setUp(self):
+        self.places = get_places()
+
+    def _check(self, shape, axis, size, step, dtype='float64'):
+        x_np = np.random.random(shape).astype(dtype)
+        expected = np.zeros(shape, dtype=dtype)
+        num_window = (shape[axis] - size) // step + 1
+        index = [slice(None)] * len(shape)
+        for w in range(num_window):
+            index[axis] = slice(w * step, w * step + size)
+            expected[tuple(index)] += 1
+        for place in self.places:
+            with base.dygraph.guard(place):
+                x = paddle.to_tensor(x_np)
+                x.stop_gradient = False
+                y = paddle.unfold(x, axis, size, step)
+                y.backward(paddle.ones_like(y))
+                np.testing.assert_allclose(x.grad.numpy(), expected)
+
+    def test_overlapping_windows(self):
+        self._check([5], 0, 3, 1)
+        self._check([16], 0, 4, 1)
+        self._check([8, 4], 0, 4, 2)
+
+    def test_overlapping_windows_float32(self):
+        self._check([5], 0, 3, 1, dtype='float32')
+
+    def test_non_overlapping_windows(self):
+        self._check([12], 0, 4, 4)
+        self._check([12], -1, 2, 5)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

本 PR 修复 strided view 的前向安全性和反向梯度正确性，覆盖 `as_strided`、`as_strided_grad`、`tensor_unfold_grad` 以及 ATen compat `as_strided` 路径。主要包含六类修改：

1. 非连续 Tensor 的 NaN/Inf 检查安全性；
2. strided view 的 shape、offset、存储范围和整数溢出校验；
3. 重叠 view 和重叠 unfold 窗口的梯度累加；
4. 非连续、嵌套 view 的反向坐标映射；
5. ATen compat `as_strided` 的 storage offset 语义对齐；
6. 公共辅助逻辑合并及回归测试补充。

#### 1. 非连续 Tensor 的 NaN/Inf 检查安全性

##### 问题

NaN/Inf 检查直接把 Tensor 当成从首地址开始的连续内存，按 `ptr[i]` 扫描 `numel()` 个元素。这个假设对 strided view 不成立：

```python
x = paddle.arange(4, dtype='float32')
y = paddle.as_strided(x, shape=[4, 4], stride=[0, 0])
```

`y` 的 16 个逻辑元素实际只映射到一个存储位置。若仍按连续内存扫描，检查范围会超过底层 allocation；对转置、切片等普通非连续 view，扫描到的内容也不是该 view 的逻辑元素。

##### 改动

在 `CheckTensorHasNanOrInf` 中检测到 Tensor 非连续时跳过这次 flat memory scan，并记录 verbose 日志。底层连续 Tensor 仍会在其自身检查路径中被检查。

##### 修改后结果

- 不再因为 stride 为 0 或非连续布局读取错误地址；
- 不会把与 view 无关的内存误判为该 Tensor 的内容；
- 连续 Tensor 的原有 NaN/Inf 检查行为不变。

该行为是本 PR 当前保留的安全策略，未进一步扩大修改范围。

#### 2. strided view 的 shape、offset、存储范围和溢出校验

##### 问题

原实现主要设置 view metadata，不完整验证 `(shape, stride, offset)` 描述的地址范围。非法 view 可能被接受，后续读写越界；短 stride 还会让后续代码访问不存在的 stride 项。

例如，以下请求都不应创建合法 view：

```python
x = paddle.zeros([16], dtype='float32')

# 访问远超过 allocation 的区域
paddle.as_strided(x, shape=[64, 64], stride=[64, 1])

# offset 超过 allocation
paddle.as_strided(x, shape=[16], stride=[1], offset=4096 * 4)

# byte offset 没有按元素大小对齐
paddle.as_strided(x, shape=[2], stride=[1], offset=1)

# shape 和 stride rank 不一致
paddle.as_strided(x, shape=[15, 3], stride=[2])

# stride * (shape - 1) 的 int64 计算溢出
paddle.as_strided(x, shape=[5], stride=[1 << 62])
```

ATen compat 路径还存在 storage offset 从元素数转换为 byte offset 时的无符号乘法问题：`(1 << 62) * 4` 可能回绕成 0，从而错误地别名到 allocation 开头。

##### 改动

- 在已有 strided view 校验中统一要求 `dims.size() == strides.size()`，并把检查放在 zero-size/其他 early return 之前；
- 新增安全的 `int64_t` 加法和乘法，溢出时抛出 `InvalidArgument`，不再依赖回绕后的结果；
- 计算 view 覆盖的最小、最大 storage element，检查是否落在底层 allocation 内；
- 检查 offset 非负、按 dtype element size 对齐；
- 在 ATen compat `as_strided` 和 `as_strided_` 中使用 checked 的 element-to-byte offset 转换，并复用同一套范围校验；
- zero-size view 仍允许不触碰存储的合法形状，非零 view 必须满足完整 rank 和范围约束。

##### 修改后结果

- 越界、负 offset、非对齐 offset、rank 不一致和算术溢出均在进入 kernel 前明确报错；
- 不会因为 int64/size_t 回绕而把非法 view 当成合法 view；
- 合法的连续、负 stride、zero-size 和带 offset view 继续保持原有结果。

#### 3. 重叠 view 和重叠 unfold 窗口的梯度累加

##### 问题

当多个逻辑位置映射到同一个 storage slot 时，反向不能使用普通 copy。旧路径会发生写覆盖，而不是把所有 incoming gradient 相加。

`as_strided` 示例：

```python
x = paddle.arange(5, dtype='float32')
x.stop_gradient = False
y = paddle.as_strided(x, shape=[3, 3], stride=[1, 1])
y.backward(paddle.ones_like(y))
```

`x.grad` 的正确结果是：

```text
[1, 2, 3, 2, 1]
```

zero-stride view 也必须累加：

```python
x = paddle.ones([1], dtype='float32')
x.stop_gradient = False
y = paddle.as_strided(x, shape=[4, 4], stride=[0, 0])
y.backward(paddle.ones_like(y))
# x.grad == [16]
```

`tensor.unfold` 在 `step < size` 时窗口相互重叠，同样存在覆盖问题。例如长度为 5、`size=3`、`step=1` 时，中间元素需要收到 3 个窗口的梯度。

##### 改动

- 增加 `MaybeOverlappingStrides`，按 stride 排序判断不同逻辑索引是否可能命中同一 storage slot；
- 增加 `StridedTensorAccumulate`，把 dense 的 `out_grad` 按 view 几何 scatter-add 到目标梯度存储；
- CPU 使用串行 host 累加，避免重复 index 在普通并行写入下丢失更新；
- GPU 在可用 dtype 上使用 `arange + index_put(accumulate=true)` 做 scatter-add；不具备对应 kernel 的 backend 使用 host fallback 后再拷回；
- `as_strided_grad` 和 `tensor_unfold_grad` 在检测到重叠时走累加路径，非重叠场景继续使用更快的 copy 路径；
- 梯度 buffer 在需要累加时先清零，保证未命中位置保持零。

##### 修改后结果

- 重复 stride、zero stride、带 offset 的重叠 view 梯度均按出现次数求和；
- overlapping unfold 的窗口贡献不再互相覆盖；
- 非重叠 view 的计算路径和结果保持不变；
- CPU 和 GPU 的梯度结果一致。

#### 4. 非连续、嵌套 view 的反向坐标映射

##### 问题

`input_grad` 是按照输入 Tensor 的逻辑 shape 分配的 dense buffer，而 `as_strided` 的 `offset`、`stride` 描述的是共享 allocation 的 storage 坐标。两者只有在输入连续且 view 完全落在输入范围内时才可以直接用 `offset - input.offset()` 对齐。

例如：

```python
base = paddle.arange(8, dtype='float32')
base.stop_gradient = False
outer = paddle.as_strided(base, shape=[6], stride=[1], offset=2 * 4)
inner = paddle.as_strided(outer, shape=[3, 3], stride=[1, 1], offset=2 * 4)
inner.backward(paddle.ones_like(inner))
```

如果直接把 storage index 当成 `outer` 的 row-major index，梯度会写入错误位置；如果 view 跨过输入自身边界，还可能写出 `input_grad`，即使它仍然位于共享 allocation 内。

##### 改动

- 对非连续输入或超出输入逻辑范围的 view，先在共享 storage 坐标中建立临时梯度 buffer；
- 将 `out_grad` 按 view 的 shape/stride/offset 累加或复制到该 storage buffer；
- 再按照输入自身的 dims/strides/offset 从 storage buffer gather 回 dense `input_grad`；
- view 与 input 不相交的 storage slot 被自然丢弃，不会写出输入梯度范围；
- 输入自身存在重叠时在入口处明确抛出 `NotImplementedError`，避免对“一个共享 slot 如何分摊到多个输入逻辑位置”做未定义猜测。

##### 修改后结果

- 转置、切片、带 offset 的 nested view 反向梯度能回到正确的输入逻辑位置；
- view 起始于输入之前、结束于输入之后或与输入完全不相交时，梯度不会越界；
- 输入自身重叠的情况得到明确诊断，要求调用方先转为 contiguous Tensor。

#### 5. ATen compat `as_strided` 语义对齐

##### 问题

ATen compat 的 `storage_offset` 按元素计数，而 Paddle 内部 metadata offset 按 byte 计数。原实现直接进行未经检查的乘法，并且 compat 路径手工构造 view，可能绕过 PHI `as_strided` kernel 的范围检查。

##### 改动

- 在 `Tensor::as_strided` 和 `Tensor::as_strided_` 中统一使用 checked element-to-byte offset 转换；
- 复用 PHI 的 storage range、alignment、rank 和 overflow 检查；
- compat 头文件改为包含统一的 `strided_utils.h`，避免两套校验逻辑漂移。

##### 修改后结果

- compat `as_strided` 与 Paddle PHI kernel 对非法范围、负 offset、溢出 offset 的行为一致；
- 合法的 contiguous、non-contiguous 和 inplace view 仍保持原有语义；
- 不再因为 offset 回绕而产生错误 alias。

#### 6. 公共辅助逻辑合并及回归测试

##### 问题

早期实现把 view 校验和 backward 辅助逻辑拆到多个新增头文件中，导致公共 compat 入口需要额外 include，逻辑容易重复且不利于维护。部分修复还只覆盖 kernel 路径，没有对应的 forward、backward、CPU/GPU 和 compat 回归测试。

##### 改动

- 将 strided view 的范围、溢出、重叠判断、copy 和 accumulate 辅助逻辑合并到已有的 `paddle/phi/kernels/funcs/strided_utils.h`；
- 删除临时拆分的 `strided_view_utils.h` 和 `strided_grad_utils.h`，不新增持久化头文件；
- 补充或强化 `test_as_strided.py`、`test_tensor_unfold.py` 和 `ATen_as_strided_test.cc`。

测试覆盖：

- 重复 stride、zero stride、带 offset 的重叠梯度；
- nested/non-contiguous input 的 backward；
- shape/stride rank 不一致；
- storage range、负 offset、非对齐 offset 和 int64 overflow；
- zero-size view 和合法 view 的兼容行为；
- ATen compat forward/inplace `as_strided` 的非法 offset 和越界行为；
- CPU、GPU 以及可用的其他 backend 路径。

##### 修改后结果

- 相关逻辑集中在现有公共辅助头文件中，减少重复实现和 include 依赖；
- 非法输入在 metadata/kernel 入口处被拒绝，合法输入保持兼容；
- 关键梯度和边界回归场景有自动化测试覆盖。

### 修改后的总体行为

| 类别 | 之前 | 之后 |
| --- | --- | --- |
| 非连续 Tensor 的 NaN/Inf 检查 | 可能按连续地址误读或越界 | 非连续 view 跳过 flat scan，避免错误内存访问 |
| shape/stride rank 不一致 | 可能被接受，后续访问缺失 stride | 入口明确报错 |
| 越界或溢出 view | 可能静默创建并在读写时破坏内存 | 范围、对齐和算术溢出检查提前拒绝 |
| 重叠 `as_strided` backward | 重复 slot 被覆盖 | 所有贡献累加 |
| overlapping `unfold` backward | 窗口贡献互相覆盖 | 按窗口出现次数累加 |
| 非连续/nested input backward | storage 坐标被误当成逻辑坐标 | 经过 storage buffer 正确 gather 回输入梯度 |
| 输入自身重叠 | 可能产生未定义梯度 | 明确抛出 `NotImplementedError` |
| ATen `storage_offset` | 元素到 byte 的转换可能回绕 | checked conversion，与 PHI 路径统一 |

合法输入的前向结果不变；修改主要影响原本可能越界、静默接受或梯度错误的边界场景。梯度数值的变化是对重叠 view 原本错误的覆盖行为进行正确累加，不是精度策略变化。

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是