### PR TITLE
[Bug Fix] Avoid overflow in CPU SiLU backward

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -2282,10 +2282,13 @@ struct SiluGradFunctor : public BaseActivationFunctor<T> {
             typename dOut,
             typename dX>
   void operator()(Device d, X x, Out out UNUSED, dOut dout, dX dx) const {
-    auto temp1 = static_cast<T>(1) + (-x).exp();  // 1+e^(-x)
-    auto temp2 = x * (-x).exp();                  // x*e^(-x)
-    dx.device(d) = dout * ((static_cast<T>(1) / temp1) *
-                           (static_cast<T>(1) + (temp2 / temp1)));
+    auto exp_neg_abs_x = (-x.abs() * static_cast<T>(0.5)).exp().square();
+    auto denominator = static_cast<T>(1) + exp_neg_abs_x;
+    auto sigmoid = (x >= static_cast<T>(0))
+                       .select(static_cast<T>(1) / denominator,
+                               exp_neg_abs_x / denominator);
+    dx.device(d) = dout * sigmoid *
+                   (static_cast<T>(1) + x * (static_cast<T>(1) - sigmoid));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return ActBwdOpFwdDeps::kDepX; }

--- a/test/legacy_test/test_silu_op.py
+++ b/test/legacy_test/test_silu_op.py
@@ -119,6 +119,69 @@ class TestSiluOpClass(unittest.TestCase):
         )
 
 
+class TestSiluLargeNegativeGradient(unittest.TestCase):
+    def _check_gradient(self, dtype, magnitude, static):
+        values = [
+            -magnitude - 2,
+            -magnitude - 1,
+            -magnitude,
+            -magnitude + 1,
+            -20,
+            -1,
+            0,
+            1,
+            20,
+            magnitude,
+        ]
+        x_np = np.asarray(values, dtype=dtype)
+        dout_np = np.asarray(
+            [1, -2, 1, -2, 0.25, 1.5, 0, -0.5, 2, 0.75], dtype=dtype
+        )
+        # Higher precision keeps the reference independent of dtype overflow.
+        x_ref = x_np.astype(np.longdouble)
+        exp_neg_abs_x = np.exp(-np.abs(x_ref))
+        sigmoid = np.where(
+            x_ref >= 0,
+            1 / (1 + exp_neg_abs_x),
+            exp_neg_abs_x / (1 + exp_neg_abs_x),
+        )
+        expected = (dout_np * sigmoid * (1 + x_ref * (1 - sigmoid))).astype(
+            dtype
+        )
+        place = base.CPUPlace()
+        if static:
+            paddle.enable_static()
+            with paddle.static.program_guard(paddle.static.Program()):
+                x = paddle.static.data('x', x_np.shape, dtype=dtype)
+                dout = paddle.static.data('dout', dout_np.shape, dtype=dtype)
+                x.stop_gradient = False
+                grad = paddle.static.gradients(F.silu(x), x, dout)[0]
+                actual = paddle.static.Executor(place).run(
+                    feed={'x': x_np, 'dout': dout_np}, fetch_list=[grad]
+                )[0]
+        else:
+            with dg.guard(place):
+                x = paddle.to_tensor(x_np, stop_gradient=False)
+                actual = paddle.grad(F.silu(x), x, paddle.to_tensor(dout_np))[
+                    0
+                ].numpy()
+        np.testing.assert_allclose(
+            actual, expected, rtol=1e-5 if dtype == 'float32' else 1e-12, atol=0
+        )
+
+    def test_float32_dygraph(self):
+        self._check_gradient('float32', 88, False)
+
+    def test_float64_dygraph(self):
+        self._check_gradient('float64', 709, False)
+
+    def test_float32_static(self):
+        self._check_gradient('float32', 88, True)
+
+    def test_float64_static(self):
+        self._check_gradient('float64', 709, True)
+
+
 class TestSiluOpClass_ZeroSize(unittest.TestCase):
     def _test_case1_cpu(self):
         x = np.random.uniform(-1, 1, size=(0, 17)).astype(np.float32)


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

Fixes #79630.

CPU SiLU backward evaluates `x * exp(-x)` before dividing by `1 + exp(-x)`. This intermediate overflows for inputs such as `-88` in float32 or `-709` in float64 even though the final gradient is finite. For example, the float64 gradient at `-709` should be approximately `-8.614807714413836e-306`.

Compute the sigmoid from `exp(-abs(x))` and evaluate `dout * sigmoid * (1 + x * (1 - sigmoid))` instead. The exponential is computed as `exp(-abs(x) / 2)^2` so Eigen's packet exponential does not clamp subnormal values around the original overflow boundary. This also preserves small, representable gradients just beyond that boundary.

Add four CPU regression tests covering float32/float64 in dynamic and static graph modes. The tests include non-unit upstream gradients, large negative inputs and ordinary positive/negative inputs, and compare against a NumPy reference with zero absolute tolerance.

Validation:

- A standalone check of the actual functor with the repository's Eigen revision reports 8 failing input/dtype combinations on the original code and 22 passing combinations after the fix.
- A full CPU source build succeeds. All 20 tests in `test/legacy_test/test_silu_op.py` pass using its compiled `libpaddle.so`, including the four new regressions and existing complex/zero-size coverage.
- Changed-file pre-commit checks pass.

The change is limited to the real-valued CPU functor. CUDA's separate implementation, the complex specialization and SiLU forward are unchanged. CUDA, oneDNN and end-to-end model training were not tested. The source build uses the build-tree Python package rather than an installed wheel.

### 是否引起精度变化

是：修正 CPU float32/float64 SiLU 反向传播中大负数输入的错误梯度。
