### PR TITLE
[Accuracy] Align CUDA bilinear interpolation with deterministic Torch

### DIFF
--- a/paddle/phi/kernels/gpu/interpolate_bilinear_compat.cuh
+++ b/paddle/phi/kernels/gpu/interpolate_bilinear_compat.cuh
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+
+namespace phi {
+namespace funcs {
+namespace bilinear_compat {
+
+// Match the separate FP32 operations in torch 2.12's _upsample_linear.
+// In particular, a fused multiply-add changes both coordinates and values.
+__device__ __forceinline__ float Coordinate(int64_t index, float scale) {
+  return fmaxf(
+      __fsub_rn(__fmul_rn(__fadd_rn(static_cast<float>(index), 0.5f), scale),
+                0.5f),
+      0.0f);
+}
+
+__device__ __forceinline__ float Weight(int64_t index, float scale) {
+  float coordinate = Coordinate(index, scale);
+  auto lower = static_cast<int64_t>(coordinate);
+  return fminf(__fsub_rn(coordinate, static_cast<float>(lower)), 1.0f);
+}
+
+__device__ __forceinline__ float Lerp(float left, float right, float weight) {
+  return __fadd_rn(left, __fmul_rn(__fsub_rn(right, left), weight));
+}
+
+static __global__ void Forward(const float* input,
+                               float* output,
+                               int64_t numel,
+                               int64_t in_h,
+                               int64_t in_w,
+                               int64_t out_h,
+                               int64_t out_w,
+                               float scale_h,
+                               float scale_w) {
+  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t index =
+           static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       index < numel;
+       index += stride) {
+    int64_t x = index % out_w;
+    int64_t y = index / out_w % out_h;
+    int64_t plane = index / (out_h * out_w);
+    float fy = Coordinate(y, scale_h);
+    float fx = Coordinate(x, scale_w);
+    auto y0 = static_cast<int64_t>(fy);
+    auto x0 = static_cast<int64_t>(fx);
+    int64_t y1 = y0 + 1 < in_h ? y0 + 1 : in_h - 1;
+    int64_t x1 = x0 + 1 < in_w ? x0 + 1 : in_w - 1;
+    float wy = fminf(__fsub_rn(fy, static_cast<float>(y0)), 1.0f);
+    float wx = fminf(__fsub_rn(fx, static_cast<float>(x0)), 1.0f);
+    const float* values = input + plane * in_h * in_w;
+    float top = Lerp(values[y0 * in_w + x0], values[y0 * in_w + x1], wx);
+    float bottom = Lerp(values[y1 * in_w + x0], values[y1 * in_w + x1], wx);
+    output[index] = Lerp(top, bottom, wy);
+  }
+}
+
+// Each corner's index map is monotone. Its inverse is an interval, so we
+// can reproduce stable index sorting without allocating or sorting indices.
+__device__ __forceinline__ int64_t LowerBound(int64_t target,
+                                              int corner,
+                                              int64_t in_size,
+                                              int64_t out_size,
+                                              float scale) {
+  int64_t first = 0;
+  int64_t last = out_size;
+  while (first < last) {
+    int64_t mid = first + (last - first) / 2;
+    int64_t source = static_cast<int64_t>(Coordinate(mid, scale)) + corner;
+    source = source < in_size ? source : in_size - 1;
+    if (source < target) {
+      first = mid + 1;
+    } else {
+      last = mid;
+    }
+  }
+  return first;
+}
+
+__device__ __forceinline__ float CornerGrad(float grad,
+                                            float wy,
+                                            float wx,
+                                            int corner) {
+  float bottom = __fmul_rn(grad, wy);
+  float row = corner >= 2 ? bottom : __fsub_rn(grad, bottom);
+  float right = __fmul_rn(row, wx);
+  return corner % 2 ? right : __fsub_rn(row, right);
+}
+
+template <bool WarpReduce>
+__device__ __forceinline__ float GatherGrad(const float* grad,
+                                            int64_t y,
+                                            int64_t x,
+                                            int64_t in_h,
+                                            int64_t in_w,
+                                            int64_t out_h,
+                                            int64_t out_w,
+                                            float scale_h,
+                                            float scale_w,
+                                            int corner) {
+  int64_t y_begin = LowerBound(y, corner / 2, in_h, out_h, scale_h);
+  int64_t y_end = LowerBound(y + 1, corner / 2, in_h, out_h, scale_h);
+  int64_t x_begin = LowerBound(x, corner % 2, in_w, out_w, scale_w);
+  int64_t x_end = LowerBound(x + 1, corner % 2, in_w, out_w, scale_w);
+  int64_t width = x_end - x_begin;
+  int64_t count = (y_end - y_begin) * width;
+  float sum = 0.0f;
+  int64_t tail = 0;
+  if constexpr (WarpReduce) {
+    // Torch's deterministic index_put sums full groups with a warp tree,
+    // then lane 0 adds the remainder in original output-index order.
+    tail = count / 32 * 32;
+    for (int64_t i = static_cast<int64_t>(threadIdx.x) % 32; i < tail; i += 32) {
+      int64_t oy = y_begin + i / width;
+      int64_t ox = x_begin + i % width;
+      sum = __fadd_rn(sum,
+                      CornerGrad(grad[oy * out_w + ox],
+                                 Weight(oy, scale_h),
+                                 Weight(ox, scale_w),
+                                 corner));
+    }
+    for (int offset = 16; offset > 0; offset /= 2) {
+      sum = __fadd_rn(sum, __shfl_down_sync(0xffffffff, sum, offset));
+    }
+  }
+  if (!WarpReduce || threadIdx.x % 32 == 0) {
+    for (int64_t i = tail; i < count; ++i) {
+      int64_t oy = y_begin + i / width;
+      int64_t ox = x_begin + i % width;
+      sum = __fadd_rn(sum,
+                      CornerGrad(grad[oy * out_w + ox],
+                                 Weight(oy, scale_h),
+                                 Weight(ox, scale_w),
+                                 corner));
+    }
+  }
+  // index_put accumulates into a zero-initialized gradient tensor.
+  return __fadd_rn(0.0f, sum);
+}
+
+template <bool WarpReduce>
+static __global__ void Backward(const float* out_grad,
+                                float* in_grad,
+                                int64_t numel,
+                                int64_t in_h,
+                                int64_t in_w,
+                                int64_t out_h,
+                                int64_t out_w,
+                                float scale_h,
+                                float scale_w) {
+  constexpr int threads_per_input = WarpReduce ? 32 : 1;
+  int64_t stride =
+      static_cast<int64_t>(blockDim.x) * gridDim.x / threads_per_input;
+  for (int64_t index =
+           (static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x) /
+           threads_per_input;
+       index < numel;
+       index += stride) {
+    int64_t x = index % in_w;
+    int64_t y = index / in_w % in_h;
+    int64_t plane = index / (in_h * in_w);
+    float result = 0.0f;
+    // The four gather nodes are created in 00,01,10,11 order. Autograd
+    // accumulates their input gradients in the reverse order, left to right.
+    for (int corner = 3; corner >= 0; --corner) {
+      float part = GatherGrad<WarpReduce>(out_grad + plane * out_h * out_w,
+                                          y,
+                                          x,
+                                          in_h,
+                                          in_w,
+                                          out_h,
+                                          out_w,
+                                          scale_h,
+                                          scale_w,
+                                          corner);
+      result = corner == 3 ? part : __fadd_rn(result, part);
+    }
+    if (!WarpReduce || threadIdx.x % 32 == 0) {
+      in_grad[index] = result;
+    }
+  }
+}
+
+inline void LaunchForward(const float* input,
+                          float* output,
+                          int64_t numel,
+                          int64_t in_h,
+                          int64_t in_w,
+                          int64_t out_h,
+                          int64_t out_w,
+                          cudaStream_t stream) {
+  if (numel == 0) return;
+  int blocks = static_cast<int>(std::min<int64_t>((numel + 255) / 256, 4096));
+  Forward<<<blocks, 256, 0, stream>>>(
+      input,
+      output,
+      numel,
+      in_h,
+      in_w,
+      out_h,
+      out_w,
+      static_cast<float>(static_cast<double>(in_h) / out_h),
+      static_cast<float>(static_cast<double>(in_w) / out_w));
+}
+
+inline void LaunchBackward(const float* out_grad,
+                           float* in_grad,
+                           int64_t numel,
+                           int64_t in_h,
+                           int64_t in_w,
+                           int64_t out_h,
+                           int64_t out_w,
+                           cudaStream_t stream) {
+  if (numel == 0) return;
+  float scale_h = static_cast<float>(static_cast<double>(in_h) / out_h);
+  float scale_w = static_cast<float>(static_cast<double>(in_w) / out_w);
+  // At most 2x upsampling has fewer than 32 contributions per corner even
+  // at clamped boundaries. A thread can reproduce the warp's remainder sum.
+  // Keep the fast-path bound in the range where d + 0.5 is exact in FP32.
+  if (out_h <= 2 * in_h && out_w <= 2 * in_w && out_h <= (1 << 23) &&
+      out_w <= (1 << 23)) {
+    int blocks = static_cast<int>(std::min<int64_t>((numel + 255) / 256, 4096));
+    Backward<false><<<blocks, 256, 0, stream>>>(
+        out_grad, in_grad, numel, in_h, in_w, out_h, out_w, scale_h, scale_w);
+  } else {
+    int blocks = static_cast<int>(std::min<int64_t>((numel + 7) / 8, 4096));
+    Backward<true><<<blocks, 256, 0, stream>>>(
+        out_grad, in_grad, numel, in_h, in_w, out_h, out_w, scale_h, scale_w);
+  }
+}
+
+}  // namespace bilinear_compat
+}  // namespace funcs
+}  // namespace phi

