### PR TITLE
[Test] Un-shadow duplicated test classes in test_lu_op.py and test_tensordot.py

### DIFF
--- a/test/legacy_test/test_lu_op.py
+++ b/test/legacy_test/test_lu_op.py
@@ -384,7 +384,7 @@ class TestLUAPI_ZeroSize(unittest.TestCase):
         self.assertEqual(x.grad.shape, x.shape)
 
 
-class TestLUOp(OpTest):
+class TestLUOpZeroSize(OpTest):
     def config(self):
         self.x_shape = [2, 0, 12]
         self.pivot = True

--- a/test/legacy_test/test_tensordot.py
+++ b/test/legacy_test/test_tensordot.py
@@ -382,24 +382,6 @@ class TestTensordotAPIFloat64ZeroSize(TestTensordotAPIZeroSize):
         self.dtype = np.float64
 
 
-class TestTensordotAPIZeroSize(TestTensordotAPI):
-    def set_input_shape(self):
-        self.x_shape = [0, 5, 5, 5]
-        self.y_shape = [0, 5, 5, 5]
-
-    def set_input_data(self):
-        self.x = np.random.random(self.x_shape).astype(self.dtype)
-        self.y = np.random.random(self.y_shape).astype(self.dtype)
-
-    def set_test_axes(self):
-        self.all_axes = [
-            [[], []],
-        ]
-
-    def set_dtype(self):
-        self.dtype = np.float64
-
-
 class TestTensordotAPIZeroSizeMultipleDims1(TestTensordotAPI):
     def set_input_shape(self):
         self.x_shape = [0, 0, 5, 5]


### PR DESCRIPTION
### PR Category

Execute Infrastructure

### PR Types

Bug fixes

### Description

Two unit-test files define a test class name twice at module level. Python keeps only the last binding, so `unittest` / `pytest` collect only the later class and the earlier case silently stops running.

**1. `test/legacy_test/test_lu_op.py`**

`TestLUOp` is defined at line 106 (`# m < n`, "case 1", `x_shape = [3, 10, 12]`) and again at line 387, where a zero-size case (`x_shape = [2, 0, 12]`) reuses the same name.

`TestLUOp2` … `TestLUOp5` still behave correctly — they subclass the first definition and captured the class object at class-creation time — but the m < n case itself is no longer collected, since the module attribute `TestLUOp` now points at the zero-size class.

Renamed the zero-size class to `TestLUOpZeroSize`, matching the `TestLUAPIZeroSize` naming already used in the same file. Both cases are then collected.

| collected class | before | after |
|---|---|---|
| `TestLUOp` | L387 zero-size `[2, 0, 12]` | L106 m < n `[3, 10, 12]` (base of `TestLUOp2`–`TestLUOp5`) |
| `TestLUOpZeroSize` | *(not collected)* | L387 zero-size `[2, 0, 12]` |

Class count is unchanged (9 before, 9 after); one case is recovered.

**2. `test/legacy_test/test_tensordot.py`**

`TestTensordotAPIZeroSize` is defined at line 365 and again at line 385. The second definition is byte-identical to the first except that it adds `set_dtype` → `np.float64` — which is exactly what `TestTensordotAPIFloat64ZeroSize` (line 380, a subclass of the *first* definition) already provides.

So the duplicate buys no extra coverage and costs the default `float32` zero-size case: the collected `TestTensordotAPIZeroSize` runs float64, and float64 is then tested twice.

Removed the second definition. `TestTensordotAPIZeroSize` goes back to the base `set_dtype` (`np.float32`) and `TestTensordotAPIFloat64ZeroSize` continues to cover float64. No class defined after line 400 subclasses `TestTensordotAPIZeroSize`, so nothing else changes binding.

| collected class | before | after |
|---|---|---|
| `TestTensordotAPIZeroSize` | float64 (duplicate of `TestTensordotAPIFloat64ZeroSize`) | float32 (base dtype) |
| `TestTensordotAPIFloat64ZeroSize` | float64 | float64 (unchanged) |

Diff is `+1 / −19`, test-only.

### 是否引起精度变化

否

（Test-only. Two previously-uncollected cases start running again; no framework or kernel code is touched.）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
