### PR TITLE
[Operator Mechanism] Align CPU elementwise broadcast backward with PyTorch bitwise

### DIFF
--- a/paddle/phi/kernels/cpu/elementwise_grad.h
+++ b/paddle/phi/kernels/cpu/elementwise_grad.h
@@ -75,6 +75,7 @@ void ElemwiseExplicitGradCompute(const CPUContext& dev_ctx,
 */
 template <typename T>
 struct IdentityGrad {
+  static constexpr bool kGradTermIsDout = true;
   HOSTDEVICE T operator()(T x UNUSED, T y UNUSED, T out UNUSED, T dout) const {
     return dout;
   }
@@ -145,6 +146,7 @@ ElementwiseAddGrad(const CPUContext& dev_ctx,
 
 template <typename T>
 struct SubGradDX {
+  static constexpr bool kGradTermIsDout = true;
   HOSTDEVICE T operator()(T x UNUSED, T y UNUSED, T out UNUSED, T dout) const {
     return dout;
   }

--- a/paddle/phi/kernels/funcs/elementwise_grad_base.h
+++ b/paddle/phi/kernels/funcs/elementwise_grad_base.h
@@ -14,6 +14,9 @@ limitations under the License. */
 
 #pragma once
 
+#include <memory>
+#include <type_traits>
+
 #include "glog/logging.h"
 
 #include "paddle/common/enforce.h"
@@ -23,6 +26,7 @@ limitations under the License. */
 #include "paddle/phi/common/memory_utils.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/cast_kernel.h"
+#include "paddle/phi/kernels/funcs/cascade_sum.h"
 #include "paddle/phi/kernels/funcs/common_shape.h"
 #include "paddle/phi/kernels/funcs/elementwise_utils.h"
 #include "paddle/phi/kernels/funcs/for_range.h"
@@ -53,6 +57,57 @@ namespace phi {
 namespace funcs {
 using DDim = DDim;
 
+// Detects grad functors whose per-element term equals dout bit-for-bit (e.g.
+// IdentityGrad of add). The broadcast reduction can then read dout directly
+// instead of materializing the terms, mirroring torch, which reduces the raw
+// gradient via sum_to_size for such functors.
+template <typename F, typename = void>
+struct GradTermEqualsDout : std::false_type {};
+
+template <typename F>
+struct GradTermEqualsDout<F, std::void_t<decltype(F::kGradTermIsDout)>>
+    : std::bool_constant<F::kGradTermIsDout> {};
+
+// Reduces the per-element gradient terms of a row-major contiguous buffer
+// laid out over the broadcast output shape over `reduce_axes`, reproducing
+// the summation order of torch's at::sum (TensorIterator cascade), which is
+// how torch reduces broadcast gradients. For fp16/bf16 torch may instead sum
+// a float32 copy and round only the result (pytorch issue 83149); mirror
+// that here.
+template <typename T>
+void ReduceGradTermsCascade(const T *terms,
+                            const std::vector<int64_t> &shape,
+                            const std::vector<int64_t> &reduce_axes,
+                            T *out_data,
+                            int64_t out_numel) {
+  std::vector<int64_t> strides(shape.size(), 1);
+  for (int i = static_cast<int>(shape.size()) - 2; i >= 0; --i) {
+    strides[i] = strides[i + 1] * shape[i + 1];
+  }
+  if constexpr (std::is_same<T, ::phi::dtype::float16>::value ||
+                std::is_same<T, ::phi::dtype::bfloat16>::value) {
+    if (NeedsFloatAccBuffer(shape, strides, reduce_axes)) {
+      int64_t terms_numel = 1;
+      for (int64_t d : shape) {
+        terms_numel *= d;
+      }
+      std::vector<float> terms_f(terms_numel);
+      for (int64_t i = 0; i < terms_numel; ++i) {
+        terms_f[i] = static_cast<float>(terms[i]);
+      }
+      std::vector<float> out_f(out_numel);
+      TorchCompatibleReduceSum<float>(
+          terms_f.data(), shape, strides, reduce_axes, out_f.data(), out_numel);
+      for (int64_t i = 0; i < out_numel; ++i) {
+        out_data[i] = static_cast<T>(out_f[i]);
+      }
+      return;
+    }
+  }
+  TorchCompatibleReduceSum<T>(
+      terms, shape, strides, reduce_axes, out_data, out_numel);
+}
+
 template <typename T, typename DX_OP, typename DY_OP, typename Tout = T>
 void CommonGradBroadcastCPU(const DenseTensor &x,
                             const DenseTensor &y,
@@ -67,64 +122,117 @@ void CommonGradBroadcastCPU(const DenseTensor &x,
                             const CPUContext &dev_ctx,
                             DX_OP dx_op,
                             DY_OP dy_op) {
-  using MT = typename MPTypeTrait<T>::Type;
-
   std::vector<int64_t> index_array(max_dim, 0);
   const T *x_data = x.data<T>();
   const T *y_data = y.data<T>();
   const Tout *out_data = out.data<Tout>();
   const Tout *dout_data = dout.data<Tout>();
 
-  DenseTensor dx_mp, dy_mp;
-  MT *dx_mp_data = nullptr;
-  MT *dy_mp_data = nullptr;
-  if (dx != nullptr) {
-    dx_mp.Resize(dx->dims());
-    dev_ctx.Alloc<MT>(&dx_mp);
-    dx_mp_data = dx_mp.data<MT>();
-    memset(dx_mp_data, 0, dx->numel() * sizeof(MT));
-  }
-  if (dy != nullptr) {
-    dy_mp.Resize(dy->dims());
-    dev_ctx.Alloc<MT>(&dy_mp);
-    dy_mp_data = dy_mp.data<MT>();
-    memset(dy_mp_data, 0, dy->numel() * sizeof(MT));
-  }
   const int64_t out_size = std::accumulate(out_dims_array,
                                            out_dims_array + max_dim,
                                            static_cast<int64_t>(1),
                                            std::multiplies<int64_t>());
+
+  // An operand expanded along a dimension (its size is 1 while the output
+  // size is larger) must have its gradient terms reduced along that
+  // dimension. The terms are materialized over the broadcast output shape
+  // (row-major, same order as out/dout) and reduced with torch-compatible
+  // cascade summation, matching the arithmetic and accumulation order of
+  // torch's broadcast backward (materialize the per-element gradient tensor,
+  // then at::sum). An operand that was not expanded is written directly:
+  // its aligned index equals the output index.
+  std::vector<int64_t> dx_reduce_axes, dy_reduce_axes;
+  for (int d = 0; d < max_dim; ++d) {
+    if (x_dims_array[d] == 1 && out_dims_array[d] > 1) {
+      dx_reduce_axes.push_back(d);
+    }
+    if (y_dims_array[d] == 1 && out_dims_array[d] > 1) {
+      dy_reduce_axes.push_back(d);
+    }
+  }
+
+  const std::vector<int64_t> out_shape(out_dims_array,
+                                       out_dims_array + max_dim);
+  // When a functor's term equals dout bit-for-bit, the reduction reads dout
+  // directly instead of the materialized terms, mirroring torch's sum_to_size
+  // on the raw gradient. Requires T == Tout so the terms really are dout.
+  const bool dx_from_dout = !dx_reduce_axes.empty() &&
+                            std::is_same<T, Tout>::value &&
+                            GradTermEqualsDout<DX_OP>::value;
+  const bool dy_from_dout = !dy_reduce_axes.empty() &&
+                            std::is_same<T, Tout>::value &&
+                            GradTermEqualsDout<DY_OP>::value;
+  // Note: a plain std::vector<T> cannot be used here because T can be bool.
+  std::unique_ptr<T[]> dx_terms, dy_terms;
+  T *dx_data = nullptr;
+  T *dy_data = nullptr;
+  if (dx != nullptr) {
+    if (dx_reduce_axes.empty()) {
+      dx_data = dev_ctx.template Alloc<T>(dx);
+    } else if (!dx_from_dout) {
+      dx_terms = std::make_unique<T[]>(out_size);
+    }
+  }
+  if (dy != nullptr) {
+    if (dy_reduce_axes.empty()) {
+      dy_data = dev_ctx.template Alloc<T>(dy);
+    } else if (!dy_from_dout) {
+      dy_terms = std::make_unique<T[]>(out_size);
+    }
+  }
+
+  const bool loop_has_work =
+      (dx != nullptr && !dx_from_dout) || (dy != nullptr && !dy_from_dout);
   int64_t x_index, y_index;
-  for (int64_t out_index = 0; out_index < out_size; ++out_index) {
+  for (int64_t out_index = 0; loop_has_work && out_index < out_size;
+       ++out_index) {
     x_index =
         GetElementwiseIndex<int64_t>(x_dims_array, max_dim, index_array.data());
     y_index =
         GetElementwiseIndex<int64_t>(y_dims_array, max_dim, index_array.data());
-    if (dx_mp_data != nullptr) {
-      dx_mp_data[x_index] += static_cast<MT>(dx_op(x_data[x_index],
-                                                   y_data[y_index],
-                                                   out_data[out_index],
-                                                   dout_data[out_index]));
+    if (dx != nullptr && !dx_from_dout) {
+      const T value = dx_op(x_data[x_index],
+                            y_data[y_index],
+                            out_data[out_index],
+                            dout_data[out_index]);
+      if (dx_data != nullptr) {
+        dx_data[out_index] = value;
+      } else {
+        dx_terms[out_index] = value;
+      }
     }
-    if (dy_mp_data != nullptr) {
-      dy_mp_data[y_index] += static_cast<MT>(dy_op(x_data[x_index],
-                                                   y_data[y_index],
-                                                   out_data[out_index],
-                                                   dout_data[out_index]));
+    if (dy != nullptr && !dy_from_dout) {
+      const T value = dy_op(x_data[x_index],
+                            y_data[y_index],
+                            out_data[out_index],
+                            dout_data[out_index]);
+      if (dy_data != nullptr) {
+        dy_data[out_index] = value;
+      } else {
+        dy_terms[out_index] = value;
+      }
     }
 
     UpdateElementwiseIndexArray<int64_t>(
         out_dims_array, max_dim, index_array.data());
   }
-  if (dx != nullptr) {
-    dev_ctx.Alloc<T>(dx);
-    CastKernel<MT, CPUContext>(
-        dev_ctx, dx_mp, CppTypeToDataType<T>::Type(), dx);
+  if (dx != nullptr && !dx_reduce_axes.empty()) {
+    dx_data = dev_ctx.template Alloc<T>(dx);
+    ReduceGradTermsCascade<T>(
+        dx_from_dout ? reinterpret_cast<const T *>(dout_data) : dx_terms.get(),
+        out_shape,
+        dx_reduce_axes,
+        dx_data,
+        dx->numel());
   }
-  if (dy != nullptr) {
-    dev_ctx.Alloc<T>(dy);
-    CastKernel<MT, CPUContext>(
-        dev_ctx, dy_mp, CppTypeToDataType<T>::Type(), dy);
+  if (dy != nullptr && !dy_reduce_axes.empty()) {
+    dy_data = dev_ctx.template Alloc<T>(dy);
+    ReduceGradTermsCascade<T>(
+        dy_from_dout ? reinterpret_cast<const T *>(dout_data) : dy_terms.get(),
+        out_shape,
+        dy_reduce_axes,
+        dy_data,
+        dy->numel());
   }
 }
 
@@ -140,43 +248,87 @@ static void ElemwiseGradBroadcast1CPU(const T *x,
                                       DY_OP dy_op,
                                       T *dx,
                                       T *dy) {
-  using MT = typename MPTypeTrait<T>::Type;
-
   if (is_xsize_larger) {
-    for (size_t j = 0; j < w; ++j) {
-      MT sum_y = static_cast<MT>(0);
-      for (size_t i = 0; i < h; ++i) {
-        size_t x_offset = i * w + j;
+    // x is [h, w] and y is [w]: dx needs no reduction; dy is reduced over the
+    // h rows when y was expanded (h > 1), with torch-compatible cascade
+    // summation over the materialized terms.
+    const bool dy_reduce = (h > 1);
+    // When the dy term equals dout bit-for-bit, reduce dout directly instead
+    // of materializing the terms, mirroring torch's sum_to_size on the raw
+    // gradient. Requires T == Tout so the terms really are dout.
+    const bool dy_from_dout = dy_reduce && std::is_same<T, Tout>::value &&
+                              GradTermEqualsDout<DY_OP>::value;
+    // Note: a plain std::vector<T> cannot be used here because T can be bool.
+    std::unique_ptr<T[]> dy_terms;
+    if (dy != nullptr && dy_reduce && !dy_from_dout) {
+      dy_terms = std::make_unique<T[]>(h * w);
+    }
+    const bool loop_has_work =
+        (dx != nullptr) || (dy != nullptr && !dy_from_dout);
+    for (size_t i = 0; loop_has_work && i < h; ++i) {
+      for (size_t j = 0; j < w; ++j) {
+        const size_t x_offset = i * w + j;
         if (dx != nullptr) {
           dx[x_offset] =
               dx_op(x[x_offset], y[j], out[x_offset], dout[x_offset]);
         }
-        if (dy != nullptr) {
-          sum_y += static_cast<MT>(
-              dy_op(x[x_offset], y[j], out[x_offset], dout[x_offset]));
+        if (dy != nullptr && !dy_from_dout) {
+          const T value =
+              dy_op(x[x_offset], y[j], out[x_offset], dout[x_offset]);
+          if (dy_reduce) {
+            dy_terms[x_offset] = value;
+          } else {
+            dy[x_offset] = value;
+          }
         }
       }
-      if (dy != nullptr) {
-        dy[j] = static_cast<T>(sum_y);
-      }
+    }
+    if (dy != nullptr && dy_reduce) {
+      ReduceGradTermsCascade<T>(
+          dy_from_dout ? reinterpret_cast<const T *>(dout) : dy_terms.get(),
+          {static_cast<int64_t>(h), static_cast<int64_t>(w)},
+          {0},
+          dy,
+          static_cast<int64_t>(w));
     }
   } else {
-    for (size_t j = 0; j < w; ++j) {
-      MT sum_x = static_cast<MT>(0);
-      for (size_t i = 0; i < h; ++i) {
-        size_t y_offset = i * w + j;
+    // y is [h, w] and x is [w]: dy needs no reduction; dx is reduced over the
+    // h rows when x was expanded (h > 1).
+    const bool dx_reduce = (h > 1);
+    const bool dx_from_dout = dx_reduce && std::is_same<T, Tout>::value &&
+                              GradTermEqualsDout<DX_OP>::value;
+    // Note: a plain std::vector<T> cannot be used here because T can be bool.
+    std::unique_ptr<T[]> dx_terms;
+    if (dx != nullptr && dx_reduce && !dx_from_dout) {
+      dx_terms = std::make_unique<T[]>(h * w);
+    }
+    const bool loop_has_work =
+        (dy != nullptr) || (dx != nullptr && !dx_from_dout);
+    for (size_t i = 0; loop_has_work && i < h; ++i) {
+      for (size_t j = 0; j < w; ++j) {
+        const size_t y_offset = i * w + j;
         if (dy != nullptr) {
           dy[y_offset] =
               dy_op(x[j], y[y_offset], out[y_offset], dout[y_offset]);
         }
-        if (dx != nullptr) {
-          sum_x += static_cast<MT>(
-              dx_op(x[j], y[y_offset], out[y_offset], dout[y_offset]));
+        if (dx != nullptr && !dx_from_dout) {
+          const T value =
+              dx_op(x[j], y[y_offset], out[y_offset], dout[y_offset]);
+          if (dx_reduce) {
+            dx_terms[y_offset] = value;
+          } else {
+            dx[y_offset] = value;
+          }
         }
       }
-      if (dx != nullptr) {
-        dx[j] = static_cast<T>(sum_x);
-      }
+    }
+    if (dx != nullptr && dx_reduce) {
+      ReduceGradTermsCascade<T>(
+          dx_from_dout ? reinterpret_cast<const T *>(dout) : dx_terms.get(),
+          {static_cast<int64_t>(h), static_cast<int64_t>(w)},
+          {0},
+          dx,
+          static_cast<int64_t>(w));
     }
   }
 }
@@ -194,47 +346,106 @@ static void ElemwiseGradBroadcast2CPU(const T *x,
                                       DY_OP dy_op,
                                       T *dx,
                                       T *dy) {
-  using MT = typename MPTypeTrait<T>::Type;
-
   if (is_xsize_larger) {
-    for (size_t j = 0; j < n; ++j) {
-      MT sum_y = static_cast<MT>(0);
-      for (size_t i = 0; i < pre; ++i) {
+    // x is [pre, n, post] and y is [n]: dx needs no reduction; dy is reduced
+    // over the pre and post groups (the dims y was expanded along), with
+    // torch-compatible cascade summation over the materialized terms.
+    const bool dy_reduce = (pre > 1 || post > 1);
+    const bool dy_from_dout = dy_reduce && std::is_same<T, Tout>::value &&
+                              GradTermEqualsDout<DY_OP>::value;
+    // Note: a plain std::vector<T> cannot be used here because T can be bool.
+    std::unique_ptr<T[]> dy_terms;
+    if (dy != nullptr && dy_reduce && !dy_from_dout) {
+      dy_terms = std::make_unique<T[]>(pre * n * post);
+    }
+    const bool loop_has_work =
+        (dx != nullptr) || (dy != nullptr && !dy_from_dout);
+    for (size_t i = 0; loop_has_work && i < pre; ++i) {
+      for (size_t j = 0; j < n; ++j) {
         for (size_t k = 0; k < post; ++k) {
-          size_t x_offset = i * n * post + j * post + k;
+          const size_t x_offset = i * n * post + j * post + k;
           if (dx != nullptr) {
             dx[x_offset] =
                 dx_op(x[x_offset], y[j], out[x_offset], dout[x_offset]);
           }
-          if (dy != nullptr) {
-            sum_y += static_cast<MT>(
-                dy_op(x[x_offset], y[j], out[x_offset], dout[x_offset]));
+          if (dy != nullptr && !dy_from_dout) {
+            const T value =
+                dy_op(x[x_offset], y[j], out[x_offset], dout[x_offset]);
+            if (dy_reduce) {
+              dy_terms[x_offset] = value;
+            } else {
+              dy[x_offset] = value;
+            }
           }
         }
       }
-      if (dy != nullptr) {
-        dy[j] = static_cast<T>(sum_y);
+    }
+    if (dy != nullptr && dy_reduce) {
+      std::vector<int64_t> reduce_axes;
+      if (pre > 1) {
+        reduce_axes.push_back(0);
       }
+      if (post > 1) {
+        reduce_axes.push_back(2);
+      }
+      ReduceGradTermsCascade<T>(
+          dy_from_dout ? reinterpret_cast<const T *>(dout) : dy_terms.get(),
+          {static_cast<int64_t>(pre),
+           static_cast<int64_t>(n),
+           static_cast<int64_t>(post)},
+          reduce_axes,
+          dy,
+          static_cast<int64_t>(n));
     }
   } else {
-    for (size_t j = 0; j < n; ++j) {
-      MT sum_x = static_cast<MT>(0);
-      for (size_t i = 0; i < pre; ++i) {
+    // y is [pre, n, post] and x is [n]: dy needs no reduction; dx is reduced
+    // over the pre and post groups (the dims x was expanded along).
+    const bool dx_reduce = (pre > 1 || post > 1);
+    const bool dx_from_dout = dx_reduce && std::is_same<T, Tout>::value &&
+                              GradTermEqualsDout<DX_OP>::value;
+    // Note: a plain std::vector<T> cannot be used here because T can be bool.
+    std::unique_ptr<T[]> dx_terms;
+    if (dx != nullptr && dx_reduce && !dx_from_dout) {
+      dx_terms = std::make_unique<T[]>(pre * n * post);
+    }
+    const bool loop_has_work =
+        (dy != nullptr) || (dx != nullptr && !dx_from_dout);
+    for (size_t i = 0; loop_has_work && i < pre; ++i) {
+      for (size_t j = 0; j < n; ++j) {
         for (size_t k = 0; k < post; ++k) {
-          size_t y_offset = i * n * post + j * post + k;
+          const size_t y_offset = i * n * post + j * post + k;
           if (dy != nullptr) {
             dy[y_offset] =
                 dy_op(x[j], y[y_offset], out[y_offset], dout[y_offset]);
           }
-          if (dx != nullptr) {
-            sum_x += static_cast<MT>(
-                dx_op(x[j], y[y_offset], out[y_offset], dout[y_offset]));
+          if (dx != nullptr && !dx_from_dout) {
+            const T value =
+                dx_op(x[j], y[y_offset], out[y_offset], dout[y_offset]);
+            if (dx_reduce) {
+              dx_terms[y_offset] = value;
+            } else {
+              dx[y_offset] = value;
+            }
           }
         }
       }
-      if (dx != nullptr) {
-        dx[j] = static_cast<T>(sum_x);
+    }
+    if (dx != nullptr && dx_reduce) {
+      std::vector<int64_t> reduce_axes;
+      if (pre > 1) {
+        reduce_axes.push_back(0);
       }
+      if (post > 1) {
+        reduce_axes.push_back(2);
+      }
+      ReduceGradTermsCascade<T>(
+          dx_from_dout ? reinterpret_cast<const T *>(dout) : dx_terms.get(),
+          {static_cast<int64_t>(pre),
+           static_cast<int64_t>(n),
+           static_cast<int64_t>(post)},
+          reduce_axes,
+          dx,
+          static_cast<int64_t>(n));
     }
   }
 }
@@ -271,6 +482,11 @@ void CommonElementwiseBroadcastBackward(const CPUContext &dev_ctx,
     dx->Resize(x_dims);
     dev_ctx.template Alloc<T>(dx);
   }
+  if (dy && dy->IsSharedBufferWith(dout)) {
+    dy->clear();
+    dy->Resize(y_dims);
+    dev_ctx.template Alloc<T>(dy);
+  }
 
   VLOG(3) << "CommonElementwiseBroadcastBackward xdims:"
           << make_ddim(x_dims_array) << " ydim:" << make_ddim(y_dims_array);
@@ -303,6 +519,25 @@ void ElemwiseGradComputeWithBroadcast(const CPUContext &dev_ctx,
                                       DenseTensor *dy,
                                       DX_OP dx_op,
                                       DY_OP dy_op) {
+  // Zero-sized broadcast output (e.g. x=[2,0] vs y=[2,1]): every gradient
+  // term is an empty sum, so both gradients are zero. The fast paths below
+  // would otherwise leave the reduced side unwritten.
+  if (out.numel() == 0) {
+    if (dx != nullptr) {
+      T *dx_data = dev_ctx.template Alloc<T>(dx);
+      if (dx->numel() != 0) {
+        std::memset(dx_data, 0, dx->numel() * sizeof(T));
+      }
+    }
+    if (dy != nullptr) {
+      T *dy_data = dev_ctx.template Alloc<T>(dy);
+      if (dy->numel() != 0) {
+        std::memset(dy_data, 0, dy->numel() * sizeof(T));
+      }
+    }
+    return;
+  }
+
   bool is_xsize_larger = true;
 
   int max_dim = x_dims.size();
@@ -354,6 +589,24 @@ void ElemwiseGradComputeWithBroadcast(const CPUContext &dev_ctx,
     CommonElementwiseBroadcastBackward<T, DX_OP, DY_OP, Tout>(
         dev_ctx, x_dims, y_dims, x, y, out, dout, axis, dx, dy, dx_op, dy_op);
     return;
+  }
+  // for inplace strategy. The eager backward may hand a grad output in as a
+  // view of dout; a reduced output is written while dout is still being read
+  // (the memset of the reduction target alone would corrupt it), so detach
+  // the reduced side first. A non-reduced output writes each element after
+  // reading it and stays safe.
+  const bool reduce_x = post == 1 ? pre > 1 : (pre > 1 || post > 1);
+  if (dx != nullptr && !is_xsize_larger && reduce_x &&
+      dx->IsSharedBufferWith(dout)) {
+    dx->clear();
+    dx->Resize(x_dims);
+    dev_ctx.template Alloc<T>(dx);
+  }
+  if (dy != nullptr && is_xsize_larger && reduce_x &&
+      dy->IsSharedBufferWith(dout)) {
+    dy->clear();
+    dy->Resize(y_dims);
+    dev_ctx.template Alloc<T>(dy);
   }
   if (post == 1) {
     ElemwiseGradBroadcast1CPU(x.data<T>(),

--- a/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
@@ -202,7 +202,7 @@ struct DivGradDX<dtype::complex<T>> {
 template <typename T>
 struct DivGradDY {
   HOSTDEVICE T operator()(T x UNUSED, T y, T out, T dout) const {
-    return -dout * out / y;
+    return -dout * (out / y);
   }
 };
 
@@ -1553,6 +1553,7 @@ void ElementwisePowGradKernel(const Context& dev_ctx,
 // RemainderGradDx
 template <typename T>
 struct RemainderGradDx {
+  static constexpr bool kGradTermIsDout = true;
   HOSTDEVICE T operator()(T x, T y, T out UNUSED, T dout) const {
     // dx = dout
     return dout;

--- a/test/legacy_test/test_elementwise_add_op.py
+++ b/test/legacy_test/test_elementwise_add_op.py
@@ -1303,6 +1303,120 @@ class TestElementwiseAddOp_Stride_ZeroSize1(TestElementwiseAddOp_Stride):
         self.y_trans = np.transpose(self.y, self.perm)
 
 
+class TestElementwiseAddBroadcastGradientsExact(unittest.TestCase):
+    def _run_case(self, x_np, y_np, dout_np, dx_axes, dy_axes, dy_only=False):
+        def expected(axes, shape):
+            if axes is None:
+                return dout_np
+            return paddle.sum(dout, axes).reshape(shape).numpy()
+
+        x = paddle.to_tensor(x_np)
+        y = paddle.to_tensor(y_np)
+        dout = paddle.to_tensor(dout_np)
+        x.stop_gradient = False
+        y.stop_gradient = False
+        out = x + y
+        if dy_only:
+            dy = paddle.grad(out, [y], dout)[0]
+            np.testing.assert_array_equal(
+                dy.numpy(), expected(dy_axes, y_np.shape)
+            )
+            return
+        dx, dy = paddle.grad(out, [x, y], dout)
+        np.testing.assert_array_equal(dx.numpy(), expected(dx_axes, x_np.shape))
+        np.testing.assert_array_equal(dy.numpy(), expected(dy_axes, y_np.shape))
+
+    def test_cpu_broadcast_gradients_exact(self):
+        with base.dygraph.guard(base.CPUPlace()):
+            for dtype in ['float32', 'float64']:
+                # Broadcast1: x is [37, 5] and y is [5]; dy is reduced over 37
+                # rows, long enough that a serial row-major accumulation
+                # differs bitwise from the cascade order.
+                x_np = (np.arange(37 * 5) / 7.0 - 3.0).astype(dtype)
+                x_np = x_np.reshape(37, 5)
+                y_np = (np.arange(5) / 11.0 - 1.0).astype(dtype)
+                dout_np = (np.arange(37 * 5) / 13.0 - 2.0).astype(dtype)
+                dout_np = dout_np.reshape(37, 5)
+                self._run_case(x_np, y_np, dout_np, None, 0)
+                self._run_case(x_np, y_np, dout_np, None, 0, dy_only=True)
+
+                # Broadcast1 with x reduced: x is [5] and y is [37, 5]; dx is
+                # reduced over 37 rows. The eager backward may hand dx in as a
+                # view of dout (inplace reuse of the gradient), so a reduced
+                # output sharing the dout buffer must be detached before the
+                # cascade reduction memsets it.
+                x_np = (np.arange(5) / 11.0 - 1.0).astype(dtype)
+                y_np = (np.arange(37 * 5) / 7.0 - 3.0).astype(dtype)
+                y_np = y_np.reshape(37, 5)
+                dout_np = (np.arange(37 * 5) / 13.0 - 2.0).astype(dtype)
+                dout_np = dout_np.reshape(37, 5)
+                self._run_case(x_np, y_np, dout_np, 0, None)
+
+                # Broadcast2 with x reduced: x is [3, 4, 1] and y is
+                # [2, 3, 4, 5]; dx is reduced over the pre and post groups
+                # (axes 0 and 3).
+                x_np = (np.arange(3 * 4) / 11.0 - 1.0).astype(dtype)
+                x_np = x_np.reshape(3, 4, 1)
+                y_np = (np.arange(2 * 3 * 4 * 5) / 9.0 - 2.0).astype(dtype)
+                y_np = y_np.reshape(2, 3, 4, 5)
+                dout_np = (np.arange(2 * 3 * 4 * 5) / 13.0 - 2.0).astype(dtype)
+                dout_np = dout_np.reshape(2, 3, 4, 5)
+                self._run_case(x_np, y_np, dout_np, [0, 3], None)
+
+                # Broadcast2 with a multi-dimension middle group: x is
+                # [2, 3, 4, 5] and y is [3, 4, 1] (the trailing 1 is trimmed
+                # so the middle group matches); dy is reduced over the pre
+                # and post groups (axes 0 and 3).
+                x_np = (np.arange(2 * 3 * 4 * 5) / 9.0 - 2.0).astype(dtype)
+                x_np = x_np.reshape(2, 3, 4, 5)
+                y_np = (np.arange(3 * 4) / 11.0 - 1.0).astype(dtype)
+                y_np = y_np.reshape(3, 4, 1)
+                dout_np = (np.arange(2 * 3 * 4 * 5) / 13.0 - 2.0).astype(dtype)
+                dout_np = dout_np.reshape(2, 3, 4, 5)
+                self._run_case(x_np, y_np, dout_np, None, [0, 3])
+
+                # Common broadcast path where both operands are expanded
+                # along different dimensions: x is [37, 1, 5] and y is
+                # [1, 9, 5]; dx is reduced over axis 1 and dy over axis 0.
+                x_np = (np.arange(37 * 5) / 7.0 - 3.0).astype(dtype)
+                x_np = x_np.reshape(37, 1, 5)
+                y_np = (np.arange(9 * 5) / 11.0 - 1.0).astype(dtype)
+                y_np = y_np.reshape(1, 9, 5)
+                dout_np = (np.arange(37 * 9 * 5) / 13.0 - 2.0).astype(dtype)
+                dout_np = dout_np.reshape(37, 9, 5)
+                self._run_case(x_np, y_np, dout_np, 1, 0)
+
+    def test_zero_size_broadcast_gradients_are_zero(self):
+        with base.dygraph.guard(base.CPUPlace()):
+            for dtype in ['float32', 'float64']:
+                # Fast path with a zero post dimension.
+                x = paddle.zeros([2, 0], dtype=dtype)
+                y = paddle.ones([2, 1], dtype=dtype)
+                x.stop_gradient = False
+                y.stop_gradient = False
+                (x + y).sum().backward()
+                np.testing.assert_array_equal(x.grad.numpy(), np.zeros([2, 0]))
+                np.testing.assert_array_equal(y.grad.numpy(), np.zeros([2, 1]))
+
+                # Fast path with a zero pre dimension.
+                x = paddle.zeros([0, 5], dtype=dtype)
+                y = paddle.ones([5], dtype=dtype)
+                x.stop_gradient = False
+                y.stop_gradient = False
+                (x + y).sum().backward()
+                np.testing.assert_array_equal(x.grad.numpy(), np.zeros([0, 5]))
+                np.testing.assert_array_equal(y.grad.numpy(), np.zeros([5]))
+
+                # Common broadcast path with a zero output.
+                x = paddle.zeros([0, 3], dtype=dtype)
+                y = paddle.ones([1, 3], dtype=dtype)
+                x.stop_gradient = False
+                y.stop_gradient = False
+                (x + y).sum().backward()
+                np.testing.assert_array_equal(x.grad.numpy(), np.zeros([0, 3]))
+                np.testing.assert_array_equal(y.grad.numpy(), np.zeros([1, 3]))
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()

--- a/test/legacy_test/test_elementwise_div_op.py
+++ b/test/legacy_test/test_elementwise_div_op.py
@@ -543,6 +543,179 @@ create_test_fp16_class(TestElementwiseDivOpXsizeLessThanYsize)
 
 
 class TestElementwiseDivBroadcast(unittest.TestCase):
+    def test_cpu_no_broadcast_gradients_exact(self):
+        with base.dygraph.guard(base.CPUPlace()):
+            x_np = np.array([[1.25, -2.5, 3.75], [4.5, -5.75, 6.25]])
+            y_np = np.array([[0.75, -1.5, 2.25], [1.25, 2.5, -3.5]])
+            dout_np = np.array([[0.5, -1.25, 2.0], [-2.5, 3.0, -0.75]])
+
+            x = paddle.to_tensor(x_np, dtype='float32')
+            y = paddle.to_tensor(y_np, dtype='float32')
+            dout = paddle.to_tensor(dout_np, dtype='float32')
+            x.stop_gradient = False
+            y.stop_gradient = False
+            out = x / y
+            dx, dy = paddle.grad(out, [x, y], dout)
+            np.testing.assert_array_equal(dx.numpy(), (dout / y).numpy())
+            np.testing.assert_array_equal(
+                dy.numpy(), (-dout * (out / y)).numpy()
+            )
+
+            out = x / y
+            dx_only = paddle.grad(out, [x], dout)[0]
+            np.testing.assert_array_equal(dx_only.numpy(), (dout / y).numpy())
+
+            out = x / y
+            dy_only = paddle.grad(out, [y], dout)[0]
+            np.testing.assert_array_equal(
+                dy_only.numpy(), (-dout * (out / y)).numpy()
+            )
+
+    def test_cpu_broadcast_gradient_paths_exact(self):
+        with base.dygraph.guard(base.CPUPlace()):
+            # dx is written directly while dy is reduced over axis 0.
+            x = paddle.to_tensor(
+                np.array([[1.25, -2.5, 3.75], [4.5, -5.75, 6.25]]),
+                dtype='float32',
+            )
+            y = paddle.to_tensor(np.array([0.75, -1.5, 2.25]), dtype='float32')
+            dout = paddle.to_tensor(
+                np.array([[0.5, -1.25, 2.0], [-2.5, 3.0, -0.75]]),
+                dtype='float32',
+            )
+            x.stop_gradient = False
+            y.stop_gradient = False
+            out = x / y
+            dx, dy = paddle.grad(out, [x, y], dout)
+            np.testing.assert_array_equal(dx.numpy(), (dout / y).numpy())
+            expected_dy = paddle.sum(-dout * (out / y), axis=0)
+            np.testing.assert_array_equal(dy.numpy(), expected_dy.numpy())
+
+            out = x / y
+            dy_only = paddle.grad(out, [y], dout)[0]
+            np.testing.assert_array_equal(dy_only.numpy(), expected_dy.numpy())
+
+            # dx is reduced over axes 0 and 1 while dy is written directly.
+            x = paddle.to_tensor(np.array([1.25, -2.5, 3.75]), dtype='float32')
+            y = paddle.to_tensor(
+                np.array(
+                    [
+                        [[0.75, -1.5, 2.25]],
+                        [[1.25, 2.5, -3.5]],
+                    ]
+                ),
+                dtype='float32',
+            )
+            dout = paddle.to_tensor(
+                np.array(
+                    [
+                        [[0.5, -1.25, 2.0]],
+                        [[-2.5, 3.0, -0.75]],
+                    ]
+                ),
+                dtype='float32',
+            )
+            x.stop_gradient = False
+            y.stop_gradient = False
+            out = x / y
+            dx, dy = paddle.grad(out, [x, y], dout)
+            expected_dx = paddle.sum(dout / y, axis=[0, 1])
+            np.testing.assert_array_equal(dx.numpy(), expected_dx.numpy())
+            np.testing.assert_array_equal(
+                dy.numpy(), (-dout * (out / y)).numpy()
+            )
+
+            # Both operands reduce over different axes; this exercises the
+            # multi-axis cascade sum path and broadcast index mapping.
+            x_np = np.array(
+                [
+                    [[1.25, -2.5, 3.75, -4.25]],
+                    [[4.5, -5.75, 6.25, -7.5]],
+                ],
+                dtype='float32',
+            )
+            y_np = np.array([[[0.75], [-1.5], [2.25]]], dtype='float32')
+            dout_np = np.array(
+                [
+                    [
+                        [0.5, -1.25, 2.0, -2.75],
+                        [1.0, 0.75, -1.5, 2.25],
+                        [-0.5, 2.5, 1.25, -1.75],
+                    ],
+                    [
+                        [-2.5, 3.0, -0.75, 1.5],
+                        [1.75, -2.25, 0.5, 3.25],
+                        [2.0, -1.0, -2.75, 0.25],
+                    ],
+                ],
+                dtype='float32',
+            )
+            x = paddle.to_tensor(x_np)
+            y = paddle.to_tensor(y_np)
+            dout = paddle.to_tensor(dout_np)
+            x.stop_gradient = False
+            y.stop_gradient = False
+            out = x / y
+            dx, dy = paddle.grad(out, [x, y], dout)
+            local_dx = dout / y
+            local_dy = -dout * (out / y)
+            expected_dx = paddle.sum(local_dx, axis=1, keepdim=True)
+            expected_dy = paddle.sum(local_dy, axis=[0, 2], keepdim=True)
+            np.testing.assert_array_equal(dx.numpy(), expected_dx.numpy())
+            np.testing.assert_array_equal(dy.numpy(), expected_dy.numpy())
+
+    def test_cpu_broadcast_gradients_exact(self):
+        with base.dygraph.guard(base.CPUPlace()):
+            for dtype in ['float32', 'float64']:
+                x_np = np.array(
+                    [[[1.25, -2.5, 3.75]], [[4.5, -5.75, 6.25]]],
+                    dtype=dtype,
+                )
+                y_np = np.array([[0.75, -1.5, 2.25]], dtype=dtype)
+                dout_np = np.array(
+                    [
+                        [[0.5, -1.25, 2.0]],
+                        [[-2.5, 3.0, -0.75]],
+                    ],
+                    dtype=dtype,
+                )
+                x = paddle.to_tensor(x_np)
+                y = paddle.to_tensor(y_np)
+                dout = paddle.to_tensor(dout_np)
+                x.stop_gradient = False
+                y.stop_gradient = False
+                out = x / y
+                dx, dy = paddle.grad(out, [x, y], dout)
+                expected_dx = dout_np / y_np
+                expected_dy = np.sum(
+                    -dout_np * (out.numpy() / y_np), axis=0
+                ).reshape(y_np.shape)
+                np.testing.assert_array_equal(dx.numpy(), expected_dx)
+                np.testing.assert_array_equal(dy.numpy(), expected_dy)
+
+                out_only = x / y
+                dx_only = paddle.grad(out_only, [x], dout)[0]
+                np.testing.assert_array_equal(dx_only.numpy(), expected_dx)
+
+    def test_zero_size_broadcast_gradients_are_zero(self):
+        with base.dygraph.guard(base.CPUPlace()):
+            for dtype in ['float32', 'float64']:
+                x = paddle.zeros([0, 3], dtype=dtype)
+                y = paddle.ones([1, 3], dtype=dtype)
+                x.stop_gradient = False
+                y.stop_gradient = False
+                (x / y).sum().backward()
+                np.testing.assert_array_equal(x.grad.numpy(), np.zeros([0, 3]))
+                np.testing.assert_array_equal(y.grad.numpy(), np.zeros([1, 3]))
+
+                x = paddle.ones([1, 3], dtype=dtype)
+                y = paddle.zeros([0, 3], dtype=dtype)
+                x.stop_gradient = False
+                y.stop_gradient = False
+                (x / y).sum().backward()
+                np.testing.assert_array_equal(x.grad.numpy(), np.zeros([1, 3]))
+                np.testing.assert_array_equal(y.grad.numpy(), np.zeros([0, 3]))
+
     def test_shape_with_batch_sizes(self):
         main_program = paddle.static.Program()
         with paddle.static.program_guard(main_program):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description

本 PR 对齐 Paddle CPU elementwise 广播反向（add / sub / div / remainder）在 `float32` / `float64` 下与 PyTorch 的逐位计算行为。此前广播侧梯度按串行顺序累加，且 div 的 `dy` 公式分组与 PyTorch 不同，导致梯度与 PyTorch CPU 存在数个 ulp 的偏差。主要包含四类修改：

1. 广播梯度归约顺序对齐（cascade sum）；
2. 除法反向公式分组对齐；
3. 恒等梯度项跳过物化（性能）与 inplace view 别名修复；
4. 空 Tensor 广播反向修复。

所有算子统一走通用 elementwise grad 路径，不引入按算子的专用实现。

#### 1. 广播梯度归约顺序对齐

##### 问题

广播输入的梯度通过通用路径串行累加，累加顺序与 PyTorch 的 cascade summation 不同。浮点加法不满足结合律，顺序不同则舍入结果不同，广播反向梯度与 PyTorch CPU 不逐位一致：

```text
串行：((a0 + a1) + a2) + a3 ...
torch：先按固定宽度分块向量内累加，再逐级归并（cascade）
```

##### 改动

`CommonGradBroadcastCPU`、`ElemwiseGradBroadcast1CPU`、`ElemwiseGradBroadcast2CPU` 对需要归约的一侧：

- 按输出 row-major 顺序物化逐元素梯度项（`dx_op(x[i], y[i], out[i], dout[i])`）；
- 使用已有的 `TorchCompatibleReduceSum`（cascade sum，与 torch `Loop2d` 派发的向量内/向量外归约同序）对物化项归约；
- 不需要归约的一侧直接写入目标梯度，不物化完整输出临时 buffer。

#### 2. 除法反向公式分组对齐

##### 问题

原 `DivGradDY` 使用 `-dout * out / y`，求值顺序为 `(-dout * out) / y`；PyTorch CPU 的 div 反向（`FunctionsManual.cpp` 中 `-grad * ((self/other)/other)`）先计算 `out / y` 再乘 `-dout`。浮点乘除不满足结合律，`float32` 下两种分组可能产生最后几位的差异。

##### 改动

- `DivGradDY` 重排为 `-dout * (out / y)`，与 PyTorch 分组一致；
- `dx` 保持 `dout / y`，与 PyTorch 的 `grad / other` 一致；
- 删除早期实现中的 `TorchCompatibleDivideGradCPU` 专用路径，由上述通用方案取代，所有 elementwise 算子共享。

#### 3. 恒等梯度项跳过物化与 inplace view 别名修复

##### 问题

逐项物化保证了归约顺序，但引入了性能回归：`[1048576] x [1]` 的 add 广播反向需要物化 4MB 中间项，耗时从约 1.03ms 升至 3.0ms。PyTorch 对梯度项与原始梯度相同的算子（add/sub 的恒等项）直接对原始梯度做 `sum_to_size`，不物化中间项。

此外，eager 反向在 `grad_out` 引用计数为 1 时，会把第一个梯度输出（`dx`）作为 `grad_out` 的 view 传入 kernel（inplace 内存复用）。若直接对 `dout` 归约，cascade 入口的 `memset` 会先清零 `dout` 的前缀，再读到的已是被破坏的数据，结果恰好"丢失首行"。

##### 改动

- 恒等 functor（add 的 `IdentityGrad`、`SubGradDX`、`RemainderGradDx`）声明 `kGradTermIsDout = true` 标签，`elementwise_grad_base.h` 通过 SFINAE trait `GradTermEqualsDout<F>` 泛型检测；
- 当梯度项与 `dout` 逐位相同（恒等 functor 且 `T == Tout`）时，跳过物化，直接对 `dout` 做 cascade 归约，并跳过无剩余工作的逐元素循环，对齐 PyTorch `sum_to_size` 的做法；
- 未标注的 functor（div、mul、pow、`SubGradDY` 等）自动走原物化路径，行为不变；
- 在 `ElemwiseGradComputeWithBroadcast` 中，归约侧输出与 `dout` 共享 buffer 时先 detach（重新分配），再进入归约；`CommonElementwiseBroadcastBackward` 补充对称的 `dy` detach guard（原有 `dx` guard 保持不变）。

`[1048576] x [1]` add 反向耗时从物化方案的 3.0ms 回落至 0.57ms（stock 串行实现 1.03ms）。

#### 4. 空 Tensor 广播反向修复

##### 问题

当广播结果 `out.numel() == 0` 时（如 `[0, 3]` 与 `[1, 3]`），原路径不会进入实际计算循环，非空一侧的输入梯度可能保持未初始化内存，而不是返回零梯度。

##### 改动

在 `ElemwiseGradComputeWithBroadcast` 入口显式处理空输出：无条件 `Alloc` 所需梯度（numel 为 0 也要分配空 holder，否则 autograd 判定该输入无梯度返回 `None`），并将非空梯度 buffer 清零。

#### 修改后的行为

| 类别 | 之前 | 之后 |
| --- | --- | --- |
| 广播反向梯度 vs PyTorch | 串行累加顺序不同，数个 ulp 偏差 | 单轴/多轴/标量/`[1M]x[1]` 逐位一致 |
| div `dy` 公式分组 | `(-dout * out) / y` | `-dout * (out / y)`，与 PyTorch 一致 |
| `[1048576]x[1]` add 反向耗时 | 物化方案 3.0ms | 0.57ms（stock 串行 1.03ms） |
| inplace view 输入 + 归约侧 | 直接归约 `dout` 会被 memset 破坏（丢首行） | 归约前 detach，结果正确 |
| 空 Tensor 广播反向 | 非空侧梯度可能未初始化 | 梯度为零，空 holder 正常分配 |
| div double-grad vs PyTorch | 最大 6 ulp、80% 元素不一致 | `g2x` 逐位一致，`g2y` <= 1 ulp（附带改善） |

合法输入的前向计算不变；梯度数值变化均为向 PyTorch 结果的对齐。
### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是