--- a/paddle/phi/kernels/gpu/interpolate_bilinear_compat.cuh
+++ b/paddle/phi/kernels/gpu/interpolate_bilinear_compat.cuh
@@ -129,7 +129,8 @@ __device__ __forceinline__ float GatherGrad(const float* grad,
     // Torch's deterministic index_put sums full groups with a warp tree,
     // then lane 0 adds the remainder in original output-index order.
     tail = count / 32 * 32;
-    for (int64_t i = static_cast<int64_t>(threadIdx.x) % 32; i < tail; i += 32) {
+    for (int64_t i = static_cast<int64_t>(threadIdx.x) % 32; i < tail;
+         i += 32) {
       int64_t oy = y_begin + i / width;
       int64_t ox = x_begin + i % width;
       sum = __fadd_rn(sum,

--- a/paddle/phi/kernels/gpu/interpolate_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_grad_kernel.cu
@@ -14,6 +14,7 @@
 
 #include "paddle/phi/kernels/interpolate_grad_kernel.h"
 
+#include "paddle/common/flags.h"
 #include "paddle/common/layout.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
@@ -26,6 +27,12 @@
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/gpu/interpolate.cuh"
 #include "paddle/phi/kernels/primitive/datamover_primitives.h"
+
+#ifdef PADDLE_WITH_CUDA
+#include "paddle/phi/kernels/gpu/interpolate_bilinear_compat.cuh"
+#endif
+
+COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
 
 namespace phi {
 
@@ -1396,6 +1403,24 @@ static void Interpolate2DCUDABwd(
     Copy(dev_ctx, output_grad, dev_ctx.GetPlace(), false, input_grad);
     return;
   }
+
+#ifdef PADDLE_WITH_CUDA
+  if constexpr (std::is_same<T, float>::value) {
+    if (FLAGS_use_accuracy_compatible_kernel && interp_method == "bilinear" &&
+        data_layout == DataLayout::NCHW && !align_corners && align_mode == 0 &&
+        scale.empty() && !scale_tensor) {
+      funcs::bilinear_compat::LaunchBackward(output_grad_data,
+                                             input_grad_data,
+                                             n * c * in_h * in_w,
+                                             in_h,
+                                             in_w,
+                                             out_h,
+                                             out_w,
+                                             dev_ctx.stream());
+      return;
+    }
+  }
+#endif
 
   using MT = typename std::conditional_t<std::is_integral<T>::value,
                                          float,

--- a/paddle/phi/kernels/gpu/interpolate_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_kernel.cu
@@ -28,6 +28,12 @@
 #include "paddle/phi/kernels/gpu/interpolate.cuh"
 #include "paddle/phi/kernels/primitive/datamover_primitives.h"
 
+#ifdef PADDLE_WITH_CUDA
+#include "paddle/phi/kernels/gpu/interpolate_bilinear_compat.cuh"
+#endif
+
+COMMON_DECLARE_bool(use_accuracy_compatible_kernel);
+
 namespace phi {
 
 template <typename T, typename MT, typename InterpFilter>
@@ -1216,6 +1222,24 @@ static void Interpolate2DCUDAFwd(
     Copy(dev_ctx, input, dev_ctx.GetPlace(), false, output);
     return;
   }
+
+#ifdef PADDLE_WITH_CUDA
+  if constexpr (std::is_same<T, float>::value) {
+    if (FLAGS_use_accuracy_compatible_kernel && interp_method == "bilinear" &&
+        data_layout == DataLayout::NCHW && !align_corners && align_mode == 0 &&
+        scale.empty() && !scale_tensor) {
+      funcs::bilinear_compat::LaunchForward(input_data,
+                                            output_data,
+                                            n * c * out_h * out_w,
+                                            in_h,
+                                            in_w,
+                                            out_h,
+                                            out_w,
+                                            dev_ctx.stream());
+      return;
+    }
+  }
+#endif
 
   using MT = std::conditional_t<std::is_integral<T>::value,
                                 float,

--- a/test/legacy_test/test_bilinear_interp_accuracy_compatible.py
+++ b/test/legacy_test/test_bilinear_interp_accuracy_compatible.py
@@ -1,0 +1,321 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.base import core
+
+
+def coordinates(in_size, out_size):
+    scale = np.float32(in_size / out_size)
+    source = np.maximum(
+        (np.arange(out_size, dtype=np.float32) + np.float32(0.5)) * scale
+        - np.float32(0.5),
+        np.float32(0),
+    )
+    lower = source.astype(np.int64)
+    upper = np.minimum(lower + 1, in_size - 1)
+    weight = np.clip(source - lower.astype(np.float32), 0, 1)
+    return lower, upper, weight
+
+
+def reference_forward(x, size):
+    """Separate NumPy ufuncs preserve the decomposition's FP32 rounding."""
+    y0, y1, wy = coordinates(x.shape[2], size[0])
+    x0, x1, wx = coordinates(x.shape[3], size[1])
+    v00 = x[:, :, y0[:, None], x0]
+    v01 = x[:, :, y0[:, None], x1]
+    v10 = x[:, :, y1[:, None], x0]
+    v11 = x[:, :, y1[:, None], x1]
+    top = v00 + (v01 - v00) * wx
+    bottom = v10 + (v11 - v10) * wx
+    return top + (bottom - top) * wy[:, None]
+
+
+def reference_backward(shape, grad):
+    """Independent stable-index reduction, including the 32-lane sum tree."""
+    y0, y1, wy = coordinates(shape[2], grad.shape[2])
+    x0, x1, wx = coordinates(shape[3], grad.shape[3])
+    bottom = grad * wy[:, None]
+    top = grad - bottom
+    contributions = [
+        top - top * wx,
+        top * wx,
+        bottom - bottom * wx,
+        bottom * wx,
+    ]
+    parts = []
+    for (ys, xs), contribution in zip(
+        [(y0, x0), (y0, x1), (y1, x0), (y1, x1)], contributions
+    ):
+        indices = (ys[:, None] * shape[3] + xs).reshape(-1)
+        values = contribution.reshape(*shape[:2], -1)
+        part = np.zeros((*shape[:2], shape[2] * shape[3]), np.float32)
+        # Filtering the original row-major positions preserves stable-sort order.
+        for index in np.unique(indices):
+            selected = values[..., indices == index]
+            count = selected.shape[-1]
+            full = count // 32 * 32
+            lanes = np.zeros((*shape[:2], 32), np.float32)
+            for start in range(0, full, 32):
+                lanes += selected[..., start : start + 32]
+            for offset in (16, 8, 4, 2, 1):
+                lanes[..., : 32 - offset] = (
+                    lanes[..., : 32 - offset] + lanes[..., offset:]
+                )
+            total = lanes[..., 0].copy()
+            for tail in range(full, count):
+                total += selected[..., tail]
+            part[..., index] = np.float32(0) + total
+        parts.append(part.reshape(shape))
+    return ((parts[3] + parts[2]) + parts[1]) + parts[0]
+
+
+def round_to_bfloat16(x):
+    # Finite normal-distributed inputs, rounded to nearest with ties to even.
+    bits = x.view(np.uint32)
+    rounded = bits + np.uint32(0x7FFF) + ((bits >> 16) & 1)
+    return (rounded & np.uint32(0xFFFF0000)).view(np.float32)
+
+
+def md5(x):
+    return hashlib.md5(x.tobytes()).hexdigest()
+
+
+@unittest.skipUnless(
+    core.is_compiled_with_cuda() and not core.is_compiled_with_rocm(),
+    "The accuracy-compatible bilinear kernel requires CUDA",
+)
+class TestBilinearAccuracyCompatible(unittest.TestCase):
+    def setUp(self):
+        self.flags = paddle.get_flags(['FLAGS_use_accuracy_compatible_kernel'])
+        self.device = paddle.device.get_device()
+        paddle.disable_static()
+        paddle.set_device('gpu:0')
+        paddle.set_flags({'FLAGS_use_accuracy_compatible_kernel': True})
+
+    def tearDown(self):
+        paddle.disable_static()
+        paddle.set_flags(self.flags)
+        paddle.set_device(self.device)
+
+    def assert_bitwise_equal(self, actual, expected):
+        self.assertEqual(actual.dtype, expected.dtype)
+        np.testing.assert_array_equal(
+            actual.view(np.uint32), expected.view(np.uint32)
+        )
+
+    def evaluate(self, data, size, grad):
+        x = paddle.to_tensor(data, stop_gradient=False)
+        y = paddle.nn.functional.interpolate(
+            x, size=size, mode='bilinear', align_corners=False, align_mode=0
+        )
+        dx = paddle.grad(y, x, grad_outputs=paddle.to_tensor(grad))[0]
+        return y.numpy(), dx.numpy()
+
+    def test_random_gradients_and_repeats(self):
+        rng = np.random.default_rng(2026)
+        for size in [(31, 68), (20, 35), (19, 37), (30, 45)]:
+            with self.subTest(size=size):
+                data = rng.standard_normal((2, 3, 52, 52)).astype(np.float32)
+                grad = rng.standard_normal((2, 3, *size)).astype(np.float32)
+                expected_y = reference_forward(data, size)
+                expected_dx = reference_backward(data.shape, grad)
+                for _ in range(3):
+                    y, dx = self.evaluate(data, size, grad)
+                    self.assert_bitwise_equal(y, expected_y)
+                    self.assert_bitwise_equal(dx, expected_dx)
+
+    def test_boundaries_and_large_reductions(self):
+        rng = np.random.default_rng(7)
+        for source, size in [
+            ((1, 1), (20, 20)),
+            ((1, 7), (1, 40)),
+            ((7, 1), (40, 1)),
+            ((2, 3), (120, 90)),
+            ((3, 4), (6, 8)),
+            ((3, 4), (7, 9)),
+            ((7, 9), (1, 1)),
+            ((7, 9), (3, 4)),
+            ((7, 9), (7, 4)),
+            ((7, 9), (3, 9)),
+            ((7, 9), (7, 9)),
+        ]:
+            with self.subTest(source=source, size=size):
+                data = rng.standard_normal((1, 2, *source)).astype(np.float32)
+                grad = rng.standard_normal((1, 2, *size)).astype(np.float32)
+                # Sparse signed gradients exercise cancellation and zero sums.
+                grad[..., ::2, ::2] = 0
+                y, dx = self.evaluate(data, size, grad)
+                self.assert_bitwise_equal(y, reference_forward(data, size))
+                self.assert_bitwise_equal(
+                    dx, reference_backward(data.shape, grad)
+                )
+
+    def test_positional_embedding_md5(self):
+        # Generated with torch 2.12.1+cu129 on CUDA, deterministic=True,
+        # default_rng(0), BF16 -> FP32 input and ones_like(output) gradients.
+        expected = {
+            (31, 68): (
+                '05f31786fbfd2f17bc3587a5872335f2',
+                '7407cf8a481e119de7e43689d6b634a0',
+            ),
+            (20, 35): (
+                'bfc8e76343b3b98acef27e373ef8f870',
+                '1161b1d927bce439cdc7589cfecb6ca8',
+            ),
+            (19, 37): (
+                'd116da26f32a919993158d9012a90cb1',
+                '1327ab280c2d20460d5469cf54224c25',
+            ),
+            (30, 45): (
+                'c8b2eec98469fbd185959fd10fac7cf5',
+                'd749fc8113211af85d17d1756d9a681e',
+            ),
+        }
+        data = round_to_bfloat16(
+            np.random.default_rng(0)
+            .standard_normal((1, 768, 52, 52))
+            .astype(np.float32)
+        )
+        self.assertEqual(md5(data), 'e4db7bd4a16d58be5e501d444b17e21a')
+        for size, (forward_hash, backward_hash) in expected.items():
+            with self.subTest(size=size):
+                y, dx = self.evaluate(
+                    data, size, np.ones((1, 768, *size), np.float32)
+                )
+                self.assertEqual(md5(y), forward_hash)
+                self.assertEqual(md5(dx), backward_hash)
+
+    def test_pir(self):
+        data = (
+            np.random.default_rng(12)
+            .standard_normal((1, 2, 7, 9))
+            .astype(np.float32)
+        )
+        grad = (
+            np.random.default_rng(13)
+            .standard_normal((1, 2, 3, 4))
+            .astype(np.float32)
+        )
+        with paddle.pir_utils.IrGuard():
+            paddle.enable_static()
+            main, startup = paddle.static.Program(), paddle.static.Program()
+            with paddle.static.program_guard(main, startup):
+                x = paddle.static.data('x', data.shape, 'float32')
+                x.stop_gradient = False
+                g = paddle.static.data('g', grad.shape, 'float32')
+                y = paddle.nn.functional.interpolate(
+                    x, size=[3, 4], mode='bilinear', align_corners=False
+                )
+                dx = paddle.static.gradients([y], [x], [g])[0]
+            executor = paddle.static.Executor(paddle.CUDAPlace(0))
+            executor.run(startup)
+            actual_y, actual_dx = executor.run(
+                main, feed={'x': data, 'g': grad}, fetch_list=[y, dx]
+            )
+        self.assert_bitwise_equal(actual_y, reference_forward(data, (3, 4)))
+        self.assert_bitwise_equal(
+            actual_dx, reference_backward(data.shape, grad)
+        )
+
+    def test_transposed_input(self):
+        data = (
+            np.random.default_rng(5)
+            .standard_normal((1, 3, 52, 52))
+            .astype(np.float32)
+        )
+        grad = (
+            np.random.default_rng(6)
+            .standard_normal((1, 3, 31, 68))
+            .astype(np.float32)
+        )
+        base = paddle.to_tensor(
+            data.transpose(0, 2, 3, 1).copy(), stop_gradient=False
+        )
+        x = base.transpose([0, 3, 1, 2])
+        y = paddle.nn.functional.interpolate(
+            x, size=[31, 68], mode='bilinear', align_corners=False
+        )
+        dx = paddle.grad(y, base, grad_outputs=paddle.to_tensor(grad))[0]
+        self.assert_bitwise_equal(y.numpy(), reference_forward(data, (31, 68)))
+        self.assert_bitwise_equal(
+            dx.numpy().transpose(0, 3, 1, 2).copy(),
+            reference_backward(data.shape, grad),
+        )
+
+    def test_linear_forward_unchanged(self):
+        rng = np.random.default_rng(0)
+        # Keep the same RNG sequence as the 2D/1D positional-embedding probe.
+        rng.standard_normal((1, 768, 52, 52))
+        data = round_to_bfloat16(
+            rng.standard_normal((1, 768, 1500)).astype(np.float32)
+        )
+        x = paddle.to_tensor(data)
+        expected = {
+            1245: 'f2a1388fcc96a79ba91f19a8423e8a08',
+            79: '0917f4636ef5910933559aa9096eb88f',
+            501: 'fa2dda66f1fae6b39f50f5300f465e72',
+            387: 'd1e3bc4f46eaab9de7ae5530db8a91f2',
+        }
+        for size, digest in expected.items():
+            with self.subTest(size=size):
+                result = paddle.nn.functional.interpolate(
+                    x,
+                    size=[size],
+                    mode='linear',
+                    align_corners=False,
+                    data_format='NCW',
+                )
+                self.assertEqual(md5(result.numpy()), digest)
+
+    def test_other_modes_keep_existing_path(self):
+        data = (
+            np.random.default_rng(1)
+            .standard_normal((1, 2, 7, 9))
+            .astype(np.float32)
+        )
+        cases = [
+            (data, {"size": [3, 4], "mode": 'bilinear', "align_corners": True}),
+            (data, {"size": [3, 4], "mode": 'bilinear', "align_mode": 1}),
+            (data, {"size": [3, 4], "mode": 'nearest'}),
+            (data, {"size": [3, 4], "mode": 'bicubic'}),
+            (data, {"scale_factor": 0.75, "mode": 'bilinear'}),
+            (
+                data.transpose(0, 2, 3, 1).copy(),
+                {"size": [3, 4], "mode": 'bilinear', "data_format": 'NHWC'},
+            ),
+            (
+                data.astype(np.float64),
+                {"size": [3, 4], "mode": 'bilinear'},
+            ),
+        ]
+        for values, kwargs in cases:
+            with self.subTest(kwargs=kwargs, dtype=values.dtype):
+                x = paddle.to_tensor(values)
+                paddle.set_flags(
+                    {'FLAGS_use_accuracy_compatible_kernel': False}
+                )
+                expected = paddle.nn.functional.interpolate(x, **kwargs).numpy()
+                paddle.set_flags({'FLAGS_use_accuracy_compatible_kernel': True})
+                actual = paddle.nn.functional.interpolate(x, **kwargs).numpy()
+                self.assertEqual(actual.tobytes(), expected.tobytes())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

Pcard-67164

修复 CUDA `F.interpolate(..., mode='bilinear')` 在开启 `FLAGS_use_accuracy_compatible_kernel` 后，仍无法与 Torch 2.12 确定性插值路径逐位对齐的问题，同时覆盖前向与输入梯度。

#### 问题与生效范围

位置编码输入 `(1, 768, 52, 52)` 经 BF16 舍入后转换为 FP32，插值到 `(31, 68)`、`(20, 35)`、`(19, 37)`、`(30, 45)` 时，原有实现的前向运算及反向累加顺序与 Torch 不同。仅开启 accuracy-compatible 标志不能消除差异。

本次新增分支限定为：CUDA、FP32、NCHW、bilinear、按输出尺寸计算插值坐标、`align_corners=False`、`align_mode=0`，且开启 `FLAGS_use_accuracy_compatible_kernel`。这里包含显式 `size`，以及 `scale_factor` 搭配 `recompute_scale_factor=True`：后者先计算输出尺寸，再按输入／输出尺寸计算坐标，与对应的显式 `size` 调用语义一致。Torch 对照开启 `torch.use_deterministic_algorithms(True)`，实际调用 `_upsample_linear_vec` 分解实现。

```python
paddle.set_flags({'FLAGS_use_accuracy_compatible_kernel': True})
y = paddle.nn.functional.interpolate(
    x, size=[31, 68], mode='bilinear', align_corners=False, align_mode=0
)
```

未开启标志时继续使用原实现。1D linear、其他 dtype/layout、`recompute_scale_factor=False/None` 的 scale-factor 调用及抗锯齿入口不进入新增分支；等尺寸仍沿用原有复制路径。

`recompute_scale_factor` 分支约定：

| 调用方式 | accuracy-compatible 标志开启后的路径 |
|---|---|
| 显式 `size` | 兼容路径 |
| `scale_factor` + `recompute_scale_factor=True` | 兼容路径 |
| `scale_factor` + `recompute_scale_factor=False/None` | 原有路径 |

该约定修正了初版说明中“所有 scale-factor 调用保持原路径”的范围表述。kernel 收到空 scale 时表示按输出尺寸计算坐标，不代表 Python 调用一定使用了显式 `size`。无需新增来源属性或改变算子接口。

#### 实现要点

- 前向依次沿宽、高计算插值，显式保留 FP32 各步舍入，避免 FMA 改变坐标、权重与输出。
- 反向复现四个 gather 分支的梯度计算与 `11 → 10 → 01 → 00` 累加顺序。
- 利用各角坐标映射的单调性，通过二分查找获取每个输入像素的输出贡献区间，按稳定索引顺序归约，无需排序索引或分配临时梯度张量。
- 贡献较多时复现 Torch 确定性 index_put 的 32-lane 归约及尾部累加；贡献数有严格上界的常见尺寸使用单线程路径。新增反向不使用原子累加。

#### 正确性验证

已完成本地完整源码编译，使用新构建的原生 `F.interpolate` 验证，未通过 monkey patch 替换接口。环境为 H800 / sm_90、Paddle CUDA 13.0、Torch 2.12.1+cu129、Python 3.12。

- 本 PR 四个文件的 `prek` 检查全部通过，包括 ast-grep、clang-format、cpplint 与 Ruff。
- 新增回归测试 **9 项全部通过**：原始 MD5、随机梯度及重复稳定性、边界与大归约、PIR 静态图、转置输入、1D 前向、重算缩放与非重算回退、其他模式保持原路径。测试使用独立 NumPy 参考实现，不依赖安装 Torch。
- 重算缩放新增 5 组配置（标量／分轴、下采样／上采样／混合缩放），与独立 NumPy 参考及对应 `size` 的前向、随机梯度逐位一致，每组重复 3 次；另外与 Torch 2.12 确定性路径对拍，5 组前向／反向全部逐位一致。非重算 `False/None` 路径验证标志开关前向逐位一致，反向采用 `rtol=atol=1e-6`，因为原有原子累加路径本身可能有舍入顺序差异。
- 原始复现的 **17 份数组全部逐位一致**，包含四组 2D 前向/输入梯度、等尺寸及 1D 前向；差异元素数均为 0。
- 原生 Paddle 与 Torch 额外 **100 组随机形状前向/反向逐位一致**；BF16 参数 → 转置 → FP32 插值 → BF16 输出的完整位置编码调用链，输出和参数梯度均逐位一致。
- PaddleAPITest：**4 组小规模 + 4 组生产规模全部逐位通过**，无 skip 或 bitwise-known 豁免。
- 现有测试按文件独立进程运行：bilinear **91 项**、linear **19 项**、interpolate API **12 项**，共 **122 项全部通过**。合并模块运行会受到已有静态图全局状态影响，因此采用独立进程验证。

```bash
python test/legacy_test/test_bilinear_interp_accuracy_compatible.py -v
python test/legacy_test/test_bilinear_interp_v2_op.py
python test/legacy_test/test_linear_interp_v2_op.py
python test/legacy_test/test_nn_functional_interpolate.py
```

原始输入使用 `np.random.default_rng(0).standard_normal((1, 768, 52, 52)).astype(np.float32)`，再做 BF16 → FP32 转换；反向使用全 1 输出梯度：

| 输出尺寸 | 前向 MD5 | 输入梯度 MD5 |
|---|---|---|
| 31×68 | `05f31786fbfd2f17bc3587a5872335f2` | `7407cf8a481e119de7e43689d6b634a0` |
| 20×35 | `bfc8e76343b3b98acef27e373ef8f870` | `1161b1d927bce439cdc7589cfecb6ca8` |
| 19×37 | `d116da26f32a919993158d9012a90cb1` | `1327ab280c2d20460d5469cf54224c25` |
| 30×45 | `c8b2eec98469fbd185959fd10fac7cf5` | `d749fc8113211af85d17d1756d9a681e` |

#### 性能结论与复核

同一张空闲 H800、相同输入及随机输出梯度，使用 eager `grad(..., retain_graph=True)` 复用前向图，单独测反向；每配置预热 20 次、计时 100 次，随机配置顺序，重复 5 轮取中位数。下表为 CUDA 同步的墙钟耗时，包含 Python 调用开销，单位 μs：

| 输出尺寸 | Paddle 原路径 | Torch 非确定性原路径 | Paddle 兼容路径 | Torch 确定性路径 |
|---|---:|---:|---:|---:|
| 31×68 | 33.8 | 39.9 | 368.0 | 1844.1 |
| 20×35 | 26.5 | 39.9 | 307.8 | 981.7 |
| 19×37 | 28.2 | 39.6 | 306.6 | 987.1 |
| 30×45 | 28.2 | 39.5 | 326.5 | 1416.0 |

- 兼容前向约 **21 μs**，与 Paddle 原路径基本一致。
- 兼容反向约 **0.30–0.37 ms**，相对 Paddle 原路径慢约 **11 倍**，但比本次对齐目标——Torch 2.12 确定性路径——快约 **3.2–5.0 倍**。固定且兼容的浮点归约顺序存在额外成本；当前实现仍有优化空间。
- 在**不导入 Paddle 的独立 Torch 进程**中复测，确定性反向为 **0.96–1.82 ms**，CUDA Event 与墙钟计时一致，结果可复现。连续发射的 CUDA Event 也可能包含发射间隙，因此另用 Profiler 检查实际 kernel 开销。
- 对 31×68 的确定性反向做单独 Profiler 采样：4 次索引梯度 kernel 合计约 **1.36 ms，占 GPU kernel 时间约 80%**；4 次排序合计仅约 **0.03 ms**。主要瓶颈是通用确定性索引梯度归约，不能把排序或 Python 调用解释为主要耗时来源。Profiler 与正式计时分开运行。
- 上述结论仅针对当前版本、硬件、形状及 eager 确定性路径，不代表 Torch 整体算子性能，也不包含 `torch.compile` 的性能评价。

### 是否引起精度变化
是
