### PR TITLE
[XPU] Remove duplicated activation op-test wrappers that shadow sqrt and silu tests

### DIFF
--- a/test/xpu/test_activation_op_xpu.py
+++ b/test/xpu/test_activation_op_xpu.py
@@ -396,32 +396,6 @@ for stype in support_types:
     create_test_class(globals(), XPUTestSqrtOP, stype)
 
 
-class XPUTestFloorOP(XPUOpTestWrapper):
-    def __init__(self):
-        self.op_name = 'floor'
-        self.use_dynamic_create_class = False
-
-    class XPUTestSqrt(TestActivationOPBase):
-        def set_case(self):
-            self.op_type = "floor"
-            self.dtype = self.in_type
-
-            x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
-            out = np.floor(x)
-
-            self.attrs = {'use_xpu': True}
-            self.inputs = {'X': OpTest.np_dtype_to_base_dtype(x)}
-            self.outputs = {'Out': out}
-
-        def test_check_grad(self):
-            self.check_output_with_place(self.place)
-
-
-support_types = get_xpu_op_support_types('floor')
-for stype in support_types:
-    create_test_class(globals(), XPUTestFloorOP, stype)
-
-
 class XPUTestAbsOP(XPUOpTestWrapper):
     def __init__(self):
         self.op_name = 'abs'
@@ -1197,30 +1171,6 @@ def ref_relu6(x, threshold=6.0):
     out[np.abs(x - threshold) < 0.005] = threshold + 0.02
     out = np.minimum(np.maximum(x, 0), threshold)
     return out
-
-
-class XPUTestSiluOP(XPUOpTestWrapper):
-    def __init__(self):
-        self.op_name = 'silu'
-        self.use_dynamic_create_class = False
-
-    class XPUTestSilu(TestActivationOPBase):
-        def set_case(self):
-            self.op_type = "silu"
-            self.dtype = self.in_type
-
-            np.random.seed(1024)
-            x = np.random.uniform(-1, 1, [11, 17]).astype(self.dtype)
-            out = x / (np.exp(-x) + 1)
-
-            self.inputs = {'X': x}
-            self.outputs = {'Out': out}
-            self.attrs = {'use_xpu': True}
-
-
-support_types = get_xpu_op_support_types('silu')
-for stype in support_types:
-    create_test_class(globals(), XPUTestSiluOP, stype)
 
 
 class XPUTestSoftReluOP(XPUOpTestWrapper):


### PR DESCRIPTION
### PR Category

Custom Device

### PR Types

Bug fixes

### Description

`test/xpu/test_activation_op_xpu.py` defines `XPUTestFloorOP` and `XPUTestSiluOP` **twice** each (lines 399 / 1025 and 184 / 1202 on `develop`).

`create_test_class()` in `test/xpu/get_test_cover_info.py` registers the generated cases into module globals keyed by the **inner** class name:

```python
for test_class in register_classes:
    ...
    cls_name = f"{test_class[0]}_{test_type}"
    func_globals[cls_name] = type(cls_name, (class_obj,), {...})
```

so a later registration that reuses an inner class name silently overwrites the earlier one.

**1. XPU `sqrt` is not being tested at all.**

The stale `XPUTestFloorOP` block names its inner class `XPUTestSqrt` (a copy‑paste leftover — the op it configures is `floor`):

```python
class XPUTestFloorOP(XPUOpTestWrapper):
    def __init__(self):
        self.op_name = 'floor'
    class XPUTestSqrt(TestActivationOPBase):   # <-- should be XPUTestFloor
        def set_case(self):
            self.op_type = "floor"
```

It is registered immediately after `XPUTestSqrtOP`, so `XPUTestSqrt_<dtype>` ends up holding the **floor** case. The test names still read `sqrt`, and `record_op_test('sqrt', ...)` still marks sqrt as covered, so the op-coverage report does not reveal the gap.

**2. The silu base case silently regressed to an older implementation.**

The stale `XPUTestSiluOP` block re-registers `XPUTestSilu_<dtype>` with an older, minimal `set_case` that drops the bfloat16 `convert_float_to_uint16` path and the `init_shape` / `set_env` / `delete_env` hooks of the current implementation. (The `TestSilu_ZeroDim`, `TestSilu_LUT` and `TestSiluLargeShape1` subclasses keep working, because they captured the current class object at class-creation time — only the base case is affected.)

**Fix**

Both stale blocks are strict subsets of the surviving definitions, so they are removed together with their `create_test_class` loops. The op each one covers is still registered exactly once by the surviving wrapper.

**Effect (resolved statically from the module, per registered base class)**

| generated base class | before | after |
|---|---|---|
| `XPUTestSqrt_<dtype>` | `XPUTestFloorOP`, op=`floor`, methods `set_case`, `test_check_grad` | `XPUTestSqrtOP`, op=`sqrt`, methods `set_case` |
| `XPUTestSilu_<dtype>` | `XPUTestSiluOP` (old), methods `set_case` | `XPUTestSiluOP` (current), methods `set_case`, `init_shape`, `set_env`, `delete_env`, `test_check_output`, `test_check_grad` |

Registered base classes: **100 before, 100 after** — no generated test class is removed, two are restored to the op they are named for. `floor` goes from two wrappers to one; `sqrt` goes from zero to one.

Diff is `+0 / −50`, test-only.

### 是否引起精度变化

否

（Test-only change. It does re-enable XPU `sqrt` op tests that have not run for some time, so `PR-CI-Kunlun` may surface a pre-existing sqrt issue — that is the point of the change rather than a regression introduced by it.）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
