### PR TITLE
[Environment Adaptation] Remove /bin/sh dependency from the paddle im…

### DIFF
--- a/python/paddle/base/core.py
+++ b/python/paddle/base/core.py
@@ -64,6 +64,30 @@ except Exception as e:
     raise e
 
 
+def _run_command(args, merge_stderr=False):
+    """
+    Run a command without spawning a shell.
+
+    Return the stripped stdout, or None if the command can not be run or
+    writes to stderr. Staying shell-free keeps ``import paddle`` working on
+    hardened images that ship no /bin/sh.
+    """
+    import subprocess
+
+    try:
+        proc = subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT if merge_stderr else subprocess.PIPE,
+        )
+        out, err = proc.communicate()
+    except OSError:
+        return None
+    if not merge_stderr and err:
+        return None
+    return out.decode('utf-8', errors='replace').strip()
+
+
 def avx_supported():
     """
     Whether current system(Linux, MacOS, Windows) is supported with AVX.
@@ -72,9 +96,8 @@ def avx_supported():
     has_avx = False
     if sysstr == 'linux':
         try:
-            pipe = os.popen('cat /proc/cpuinfo | grep -i avx')
-            has_avx = pipe.read() != ''
-            pipe.close()
+            with open('/proc/cpuinfo') as cpuinfo:
+                has_avx = 'avx' in cpuinfo.read().lower()
         except Exception as e:
             sys.stderr.write(
                 'Can not get the AVX flag from /proc/cpuinfo.\n'
@@ -82,26 +105,20 @@ def avx_supported():
             )
         return has_avx
     elif sysstr == 'darwin':
-        try:
-            pipe = os.popen('sysctl machdep.cpu.features | grep -i avx')
-            has_avx = pipe.read() != ''
-            pipe.close()
-        except Exception as e:
+        features = _run_command(['sysctl', 'machdep.cpu.features'])
+        if features is None:
             sys.stderr.write(
                 'Can not get the AVX flag from machdep.cpu.features.\n'
-                f'The original error is: {e}\n'
             )
+        else:
+            has_avx = 'avx' in features.lower()
         if not has_avx:
-            import subprocess
-
-            pipe = subprocess.Popen(
-                'sysctl machdep.cpu.leaf7_features | grep -i avx',
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+            leaf7_features = _run_command(
+                ['sysctl', 'machdep.cpu.leaf7_features']
             )
-            _ = pipe.communicate()
-            has_avx = True if pipe.returncode == 0 else False
+            has_avx = (
+                leaf7_features is not None and 'avx' in leaf7_features.lower()
+            )
         return has_avx
     elif sysstr == 'windows':
         import ctypes
@@ -181,25 +198,19 @@ def avx_supported():
         return False
 
 
-def run_shell_command(cmd):
-    import subprocess
-
-    out, err = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
-    ).communicate()
-    if err:
-        return None
-    else:
-        return out.decode('utf-8').strip()
-
-
 def get_dso_path(core_so, dso_name):
-    if core_so and dso_name:
-        return run_shell_command(
-            f"ldd {core_so}|grep {dso_name}|awk '{{print $3}}'"
-        )
-    else:
+    if not core_so or not dso_name:
         return None
+    ldd_out = _run_command(['ldd', core_so])
+    if not ldd_out:
+        return None
+    for line in ldd_out.splitlines():
+        if dso_name in line:
+            # "libgomp.so.1 => /path/to/libgomp.so.1 (0x00007f...)"
+            fields = line.split()
+            if len(fields) >= 3:
+                return fields[2]
+    return None
 
 
 def load_dso(dso_absolute_path):
@@ -222,13 +233,25 @@ def pre_load(dso_name):
 
 
 def get_libc_ver():
-    ldd_glibc = run_shell_command("ldd --version | awk '/ldd/{print $NF}'")
-    if ldd_glibc is not None:
-        return ("glibc", ldd_glibc)
+    # NOTE: CS_GNU_LIBC_VERSION is answered by libc itself, so it needs
+    # neither a shell nor the ldd script, which is a shell script on glibc.
+    if hasattr(os, 'confstr') and 'CS_GNU_LIBC_VERSION' in os.confstr_names:
+        try:
+            libc_ver = os.confstr('CS_GNU_LIBC_VERSION')
+        except (OSError, ValueError):
+            libc_ver = None
+        if libc_ver:
+            fields = libc_ver.split()
+            if len(fields) == 2:
+                return ("glibc", fields[1])
 
-    ldd_musl = run_shell_command("ldd 2>&1 | awk '/Version/{print $NF}'")
-    if ldd_musl is not None:
-        return ("musl", ldd_musl)
+    # musl does not implement confstr(CS_GNU_LIBC_VERSION), so fall back to
+    # its ldd banner, which is printed on stderr.
+    ldd_musl = _run_command(['ldd'], merge_stderr=True)
+    if ldd_musl:
+        for line in ldd_musl.splitlines():
+            if 'Version' in line:
+                return ("musl", line.split()[-1])
     return (None, None)
 
 

--- a/test/legacy_test/test_core_env_probe.py
+++ b/test/legacy_test/test_core_env_probe.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+from unittest import mock
+
+from paddle.base import core
+
+
+class TestRunCommand(unittest.TestCase):
+    def test_missing_binary_returns_none(self):
+        self.assertIsNone(core._run_command(['paddle-no-such-binary-xyz']))
+
+    def test_never_spawns_a_shell(self):
+        # This is the point of _run_command: hardened images may ship no
+        # /bin/sh, so the command has to be executed directly.
+        with mock.patch('subprocess.Popen') as popen:
+            popen.return_value.communicate.return_value = (b'out', b'')
+            core._run_command(['echo', 'hello'])
+        args, kwargs = popen.call_args
+        self.assertEqual(args[0], ['echo', 'hello'])
+        self.assertFalse(kwargs.get('shell', False))
+
+    def test_output_on_stderr_returns_none(self):
+        with mock.patch('subprocess.Popen') as popen:
+            popen.return_value.communicate.return_value = (b'out', b'boom')
+            self.assertIsNone(core._run_command(['whatever']))
+
+    def test_merge_stderr_keeps_output(self):
+        with mock.patch('subprocess.Popen') as popen:
+            popen.return_value.communicate.return_value = (b' out \n', None)
+            self.assertEqual(
+                core._run_command(['whatever'], merge_stderr=True), 'out'
+            )
+
+
+class TestAvxSupported(unittest.TestCase):
+    def test_returns_bool(self):
+        self.assertIsInstance(core.avx_supported(), bool)
+
+
+class TestGetDsoPath(unittest.TestCase):
+    def test_missing_argument_returns_none(self):
+        self.assertIsNone(core.get_dso_path(None, 'libgomp'))
+        self.assertIsNone(core.get_dso_path('/path/libpaddle.so', None))
+
+    def test_unavailable_ldd_returns_none(self):
+        with mock.patch.object(core, '_run_command', return_value=None):
+            self.assertIsNone(core.get_dso_path('/no/such.so', 'libgomp'))
+
+    def test_parses_ldd_output(self):
+        ldd_out = (
+            '\tlinux-vdso.so.1 (0x00007ffd)\n'
+            '\tlibgomp.so.1 => /lib/x86_64-linux-gnu/libgomp.so.1 (0x7f00)\n'
+            '\tlibc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x7f01)'
+        )
+        with mock.patch.object(core, '_run_command', return_value=ldd_out):
+            self.assertEqual(
+                core.get_dso_path('/path/libpaddle.so', 'libgomp'),
+                '/lib/x86_64-linux-gnu/libgomp.so.1',
+            )
+
+    def test_unmatched_dso_returns_none(self):
+        with mock.patch.object(
+            core, '_run_command', return_value='\tstatically linked'
+        ):
+            self.assertIsNone(
+                core.get_dso_path('/path/libpaddle.so', 'libgomp')
+            )
+
+
+@unittest.skipUnless(
+    sys.platform.startswith('linux'), 'get_libc_ver is only used on Linux'
+)
+class TestGetLibcVer(unittest.TestCase):
+    def test_result_is_usable_by_the_import_path(self):
+        libc_type, libc_ver = core.get_libc_ver()
+        self.assertIn(libc_type, (None, 'glibc', 'musl'))
+        if libc_type is None:
+            self.assertIsNone(libc_ver)
+        else:
+            self.assertTrue(libc_ver)
+            # core.py compares the version at import time, it must not raise.
+            self.assertIsInstance(core.less_than_ver(libc_ver, '2.23'), bool)
+
+    def test_musl_banner_is_parsed(self):
+        banner = 'musl libc (x86_64)\nVersion 1.2.4\nDynamic Program Loader\n'
+        with (
+            mock.patch.object(core.os, 'confstr', return_value=None),
+            mock.patch.object(core, '_run_command', return_value=banner),
+        ):
+            self.assertEqual(core.get_libc_ver(), ('musl', '1.2.4'))
+
+    def test_no_libc_information_returns_none(self):
+        with (
+            mock.patch.object(core.os, 'confstr', return_value=None),
+            mock.patch.object(core, '_run_command', return_value=None),
+        ):
+            self.assertEqual(core.get_libc_ver(), (None, None))
+            # This used to return ("musl", "") and blow up less_than_ver.
+            self.assertFalse(core.less_than_ver(None, '2.23'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### PR Category

Environment Adaptation

### PR Types

Bug fixes

### Description

**Motivation.** Security-hardened base images commonly ship without a usable
`/bin/sh`. Paddle cannot be imported at all on such an image, which currently
forces users to patch `paddle/base/core.py` inside the image by hand.

**Problem.** `python/paddle/base/core.py` runs at `import paddle` time and, on
Linux, unconditionally shells out:

core.py:257  libc_type, libc_ver = get_libc_ver()
core.py:225  run_shell_command("ldd --version | awk '/ldd/{print $NF}'")
core.py:187  subprocess.Popen(cmd, ..., shell=True)   # no error handling

With no usable `/bin/sh` this raises before `libpaddle` is loaded:

File "paddle/base/core.py", line 187, in run_shell_command
    out, err = subprocess.Popen(
PermissionError: [Errno 13] Permission denied: '/bin/sh'

`avx_supported()` and `get_dso_path()` have the same dependency. They are
wrapped in `except`, so they do not break the import, but they degrade
silently: on a shell-less machine `avx_supported()` returned `False` an
printed the misleading "your machine doesn't support AVX" hint even on
AVX-capable CPU.

**Changes** (confined to the import path, `python/paddle/base/core.py`)

- Replace `run_shell_command()` with `_run_command()`, which executes a command
  from an argument list, never through a shell, and returns `None` when the
  binary cannot be executed.
- `get_libc_ver()` now asks libc directly through
  `os.confstr('CS_GNU_LIBC_VERSION')`. This matters because on glibc `ldd` is
  itself a shell script, so dropping `shell=True` alone would not have
  enough. The musl fallback still reads the `ldd` banner, parsed in Pyt
  instead of `awk`.
- `avx_supported()` reads `/proc/cpuinfo` directly on Linux and runs `sysctl`
  without a shell on macOS. The Windows branch is untouched.
- `get_dso_path()` parses `ldd` output in Python instead of `grep`/`awk

Also fixes a latent crash: when `ldd` was unavailable, `get_libc_ver()` returned
`("musl", "")` and `less_than_ver("", "2.23")` raised `ValueError` on `
It now returns `(None, None)`.

**Verification.**

- Added `test/legacy_test/test_core_env_probe.py` (12 tests), including
  explicit assertion that `_run_command` never passes `shell=True`. The
  discriminates: 9 of the 12 fail against the unpatched module.
- Reproduced the original failure and the fix on a real Paddle install, with
  `/bin/sh` genuinely unusable (mount namespace, `mount --bind /dev/null
  /bin/sh`): unpatched raises `PermissionError` at `core.py:187`; patched
  imports cleanly and `paddle.utils.run_check()` passes. All 12 tests a
  inside that shell-less namespace.
- Confirmed behaviour parity on an ordinary system: `get_libc_ver()` returns the
  same value as `ldd --version | awk '/ldd/{print $NF}'`, `avx_supporte
  matches `grep -i avx /proc/cpuinfo`, and `get_dso_path()` returns the same
  path as `ldd | grep | awk '{print $3}'`.

`tools/summary_env.py` keeps its own copy of `run_shell_command`. It is a
diagnostic tool rather than part of the import path, so it is left for
follow-up.

### 是否引起精度变化

否