### PR TITLE
Add machine-balanced partitioning for Muon 2D sharding

### DIFF
--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -117,6 +117,7 @@ message DygraphShardingConfig {
   optional NCCLConfig check_nccl_config = 12;
   optional int32 offload_opt_buffer_size = 13 [ default = -1 ];
   optional bool comm_group_call_opt = 14 [ default = false ];
+  optional bool machine_balanced_2d_partition = 15 [ default = false ];
 }
 
 message HybridConfig {

--- a/python/paddle/distributed/auto_parallel/constants.py
+++ b/python/paddle/distributed/auto_parallel/constants.py
@@ -161,7 +161,7 @@ set_field_default_config(SHARDING, "release_gradients", False)
 set_field_default_config(SHARDING, "comm_buffer_size_MB", 256)
 set_field_default_config(SHARDING, "enable_tensor_fusion", False)
 set_field_default_config(SHARDING, "save_unbalanced_param", True)
-
+set_field_default_config(SHARDING, "machine_balanced_2d_partition", False)
 
 if TYPE_CHECKING:
 

--- a/python/paddle/distributed/fleet/meta_optimizers/muon_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/muon_sharding_optimizer.py
@@ -199,6 +199,9 @@ class MuonShardingOptimizer:
         self.accumulate_steps = sharding_configs.accumulate_steps
         self.comm_overlap = sharding_configs.comm_overlap
         self.comm_buffer_size_MB = sharding_configs.comm_buffer_size_MB
+        self.machine_balanced_2d_partition = (
+            sharding_configs.machine_balanced_2d_partition
+        )
         self.use_reduce_avg = sharding_configs.use_reduce_avg
         self.enable_fuse_optimizer_states = (
             sharding_configs.enable_fuse_optimizer_states
@@ -330,33 +333,70 @@ class MuonShardingOptimizer:
                 self._params_1d.append(p)
 
         # ---- Step 2: Partition 2D params for each color group ----
-        # Owners are planned globally so that every rank agrees, then each rank
-        # keeps the mapping of the groups it belongs to.
-        rank_to_machine = self._build_rank_to_machine()
-        all_color_group_info = self._gather_all_color_group_info()
-        color_group_to_ranks = self._partition_2d_parameters(
-            all_color_group_info, rank_to_machine
-        )
-
         self._rank2params_2d_by_color = {}  # color -> {rank -> [params]}
         self._param2rank_2d_by_color = {}  # color -> {param_name -> rank}
-        for color_key, params_2d in self._params_2d_by_color.items():
-            group = self._color_to_group_info[color_key]['group']
-            group_ranks = tuple(group.ranks) if group else (self._global_rank,)
-            param_by_name = {p.name: p for p in params_2d}
-            self._rank2params_2d_by_color[color_key] = {
-                local_rank: [param_by_name[n] for n in names]
-                for local_rank, names in color_group_to_ranks[
-                    (color_key, group_ranks)
-                ].items()
-            }
-            self._param2rank_2d_by_color[color_key] = {
-                p.name: local_rank
-                for local_rank, ps in self._rank2params_2d_by_color[
-                    color_key
-                ].items()
-                for p in ps
-            }
+        if self.machine_balanced_2d_partition:
+            # Owners are planned globally so that every rank agrees, then each
+            # rank keeps the mapping of the groups it belongs to. Both gathers
+            # below run on the global world, so every rank of the job must take
+            # this branch.
+            rank_to_machine = self._build_rank_to_machine()
+            all_color_group_info = self._gather_all_color_group_info()
+            color_group_to_ranks = (
+                self._partition_2d_parameters_machine_balanced(
+                    all_color_group_info, rank_to_machine
+                )
+            )
+            for color_key, params_2d in self._params_2d_by_color.items():
+                group = self._color_to_group_info[color_key]['group']
+                group_ranks = (
+                    tuple(group.ranks) if group else (self._global_rank,)
+                )
+                param_by_name = {p.name: p for p in params_2d}
+                self._rank2params_2d_by_color[color_key] = {
+                    local_rank: [param_by_name[n] for n in names]
+                    for local_rank, names in color_group_to_ranks[
+                        (color_key, group_ranks)
+                    ].items()
+                }
+                self._param2rank_2d_by_color[color_key] = {
+                    p.name: local_rank
+                    for local_rank, ps in self._rank2params_2d_by_color[
+                        color_key
+                    ].items()
+                    for p in ps
+                }
+        else:
+            # For each color, compute rank-to-params and param-to-rank mappings
+            for color_key, params_2d in self._params_2d_by_color.items():
+                group_info = self._color_to_group_info.get(color_key, {})
+                world_size = group_info.get('world_size', 1)
+
+                if world_size <= 1:
+                    # No partition needed, all params stay on rank 0
+                    self._rank2params_2d_by_color[color_key] = {
+                        0: list(params_2d)
+                    }
+                    self._param2rank_2d_by_color[color_key] = {
+                        p.name: 0 for p in params_2d
+                    }
+                else:
+                    # Greedy partition across ranks
+                    label = color_key if color_key else "default"
+                    self._rank2params_2d_by_color[color_key] = (
+                        self._partition_2d_parameters(
+                            list(params_2d), world_size, label=label
+                        )
+                    )
+                    self._param2rank_2d_by_color[color_key] = {}
+                    for rank, params in self._rank2params_2d_by_color[
+                        color_key
+                    ].items():
+                        for p in params:
+                            self._param2rank_2d_by_color[color_key][
+                                p.name
+                            ] = rank
+
         # Sort params within each color by owner rank for deterministic ordering
         for color_key, params_2d in self._params_2d_by_color.items():
             params_2d.sort(
@@ -614,7 +654,9 @@ class MuonShardingOptimizer:
                 all_color_group_info[color_group_key] = params
         return all_color_group_info
 
-    def _partition_2d_parameters(self, all_color_group_info, rank_to_machine):
+    def _partition_2d_parameters_machine_balanced(
+        self, all_color_group_info, rank_to_machine
+    ):
         """Assign every color's 2D params to owner ranks.
 
         Balances parameter bytes across machines first, spreads owners away
@@ -728,11 +770,15 @@ class MuonShardingOptimizer:
                 machine_free_ranks.remove(owner)
                 owners.append(owner)
 
-                # Crowding is a weighted owner count, not bytes, so it does not
-                # re-measure machine_load. 1/d^2 stays non-zero across the
-                # whole cluster; CROWD_NEAR_WEIGHT being a quarter of
-                # CROWD_SELF_WEIGHT keeps 2 * sum(1/d^2) under one self weight,
-                # so no machine takes a second owner before all have one.
+                # Crowding spreads the owners apart: the machine that just
+                # took one is penalised the most, and its neighbours by
+                # 1 / d^2 of that penalty. A machine with no owner of its own
+                # therefore still counts as crowded when the machines near it
+                # have one. CROWD_SELF_WEIGHT is the penalty on the machine
+                # that just took an owner; CROWD_NEAR_WEIGHT is a quarter of
+                # it, which keeps 2 * sum(1/d^2) under one self weight and so
+                # makes sure no machine gets a second owner before every
+                # machine has one.
                 machine_crowding[machine] += CROWD_SELF_WEIGHT
                 machine_pos = machine_index[machine]
                 for other in machines:
@@ -861,6 +907,70 @@ class MuonShardingOptimizer:
         synchronously in ``reduce_gradients`` instead of via the overlap hook.
         """
         return [b for b in buffers if cls._buffer_color(b) in shared_colors]
+
+    def _partition_2d_parameters(self, params, world_size, label=""):
+        """Partition 2D parameters among ranks, bin-packing each dtype apart.
+
+        A FusedCommBuffer never mixes dtypes, since ``AssignGroupBySize`` keys
+        its groups on dtype. Bin-packing all dtypes together therefore sizes
+        ``active_ranks`` from the total of the whole color group, and a dtype
+        that only holds a small share of the parameters gets spread over far
+        more ranks than its own volume needs. Each of those ranks then builds a
+        tiny buffer of that dtype instead of one fused buffer. Running the same
+        greedy packing once per dtype keeps every dtype on as few ranks as it
+        actually needs.
+
+        Within a dtype, only the first n ranks are assigned parameters such that
+        total size > comm_buffer_size_MB. Remaining ranks get no parameters.
+        """
+        mapping = {}
+        for rank in range(world_size):
+            mapping[rank] = []
+
+        params_by_dtype = defaultdict(list)
+        for p in params:
+            params_by_dtype[p.dtype].append(p)
+
+        # Sorted so the result is fully determined by the input list rather than
+        # by the order the dtypes happen to appear in it. Owner assignment does
+        # not depend on this -- every dtype packs from rank 0 independently --
+        # but the order of each rank's param list does, and that order is what
+        # ``_local_2d`` is built from.
+        for dtype in sorted(params_by_dtype, key=str):
+            parameters = params_by_dtype[dtype]
+            parameters.sort(
+                key=lambda p: functools_reduce(lambda x, y: x * y, p.shape),
+                reverse=True,
+            )
+
+            total_numel = sum(
+                functools_reduce(lambda x, y: x * y, p.shape, 1)
+                for p in parameters
+            )
+            total_size_bytes = total_numel * 4
+            total_size_mb = total_size_bytes / (1024**2)
+
+            buffer_size_mb = (
+                self.comm_buffer_size_MB
+                if self.comm_buffer_size_MB > 0
+                else 256
+            )
+            min_active_ranks = 1
+            if total_size_mb > 0:
+                min_active_ranks = max(
+                    1, int(total_size_mb / buffer_size_mb) + 1
+                )
+
+            active_ranks = min(min_active_ranks, world_size)
+            sizes = [0] * active_ranks
+
+            for param in parameters:
+                rank = sizes.index(min(sizes))
+                mapping[rank].append(param)
+                numel = functools_reduce(lambda x, y: x * y, param.shape, 1)
+                sizes[rank] += numel
+
+        return mapping
 
     def _build_2d_comm_buffers(self):
         """Build communication buffers for 2D (Tensor-wise) parameters using all-reduce."""

--- a/python/paddle/distributed/fleet/meta_optimizers/muon_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/muon_sharding_optimizer.py
@@ -35,6 +35,7 @@ communication group to use:
 
 import math
 import os
+import socket
 import warnings
 from collections import defaultdict
 from functools import reduce as functools_reduce
@@ -43,6 +44,7 @@ import numpy as np
 
 import paddle
 from paddle import framework
+from paddle.base import core
 from paddle.base.framework import EagerParamBase
 from paddle.distributed import fleet
 from paddle.distributed.communication.batch_isend_irecv import (
@@ -63,6 +65,8 @@ from paddle.distributed.fleet.utils.tensor_fusion_helper import (
 g_shard_bypass_dygraph_optimizer = int(
     os.environ.get("FLAGS_shard_bypass_dygraph_optimizer", 0)
 )
+CROWD_SELF_WEIGHT = 1 << 20
+CROWD_NEAR_WEIGHT = CROWD_SELF_WEIGHT // 4
 
 
 def _is_trainable(param):
@@ -326,35 +330,33 @@ class MuonShardingOptimizer:
                 self._params_1d.append(p)
 
         # ---- Step 2: Partition 2D params for each color group ----
-        # For each color, compute rank-to-params and param-to-rank mappings
+        # Owners are planned globally so that every rank agrees, then each rank
+        # keeps the mapping of the groups it belongs to.
+        rank_to_machine = self._build_rank_to_machine()
+        all_color_group_info = self._gather_all_color_group_info()
+        color_group_to_ranks = self._partition_2d_parameters(
+            all_color_group_info, rank_to_machine
+        )
+
         self._rank2params_2d_by_color = {}  # color -> {rank -> [params]}
         self._param2rank_2d_by_color = {}  # color -> {param_name -> rank}
-
         for color_key, params_2d in self._params_2d_by_color.items():
-            group_info = self._color_to_group_info.get(color_key, {})
-            world_size = group_info.get('world_size', 1)
-
-            if world_size <= 1:
-                # No partition needed, all params stay on rank 0
-                self._rank2params_2d_by_color[color_key] = {0: list(params_2d)}
-                self._param2rank_2d_by_color[color_key] = {
-                    p.name: 0 for p in params_2d
-                }
-            else:
-                # Greedy partition across ranks
-                label = color_key if color_key else "default"
-                self._rank2params_2d_by_color[color_key] = (
-                    self._partition_2d_parameters(
-                        list(params_2d), world_size, label=label
-                    )
-                )
-                self._param2rank_2d_by_color[color_key] = {}
-                for rank, params in self._rank2params_2d_by_color[
+            group = self._color_to_group_info[color_key]['group']
+            group_ranks = tuple(group.ranks) if group else (self._global_rank,)
+            param_by_name = {p.name: p for p in params_2d}
+            self._rank2params_2d_by_color[color_key] = {
+                local_rank: [param_by_name[n] for n in names]
+                for local_rank, names in color_group_to_ranks[
+                    (color_key, group_ranks)
+                ].items()
+            }
+            self._param2rank_2d_by_color[color_key] = {
+                p.name: local_rank
+                for local_rank, ps in self._rank2params_2d_by_color[
                     color_key
-                ].items():
-                    for p in params:
-                        self._param2rank_2d_by_color[color_key][p.name] = rank
-
+                ].items()
+                for p in ps
+            }
         # Sort params within each color by owner rank for deterministic ordering
         for color_key, params_2d in self._params_2d_by_color.items():
             params_2d.sort(
@@ -565,6 +567,224 @@ class MuonShardingOptimizer:
     # ------------------------------------------------------------------
     # 2D partition (V1-style greedy)
     # ------------------------------------------------------------------
+    @staticmethod
+    def _build_rank_to_machine():
+        """
+        Map every global rank to the machine hosting it.
+        """
+        hostnames = []
+        paddle.distributed.all_gather_object(hostnames, socket.gethostname())
+        return dict(enumerate(hostnames))
+
+    def _gather_all_color_group_info(self):
+        """
+        Collect every color group's 2D params so all ranks partition alike.
+
+        Returns {(color_key, group_ranks): [(name, numel, dtype_str, itemsize)]}
+        """
+        local_color_group_info = {}
+        for color_key, params_2d in self._params_2d_by_color.items():
+            group = self._color_to_group_info[color_key]['group']
+            group_ranks = tuple(group.ranks) if group else (self._global_rank,)
+            # itemsize travels with the entry so remote colors need no dtype
+            # object reconstruction.
+            local_color_group_info[(color_key, group_ranks)] = [
+                (
+                    p.name,
+                    int(functools_reduce(lambda x, y: x * y, p.shape, 1)),
+                    str(p.dtype),
+                    int(core.size_of_dtype(p.dtype)),
+                )
+                for p in params_2d
+            ]
+
+        gathered_color_group_info = []
+        paddle.distributed.all_gather_object(
+            gathered_color_group_info, local_color_group_info
+        )
+
+        all_color_group_info = {}
+        for rank_color_group_info in gathered_color_group_info:
+            for color_group_key, params in rank_color_group_info.items():
+                existing = all_color_group_info.get(color_group_key)
+                assert existing is None or existing == params, (
+                    "group members disagree on the 2D params of "
+                    f"{color_group_key!r}"
+                )
+                all_color_group_info[color_group_key] = params
+        return all_color_group_info
+
+    def _partition_2d_parameters(self, all_color_group_info, rank_to_machine):
+        """Assign every color's 2D params to owner ranks.
+
+        Balances parameter bytes across machines first, spreads owners away
+        from machines that already have nearby owners, and balances per-rank
+        bytes last. Every rank partitions over the same ``all_color_group_info``
+        and must reach the same answer, since owners become the reduce dst /
+        broadcast src, so all orderings here are total and all accumulators
+        integer.
+
+        Returns {(color_key, group_ranks): {local_rank_in_group: [name, ...]}}.
+        """
+        # Step 1: order machines.
+        machines = list(
+            dict.fromkeys(rank_to_machine[r] for r in sorted(rank_to_machine))
+        )
+        machine_index = {m: i for i, m in enumerate(machines)}
+
+        machine_load = defaultdict(int)  # machine -> owned parameter bytes
+        rank_load = defaultdict(int)  # global rank -> owned parameter bytes
+        machine_crowding = defaultdict(int)  # machine -> weighted owner count
+
+        # Step 2: one bucket per (color, dtype), since a FusedCommBuffer never
+        # mixes dtypes.
+        buckets = []
+        for color_group_key, color_group_params in all_color_group_info.items():
+            param_by_dtype = defaultdict(list)
+            for name, numel, dtype_str, itemsize in color_group_params:
+                param_by_dtype[dtype_str].append((name, numel, itemsize))
+            for dtype_str, params_info in param_by_dtype.items():
+                buckets.append(
+                    {
+                        'color_group_key': color_group_key,
+                        'dtype_str': dtype_str,
+                        'group_ranks': color_group_key[1],
+                        'params_info': params_info,
+                        'param_bytes': sum(n * it for _, n, it in params_info),
+                        'numel': sum(n for _, n, _ in params_info),
+                    }
+                )
+
+        # Step 3: biggest bucket first, since it constrains the final
+        # distribution most. str() because color keys mix None with strings,
+        # and group_ranks because one color spans several groups under PP/EP.
+        buckets.sort(
+            key=lambda b: (
+                -b['param_bytes'],
+                str(b['color_group_key'][0]),
+                b['dtype_str'],
+                b['group_ranks'],
+            )
+        )
+
+        color_group_to_ranks = {
+            color_group_key: {i: [] for i in range(len(color_group_key[1]))}
+            for color_group_key in all_color_group_info
+        }
+
+        for bucket in buckets:
+            group_ranks = bucket['group_ranks']
+
+            # Step 4: owner count, unchanged from the original partition. The
+            # numel * 4 is the fp32 main_grad width that actually gets
+            # reduced, so comm buffer sizes stay as they are.
+            total_size_mb = bucket['numel'] * 4 / (1024**2)
+            buffer_size_mb = (
+                self.comm_buffer_size_MB
+                if self.comm_buffer_size_MB > 0
+                else 256
+            )
+            min_active_ranks = 1
+            if total_size_mb > 0:
+                min_active_ranks = max(
+                    1, int(total_size_mb / buffer_size_mb) + 1
+                )
+            active_ranks = min(min_active_ranks, len(group_ranks))
+
+            # Step 5: pick owners -- least loaded machine, then least crowded,
+            # then the least loaded free rank on it.
+            candidate_machines = {rank_to_machine[r] for r in group_ranks}
+            free_ranks_in_machine = defaultdict(list)
+            for r in group_ranks:
+                free_ranks_in_machine[rank_to_machine[r]].append(r)
+
+            # Byte loads almost never tie, so without a tolerance the crowding
+            # term would never be reached. Machines within one owner's share of
+            # each other count as equally loaded, which puts every machine in
+            # one tier while loads are still zero.
+            load_tolerance = bucket['param_bytes'] // active_ranks
+
+            owners = []
+            while len(owners) < active_ranks:
+                min_load = min(machine_load[m] for m in candidate_machines)
+                least_loaded_machines = [
+                    m
+                    for m in candidate_machines
+                    if machine_load[m] <= min_load + load_tolerance
+                ]
+                machine = min(
+                    least_loaded_machines,
+                    key=lambda m: (
+                        machine_crowding[m],
+                        machine_load[m],
+                        machine_index[m],
+                    ),
+                )
+                machine_free_ranks = free_ranks_in_machine[machine]
+                if not machine_free_ranks:
+                    candidate_machines.discard(machine)
+                    continue
+                owner = min(machine_free_ranks, key=lambda r: (rank_load[r], r))
+                machine_free_ranks.remove(owner)
+                owners.append(owner)
+
+                # Crowding is a weighted owner count, not bytes, so it does not
+                # re-measure machine_load. 1/d^2 stays non-zero across the
+                # whole cluster; CROWD_NEAR_WEIGHT being a quarter of
+                # CROWD_SELF_WEIGHT keeps 2 * sum(1/d^2) under one self weight,
+                # so no machine takes a second owner before all have one.
+                machine_crowding[machine] += CROWD_SELF_WEIGHT
+                machine_pos = machine_index[machine]
+                for other in machines:
+                    d = abs(machine_index[other] - machine_pos)
+                    if d:
+                        machine_crowding[other] += CROWD_NEAR_WEIGHT // (d * d)
+
+            # Step 6: place params, largest first onto the lightest owner.
+            local_rank_of = {r: i for i, r in enumerate(group_ranks)}
+            for name, numel, itemsize in sorted(
+                bucket['params_info'], key=lambda info: (-info[1], info[0])
+            ):
+                owner = min(
+                    owners,
+                    key=lambda r: (
+                        machine_load[rank_to_machine[r]],
+                        rank_load[r],
+                        r,
+                    ),
+                )
+                color_group_to_ranks[bucket['color_group_key']][
+                    local_rank_of[owner]
+                ].append(name)
+                nbytes = numel * itemsize
+                rank_load[owner] += nbytes
+                machine_load[rank_to_machine[owner]] += nbytes
+
+        # Step 7: report the distribution. adjacent_pair_max tracks the backup
+        # cost of the heaviest neighbouring pair.
+        if self._global_rank == 0:
+            machine_mb = [machine_load[m] / (1024**2) for m in machines]
+            peak = max(machine_mb)
+            spread = (peak - min(machine_mb)) / peak if peak else 0.0
+            adjacent_max = max(
+                (
+                    machine_mb[i] + machine_mb[i + 1]
+                    for i in range(len(machine_mb) - 1)
+                ),
+                default=0.0,
+            )
+            logger.info(
+                "[MuonSharding 2D placement] "
+                f"machines={len(machines)} "
+                f"used={sum(1 for v in machine_mb if v > 0)} "
+                f"owner_ranks={sum(1 for v in rank_load.values() if v > 0)} | "
+                f"per-machine MB={[f'{v:.1f}' for v in machine_mb]} | "
+                f"max={peak:.1f} min={min(machine_mb):.1f} "
+                f"spread={spread:.3f} "
+                f"adjacent_pair_max MB={adjacent_max:.1f}"
+            )
+
+        return color_group_to_ranks
 
     @staticmethod
     def _build_color_to_group_info_from_params(parameter_list, default_group):
@@ -641,70 +861,6 @@ class MuonShardingOptimizer:
         synchronously in ``reduce_gradients`` instead of via the overlap hook.
         """
         return [b for b in buffers if cls._buffer_color(b) in shared_colors]
-
-    def _partition_2d_parameters(self, params, world_size, label=""):
-        """Partition 2D parameters among ranks, bin-packing each dtype apart.
-
-        A FusedCommBuffer never mixes dtypes, since ``AssignGroupBySize`` keys
-        its groups on dtype. Bin-packing all dtypes together therefore sizes
-        ``active_ranks`` from the total of the whole color group, and a dtype
-        that only holds a small share of the parameters gets spread over far
-        more ranks than its own volume needs. Each of those ranks then builds a
-        tiny buffer of that dtype instead of one fused buffer. Running the same
-        greedy packing once per dtype keeps every dtype on as few ranks as it
-        actually needs.
-
-        Within a dtype, only the first n ranks are assigned parameters such that
-        total size > comm_buffer_size_MB. Remaining ranks get no parameters.
-        """
-        mapping = {}
-        for rank in range(world_size):
-            mapping[rank] = []
-
-        params_by_dtype = defaultdict(list)
-        for p in params:
-            params_by_dtype[p.dtype].append(p)
-
-        # Sorted so the result is fully determined by the input list rather than
-        # by the order the dtypes happen to appear in it. Owner assignment does
-        # not depend on this -- every dtype packs from rank 0 independently --
-        # but the order of each rank's param list does, and that order is what
-        # ``_local_2d`` is built from.
-        for dtype in sorted(params_by_dtype, key=str):
-            parameters = params_by_dtype[dtype]
-            parameters.sort(
-                key=lambda p: functools_reduce(lambda x, y: x * y, p.shape),
-                reverse=True,
-            )
-
-            total_numel = sum(
-                functools_reduce(lambda x, y: x * y, p.shape, 1)
-                for p in parameters
-            )
-            total_size_bytes = total_numel * 4
-            total_size_mb = total_size_bytes / (1024**2)
-
-            buffer_size_mb = (
-                self.comm_buffer_size_MB
-                if self.comm_buffer_size_MB > 0
-                else 256
-            )
-            min_active_ranks = 1
-            if total_size_mb > 0:
-                min_active_ranks = max(
-                    1, int(total_size_mb / buffer_size_mb) + 1
-                )
-
-            active_ranks = min(min_active_ranks, world_size)
-            sizes = [0] * active_ranks
-
-            for param in parameters:
-                rank = sizes.index(min(sizes))
-                mapping[rank].append(param)
-                numel = functools_reduce(lambda x, y: x * y, param.shape, 1)
-                sizes[rank] += numel
-
-        return mapping
 
     def _build_2d_comm_buffers(self):
         """Build communication buffers for 2D (Tensor-wise) parameters using all-reduce."""

--- a/python/paddle/distributed/fleet/meta_optimizers/muon_sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/muon_sharding_optimizer.py
@@ -393,9 +393,9 @@ class MuonShardingOptimizer:
                         color_key
                     ].items():
                         for p in params:
-                            self._param2rank_2d_by_color[color_key][
-                                p.name
-                            ] = rank
+                            self._param2rank_2d_by_color[color_key][p.name] = (
+                                rank
+                            )
 
         # Sort params within each color by owner rank for deterministic ordering
         for color_key, params_2d in self._params_2d_by_color.items():

--- a/test/legacy_test/test_muon_2d_partition.py
+++ b/test/legacy_test/test_muon_2d_partition.py
@@ -15,10 +15,13 @@
 """Single-process tests for MuonShardingOptimizer._partition_2d_parameters.
 
 The method maps every 2D (Muon) parameter to an owner rank. It reads nothing
-but ``self.comm_buffer_size_MB`` and each parameter's ``shape``/``dtype``, so it
-can be exercised directly against stub parameters -- no communication groups, no
-accelerators, no launcher. The multi-process behaviour it feeds into is covered
-by test/collective/fleet/test_muon_sharding_mixed_dtype_partition.py.
+but ``self.comm_buffer_size_MB`` and ``self._global_rank``, and takes the
+parameters as plain ``(name, numel, dtype_str, itemsize)`` tuples, so it can be
+exercised directly -- no communication groups, no accelerators, no launcher.
+These tests put every rank on one machine, which makes the machine-level terms
+constant and leaves the per-rank packing they are about. The multi-process
+behaviour it feeds into is covered by
+test/collective/fleet/test_muon_sharding_mixed_dtype_partition.py.
 """
 
 import unittest
@@ -30,6 +33,7 @@ from paddle.distributed.fleet.meta_optimizers.muon_sharding_optimizer import (
 
 WORLD_SIZES = (1, 2, 4, 8, 16, 32)
 BUFFER_SIZES_MB = (0, 1, 64, 128, 256, 512)
+ITEMSIZE = {"bfloat16": 2, "float16": 2, "float32": 4}
 
 
 class _StubParam:
@@ -44,18 +48,34 @@ class _StubPartitioner:
 
     _partition_2d_parameters = MuonShardingOptimizer._partition_2d_parameters
 
-    def __init__(self, comm_buffer_size_MB):
+    def __init__(self, comm_buffer_size_MB, global_rank=1):
         self.comm_buffer_size_MB = comm_buffer_size_MB
+        # Non-zero by default so the rank-0 placement summary stays out of the
+        # output of the hundreds of subTest combinations below.
+        self._global_rank = global_rank
 
 
 def _numel(param):
     return reduce(lambda x, y: x * y, param.shape, 1)
 
 
-def _partition(params, world_size, comm_buffer_size_MB):
-    return _StubPartitioner(comm_buffer_size_MB)._partition_2d_parameters(
-        list(params), world_size
-    )
+def _partition(params, world_size, comm_buffer_size_MB, global_rank=1):
+    color_group_key = (None, tuple(range(world_size)))
+    owners = _StubPartitioner(
+        comm_buffer_size_MB, global_rank
+    )._partition_2d_parameters(
+        {
+            color_group_key: [
+                (p.name, _numel(p), p.dtype, ITEMSIZE[p.dtype]) for p in params
+            ]
+        },
+        dict.fromkeys(range(world_size), "host0"),
+    )[color_group_key]
+    by_name = {p.name: p for p in params}
+    return {
+        rank: [by_name[name] for name in names]
+        for rank, names in owners.items()
+    }
 
 
 def _active_ranks(volume_numel, world_size, comm_buffer_size_MB):
@@ -148,7 +168,12 @@ class TestPartition2DParameters(unittest.TestCase):
                         )
 
     def test_single_dtype_matches_whole_group_packing(self):
-        """A single-dtype list must reproduce the pre-change mapping exactly."""
+        """A single-dtype list must reproduce the pre-change mapping exactly.
+
+        With one machine and one dtype the machine-level terms tie for every
+        candidate, so owner choice falls through to the least loaded rank --
+        which is what the original greedy did.
+        """
         for label in ("empty", "single", "bf16_only", "fp32_only"):
             params = PARAM_SETS[label]
             for world_size in WORLD_SIZES:
@@ -227,10 +252,11 @@ class TestPartition2DParameters(unittest.TestCase):
     def test_dtype_iteration_order_does_not_change_owners(self):
         """Owner assignment must not depend on dtype discovery order.
 
-        Each dtype is packed from rank 0 with a fresh size vector, so the order
-        the dtypes are visited in cannot move a param to another rank. Feeding
-        the same params with the dtypes grouped in the opposite order (relative
-        order within each dtype preserved) must give the same owners.
+        Buckets are sorted by (volume, color, dtype, group ranks) before any
+        owner is picked, so the order the dtypes appear in the input cannot
+        move a param. Feeding the same params with the dtypes grouped in the
+        opposite order (relative order within each dtype preserved) must give
+        the same owners.
         """
         bf16, fp32 = _bf16(5), _fp32(3)
         for world_size in (2, 4, 8):
@@ -251,6 +277,161 @@ class TestPartition2DParameters(unittest.TestCase):
         before = [p.name for p in params]
         _partition(params, 8, 1)
         self.assertEqual([p.name for p in params], before)
+
+
+# ---------------------------------------------------------------------------
+# PP + EP + sharding: several groups per color, spread over several machines
+# ---------------------------------------------------------------------------
+
+MOE_SHARDING, PP, EP, CARDS_PER_MACHINE = 2, 2, 4, 8
+
+
+def _hybrid_layout():
+    """Rank layout of the MoE topology order ['moe_sharding', 'pipe', 'expert'].
+
+    Mirrors the rank formula the optimizer relies on for group_call_opt,
+    ``moe_sharding_idx * pp * ep + pp_idx * ep + ep_idx``. Dense params shard
+    across everything but the pipe axis, so there is one dense group per PP
+    stage; expert params shard along moe_sharding only, so there is one group
+    per (stage, expert). Both kinds of group straddle the two machines.
+    """
+
+    def rank_of(sharding_idx, pp_idx, ep_idx):
+        return sharding_idx * PP * EP + pp_idx * EP + ep_idx
+
+    dense_groups = [
+        tuple(
+            sorted(
+                rank_of(s, pp_idx, e)
+                for s in range(MOE_SHARDING)
+                for e in range(EP)
+            )
+        )
+        for pp_idx in range(PP)
+    ]
+    moe_groups = [
+        tuple(sorted(rank_of(s, pp_idx, e) for s in range(MOE_SHARDING)))
+        for pp_idx in range(PP)
+        for e in range(EP)
+    ]
+    rank_to_machine = {
+        rank: f"host{rank // CARDS_PER_MACHINE}"
+        for rank in range(MOE_SHARDING * PP * EP)
+    }
+    return dense_groups, moe_groups, rank_to_machine
+
+
+def _hybrid_color_group_info(dense_groups, moe_groups):
+    """Six dense weights per stage, two expert weights per (stage, expert)."""
+    info = {}
+    for stage, group_ranks in enumerate(dense_groups):
+        info[(None, group_ranks)] = [
+            (f"stage{stage}.layer{i}.w", 4096 * 4096, "bfloat16", 2)
+            for i in range(6)
+        ]
+    for idx, group_ranks in enumerate(moe_groups):
+        info[("moe_expert", group_ranks)] = [
+            (f"expert{idx}.w{i}", 2048 * 4096, "bfloat16", 2) for i in range(2)
+        ]
+    return info
+
+
+class TestHybridParallelPartition(unittest.TestCase):
+    """The partitioner sees every color group in the job, not just its own."""
+
+    def setUp(self):
+        self.dense, self.moe, self.rank_to_machine = _hybrid_layout()
+        self.info = _hybrid_color_group_info(self.dense, self.moe)
+
+    def _run(self, comm_buffer_size_MB, global_rank=0):
+        return _StubPartitioner(
+            comm_buffer_size_MB, global_rank
+        )._partition_2d_parameters(self.info, self.rank_to_machine)
+
+    def test_one_entry_per_group_not_per_color(self):
+        """color_key alone is not an identity once PP or EP is on.
+
+        ``None`` names one dense group per PP stage and ``moe_expert`` one per
+        (stage, expert), so keying on the color alone would collapse them and
+        lose every group but the last.
+        """
+        for buffer_mb in (64, 256):
+            with self.subTest(buffer=buffer_mb):
+                result = self._run(buffer_mb)
+                self.assertEqual(set(result), set(self.info))
+                self.assertEqual(
+                    len([k for k in result if k[0] is None]), len(self.dense)
+                )
+                self.assertEqual(
+                    len([k for k in result if k[0] == "moe_expert"]),
+                    len(self.moe),
+                )
+                for key, params in self.info.items():
+                    self.assertEqual(set(result[key]), set(range(len(key[1]))))
+                    self.assertEqual(
+                        sorted(
+                            n for names in result[key].values() for n in names
+                        ),
+                        sorted(p[0] for p in params),
+                    )
+
+    def test_owner_is_a_member_of_its_own_group(self):
+        """Every param has exactly one owner, and it is inside its own group."""
+        for buffer_mb in (64, 256):
+            with self.subTest(buffer=buffer_mb):
+                owner_of = {}
+                for key, ranks_map in self._run(buffer_mb).items():
+                    group_ranks = key[1]
+                    for local_rank, names in ranks_map.items():
+                        for name in names:
+                            self.assertNotIn(name, owner_of)
+                            owner_of[name] = group_ranks[local_rank]
+                self.assertEqual(
+                    set(owner_of),
+                    {p[0] for ps in self.info.values() for p in ps},
+                )
+
+    def test_result_does_not_depend_on_merge_order(self):
+        """Every rank must reach the same answer whatever order it merged in.
+
+        Owners become the reduce dst, so a rank that ordered the gathered
+        groups differently and derived different owners would hang the job.
+        """
+        reversed_info = dict(reversed(list(self.info.items())))
+        for buffer_mb in (64, 256):
+            with self.subTest(buffer=buffer_mb):
+                expected = self._run(buffer_mb)
+                actual = _StubPartitioner(
+                    buffer_mb, 0
+                )._partition_2d_parameters(reversed_info, self.rank_to_machine)
+                self.assertEqual(actual, expected)
+
+    def test_load_is_spread_over_every_machine(self):
+        """Both machines must carry owners, and carry about the same volume.
+
+        Taking the first ``active_ranks`` local indices of each group instead
+        would put every owner of both dense stages and all eight expert groups
+        on host0 at 256MB buckets, i.e. a spread of 1.0.
+        """
+        for buffer_mb in (64, 256):
+            with self.subTest(buffer=buffer_mb):
+                size_of = {
+                    p[0]: p[1] * p[3] for ps in self.info.values() for p in ps
+                }
+                machine_bytes = dict.fromkeys(
+                    set(self.rank_to_machine.values()), 0
+                )
+                for key, ranks_map in self._run(buffer_mb).items():
+                    for local_rank, names in ranks_map.items():
+                        machine = self.rank_to_machine[key[1][local_rank]]
+                        for name in names:
+                            machine_bytes[machine] += size_of[name]
+
+                loads = list(machine_bytes.values())
+                self.assertTrue(all(loads), machine_bytes)
+                self.assertLessEqual(
+                    (max(loads) - min(loads)) / max(loads), 0.05, machine_bytes
+                )
 
 
 if __name__ == "__main__":

--- a/test/legacy_test/test_muon_2d_partition.py
+++ b/test/legacy_test/test_muon_2d_partition.py
@@ -12,15 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Single-process tests for MuonShardingOptimizer._partition_2d_parameters.
+"""Single-process tests for MuonShardingOptimizer's 2D partitioners.
 
-The method maps every 2D (Muon) parameter to an owner rank. It reads nothing
-but ``self.comm_buffer_size_MB`` and ``self._global_rank``, and takes the
-parameters as plain ``(name, numel, dtype_str, itemsize)`` tuples, so it can be
-exercised directly -- no communication groups, no accelerators, no launcher.
-These tests put every rank on one machine, which makes the machine-level terms
-constant and leaves the per-rank packing they are about. The multi-process
-behaviour it feeds into is covered by
+Both map every 2D (Muon) parameter to an owner rank, and which one runs is
+picked by the ``machine_balanced_2d_partition`` sharding config.
+``_partition_2d_parameters_machine_balanced`` reads nothing but
+``self.comm_buffer_size_MB`` and ``self._global_rank``, and takes the parameters
+as plain ``(name, numel, dtype_str, itemsize)`` tuples; the legacy
+``_partition_2d_parameters`` reads only ``self.comm_buffer_size_MB`` and each
+parameter's ``shape``/``dtype``. So both can be exercised directly -- no
+communication groups, no accelerators, no launcher. Most tests here put every
+rank on one machine, which makes the machine-level terms constant and leaves the
+per-rank packing they are about. The multi-process behaviour they feed into is
+covered by
 test/collective/fleet/test_muon_sharding_mixed_dtype_partition.py.
 """
 
@@ -44,9 +48,12 @@ class _StubParam:
 
 
 class _StubPartitioner:
-    """Carries only the state ``_partition_2d_parameters`` actually reads."""
+    """Carries only the state the partitioners actually read."""
 
     _partition_2d_parameters = MuonShardingOptimizer._partition_2d_parameters
+    _partition_2d_parameters_machine_balanced = (
+        MuonShardingOptimizer._partition_2d_parameters_machine_balanced
+    )
 
     def __init__(self, comm_buffer_size_MB, global_rank=1):
         self.comm_buffer_size_MB = comm_buffer_size_MB
@@ -63,7 +70,7 @@ def _partition(params, world_size, comm_buffer_size_MB, global_rank=1):
     color_group_key = (None, tuple(range(world_size)))
     owners = _StubPartitioner(
         comm_buffer_size_MB, global_rank
-    )._partition_2d_parameters(
+    )._partition_2d_parameters_machine_balanced(
         {
             color_group_key: [
                 (p.name, _numel(p), p.dtype, ITEMSIZE[p.dtype]) for p in params
@@ -76,6 +83,13 @@ def _partition(params, world_size, comm_buffer_size_MB, global_rank=1):
         rank: [by_name[name] for name in names]
         for rank, names in owners.items()
     }
+
+
+def _partition_legacy(params, world_size, comm_buffer_size_MB):
+    """The path taken when ``machine_balanced_2d_partition`` is off."""
+    return _StubPartitioner(comm_buffer_size_MB)._partition_2d_parameters(
+        list(params), world_size
+    )
 
 
 def _active_ranks(volume_numel, world_size, comm_buffer_size_MB):
@@ -279,6 +293,63 @@ class TestPartition2DParameters(unittest.TestCase):
         self.assertEqual([p.name for p in params], before)
 
 
+class TestLegacyPartition2DParameters(unittest.TestCase):
+    """The machine_balanced_2d_partition=False path, kept as it was.
+
+    It packs each color group from its own rank 0 and knows nothing about
+    machines, so only the per-dtype packing it exists for is asserted here.
+    """
+
+    def test_every_param_owned_exactly_once(self):
+        for label, params in PARAM_SETS.items():
+            for world_size in WORLD_SIZES:
+                for buffer_mb in BUFFER_SIZES_MB:
+                    with self.subTest(
+                        params=label, world_size=world_size, buffer=buffer_mb
+                    ):
+                        mapping = _partition_legacy(
+                            params, world_size, buffer_mb
+                        )
+                        self.assertEqual(
+                            set(mapping),
+                            set(range(world_size)),
+                            "every rank must be present as a key, even if empty",
+                        )
+                        self.assertEqual(
+                            sorted(_owner_of(mapping)),
+                            sorted(p.name for p in params),
+                            "params must be neither dropped nor duplicated",
+                        )
+
+    def test_rank_count_follows_own_dtype_volume(self):
+        """Each dtype spreads only as wide as its own volume requires."""
+        for label, params in PARAM_SETS.items():
+            dtypes = {p.dtype for p in params}
+            for world_size in WORLD_SIZES:
+                for buffer_mb in BUFFER_SIZES_MB:
+                    mapping = _partition_legacy(params, world_size, buffer_mb)
+                    for dtype in dtypes:
+                        own = [p for p in params if p.dtype == dtype]
+                        expected = min(
+                            _active_ranks(
+                                sum(_numel(p) for p in own),
+                                world_size,
+                                buffer_mb,
+                            ),
+                            len(own),
+                        )
+                        with self.subTest(
+                            params=label,
+                            world_size=world_size,
+                            buffer=buffer_mb,
+                            dtype=dtype,
+                        ):
+                            self.assertEqual(
+                                len(_ranks_holding(mapping, dtype)),
+                                expected,
+                            )
+
+
 # ---------------------------------------------------------------------------
 # PP + EP + sharding: several groups per color, spread over several machines
 # ---------------------------------------------------------------------------
@@ -346,7 +417,9 @@ class TestHybridParallelPartition(unittest.TestCase):
     def _run(self, comm_buffer_size_MB, global_rank=0):
         return _StubPartitioner(
             comm_buffer_size_MB, global_rank
-        )._partition_2d_parameters(self.info, self.rank_to_machine)
+        )._partition_2d_parameters_machine_balanced(
+            self.info, self.rank_to_machine
+        )
 
     def test_one_entry_per_group_not_per_color(self):
         """color_key alone is not an identity once PP or EP is on.
@@ -403,7 +476,9 @@ class TestHybridParallelPartition(unittest.TestCase):
                 expected = self._run(buffer_mb)
                 actual = _StubPartitioner(
                     buffer_mb, 0
-                )._partition_2d_parameters(reversed_info, self.rank_to_machine)
+                )._partition_2d_parameters_machine_balanced(
+                    reversed_info, self.rank_to_machine
+                )
                 self.assertEqual(actual, expected)
 
     def test_load_is_spread_over_every_machine(self):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | CINN | Custom Device | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Auto Parallel | Inference | Environment Adaptation ] -->
Performance Optimization 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Improvements

### Description
<!-- Describe what you’ve done -->
优化muon 2d参数的切分，增加了machine_balanced_2d_partition开关（默认为关），当开启后参数切分将会尽可能做到机器之间的均衡

步骤如下：
1. 通信拿到所有rank和机器node的映射
2. 通信是的每个rank可以看到全局的muon 2D参数
3. 贪心的将数据往rank上放，放的顺序如下
    a. 找到压力最小的机器
    b. 找到拥挤程度最低的机器
    c. 找到该机器上压力最小的rank

【测试结果】：在8机情况下，开启ep=4，pp=0的测试条件下，生成checkpoint
1. **正确性检验：** 
    a. 接续热启训练：checkpoint-10、checkpoint-40为老版本代码生成；checkpoint-20、checkpoint-30为新版本代码生成。 四次训练的loss值正常接续
    b. 代码修改前后收敛测试结果验证（4000步误差<0.001）：
<img width="2200" height="1320" alt="loss_norm_compare" src="https://github.com/user-attachments/assets/4088a2da-df05-478f-a21a-2e974c9c01fb" />


2. **负载均衡检验：** 
  文件大小：
  老版本的所有权重均聚集于排序靠前的rank
  <img width="340" height="142" alt="image" src="https://github.com/user-attachments/assets/0d2c4505-625e-49ac-8d1e-5d23f4cc29e5" />
  

  新版本权重按照机器均分，高负载机器尽可能远离（1号机器和8号机器）
  <img width="350" height="162" alt="image" src="https://github.com/user-attachments/assets/352edfc1-19d4-4fb5-9f82-4c54350a0ccb" />

TODO：目前开启machine_balanced_2d_partition的同时开启EMA会产生问题，因为PaddleFormers在判定机器布局，并行策略相同后就不会进行reshard，这是不对的，需要进行修改。待修改后才可同时使用 （fixed by：https://github.com/PaddlePaddle/PaddleFleet/pull/2056 ）

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是

精度变化仅来源于 nccl reduce 的 dst 不同时累加顺序有变化，理论上和上面实测都是零偏