### PR TITLE
[Bug Fix] Gate the fp8 fast transpose on the base pointer alignment

### DIFF
--- a/paddle/phi/kernels/funcs/transpose_function.cuh
+++ b/paddle/phi/kernels/funcs/transpose_function.cuh
@@ -662,7 +662,16 @@ void SendSwapDim1And2InTranspose(const GPUContext& d,
                                  T* output) {
   // FP8 fast path
   if constexpr (std::is_same<T, phi::float8_e4m3fn>::value) {
-    if (input_dims[1] >= 128 && input_dims[2] >= 128 &&
+    // The kernel moves 8 bytes at a time through fp8x8_t, whose alignment is 8.
+    // Both extents are multiples of 128, so every row start keeps the alignment
+    // class of the base pointer and checking the two base pointers is enough.
+    // A one-byte dtype makes this a real question: a view into a larger buffer
+    // can start at any byte, and an unaligned vector load faults.
+    constexpr uintptr_t kFp8VecAlign = 8;
+    const bool aligned =
+        reinterpret_cast<uintptr_t>(input) % kFp8VecAlign == 0 &&
+        reinterpret_cast<uintptr_t>(output) % kFp8VecAlign == 0;
+    if (aligned && input_dims[1] >= 128 && input_dims[2] >= 128 &&
         input_dims[1] % 128 == 0 && input_dims[2] % 128 == 0) {
       dispatch_fp8_fast_transpose_kernel<T, IndexType>(
           d, input, input_dims[0], input_dims[1], input_dims[2], output);

--- a/test/legacy_test/test_stride_offset_kernel.py
+++ b/test/legacy_test/test_stride_offset_kernel.py
@@ -363,6 +363,35 @@ class TestContiguousNonZeroOffset(StrideFlagTestCase):
                     out.numpy(), np.ascontiguousarray(ref)
                 )
 
+    @unittest.skipIf(
+        not paddle.is_compiled_with_cuda()
+        or paddle.device.cuda.get_device_capability() < (8, 9),
+        "float8_e4m3fn needs compute capability 89",
+    )
+    def test_float8_offset_breaks_vector_alignment(self):
+        """A one-byte dtype can start at any byte, unlike the wider ones.
+
+        The float8 tile transpose moves eight bytes at a time, so a view whose
+        offset is not a multiple of eight must not reach it. Its extents are
+        multiples of 128 here, which is what the shape side of that gate asks
+        for, leaving the base pointer as the only thing that can reject it.
+        """
+        shape = [256, 384]
+        n = _numel(shape)
+        for off in (0, 1, 3, 7, 8, 1024):
+            with self.subTest(offset=off):
+                # float8 has no numpy dtype, so the buffer is cast on device
+                # and the reference is read back as the raw bytes.
+                buf = paddle.to_tensor(
+                    _host_values(n + off, "float32", 8400 + off)
+                ).astype("float8_e4m3fn")
+                bits = buf.numpy()
+                view = buf[off : off + n].reshape(shape)
+                self.assertEqual(view.data_ptr() % 8, off % 8)
+                out = paddle.transpose(view, [1, 0]).contiguous()
+                ref = np.ascontiguousarray(bits[off : off + n].reshape(shape).T)
+                np.testing.assert_array_equal(out.numpy(), ref)
+
     def test_assign_materializes_the_same_bits(self):
         """paddle.assign has to materialize the view too, and agree."""
         _, view, host = self._view([1024, 1024], "bfloat16", 1024, 8300)


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

release/3.4 上的后续修复，跟进 #79742（已合入 4d8f64b704）遗漏的一处地址对齐保护。

**问题**

`SendSwapDim1And2InTranspose` 的 fp8 快速路径（`paddle/phi/kernels/funcs/transpose_function.cuh`）只检查了 shape：

```cpp
if (input_dims[1] >= 128 && input_dims[2] >= 128 &&
    input_dims[1] % 128 == 0 && input_dims[2] % 128 == 0)
```

而 `fp8_fast_transpose_kernel` 通过 `fp8x8_t`（`alignas(8)`，底层是 `uint2`）一次搬 8 字节。访存地址是 `src + batch*M*N + row*N + col_start`，其中 `col_start` 是 8 的倍数，`M`、`N` 均为 128 的倍数，batch stride 也是 128×128 的倍数——所有偏移都保持 8 的整数倍，因此唯一可能破坏对齐的是基址本身，而基址此前完全没有被检查。

**为什么可达**

fp8 是 1 字节 dtype，view 可以从任意字节开始；#79742 同时放开了 `is_only_transposed()` 对 `offset != 0` 的拒绝，转置 view 上的 `.contiguous()` 现在会带着非零 offset 进入 `TransposeKernel`。于是

```python
buf[1 : 1 + n].reshape([256, 384]).transpose([1, 0]).contiguous()
```

这类调用会命中 128 倍数 shape 的快速路径，并对未对齐地址发起 `uint2` 访存，触发 CUDA misaligned address 或产生错误结果。

**改动**

门禁处增加基址对齐判断，kernel 本身不变；不满足时回退到原有标量 tiling 路径（只是更慢，不会更错）。输出张量是新分配的（256 字节对齐），一并检查代价可忽略。

同时补充回归用例 `test_float8_offset_breaks_vector_alignment`，覆盖 offset ∈ {0, 1, 3, 7, 8, 1024}，其中 1/3/7 正是原先会 fault 的取值。

对应 develop 分支修复：https://github.com/PaddlePaddle/Paddle/pull/79743

### 是否引起精度变化

**否**。只收窄快速路径的进入条件，两条路径都只做数据搬运、不含任何算术；原先能命中快速路径的对齐输入行为完全不变，未对齐输入由「未定义行为/报错」改为走标量路径给出正确结果。
